### PR TITLE
chore: add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Build artifacts from printing-press verify/scorecard
+*-validation
+
+# Go binaries (Windows)
+*.exe
+
+# Go build cache
+.cache/
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*~
+.idea/
+.vscode/


### PR DESCRIPTION
## Summary

- Adds a root `.gitignore` to prevent accidental commits of build artifacts from the printing-press pipeline

## What it covers

| Pattern | What it catches | Where it comes from |
|---------|----------------|-------------------|
| `*-validation` | Verify binaries (e.g. `dub-cli-validation`) | `printing-press verify` compiles the CLI to test it |
| `.cache/` | Go module download cache (172MB+) | `go build` quality gates download dependencies |
| `*.exe` | Windows Go binaries | Cross-compilation or Windows builds |
| `.DS_Store` | macOS Finder metadata | Any macOS user browsing the repo |

## What it does NOT cover

Go binaries built in the CLI directory (e.g. `./dub-pp-cli`) are not covered because the binary name varies per CLI and a gitignore rule like `dub-pp-cli` would also match the `dub-pp-cli/` source directory. The generator should clean up binaries after verify, or adopt a `bin/` output convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)