### PR TITLE
feat: add tools manifests and registry fields for mega MCP

### DIFF
--- a/library/developer-tools/postman-explore-pp-cli/tools-manifest.json
+++ b/library/developer-tools/postman-explore-pp-cli/tools-manifest.json
@@ -1,0 +1,179 @@
+{
+  "api_name": "postman-explore",
+  "base_url": "https://www.postman.com/_api/ws/proxy",
+  "description": "Undocumented internal API powering the Postman API Network explore site (postman.com/explore).\nAll requests go through a proxy endpoint as POST requests with a JSON body containing\n{service, method, path, body?}. This spec models the logical endpoints directly.\n\nNo authentication required for public browsing and search.",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "none"
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "category_get",
+      "description": "Get details for a specific category",
+      "method": "GET",
+      "path": "/v2/api/category/{slug}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "path",
+          "description": "Category URL slug (e.g., artificial-intelligence, devops)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "category_list-categories",
+      "description": "List all API categories",
+      "method": "GET",
+      "path": "/v2/api/category",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "sort",
+          "type": "string",
+          "location": "query",
+          "description": "Sort order"
+        }
+      ]
+    },
+    {
+      "name": "networkentity_get-network-entity-counts",
+      "description": "Get total counts of entities on the network",
+      "method": "GET",
+      "path": "/v1/api/networkentity/count",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "flattenAPIVersions",
+          "type": "bool",
+          "location": "query",
+          "description": "Flatten apiversions"
+        }
+      ]
+    },
+    {
+      "name": "networkentity_list-network-entities",
+      "description": "Browse public entities on the API network",
+      "method": "GET",
+      "path": "/v1/api/networkentity",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "entityType",
+          "type": "string",
+          "location": "query",
+          "description": "Type of entity to browse",
+          "required": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "location": "query",
+          "description": "Number of results per page"
+        },
+        {
+          "name": "offset",
+          "type": "int",
+          "location": "query",
+          "description": "Pagination offset"
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "location": "query",
+          "description": "Sort order for results"
+        },
+        {
+          "name": "categoryId",
+          "type": "int",
+          "location": "query",
+          "description": "Filter by category ID (numeric, from categories endpoint)"
+        }
+      ]
+    },
+    {
+      "name": "search-all_search_all",
+      "description": "Full-text search across the public API network",
+      "method": "POST",
+      "path": "/search-all",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "Search domain scope"
+        },
+        {
+          "name": "from",
+          "type": "int",
+          "location": "body",
+          "description": "Pagination offset"
+        },
+        {
+          "name": "mergeEntities",
+          "type": "bool",
+          "location": "body",
+          "description": "Merge entities"
+        },
+        {
+          "name": "nested",
+          "type": "bool",
+          "location": "body",
+          "description": "Nested"
+        },
+        {
+          "name": "nonNestedRequests",
+          "type": "bool",
+          "location": "body",
+          "description": "Non nested requests"
+        },
+        {
+          "name": "queryIndices",
+          "type": "array",
+          "location": "body",
+          "description": "Entity types to search across",
+          "required": true
+        },
+        {
+          "name": "queryText",
+          "type": "string",
+          "location": "body",
+          "description": "Search query text",
+          "required": true
+        },
+        {
+          "name": "size",
+          "type": "int",
+          "location": "body",
+          "description": "Number of results to return",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "team_list",
+      "description": "List publisher teams on the API network",
+      "method": "GET",
+      "path": "/v1/api/team",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "limit",
+          "type": "int",
+          "location": "query",
+          "description": "Limit"
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "location": "query",
+          "description": "Sort"
+        }
+      ]
+    }
+  ]
+}

--- a/library/marketing/dub-pp-cli/tools-manifest.json
+++ b/library/marketing/dub-pp-cli/tools-manifest.json
@@ -1,0 +1,3018 @@
+{
+  "api_name": "dub",
+  "base_url": "https://api.dub.co",
+  "description": "Dub is the modern link attribution platform for short links, conversion tracking, and affiliate programs.",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "bearer_token",
+    "header": "Authorization",
+    "env_vars": [
+      "DUB_TOKEN"
+    ]
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "analytics_retrieve",
+      "description": "Retrieve analytics for a link, a domain, or the authenticated workspace.",
+      "method": "GET",
+      "path": "/analytics",
+      "params": [
+        {
+          "name": "event",
+          "type": "string",
+          "location": "query",
+          "description": "The type of event to retrieve analytics for. Defaults to `clicks`."
+        },
+        {
+          "name": "groupBy",
+          "type": "string",
+          "location": "query",
+          "description": "The parameter to group the analytics data points by. Defaults to `count` if undefined."
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "query",
+          "description": "The domain to filter analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `dub.co`, `dub.co,google.com`, `-spam.com`."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the short link to retrieve analytics for. Must be used along with the corresponding `domain` of the short link to fetch analytics for a specific short link."
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "query",
+          "description": "The unique ID of the link to retrieve analytics for.Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `link_123`, `link_123,link_456`, `-link_789`."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the link in the your database. Must be prefixed with 'ext_' when passed as a query parameter."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the tenant that created the link inside your system. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `tenant_123`, `tenant_123,tenant_456`, `-tenant_789`."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "query",
+          "description": "The tag ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `tag_123`, `tag_123,tag_456`, `-tag_789`."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "query",
+          "description": "The folder ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `folder_123`, `folder_123,folder_456`, `-folder_789`. If not provided, return analytics for all links."
+        },
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "query",
+          "description": "The group ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `grp_123`, `grp_123,grp_456`, `-grp_789`."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `pn_123`, `pn_123,pn_456`, `-pn_789`."
+        },
+        {
+          "name": "customerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the customer to retrieve analytics for."
+        },
+        {
+          "name": "interval",
+          "type": "string",
+          "location": "query",
+          "description": "The interval to retrieve analytics for. If undefined, defaults to 24h."
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "The start date and time when to retrieve analytics from. If set, takes precedence over `interval`."
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "The end date and time when to retrieve analytics from. If not provided, defaults to the current date. If set along with `start`, takes precedence over `interval`."
+        },
+        {
+          "name": "timezone",
+          "type": "string",
+          "location": "query",
+          "description": "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC."
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "location": "query",
+          "description": "The country to retrieve analytics for. Must be passed as a 2-letter ISO 3166-1 country code (see https://d.to/geo). Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `US`, `US,BR,FR`, `-US`."
+        },
+        {
+          "name": "city",
+          "type": "string",
+          "location": "query",
+          "description": "The city to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `New York`, `New York,London`, `-New York`."
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "location": "query",
+          "description": "The ISO 3166-2 region code to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `NY`, `NY,CA`, `-NY`."
+        },
+        {
+          "name": "continent",
+          "type": "string",
+          "location": "query",
+          "description": "The continent to retrieve analytics for. Valid values: AF, AN, AS, EU, NA, OC, SA. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `NA`, `NA,EU`, `-AS`."
+        },
+        {
+          "name": "device",
+          "type": "string",
+          "location": "query",
+          "description": "The device to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Desktop`, `Mobile,Tablet`, `-Mobile`."
+        },
+        {
+          "name": "browser",
+          "type": "string",
+          "location": "query",
+          "description": "The browser to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Chrome`, `Chrome,Firefox,Safari`, `-IE`."
+        },
+        {
+          "name": "os",
+          "type": "string",
+          "location": "query",
+          "description": "The OS to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Windows`, `Mac,Windows,Linux`, `-Windows`."
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "query",
+          "description": "The trigger to retrieve analytics for. Valid values: qr, link, pageview. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `qr`, `qr,link`, `-qr`. If undefined, returns all trigger types."
+        },
+        {
+          "name": "referer",
+          "type": "string",
+          "location": "query",
+          "description": "The referer hostname to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `google.com`, `google.com,twitter.com`, `-facebook.com`."
+        },
+        {
+          "name": "refererUrl",
+          "type": "string",
+          "location": "query",
+          "description": "The full referer URL to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `https://google.com`, `https://google.com,https://twitter.com`, `-https://spam.com`."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "query",
+          "description": "The destination URL to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `https://example.com`, `https://example.com,https://other.com`, `-https://spam.com`."
+        },
+        {
+          "name": "utm_source",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM source to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `google`, `google,twitter`, `-spam`."
+        },
+        {
+          "name": "utm_medium",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM medium to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `cpc`, `cpc,social`, `-email`."
+        },
+        {
+          "name": "utm_campaign",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM campaign to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `summer_sale`, `summer_sale,winter_sale`, `-old_campaign`."
+        },
+        {
+          "name": "utm_term",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM term to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`)."
+        },
+        {
+          "name": "utm_content",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM content to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`)."
+        },
+        {
+          "name": "root",
+          "type": "bool",
+          "location": "query",
+          "description": "Filter for root domains. If true, filter for domains only. If false, filter for links only. If undefined, return both."
+        },
+        {
+          "name": "saleType",
+          "type": "string",
+          "location": "query",
+          "description": "Filter sales by type: 'new' for first-time purchases, 'recurring' for repeat purchases. If undefined, returns both."
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "location": "query",
+          "description": "Search the events by a custom metadata value. Only available for lead and sale events. Examples: `metadata['key']:'value'`"
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: This is automatically inferred from your workspace's defaultProgramId. The ID of the program to retrieve analytics for."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: Use `tagId` instead. The tag IDs to retrieve analytics for."
+        },
+        {
+          "name": "qr",
+          "type": "bool",
+          "location": "query",
+          "description": "Deprecated: Use the `trigger` field instead. Filter for QR code scans. If true, filter for QR codes only. If false, filter for links only. If undefined, return both."
+        }
+      ]
+    },
+    {
+      "name": "bounties_submissions_approve-bounty",
+      "description": "Approve a bounty submission",
+      "method": "POST",
+      "path": "/bounties/{bountyId}/submissions/{submissionId}/approve",
+      "params": [
+        {
+          "name": "bountyId",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the bounty",
+          "required": true
+        },
+        {
+          "name": "submissionId",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the bounty submission",
+          "required": true
+        },
+        {
+          "name": "rewardAmount",
+          "type": "float",
+          "location": "body",
+          "description": "The reward amount for the performance-based bounty. Applicable if the bounty reward amount is not set."
+        }
+      ]
+    },
+    {
+      "name": "bounties_submissions_list-bounty",
+      "description": "List bounty submissions",
+      "method": "GET",
+      "path": "/bounties/{bountyId}/submissions",
+      "params": [
+        {
+          "name": "bountyId",
+          "type": "string",
+          "location": "path",
+          "description": "The unique ID of the bounty on Dub. Can be found in the URL of the bounty page, prefixed with `bnty_`.",
+          "required": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "query",
+          "description": "The status of the submissions to list."
+        },
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the group to list submissions for."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner to list submissions for."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the submissions by."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The order to sort the submissions by."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "bounties_submissions_reject-bounty",
+      "description": "Reject a bounty submission",
+      "method": "POST",
+      "path": "/bounties/{bountyId}/submissions/{submissionId}/reject",
+      "params": [
+        {
+          "name": "bountyId",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the bounty",
+          "required": true
+        },
+        {
+          "name": "submissionId",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the bounty submission",
+          "required": true
+        },
+        {
+          "name": "rejectionNote",
+          "type": "string",
+          "location": "body",
+          "description": "The note for rejecting the submission."
+        },
+        {
+          "name": "rejectionReason",
+          "type": "string",
+          "location": "body",
+          "description": "The reason for rejecting the submission."
+        }
+      ]
+    },
+    {
+      "name": "commissions_bulk-update",
+      "description": "Bulk update commissions",
+      "method": "PATCH",
+      "path": "/commissions/bulk",
+      "params": [
+        {
+          "name": "commissionIds",
+          "type": "array",
+          "location": "body",
+          "description": "Commission ids",
+          "required": true
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "body",
+          "description": "The status to apply to every commission in the batch.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "commissions_list",
+      "description": "List all commissions",
+      "method": "GET",
+      "path": "/commissions",
+      "params": [
+        {
+          "name": "type",
+          "type": "string",
+          "location": "query",
+          "description": "Type"
+        },
+        {
+          "name": "customerId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated customer."
+        },
+        {
+          "name": "payoutId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated payout."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated partner. When specified, takes precedence over `tenantId`."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated partner's `tenantId` (their unique ID within your database)."
+        },
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated partner group."
+        },
+        {
+          "name": "invoiceId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by the associated invoice. Since invoiceId is unique on a per-program basis, this will only return one commission per invoice."
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of commissions by their corresponding status."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the list of commissions by."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order for the list of commissions."
+        },
+        {
+          "name": "interval",
+          "type": "string",
+          "location": "query",
+          "description": "The interval to retrieve commissions for."
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "The start date of the date range to filter the commissions by."
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "The end date of the date range to filter the commissions by."
+        },
+        {
+          "name": "timezone",
+          "type": "string",
+          "location": "query",
+          "description": "Timezone"
+        },
+        {
+          "name": "endingBefore",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results before this cursor. Mutually exclusive with `startingAfter`."
+        },
+        {
+          "name": "startingAfter",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results after this cursor. Mutually exclusive with `endingBefore`."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "DEPRECATED. Use `startingAfter` instead."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "commissions_update",
+      "description": "Update a commission",
+      "method": "PATCH",
+      "path": "/commissions/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The commission's unique ID on Dub.",
+          "required": true
+        },
+        {
+          "name": "amount",
+          "type": "float",
+          "location": "body",
+          "description": "Deprecated. Use `saleAmount` instead."
+        },
+        {
+          "name": "currency",
+          "type": "string",
+          "location": "body",
+          "description": "The currency of the sale amount to update. Accepts ISO 4217 currency codes."
+        },
+        {
+          "name": "earnings",
+          "type": "float",
+          "location": "body",
+          "description": "The new absolute earnings for the custom commission. Paid commissions cannot be updated."
+        },
+        {
+          "name": "modifyAmount",
+          "type": "float",
+          "location": "body",
+          "description": "Deprecated. Use `modifySaleAmount` instead."
+        },
+        {
+          "name": "modifySaleAmount",
+          "type": "float",
+          "location": "body",
+          "description": "Modify the current sale amount: use positive values to increase the amount, negative values to decrease it. Takes precedence over `saleAmount`. Paid commissions cannot be updated."
+        },
+        {
+          "name": "saleAmount",
+          "type": "float",
+          "location": "body",
+          "description": "The new absolute amount for the sale. Paid commissions cannot be updated."
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "body",
+          "description": "Useful for marking a commission as pending, refunded, duplicate, canceled, or fraudulent. Takes precedence over `saleAmount` and `modifySaleAmount`. When a commission is marked as pending, refunded, duplicate, canceled, or fraudulent, it will be omitted from the payout, and the payout amount will be recalculated accordingly. Paid commissions cannot be updated."
+        }
+      ]
+    },
+    {
+      "name": "customers_delete",
+      "description": "Delete a customer",
+      "method": "DELETE",
+      "path": "/customers/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The unique ID of the customer. You may use either the customer's `id` on Dub (obtained via `/customers` endpoint) or their `externalId` (unique ID within your system, prefixed with `ext_`, e.g. `ext_123`).",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "customers_get",
+      "description": "Retrieve a list of customers",
+      "method": "GET",
+      "path": "/customers",
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "query",
+          "description": "A case-sensitive filter on the list based on the customer's `email` field. The value must be a string. Takes precedence over `externalId`."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "A case-sensitive filter on the list based on the customer's `externalId` field. The value must be a string. Takes precedence over `search`."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "A search query to filter customers by email, externalId, or name. If `email` or `externalId` is provided, this will be ignored."
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "location": "query",
+          "description": "A filter on the list based on the customer's `country` field."
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "query",
+          "description": "A filter on the list based on the customer's `linkId` field (the referral link ID)."
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "query",
+          "description": "Program ID to filter by."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "Partner ID to filter by."
+        },
+        {
+          "name": "includeExpandedFields",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include expanded fields on the customer (`link`, `partner`, `discount`)."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the customers by. The default is `createdAt`."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order. The default is `desc`."
+        },
+        {
+          "name": "endingBefore",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results before this cursor. Mutually exclusive with `startingAfter`."
+        },
+        {
+          "name": "startingAfter",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results after this cursor. Mutually exclusive with `endingBefore`."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "DEPRECATED. Use `startingAfter` instead."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "customers_get-id",
+      "description": "Retrieve a customer",
+      "method": "GET",
+      "path": "/customers/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The unique ID of the customer. You may use either the customer's `id` on Dub (obtained via `/customers` endpoint) or their `externalId` (unique ID within your system, prefixed with `ext_`, e.g. `ext_123`).",
+          "required": true
+        },
+        {
+          "name": "includeExpandedFields",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include expanded fields on the customer (`link`, `partner`, `discount`)."
+        }
+      ]
+    },
+    {
+      "name": "customers_update",
+      "description": "Update a customer",
+      "method": "PATCH",
+      "path": "/customers/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The unique ID of the customer. You may use either the customer's `id` on Dub (obtained via `/customers` endpoint) or their `externalId` (unique ID within your system, prefixed with `ext_`, e.g. `ext_123`).",
+          "required": true
+        },
+        {
+          "name": "includeExpandedFields",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include expanded fields on the customer (`link`, `partner`, `discount`)."
+        },
+        {
+          "name": "avatar",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's avatar URL. If not provided, a random avatar will be generated."
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's country in ISO 3166-1 alpha-2 format. Updating this field will only affect the customer's country in Dub's system (and has no effect on existing conversion events)."
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's email address."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's unique identifier your database. This is useful for associating subsequent conversion events from Dub's API to your internal systems."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's name. If not provided, the email address will be used, and if email is not provided, a random name will be generated."
+        },
+        {
+          "name": "stripeCustomerId",
+          "type": "string",
+          "location": "body",
+          "description": "The customer's Stripe customer ID. This is useful for attributing recurring sale events to the partner who referred the customer."
+        }
+      ]
+    },
+    {
+      "name": "domains_check-status",
+      "description": "Check the availability of one or more domains",
+      "method": "GET",
+      "path": "/domains/status",
+      "params": [
+        {
+          "name": "domains",
+          "type": "string",
+          "location": "query",
+          "description": "The domains to search. We only support .link domains for now.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "domains_create",
+      "description": "Create a domain",
+      "method": "POST",
+      "path": "/domains",
+      "params": [
+        {
+          "name": "appleAppSiteAssociation",
+          "type": "string",
+          "location": "body",
+          "description": "apple-app-site-association configuration file (for deep link support on iOS)."
+        },
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to archive this domain. `false` will unarchive a previously archived domain."
+        },
+        {
+          "name": "assetLinks",
+          "type": "string",
+          "location": "body",
+          "description": "assetLinks.json configuration file (for deep link support on Android)."
+        },
+        {
+          "name": "expiredUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Redirect users to a specific URL when any link under this domain has expired."
+        },
+        {
+          "name": "logo",
+          "type": "string",
+          "location": "body",
+          "description": "The logo of the domain."
+        },
+        {
+          "name": "notFoundUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Redirect users to a specific URL when a link under this domain doesn't exist."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "location": "body",
+          "description": "Provide context to your teammates in the link creation modal by showing them an example of a link to be shortened."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the domain.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "domains_delete",
+      "description": "Delete a domain",
+      "method": "DELETE",
+      "path": "/domains/{slug}",
+      "params": [
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "path",
+          "description": "The domain name.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "domains_list",
+      "description": "Retrieve a list of domains",
+      "method": "GET",
+      "path": "/domains",
+      "params": [
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include archived domains in the response. Defaults to `false` if not provided."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "The search term to filter the domains by."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "domains_register",
+      "description": "Register a domain",
+      "method": "POST",
+      "path": "/domains/register",
+      "params": [
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "The domain to claim. We only support .link domains for now.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "domains_update",
+      "description": "Update a domain",
+      "method": "PATCH",
+      "path": "/domains/{slug}",
+      "params": [
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "path",
+          "description": "The domain name.",
+          "required": true
+        },
+        {
+          "name": "appleAppSiteAssociation",
+          "type": "string",
+          "location": "body",
+          "description": "apple-app-site-association configuration file (for deep link support on iOS)."
+        },
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to archive this domain. `false` will unarchive a previously archived domain."
+        },
+        {
+          "name": "assetLinks",
+          "type": "string",
+          "location": "body",
+          "description": "assetLinks.json configuration file (for deep link support on Android)."
+        },
+        {
+          "name": "expiredUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Redirect users to a specific URL when any link under this domain has expired."
+        },
+        {
+          "name": "logo",
+          "type": "string",
+          "location": "body",
+          "description": "The logo of the domain."
+        },
+        {
+          "name": "notFoundUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Redirect users to a specific URL when a link under this domain doesn't exist."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "location": "body",
+          "description": "Provide context to your teammates in the link creation modal by showing them an example of a link to be shortened."
+        }
+      ]
+    },
+    {
+      "name": "events_list",
+      "description": "Retrieve a list of events",
+      "method": "GET",
+      "path": "/events",
+      "params": [
+        {
+          "name": "event",
+          "type": "string",
+          "location": "query",
+          "description": "The type of event to retrieve analytics for. Defaults to 'clicks'."
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "query",
+          "description": "The domain to filter analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `dub.co`, `dub.co,google.com`, `-spam.com`."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the short link to retrieve analytics for. Must be used along with the corresponding `domain` of the short link to fetch analytics for a specific short link."
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "query",
+          "description": "The unique ID of the link to retrieve analytics for.Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `link_123`, `link_123,link_456`, `-link_789`."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the link in the your database. Must be prefixed with 'ext_' when passed as a query parameter."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the tenant that created the link inside your system. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `tenant_123`, `tenant_123,tenant_456`, `-tenant_789`."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "query",
+          "description": "The tag ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `tag_123`, `tag_123,tag_456`, `-tag_789`."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "query",
+          "description": "The folder ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `folder_123`, `folder_123,folder_456`, `-folder_789`. If not provided, return analytics for all links."
+        },
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "query",
+          "description": "The group ID to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `grp_123`, `grp_123,grp_456`, `-grp_789`."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `pn_123`, `pn_123,pn_456`, `-pn_789`."
+        },
+        {
+          "name": "customerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the customer to retrieve analytics for."
+        },
+        {
+          "name": "interval",
+          "type": "string",
+          "location": "query",
+          "description": "The interval to retrieve analytics for. If undefined, defaults to 24h."
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "The start date and time when to retrieve analytics from. If set, takes precedence over `interval`."
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "The end date and time when to retrieve analytics from. If not provided, defaults to the current date. If set along with `start`, takes precedence over `interval`."
+        },
+        {
+          "name": "timezone",
+          "type": "string",
+          "location": "query",
+          "description": "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC."
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "location": "query",
+          "description": "The country to retrieve analytics for. Must be passed as a 2-letter ISO 3166-1 country code (see https://d.to/geo). Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `US`, `US,BR,FR`, `-US`."
+        },
+        {
+          "name": "city",
+          "type": "string",
+          "location": "query",
+          "description": "The city to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `New York`, `New York,London`, `-New York`."
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "location": "query",
+          "description": "The ISO 3166-2 region code to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `NY`, `NY,CA`, `-NY`."
+        },
+        {
+          "name": "continent",
+          "type": "string",
+          "location": "query",
+          "description": "The continent to retrieve analytics for. Valid values: AF, AN, AS, EU, NA, OC, SA. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `NA`, `NA,EU`, `-AS`."
+        },
+        {
+          "name": "device",
+          "type": "string",
+          "location": "query",
+          "description": "The device to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Desktop`, `Mobile,Tablet`, `-Mobile`."
+        },
+        {
+          "name": "browser",
+          "type": "string",
+          "location": "query",
+          "description": "The browser to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Chrome`, `Chrome,Firefox,Safari`, `-IE`."
+        },
+        {
+          "name": "os",
+          "type": "string",
+          "location": "query",
+          "description": "The OS to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `Windows`, `Mac,Windows,Linux`, `-Windows`."
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "query",
+          "description": "The trigger to retrieve analytics for. Valid values: qr, link, pageview. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `qr`, `qr,link`, `-qr`. If undefined, returns all trigger types."
+        },
+        {
+          "name": "referer",
+          "type": "string",
+          "location": "query",
+          "description": "The referer hostname to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `google.com`, `google.com,twitter.com`, `-facebook.com`."
+        },
+        {
+          "name": "refererUrl",
+          "type": "string",
+          "location": "query",
+          "description": "The full referer URL to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `https://google.com`, `https://google.com,https://twitter.com`, `-https://spam.com`."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "query",
+          "description": "The destination URL to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `https://example.com`, `https://example.com,https://other.com`, `-https://spam.com`."
+        },
+        {
+          "name": "utm_source",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM source to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `google`, `google,twitter`, `-spam`."
+        },
+        {
+          "name": "utm_medium",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM medium to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `cpc`, `cpc,social`, `-email`."
+        },
+        {
+          "name": "utm_campaign",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM campaign to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`). Examples: `summer_sale`, `summer_sale,winter_sale`, `-old_campaign`."
+        },
+        {
+          "name": "utm_term",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM term to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`)."
+        },
+        {
+          "name": "utm_content",
+          "type": "string",
+          "location": "query",
+          "description": "The UTM content to retrieve analytics for. Supports advanced filtering: single value, multiple values (comma-separated), or exclusion (prefix with `-`)."
+        },
+        {
+          "name": "root",
+          "type": "bool",
+          "location": "query",
+          "description": "Filter for root domains. If true, filter for domains only. If false, filter for links only. If undefined, return both."
+        },
+        {
+          "name": "saleType",
+          "type": "string",
+          "location": "query",
+          "description": "Filter sales by type: 'new' for first-time purchases, 'recurring' for repeat purchases. If undefined, returns both."
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "location": "query",
+          "description": "Search the events by a custom metadata value. Only available for lead and sale events. Examples: `metadata['key']:'value'`"
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: This is automatically inferred from your workspace's defaultProgramId. The ID of the program to retrieve analytics for."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: Use `tagId` instead. The tag IDs to retrieve analytics for."
+        },
+        {
+          "name": "qr",
+          "type": "bool",
+          "location": "query",
+          "description": "Deprecated: Use the `trigger` field instead. Filter for QR code scans. If true, filter for QR codes only. If false, filter for links only. If undefined, return both."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "Page"
+        },
+        {
+          "name": "limit",
+          "type": "float",
+          "location": "query",
+          "description": "Limit"
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order. The default is `desc`."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the events by. The default is `timestamp`."
+        },
+        {
+          "name": "order",
+          "type": "string",
+          "location": "query",
+          "description": "DEPRECATED. Use `sortOrder` instead."
+        }
+      ]
+    },
+    {
+      "name": "folders_create",
+      "description": "Create a folder",
+      "method": "POST",
+      "path": "/folders",
+      "params": [
+        {
+          "name": "accessLevel",
+          "type": "string",
+          "location": "body",
+          "description": "The access level of the folder within the workspace."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "The description of the folder."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the folder.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "folders_delete",
+      "description": "Delete a folder",
+      "method": "DELETE",
+      "path": "/folders/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the folder to delete.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "folders_list",
+      "description": "Retrieve a list of folders",
+      "method": "GET",
+      "path": "/folders",
+      "params": [
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "The search term to filter the folders by."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "folders_update",
+      "description": "Update a folder",
+      "method": "PATCH",
+      "path": "/folders/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the folder to update.",
+          "required": true
+        },
+        {
+          "name": "accessLevel",
+          "type": "string",
+          "location": "body",
+          "description": "The access level of the folder within the workspace."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "The description of the folder."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the folder."
+        }
+      ]
+    },
+    {
+      "name": "links_bulk-create",
+      "description": "Bulk create links",
+      "method": "POST",
+      "path": "/links/bulk",
+      "params": []
+    },
+    {
+      "name": "links_bulk-delete",
+      "description": "Bulk delete links",
+      "method": "DELETE",
+      "path": "/links/bulk",
+      "params": [
+        {
+          "name": "linkIds",
+          "type": "array",
+          "location": "query",
+          "description": "Comma-separated list of link IDs to delete. Maximum of 100 IDs. Non-existing IDs will be ignored.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "links_bulk-update",
+      "description": "Bulk update links",
+      "method": "PATCH",
+      "path": "/links/bulk",
+      "params": [
+        {
+          "name": "externalIds",
+          "type": "array",
+          "location": "body",
+          "description": "The external IDs of the links to update as stored in your database."
+        },
+        {
+          "name": "linkIds",
+          "type": "array",
+          "location": "body",
+          "description": "The IDs of the links to update. Takes precedence over `externalIds`."
+        }
+      ]
+    },
+    {
+      "name": "links_create",
+      "description": "Create a link",
+      "method": "POST",
+      "path": "/links",
+      "params": [
+        {
+          "name": "android",
+          "type": "string",
+          "location": "body",
+          "description": "The Android destination URL for the short link for Android device targeting."
+        },
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link is archived. Defaults to `false` if not provided."
+        },
+        {
+          "name": "comments",
+          "type": "string",
+          "location": "body",
+          "description": "The comments for the short link."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview description (og:description). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "doIndex",
+          "type": "bool",
+          "location": "body",
+          "description": "Allow search engines to index your short link. Defaults to `false` if not provided. Learn more: https://d.to/noindex"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "The domain of the short link (without protocol). If not provided, the primary domain for the workspace will be used (or `dub.sh` if the workspace has no domains)."
+        },
+        {
+          "name": "expiredUrl",
+          "type": "string",
+          "location": "body",
+          "description": "The URL to redirect to when the short link has expired."
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the short link will expire at."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the link in your database. If set, it can be used to identify the link in future API requests (must be prefixed with 'ext_' when passed as a query parameter). This key is unique across your workspace."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID existing folder to assign the short link to."
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview image (og:image). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "ios",
+          "type": "string",
+          "location": "body",
+          "description": "The iOS destination URL for the short link for iOS device targeting."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "The short link slug. If not provided, a random 7-character slug will be generated."
+        },
+        {
+          "name": "keyLength",
+          "type": "float",
+          "location": "body",
+          "description": "The length of the short link slug. Defaults to 7 if not provided. When used with `prefix`, the total length of the key will be `prefix.length + keyLength`."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner the short link is associated with."
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "The password required to access the destination URL of the short link."
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "location": "body",
+          "description": "The prefix of the short link slug for randomly-generated keys (e.g. if prefix is `/c/`, generated keys will be in the `/c/:key` format). Will be ignored if `key` is provided."
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the program the short link is associated with."
+        },
+        {
+          "name": "proxy",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses Custom Link Previews feature. Defaults to `false` if not provided."
+        },
+        {
+          "name": "publicStats",
+          "type": "bool",
+          "location": "body",
+          "description": "Deprecated: Use `dashboard` instead. Whether the short link's stats are publicly accessible. Defaults to `false` if not provided."
+        },
+        {
+          "name": "ref",
+          "type": "string",
+          "location": "body",
+          "description": "The referral tag of the short link. If set, this will populate or override the `ref` query parameter in the destination URL."
+        },
+        {
+          "name": "rewrite",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses link cloaking. Defaults to `false` if not provided."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "body",
+          "description": "Deprecated: Use `tagIds` instead. The unique ID of the tag assigned to the short link."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "body",
+          "description": "The unique IDs of the tags assigned to the short link."
+        },
+        {
+          "name": "tagNames",
+          "type": "string",
+          "location": "body",
+          "description": "The unique name of the tags assigned to the short link (case insensitive)."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the tenant that created the link inside your system. If set, it can be used to fetch all links for a tenant."
+        },
+        {
+          "name": "testCompletedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests were or will be completed."
+        },
+        {
+          "name": "testStartedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests started."
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview title (og:title). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "trackConversion",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to track conversions for the short link. Defaults to `false` if not provided."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "body",
+          "description": "The destination URL of the short link.",
+          "required": true
+        },
+        {
+          "name": "utm_campaign",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM campaign of the short link. If set, this will populate or override the UTM campaign in the destination URL."
+        },
+        {
+          "name": "utm_content",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM content of the short link. If set, this will populate or override the UTM content in the destination URL."
+        },
+        {
+          "name": "utm_medium",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM medium of the short link. If set, this will populate or override the UTM medium in the destination URL."
+        },
+        {
+          "name": "utm_source",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM source of the short link. If set, this will populate or override the UTM source in the destination URL."
+        },
+        {
+          "name": "utm_term",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM term of the short link. If set, this will populate or override the UTM term in the destination URL."
+        },
+        {
+          "name": "video",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview video (og:video). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "webhookIds",
+          "type": "array",
+          "location": "body",
+          "description": "An array of webhook IDs to trigger when the link is clicked. These webhooks will receive click event data."
+        }
+      ]
+    },
+    {
+      "name": "links_delete",
+      "description": "Delete a link",
+      "method": "DELETE",
+      "path": "/links/{linkId}",
+      "params": [
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "The id of the link to delete. You may use either `linkId` (obtained via `/links/info` endpoint) or `externalId` prefixed with `ext_`.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "links_get",
+      "description": "Retrieve a list of links",
+      "method": "GET",
+      "path": "/links",
+      "params": [
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "query",
+          "description": "The domain to filter the links by. E.g. `ac.me`. If not provided, all links for the workspace will be returned."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: Use `tagIds` instead. The tag ID to filter the links by."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "query",
+          "description": "The tag IDs to filter the links by."
+        },
+        {
+          "name": "tagNames",
+          "type": "string",
+          "location": "query",
+          "description": "The unique name of the tags assigned to the short link (case insensitive)."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "query",
+          "description": "The folder ID to filter the links by."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "The search term to filter the links by. The search term will be matched against the short link slug and the destination url."
+        },
+        {
+          "name": "userId",
+          "type": "string",
+          "location": "query",
+          "description": "The user ID to filter the links by."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the tenant that created the link inside your system. If set, will only return links for the specified tenant."
+        },
+        {
+          "name": "showArchived",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include archived links in the response. Defaults to `false` if not provided."
+        },
+        {
+          "name": "withTags",
+          "type": "bool",
+          "location": "query",
+          "description": "DEPRECATED. Filter for links that have at least one tag assigned to them."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the links by. The default is `createdAt`."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order. The default is `desc`."
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "location": "query",
+          "description": "DEPRECATED. Use `sortBy` instead."
+        },
+        {
+          "name": "endingBefore",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results before this cursor. Mutually exclusive with `startingAfter`."
+        },
+        {
+          "name": "startingAfter",
+          "type": "string",
+          "location": "query",
+          "description": "If specified, the query only searches for results after this cursor. Mutually exclusive with `endingBefore`."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "DEPRECATED. Use `startingAfter` instead."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "links_get-count",
+      "description": "Retrieve links count",
+      "method": "GET",
+      "path": "/links/count",
+      "params": [
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "query",
+          "description": "The domain to filter the links by. E.g. `ac.me`. If not provided, all links for the workspace will be returned."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: Use `tagIds` instead. The tag ID to filter the links by."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "query",
+          "description": "The tag IDs to filter the links by."
+        },
+        {
+          "name": "tagNames",
+          "type": "string",
+          "location": "query",
+          "description": "The unique name of the tags assigned to the short link (case insensitive)."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "query",
+          "description": "The folder ID to filter the links by."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "The search term to filter the links by. The search term will be matched against the short link slug and the destination url."
+        },
+        {
+          "name": "userId",
+          "type": "string",
+          "location": "query",
+          "description": "The user ID to filter the links by."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the tenant that created the link inside your system. If set, will only return links for the specified tenant."
+        },
+        {
+          "name": "showArchived",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to include archived links in the response. Defaults to `false` if not provided."
+        },
+        {
+          "name": "withTags",
+          "type": "bool",
+          "location": "query",
+          "description": "DEPRECATED. Filter for links that have at least one tag assigned to them."
+        },
+        {
+          "name": "groupBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to group the links by."
+        }
+      ]
+    },
+    {
+      "name": "links_get-info",
+      "description": "Retrieve a link",
+      "method": "GET",
+      "path": "/links/info",
+      "params": [
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "query",
+          "description": "Domain"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Key"
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "query",
+          "description": "The unique ID of the short link."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "This is the ID of the link in the your database."
+        }
+      ]
+    },
+    {
+      "name": "links_update",
+      "description": "Update a link",
+      "method": "PATCH",
+      "path": "/links/{linkId}",
+      "params": [
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "The id of the link to update. You may use either `linkId` (obtained via `/links/info` endpoint) or `externalId` prefixed with `ext_`.",
+          "required": true
+        },
+        {
+          "name": "android",
+          "type": "string",
+          "location": "body",
+          "description": "The Android destination URL for the short link for Android device targeting."
+        },
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link is archived. Defaults to `false` if not provided."
+        },
+        {
+          "name": "comments",
+          "type": "string",
+          "location": "body",
+          "description": "The comments for the short link."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview description (og:description). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "doIndex",
+          "type": "bool",
+          "location": "body",
+          "description": "Allow search engines to index your short link. Defaults to `false` if not provided. Learn more: https://d.to/noindex"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "The domain of the short link (without protocol). If not provided, the primary domain for the workspace will be used (or `dub.sh` if the workspace has no domains)."
+        },
+        {
+          "name": "expiredUrl",
+          "type": "string",
+          "location": "body",
+          "description": "The URL to redirect to when the short link has expired."
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the short link will expire at."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the link in your database. If set, it can be used to identify the link in future API requests (must be prefixed with 'ext_' when passed as a query parameter). This key is unique across your workspace."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID existing folder to assign the short link to."
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "location": "body",
+          "description": "Image"
+        },
+        {
+          "name": "ios",
+          "type": "string",
+          "location": "body",
+          "description": "The iOS destination URL for the short link for iOS device targeting."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "The short link slug. If not provided, a random 7-character slug will be generated."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner the short link is associated with."
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "The password required to access the destination URL of the short link."
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the program the short link is associated with."
+        },
+        {
+          "name": "proxy",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses Custom Link Previews feature. Defaults to `false` if not provided."
+        },
+        {
+          "name": "publicStats",
+          "type": "bool",
+          "location": "body",
+          "description": "Deprecated: Use `dashboard` instead. Whether the short link's stats are publicly accessible. Defaults to `false` if not provided."
+        },
+        {
+          "name": "ref",
+          "type": "string",
+          "location": "body",
+          "description": "The referral tag of the short link. If set, this will populate or override the `ref` query parameter in the destination URL."
+        },
+        {
+          "name": "rewrite",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses link cloaking. Defaults to `false` if not provided."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "body",
+          "description": "Deprecated: Use `tagIds` instead. The unique ID of the tag assigned to the short link."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "body",
+          "description": "The unique IDs of the tags assigned to the short link."
+        },
+        {
+          "name": "tagNames",
+          "type": "string",
+          "location": "body",
+          "description": "The unique name of the tags assigned to the short link (case insensitive)."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the tenant that created the link inside your system. If set, it can be used to fetch all links for a tenant."
+        },
+        {
+          "name": "testCompletedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests were or will be completed."
+        },
+        {
+          "name": "testStartedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests started."
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview title (og:title). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "trackConversion",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to track conversions for the short link. Defaults to `false` if not provided."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "body",
+          "description": "The destination URL of the short link."
+        },
+        {
+          "name": "utm_campaign",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM campaign of the short link. If set, this will populate or override the UTM campaign in the destination URL."
+        },
+        {
+          "name": "utm_content",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM content of the short link. If set, this will populate or override the UTM content in the destination URL."
+        },
+        {
+          "name": "utm_medium",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM medium of the short link. If set, this will populate or override the UTM medium in the destination URL."
+        },
+        {
+          "name": "utm_source",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM source of the short link. If set, this will populate or override the UTM source in the destination URL."
+        },
+        {
+          "name": "utm_term",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM term of the short link. If set, this will populate or override the UTM term in the destination URL."
+        },
+        {
+          "name": "video",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview video (og:video). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "webhookIds",
+          "type": "array",
+          "location": "body",
+          "description": "An array of webhook IDs to trigger when the link is clicked. These webhooks will receive click event data."
+        }
+      ]
+    },
+    {
+      "name": "links_upsert",
+      "description": "Upsert a link",
+      "method": "PUT",
+      "path": "/links/upsert",
+      "params": [
+        {
+          "name": "android",
+          "type": "string",
+          "location": "body",
+          "description": "The Android destination URL for the short link for Android device targeting."
+        },
+        {
+          "name": "archived",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link is archived. Defaults to `false` if not provided."
+        },
+        {
+          "name": "comments",
+          "type": "string",
+          "location": "body",
+          "description": "The comments for the short link."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview description (og:description). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "doIndex",
+          "type": "bool",
+          "location": "body",
+          "description": "Allow search engines to index your short link. Defaults to `false` if not provided. Learn more: https://d.to/noindex"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "The domain of the short link (without protocol). If not provided, the primary domain for the workspace will be used (or `dub.sh` if the workspace has no domains)."
+        },
+        {
+          "name": "expiredUrl",
+          "type": "string",
+          "location": "body",
+          "description": "The URL to redirect to when the short link has expired."
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the short link will expire at."
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the link in your database. If set, it can be used to identify the link in future API requests (must be prefixed with 'ext_' when passed as a query parameter). This key is unique across your workspace."
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID existing folder to assign the short link to."
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview image (og:image). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "ios",
+          "type": "string",
+          "location": "body",
+          "description": "The iOS destination URL for the short link for iOS device targeting."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "The short link slug. If not provided, a random 7-character slug will be generated."
+        },
+        {
+          "name": "keyLength",
+          "type": "float",
+          "location": "body",
+          "description": "The length of the short link slug. Defaults to 7 if not provided. When used with `prefix`, the total length of the key will be `prefix.length + keyLength`."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner the short link is associated with."
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "The password required to access the destination URL of the short link."
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "location": "body",
+          "description": "The prefix of the short link slug for randomly-generated keys (e.g. if prefix is `/c/`, generated keys will be in the `/c/:key` format). Will be ignored if `key` is provided."
+        },
+        {
+          "name": "programId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the program the short link is associated with."
+        },
+        {
+          "name": "proxy",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses Custom Link Previews feature. Defaults to `false` if not provided."
+        },
+        {
+          "name": "publicStats",
+          "type": "bool",
+          "location": "body",
+          "description": "Deprecated: Use `dashboard` instead. Whether the short link's stats are publicly accessible. Defaults to `false` if not provided."
+        },
+        {
+          "name": "ref",
+          "type": "string",
+          "location": "body",
+          "description": "The referral tag of the short link. If set, this will populate or override the `ref` query parameter in the destination URL."
+        },
+        {
+          "name": "rewrite",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the short link uses link cloaking. Defaults to `false` if not provided."
+        },
+        {
+          "name": "tagId",
+          "type": "string",
+          "location": "body",
+          "description": "Deprecated: Use `tagIds` instead. The unique ID of the tag assigned to the short link."
+        },
+        {
+          "name": "tagIds",
+          "type": "string",
+          "location": "body",
+          "description": "The unique IDs of the tags assigned to the short link."
+        },
+        {
+          "name": "tagNames",
+          "type": "string",
+          "location": "body",
+          "description": "The unique name of the tags assigned to the short link (case insensitive)."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the tenant that created the link inside your system. If set, it can be used to fetch all links for a tenant."
+        },
+        {
+          "name": "testCompletedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests were or will be completed."
+        },
+        {
+          "name": "testStartedAt",
+          "type": "string",
+          "location": "body",
+          "description": "The date and time when the tests started."
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview title (og:title). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "trackConversion",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to track conversions for the short link. Defaults to `false` if not provided."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "body",
+          "description": "The destination URL of the short link.",
+          "required": true
+        },
+        {
+          "name": "utm_campaign",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM campaign of the short link. If set, this will populate or override the UTM campaign in the destination URL."
+        },
+        {
+          "name": "utm_content",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM content of the short link. If set, this will populate or override the UTM content in the destination URL."
+        },
+        {
+          "name": "utm_medium",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM medium of the short link. If set, this will populate or override the UTM medium in the destination URL."
+        },
+        {
+          "name": "utm_source",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM source of the short link. If set, this will populate or override the UTM source in the destination URL."
+        },
+        {
+          "name": "utm_term",
+          "type": "string",
+          "location": "body",
+          "description": "The UTM term of the short link. If set, this will populate or override the UTM term in the destination URL."
+        },
+        {
+          "name": "video",
+          "type": "string",
+          "location": "body",
+          "description": "The custom link preview video (og:video). Will be used for Custom Link Previews if `proxy` is true. Learn more: https://d.to/og"
+        },
+        {
+          "name": "webhookIds",
+          "type": "array",
+          "location": "body",
+          "description": "An array of webhook IDs to trigger when the link is clicked. These webhooks will receive click event data."
+        }
+      ]
+    },
+    {
+      "name": "partners_ban",
+      "description": "Ban a partner",
+      "method": "POST",
+      "path": "/partners/ban",
+      "params": [
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "location": "body",
+          "description": "Reason",
+          "required": true
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        }
+      ]
+    },
+    {
+      "name": "partners_create",
+      "description": "Create or update a partner",
+      "method": "POST",
+      "path": "/partners",
+      "params": [
+        {
+          "name": "country",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's country of residence. Must be passed as a 2-letter ISO 3166-1 country code. See https://d.to/geo for more information."
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "A brief description of the partner and their background. Max 5,000 characters."
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's email address. Partners will be able to claim their profile by signing up at `partners.dub.co` with this email.",
+          "required": true
+        },
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "body",
+          "description": "The group ID to add the partner to. If not provided, the partner will be added to the default group."
+        },
+        {
+          "name": "image",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's avatar image. If not provided, a default avatar will be used."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's full name. If undefined, the partner's email will be used in lieu of their name (e.g. `john@acme.com`)"
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's unique ID in your system. Useful for retrieving the partner's links and stats later on. If not provided, the partner will be created as a standalone partner."
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "location": "body",
+          "description": "The partner's unique username in your system (max 100 characters). This will be used to create a short link for the partner using your program's default domain. If not provided, Dub will try to generate a username from the partner's name or email."
+        }
+      ]
+    },
+    {
+      "name": "partners_create-link",
+      "description": "Create a link for a partner",
+      "method": "POST",
+      "path": "/partners/links",
+      "params": [
+        {
+          "name": "comments",
+          "type": "string",
+          "location": "body",
+          "description": "The comments for the short link."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "The short link slug. If not provided, a random 7-character slug will be generated."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "body",
+          "description": "The URL to shorten (if not provided, the program's default URL will be used). Will throw an error if the domain doesn't match the program's default URL domain."
+        }
+      ]
+    },
+    {
+      "name": "partners_deactivate",
+      "description": "Deactivate a partner",
+      "method": "POST",
+      "path": "/partners/deactivate",
+      "params": [
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        }
+      ]
+    },
+    {
+      "name": "partners_list",
+      "description": "List all partners",
+      "method": "GET",
+      "path": "/partners",
+      "params": [
+        {
+          "name": "groupId",
+          "type": "string",
+          "location": "query",
+          "description": "A filter on the list based on the partner's `groupId` field."
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "query",
+          "description": "A filter on the list based on the partner's `status` field."
+        },
+        {
+          "name": "country",
+          "type": "string",
+          "location": "query",
+          "description": "A filter on the list based on the partner's `country` field."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the partners by. The default is `totalSaleAmount`."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order. The default is `desc`."
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the partner list based on the partner's `email`. The value must be a string. Takes precedence over `search`."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the partner list based on the partner's `tenantId`. The value must be a string. Takes precedence over `email` and `search`."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "A search query to filter partners by ID, name, email, or link."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "partners_retrieve-analytics",
+      "description": "Retrieve analytics for a partner",
+      "method": "GET",
+      "path": "/partners/analytics",
+      "params": [
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        },
+        {
+          "name": "interval",
+          "type": "string",
+          "location": "query",
+          "description": "The interval to retrieve analytics for. If undefined, defaults to 24h."
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "The start date and time when to retrieve analytics from. If set, takes precedence over `interval`."
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "The end date and time when to retrieve analytics from. If not provided, defaults to the current date. If set along with `start`, takes precedence over `interval`."
+        },
+        {
+          "name": "timezone",
+          "type": "string",
+          "location": "query",
+          "description": "The IANA time zone code for aligning timeseries granularity (e.g. America/New_York). Defaults to UTC."
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "location": "query",
+          "description": "Search the events by a custom metadata value. Only available for lead and sale events. Examples: `metadata['key']:'value'`"
+        },
+        {
+          "name": "groupBy",
+          "type": "string",
+          "location": "query",
+          "description": "The parameter to group the analytics data points by. Defaults to `count` if undefined."
+        }
+      ]
+    },
+    {
+      "name": "partners_retrieve-links",
+      "description": "Retrieve a partner's links.",
+      "method": "GET",
+      "path": "/partners/links",
+      "params": [
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        }
+      ]
+    },
+    {
+      "name": "partners_upsert-link",
+      "description": "Upsert a link for a partner",
+      "method": "PUT",
+      "path": "/partners/links/upsert",
+      "params": [
+        {
+          "name": "comments",
+          "type": "string",
+          "location": "body",
+          "description": "The comments for the short link."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "The short link slug. If not provided, a random 7-character slug will be generated."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner to create a link for. Will take precedence over `tenantId` if provided."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "The ID of the partner in your system. If both `partnerId` and `tenantId` are not provided, an error will be thrown."
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "location": "body",
+          "description": "The URL to upsert for. Will throw an error if the domain doesn't match the program's default URL domain.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "payouts_list",
+      "description": "List all payouts",
+      "method": "GET",
+      "path": "/payouts",
+      "params": [
+        {
+          "name": "status",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of payouts by their corresponding status."
+        },
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of payouts by the associated partner. When specified, takes precedence over `tenantId`."
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of payouts by the associated partner's `tenantId` (their unique ID within your database)."
+        },
+        {
+          "name": "invoiceId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter the list of payouts by invoice ID (the unique ID of the invoice you receive for each batch payout you process on Dub). Pending payouts will not have an invoice ID."
+        },
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the list of payouts by."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The sort order for the list of payouts."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "qr_get-qrcode",
+      "description": "Retrieve a QR code",
+      "method": "GET",
+      "path": "/qr",
+      "params": [
+        {
+          "name": "url",
+          "type": "string",
+          "location": "query",
+          "description": "The URL to generate a QR code for.",
+          "required": true
+        },
+        {
+          "name": "logo",
+          "type": "string",
+          "location": "query",
+          "description": "The logo to include in the QR code. Can only be used with a paid plan on Dub."
+        },
+        {
+          "name": "size",
+          "type": "float",
+          "location": "query",
+          "description": "The size of the QR code in pixels. Defaults to `600` if not provided."
+        },
+        {
+          "name": "level",
+          "type": "string",
+          "location": "query",
+          "description": "The level of error correction to use for the QR code. Defaults to `L` if not provided."
+        },
+        {
+          "name": "fgColor",
+          "type": "string",
+          "location": "query",
+          "description": "The foreground color of the QR code in hex format. Defaults to `#000000` if not provided."
+        },
+        {
+          "name": "bgColor",
+          "type": "string",
+          "location": "query",
+          "description": "The background color of the QR code in hex format. Defaults to `#ffffff` if not provided."
+        },
+        {
+          "name": "hideLogo",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to hide the logo in the QR code. Can only be used with a paid plan on Dub."
+        },
+        {
+          "name": "margin",
+          "type": "float",
+          "location": "query",
+          "description": "The size of the margin around the QR code. Defaults to 2 if not provided."
+        },
+        {
+          "name": "includeMargin",
+          "type": "bool",
+          "location": "query",
+          "description": "DEPRECATED: Margin is included by default. Use the `margin` prop to customize the margin size."
+        }
+      ]
+    },
+    {
+      "name": "tags_create",
+      "description": "Create a tag",
+      "method": "POST",
+      "path": "/tags",
+      "params": [
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "The color of the tag. If not provided, a random color will be used from the list: red, yellow, green, blue, purple, brown, gray."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the tag to create."
+        },
+        {
+          "name": "tag",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the tag to create."
+        }
+      ]
+    },
+    {
+      "name": "tags_delete",
+      "description": "Delete a tag",
+      "method": "DELETE",
+      "path": "/tags/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the tag to delete.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "tags_get",
+      "description": "Retrieve a list of tags",
+      "method": "GET",
+      "path": "/tags",
+      "params": [
+        {
+          "name": "sortBy",
+          "type": "string",
+          "location": "query",
+          "description": "The field to sort the tags by."
+        },
+        {
+          "name": "sortOrder",
+          "type": "string",
+          "location": "query",
+          "description": "The order to sort the tags by."
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "location": "query",
+          "description": "The search term to filter the tags by."
+        },
+        {
+          "name": "ids",
+          "type": "string",
+          "location": "query",
+          "description": "IDs of tags to filter by."
+        },
+        {
+          "name": "page",
+          "type": "float",
+          "location": "query",
+          "description": "The page number for pagination."
+        },
+        {
+          "name": "pageSize",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items per page."
+        }
+      ]
+    },
+    {
+      "name": "tags_update",
+      "description": "Update a tag",
+      "method": "PATCH",
+      "path": "/tags/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "string",
+          "location": "path",
+          "description": "The ID of the tag to update.",
+          "required": true
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "The color of the tag. If not provided, a random color will be used from the list: red, yellow, green, blue, purple, brown, gray."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the tag to create."
+        },
+        {
+          "name": "tag",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the tag to create."
+        }
+      ]
+    },
+    {
+      "name": "tokens_create-referrals-embed",
+      "description": "Create a referrals embed token",
+      "method": "POST",
+      "path": "/tokens/embed/referrals",
+      "params": [
+        {
+          "name": "partnerId",
+          "type": "string",
+          "location": "body",
+          "description": "Partner id"
+        },
+        {
+          "name": "tenantId",
+          "type": "string",
+          "location": "body",
+          "description": "Tenant id"
+        }
+      ]
+    },
+    {
+      "name": "track_lead",
+      "description": "Track a lead",
+      "method": "POST",
+      "path": "/track/lead",
+      "params": [
+        {
+          "name": "clickId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID of the click that the lead conversion event is attributed to. You can read this value from `dub_id` cookie. [For deferred lead tracking]: If an empty string is provided, Dub will try to find an existing customer with the provided `customerExternalId` and use the `clickId` from the customer if found.",
+          "required": true
+        },
+        {
+          "name": "customerAvatar",
+          "type": "string",
+          "location": "body",
+          "description": "The avatar URL of the customer."
+        },
+        {
+          "name": "customerEmail",
+          "type": "string",
+          "location": "body",
+          "description": "The email address of the customer."
+        },
+        {
+          "name": "customerExternalId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID of the customer in your system. Will be used to identify and attribute all future events to this customer.",
+          "required": true
+        },
+        {
+          "name": "customerName",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the customer. If not passed, a random name will be generated (e.g. “Big Red Caribou”)."
+        },
+        {
+          "name": "eventName",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the lead event to track. Can also be used as a unique identifier to associate a given lead event for a customer for a subsequent sale event (via the `leadEventName` prop in `/track/sale`).",
+          "required": true
+        },
+        {
+          "name": "eventQuantity",
+          "type": "float",
+          "location": "body",
+          "description": "The numerical value associated with this lead event (e.g., number of provisioned seats in a free trial). If defined as N, the lead event will be tracked N times."
+        },
+        {
+          "name": "mode",
+          "type": "string",
+          "location": "body",
+          "description": "The mode to use for tracking the lead event. `async` will not block the request; `wait` will block the request until the lead event is fully recorded in Dub; `deferred` will defer the lead event creation to a subsequent request."
+        }
+      ]
+    },
+    {
+      "name": "track_open",
+      "description": "Track a deep link open event",
+      "method": "POST",
+      "path": "/track/open",
+      "params": [
+        {
+          "name": "deepLink",
+          "type": "string",
+          "location": "body",
+          "description": "The deep link that brought the user to the app. If left blank, Dub will fallback to probabilistic tracking by using the `dubDomain` parameter to check if there is an associated click event for the user's IP address. Learn more: https://d.to/ddl"
+        },
+        {
+          "name": "dubDomain",
+          "type": "string",
+          "location": "body",
+          "description": "Your deep link custom domain on Dub (e.g. `acme.link`). This is used in probabilistic tracking to check if there is an associated click event for the user's IP address. Learn more: https://d.to/ddl"
+        }
+      ]
+    },
+    {
+      "name": "track_sale",
+      "description": "Track a sale",
+      "method": "POST",
+      "path": "/track/sale",
+      "params": [
+        {
+          "name": "amount",
+          "type": "int",
+          "location": "body",
+          "description": "The amount of the sale in cents (for all two-decimal currencies). If the sale is in a zero-decimal currency, pass the full integer value (e.g. `1580` JPY). Learn more: https://d.to/currency",
+          "required": true
+        },
+        {
+          "name": "clickId",
+          "type": "string",
+          "location": "body",
+          "description": "[For direct sale tracking]: The unique ID of the click that the sale conversion event is attributed to. You can read this value from `dub_id` cookie."
+        },
+        {
+          "name": "currency",
+          "type": "string",
+          "location": "body",
+          "description": "The currency of the sale. Accepts ISO 4217 currency codes. Sales will be automatically converted and stored as USD at the latest exchange rates. Learn more: https://d.to/currency"
+        },
+        {
+          "name": "customerAvatar",
+          "type": "string",
+          "location": "body",
+          "description": "[For direct sale tracking]: The avatar URL of the customer."
+        },
+        {
+          "name": "customerEmail",
+          "type": "string",
+          "location": "body",
+          "description": "[For direct sale tracking]: The email address of the customer."
+        },
+        {
+          "name": "customerExternalId",
+          "type": "string",
+          "location": "body",
+          "description": "The unique ID of the customer in your system. Will be used to identify and attribute all future events to this customer.",
+          "required": true
+        },
+        {
+          "name": "customerName",
+          "type": "string",
+          "location": "body",
+          "description": "[For direct sale tracking]: The name of the customer. If not passed, a random name will be generated (e.g. “Big Red Caribou”)."
+        },
+        {
+          "name": "eventName",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the sale event. Recommended format: `Invoice paid` or `Subscription created`."
+        },
+        {
+          "name": "invoiceId",
+          "type": "string",
+          "location": "body",
+          "description": "The invoice ID of the sale. Can be used as a idempotency key – only one sale event can be recorded for a given invoice ID."
+        },
+        {
+          "name": "leadEventName",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the lead event that occurred before the sale (case-sensitive). This is used to associate the sale event with a particular lead event (instead of the latest lead event for a link-customer combination, which is the default behavior). For direct sale tracking, this field can also be used to specify the lead event name."
+        },
+        {
+          "name": "paymentProcessor",
+          "type": "string",
+          "location": "body",
+          "description": "The payment processor via which the sale was made."
+        }
+      ]
+    }
+  ]
+}

--- a/library/media-and-entertainment/espn-pp-cli/tools-manifest.json
+++ b/library/media-and-entertainment/espn-pp-cli/tools-manifest.json
@@ -1,0 +1,28 @@
+{
+  "api_name": "espn-fantasy-football",
+  "base_url": "https://lm-api-reads.fantasy.espn.com",
+  "description": "ESPN Fantasy Football league data (public, no auth required)",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "none"
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "v3_get-league",
+      "description": "Get fantasy football league details by ID",
+      "method": "GET",
+      "path": "/apis/v3/games/ffl/seasons/2024/segments/0/leagues/{league_id}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "league_id",
+          "type": "string",
+          "location": "path",
+          "description": "The league_id identifier",
+          "required": true
+        }
+      ]
+    }
+  ]
+}

--- a/library/media-and-entertainment/steam-web-pp-cli/tools-manifest.json
+++ b/library/media-and-entertainment/steam-web-pp-cli/tools-manifest.json
@@ -1,0 +1,5019 @@
+{
+  "api_name": "steam-web",
+  "base_url": "https://api.steampowered.com",
+  "description": "Official Steam Web API. Get your API key at https://steamcommunity.com/dev/apikey",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "api_key",
+    "header": "key",
+    "in": "query",
+    "env_vars": [
+      "STEAM_WEB_API_KEY"
+    ]
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "iauthentication-service_begin-auth-session-via-credentials",
+      "description": "BeginAuthSessionViaCredentials operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/BeginAuthSessionViaCredentials/v1",
+      "params": [
+        {
+          "name": "account_name",
+          "type": "string",
+          "location": "body",
+          "description": "Account name",
+          "required": true
+        },
+        {
+          "name": "device_details",
+          "type": "string",
+          "location": "body",
+          "description": "User-supplied details about the device attempting to sign in",
+          "required": true
+        },
+        {
+          "name": "device_friendly_name",
+          "type": "string",
+          "location": "body",
+          "description": "Device friendly name",
+          "required": true
+        },
+        {
+          "name": "encrypted_password",
+          "type": "string",
+          "location": "body",
+          "description": "password, RSA encrypted client side",
+          "required": true
+        },
+        {
+          "name": "encryption_timestamp",
+          "type": "int",
+          "location": "body",
+          "description": "timestamp to map to a key - STime",
+          "required": true
+        },
+        {
+          "name": "guard_data",
+          "type": "string",
+          "location": "body",
+          "description": "steam guard data for client login",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "body",
+          "description": "Language",
+          "required": true
+        },
+        {
+          "name": "persistence",
+          "type": "string",
+          "location": "body",
+          "description": "whether we are requesting a persistent or an ephemeral session"
+        },
+        {
+          "name": "platform_type",
+          "type": "string",
+          "location": "body",
+          "description": "Platform type",
+          "required": true
+        },
+        {
+          "name": "qos_level",
+          "type": "int",
+          "location": "body",
+          "description": "[ENetQOSLevel] client-specified priority for this auth attempt"
+        },
+        {
+          "name": "remember_login",
+          "type": "bool",
+          "location": "body",
+          "description": "deprecated",
+          "required": true
+        },
+        {
+          "name": "website_id",
+          "type": "string",
+          "location": "body",
+          "description": "(EMachineAuthWebDomain) identifier of client requesting auth"
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_begin-auth-session-via-qr",
+      "description": "BeginAuthSessionViaQR operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/BeginAuthSessionViaQR/v1",
+      "params": [
+        {
+          "name": "device_details",
+          "type": "string",
+          "location": "body",
+          "description": "User-supplied details about the device attempting to sign in",
+          "required": true
+        },
+        {
+          "name": "device_friendly_name",
+          "type": "string",
+          "location": "body",
+          "description": "Device friendly name",
+          "required": true
+        },
+        {
+          "name": "platform_type",
+          "type": "string",
+          "location": "body",
+          "description": "Platform type",
+          "required": true
+        },
+        {
+          "name": "website_id",
+          "type": "string",
+          "location": "body",
+          "description": "(EMachineAuthWebDomain) identifier of client requesting auth"
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_get-auth-session-info",
+      "description": "GetAuthSessionInfo operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/GetAuthSessionInfo/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "client ID from scanned QR Code, used for routing",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_get-auth-session-risk-info",
+      "description": "GetAuthSessionRiskInfo operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/GetAuthSessionRiskInfo/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "client ID from scanned QR Code, used for routing",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "body",
+          "description": "language for optimistic localization of geoloc data",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_get-password-rsapublic-key",
+      "description": "GetPasswordRSAPublicKey operation of IAuthenticationService",
+      "method": "GET",
+      "path": "/IAuthenticationService/GetPasswordRSAPublicKey/v1",
+      "params": [
+        {
+          "name": "account_name",
+          "type": "string",
+          "location": "query",
+          "description": "user-provided account name to get an RSA key for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_notify-risk-quiz-results",
+      "description": "NotifyRiskQuizResults operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/NotifyRiskQuizResults/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "client ID for the auth session, used for routing",
+          "required": true
+        },
+        {
+          "name": "did_confirm_login",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether or not the user went on to confirm the login or not in the case of a passed quiz",
+          "required": true
+        },
+        {
+          "name": "results",
+          "type": "string",
+          "location": "body",
+          "description": "Whether or not the user correctly answered each risk quiz question",
+          "required": true
+        },
+        {
+          "name": "selected_action",
+          "type": "string",
+          "location": "body",
+          "description": "The action being taken selected by the user during the quiz",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_poll-auth-session-status",
+      "description": "PollAuthSessionStatus operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/PollAuthSessionStatus/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "request_id",
+          "type": "string",
+          "location": "body",
+          "description": "Request id",
+          "required": true
+        },
+        {
+          "name": "token_to_revoke",
+          "type": "int",
+          "location": "body",
+          "description": "If this is set to a token owned by this user, that token will be retired",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_update-auth-session-with-mobile-confirmation",
+      "description": "UpdateAuthSessionWithMobileConfirmation operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/UpdateAuthSessionWithMobileConfirmation/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "pending client ID, from scanned QR Code",
+          "required": true
+        },
+        {
+          "name": "confirm",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to confirm the login (true) or deny the login (false)"
+        },
+        {
+          "name": "persistence",
+          "type": "string",
+          "location": "body",
+          "description": "whether we are requesting a persistent or an ephemeral session"
+        },
+        {
+          "name": "signature",
+          "type": "string",
+          "location": "body",
+          "description": "HMAC digest over {version,client_id,steamid} via user's private key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "user who wants to login",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "int",
+          "location": "body",
+          "description": "version field",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iauthentication-service_update-auth-session-with-steam-guard-code",
+      "description": "UpdateAuthSessionWithSteamGuardCode operation of IAuthenticationService",
+      "method": "POST",
+      "path": "/IAuthenticationService/UpdateAuthSessionWithSteamGuardCode/v1",
+      "params": [
+        {
+          "name": "client_id",
+          "type": "int",
+          "location": "body",
+          "description": "pending client ID, from initialized session",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "confirmation code",
+          "required": true
+        },
+        {
+          "name": "code_type",
+          "type": "string",
+          "location": "body",
+          "description": "type of confirmation code",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "user who wants to login",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ibroadcast-service_post-game-data-frame-rtmp",
+      "description": "PostGameDataFrameRTMP operation of IBroadcastService",
+      "method": "POST",
+      "path": "/IBroadcastService/PostGameDataFrameRTMP/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "AppID of the game being broadcasted",
+          "required": true
+        },
+        {
+          "name": "frame_data",
+          "type": "string",
+          "location": "body",
+          "description": "game data frame expressing current state of game (string, zipped, whatever)",
+          "required": true
+        },
+        {
+          "name": "rtmp_token",
+          "type": "string",
+          "location": "body",
+          "description": "Valid RTMP token for the Broadcaster",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "Broadcasters SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icheat-reporting-service_report-cheat-data",
+      "description": "ReportCheatData operation of ICheatReportingService",
+      "method": "POST",
+      "path": "/ICheatReportingService/ReportCheatData/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "The appid.",
+          "required": true
+        },
+        {
+          "name": "cheat_data_dump",
+          "type": "string",
+          "location": "body",
+          "description": "data collection in json format",
+          "required": true
+        },
+        {
+          "name": "cheat_param_1",
+          "type": "int",
+          "location": "body",
+          "description": "cheat param 1",
+          "required": true
+        },
+        {
+          "name": "cheat_param_2",
+          "type": "int",
+          "location": "body",
+          "description": "cheat param 2",
+          "required": true
+        },
+        {
+          "name": "cheat_process_id",
+          "type": "int",
+          "location": "body",
+          "description": "process ID of the cheat process that ran",
+          "required": true
+        },
+        {
+          "name": "cheatname",
+          "type": "string",
+          "location": "body",
+          "description": "descriptive name for the cheat.",
+          "required": true
+        },
+        {
+          "name": "game_process_id",
+          "type": "int",
+          "location": "body",
+          "description": "process ID of the running game.",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "pathandfilename",
+          "type": "string",
+          "location": "body",
+          "description": "path and file name of the cheat executable.",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "steamid of the user running and reporting the cheat.",
+          "required": true
+        },
+        {
+          "name": "time_now",
+          "type": "int",
+          "location": "body",
+          "description": "local system time now.",
+          "required": true
+        },
+        {
+          "name": "time_started",
+          "type": "int",
+          "location": "body",
+          "description": "local system time when cheat process started. ( 0 if not yet run )",
+          "required": true
+        },
+        {
+          "name": "time_stopped",
+          "type": "int",
+          "location": "body",
+          "description": "local system time when cheat process stopped. ( 0 if still running )",
+          "required": true
+        },
+        {
+          "name": "webcheaturl",
+          "type": "string",
+          "location": "body",
+          "description": "web url where the cheat was found and downloaded.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iclient-stats-1046930_report-event",
+      "description": "ReportEvent operation of IClientStats_1046930",
+      "method": "POST",
+      "path": "/IClientStats_1046930/ReportEvent/v1",
+      "params": []
+    },
+    {
+      "name": "icontent-server-config-service_get-steam-cache-node-params",
+      "description": "GetSteamCacheNodeParams operation of IContentServerConfigService",
+      "method": "GET",
+      "path": "/IContentServerConfigService/GetSteamCacheNodeParams/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "cache_id",
+          "type": "int",
+          "location": "query",
+          "description": "Unique ID number",
+          "required": true
+        },
+        {
+          "name": "cache_key",
+          "type": "string",
+          "location": "query",
+          "description": "Valid current cache API key",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-config-service_set-steam-cache-client-filters",
+      "description": "SetSteamCacheClientFilters operation of IContentServerConfigService",
+      "method": "POST",
+      "path": "/IContentServerConfigService/SetSteamCacheClientFilters/v1",
+      "params": [
+        {
+          "name": "allowed_ip_blocks",
+          "type": "string",
+          "location": "body",
+          "description": "comma-separated list of allowed IP address blocks in CIDR format - blank to clear unfilter",
+          "required": true
+        },
+        {
+          "name": "cache_id",
+          "type": "int",
+          "location": "body",
+          "description": "Unique ID number",
+          "required": true
+        },
+        {
+          "name": "cache_key",
+          "type": "string",
+          "location": "body",
+          "description": "Valid current cache API key",
+          "required": true
+        },
+        {
+          "name": "change_notes",
+          "type": "string",
+          "location": "body",
+          "description": "Notes",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-config-service_set-steam-cache-performance-stats",
+      "description": "SetSteamCachePerformanceStats operation of IContentServerConfigService",
+      "method": "POST",
+      "path": "/IContentServerConfigService/SetSteamCachePerformanceStats/v1",
+      "params": [
+        {
+          "name": "cache_hit_percent",
+          "type": "int",
+          "location": "body",
+          "description": "Percent cache hits",
+          "required": true
+        },
+        {
+          "name": "cache_id",
+          "type": "int",
+          "location": "body",
+          "description": "Unique ID number",
+          "required": true
+        },
+        {
+          "name": "cache_key",
+          "type": "string",
+          "location": "body",
+          "description": "Valid current cache API key",
+          "required": true
+        },
+        {
+          "name": "cpu_percent",
+          "type": "int",
+          "location": "body",
+          "description": "Percent CPU load",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "mbps_recv",
+          "type": "int",
+          "location": "body",
+          "description": "Incoming network traffic in Mbps",
+          "required": true
+        },
+        {
+          "name": "mbps_sent",
+          "type": "int",
+          "location": "body",
+          "description": "Outgoing network traffic in Mbps",
+          "required": true
+        },
+        {
+          "name": "num_connected_ips",
+          "type": "int",
+          "location": "body",
+          "description": "Number of unique connected IP addresses",
+          "required": true
+        },
+        {
+          "name": "upstream_egress_utilization",
+          "type": "int",
+          "location": "body",
+          "description": "(deprecated) What is the percent utilization of the busiest datacenter egress link?",
+          "required": true
+        },
+        {
+          "name": "upstream_peering_utilization",
+          "type": "int",
+          "location": "body",
+          "description": "What is the percent utilization of the busiest peering link?",
+          "required": true
+        },
+        {
+          "name": "upstream_transit_utilization",
+          "type": "int",
+          "location": "body",
+          "description": "What is the percent utilization of the busiest transit link?",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-directory-service_get-cdnfor-video",
+      "description": "GetCDNForVideo operation of IContentServerDirectoryService",
+      "method": "GET",
+      "path": "/IContentServerDirectoryService/GetCDNForVideo/v1",
+      "params": [
+        {
+          "name": "property_type",
+          "type": "int",
+          "location": "query",
+          "description": "ECDNPropertyType",
+          "required": true
+        },
+        {
+          "name": "client_ip",
+          "type": "string",
+          "location": "query",
+          "description": "client IP address",
+          "required": true
+        },
+        {
+          "name": "client_region",
+          "type": "string",
+          "location": "query",
+          "description": "client region",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-directory-service_get-client-update-hosts",
+      "description": "GetClientUpdateHosts operation of IContentServerDirectoryService",
+      "method": "GET",
+      "path": "/IContentServerDirectoryService/GetClientUpdateHosts/v1",
+      "params": [
+        {
+          "name": "cached_signature",
+          "type": "string",
+          "location": "query",
+          "description": "Cached signature",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-directory-service_get-depot-patch-info",
+      "description": "GetDepotPatchInfo operation of IContentServerDirectoryService",
+      "method": "GET",
+      "path": "/IContentServerDirectoryService/GetDepotPatchInfo/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "Appid",
+          "required": true
+        },
+        {
+          "name": "depotid",
+          "type": "int",
+          "location": "query",
+          "description": "Depotid",
+          "required": true
+        },
+        {
+          "name": "source_manifestid",
+          "type": "int",
+          "location": "query",
+          "description": "Source manifestid",
+          "required": true
+        },
+        {
+          "name": "target_manifestid",
+          "type": "int",
+          "location": "query",
+          "description": "Target manifestid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-directory-service_get-servers-for-steam-pipe",
+      "description": "GetServersForSteamPipe operation of IContentServerDirectoryService",
+      "method": "GET",
+      "path": "/IContentServerDirectoryService/GetServersForSteamPipe/v1",
+      "params": [
+        {
+          "name": "cell_id",
+          "type": "int",
+          "location": "query",
+          "description": "client Cell ID",
+          "required": true
+        },
+        {
+          "name": "max_servers",
+          "type": "int",
+          "location": "query",
+          "description": "max servers in response list"
+        },
+        {
+          "name": "ip_override",
+          "type": "string",
+          "location": "query",
+          "description": "client IP address"
+        },
+        {
+          "name": "launcher_type",
+          "type": "int",
+          "location": "query",
+          "description": "launcher type"
+        },
+        {
+          "name": "ipv6_public",
+          "type": "string",
+          "location": "query",
+          "description": "client public ipv6 address if it knows it"
+        },
+        {
+          "name": "current_connections",
+          "type": "string",
+          "location": "query",
+          "description": "what sources is the client currently using",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icontent-server-directory-service_pick-single-content-server",
+      "description": "PickSingleContentServer operation of IContentServerDirectoryService",
+      "method": "GET",
+      "path": "/IContentServerDirectoryService/PickSingleContentServer/v1",
+      "params": [
+        {
+          "name": "property_type",
+          "type": "int",
+          "location": "query",
+          "description": "ECDNPropertyType",
+          "required": true
+        },
+        {
+          "name": "cell_id",
+          "type": "int",
+          "location": "query",
+          "description": "client Cell ID",
+          "required": true
+        },
+        {
+          "name": "client_ip",
+          "type": "string",
+          "location": "query",
+          "description": "client IP address",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgoplayers-730_get-next-match-sharing-code",
+      "description": "GetNextMatchSharingCode operation of ICSGOPlayers_730",
+      "method": "GET",
+      "path": "/ICSGOPlayers_730/GetNextMatchSharingCode/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The SteamID of the user",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "query",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        },
+        {
+          "name": "knowncode",
+          "type": "string",
+          "location": "query",
+          "description": "Previously known match sharing code obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgoservers-730_get-game-maps-playtime",
+      "description": "GetGameMapsPlaytime operation of ICSGOServers_730",
+      "method": "GET",
+      "path": "/ICSGOServers_730/GetGameMapsPlaytime/v1",
+      "params": [
+        {
+          "name": "interval",
+          "type": "string",
+          "location": "query",
+          "description": "What recent interval is requested, possible values: day, week, month",
+          "required": true
+        },
+        {
+          "name": "gamemode",
+          "type": "string",
+          "location": "query",
+          "description": "What game mode is requested, possible values: competitive, casual",
+          "required": true
+        },
+        {
+          "name": "mapgroup",
+          "type": "string",
+          "location": "query",
+          "description": "What maps are requested, possible values: operation",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgoservers-730_get-game-servers-status",
+      "description": "GetGameServersStatus operation of ICSGOServers_730",
+      "method": "GET",
+      "path": "/ICSGOServers_730/GetGameServersStatus/v1",
+      "params": []
+    },
+    {
+      "name": "icsgotournaments-730_get-tournament-fantasy-lineup",
+      "description": "GetTournamentFantasyLineup operation of ICSGOTournaments_730",
+      "method": "GET",
+      "path": "/ICSGOTournaments_730/GetTournamentFantasyLineup/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "query",
+          "description": "The event ID",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The SteamID of the user inventory",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "query",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgotournaments-730_get-tournament-items",
+      "description": "GetTournamentItems operation of ICSGOTournaments_730",
+      "method": "GET",
+      "path": "/ICSGOTournaments_730/GetTournamentItems/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "query",
+          "description": "The event ID",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The SteamID of the user inventory",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "query",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgotournaments-730_get-tournament-layout",
+      "description": "GetTournamentLayout operation of ICSGOTournaments_730",
+      "method": "GET",
+      "path": "/ICSGOTournaments_730/GetTournamentLayout/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "query",
+          "description": "The event ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgotournaments-730_get-tournament-predictions",
+      "description": "GetTournamentPredictions operation of ICSGOTournaments_730",
+      "method": "GET",
+      "path": "/ICSGOTournaments_730/GetTournamentPredictions/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "query",
+          "description": "The event ID",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The SteamID of the user inventory",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "query",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgotournaments-730_upload-tournament-fantasy-lineup",
+      "description": "UploadTournamentFantasyLineup operation of ICSGOTournaments_730",
+      "method": "POST",
+      "path": "/ICSGOTournaments_730/UploadTournamentFantasyLineup/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "body",
+          "description": "The event ID",
+          "required": true
+        },
+        {
+          "name": "itemid0",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "itemid1",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "itemid2",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "itemid3",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "itemid4",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "pickid0",
+          "type": "int",
+          "location": "body",
+          "description": "PickID to select for the slot",
+          "required": true
+        },
+        {
+          "name": "pickid1",
+          "type": "int",
+          "location": "body",
+          "description": "PickID to select for the slot",
+          "required": true
+        },
+        {
+          "name": "pickid2",
+          "type": "int",
+          "location": "body",
+          "description": "PickID to select for the slot",
+          "required": true
+        },
+        {
+          "name": "pickid3",
+          "type": "int",
+          "location": "body",
+          "description": "PickID to select for the slot",
+          "required": true
+        },
+        {
+          "name": "pickid4",
+          "type": "int",
+          "location": "body",
+          "description": "PickID to select for the slot",
+          "required": true
+        },
+        {
+          "name": "sectionid",
+          "type": "int",
+          "location": "body",
+          "description": "Event section id",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The SteamID of the user inventory",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "body",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "icsgotournaments-730_upload-tournament-predictions",
+      "description": "UploadTournamentPredictions operation of ICSGOTournaments_730",
+      "method": "POST",
+      "path": "/ICSGOTournaments_730/UploadTournamentPredictions/v1",
+      "params": [
+        {
+          "name": "event",
+          "type": "int",
+          "location": "body",
+          "description": "The event ID",
+          "required": true
+        },
+        {
+          "name": "groupid",
+          "type": "int",
+          "location": "body",
+          "description": "Event group id",
+          "required": true
+        },
+        {
+          "name": "index",
+          "type": "int",
+          "location": "body",
+          "description": "Index in group",
+          "required": true
+        },
+        {
+          "name": "itemid",
+          "type": "int",
+          "location": "body",
+          "description": "ItemID to lock in for the pick",
+          "required": true
+        },
+        {
+          "name": "pickid",
+          "type": "int",
+          "location": "body",
+          "description": "Pick ID to select",
+          "required": true
+        },
+        {
+          "name": "sectionid",
+          "type": "int",
+          "location": "body",
+          "description": "Event section id",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The SteamID of the user inventory",
+          "required": true
+        },
+        {
+          "name": "steamidkey",
+          "type": "string",
+          "location": "body",
+          "description": "Authentication obtained from the SteamID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-live-league-games",
+      "description": "GetLiveLeagueGames operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetLiveLeagueGames/v1",
+      "params": [
+        {
+          "name": "league_id",
+          "type": "int",
+          "location": "query",
+          "description": "Only show matches of the specified league id"
+        },
+        {
+          "name": "match_id",
+          "type": "int",
+          "location": "query",
+          "description": "Only show matches of the specified match id"
+        },
+        {
+          "name": "dpc",
+          "type": "bool",
+          "location": "query",
+          "description": "Only show matches that are part of the DPC"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-match-details",
+      "description": "GetMatchDetails operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetMatchDetails/v1",
+      "params": [
+        {
+          "name": "match_id",
+          "type": "int",
+          "location": "query",
+          "description": "Match id",
+          "required": true
+        },
+        {
+          "name": "include_persona_names",
+          "type": "bool",
+          "location": "query",
+          "description": "Include persona names as part of the response"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-match-history",
+      "description": "GetMatchHistory operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetMatchHistory/v1",
+      "params": [
+        {
+          "name": "hero_id",
+          "type": "int",
+          "location": "query",
+          "description": "The ID of the hero that must be in the matches being queried"
+        },
+        {
+          "name": "game_mode",
+          "type": "int",
+          "location": "query",
+          "description": "Which game mode to return matches for"
+        },
+        {
+          "name": "skill",
+          "type": "int",
+          "location": "query",
+          "description": "The average skill range of the match, these can be [1-3] with lower numbers being lower skill. Ignored if an account ID is specified"
+        },
+        {
+          "name": "min_players",
+          "type": "string",
+          "location": "query",
+          "description": "Minimum number of human players that must be in a match for it to be returned"
+        },
+        {
+          "name": "account_id",
+          "type": "string",
+          "location": "query",
+          "description": "An account ID to get matches from. This will fail if the user has their match history hidden"
+        },
+        {
+          "name": "league_id",
+          "type": "string",
+          "location": "query",
+          "description": "The league ID to return games from"
+        },
+        {
+          "name": "start_at_match_id",
+          "type": "int",
+          "location": "query",
+          "description": "The minimum match ID to start from"
+        },
+        {
+          "name": "matches_requested",
+          "type": "string",
+          "location": "query",
+          "description": "The number of requested matches to return (maximum 100)"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-match-history-by-sequence-num",
+      "description": "GetMatchHistoryBySequenceNum operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetMatchHistoryBySequenceNum/v1",
+      "params": [
+        {
+          "name": "start_at_match_seq_num",
+          "type": "int",
+          "location": "query",
+          "description": "Start at match seq num"
+        },
+        {
+          "name": "matches_requested",
+          "type": "int",
+          "location": "query",
+          "description": "Matches requested"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-team-info-by-team-id",
+      "description": "GetTeamInfoByTeamID operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTeamInfoByTeamID/v1",
+      "params": [
+        {
+          "name": "start_at_team_id",
+          "type": "int",
+          "location": "query",
+          "description": "Start at team id"
+        },
+        {
+          "name": "teams_requested",
+          "type": "int",
+          "location": "query",
+          "description": "Teams requested"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-top-live-event-game",
+      "description": "GetTopLiveEventGame operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTopLiveEventGame/v1",
+      "params": [
+        {
+          "name": "partner",
+          "type": "int",
+          "location": "query",
+          "description": "Which partner's games to use.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-top-live-game",
+      "description": "GetTopLiveGame operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTopLiveGame/v1",
+      "params": [
+        {
+          "name": "partner",
+          "type": "int",
+          "location": "query",
+          "description": "Which partner's games to use.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-top-weekend-tourney-games",
+      "description": "GetTopWeekendTourneyGames operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTopWeekendTourneyGames/v1",
+      "params": [
+        {
+          "name": "partner",
+          "type": "int",
+          "location": "query",
+          "description": "Which partner's games to use.",
+          "required": true
+        },
+        {
+          "name": "home_division",
+          "type": "int",
+          "location": "query",
+          "description": "Prefer matches from this division."
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-tournament-player-stats",
+      "description": "GetTournamentPlayerStats operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTournamentPlayerStats/v1",
+      "params": [
+        {
+          "name": "account_id",
+          "type": "string",
+          "location": "query",
+          "description": "Account id",
+          "required": true
+        },
+        {
+          "name": "league_id",
+          "type": "string",
+          "location": "query",
+          "description": "League id"
+        },
+        {
+          "name": "hero_id",
+          "type": "string",
+          "location": "query",
+          "description": "Hero id"
+        },
+        {
+          "name": "time_frame",
+          "type": "string",
+          "location": "query",
+          "description": "Time frame"
+        },
+        {
+          "name": "match_id",
+          "type": "int",
+          "location": "query",
+          "description": "Match id"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-570_get-tournament-player-stats-idota2match570",
+      "description": "GetTournamentPlayerStats operation of IDOTA2Match_570",
+      "method": "GET",
+      "path": "/IDOTA2Match_570/GetTournamentPlayerStats/v2",
+      "params": [
+        {
+          "name": "account_id",
+          "type": "string",
+          "location": "query",
+          "description": "Account id",
+          "required": true
+        },
+        {
+          "name": "league_id",
+          "type": "string",
+          "location": "query",
+          "description": "League id"
+        },
+        {
+          "name": "hero_id",
+          "type": "string",
+          "location": "query",
+          "description": "Hero id"
+        },
+        {
+          "name": "time_frame",
+          "type": "string",
+          "location": "query",
+          "description": "Time frame"
+        },
+        {
+          "name": "match_id",
+          "type": "int",
+          "location": "query",
+          "description": "Match id"
+        },
+        {
+          "name": "phase_id",
+          "type": "int",
+          "location": "query",
+          "description": "Phase id"
+        }
+      ]
+    },
+    {
+      "name": "idota2-match-stats-570_get-realtime-stats",
+      "description": "GetRealtimeStats operation of IDOTA2MatchStats_570",
+      "method": "GET",
+      "path": "/IDOTA2MatchStats_570/GetRealtimeStats/v1",
+      "params": [
+        {
+          "name": "server_steam_id",
+          "type": "int",
+          "location": "query",
+          "description": "Server steam id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-stream-system-570_get-broadcaster-info",
+      "description": "GetBroadcasterInfo operation of IDOTA2StreamSystem_570",
+      "method": "GET",
+      "path": "/IDOTA2StreamSystem_570/GetBroadcasterInfo/v1",
+      "params": [
+        {
+          "name": "broadcaster_steam_id",
+          "type": "int",
+          "location": "query",
+          "description": "64-bit Steam ID of the broadcaster",
+          "required": true
+        },
+        {
+          "name": "league_id",
+          "type": "int",
+          "location": "query",
+          "description": "LeagueID to use if we aren't in a lobby"
+        }
+      ]
+    },
+    {
+      "name": "idota2-ticket-570_get-steam-idfor-badge-id",
+      "description": "GetSteamIDForBadgeID operation of IDOTA2Ticket_570",
+      "method": "GET",
+      "path": "/IDOTA2Ticket_570/GetSteamIDForBadgeID/v1",
+      "params": [
+        {
+          "name": "BadgeID",
+          "type": "string",
+          "location": "query",
+          "description": "The badge ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-ticket-570_set-steam-account-purchased",
+      "description": "SetSteamAccountPurchased operation of IDOTA2Ticket_570",
+      "method": "POST",
+      "path": "/IDOTA2Ticket_570/SetSteamAccountPurchased/v1",
+      "params": [
+        {
+          "name": "BadgeType",
+          "type": "int",
+          "location": "body",
+          "description": "Badge Type",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The 64-bit Steam ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "idota2-ticket-570_steam-account-valid-for-badge-type",
+      "description": "SteamAccountValidForBadgeType operation of IDOTA2Ticket_570",
+      "method": "GET",
+      "path": "/IDOTA2Ticket_570/SteamAccountValidForBadgeType/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The 64-bit Steam ID",
+          "required": true
+        },
+        {
+          "name": "ValidBadgeType1",
+          "type": "int",
+          "location": "query",
+          "description": "Valid Badge Type 1",
+          "required": true
+        },
+        {
+          "name": "ValidBadgeType2",
+          "type": "int",
+          "location": "query",
+          "description": "Valid Badge Type 2",
+          "required": true
+        },
+        {
+          "name": "ValidBadgeType3",
+          "type": "int",
+          "location": "query",
+          "description": "Valid Badge Type 3",
+          "required": true
+        },
+        {
+          "name": "ValidBadgeType4",
+          "type": "int",
+          "location": "query",
+          "description": "Valid Badge Type 4"
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-event-stats-for-account",
+      "description": "GetEventStatsForAccount operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetEventStatsForAccount/v1",
+      "params": [
+        {
+          "name": "eventid",
+          "type": "int",
+          "location": "query",
+          "description": "The Event ID of the event you're looking for.",
+          "required": true
+        },
+        {
+          "name": "accountid",
+          "type": "int",
+          "location": "query",
+          "description": "The account ID to look up.",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to provide hero names in."
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-heroes",
+      "description": "GetHeroes operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetHeroes/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to provide hero names in."
+        },
+        {
+          "name": "itemizedonly",
+          "type": "bool",
+          "location": "query",
+          "description": "Return a list of itemized heroes only."
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-item-creators",
+      "description": "GetItemCreators operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetItemCreators/v1",
+      "params": [
+        {
+          "name": "itemdef",
+          "type": "int",
+          "location": "query",
+          "description": "The item definition to get creator information for.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-item-workshop-published-file-ids",
+      "description": "GetItemWorkshopPublishedFileIDs operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetItemWorkshopPublishedFileIDs/v1",
+      "params": [
+        {
+          "name": "itemdef",
+          "type": "int",
+          "location": "query",
+          "description": "The item definition to get published file ids for.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-rarities",
+      "description": "GetRarities operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetRarities/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to provide rarity names in."
+        }
+      ]
+    },
+    {
+      "name": "iecon-dota2-570_get-tournament-prize-pool",
+      "description": "GetTournamentPrizePool operation of IEconDOTA2_570",
+      "method": "GET",
+      "path": "/IEconDOTA2_570/GetTournamentPrizePool/v1",
+      "params": [
+        {
+          "name": "leagueid",
+          "type": "int",
+          "location": "query",
+          "description": "The ID of the league to get the prize pool of"
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-1046930_get-player-items",
+      "description": "GetPlayerItems operation of IEconItems_1046930",
+      "method": "GET",
+      "path": "/IEconItems_1046930/GetPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-1269260_get-equipped-player-items",
+      "description": "GetEquippedPlayerItems operation of IEconItems_1269260",
+      "method": "GET",
+      "path": "/IEconItems_1269260/GetEquippedPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        },
+        {
+          "name": "class_id",
+          "type": "int",
+          "location": "query",
+          "description": "Return items equipped for this class id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-player-items",
+      "description": "GetPlayerItems operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-schema",
+      "description": "GetSchema operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetSchema/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to return the names in. Defaults to returning string keys."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-schema-items",
+      "description": "GetSchemaItems operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetSchemaItems/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to return the names in. Defaults to returning string keys."
+        },
+        {
+          "name": "start",
+          "type": "int",
+          "location": "query",
+          "description": "The first item id to return. Defaults to 0. Response will indicate next value to query if applicable."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-schema-overview",
+      "description": "GetSchemaOverview operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetSchemaOverview/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to return the names in. Defaults to returning string keys."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-schema-url",
+      "description": "GetSchemaURL operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetSchemaURL/v1",
+      "params": []
+    },
+    {
+      "name": "iecon-items-440_get-store-meta-data",
+      "description": "GetStoreMetaData operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetStoreMetaData/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to results in."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-440_get-store-status",
+      "description": "GetStoreStatus operation of IEconItems_440",
+      "method": "GET",
+      "path": "/IEconItems_440/GetStoreStatus/v1",
+      "params": []
+    },
+    {
+      "name": "iecon-items-570_get-player-items",
+      "description": "GetPlayerItems operation of IEconItems_570",
+      "method": "GET",
+      "path": "/IEconItems_570/GetPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-570_get-store-meta-data",
+      "description": "GetStoreMetaData operation of IEconItems_570",
+      "method": "GET",
+      "path": "/IEconItems_570/GetStoreMetaData/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to results in."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-583950_get-equipped-player-items",
+      "description": "GetEquippedPlayerItems operation of IEconItems_583950",
+      "method": "GET",
+      "path": "/IEconItems_583950/GetEquippedPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        },
+        {
+          "name": "class_id",
+          "type": "int",
+          "location": "query",
+          "description": "Return items equipped for this class id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-620_get-player-items",
+      "description": "GetPlayerItems operation of IEconItems_620",
+      "method": "GET",
+      "path": "/IEconItems_620/GetPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-620_get-schema",
+      "description": "GetSchema operation of IEconItems_620",
+      "method": "GET",
+      "path": "/IEconItems_620/GetSchema/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to return the names in. Defaults to returning string keys."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-730_get-player-items",
+      "description": "GetPlayerItems operation of IEconItems_730",
+      "method": "GET",
+      "path": "/IEconItems_730/GetPlayerItems/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The Steam ID to fetch items for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-730_get-schema",
+      "description": "GetSchema operation of IEconItems_730",
+      "method": "GET",
+      "path": "/IEconItems_730/GetSchema/v2",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to return the names in. Defaults to returning string keys."
+        }
+      ]
+    },
+    {
+      "name": "iecon-items-730_get-schema-url",
+      "description": "GetSchemaURL operation of IEconItems_730",
+      "method": "GET",
+      "path": "/IEconItems_730/GetSchemaURL/v2",
+      "params": []
+    },
+    {
+      "name": "iecon-items-730_get-store-meta-data",
+      "description": "GetStoreMetaData operation of IEconItems_730",
+      "method": "GET",
+      "path": "/IEconItems_730/GetStoreMetaData/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to results in."
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-history",
+      "description": "GetTradeHistory operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeHistory/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "max_trades",
+          "type": "int",
+          "location": "query",
+          "description": "The number of trades to return information for",
+          "required": true
+        },
+        {
+          "name": "start_after_time",
+          "type": "int",
+          "location": "query",
+          "description": "The time of the last trade shown on the previous page of results, or the time of the first trade if navigating back",
+          "required": true
+        },
+        {
+          "name": "start_after_tradeid",
+          "type": "int",
+          "location": "query",
+          "description": "The tradeid shown on the previous page of results, or the ID of the first trade if navigating back",
+          "required": true
+        },
+        {
+          "name": "navigating_back",
+          "type": "bool",
+          "location": "query",
+          "description": "The user wants the previous page of results, so return the previous max_trades trades before the start time and ID",
+          "required": true
+        },
+        {
+          "name": "get_descriptions",
+          "type": "bool",
+          "location": "query",
+          "description": "If set, the item display data for the items included in the returned trades will also be returned",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to use when loading item display data",
+          "required": true
+        },
+        {
+          "name": "include_failed",
+          "type": "bool",
+          "location": "query",
+          "description": "Include failed",
+          "required": true
+        },
+        {
+          "name": "include_total",
+          "type": "bool",
+          "location": "query",
+          "description": "If set, the total number of trades the account has participated in will be included in the response",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-hold-durations",
+      "description": "GetTradeHoldDurations operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeHoldDurations/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid_target",
+          "type": "int",
+          "location": "query",
+          "description": "User you are trading with",
+          "required": true
+        },
+        {
+          "name": "trade_offer_access_token",
+          "type": "string",
+          "location": "query",
+          "description": "A special token that allows for trade offers from non-friends.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-offer",
+      "description": "GetTradeOffer operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeOffer/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "tradeofferid",
+          "type": "int",
+          "location": "query",
+          "description": "Tradeofferid",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "Language",
+          "required": true
+        },
+        {
+          "name": "get_descriptions",
+          "type": "bool",
+          "location": "query",
+          "description": "If set, the item display data for the items included in the returned trade offers will also be returned. If one or more descriptions can't be retrieved, then your request will fail.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-offers",
+      "description": "GetTradeOffers operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeOffers/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "get_sent_offers",
+          "type": "bool",
+          "location": "query",
+          "description": "Request the list of sent offers.",
+          "required": true
+        },
+        {
+          "name": "get_received_offers",
+          "type": "bool",
+          "location": "query",
+          "description": "Request the list of received offers.",
+          "required": true
+        },
+        {
+          "name": "get_descriptions",
+          "type": "bool",
+          "location": "query",
+          "description": "If set, the item display data for the items included in the returned trade offers will also be returned. If one or more descriptions can't be retrieved, then your request will fail.",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to use when loading item display data.",
+          "required": true
+        },
+        {
+          "name": "active_only",
+          "type": "bool",
+          "location": "query",
+          "description": "Indicates we should only return offers which are still active, or offers that have changed in state since the time_historical_cutoff",
+          "required": true
+        },
+        {
+          "name": "historical_only",
+          "type": "bool",
+          "location": "query",
+          "description": "Indicates we should only return offers which are not active.",
+          "required": true
+        },
+        {
+          "name": "time_historical_cutoff",
+          "type": "int",
+          "location": "query",
+          "description": "When active_only is set, offers updated since this time will also be returned. When historical_only is set, only offers updated since this time are included.",
+          "required": true
+        },
+        {
+          "name": "cursor",
+          "type": "int",
+          "location": "query",
+          "description": "Cursor aka start index"
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-offers-summary",
+      "description": "GetTradeOffersSummary operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeOffersSummary/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "time_last_visit",
+          "type": "int",
+          "location": "query",
+          "description": "The time the user last visited.  If not passed, will use the time the user last visited the trade offer page.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iecon-service_get-trade-status",
+      "description": "GetTradeStatus operation of IEconService",
+      "method": "GET",
+      "path": "/IEconService/GetTradeStatus/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "tradeid",
+          "type": "int",
+          "location": "query",
+          "description": "Tradeid",
+          "required": true
+        },
+        {
+          "name": "get_descriptions",
+          "type": "bool",
+          "location": "query",
+          "description": "If set, the item display data for the items included in the returned trades will also be returned",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The language to use when loading item display data",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-notifications-service_user-create-session",
+      "description": "UserCreateSession operation of IGameNotificationsService",
+      "method": "POST",
+      "path": "/IGameNotificationsService/UserCreateSession/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "The appid to create the session for.",
+          "required": true
+        },
+        {
+          "name": "context",
+          "type": "int",
+          "location": "body",
+          "description": "Game-specified context value the game can used to associate the session with some object on their backend.",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "(Optional) steamid to make the request on behalf of -- if specified, the user must be in the session and all users being added to the session must be friends with the user.",
+          "required": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "The title of the session to be displayed within each user's list of sessions.",
+          "required": true
+        },
+        {
+          "name": "users",
+          "type": "string",
+          "location": "body",
+          "description": "The initial state of all users in the session.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-notifications-service_user-delete-session",
+      "description": "UserDeleteSession operation of IGameNotificationsService",
+      "method": "POST",
+      "path": "/IGameNotificationsService/UserDeleteSession/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "The appid of the session to delete.",
+          "required": true
+        },
+        {
+          "name": "sessionid",
+          "type": "int",
+          "location": "body",
+          "description": "The sessionid to delete.",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "(Optional) steamid to make the request on behalf of -- if specified, the user must be in the session.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-notifications-service_user-update-session",
+      "description": "UserUpdateSession operation of IGameNotificationsService",
+      "method": "POST",
+      "path": "/IGameNotificationsService/UserUpdateSession/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "The appid of the session to update.",
+          "required": true
+        },
+        {
+          "name": "sessionid",
+          "type": "int",
+          "location": "body",
+          "description": "The sessionid to update.",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "(Optional) steamid to make the request on behalf of -- if specified, the user must be in the session and all users being added to the session must be friends with the user.",
+          "required": true
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "(Optional) The new title of the session.  If not specified, the title will not be changed.",
+          "required": true
+        },
+        {
+          "name": "users",
+          "type": "string",
+          "location": "body",
+          "description": "(Optional) A list of users whose state will be updated to reflect the given state. If the users are not already in the session, they will be added to it.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_create-account",
+      "description": "CreateAccount operation of IGameServersService",
+      "method": "POST",
+      "path": "/IGameServersService/CreateAccount/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "The app to use the account for",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "memo",
+          "type": "string",
+          "location": "body",
+          "description": "The memo to set on the new account",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_delete-account",
+      "description": "DeleteAccount operation of IGameServersService",
+      "method": "POST",
+      "path": "/IGameServersService/DeleteAccount/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The SteamID of the game server account to delete",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_get-account-list",
+      "description": "GetAccountList operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/GetAccountList/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_get-account-public-info",
+      "description": "GetAccountPublicInfo operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/GetAccountPublicInfo/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The SteamID of the game server to get info on",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_get-server-ips-by-steam-id",
+      "description": "GetServerIPsBySteamID operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/GetServerIPsBySteamID/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "server_steamids",
+          "type": "int",
+          "location": "query",
+          "description": "Server steamids",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_get-server-steam-ids-by-ip",
+      "description": "GetServerSteamIDsByIP operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/GetServerSteamIDsByIP/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "server_ips",
+          "type": "string",
+          "location": "query",
+          "description": "Server ips",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_query-by-fake-ip",
+      "description": "QueryByFakeIP operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/QueryByFakeIP/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "fake_ip",
+          "type": "int",
+          "location": "query",
+          "description": "FakeIP of server to query.",
+          "required": true
+        },
+        {
+          "name": "fake_port",
+          "type": "int",
+          "location": "query",
+          "description": "Fake port of server to query.",
+          "required": true
+        },
+        {
+          "name": "app_id",
+          "type": "int",
+          "location": "query",
+          "description": "AppID to use.  Each AppID has its own FakeIP address.",
+          "required": true
+        },
+        {
+          "name": "query_type",
+          "type": "string",
+          "location": "query",
+          "description": "What type of query?",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_query-login-token",
+      "description": "QueryLoginToken operation of IGameServersService",
+      "method": "GET",
+      "path": "/IGameServersService/QueryLoginToken/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "login_token",
+          "type": "string",
+          "location": "query",
+          "description": "Login token to query",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_reset-login-token",
+      "description": "ResetLoginToken operation of IGameServersService",
+      "method": "POST",
+      "path": "/IGameServersService/ResetLoginToken/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The SteamID of the game server to reset the login token of",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igame-servers-service_set-memo",
+      "description": "SetMemo operation of IGameServersService",
+      "method": "POST",
+      "path": "/IGameServersService/SetMemo/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "memo",
+          "type": "string",
+          "location": "body",
+          "description": "The memo to set on the new account",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "The SteamID of the game server to set the memo on",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "igcversion-1046930_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_1046930",
+      "method": "GET",
+      "path": "/IGCVersion_1046930/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-1046930_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_1046930",
+      "method": "GET",
+      "path": "/IGCVersion_1046930/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-1269260_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_1269260",
+      "method": "GET",
+      "path": "/IGCVersion_1269260/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-1269260_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_1269260",
+      "method": "GET",
+      "path": "/IGCVersion_1269260/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-1422450_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_1422450",
+      "method": "GET",
+      "path": "/IGCVersion_1422450/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-1422450_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_1422450",
+      "method": "GET",
+      "path": "/IGCVersion_1422450/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-440_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_440",
+      "method": "GET",
+      "path": "/IGCVersion_440/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-440_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_440",
+      "method": "GET",
+      "path": "/IGCVersion_440/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-570_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_570",
+      "method": "GET",
+      "path": "/IGCVersion_570/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-570_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_570",
+      "method": "GET",
+      "path": "/IGCVersion_570/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-583950_get-client-version",
+      "description": "GetClientVersion operation of IGCVersion_583950",
+      "method": "GET",
+      "path": "/IGCVersion_583950/GetClientVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-583950_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_583950",
+      "method": "GET",
+      "path": "/IGCVersion_583950/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "igcversion-730_get-server-version",
+      "description": "GetServerVersion operation of IGCVersion_730",
+      "method": "GET",
+      "path": "/IGCVersion_730/GetServerVersion/v1",
+      "params": []
+    },
+    {
+      "name": "ihelp-request-logs-service_get-application-log-demand",
+      "description": "GetApplicationLogDemand operation of IHelpRequestLogsService",
+      "method": "POST",
+      "path": "/IHelpRequestLogsService/GetApplicationLogDemand/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "Appid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ihelp-request-logs-service_upload-user-application-log",
+      "description": "UploadUserApplicationLog operation of IHelpRequestLogsService",
+      "method": "POST",
+      "path": "/IHelpRequestLogsService/UploadUserApplicationLog/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "Appid",
+          "required": true
+        },
+        {
+          "name": "log_contents",
+          "type": "string",
+          "location": "body",
+          "description": "Log contents",
+          "required": true
+        },
+        {
+          "name": "log_type",
+          "type": "string",
+          "location": "body",
+          "description": "Log type",
+          "required": true
+        },
+        {
+          "name": "request_id",
+          "type": "int",
+          "location": "body",
+          "description": "Request id",
+          "required": true
+        },
+        {
+          "name": "version_string",
+          "type": "string",
+          "location": "body",
+          "description": "Version string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iinventory-service_combine-item-stacks",
+      "description": "CombineItemStacks operation of IInventoryService",
+      "method": "POST",
+      "path": "/IInventoryService/CombineItemStacks/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "Appid",
+          "required": true
+        },
+        {
+          "name": "destitemid",
+          "type": "int",
+          "location": "body",
+          "description": "Destitemid",
+          "required": true
+        },
+        {
+          "name": "fromitemid",
+          "type": "int",
+          "location": "body",
+          "description": "Fromitemid",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "quantity",
+          "type": "int",
+          "location": "body",
+          "description": "Quantity",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "Steamid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iinventory-service_get-price-sheet",
+      "description": "GetPriceSheet operation of IInventoryService",
+      "method": "GET",
+      "path": "/IInventoryService/GetPriceSheet/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "ecurrency",
+          "type": "int",
+          "location": "query",
+          "description": "Ecurrency",
+          "required": true
+        },
+        {
+          "name": "currency_code",
+          "type": "string",
+          "location": "query",
+          "description": "Standard short code of the requested currency (preferred)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iinventory-service_split-item-stack",
+      "description": "SplitItemStack operation of IInventoryService",
+      "method": "POST",
+      "path": "/IInventoryService/SplitItemStack/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "body",
+          "description": "Appid",
+          "required": true
+        },
+        {
+          "name": "itemid",
+          "type": "int",
+          "location": "body",
+          "description": "Itemid",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "quantity",
+          "type": "int",
+          "location": "body",
+          "description": "Quantity",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "Steamid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_get-badges",
+      "description": "GetBadges operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/GetBadges/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_get-community-badge-progress",
+      "description": "GetCommunityBadgeProgress operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/GetCommunityBadgeProgress/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        },
+        {
+          "name": "badgeid",
+          "type": "int",
+          "location": "query",
+          "description": "The badge we're asking about",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_get-owned-games",
+      "description": "GetOwnedGames operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/GetOwnedGames/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        },
+        {
+          "name": "include_appinfo",
+          "type": "bool",
+          "location": "query",
+          "description": "true if we want additional details (name, icon) about each game",
+          "required": true
+        },
+        {
+          "name": "include_played_free_games",
+          "type": "bool",
+          "location": "query",
+          "description": "Free games are excluded by default.  If this is set, free games the user has played will be returned.",
+          "required": true
+        },
+        {
+          "name": "appids_filter",
+          "type": "int",
+          "location": "query",
+          "description": "if set, restricts result set to the passed in apps",
+          "required": true
+        },
+        {
+          "name": "include_free_sub",
+          "type": "bool",
+          "location": "query",
+          "description": "Some games are in the free sub, which are excluded by default.",
+          "required": true
+        },
+        {
+          "name": "skip_unvetted_apps",
+          "type": "bool",
+          "location": "query",
+          "description": "if set, skip unvetted store apps"
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "Will return appinfo in this language",
+          "required": true
+        },
+        {
+          "name": "include_extended_appinfo",
+          "type": "bool",
+          "location": "query",
+          "description": "true if we want even more details (capsule, sortas, and capabilities) about each game.  include_appinfo must also be true.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_get-recently-played-games",
+      "description": "GetRecentlyPlayedGames operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/GetRecentlyPlayedGames/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        },
+        {
+          "name": "count",
+          "type": "int",
+          "location": "query",
+          "description": "The number of games to return (0/unset: all)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_get-steam-level",
+      "description": "GetSteamLevel operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/GetSteamLevel/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_is-playing-shared-game",
+      "description": "IsPlayingSharedGame operation of IPlayerService",
+      "method": "GET",
+      "path": "/IPlayerService/IsPlayingSharedGame/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "The player we're asking about",
+          "required": true
+        },
+        {
+          "name": "appid_playing",
+          "type": "int",
+          "location": "query",
+          "description": "The game player is currently playing",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iplayer-service_record-offline-playtime",
+      "description": "RecordOfflinePlaytime operation of IPlayerService",
+      "method": "POST",
+      "path": "/IPlayerService/RecordOfflinePlaytime/v1",
+      "params": [
+        {
+          "name": "play_sessions",
+          "type": "string",
+          "location": "body",
+          "description": "Play sessions",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "body",
+          "description": "Steamid",
+          "required": true
+        },
+        {
+          "name": "ticket",
+          "type": "string",
+          "location": "body",
+          "description": "Ticket",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "iportal2-leaderboards-620_get-bucketized-data",
+      "description": "GetBucketizedData operation of IPortal2Leaderboards_620",
+      "method": "GET",
+      "path": "/IPortal2Leaderboards_620/GetBucketizedData/v1",
+      "params": [
+        {
+          "name": "leaderboardName",
+          "type": "string",
+          "location": "query",
+          "description": "The leaderboard name to fetch data for.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_get-details",
+      "description": "GetDetails operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/GetDetails/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "publishedfileids",
+          "type": "int",
+          "location": "query",
+          "description": "Set of published file Ids to retrieve details for.",
+          "required": true
+        },
+        {
+          "name": "includetags",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return tag information in the returned details.",
+          "required": true
+        },
+        {
+          "name": "includeadditionalpreviews",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return preview information in the returned details.",
+          "required": true
+        },
+        {
+          "name": "includechildren",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return children in the returned details.",
+          "required": true
+        },
+        {
+          "name": "includekvtags",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return key value tags in the returned details.",
+          "required": true
+        },
+        {
+          "name": "includevotes",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return vote data in the returned details.",
+          "required": true
+        },
+        {
+          "name": "short_description",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return a short description instead of the full description.",
+          "required": true
+        },
+        {
+          "name": "includeforsaledata",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, return pricing data, if applicable.",
+          "required": true
+        },
+        {
+          "name": "includemetadata",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, populate the metadata field.",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "query",
+          "description": "Specifies the localized text to return. Defaults to English."
+        },
+        {
+          "name": "return_playtime_stats",
+          "type": "int",
+          "location": "query",
+          "description": "Return playtime stats for the specified number of days before today.",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "Appid",
+          "required": true
+        },
+        {
+          "name": "strip_description_bbcode",
+          "type": "bool",
+          "location": "query",
+          "description": "Strips BBCode from descriptions.",
+          "required": true
+        },
+        {
+          "name": "desired_revision",
+          "type": "string",
+          "location": "query",
+          "description": "Return the data for the specified revision."
+        },
+        {
+          "name": "includereactions",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, then reactions to items will be returned."
+        },
+        {
+          "name": "admin_query",
+          "type": "bool",
+          "location": "query",
+          "description": "Admin tool is doing a query, return hidden items",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_get-sub-section-data",
+      "description": "GetSubSectionData operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/GetSubSectionData/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "publishedfileid",
+          "type": "int",
+          "location": "query",
+          "description": "Publishedfileid",
+          "required": true
+        },
+        {
+          "name": "for_table_of_contents",
+          "type": "bool",
+          "location": "query",
+          "description": "For table of contents",
+          "required": true
+        },
+        {
+          "name": "specific_sectionid",
+          "type": "int",
+          "location": "query",
+          "description": "Specific sectionid",
+          "required": true
+        },
+        {
+          "name": "desired_revision",
+          "type": "string",
+          "location": "query",
+          "description": "Return the data for the specified revision."
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_get-user-file-count",
+      "description": "GetUserFileCount operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/GetUserFileCount/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "Steam ID of the user whose files are being requested.",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "App Id of the app that the files were published to.",
+          "required": true
+        },
+        {
+          "name": "shortcutid",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) Shortcut Id to retrieve published files from.",
+          "required": true
+        },
+        {
+          "name": "page",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) Starting page for results."
+        },
+        {
+          "name": "numperpage",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) The number of results, per page to return."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Type of files to be returned."
+        },
+        {
+          "name": "sortmethod",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Sorting method to use on returned values."
+        },
+        {
+          "name": "privacy",
+          "type": "int",
+          "location": "query",
+          "description": "(optional) Filter by privacy settings.",
+          "required": true
+        },
+        {
+          "name": "requiredtags",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Tags that must be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "excludedtags",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Tags that must NOT be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "required_kv_tags",
+          "type": "string",
+          "location": "query",
+          "description": "Required key-value tags to match on.",
+          "required": true
+        },
+        {
+          "name": "filetype",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) File type to match files to.",
+          "required": true
+        },
+        {
+          "name": "creator_appid",
+          "type": "int",
+          "location": "query",
+          "description": "App Id of the app that published the files, only matched if specified.",
+          "required": true
+        },
+        {
+          "name": "match_cloud_filename",
+          "type": "string",
+          "location": "query",
+          "description": "Match this cloud filename if specified.",
+          "required": true
+        },
+        {
+          "name": "cache_max_age_seconds",
+          "type": "int",
+          "location": "query",
+          "description": "Allow stale data to be returned for the specified number of seconds."
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "query",
+          "description": "Specifies the localized text to return. Defaults to English."
+        },
+        {
+          "name": "taggroups",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) At least one of the tags must be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "excluded_content_descriptors",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Filter out items that have these content descriptors.",
+          "required": true
+        },
+        {
+          "name": "admin_query",
+          "type": "bool",
+          "location": "query",
+          "description": "Admin tool is doing a query, return hidden items",
+          "required": true
+        },
+        {
+          "name": "totalonly",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the total number of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "ids_only",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the published file ids of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "return_vote_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return vote data"
+        },
+        {
+          "name": "return_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return tags in the file details",
+          "required": true
+        },
+        {
+          "name": "return_kv_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return key-value tags in the file details"
+        },
+        {
+          "name": "return_previews",
+          "type": "bool",
+          "location": "query",
+          "description": "Return preview image and video details in the file details",
+          "required": true
+        },
+        {
+          "name": "return_children",
+          "type": "bool",
+          "location": "query",
+          "description": "Return child item ids in the file details",
+          "required": true
+        },
+        {
+          "name": "return_short_description",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the short_description field instead of file_description"
+        },
+        {
+          "name": "return_for_sale_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return pricing information, if applicable",
+          "required": true
+        },
+        {
+          "name": "return_metadata",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the metadata field"
+        },
+        {
+          "name": "return_playtime_stats",
+          "type": "int",
+          "location": "query",
+          "description": "Return playtime stats for the specified number of days before today.",
+          "required": true
+        },
+        {
+          "name": "strip_description_bbcode",
+          "type": "bool",
+          "location": "query",
+          "description": "Strips BBCode from descriptions.",
+          "required": true
+        },
+        {
+          "name": "return_reactions",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, then reactions to items will be returned."
+        },
+        {
+          "name": "startindex_override",
+          "type": "int",
+          "location": "query",
+          "description": "Backwards compatible for the client.",
+          "required": true
+        },
+        {
+          "name": "desired_revision",
+          "type": "string",
+          "location": "query",
+          "description": "Return the data for the specified revision."
+        },
+        {
+          "name": "return_apps",
+          "type": "bool",
+          "location": "query",
+          "description": "Return list of apps the items belong to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_get-user-files",
+      "description": "GetUserFiles operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/GetUserFiles/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "Steam ID of the user whose files are being requested.",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "App Id of the app that the files were published to.",
+          "required": true
+        },
+        {
+          "name": "shortcutid",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) Shortcut Id to retrieve published files from.",
+          "required": true
+        },
+        {
+          "name": "page",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) Starting page for results."
+        },
+        {
+          "name": "numperpage",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) The number of results, per page to return."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Type of files to be returned."
+        },
+        {
+          "name": "sortmethod",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Sorting method to use on returned values."
+        },
+        {
+          "name": "privacy",
+          "type": "int",
+          "location": "query",
+          "description": "(optional) Filter by privacy settings.",
+          "required": true
+        },
+        {
+          "name": "requiredtags",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Tags that must be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "excludedtags",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Tags that must NOT be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "required_kv_tags",
+          "type": "string",
+          "location": "query",
+          "description": "Required key-value tags to match on.",
+          "required": true
+        },
+        {
+          "name": "filetype",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) File type to match files to.",
+          "required": true
+        },
+        {
+          "name": "creator_appid",
+          "type": "int",
+          "location": "query",
+          "description": "App Id of the app that published the files, only matched if specified.",
+          "required": true
+        },
+        {
+          "name": "match_cloud_filename",
+          "type": "string",
+          "location": "query",
+          "description": "Match this cloud filename if specified.",
+          "required": true
+        },
+        {
+          "name": "cache_max_age_seconds",
+          "type": "int",
+          "location": "query",
+          "description": "Allow stale data to be returned for the specified number of seconds."
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "query",
+          "description": "Specifies the localized text to return. Defaults to English."
+        },
+        {
+          "name": "taggroups",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) At least one of the tags must be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "excluded_content_descriptors",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Filter out items that have these content descriptors.",
+          "required": true
+        },
+        {
+          "name": "admin_query",
+          "type": "bool",
+          "location": "query",
+          "description": "Admin tool is doing a query, return hidden items",
+          "required": true
+        },
+        {
+          "name": "totalonly",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the total number of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "ids_only",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the published file ids of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "return_vote_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return vote data"
+        },
+        {
+          "name": "return_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return tags in the file details",
+          "required": true
+        },
+        {
+          "name": "return_kv_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return key-value tags in the file details"
+        },
+        {
+          "name": "return_previews",
+          "type": "bool",
+          "location": "query",
+          "description": "Return preview image and video details in the file details",
+          "required": true
+        },
+        {
+          "name": "return_children",
+          "type": "bool",
+          "location": "query",
+          "description": "Return child item ids in the file details",
+          "required": true
+        },
+        {
+          "name": "return_short_description",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the short_description field instead of file_description"
+        },
+        {
+          "name": "return_for_sale_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return pricing information, if applicable",
+          "required": true
+        },
+        {
+          "name": "return_metadata",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the metadata field"
+        },
+        {
+          "name": "return_playtime_stats",
+          "type": "int",
+          "location": "query",
+          "description": "Return playtime stats for the specified number of days before today.",
+          "required": true
+        },
+        {
+          "name": "strip_description_bbcode",
+          "type": "bool",
+          "location": "query",
+          "description": "Strips BBCode from descriptions.",
+          "required": true
+        },
+        {
+          "name": "return_reactions",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, then reactions to items will be returned."
+        },
+        {
+          "name": "startindex_override",
+          "type": "int",
+          "location": "query",
+          "description": "Backwards compatible for the client.",
+          "required": true
+        },
+        {
+          "name": "desired_revision",
+          "type": "string",
+          "location": "query",
+          "description": "Return the data for the specified revision."
+        },
+        {
+          "name": "return_apps",
+          "type": "bool",
+          "location": "query",
+          "description": "Return list of apps the items belong to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_get-user-vote-summary",
+      "description": "GetUserVoteSummary operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/GetUserVoteSummary/v1",
+      "params": [
+        {
+          "name": "publishedfileids",
+          "type": "int",
+          "location": "query",
+          "description": "Publishedfileids",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ipublished-file-service_query-files",
+      "description": "QueryFiles operation of IPublishedFileService",
+      "method": "GET",
+      "path": "/IPublishedFileService/QueryFiles/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Access key",
+          "required": true
+        },
+        {
+          "name": "query_type",
+          "type": "int",
+          "location": "query",
+          "description": "enumeration EPublishedFileQueryType in clientenums.h",
+          "required": true
+        },
+        {
+          "name": "page",
+          "type": "int",
+          "location": "query",
+          "description": "Current page",
+          "required": true
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "location": "query",
+          "description": "Cursor to paginate through the results (set to '*' for the first request).  Prefer this over using the page parameter, as it will allow you to do deep pagination.  When used, the page parameter will be ignored.",
+          "required": true
+        },
+        {
+          "name": "numperpage",
+          "type": "int",
+          "location": "query",
+          "description": "(Optional) The number of results, per page to return."
+        },
+        {
+          "name": "creator_appid",
+          "type": "int",
+          "location": "query",
+          "description": "App that created the files",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "App that consumes the files",
+          "required": true
+        },
+        {
+          "name": "requiredtags",
+          "type": "string",
+          "location": "query",
+          "description": "Tags to match on. See match_all_tags parameter below",
+          "required": true
+        },
+        {
+          "name": "excludedtags",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Tags that must NOT be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "match_all_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, then items must have all the tags specified, otherwise they must have at least one of the tags."
+        },
+        {
+          "name": "required_flags",
+          "type": "string",
+          "location": "query",
+          "description": "Required flags that must be set on any returned items",
+          "required": true
+        },
+        {
+          "name": "omitted_flags",
+          "type": "string",
+          "location": "query",
+          "description": "Flags that must not be set on any returned items",
+          "required": true
+        },
+        {
+          "name": "search_text",
+          "type": "string",
+          "location": "query",
+          "description": "Text to match in the item's title or description",
+          "required": true
+        },
+        {
+          "name": "filetype",
+          "type": "int",
+          "location": "query",
+          "description": "EPublishedFileInfoMatchingFileType",
+          "required": true
+        },
+        {
+          "name": "child_publishedfileid",
+          "type": "int",
+          "location": "query",
+          "description": "Find all items that reference the given item.",
+          "required": true
+        },
+        {
+          "name": "days",
+          "type": "int",
+          "location": "query",
+          "description": "If query_type is k_PublishedFileQueryType_RankedByTrend, then this is the number of days to get votes for [1,7].",
+          "required": true
+        },
+        {
+          "name": "include_recent_votes_only",
+          "type": "bool",
+          "location": "query",
+          "description": "If query_type is k_PublishedFileQueryType_RankedByTrend, then limit result set just to items that have votes within the day range given",
+          "required": true
+        },
+        {
+          "name": "cache_max_age_seconds",
+          "type": "int",
+          "location": "query",
+          "description": "Allow stale data to be returned for the specified number of seconds."
+        },
+        {
+          "name": "language",
+          "type": "int",
+          "location": "query",
+          "description": "Language to search in and also what gets returned. Defaults to English."
+        },
+        {
+          "name": "required_kv_tags",
+          "type": "string",
+          "location": "query",
+          "description": "Required key-value tags to match on.",
+          "required": true
+        },
+        {
+          "name": "taggroups",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) At least one of the tags must be present on a published file to satisfy the query.",
+          "required": true
+        },
+        {
+          "name": "date_range_created",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Filter to items created within this range.",
+          "required": true
+        },
+        {
+          "name": "date_range_updated",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Filter to items updated within this range.",
+          "required": true
+        },
+        {
+          "name": "excluded_content_descriptors",
+          "type": "string",
+          "location": "query",
+          "description": "(Optional) Filter out items that have these content descriptors.",
+          "required": true
+        },
+        {
+          "name": "admin_query",
+          "type": "bool",
+          "location": "query",
+          "description": "Admin tool is doing a query, return hidden items",
+          "required": true
+        },
+        {
+          "name": "special_filter",
+          "type": "string",
+          "location": "query",
+          "description": "Additional special filtering",
+          "required": true
+        },
+        {
+          "name": "totalonly",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the total number of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "ids_only",
+          "type": "bool",
+          "location": "query",
+          "description": "(Optional) If true, only return the published file ids of files that satisfy this query.",
+          "required": true
+        },
+        {
+          "name": "return_vote_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return vote data",
+          "required": true
+        },
+        {
+          "name": "return_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return tags in the file details",
+          "required": true
+        },
+        {
+          "name": "return_kv_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Return key-value tags in the file details",
+          "required": true
+        },
+        {
+          "name": "return_previews",
+          "type": "bool",
+          "location": "query",
+          "description": "Return preview image and video details in the file details",
+          "required": true
+        },
+        {
+          "name": "return_children",
+          "type": "bool",
+          "location": "query",
+          "description": "Return child item ids in the file details",
+          "required": true
+        },
+        {
+          "name": "return_short_description",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the short_description field instead of file_description",
+          "required": true
+        },
+        {
+          "name": "return_for_sale_data",
+          "type": "bool",
+          "location": "query",
+          "description": "Return pricing information, if applicable",
+          "required": true
+        },
+        {
+          "name": "return_metadata",
+          "type": "bool",
+          "location": "query",
+          "description": "Populate the metadata"
+        },
+        {
+          "name": "return_playtime_stats",
+          "type": "int",
+          "location": "query",
+          "description": "Return playtime stats for the specified number of days before today.",
+          "required": true
+        },
+        {
+          "name": "return_details",
+          "type": "bool",
+          "location": "query",
+          "description": "By default, if none of the other 'return_*' fields are set, only some voting details are returned. Set this to true to return the default set of details.",
+          "required": true
+        },
+        {
+          "name": "strip_description_bbcode",
+          "type": "bool",
+          "location": "query",
+          "description": "Strips BBCode from descriptions.",
+          "required": true
+        },
+        {
+          "name": "desired_revision",
+          "type": "string",
+          "location": "query",
+          "description": "Return the data for the specified revision."
+        },
+        {
+          "name": "return_reactions",
+          "type": "bool",
+          "location": "query",
+          "description": "If true, then reactions to items will be returned."
+        }
+      ]
+    },
+    {
+      "name": "isteam-apps_get-sdrconfig",
+      "description": "GetSDRConfig operation of ISteamApps",
+      "method": "GET",
+      "path": "/ISteamApps/GetSDRConfig/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID of game",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-apps_get-servers-at-address",
+      "description": "GetServersAtAddress operation of ISteamApps",
+      "method": "GET",
+      "path": "/ISteamApps/GetServersAtAddress/v1",
+      "params": [
+        {
+          "name": "addr",
+          "type": "string",
+          "location": "query",
+          "description": "IP or IP:queryport to list",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-apps_up-to-date-check",
+      "description": "UpToDateCheck operation of ISteamApps",
+      "method": "GET",
+      "path": "/ISteamApps/UpToDateCheck/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID of game",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "int",
+          "location": "query",
+          "description": "The installed version of the game",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-broadcast_player-stats",
+      "description": "PlayerStats operation of ISteamBroadcast",
+      "method": "POST",
+      "path": "/ISteamBroadcast/PlayerStats/v1",
+      "params": []
+    },
+    {
+      "name": "isteam-broadcast_viewer-heartbeat",
+      "description": "ViewerHeartbeat operation of ISteamBroadcast",
+      "method": "GET",
+      "path": "/ISteamBroadcast/ViewerHeartbeat/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "Steam ID of the broadcaster",
+          "required": true
+        },
+        {
+          "name": "sessionid",
+          "type": "int",
+          "location": "query",
+          "description": "Broadcast Session ID",
+          "required": true
+        },
+        {
+          "name": "token",
+          "type": "int",
+          "location": "query",
+          "description": "Viewer token",
+          "required": true
+        },
+        {
+          "name": "stream",
+          "type": "int",
+          "location": "query",
+          "description": "video stream representation watching"
+        }
+      ]
+    },
+    {
+      "name": "isteam-cdn_set-client-filters",
+      "description": "SetClientFilters operation of ISteamCDN",
+      "method": "POST",
+      "path": "/ISteamCDN/SetClientFilters/v1",
+      "params": [
+        {
+          "name": "allowedasns",
+          "type": "string",
+          "location": "body",
+          "description": "comma-separated list of allowed client network AS numbers - blank for not used"
+        },
+        {
+          "name": "allowedipblocks",
+          "type": "string",
+          "location": "body",
+          "description": "comma-separated list of allowed IP address blocks in CIDR format - blank for not used"
+        },
+        {
+          "name": "allowedipcountries",
+          "type": "string",
+          "location": "body",
+          "description": "comma-separated list of allowed client IP country codes in ISO 3166-1 format - blank for not used"
+        },
+        {
+          "name": "cdnname",
+          "type": "string",
+          "location": "body",
+          "description": "Steam name of CDN property",
+          "required": true
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "access key",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-cdn_set-performance-stats",
+      "description": "SetPerformanceStats operation of ISteamCDN",
+      "method": "POST",
+      "path": "/ISteamCDN/SetPerformanceStats/v1",
+      "params": [
+        {
+          "name": "cache_hit_percent",
+          "type": "int",
+          "location": "body",
+          "description": "Percent cache hits"
+        },
+        {
+          "name": "cdnname",
+          "type": "string",
+          "location": "body",
+          "description": "Steam name of CDN property",
+          "required": true
+        },
+        {
+          "name": "cpu_percent",
+          "type": "int",
+          "location": "body",
+          "description": "Percent CPU load"
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "location": "body",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "mbps_recv",
+          "type": "int",
+          "location": "body",
+          "description": "Incoming network traffic in Mbps"
+        },
+        {
+          "name": "mbps_sent",
+          "type": "int",
+          "location": "body",
+          "description": "Outgoing network traffic in Mbps"
+        }
+      ]
+    },
+    {
+      "name": "isteam-directory_get-cmlist",
+      "description": "GetCMList operation of ISteamDirectory",
+      "method": "GET",
+      "path": "/ISteamDirectory/GetCMList/v1",
+      "params": [
+        {
+          "name": "cellid",
+          "type": "int",
+          "location": "query",
+          "description": "Client's Steam cell ID",
+          "required": true
+        },
+        {
+          "name": "maxcount",
+          "type": "int",
+          "location": "query",
+          "description": "Max number of servers to return"
+        }
+      ]
+    },
+    {
+      "name": "isteam-directory_get-cmlist-for-connect",
+      "description": "GetCMListForConnect operation of ISteamDirectory",
+      "method": "GET",
+      "path": "/ISteamDirectory/GetCMListForConnect/v1",
+      "params": [
+        {
+          "name": "cellid",
+          "type": "int",
+          "location": "query",
+          "description": "Client's Steam cell ID, uses IP location if blank"
+        },
+        {
+          "name": "cmtype",
+          "type": "string",
+          "location": "query",
+          "description": "Optional CM type filter"
+        },
+        {
+          "name": "realm",
+          "type": "string",
+          "location": "query",
+          "description": "Optional Steam Realm filter"
+        },
+        {
+          "name": "maxcount",
+          "type": "int",
+          "location": "query",
+          "description": "Max number of servers to return"
+        },
+        {
+          "name": "qoslevel",
+          "type": "int",
+          "location": "query",
+          "description": "Desired connection priority"
+        }
+      ]
+    },
+    {
+      "name": "isteam-directory_get-steam-pipe-domains",
+      "description": "GetSteamPipeDomains operation of ISteamDirectory",
+      "method": "GET",
+      "path": "/ISteamDirectory/GetSteamPipeDomains/v1",
+      "params": []
+    },
+    {
+      "name": "isteam-economy_get-asset-class-info",
+      "description": "GetAssetClassInfo operation of ISteamEconomy",
+      "method": "GET",
+      "path": "/ISteamEconomy/GetAssetClassInfo/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "Must be a steam economy app.",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The user's local language"
+        },
+        {
+          "name": "class_count",
+          "type": "int",
+          "location": "query",
+          "description": "Number of classes requested. Must be at least one.",
+          "required": true
+        },
+        {
+          "name": "classid0",
+          "type": "int",
+          "location": "query",
+          "description": "Class ID of the nth class.",
+          "required": true
+        },
+        {
+          "name": "instanceid0",
+          "type": "int",
+          "location": "query",
+          "description": "Instance ID of the nth class."
+        }
+      ]
+    },
+    {
+      "name": "isteam-economy_get-asset-prices",
+      "description": "GetAssetPrices operation of ISteamEconomy",
+      "method": "GET",
+      "path": "/ISteamEconomy/GetAssetPrices/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "Must be a steam economy app.",
+          "required": true
+        },
+        {
+          "name": "currency",
+          "type": "string",
+          "location": "query",
+          "description": "The currency to filter for"
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "The user's local language"
+        }
+      ]
+    },
+    {
+      "name": "isteam-news_get-news-for-app",
+      "description": "GetNewsForApp operation of ISteamNews",
+      "method": "GET",
+      "path": "/ISteamNews/GetNewsForApp/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID to retrieve news for",
+          "required": true
+        },
+        {
+          "name": "maxlength",
+          "type": "int",
+          "location": "query",
+          "description": "Maximum length for the content to return, if this is 0 the full content is returned, if it's less then a blurb is generated to fit."
+        },
+        {
+          "name": "enddate",
+          "type": "int",
+          "location": "query",
+          "description": "Retrieve posts earlier than this date (unix epoch timestamp)"
+        },
+        {
+          "name": "count",
+          "type": "int",
+          "location": "query",
+          "description": "# of posts to retrieve (default 20)"
+        },
+        {
+          "name": "tags",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-separated list of tags to filter by (e.g. 'patchnodes')"
+        }
+      ]
+    },
+    {
+      "name": "isteam-news_get-news-for-app-isteamnews",
+      "description": "GetNewsForApp operation of ISteamNews",
+      "method": "GET",
+      "path": "/ISteamNews/GetNewsForApp/v2",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID to retrieve news for",
+          "required": true
+        },
+        {
+          "name": "maxlength",
+          "type": "int",
+          "location": "query",
+          "description": "Maximum length for the content to return, if this is 0 the full content is returned, if it's less then a blurb is generated to fit."
+        },
+        {
+          "name": "enddate",
+          "type": "int",
+          "location": "query",
+          "description": "Retrieve posts earlier than this date (unix epoch timestamp)"
+        },
+        {
+          "name": "count",
+          "type": "int",
+          "location": "query",
+          "description": "# of posts to retrieve (default 20)"
+        },
+        {
+          "name": "feeds",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-separated list of feed names to return news for"
+        },
+        {
+          "name": "tags",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-separated list of tags to filter by (e.g. 'patchnodes')"
+        }
+      ]
+    },
+    {
+      "name": "isteam-remote-storage_get-collection-details",
+      "description": "GetCollectionDetails operation of ISteamRemoteStorage",
+      "method": "POST",
+      "path": "/ISteamRemoteStorage/GetCollectionDetails/v1",
+      "params": [
+        {
+          "name": "collectioncount",
+          "type": "int",
+          "location": "body",
+          "description": "Number of collections being requested",
+          "required": true
+        },
+        {
+          "name": "publishedfileids[0]",
+          "type": "int",
+          "location": "body",
+          "description": "collection ids to get the details for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-remote-storage_get-published-file-details",
+      "description": "GetPublishedFileDetails operation of ISteamRemoteStorage",
+      "method": "POST",
+      "path": "/ISteamRemoteStorage/GetPublishedFileDetails/v1",
+      "params": [
+        {
+          "name": "itemcount",
+          "type": "int",
+          "location": "body",
+          "description": "Number of items being requested",
+          "required": true
+        },
+        {
+          "name": "publishedfileids[0]",
+          "type": "int",
+          "location": "body",
+          "description": "published file id to look up",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-remote-storage_get-ugcfile-details",
+      "description": "GetUGCFileDetails operation of ISteamRemoteStorage",
+      "method": "GET",
+      "path": "/ISteamRemoteStorage/GetUGCFileDetails/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "If specified, only returns details if the file is owned by the SteamID specified"
+        },
+        {
+          "name": "ugcid",
+          "type": "int",
+          "location": "query",
+          "description": "ID of UGC file to get info for",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appID of product",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_get-friend-list",
+      "description": "GetFriendList operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/GetFriendList/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "SteamID of user",
+          "required": true
+        },
+        {
+          "name": "relationship",
+          "type": "string",
+          "location": "query",
+          "description": "relationship type (ex: friend)"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_get-player-bans",
+      "description": "GetPlayerBans operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/GetPlayerBans/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamids",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-delimited list of SteamIDs",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_get-player-summaries",
+      "description": "GetPlayerSummaries operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/GetPlayerSummaries/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamids",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-delimited list of SteamIDs",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_get-player-summaries-isteamuser",
+      "description": "GetPlayerSummaries operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/GetPlayerSummaries/v2",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamids",
+          "type": "string",
+          "location": "query",
+          "description": "Comma-delimited list of SteamIDs (max: 100)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_get-user-group-list",
+      "description": "GetUserGroupList operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/GetUserGroupList/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "SteamID of user",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user_resolve-vanity-url",
+      "description": "ResolveVanityURL operation of ISteamUser",
+      "method": "GET",
+      "path": "/ISteamUser/ResolveVanityURL/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "vanityurl",
+          "type": "string",
+          "location": "query",
+          "description": "The vanity URL to get a SteamID for",
+          "required": true
+        },
+        {
+          "name": "url_type",
+          "type": "int",
+          "location": "query",
+          "description": "The type of vanity URL. 1 (default): Individual profile, 2: Group, 3: Official game group"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-auth_authenticate-user-ticket",
+      "description": "AuthenticateUserTicket operation of ISteamUserAuth",
+      "method": "GET",
+      "path": "/ISteamUserAuth/AuthenticateUserTicket/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appid of game",
+          "required": true
+        },
+        {
+          "name": "ticket",
+          "type": "string",
+          "location": "query",
+          "description": "Ticket from GetAuthSessionTicket.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-oauth_get-token-details",
+      "description": "GetTokenDetails operation of ISteamUserOAuth",
+      "method": "GET",
+      "path": "/ISteamUserOAuth/GetTokenDetails/v1",
+      "params": [
+        {
+          "name": "access_token",
+          "type": "string",
+          "location": "query",
+          "description": "OAuth2 token for which to return details",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-global-achievement-percentages-for-app",
+      "description": "GetGlobalAchievementPercentagesForApp operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v1",
+      "params": [
+        {
+          "name": "gameid",
+          "type": "int",
+          "location": "query",
+          "description": "GameID to retrieve the achievement percentages for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-global-achievement-percentages-for-app-isteamuserstats",
+      "description": "GetGlobalAchievementPercentagesForApp operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2",
+      "params": [
+        {
+          "name": "gameid",
+          "type": "int",
+          "location": "query",
+          "description": "GameID to retrieve the achievement percentages for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-global-stats-for-game",
+      "description": "GetGlobalStatsForGame operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetGlobalStatsForGame/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID that we're getting global stats for",
+          "required": true
+        },
+        {
+          "name": "count",
+          "type": "int",
+          "location": "query",
+          "description": "Number of stats get data for",
+          "required": true
+        },
+        {
+          "name": "name[0]",
+          "type": "string",
+          "location": "query",
+          "description": "Names of stat to get data for",
+          "required": true
+        },
+        {
+          "name": "startdate",
+          "type": "int",
+          "location": "query",
+          "description": "Start date for daily totals (unix epoch timestamp)"
+        },
+        {
+          "name": "enddate",
+          "type": "int",
+          "location": "query",
+          "description": "End date for daily totals (unix epoch timestamp)"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-number-of-current-players",
+      "description": "GetNumberOfCurrentPlayers operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetNumberOfCurrentPlayers/v1",
+      "params": [
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID that we're getting user count for",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-player-achievements",
+      "description": "GetPlayerAchievements operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetPlayerAchievements/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "SteamID of user",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "AppID to get achievements for",
+          "required": true
+        },
+        {
+          "name": "l",
+          "type": "string",
+          "location": "query",
+          "description": "Language to return strings for"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-schema-for-game",
+      "description": "GetSchemaForGame operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetSchemaForGame/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appid of game",
+          "required": true
+        },
+        {
+          "name": "l",
+          "type": "string",
+          "location": "query",
+          "description": "localized langauge to return (english, french, etc.)"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-schema-for-game-isteamuserstats",
+      "description": "GetSchemaForGame operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetSchemaForGame/v2",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appid of game",
+          "required": true
+        },
+        {
+          "name": "l",
+          "type": "string",
+          "location": "query",
+          "description": "localized language to return (english, french, etc.)"
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-user-stats-for-game",
+      "description": "GetUserStatsForGame operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetUserStatsForGame/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "SteamID of user",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appid of game",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-user-stats_get-user-stats-for-game-isteamuserstats",
+      "description": "GetUserStatsForGame operation of ISteamUserStats",
+      "method": "GET",
+      "path": "/ISteamUserStats/GetUserStatsForGame/v2",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key",
+          "required": true
+        },
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "SteamID of user",
+          "required": true
+        },
+        {
+          "name": "appid",
+          "type": "int",
+          "location": "query",
+          "description": "appid of game",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "isteam-web-apiutil_get-server-info",
+      "description": "GetServerInfo operation of ISteamWebAPIUtil",
+      "method": "GET",
+      "path": "/ISteamWebAPIUtil/GetServerInfo/v1",
+      "params": []
+    },
+    {
+      "name": "isteam-web-apiutil_get-supported-apilist",
+      "description": "GetSupportedAPIList operation of ISteamWebAPIUtil",
+      "method": "GET",
+      "path": "/ISteamWebAPIUtil/GetSupportedAPIList/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "access key"
+        }
+      ]
+    },
+    {
+      "name": "istore-service_get-app-list",
+      "description": "Gets a list of all apps available on the Steam Store",
+      "method": "GET",
+      "path": "/IStoreService/GetAppList/v1",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "location": "query",
+          "description": "Steam Web API key",
+          "required": true
+        },
+        {
+          "name": "max_results",
+          "type": "int",
+          "location": "query",
+          "description": "Maximum number of results to return"
+        },
+        {
+          "name": "last_appid",
+          "type": "int",
+          "location": "query",
+          "description": "Cursor for pagination — pass the last appid from previous page"
+        }
+      ]
+    },
+    {
+      "name": "istore-service_get-games-followed",
+      "description": "GetGamesFollowed operation of IStoreService",
+      "method": "GET",
+      "path": "/IStoreService/GetGamesFollowed/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "Steamid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "istore-service_get-games-followed-count",
+      "description": "GetGamesFollowedCount operation of IStoreService",
+      "method": "GET",
+      "path": "/IStoreService/GetGamesFollowedCount/v1",
+      "params": [
+        {
+          "name": "steamid",
+          "type": "int",
+          "location": "query",
+          "description": "Steamid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "istore-service_get-recommended-tags-for-user",
+      "description": "GetRecommendedTagsForUser operation of IStoreService",
+      "method": "GET",
+      "path": "/IStoreService/GetRecommendedTagsForUser/v1",
+      "params": [
+        {
+          "name": "language",
+          "type": "string",
+          "location": "query",
+          "description": "Language",
+          "required": true
+        },
+        {
+          "name": "country_code",
+          "type": "string",
+          "location": "query",
+          "description": "Country code",
+          "required": true
+        },
+        {
+          "name": "favor_rarer_tags",
+          "type": "bool",
+          "location": "query",
+          "description": "Biases tags towards tags that are less common. e.g. Favor Zombies over Action if the user plays the same number of games with both tags.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "itfitems-440_get-golden-wrenches",
+      "description": "GetGoldenWrenches operation of ITFItems_440",
+      "method": "GET",
+      "path": "/ITFItems_440/GetGoldenWrenches/v1",
+      "params": []
+    },
+    {
+      "name": "itfitems-440_get-golden-wrenches-itfitems440",
+      "description": "GetGoldenWrenches operation of ITFItems_440",
+      "method": "GET",
+      "path": "/ITFItems_440/GetGoldenWrenches/v2",
+      "params": []
+    }
+  ]
+}

--- a/library/other/pagliacci-pizza-pp-cli/tools-manifest.json
+++ b/library/other/pagliacci-pizza-pp-cli/tools-manifest.json
@@ -1,0 +1,687 @@
+{
+  "api_name": "pagliacci-pizza",
+  "base_url": "https://pag-api.azurewebsites.net/api",
+  "description": "REST API for Pagliacci Pizza - Seattle's favorite pizza. Browse stores, menus, slices, time windows, manage rewards, view order history, and place orders. Authenticated endpoints use the custom PagliacciAuth scheme with a required Version-Num header.",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "api_key",
+    "header": "Authorization",
+    "in": "header",
+    "env_vars": [
+      "PAGLIACCI_PIZZA_PAGLIACCI_AUTH"
+    ]
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "access-device_get",
+      "description": "Get device access info (requires API key)",
+      "method": "GET",
+      "path": "/AccessDevice",
+      "params": []
+    },
+    {
+      "name": "address-info_lookup-address",
+      "description": "Validate and look up a delivery address",
+      "method": "POST",
+      "path": "/AddressInfo",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "Address",
+          "type": "string",
+          "location": "body",
+          "description": "Address"
+        },
+        {
+          "name": "City",
+          "type": "string",
+          "location": "body",
+          "description": "City"
+        },
+        {
+          "name": "State",
+          "type": "string",
+          "location": "body",
+          "description": "State"
+        },
+        {
+          "name": "Zip",
+          "type": "string",
+          "location": "body",
+          "description": "Zip"
+        }
+      ]
+    },
+    {
+      "name": "address-name_list-saved-addresses",
+      "description": "List saved delivery addresses (requires API key)",
+      "method": "GET",
+      "path": "/AddressName",
+      "params": []
+    },
+    {
+      "name": "customer_get",
+      "description": "Get customer profile (requires API key)",
+      "method": "GET",
+      "path": "/Customer/{customerId}",
+      "params": [
+        {
+          "name": "customerId",
+          "type": "int",
+          "location": "path",
+          "description": "Customer ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "feedback_submit",
+      "description": "Submit customer feedback",
+      "method": "POST",
+      "path": "/Feedback",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "Email",
+          "type": "string",
+          "location": "body",
+          "description": "Email"
+        },
+        {
+          "name": "Message",
+          "type": "string",
+          "location": "body",
+          "description": "Message"
+        },
+        {
+          "name": "Name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "OrderId",
+          "type": "int",
+          "location": "body",
+          "description": "Order id"
+        },
+        {
+          "name": "StoreId",
+          "type": "int",
+          "location": "body",
+          "description": "Store id"
+        }
+      ]
+    },
+    {
+      "name": "login_login",
+      "description": "Log in to account",
+      "method": "POST",
+      "path": "/Login",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "Password",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "logout_logout",
+      "description": "Log out of account (requires API key)",
+      "method": "POST",
+      "path": "/Logout",
+      "params": []
+    },
+    {
+      "name": "menu-cache_get",
+      "description": "Get full cached menu",
+      "method": "GET",
+      "path": "/MenuCache/{storeId}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "menu-slices_list",
+      "description": "List available pizza slices",
+      "method": "GET",
+      "path": "/MenuSlices",
+      "no_auth": true,
+      "params": []
+    },
+    {
+      "name": "menu-top_get",
+      "description": "Get featured menu items",
+      "method": "GET",
+      "path": "/MenuTop/{storeId}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "migrate-answer_migrate_answer",
+      "description": "Answer account migration question",
+      "method": "POST",
+      "path": "/MigrateAnswer",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "answer",
+          "type": "string",
+          "location": "body",
+          "description": "Answer",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "migrate-question_migrate_question",
+      "description": "Get account migration question",
+      "method": "POST",
+      "path": "/MigrateQuestion",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "order-list_list-orders",
+      "description": "List order history (paginated) (requires API key)",
+      "method": "GET",
+      "path": "/OrderList/{page}/{pageSize}",
+      "params": [
+        {
+          "name": "page",
+          "type": "int",
+          "location": "query",
+          "description": "Page number (1-based)"
+        },
+        {
+          "name": "pageSize",
+          "type": "int",
+          "location": "query",
+          "description": "Number of orders per page"
+        }
+      ]
+    },
+    {
+      "name": "order-list-item_get-order-details",
+      "description": "Get specific order details (requires API key)",
+      "method": "GET",
+      "path": "/OrderListItem/{orderId}",
+      "params": [
+        {
+          "name": "orderId",
+          "type": "int",
+          "location": "path",
+          "description": "Order ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "order-list-pending_list-pending-orders",
+      "description": "List active/pending orders (requires API key)",
+      "method": "GET",
+      "path": "/OrderListPending",
+      "params": []
+    },
+    {
+      "name": "order-price_price-order",
+      "description": "Price an order (requires API key)",
+      "method": "POST",
+      "path": "/OrderPrice",
+      "params": [
+        {
+          "name": "ServiceType",
+          "type": "string",
+          "location": "body",
+          "description": "Service type"
+        },
+        {
+          "name": "StoreId",
+          "type": "int",
+          "location": "body",
+          "description": "Store id"
+        }
+      ]
+    },
+    {
+      "name": "order-price_price-order-guest",
+      "description": "Price an order as guest",
+      "method": "POST",
+      "path": "/OrderPrice/guest",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "ServiceType",
+          "type": "string",
+          "location": "body",
+          "description": "Service type"
+        },
+        {
+          "name": "StoreId",
+          "type": "int",
+          "location": "body",
+          "description": "Store id"
+        }
+      ]
+    },
+    {
+      "name": "order-send_send-order",
+      "description": "Submit an order (requires API key)",
+      "method": "POST",
+      "path": "/OrderSend",
+      "params": [
+        {
+          "name": "DeliveryAddress",
+          "type": "string",
+          "location": "body",
+          "description": "Delivery address"
+        },
+        {
+          "name": "PaymentMethod",
+          "type": "string",
+          "location": "body",
+          "description": "Payment method"
+        },
+        {
+          "name": "ServiceType",
+          "type": "string",
+          "location": "body",
+          "description": "Service type"
+        },
+        {
+          "name": "StoreId",
+          "type": "int",
+          "location": "body",
+          "description": "Store id"
+        },
+        {
+          "name": "TimeWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Time window"
+        },
+        {
+          "name": "Tip",
+          "type": "float",
+          "location": "body",
+          "description": "Tip"
+        }
+      ]
+    },
+    {
+      "name": "order-send_verify-order",
+      "description": "Verify an order before submission (requires API key)",
+      "method": "POST",
+      "path": "/OrderSend/verify",
+      "params": [
+        {
+          "name": "DeliveryAddress",
+          "type": "string",
+          "location": "body",
+          "description": "Delivery address"
+        },
+        {
+          "name": "PaymentMethod",
+          "type": "string",
+          "location": "body",
+          "description": "Payment method"
+        },
+        {
+          "name": "ServiceType",
+          "type": "string",
+          "location": "body",
+          "description": "Service type"
+        },
+        {
+          "name": "StoreId",
+          "type": "int",
+          "location": "body",
+          "description": "Store id"
+        },
+        {
+          "name": "TimeWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Time window"
+        },
+        {
+          "name": "Tip",
+          "type": "float",
+          "location": "body",
+          "description": "Tip"
+        }
+      ]
+    },
+    {
+      "name": "order-suggestion_get",
+      "description": "Get suggested orders (requires API key)",
+      "method": "GET",
+      "path": "/OrderSuggestion",
+      "params": []
+    },
+    {
+      "name": "password-forgot_forgot-password",
+      "description": "Request password reset email",
+      "method": "POST",
+      "path": "/PasswordForgot",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "password-reset_reset-password",
+      "description": "Reset password",
+      "method": "POST",
+      "path": "/PasswordReset",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "newPassword",
+          "type": "string",
+          "location": "body",
+          "description": "New password",
+          "required": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "location": "body",
+          "description": "Token",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "product-price_get",
+      "description": "Get product pricing",
+      "method": "GET",
+      "path": "/ProductPrice",
+      "no_auth": true,
+      "params": []
+    },
+    {
+      "name": "quote-building_get",
+      "description": "Get delivery building quote (requires API key)",
+      "method": "GET",
+      "path": "/QuoteBuilding/{buildingId}",
+      "params": [
+        {
+          "name": "buildingId",
+          "type": "int",
+          "location": "path",
+          "description": "Building ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "quote-store_get",
+      "description": "Get store-specific pricing",
+      "method": "GET",
+      "path": "/QuoteStore/{storeId}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "quote-store_list",
+      "description": "List store availability and pricing",
+      "method": "GET",
+      "path": "/QuoteStore",
+      "no_auth": true,
+      "params": []
+    },
+    {
+      "name": "register_register",
+      "description": "Create a new account",
+      "method": "POST",
+      "path": "/Register",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        },
+        {
+          "name": "firstName",
+          "type": "string",
+          "location": "body",
+          "description": "First name",
+          "required": true
+        },
+        {
+          "name": "lastName",
+          "type": "string",
+          "location": "body",
+          "description": "Last name",
+          "required": true
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "Password",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "Phone"
+        }
+      ]
+    },
+    {
+      "name": "reward-card_get",
+      "description": "Get loyalty rewards card (requires API key)",
+      "method": "GET",
+      "path": "/RewardCard",
+      "params": []
+    },
+    {
+      "name": "site-wide-message_get",
+      "description": "Get system-wide message",
+      "method": "GET",
+      "path": "/SiteWideMessage",
+      "no_auth": true,
+      "params": []
+    },
+    {
+      "name": "store_list",
+      "description": "List all Pagliacci Pizza stores",
+      "method": "GET",
+      "path": "/Store",
+      "no_auth": true,
+      "params": []
+    },
+    {
+      "name": "stored-coupons_list",
+      "description": "List saved coupons (requires API key)",
+      "method": "GET",
+      "path": "/StoredCoupons",
+      "params": []
+    },
+    {
+      "name": "stored-credit_get",
+      "description": "Get account credit balance (requires API key)",
+      "method": "GET",
+      "path": "/StoredCredit",
+      "params": []
+    },
+    {
+      "name": "stored-gift_get",
+      "description": "Get gift card info (requires API key)",
+      "method": "GET",
+      "path": "/StoredGift",
+      "params": []
+    },
+    {
+      "name": "time-window-days_get",
+      "description": "Get available days for service",
+      "method": "GET",
+      "path": "/TimeWindowDays/{storeId}/{serviceType}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        },
+        {
+          "name": "serviceType",
+          "type": "string",
+          "location": "query",
+          "description": "Service type: PICK for pickup, DEL for delivery"
+        }
+      ]
+    },
+    {
+      "name": "time-windows_get-by-date",
+      "description": "Get time slots for a specific day",
+      "method": "GET",
+      "path": "/TimeWindows/{storeId}/{serviceType}/{date}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        },
+        {
+          "name": "serviceType",
+          "type": "string",
+          "location": "query",
+          "description": "Service type: PICK for pickup, DEL for delivery"
+        },
+        {
+          "name": "date",
+          "type": "string",
+          "location": "query",
+          "description": "Date in YYYYMMDD format",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "time-windows_get-today",
+      "description": "Get today's time slots",
+      "method": "GET",
+      "path": "/TimeWindows/{storeId}/{serviceType}",
+      "no_auth": true,
+      "params": [
+        {
+          "name": "storeId",
+          "type": "int",
+          "location": "path",
+          "description": "Store ID",
+          "required": true
+        },
+        {
+          "name": "serviceType",
+          "type": "string",
+          "location": "query",
+          "description": "Service type: PICK for pickup, DEL for delivery"
+        }
+      ]
+    },
+    {
+      "name": "transfer-gift_transfer_gift",
+      "description": "Transfer a gift card (requires API key)",
+      "method": "POST",
+      "path": "/TransferGift",
+      "params": [
+        {
+          "name": "amount",
+          "type": "float",
+          "location": "body",
+          "description": "Amount to transfer (omit for full balance)"
+        },
+        {
+          "name": "cardNumber",
+          "type": "string",
+          "location": "body",
+          "description": "Card number",
+          "required": true
+        },
+        {
+          "name": "recipientEmail",
+          "type": "string",
+          "location": "body",
+          "description": "Recipient email",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "version_get",
+      "description": "Get API version",
+      "method": "GET",
+      "path": "/Version",
+      "no_auth": true,
+      "params": []
+    }
+  ]
+}

--- a/library/productivity/cal-com-pp-cli/tools-manifest.json
+++ b/library/productivity/cal-com-pp-cli/tools-manifest.json
@@ -1,0 +1,10934 @@
+{
+  "api_name": "cal-com",
+  "base_url": "https://api.cal.com",
+  "description": "Cal.com v2 API — scheduling infrastructure. Authenticate with a Bearer token (API key from Settings \u003e Developer \u003e API Keys). Supports per-endpoint versioning via cal-api-version header.",
+  "mcp_ready": "full",
+  "auth": {
+    "type": "bearer_token",
+    "header": "Authorization",
+    "env_vars": [
+      "CAL_COM_TOKEN"
+    ]
+  },
+  "required_headers": [],
+  "tools": [
+    {
+      "name": "api-keys_keys-refresh",
+      "description": "Refresh API Key",
+      "method": "POST",
+      "path": "/v2/api-keys/refresh",
+      "params": [
+        {
+          "name": "apiKeyDaysValid",
+          "type": "float",
+          "location": "body",
+          "description": "For how many days is managed organization api key valid. Defaults to 30 days."
+        },
+        {
+          "name": "apiKeyNeverExpires",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, organization api key never expires."
+        }
+      ]
+    },
+    {
+      "name": "auth_oauth2-get-client",
+      "description": "Get OAuth2 client",
+      "method": "GET",
+      "path": "/v2/auth/oauth2/clients/{clientId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "auth_oauth2-token",
+      "description": "Exchange authorization code or refresh token for tokens",
+      "method": "POST",
+      "path": "/v2/auth/oauth2/token",
+      "params": []
+    },
+    {
+      "name": "bookings_create",
+      "description": "Create a booking",
+      "method": "POST",
+      "path": "/v2/bookings",
+      "params": []
+    },
+    {
+      "name": "bookings_get",
+      "description": "Get all bookings",
+      "method": "GET",
+      "path": "/v2/bookings",
+      "params": [
+        {
+          "name": "status",
+          "type": "array",
+          "location": "query",
+          "description": "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma."
+        },
+        {
+          "name": "attendeeEmail",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's email address."
+        },
+        {
+          "name": "attendeeName",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's name."
+        },
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the booking Uid."
+        },
+        {
+          "name": "eventTypeIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type ids belonging to the user. Event type ids must be separated by a comma."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type id belonging to the user."
+        },
+        {
+          "name": "teamsIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team ids that user is part of. Team ids must be separated by a comma."
+        },
+        {
+          "name": "teamId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team id that user is part of"
+        },
+        {
+          "name": "afterStart",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with start after this date string."
+        },
+        {
+          "name": "beforeEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with end before this date string."
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created after this date string."
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created before this date string."
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated after this date string."
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated before this date string."
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "sortCreated",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their creation time (when booking was made) in ascending or descending order."
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their updated time (for example when booking status changes) in ascending or descending order."
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "bookings_get-bookinguid",
+      "description": "Get a booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_get-by-seat-uid",
+      "description": "Get a booking by seat UID",
+      "method": "GET",
+      "path": "/v2/bookings/by-seat/{seatUid}",
+      "params": [
+        {
+          "name": "seatUid",
+          "type": "string",
+          "location": "path",
+          "description": "Seat uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_attendees_booking-add",
+      "description": "Add an attendee to a booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/attendees",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "The email of the attendee.",
+          "required": true
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "location": "body",
+          "description": "The preferred language of the attendee. Used for booking confirmation."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "The name of the attendee.",
+          "required": true
+        },
+        {
+          "name": "phoneNumber",
+          "type": "string",
+          "location": "body",
+          "description": "The phone number of the attendee in international format."
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "The time zone of the attendee.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_attendees_booking-get-booking",
+      "description": "Get all attendees for a booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/attendees",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_attendees_booking-get-booking-bookings",
+      "description": "Get a specific attendee for a booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/attendees/{attendeeId}",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "attendeeId",
+          "type": "float",
+          "location": "path",
+          "description": "Attendee id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_calendar-links_bookings-get",
+      "description": "Get 'Add to Calendar' links for a booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/calendar-links",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_cancel_bookings-booking",
+      "description": "Cancel a booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/cancel",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_conferencing-sessions_bookings-get-video-sessions",
+      "description": "Get Video Meeting Sessions. Only supported for Cal Video",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/conferencing-sessions",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_confirm_bookings-booking",
+      "description": "Confirm a booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/confirm",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_decline_bookings-booking",
+      "description": "Decline a booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/decline",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "location": "body",
+          "description": "Reason for declining a booking that requires a confirmation"
+        }
+      ]
+    },
+    {
+      "name": "bookings_guests_booking-add",
+      "description": "Add guests to an existing booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/guests",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_location_booking-update-booking",
+      "description": "Update booking location for an existing booking",
+      "method": "PATCH",
+      "path": "/v2/bookings/{bookingUid}/location",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "location",
+          "type": "string",
+          "location": "body",
+          "description": "One of the event type locations. If instead of passing one of the location objects as required by schema you are still passing a string please use an object."
+        }
+      ]
+    },
+    {
+      "name": "bookings_mark-absent_bookings-mark-no-show",
+      "description": "Mark a booking absence",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/mark-absent",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "host",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether the host was absent"
+        }
+      ]
+    },
+    {
+      "name": "bookings_reassign_bookings-booking",
+      "description": "Reassign a booking to auto-selected host",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/reassign",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_reassign_bookings-booking-to-user",
+      "description": "Reassign a booking to a specific host",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/reassign/{userId}",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "location": "body",
+          "description": "Reason for reassigning the booking"
+        }
+      ]
+    },
+    {
+      "name": "bookings_recordings_bookings-get-booking",
+      "description": "Get all the recordings for the booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/recordings",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_references_bookings-get-booking",
+      "description": "Get booking references",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/references",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "query",
+          "description": "Filter booking references by type"
+        }
+      ]
+    },
+    {
+      "name": "bookings_reschedule_bookings-booking",
+      "description": "Reschedule a booking",
+      "method": "POST",
+      "path": "/v2/bookings/{bookingUid}/reschedule",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "bookings_transcripts_bookings-get-booking",
+      "description": "Get Cal Video real time transcript download links for the booking",
+      "method": "GET",
+      "path": "/v2/bookings/{bookingUid}/transcripts",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-create-connection-event",
+      "description": "Create event on a connection",
+      "method": "POST",
+      "path": "/v2/calendars/connections/{connectionId}/events",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Connection id",
+          "required": true
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar id"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the event"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title of the calendar event",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-delete-connection-event",
+      "description": "Delete event for a connection",
+      "method": "DELETE",
+      "path": "/v2/calendars/connections/{connectionId}/events/{eventId}",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Connection id",
+          "required": true
+        },
+        {
+          "name": "eventId",
+          "type": "string",
+          "location": "path",
+          "description": "Event id",
+          "required": true
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar id"
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-get-connection-event",
+      "description": "Get event for a connection",
+      "method": "GET",
+      "path": "/v2/calendars/connections/{connectionId}/events/{eventId}",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Connection id",
+          "required": true
+        },
+        {
+          "name": "eventId",
+          "type": "string",
+          "location": "path",
+          "description": "Event id",
+          "required": true
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar id"
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-get-connection-free-busy",
+      "description": "Get free/busy for a connection",
+      "method": "GET",
+      "path": "/v2/calendars/connections/{connectionId}/freebusy",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Connection id",
+          "required": true
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "location": "query",
+          "description": "Start of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "location": "query",
+          "description": "End of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "IANA time zone (e.g. America/New_York)"
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-list-connection-events",
+      "description": "List events for a connection",
+      "method": "GET",
+      "path": "/v2/calendars/connections/{connectionId}/events",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Calendar connection ID from GET /connections",
+          "required": true
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "location": "query",
+          "description": "Start of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "location": "query",
+          "description": "End of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "IANA time zone for the request (e.g. America/New_York)"
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar ID. Use 'primary' for the user's primary calendar, or the external ID of a connected calendar."
+        }
+      ]
+    },
+    {
+      "name": "calendars_cal-unified-list-connections",
+      "description": "List calendar connections",
+      "method": "GET",
+      "path": "/v2/calendars/connections",
+      "params": []
+    },
+    {
+      "name": "calendars_cal-unified-update-connection-event",
+      "description": "Update event for a connection",
+      "method": "PATCH",
+      "path": "/v2/calendars/connections/{connectionId}/events/{eventId}",
+      "params": [
+        {
+          "name": "connectionId",
+          "type": "string",
+          "location": "path",
+          "description": "Connection id",
+          "required": true
+        },
+        {
+          "name": "eventId",
+          "type": "string",
+          "location": "path",
+          "description": "Event id",
+          "required": true
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar id"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Detailed description of the calendar event"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "body",
+          "description": "Status of the event (accepted, pending, declined, cancelled)"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title of the calendar event"
+        }
+      ]
+    },
+    {
+      "name": "calendars_check-ics-feed",
+      "description": "Check an ICS feed",
+      "method": "GET",
+      "path": "/v2/calendars/ics-feed/check",
+      "params": []
+    },
+    {
+      "name": "calendars_create-ics-feed",
+      "description": "Save an ICS feed",
+      "method": "POST",
+      "path": "/v2/calendars/ics-feed/save",
+      "params": [
+        {
+          "name": "readOnly",
+          "type": "bool",
+          "location": "body",
+          "description": "Whether to allowing writing to the calendar or not"
+        },
+        {
+          "name": "urls",
+          "type": "array",
+          "location": "body",
+          "description": "An array of ICS URLs",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_get",
+      "description": "Get all calendars",
+      "method": "GET",
+      "path": "/v2/calendars",
+      "params": []
+    },
+    {
+      "name": "calendars_get-busy-times",
+      "description": "Get busy times",
+      "method": "GET",
+      "path": "/v2/calendars/busy-times",
+      "params": [
+        {
+          "name": "loggedInUsersTz",
+          "type": "string",
+          "location": "query",
+          "description": "Deprecated: Use timeZone instead. The timezone of the user represented as a string"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "The timezone for the busy times query represented as a string"
+        },
+        {
+          "name": "dateFrom",
+          "type": "string",
+          "location": "query",
+          "description": "The starting date for the busy times query"
+        },
+        {
+          "name": "dateTo",
+          "type": "string",
+          "location": "query",
+          "description": "The ending date for the busy times query"
+        },
+        {
+          "name": "credentialId",
+          "type": "float",
+          "location": "query",
+          "description": "Credential id",
+          "required": true
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "External id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_check_calendars",
+      "description": "Check a calendar connection",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/check",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        }
+      ]
+    },
+    {
+      "name": "calendars_connect_calendars-redirect",
+      "description": "Get OAuth connect URL",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/connect",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "isDryRun",
+          "type": "bool",
+          "location": "query",
+          "description": "Is dry run",
+          "required": true
+        },
+        {
+          "name": "redir",
+          "type": "string",
+          "location": "query",
+          "description": "Redirect URL after successful calendar authorization."
+        }
+      ]
+    },
+    {
+      "name": "calendars_credentials_calendars-sync",
+      "description": "Save Apple calendar credentials",
+      "method": "POST",
+      "path": "/v2/calendars/{calendar}/credentials",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "location": "body",
+          "description": "Password",
+          "required": true
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "location": "body",
+          "description": "Username",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_disconnect_calendars-delete-calendar-credentials",
+      "description": "Disconnect a calendar",
+      "method": "POST",
+      "path": "/v2/calendars/{calendar}/disconnect",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "id",
+          "type": "int",
+          "location": "body",
+          "description": "Credential ID of the calendar to delete, as returned by the /calendars endpoint",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_event_cal-unified-calendars-get-calendar-details",
+      "description": "Get meeting details from calendar",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/event/{eventUid}",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "eventUid",
+          "type": "string",
+          "location": "path",
+          "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: https://cal.com/docs/api-reference/v2/orgs-teams-bookings/get-booking-references-for-a-booking\n\n- For user events: https://cal.com/docs/api-reference/v2/bookings/get-booking-references-for-a-booking",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_event_cal-unified-calendars-update-calendar",
+      "description": "Update meeting details in calendar",
+      "method": "PATCH",
+      "path": "/v2/calendars/{calendar}/event/{eventUid}",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "eventUid",
+          "type": "string",
+          "location": "path",
+          "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: https://cal.com/docs/api-reference/v2/orgs-teams-bookings/get-booking-references-for-a-booking\n\n- For user events: https://cal.com/docs/api-reference/v2/bookings/get-booking-references-for-a-booking",
+          "required": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Detailed description of the calendar event"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "body",
+          "description": "Status of the event (accepted, pending, declined, cancelled)"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title of the calendar event"
+        }
+      ]
+    },
+    {
+      "name": "calendars_events_cal-unified-calendars-create-calendar",
+      "description": "Create a calendar event",
+      "method": "POST",
+      "path": "/v2/calendars/{calendar}/events",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the event"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title of the calendar event",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_events_cal-unified-calendars-delete-calendar",
+      "description": "Delete a calendar event",
+      "method": "DELETE",
+      "path": "/v2/calendars/{calendar}/events/{eventUid}",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "eventUid",
+          "type": "string",
+          "location": "path",
+          "description": "The calendar provider's event ID (e.g. Google Calendar event ID)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_events_cal-unified-calendars-get-calendar-details",
+      "description": "Get meeting details from calendar",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/events/{eventUid}",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "eventUid",
+          "type": "string",
+          "location": "path",
+          "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: https://cal.com/docs/api-reference/v2/orgs-teams-bookings/get-booking-references-for-a-booking\n\n- For user events: https://cal.com/docs/api-reference/v2/bookings/get-booking-references-for-a-booking",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "calendars_events_cal-unified-calendars-list-calendar",
+      "description": "List calendar events",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/events",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "location": "query",
+          "description": "Start of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "location": "query",
+          "description": "End of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "IANA time zone for the request (e.g. America/New_York)"
+        },
+        {
+          "name": "calendarId",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar ID. Use 'primary' for the user's primary calendar, or the external ID of a connected calendar."
+        }
+      ]
+    },
+    {
+      "name": "calendars_events_cal-unified-calendars-update-calendar",
+      "description": "Update meeting details in calendar",
+      "method": "PATCH",
+      "path": "/v2/calendars/{calendar}/events/{eventUid}",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "eventUid",
+          "type": "string",
+          "location": "path",
+          "description": "The Google Calendar event ID. You can retrieve this by getting booking references from the following endpoints:\n\n- For team events: https://cal.com/docs/api-reference/v2/orgs-teams-bookings/get-booking-references-for-a-booking\n\n- For user events: https://cal.com/docs/api-reference/v2/bookings/get-booking-references-for-a-booking",
+          "required": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Detailed description of the calendar event"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "location": "body",
+          "description": "Status of the event (accepted, pending, declined, cancelled)"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title of the calendar event"
+        }
+      ]
+    },
+    {
+      "name": "calendars_freebusy_cal-unified-calendars-get-free-busy",
+      "description": "Get free/busy times",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/freebusy",
+      "params": [
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "location": "query",
+          "description": "Start of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "location": "query",
+          "description": "End of the date range (ISO 8601 date or date-time)",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "IANA time zone (e.g. America/New_York)"
+        }
+      ]
+    },
+    {
+      "name": "calendars_save_calendars",
+      "description": "Save Google or Outlook calendar credentials",
+      "method": "GET",
+      "path": "/v2/calendars/{calendar}/save",
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
+          "location": "query",
+          "description": "State",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "query",
+          "description": "Code",
+          "required": true
+        },
+        {
+          "name": "calendar",
+          "type": "string",
+          "location": "query",
+          "description": "Calendar"
+        }
+      ]
+    },
+    {
+      "name": "conferencing_get-default",
+      "description": "Get your default conferencing application",
+      "method": "GET",
+      "path": "/v2/conferencing/default",
+      "params": []
+    },
+    {
+      "name": "conferencing_list-installed-apps",
+      "description": "List your conferencing applications",
+      "method": "GET",
+      "path": "/v2/conferencing",
+      "params": []
+    },
+    {
+      "name": "conferencing_connect_conferencing",
+      "description": "Connect your conferencing application",
+      "method": "POST",
+      "path": "/v2/conferencing/{app}/connect",
+      "params": [
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        }
+      ]
+    },
+    {
+      "name": "conferencing_default_conferencing",
+      "description": "Set your default conferencing application",
+      "method": "POST",
+      "path": "/v2/conferencing/{app}/default",
+      "params": [
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        }
+      ]
+    },
+    {
+      "name": "conferencing_disconnect_conferencing",
+      "description": "Disconnect your conferencing application",
+      "method": "DELETE",
+      "path": "/v2/conferencing/{app}/disconnect",
+      "params": [
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        }
+      ]
+    },
+    {
+      "name": "conferencing_oauth_conferencing-redirect",
+      "description": "Get OAuth conferencing app auth URL",
+      "method": "GET",
+      "path": "/v2/conferencing/{app}/oauth/auth-url",
+      "params": [
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        },
+        {
+          "name": "returnTo",
+          "type": "string",
+          "location": "query",
+          "description": "Return to",
+          "required": true
+        },
+        {
+          "name": "onErrorReturnTo",
+          "type": "string",
+          "location": "query",
+          "description": "On error return to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "conferencing_oauth_conferencing-save",
+      "description": "Conferencing app OAuth callback",
+      "method": "GET",
+      "path": "/v2/conferencing/{app}/oauth/callback",
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
+          "location": "query",
+          "description": "State",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "query",
+          "description": "Code",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "destination-calendars_update",
+      "description": "Update destination calendars",
+      "method": "PUT",
+      "path": "/v2/destination-calendars",
+      "params": [
+        {
+          "name": "delegationCredentialId",
+          "type": "string",
+          "location": "body",
+          "description": "Delegation credential id"
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "Unique identifier used to represent the specific calendar, as returned by the /calendars endpoint",
+          "required": true
+        },
+        {
+          "name": "integration",
+          "type": "string",
+          "location": "body",
+          "description": "The calendar service you want to integrate, as returned by the /calendars endpoint",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_create",
+      "description": "Create an event type",
+      "method": "POST",
+      "path": "/v2/event-types",
+      "params": [
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes",
+          "required": true
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug",
+          "required": true
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title",
+          "required": true
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "event-types_delete",
+      "description": "Delete an event type",
+      "method": "DELETE",
+      "path": "/v2/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_get",
+      "description": "Get all event types",
+      "method": "GET",
+      "path": "/v2/event-types",
+      "params": [
+        {
+          "name": "username",
+          "type": "string",
+          "location": "query",
+          "description": "The username of the user to get event types for. If only username provided will get all event types."
+        },
+        {
+          "name": "eventSlug",
+          "type": "string",
+          "location": "query",
+          "description": "Slug of event type to return. Notably, if eventSlug is provided then username must be provided too, because multiple users can have event with same slug."
+        },
+        {
+          "name": "usernames",
+          "type": "string",
+          "location": "query",
+          "description": "Get dynamic event type for multiple usernames separated by comma. e.g `usernames=alice,bob`"
+        },
+        {
+          "name": "orgSlug",
+          "type": "string",
+          "location": "query",
+          "description": "slug of the user's organization if he is in one, orgId is not required if using this parameter"
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "query",
+          "description": "ID of the organization of the user you want the get the event-types of, orgSlug is not needed when using this parameter"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort event types by creation date. When not provided, no explicit ordering is applied."
+        }
+      ]
+    },
+    {
+      "name": "event-types_get-by-id",
+      "description": "Get an event type",
+      "method": "GET",
+      "path": "/v2/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_update",
+      "description": "Update an event type",
+      "method": "PATCH",
+      "path": "/v2/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes"
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug"
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title"
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "event-types_private-links_event-types-create",
+      "description": "Create a private link for an event type",
+      "method": "POST",
+      "path": "/v2/event-types/{eventTypeId}/private-links",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "Expiration date for time-based links"
+        },
+        {
+          "name": "maxUsageCount",
+          "type": "float",
+          "location": "body",
+          "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use)."
+        }
+      ]
+    },
+    {
+      "name": "event-types_private-links_event-types-delete",
+      "description": "Delete a private link for an event type",
+      "method": "DELETE",
+      "path": "/v2/event-types/{eventTypeId}/private-links/{linkId}",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "Link id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_private-links_event-types-get",
+      "description": "Get all private links for an event type",
+      "method": "GET",
+      "path": "/v2/event-types/{eventTypeId}/private-links",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_private-links_event-types-update",
+      "description": "Update a private link for an event type",
+      "method": "PATCH",
+      "path": "/v2/event-types/{eventTypeId}/private-links/{linkId}",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "Link id",
+          "required": true
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "New expiration date for time-based links"
+        },
+        {
+          "name": "maxUsageCount",
+          "type": "float",
+          "location": "body",
+          "description": "New maximum number of times the link can be used"
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-create-event-type",
+      "description": "Create a webhook",
+      "method": "POST",
+      "path": "/v2/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active",
+          "required": true
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url",
+          "required": true
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-delete-all-event-type",
+      "description": "Delete all webhooks",
+      "method": "DELETE",
+      "path": "/v2/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-delete-event-type",
+      "description": "Delete a webhook",
+      "method": "DELETE",
+      "path": "/v2/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-get-event-type",
+      "description": "Get all webhooks",
+      "method": "GET",
+      "path": "/v2/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-get-event-type-eventtypes",
+      "description": "Get a webhook",
+      "method": "GET",
+      "path": "/v2/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "event-types_webhooks_event-type-update-event-type",
+      "description": "Update a webhook",
+      "method": "PATCH",
+      "path": "/v2/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active"
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url"
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "me_get",
+      "description": "Get my profile",
+      "method": "GET",
+      "path": "/v2/me",
+      "params": []
+    },
+    {
+      "name": "me_update",
+      "description": "Update my profile",
+      "method": "PATCH",
+      "path": "/v2/me",
+      "params": [
+        {
+          "name": "avatarUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the user's avatar image"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "defaultScheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "Default schedule id"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "location": "body",
+          "description": "Locale"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Must be 12 or 24"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Time zone"
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "oauth_refresh_oauth-flow-tokens",
+      "description": "Refresh managed user tokens",
+      "method": "POST",
+      "path": "/v2/oauth/{clientId}/refresh",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "refreshToken",
+          "type": "string",
+          "location": "body",
+          "description": "Managed user's refresh token.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_create",
+      "description": "Create an OAuth client",
+      "method": "POST",
+      "path": "/v2/oauth-clients",
+      "params": [
+        {
+          "name": "areCalendarEventsEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "If true and if managed user has calendar connected, calendar events will be created. Disable it if you manually create calendar events. Default to true."
+        },
+        {
+          "name": "areDefaultEventTypesEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, when creating a managed user the managed user will have 4 default event types: 30 and 60 minutes without Cal video, 30 and 60 minutes with Cal video. Set this as false if you want to create a managed user and then manually create event types for the user."
+        },
+        {
+          "name": "areEmailsEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "Are emails enabled"
+        },
+        {
+          "name": "bookingCancelRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking cancel redirect uri"
+        },
+        {
+          "name": "bookingRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking redirect uri"
+        },
+        {
+          "name": "bookingRescheduleRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking reschedule redirect uri"
+        },
+        {
+          "name": "logo",
+          "type": "string",
+          "location": "body",
+          "description": "Logo"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Array of permission keys like [\"BOOKING_READ\", \"BOOKING_WRITE\"]. Use [\"*\"] to grant all permissions.",
+          "required": true
+        },
+        {
+          "name": "redirectUris",
+          "type": "array",
+          "location": "body",
+          "description": "Redirect uris",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_delete",
+      "description": "Delete an OAuth client",
+      "method": "DELETE",
+      "path": "/v2/oauth-clients/{clientId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_get",
+      "description": "Get all OAuth clients",
+      "method": "GET",
+      "path": "/v2/oauth-clients",
+      "params": []
+    },
+    {
+      "name": "oauth-clients_get-by-id",
+      "description": "Get an OAuth client",
+      "method": "GET",
+      "path": "/v2/oauth-clients/{clientId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_update",
+      "description": "Update an OAuth client",
+      "method": "PATCH",
+      "path": "/v2/oauth-clients/{clientId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "areCalendarEventsEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "If true and if managed user has calendar connected, calendar events will be created. Disable it if you manually create calendar events. Default to true."
+        },
+        {
+          "name": "areDefaultEventTypesEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, when creating a managed user the managed user will have 4 default event types: 30 and 60 minutes without Cal video, 30 and 60 minutes with Cal video. Set this as false if you want to create a managed user and then manually create event types for the user."
+        },
+        {
+          "name": "areEmailsEnabled",
+          "type": "bool",
+          "location": "body",
+          "description": "Are emails enabled"
+        },
+        {
+          "name": "bookingCancelRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking cancel redirect uri"
+        },
+        {
+          "name": "bookingRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking redirect uri"
+        },
+        {
+          "name": "bookingRescheduleRedirectUri",
+          "type": "string",
+          "location": "body",
+          "description": "Booking reschedule redirect uri"
+        },
+        {
+          "name": "logo",
+          "type": "string",
+          "location": "body",
+          "description": "Logo"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "redirectUris",
+          "type": "array",
+          "location": "body",
+          "description": "Redirect uris"
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-create",
+      "description": "Create a managed user",
+      "method": "POST",
+      "path": "/v2/oauth-clients/{clientId}/users",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "avatarUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the user's avatar image"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email",
+          "required": true
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "location": "body",
+          "description": "Locale"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Managed user's name is used in emails",
+          "required": true
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Must be a number 12 or 24"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to create user's default schedule from Monday to Friday from 9AM to 5PM. If it is not passed then user does not have\n      a default schedule and it must be created manually via the /schedules endpoint. Until the schedule is created, the user can't access availability atom to set his / her availability nor booked.\n      It will default to Europe/London if not passed."
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-delete",
+      "description": "Delete a managed user",
+      "method": "DELETE",
+      "path": "/v2/oauth-clients/{clientId}/users/{userId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-force-refresh",
+      "description": "Force refresh tokens",
+      "method": "POST",
+      "path": "/v2/oauth-clients/{clientId}/users/{userId}/force-refresh",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-get-by-id",
+      "description": "Get a managed user",
+      "method": "GET",
+      "path": "/v2/oauth-clients/{clientId}/users/{userId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-get-managed",
+      "description": "Get all managed users",
+      "method": "GET",
+      "path": "/v2/oauth-clients/{clientId}/users",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "limit",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "offset",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        },
+        {
+          "name": "emails",
+          "type": "array",
+          "location": "query",
+          "description": "Filter managed users by email. If you want to filter by multiple emails, separate them with a comma."
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_users_oauth-client-update",
+      "description": "Update a managed user",
+      "method": "PATCH",
+      "path": "/v2/oauth-clients/{clientId}/users/{userId}",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "avatarUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the user's avatar image"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "defaultScheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "Default schedule id"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "location": "body",
+          "description": "Locale"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Must be 12 or 24"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Time zone"
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-create-oauth-client",
+      "description": "Create a webhook",
+      "method": "POST",
+      "path": "/v2/oauth-clients/{clientId}/webhooks",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active",
+          "required": true
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url",
+          "required": true
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-delete-all-oauth-client",
+      "description": "Delete all webhooks",
+      "method": "DELETE",
+      "path": "/v2/oauth-clients/{clientId}/webhooks",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-delete-oauth-client",
+      "description": "Delete a webhook",
+      "method": "DELETE",
+      "path": "/v2/oauth-clients/{clientId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-get-oauth-client",
+      "description": "Get all webhooks",
+      "method": "GET",
+      "path": "/v2/oauth-clients/{clientId}/webhooks",
+      "params": [
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-get-oauth-client-oauthclients",
+      "description": "Get a webhook",
+      "method": "GET",
+      "path": "/v2/oauth-clients/{clientId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-clients_webhooks_oauth-client-update-oauth-client",
+      "description": "Update a webhook",
+      "method": "PATCH",
+      "path": "/v2/oauth-clients/{clientId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "clientId",
+          "type": "string",
+          "location": "path",
+          "description": "Client id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active"
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url"
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-create-organization",
+      "description": "Create an attribute",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/attributes",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "enabled",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabled"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug",
+          "required": true
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "body",
+          "description": "Type",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-delete-organization",
+      "description": "Delete an attribute",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-get-organization",
+      "description": "Get all attributes",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-get-organization-organizations",
+      "description": "Get an attribute",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-assign-organization-option-to-user",
+      "description": "Assign an attribute to a user",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/attributes/options/{userId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "body",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "attributeOptionId",
+          "type": "string",
+          "location": "body",
+          "description": "Attribute option id"
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "location": "body",
+          "description": "Value"
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-create-organization-option",
+      "description": "Create an attribute option",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}/options",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug",
+          "required": true
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "location": "body",
+          "description": "Value",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-delete-organization-option",
+      "description": "Delete an attribute option",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}/options/{optionId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "optionId",
+          "type": "string",
+          "location": "path",
+          "description": "Option id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-get-organization-assigned-options",
+      "description": "Get all assigned attribute options by attribute ID",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}/options/assigned",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "assignedOptionIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by assigned attribute option ids. ids must be separated by a comma."
+        },
+        {
+          "name": "teamIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by teamIds. Team ids must be separated by a comma."
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-get-organization-assigned-options-by-slug",
+      "description": "Get all assigned attribute options by attribute slug",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes/slugs/{attributeSlug}/options/assigned",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeSlug",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute slug",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "assignedOptionIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by assigned attribute option ids. ids must be separated by a comma."
+        },
+        {
+          "name": "teamIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by teamIds. Team ids must be separated by a comma."
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-get-organization-options",
+      "description": "Get all attribute options",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}/options",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-get-organization-options-for-user",
+      "description": "Get all attribute options for a user",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/attributes/options/{userId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-unassign-organization-option-from-user",
+      "description": "Unassign an attribute from a user",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/attributes/options/{userId}/{attributeOptionId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "attributeOptionId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute option id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-options-update-organization-option",
+      "description": "Update an attribute option",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}/options/{optionId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "optionId",
+          "type": "string",
+          "location": "path",
+          "description": "Option id",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug"
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "location": "body",
+          "description": "Value"
+        }
+      ]
+    },
+    {
+      "name": "organizations_attributes_organizations-update-organization",
+      "description": "Update an attribute",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/attributes/{attributeId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "attributeId",
+          "type": "string",
+          "location": "path",
+          "description": "Attribute id",
+          "required": true
+        },
+        {
+          "name": "enabled",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabled"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "body",
+          "description": "Type"
+        }
+      ]
+    },
+    {
+      "name": "organizations_bookings_organizations-get-all-org-team",
+      "description": "Get organization bookings",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/bookings",
+      "params": [
+        {
+          "name": "status",
+          "type": "array",
+          "location": "query",
+          "description": "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma."
+        },
+        {
+          "name": "attendeeEmail",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's email address."
+        },
+        {
+          "name": "attendeeName",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's name."
+        },
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the booking Uid."
+        },
+        {
+          "name": "eventTypeIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type ids belonging to the user. Event type ids must be separated by a comma."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type id belonging to the user."
+        },
+        {
+          "name": "teamsIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team ids that user is part of. Team ids must be separated by a comma."
+        },
+        {
+          "name": "teamId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team id that user is part of"
+        },
+        {
+          "name": "afterStart",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with start after this date string."
+        },
+        {
+          "name": "beforeEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with end before this date string."
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created after this date string."
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created before this date string."
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated after this date string."
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated before this date string."
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "sortCreated",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their creation time (when booking was made) in ascending or descending order."
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their updated time (for example when booking status changes) in ascending or descending order."
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        },
+        {
+          "name": "userIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by ids of users within your organization."
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_delegation-credentials_organizations-create",
+      "description": "Save delegation credentials for your organization",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/delegation-credentials",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "location": "body",
+          "description": "Domain",
+          "required": true
+        },
+        {
+          "name": "workspacePlatformSlug",
+          "type": "string",
+          "location": "body",
+          "description": "Workspace platform slug",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_delegation-credentials_organizations-update",
+      "description": "Update delegation credentials of your organization",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/delegation-credentials/{credentialId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "credentialId",
+          "type": "string",
+          "location": "path",
+          "description": "Credential id",
+          "required": true
+        },
+        {
+          "name": "enabled",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabled"
+        }
+      ]
+    },
+    {
+      "name": "organizations_memberships_organizations-create",
+      "description": "Create a membership",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/memberships",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "If you are platform customer then managed users should only have MEMBER role.",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "body",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_memberships_organizations-delete",
+      "description": "Delete a membership",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_memberships_organizations-get-all",
+      "description": "Get all memberships",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/memberships",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_memberships_organizations-get-org",
+      "description": "Get a membership",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_memberships_organizations-update",
+      "description": "Update a membership",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "Role"
+        }
+      ]
+    },
+    {
+      "name": "organizations_ooo_organizations-users-ooocontroller-get-organization-users",
+      "description": "Get all out-of-office entries for organization users",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/ooo",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "query",
+          "description": "Filter ooo entries by the user email address. user must be within your organization."
+        }
+      ]
+    },
+    {
+      "name": "organizations_organizations_create",
+      "description": "Create an organization within an organization",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/organizations",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "apiKeyDaysValid",
+          "type": "float",
+          "location": "body",
+          "description": "For how many days is managed organization api key valid. Defaults to 30 days."
+        },
+        {
+          "name": "apiKeyNeverExpires",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, organization api key never expires."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the organization",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Organization slug in kebab-case - if not provided will be generated automatically based on name."
+        }
+      ]
+    },
+    {
+      "name": "organizations_organizations_delete",
+      "description": "Delete an organization within an organization",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/organizations/{managedOrganizationId}",
+      "params": [
+        {
+          "name": "managedOrganizationId",
+          "type": "float",
+          "location": "path",
+          "description": "Managed organization id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_organizations_get",
+      "description": "Get all organizations within an organization",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/organizations",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the managed organization"
+        },
+        {
+          "name": "metadataKey",
+          "type": "string",
+          "location": "query",
+          "description": "The key of the metadata - it is case sensitive so provide exactly as stored. If you provide it then you must also provide metadataValue"
+        },
+        {
+          "name": "metadataValue",
+          "type": "string",
+          "location": "query",
+          "description": "The value of the metadata - it is case sensitive so provide exactly as stored. If you provide it then you must also provide metadataKey"
+        }
+      ]
+    },
+    {
+      "name": "organizations_organizations_get-organizations",
+      "description": "Get an organization within an organization",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/organizations/{managedOrganizationId}",
+      "params": [
+        {
+          "name": "managedOrganizationId",
+          "type": "float",
+          "location": "path",
+          "description": "Managed organization id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_organizations_update",
+      "description": "Update an organization within an organization",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/organizations/{managedOrganizationId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "managedOrganizationId",
+          "type": "float",
+          "location": "path",
+          "description": "Managed organization id",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the organization"
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-create",
+      "description": "Create a new organization role",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/roles",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "Color for the role (hex code)"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the role"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the role",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions for this role (format: resource.action). On update, this field replaces the entire permission set for the role (full replace). Use granular permission endpoints for one-by-one changes."
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-delete",
+      "description": "Delete an organization role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-get",
+      "description": "Get a specific organization role",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-get-all",
+      "description": "Get all organization roles",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/roles",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-permissions-add-permissions",
+      "description": "Add permissions to an organization role (single or batch)",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions to add (format: resource.action)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-permissions-list-permissions",
+      "description": "List permissions for an organization role",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-permissions-remove-permission",
+      "description": "Remove a permission from an organization role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}/permissions/{permission}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permission",
+          "type": "string",
+          "location": "path",
+          "description": "Permission",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-permissions-remove-permissions",
+      "description": "Remove multiple permissions from an organization role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "query",
+          "description": "Permissions to remove (format: resource.action). Supports comma-separated values as well as repeated query params."
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-permissions-set-permissions",
+      "description": "Replace all permissions for an organization role",
+      "method": "PUT",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions to add (format: resource.action)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_roles_organizations-update",
+      "description": "Update an organization role",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "Color for the role (hex code)"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the role"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the role"
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions for this role (format: resource.action). On update, this field replaces the entire permission set for the role (full replace). Use granular permission endpoints for one-by-one changes."
+        }
+      ]
+    },
+    {
+      "name": "organizations_routing-forms_organizations-get-organization",
+      "description": "Get organization routing forms",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/routing-forms",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by creation time"
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by update time"
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created before this date"
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses updated before this date"
+        },
+        {
+          "name": "routedToBookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses routed to a specific booking"
+        },
+        {
+          "name": "teamIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by teamIds. Team ids must be separated by a comma."
+        }
+      ]
+    },
+    {
+      "name": "organizations_routing-forms_organizations-responses-create-response",
+      "description": "Create routing form response and get available slots",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/routing-forms/{routingFormId}/responses",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "Time starting from which available slots should be checked.\n    \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to start of day or specify hours:\n      2024-08-13 (will have hours 00:00:00 aka at very beginning of the date) or you can specify hours manually like 2024-08-13T09:00:00Z",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "Time until which available slots should be checked.\n      \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to end of day or specify hours:\n      2024-08-20 (will have hours 23:59:59 aka at the very end of the date) or you can specify hours manually like 2024-08-20T18:00:00Z",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "Time zone in which the available slots should be returned. Defaults to UTC."
+        },
+        {
+          "name": "duration",
+          "type": "float",
+          "location": "query",
+          "description": "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long."
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "location": "query",
+          "description": "Format of slot times in response. Use 'range' to get start and end times."
+        },
+        {
+          "name": "bookingUidToReschedule",
+          "type": "string",
+          "location": "query",
+          "description": "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling."
+        },
+        {
+          "name": "queueResponse",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to queue the form response."
+        }
+      ]
+    },
+    {
+      "name": "organizations_routing-forms_organizations-responses-get-responses",
+      "description": "Get routing form responses",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/routing-forms/{routingFormId}/responses",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by creation time"
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by update time"
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created before this date"
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses updated before this date"
+        },
+        {
+          "name": "routedToBookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses routed to a specific booking"
+        }
+      ]
+    },
+    {
+      "name": "organizations_routing-forms_organizations-responses-update-response",
+      "description": "Update routing form response",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/routing-forms/{routingFormId}/responses/{responseId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "responseId",
+          "type": "float",
+          "location": "path",
+          "description": "Response id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_schedules_organizations-get-organization",
+      "description": "Get all schedules",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/schedules",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-get-verified-email-by-id",
+      "description": "Get verified email of an org team by id",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/emails/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-get-verified-emails",
+      "description": "Get list of verified emails of an org team",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/emails",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-get-verified-phone-by-id",
+      "description": "Get verified phone number of an org team by id",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/phones/{id}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-get-verified-phone-numbers",
+      "description": "Get list of verified phone numbers of an org team",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/phones",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-request-email-verification-code",
+      "description": "Request email verification code",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/emails/verification-code/request",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-request-phone-verification-code",
+      "description": "Request phone number verification code",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/phones/verification-code/request",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "Phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-verify-email",
+      "description": "Verify an email for an org team",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/emails/verification-code/verify",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the email to verify",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_org-verified-resources-verify-phone-number",
+      "description": "Verify a phone number for an org team",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/verified-resources/phones/verification-code/verify",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the phone number to verify",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-create-event-type-workflow",
+      "description": "Create organization team workflow for event-types",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the workflow",
+          "required": true
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "body",
+          "description": "Trigger configuration for the event-type workflow, allowed triggers are beforeEvent,eventCancelled,newEvent,afterEvent,rescheduleEvent,afterHostsCalVideoNoShow,afterGuestsCalVideoNoShow,bookingRejected,bookingRequested,bookingPaymentInitiated,bookingPaid,bookingNoShowUpdated",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-create-form-workflow",
+      "description": "Create organization team workflow for routing-forms",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/routing-form",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the workflow",
+          "required": true
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "body",
+          "description": "Trigger configuration for the routing-form workflow, allowed triggers are formSubmitted,formSubmittedNoEvent",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-delete-routing-form-workflow",
+      "description": "Delete organization team routing-form workflow",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}/routing-form",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-delete-workflow",
+      "description": "Delete organization team workflow",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-get-routing-form-workflow-by-id",
+      "description": "Get organization team workflow",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}/routing-form",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-get-routing-form-workflows",
+      "description": "Get organization team workflows",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/routing-form",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-get-workflow-by-id",
+      "description": "Get organization team workflow",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-get-workflows",
+      "description": "Get organization team workflows",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-update-routing-form-workflow",
+      "description": "Update organization routing form team workflow",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}/routing-form",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the workflow"
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "body",
+          "description": "Trigger configuration for the routing-form workflow, allowed triggers are formSubmitted,formSubmittedNoEvent"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organization-workflows-update-workflow",
+      "description": "Update organization team workflow",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/workflows/{workflowId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "workflowId",
+          "type": "float",
+          "location": "path",
+          "description": "Workflow id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the workflow"
+        },
+        {
+          "name": "trigger",
+          "type": "string",
+          "location": "body",
+          "description": "Trigger configuration for the event-type workflow, allowed triggers are beforeEvent,eventCancelled,newEvent,afterEvent,rescheduleEvent,afterHostsCalVideoNoShow,afterGuestsCalVideoNoShow,bookingRejected,bookingRequested,bookingPaymentInitiated,bookingPaid,bookingNoShowUpdated"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-bookings-get-all-org-bookings",
+      "description": "Get organization team bookings",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/bookings",
+      "params": [
+        {
+          "name": "status",
+          "type": "array",
+          "location": "query",
+          "description": "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma."
+        },
+        {
+          "name": "attendeeEmail",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's email address."
+        },
+        {
+          "name": "attendeeName",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's name."
+        },
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the booking Uid."
+        },
+        {
+          "name": "eventTypeIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type ids belonging to the team. Event type ids must be separated by a comma."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type id belonging to the team."
+        },
+        {
+          "name": "afterStart",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with start after this date string."
+        },
+        {
+          "name": "beforeEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with end before this date string."
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "sortCreated",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their creation time (when booking was made) in ascending or descending order."
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-bookings-get-booking-references",
+      "description": "Get booking references",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/bookings/{bookingUid}/references",
+      "params": [
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "path",
+          "description": "Booking uid",
+          "required": true
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "location": "query",
+          "description": "Filter booking references by type"
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-connect-app",
+      "description": "Connect your conferencing application to a team",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/{app}/connect",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-disconnect-app",
+      "description": "Disconnect team conferencing application",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/{app}/disconnect",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-get-default-app",
+      "description": "Get team default conferencing application",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/default",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-get-oauth-url",
+      "description": "Get OAuth conferencing app's auth URL for a team",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/{app}/oauth/auth-url",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "string",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        },
+        {
+          "name": "returnTo",
+          "type": "string",
+          "location": "query",
+          "description": "Return to",
+          "required": true
+        },
+        {
+          "name": "onErrorReturnTo",
+          "type": "string",
+          "location": "query",
+          "description": "On error return to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-list-conferencing-apps",
+      "description": "List team conferencing applications",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-save-oauth-credentials",
+      "description": "Save conferencing app OAuth credentials",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/{app}/oauth/callback",
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
+          "location": "query",
+          "description": "State",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "query",
+          "description": "Code",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "path",
+          "description": "App",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-conferencing-set-default-app",
+      "description": "Set team default conferencing application",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/conferencing/{app}/default",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "app",
+          "type": "string",
+          "location": "query",
+          "description": "Conferencing application type"
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-create",
+      "description": "Create a team",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "appIconLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App icon logo"
+        },
+        {
+          "name": "appLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App logo"
+        },
+        {
+          "name": "autoAcceptCreator",
+          "type": "bool",
+          "location": "body",
+          "description": "If you are a platform customer, don't pass 'false', because then team creator won't be able to create team event types."
+        },
+        {
+          "name": "bannerUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams banner image which is shown on booker"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "brandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Brand color"
+        },
+        {
+          "name": "calVideoLogo",
+          "type": "string",
+          "location": "body",
+          "description": "Cal video logo"
+        },
+        {
+          "name": "darkBrandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Dark brand color"
+        },
+        {
+          "name": "hideBookATeamMember",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide book ateam member"
+        },
+        {
+          "name": "hideBranding",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide branding"
+        },
+        {
+          "name": "isPrivate",
+          "type": "bool",
+          "location": "body",
+          "description": "Is private"
+        },
+        {
+          "name": "logoUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams logo image"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the team",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Team slug in kebab-case - if not provided will be generated automatically based on name."
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "location": "body",
+          "description": "Theme"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Time format"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to create teams's default schedule from Monday to Friday from 9AM to 5PM. It will default to Europe/London if not passed."
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-delete",
+      "description": "Delete a team",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-create-event-type",
+      "description": "Create an event type",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "assignAllTeamMembers",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, all current and future team members will be assigned to this event type. Provide either assignAllTeamMembers or hosts but not both"
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes",
+          "required": true
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "rescheduleWithSameRoundRobinHost",
+          "type": "bool",
+          "location": "body",
+          "description": "Rescheduled events will be assigned to the same host as initially scheduled."
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "schedulingType",
+          "type": "string",
+          "location": "body",
+          "description": "The scheduling type for the team event - collective, roundRobin or managed.",
+          "required": true
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug",
+          "required": true
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title",
+          "required": true
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-create-phone-call",
+      "description": "Create a phone call",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/create-phone-call",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "beginMessage",
+          "type": "string",
+          "location": "body",
+          "description": "Begin message"
+        },
+        {
+          "name": "calApiKey",
+          "type": "string",
+          "location": "body",
+          "description": "CAL API Key",
+          "required": true
+        },
+        {
+          "name": "generalPrompt",
+          "type": "string",
+          "location": "body",
+          "description": "General prompt"
+        },
+        {
+          "name": "guestCompany",
+          "type": "string",
+          "location": "body",
+          "description": "Guest company"
+        },
+        {
+          "name": "guestEmail",
+          "type": "string",
+          "location": "body",
+          "description": "Guest email"
+        },
+        {
+          "name": "guestName",
+          "type": "string",
+          "location": "body",
+          "description": "Guest name"
+        },
+        {
+          "name": "numberToCall",
+          "type": "string",
+          "location": "body",
+          "description": "Number to call",
+          "required": true
+        },
+        {
+          "name": "schedulerName",
+          "type": "string",
+          "location": "body",
+          "description": "Scheduler name"
+        },
+        {
+          "name": "templateType",
+          "type": "string",
+          "location": "body",
+          "description": "Template type",
+          "required": true
+        },
+        {
+          "name": "yourPhoneNumber",
+          "type": "string",
+          "location": "body",
+          "description": "Your phone number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-delete-event-type",
+      "description": "Delete a team event type",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-get-event-type",
+      "description": "Get an event type",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-get-event-types",
+      "description": "Get all team event types",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/event-types",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort event types by creation date. When not provided, no explicit ordering is applied."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-get-event-types-organizations",
+      "description": "Get team event types",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventSlug",
+          "type": "string",
+          "location": "query",
+          "description": "Slug of team event type to return."
+        },
+        {
+          "name": "hostsLimit",
+          "type": "float",
+          "location": "query",
+          "description": "Specifies the maximum number of hosts to include in the response. This limit helps optimize performance. If not provided, all Hosts will be fetched."
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort event types by creation date. When not provided, no explicit ordering is applied."
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-private-links-create-private-link",
+      "description": "Create a private link for a team event type",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "expiresAt",
+          "type": "string",
+          "location": "body",
+          "description": "Expiration date for time-based links"
+        },
+        {
+          "name": "maxUsageCount",
+          "type": "float",
+          "location": "body",
+          "description": "Maximum number of times the link can be used. If omitted and expiresAt is not provided, defaults to 1 (one time use)."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-private-links-delete-private-link",
+      "description": "Delete a private link for a team event type",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links/{linkId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "Link id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-private-links-get-private-links",
+      "description": "Get all private links for a team event type",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-private-links-update-private-link",
+      "description": "Update a private link for a team event type",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}/private-links/{linkId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "linkId",
+          "type": "string",
+          "location": "path",
+          "description": "Link id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-event-types-update-event-type",
+      "description": "Update a team event type",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "assignAllTeamMembers",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, all current and future team members will be assigned to this event type. Provide either assignAllTeamMembers or hosts but not both"
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes"
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "rescheduleWithSameRoundRobinHost",
+          "type": "bool",
+          "location": "body",
+          "description": "Rescheduled events will be assigned to the same host as initially scheduled."
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "schedulingType",
+          "type": "string",
+          "location": "body",
+          "description": "The scheduling type for the team event - collective or roundRobin. ❗If you change scheduling type you must also provide `hosts` or `assignAllTeamMembers` in the request body, otherwise the event type will have no hosts - this is required because\n      in case of collective event type all hosts are mandatory but in case of round robin some or non can be mandatory so we can't predict how you want the hosts to be setup which is why you must provide that information.  If you want to convert round robin or collective into managed or managed into round robin or collective then you will have to create a new team event type and delete old one."
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug"
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title"
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-get",
+      "description": "Get a team",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-get-all",
+      "description": "Get all teams",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-get-my",
+      "description": "Get teams membership for user",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/me",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-invite-create-invite",
+      "description": "Create team invite link",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/invite",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-memberships-create-org-membership",
+      "description": "Create a membership",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/memberships",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "Role",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "body",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-memberships-delete-org-membership",
+      "description": "Delete a membership",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-memberships-get-all-org-memberships",
+      "description": "Get all memberships",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/memberships",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-memberships-get-org-membership",
+      "description": "Get a membership",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-memberships-update-org-membership",
+      "description": "Update a membership",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "Role"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-create-role",
+      "description": "Create a new organization team role",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "Color for the role (hex code)"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the role"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the role",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions for this role (format: resource.action). On update, this field replaces the entire permission set for the role (full replace). Use granular permission endpoints for one-by-one changes."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-delete-role",
+      "description": "Delete an organization team role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-get-all-roles",
+      "description": "Get all organization team roles",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-get-role",
+      "description": "Get a specific organization team role",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-permissions-add-permissions",
+      "description": "Add permissions to an organization team role (single or batch)",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions to add (format: resource.action)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-permissions-list-permissions",
+      "description": "List permissions for an organization team role",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-permissions-remove-permission",
+      "description": "Remove a permission from an organization team role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}/permissions/{permission}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permission",
+          "type": "string",
+          "location": "path",
+          "description": "Permission",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-permissions-remove-permissions",
+      "description": "Remove multiple permissions from an organization team role",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "query",
+          "description": "Permissions to remove (format: resource.action). Supports comma-separated values as well as repeated query params."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-permissions-set-permissions",
+      "description": "Replace all permissions for an organization team role",
+      "method": "PUT",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}/permissions",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions to add (format: resource.action)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-roles-update-role",
+      "description": "Update an organization team role",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/roles/{roleId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "roleId",
+          "type": "string",
+          "location": "path",
+          "description": "Role id",
+          "required": true
+        },
+        {
+          "name": "color",
+          "type": "string",
+          "location": "body",
+          "description": "Color for the role (hex code)"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description of the role"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the role"
+        },
+        {
+          "name": "permissions",
+          "type": "array",
+          "location": "body",
+          "description": "Permissions for this role (format: resource.action). On update, this field replaces the entire permission set for the role (full replace). Use granular permission endpoints for one-by-one changes."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-routing-forms-get-routing-forms",
+      "description": "Get team routing forms",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/routing-forms",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by creation time"
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by update time"
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created before this date"
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses updated before this date"
+        },
+        {
+          "name": "routedToBookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses routed to a specific booking"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-routing-forms-responses-create-routing-form-response",
+      "description": "Create routing form response and get available slots",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/routing-forms/{routingFormId}/responses",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "Time starting from which available slots should be checked.\n    \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to start of day or specify hours:\n      2024-08-13 (will have hours 00:00:00 aka at very beginning of the date) or you can specify hours manually like 2024-08-13T09:00:00Z",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "Time until which available slots should be checked.\n      \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to end of day or specify hours:\n      2024-08-20 (will have hours 23:59:59 aka at the very end of the date) or you can specify hours manually like 2024-08-20T18:00:00Z",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "Time zone in which the available slots should be returned. Defaults to UTC."
+        },
+        {
+          "name": "duration",
+          "type": "float",
+          "location": "query",
+          "description": "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long."
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "location": "query",
+          "description": "Format of slot times in response. Use 'range' to get start and end times."
+        },
+        {
+          "name": "bookingUidToReschedule",
+          "type": "string",
+          "location": "query",
+          "description": "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling."
+        },
+        {
+          "name": "queueResponse",
+          "type": "bool",
+          "location": "query",
+          "description": "Whether to queue the form response."
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-routing-forms-responses-get-routing-form-responses",
+      "description": "Get organization team routing form responses",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/routing-forms/{routingFormId}/responses",
+      "params": [
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to skip"
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Number of responses to take"
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by creation time"
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort by update time"
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created before this date"
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses created after this date"
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses updated before this date"
+        },
+        {
+          "name": "routedToBookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter by responses routed to a specific booking"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-routing-forms-responses-update-routing-form-response",
+      "description": "Update routing form response",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/routing-forms/{routingFormId}/responses/{responseId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        },
+        {
+          "name": "responseId",
+          "type": "float",
+          "location": "path",
+          "description": "Response id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-schedules-get-schedules",
+      "description": "Get all team member schedules",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/schedules",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "query",
+          "description": "Filter schedules by event type ID"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-schedules-get-user-schedules",
+      "description": "Get schedules of a team member",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/users/{userId}/schedules",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "query",
+          "description": "Filter schedules by event type ID"
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-stripe-check-stripe-connection",
+      "description": "Check team Stripe connection",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/stripe/check",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-stripe-get-stripe-connect-url",
+      "description": "Get Stripe connect URL for a team",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/stripe/connect",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "string",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "returnTo",
+          "type": "string",
+          "location": "query",
+          "description": "Return to",
+          "required": true
+        },
+        {
+          "name": "onErrorReturnTo",
+          "type": "string",
+          "location": "query",
+          "description": "On error return to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-stripe-save",
+      "description": "Save Stripe credentials",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}/stripe/save",
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
+          "location": "query",
+          "description": "State",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "query",
+          "description": "Code",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_teams_organizations-update",
+      "description": "Update a team",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/teams/{teamId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "appIconLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App icon logo"
+        },
+        {
+          "name": "appLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App logo"
+        },
+        {
+          "name": "bannerUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams banner image which is shown on booker"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "bookingLimits",
+          "type": "string",
+          "location": "body",
+          "description": "Booking limits"
+        },
+        {
+          "name": "brandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Brand color"
+        },
+        {
+          "name": "calVideoLogo",
+          "type": "string",
+          "location": "body",
+          "description": "Cal video logo"
+        },
+        {
+          "name": "darkBrandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Dark brand color"
+        },
+        {
+          "name": "hideBookATeamMember",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide book ateam member"
+        },
+        {
+          "name": "hideBranding",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide branding"
+        },
+        {
+          "name": "includeManagedEventsInLimits",
+          "type": "bool",
+          "location": "body",
+          "description": "Include managed events in limits"
+        },
+        {
+          "name": "isPrivate",
+          "type": "bool",
+          "location": "body",
+          "description": "Is private"
+        },
+        {
+          "name": "logoUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams logo image"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the team"
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Team slug"
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "location": "body",
+          "description": "Theme"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Time format"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to create teams's default schedule from Monday to Friday from 9AM to 5PM. It will default to Europe/London if not passed."
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-bookings-get-organization-bookings",
+      "description": "Get all bookings for an organization user",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/users/{userId}/bookings",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "status",
+          "type": "array",
+          "location": "query",
+          "description": "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma."
+        },
+        {
+          "name": "attendeeEmail",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's email address."
+        },
+        {
+          "name": "attendeeName",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's name."
+        },
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the booking Uid."
+        },
+        {
+          "name": "eventTypeIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type ids belonging to the user. Event type ids must be separated by a comma."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type id belonging to the user."
+        },
+        {
+          "name": "teamsIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team ids that user is part of. Team ids must be separated by a comma."
+        },
+        {
+          "name": "teamId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by team id that user is part of"
+        },
+        {
+          "name": "afterStart",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with start after this date string."
+        },
+        {
+          "name": "beforeEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with end before this date string."
+        },
+        {
+          "name": "afterCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created after this date string."
+        },
+        {
+          "name": "beforeCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been created before this date string."
+        },
+        {
+          "name": "afterUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated after this date string."
+        },
+        {
+          "name": "beforeUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings that have been updated before this date string."
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "sortCreated",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their creation time (when booking was made) in ascending or descending order."
+        },
+        {
+          "name": "sortUpdatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their updated time (for example when booking status changes) in ascending or descending order."
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-create-organization",
+      "description": "Create a user",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/users",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "appTheme",
+          "type": "string",
+          "location": "body",
+          "description": "Application theme"
+        },
+        {
+          "name": "autoAccept",
+          "type": "bool",
+          "location": "body",
+          "description": "Auto accept"
+        },
+        {
+          "name": "avatarUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Avatar URL"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "brandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Brand color in HEX format"
+        },
+        {
+          "name": "darkBrandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Dark brand color in HEX format"
+        },
+        {
+          "name": "defaultScheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "Default schedule ID"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "User email address",
+          "required": true
+        },
+        {
+          "name": "hideBranding",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide branding"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "location": "body",
+          "description": "Locale"
+        },
+        {
+          "name": "organizationRole",
+          "type": "string",
+          "location": "body",
+          "description": "Organization role"
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "location": "body",
+          "description": "Theme"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Time format"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Time zone"
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "location": "body",
+          "description": "Username"
+        },
+        {
+          "name": "weekday",
+          "type": "string",
+          "location": "body",
+          "description": "Preferred weekday"
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-delete-organization",
+      "description": "Delete a user",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/users/{userId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-get-organizations",
+      "description": "Get all users",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/users",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        },
+        {
+          "name": "emails",
+          "type": "array",
+          "location": "query",
+          "description": "The email address or an array of email addresses to filter by"
+        },
+        {
+          "name": "assignedOptionIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by assigned attribute option ids. ids must be separated by a comma."
+        },
+        {
+          "name": "attributeQueryOperator",
+          "type": "string",
+          "location": "query",
+          "description": "Query operator used to filter assigned options, AND by default."
+        },
+        {
+          "name": "teamIds",
+          "type": "array",
+          "location": "query",
+          "description": "Filter by teamIds. Team ids must be separated by a comma."
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-ooocontroller-create-organization-ooo",
+      "description": "Create an out-of-office entry for a user",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/users/{userId}/ooo",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "body",
+          "description": "The end date and time of the out of office period in ISO 8601 format in UTC timezone.",
+          "required": true
+        },
+        {
+          "name": "notes",
+          "type": "string",
+          "location": "body",
+          "description": "Optional notes for the out of office entry."
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "location": "body",
+          "description": "the reason for the out of office entry, if applicable"
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "body",
+          "description": "The start date and time of the out of office period in ISO 8601 format in UTC timezone.",
+          "required": true
+        },
+        {
+          "name": "toUserId",
+          "type": "float",
+          "location": "body",
+          "description": "The ID of the user covering for the out of office period, if applicable."
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-ooocontroller-delete-organization-ooo",
+      "description": "Delete an out-of-office entry for a user",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/users/{userId}/ooo/{oooId}",
+      "params": [
+        {
+          "name": "oooId",
+          "type": "float",
+          "location": "path",
+          "description": "Ooo id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-ooocontroller-get-organization-ooo",
+      "description": "Get all out-of-office entries for a user",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/users/{userId}/ooo",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-ooocontroller-update-organization-ooo",
+      "description": "Update an out-of-office entry for a user",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/users/{userId}/ooo/{oooId}",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "oooId",
+          "type": "float",
+          "location": "path",
+          "description": "Ooo id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "body",
+          "description": "The end date and time of the out of office period in ISO 8601 format in UTC timezone."
+        },
+        {
+          "name": "notes",
+          "type": "string",
+          "location": "body",
+          "description": "Optional notes for the out of office entry."
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "location": "body",
+          "description": "the reason for the out of office entry, if applicable"
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "body",
+          "description": "The start date and time of the out of office period in ISO 8601 format in UTC timezone."
+        },
+        {
+          "name": "toUserId",
+          "type": "float",
+          "location": "body",
+          "description": "The ID of the user covering for the out of office period, if applicable."
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-schedules-create-schedule",
+      "description": "Create a schedule",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/users/{userId}/schedules",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "isDefault",
+          "type": "bool",
+          "location": "body",
+          "description": "Each user should have 1 default schedule. If you specified `timeZone` when creating managed user, then the default schedule will be created with that timezone.\n    Default schedule means that if an event type is not tied to a specific schedule then the default schedule is used.",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to calculate available times when an event using the schedule is booked.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-schedules-delete-schedule",
+      "description": "Delete a schedule",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/users/{userId}/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-schedules-get-schedule",
+      "description": "Get a schedule",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/users/{userId}/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-schedules-get-schedules",
+      "description": "Get all schedules",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/users/{userId}/schedules",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-schedules-update-schedule",
+      "description": "Update a schedule",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/users/{userId}/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "isDefault",
+          "type": "bool",
+          "location": "body",
+          "description": "Is default"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Time zone"
+        }
+      ]
+    },
+    {
+      "name": "organizations_users_organizations-update-organization",
+      "description": "Update a user",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/users/{userId}",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "path",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_webhooks_organizations-create-organization",
+      "description": "Create a webhook",
+      "method": "POST",
+      "path": "/v2/organizations/{orgId}/webhooks",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active",
+          "required": true
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url",
+          "required": true
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "organizations_webhooks_organizations-delete",
+      "description": "Delete a webhook",
+      "method": "DELETE",
+      "path": "/v2/organizations/{orgId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_webhooks_organizations-get-all-organization",
+      "description": "Get all webhooks",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/webhooks",
+      "params": [
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "organizations_webhooks_organizations-get-organization",
+      "description": "Get a webhook",
+      "method": "GET",
+      "path": "/v2/organizations/{orgId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "organizations_webhooks_organizations-update-org",
+      "description": "Update a webhook",
+      "method": "PATCH",
+      "path": "/v2/organizations/{orgId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active"
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url"
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "routing-forms_calculate-slots_routing-forms-based-on-routing-form-response",
+      "description": "Calculate slots based on routing form response",
+      "method": "POST",
+      "path": "/v2/routing-forms/{routingFormId}/calculate-slots",
+      "params": [
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "Time starting from which available slots should be checked.\n    \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to start of day or specify hours:\n      2024-08-13 (will have hours 00:00:00 aka at very beginning of the date) or you can specify hours manually like 2024-08-13T09:00:00Z",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "Time until which available slots should be checked.\n      \n      Must be in UTC timezone as ISO 8601 datestring.\n      \n      You can pass date without hours which defaults to end of day or specify hours:\n      2024-08-20 (will have hours 23:59:59 aka at the very end of the date) or you can specify hours manually like 2024-08-20T18:00:00Z",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "Time zone in which the available slots should be returned. Defaults to UTC."
+        },
+        {
+          "name": "duration",
+          "type": "float",
+          "location": "query",
+          "description": "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long."
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "location": "query",
+          "description": "Format of slot times in response. Use 'range' to get start and end times."
+        },
+        {
+          "name": "bookingUidToReschedule",
+          "type": "string",
+          "location": "query",
+          "description": "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling."
+        },
+        {
+          "name": "routingFormId",
+          "type": "string",
+          "location": "path",
+          "description": "Routing form id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "schedules_create",
+      "description": "Create a schedule",
+      "method": "POST",
+      "path": "/v2/schedules",
+      "params": [
+        {
+          "name": "isDefault",
+          "type": "bool",
+          "location": "body",
+          "description": "Each user should have 1 default schedule. If you specified `timeZone` when creating managed user, then the default schedule will be created with that timezone.\n    Default schedule means that if an event type is not tied to a specific schedule then the default schedule is used.",
+          "required": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name",
+          "required": true
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to calculate available times when an event using the schedule is booked.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "schedules_delete",
+      "description": "Delete a schedule",
+      "method": "DELETE",
+      "path": "/v2/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "schedules_get",
+      "description": "Get all schedules",
+      "method": "GET",
+      "path": "/v2/schedules",
+      "params": []
+    },
+    {
+      "name": "schedules_get-default",
+      "description": "Get default schedule",
+      "method": "GET",
+      "path": "/v2/schedules/default",
+      "params": []
+    },
+    {
+      "name": "schedules_get-scheduleid",
+      "description": "Get a schedule",
+      "method": "GET",
+      "path": "/v2/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "schedules_update",
+      "description": "Update a schedule",
+      "method": "PATCH",
+      "path": "/v2/schedules/{scheduleId}",
+      "params": [
+        {
+          "name": "scheduleId",
+          "type": "string",
+          "location": "path",
+          "description": "Schedule id",
+          "required": true
+        },
+        {
+          "name": "isDefault",
+          "type": "bool",
+          "location": "body",
+          "description": "Is default"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Time zone"
+        }
+      ]
+    },
+    {
+      "name": "selected-calendars_add",
+      "description": "Add a selected calendar",
+      "method": "POST",
+      "path": "/v2/selected-calendars",
+      "params": [
+        {
+          "name": "credentialId",
+          "type": "float",
+          "location": "body",
+          "description": "Credential id",
+          "required": true
+        },
+        {
+          "name": "delegationCredentialId",
+          "type": "string",
+          "location": "body",
+          "description": "Delegation credential id"
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "body",
+          "description": "External id",
+          "required": true
+        },
+        {
+          "name": "integration",
+          "type": "string",
+          "location": "body",
+          "description": "Integration",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "selected-calendars_delete",
+      "description": "Delete a selected calendar",
+      "method": "DELETE",
+      "path": "/v2/selected-calendars",
+      "params": [
+        {
+          "name": "integration",
+          "type": "string",
+          "location": "query",
+          "description": "Integration",
+          "required": true
+        },
+        {
+          "name": "externalId",
+          "type": "string",
+          "location": "query",
+          "description": "External id",
+          "required": true
+        },
+        {
+          "name": "credentialId",
+          "type": "string",
+          "location": "query",
+          "description": "Credential id",
+          "required": true
+        },
+        {
+          "name": "delegationCredentialId",
+          "type": "string",
+          "location": "query",
+          "description": "Delegation credential id"
+        }
+      ]
+    },
+    {
+      "name": "slots_delete-reserved",
+      "description": "Delete a reserved slot",
+      "method": "DELETE",
+      "path": "/v2/slots/reservations/{uid}",
+      "params": [
+        {
+          "name": "uid",
+          "type": "string",
+          "location": "path",
+          "description": "Uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "slots_get-available",
+      "description": "Get available time slots for an event type",
+      "method": "GET",
+      "path": "/v2/slots",
+      "params": [
+        {
+          "name": "bookingUidToReschedule",
+          "type": "string",
+          "location": "query",
+          "description": "The unique identifier of the booking being rescheduled. When provided will ensure that the original booking time appears within the returned available slots when rescheduling."
+        },
+        {
+          "name": "start",
+          "type": "string",
+          "location": "query",
+          "description": "Time starting from which available slots should be checked.\n\n      Must be in UTC timezone as ISO 8601 datestring.\n\n      You can pass date without hours which defaults to start of day or specify hours:\n      2024-08-13 (will have hours 00:00:00 aka at very beginning of the date) or you can specify hours manually like 2024-08-13T09:00:00Z.",
+          "required": true
+        },
+        {
+          "name": "end",
+          "type": "string",
+          "location": "query",
+          "description": "Time until which available slots should be checked.\n\n    Must be in UTC timezone as ISO 8601 datestring.\n\n    You can pass date without hours which defaults to end of day or specify hours:\n    2024-08-20 (will have hours 23:59:59 aka at the very end of the date) or you can specify hours manually like 2024-08-20T18:00:00Z.",
+          "required": true
+        },
+        {
+          "name": "organizationSlug",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the organization to which user with username belongs or team with teamSlug belongs."
+        },
+        {
+          "name": "teamSlug",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the team who owns event type with eventTypeSlug - used when slots are checked for team event type."
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "location": "query",
+          "description": "The username of the user who owns event type with eventTypeSlug - used when slots are checked for individual user event type."
+        },
+        {
+          "name": "eventTypeSlug",
+          "type": "string",
+          "location": "query",
+          "description": "The slug of the event type for which available slots should be checked. If slug is provided then username or teamSlug must be provided too and if relevant organizationSlug too."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "query",
+          "description": "The ID of the event type for which available slots should be checked."
+        },
+        {
+          "name": "usernames",
+          "type": "string",
+          "location": "query",
+          "description": "The usernames for which available slots should be checked separated by a comma.\n\n    Checking slots by usernames is used mainly for dynamic events where there is no specific event but we just want to know when 2 or more people are available.\n\n    Must contain at least 2 usernames."
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "location": "query",
+          "description": "Format of slot times in response. Use 'range' to get start and end times. Use 'time' or omit this query parameter to get only start time."
+        },
+        {
+          "name": "duration",
+          "type": "float",
+          "location": "query",
+          "description": "If event type has multiple possible durations then you can specify the desired duration here. Also, if you are fetching slots for a dynamic event then you can specify the duration her which defaults to 30, meaning that returned slots will be each 30 minutes long."
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "query",
+          "description": "Time zone in which the available slots should be returned. Defaults to UTC."
+        }
+      ]
+    },
+    {
+      "name": "slots_get-reserved",
+      "description": "Get reserved slot",
+      "method": "GET",
+      "path": "/v2/slots/reservations/{uid}",
+      "params": [
+        {
+          "name": "uid",
+          "type": "string",
+          "location": "path",
+          "description": "Uid",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "slots_reserve",
+      "description": "Reserve a slot",
+      "method": "POST",
+      "path": "/v2/slots/reservations",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "body",
+          "description": "The ID of the event type for which slot should be reserved.",
+          "required": true
+        },
+        {
+          "name": "reservationDuration",
+          "type": "float",
+          "location": "body",
+          "description": "ONLY for authenticated requests with api key, access token or OAuth credentials (ID + secret).\n      \n      For how many minutes the slot should be reserved - for this long time noone else can book this event type at `start` time. If not provided, defaults to 5 minutes."
+        },
+        {
+          "name": "slotDuration",
+          "type": "float",
+          "location": "body",
+          "description": "By default slot duration is equal to event type length, but if you want to reserve a slot for an event type that has a variable length you can specify it here as a number in minutes. If you don't have this set explicitly that event type can have one of many lengths you can omit this."
+        },
+        {
+          "name": "slotStart",
+          "type": "string",
+          "location": "body",
+          "description": "ISO 8601 datestring in UTC timezone representing available slot.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "slots_update-reserved",
+      "description": "Update a reserved slot",
+      "method": "PATCH",
+      "path": "/v2/slots/reservations/{uid}",
+      "params": [
+        {
+          "name": "uid",
+          "type": "string",
+          "location": "path",
+          "description": "Uid",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "body",
+          "description": "The ID of the event type for which slot should be reserved.",
+          "required": true
+        },
+        {
+          "name": "reservationDuration",
+          "type": "float",
+          "location": "body",
+          "description": "ONLY for authenticated requests with api key, access token or OAuth credentials (ID + secret).\n      \n      For how many minutes the slot should be reserved - for this long time noone else can book this event type at `start` time. If not provided, defaults to 5 minutes."
+        },
+        {
+          "name": "slotDuration",
+          "type": "float",
+          "location": "body",
+          "description": "By default slot duration is equal to event type length, but if you want to reserve a slot for an event type that has a variable length you can specify it here as a number in minutes. If you don't have this set explicitly that event type can have one of many lengths you can omit this."
+        },
+        {
+          "name": "slotStart",
+          "type": "string",
+          "location": "body",
+          "description": "ISO 8601 datestring in UTC timezone representing available slot.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "stripe_check",
+      "description": "Check Stripe connection",
+      "method": "GET",
+      "path": "/v2/stripe/check",
+      "params": []
+    },
+    {
+      "name": "stripe_redirect",
+      "description": "Get Stripe connect URL",
+      "method": "GET",
+      "path": "/v2/stripe/connect",
+      "params": []
+    },
+    {
+      "name": "stripe_save",
+      "description": "Save Stripe credentials",
+      "method": "GET",
+      "path": "/v2/stripe/save",
+      "params": [
+        {
+          "name": "state",
+          "type": "string",
+          "location": "query",
+          "description": "State",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "query",
+          "description": "Code",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_create",
+      "description": "Create a team",
+      "method": "POST",
+      "path": "/v2/teams",
+      "params": [
+        {
+          "name": "appIconLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App icon logo"
+        },
+        {
+          "name": "appLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App logo"
+        },
+        {
+          "name": "autoAcceptCreator",
+          "type": "bool",
+          "location": "body",
+          "description": "If you are a platform customer, don't pass 'false', because then team creator won't be able to create team event types."
+        },
+        {
+          "name": "bannerUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams banner image which is shown on booker"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "brandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Brand color"
+        },
+        {
+          "name": "calVideoLogo",
+          "type": "string",
+          "location": "body",
+          "description": "Cal video logo"
+        },
+        {
+          "name": "darkBrandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Dark brand color"
+        },
+        {
+          "name": "hideBookATeamMember",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide book ateam member"
+        },
+        {
+          "name": "hideBranding",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide branding"
+        },
+        {
+          "name": "isPrivate",
+          "type": "bool",
+          "location": "body",
+          "description": "Is private"
+        },
+        {
+          "name": "logoUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams logo image"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the team",
+          "required": true
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Team slug in kebab-case - if not provided will be generated automatically based on name."
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "location": "body",
+          "description": "Theme"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Time format"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to create teams's default schedule from Monday to Friday from 9AM to 5PM. It will default to Europe/London if not passed."
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "teams_delete",
+      "description": "Delete a team",
+      "method": "DELETE",
+      "path": "/v2/teams/{teamId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_get",
+      "description": "Get teams",
+      "method": "GET",
+      "path": "/v2/teams",
+      "params": []
+    },
+    {
+      "name": "teams_get-teamid",
+      "description": "Get a team",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_update",
+      "description": "Update a team",
+      "method": "PATCH",
+      "path": "/v2/teams/{teamId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "appIconLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App icon logo"
+        },
+        {
+          "name": "appLogo",
+          "type": "string",
+          "location": "body",
+          "description": "App logo"
+        },
+        {
+          "name": "bannerUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams banner image which is shown on booker"
+        },
+        {
+          "name": "bio",
+          "type": "string",
+          "location": "body",
+          "description": "Bio"
+        },
+        {
+          "name": "bookingLimits",
+          "type": "string",
+          "location": "body",
+          "description": "Booking limits"
+        },
+        {
+          "name": "brandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Brand color"
+        },
+        {
+          "name": "calVideoLogo",
+          "type": "string",
+          "location": "body",
+          "description": "Cal video logo"
+        },
+        {
+          "name": "darkBrandColor",
+          "type": "string",
+          "location": "body",
+          "description": "Dark brand color"
+        },
+        {
+          "name": "hideBookATeamMember",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide book ateam member"
+        },
+        {
+          "name": "hideBranding",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide branding"
+        },
+        {
+          "name": "includeManagedEventsInLimits",
+          "type": "bool",
+          "location": "body",
+          "description": "Include managed events in limits"
+        },
+        {
+          "name": "isPrivate",
+          "type": "bool",
+          "location": "body",
+          "description": "Is private"
+        },
+        {
+          "name": "logoUrl",
+          "type": "string",
+          "location": "body",
+          "description": "URL of the teams logo image"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "location": "body",
+          "description": "Name of the team"
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Team slug"
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "location": "body",
+          "description": "Theme"
+        },
+        {
+          "name": "timeFormat",
+          "type": "float",
+          "location": "body",
+          "description": "Time format"
+        },
+        {
+          "name": "timeZone",
+          "type": "string",
+          "location": "body",
+          "description": "Timezone is used to create teams's default schedule from Monday to Friday from 9AM to 5PM. It will default to Europe/London if not passed."
+        },
+        {
+          "name": "weekStart",
+          "type": "string",
+          "location": "body",
+          "description": "Week start"
+        }
+      ]
+    },
+    {
+      "name": "teams_bookings_teams-get-all-team",
+      "description": "Get team bookings",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/bookings",
+      "params": [
+        {
+          "name": "status",
+          "type": "array",
+          "location": "query",
+          "description": "Filter bookings by status. If you want to filter by multiple statuses, separate them with a comma."
+        },
+        {
+          "name": "attendeeEmail",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's email address."
+        },
+        {
+          "name": "attendeeName",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the attendee's name."
+        },
+        {
+          "name": "bookingUid",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by the booking Uid."
+        },
+        {
+          "name": "eventTypeIds",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type ids belonging to the team. Event type ids must be separated by a comma."
+        },
+        {
+          "name": "eventTypeId",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings by event type id belonging to the team."
+        },
+        {
+          "name": "afterStart",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with start after this date string."
+        },
+        {
+          "name": "beforeEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Filter bookings with end before this date string."
+        },
+        {
+          "name": "sortStart",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their start time in ascending or descending order."
+        },
+        {
+          "name": "sortEnd",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their end time in ascending or descending order."
+        },
+        {
+          "name": "sortCreated",
+          "type": "string",
+          "location": "query",
+          "description": "Sort results by their creation time (when booking was made) in ascending or descending order."
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "The number of items to skip"
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-create-phone-call",
+      "description": "Create a phone call",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/create-phone-call",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "orgId",
+          "type": "float",
+          "location": "path",
+          "description": "Org id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "beginMessage",
+          "type": "string",
+          "location": "body",
+          "description": "Begin message"
+        },
+        {
+          "name": "calApiKey",
+          "type": "string",
+          "location": "body",
+          "description": "CAL API Key",
+          "required": true
+        },
+        {
+          "name": "generalPrompt",
+          "type": "string",
+          "location": "body",
+          "description": "General prompt"
+        },
+        {
+          "name": "guestCompany",
+          "type": "string",
+          "location": "body",
+          "description": "Guest company"
+        },
+        {
+          "name": "guestEmail",
+          "type": "string",
+          "location": "body",
+          "description": "Guest email"
+        },
+        {
+          "name": "guestName",
+          "type": "string",
+          "location": "body",
+          "description": "Guest name"
+        },
+        {
+          "name": "numberToCall",
+          "type": "string",
+          "location": "body",
+          "description": "Number to call",
+          "required": true
+        },
+        {
+          "name": "schedulerName",
+          "type": "string",
+          "location": "body",
+          "description": "Scheduler name"
+        },
+        {
+          "name": "templateType",
+          "type": "string",
+          "location": "body",
+          "description": "Template type",
+          "required": true
+        },
+        {
+          "name": "yourPhoneNumber",
+          "type": "string",
+          "location": "body",
+          "description": "Your phone number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-create-team",
+      "description": "Create an event type",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/event-types",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "assignAllTeamMembers",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, all current and future team members will be assigned to this event type. Provide either assignAllTeamMembers or hosts but not both"
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes",
+          "required": true
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "rescheduleWithSameRoundRobinHost",
+          "type": "bool",
+          "location": "body",
+          "description": "Rescheduled events will be assigned to the same host as initially scheduled."
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "schedulingType",
+          "type": "string",
+          "location": "body",
+          "description": "The scheduling type for the team event - collective, roundRobin or managed.",
+          "required": true
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug",
+          "required": true
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title",
+          "required": true
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-delete-team",
+      "description": "Delete a team event type",
+      "method": "DELETE",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-get-team",
+      "description": "Get team event types",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/event-types",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventSlug",
+          "type": "string",
+          "location": "query",
+          "description": "Slug of team event type to return."
+        },
+        {
+          "name": "hostsLimit",
+          "type": "float",
+          "location": "query",
+          "description": "Specifies the maximum number of hosts to include in the response. This limit helps optimize performance. If not provided, all Hosts will be fetched."
+        },
+        {
+          "name": "sortCreatedAt",
+          "type": "string",
+          "location": "query",
+          "description": "Sort event types by creation date. When not provided, no explicit ordering is applied."
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-get-team-teams",
+      "description": "Get an event type",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-update-team",
+      "description": "Update a team event type",
+      "method": "PATCH",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "afterEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar after a meeting ends. This gives you time to wrap up, add notes, or decompress before your next commitment."
+        },
+        {
+          "name": "allowReschedulingCancelledBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "When enabled, users will be able to create a new booking when trying to reschedule a cancelled booking."
+        },
+        {
+          "name": "allowReschedulingPastBookings",
+          "type": "bool",
+          "location": "body",
+          "description": "Enabling this option allows for past events to be rescheduled."
+        },
+        {
+          "name": "assignAllTeamMembers",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, all current and future team members will be assigned to this event type. Provide either assignAllTeamMembers or hosts but not both"
+        },
+        {
+          "name": "beforeEventBuffer",
+          "type": "float",
+          "location": "body",
+          "description": "Extra time automatically blocked on your calendar before a meeting starts. This gives you time to prepare, review notes, or transition from your previous activity."
+        },
+        {
+          "name": "bookerActiveBookingsLimit",
+          "type": "string",
+          "location": "body",
+          "description": "Limit the number of active bookings a booker can make for this event type."
+        },
+        {
+          "name": "bookingLimitsCount",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how many times this event can be booked"
+        },
+        {
+          "name": "bookingLimitsDuration",
+          "type": "string",
+          "location": "body",
+          "description": "Limit total amount of time that this event can be booked"
+        },
+        {
+          "name": "bookingRequiresAuthentication",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to require authentication for booking this event type via api. If true, only authenticated users who are the event-type owner or org/team admin/owner can book this event type."
+        },
+        {
+          "name": "bookingWindow",
+          "type": "string",
+          "location": "body",
+          "description": "Limit how far in the future this event can be booked"
+        },
+        {
+          "name": "confirmationPolicy",
+          "type": "string",
+          "location": "body",
+          "description": "Specify how the booking needs to be manually confirmed before it is pushed to the integrations and a confirmation mail is sent."
+        },
+        {
+          "name": "customName",
+          "type": "string",
+          "location": "body",
+          "description": "Customizable event name with valid variables:\n      {Event type title}, {Organiser}, {Scheduler}, {Location}, {Organiser first name},\n      {Scheduler first name}, {Scheduler last name}, {Event duration}, {LOCATION},\n      {HOST/ATTENDEE}, {HOST}, {ATTENDEE}, {USER}"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "location": "body",
+          "description": "Description"
+        },
+        {
+          "name": "disableGuests",
+          "type": "bool",
+          "location": "body",
+          "description": "If true, person booking this event can't add guests via their emails."
+        },
+        {
+          "name": "hidden",
+          "type": "bool",
+          "location": "body",
+          "description": "Hidden"
+        },
+        {
+          "name": "hideCalendarEventDetails",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar event details"
+        },
+        {
+          "name": "hideCalendarNotes",
+          "type": "bool",
+          "location": "body",
+          "description": "Hide calendar notes"
+        },
+        {
+          "name": "hideOrganizerEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Boolean to Hide organizer's email address from the booking screen, email notifications, and calendar events"
+        },
+        {
+          "name": "interfaceLanguage",
+          "type": "string",
+          "location": "body",
+          "description": "Set preferred language for the booking interface. Use empty string for visitor's browser language (default)."
+        },
+        {
+          "name": "lengthInMinutes",
+          "type": "float",
+          "location": "body",
+          "description": "Length in minutes"
+        },
+        {
+          "name": "lengthInMinutesOptions",
+          "type": "array",
+          "location": "body",
+          "description": "If you want that user can choose between different lengths of the event you can specify them here. Must include the provided `lengthInMinutes`."
+        },
+        {
+          "name": "lockTimeZoneToggleOnBookingPage",
+          "type": "bool",
+          "location": "body",
+          "description": "Lock time zone toggle on booking page"
+        },
+        {
+          "name": "minimumBookingNotice",
+          "type": "float",
+          "location": "body",
+          "description": "Minimum number of minutes before the event that a booking can be made."
+        },
+        {
+          "name": "offsetStart",
+          "type": "float",
+          "location": "body",
+          "description": "Offset timeslots shown to bookers by a specified number of minutes"
+        },
+        {
+          "name": "onlyShowFirstAvailableSlot",
+          "type": "bool",
+          "location": "body",
+          "description": "This will limit your availability for this event type to one slot per day, scheduled at the earliest available time."
+        },
+        {
+          "name": "recurrence",
+          "type": "string",
+          "location": "body",
+          "description": "Create a recurring event type."
+        },
+        {
+          "name": "requiresBookerEmailVerification",
+          "type": "bool",
+          "location": "body",
+          "description": "Requires booker email verification"
+        },
+        {
+          "name": "rescheduleWithSameRoundRobinHost",
+          "type": "bool",
+          "location": "body",
+          "description": "Rescheduled events will be assigned to the same host as initially scheduled."
+        },
+        {
+          "name": "scheduleId",
+          "type": "float",
+          "location": "body",
+          "description": "If you want that this event has different schedule than user's default one you can specify it here."
+        },
+        {
+          "name": "schedulingType",
+          "type": "string",
+          "location": "body",
+          "description": "The scheduling type for the team event - collective or roundRobin. ❗If you change scheduling type you must also provide `hosts` or `assignAllTeamMembers` in the request body, otherwise the event type will have no hosts - this is required because\n      in case of collective event type all hosts are mandatory but in case of round robin some or non can be mandatory so we can't predict how you want the hosts to be setup which is why you must provide that information.  If you want to convert round robin or collective into managed or managed into round robin or collective then you will have to create a new team event type and delete old one."
+        },
+        {
+          "name": "seats",
+          "type": "string",
+          "location": "body",
+          "description": "Create an event type with multiple seats."
+        },
+        {
+          "name": "showOptimizedSlots",
+          "type": "bool",
+          "location": "body",
+          "description": "Arrange time slots to optimize availability."
+        },
+        {
+          "name": "slotInterval",
+          "type": "float",
+          "location": "body",
+          "description": "Number representing length of each slot when event is booked. By default it equal length of the event type.\n      If event length is 60 minutes then we would have slots 9AM, 10AM, 11AM etc. but if it was changed to 30 minutes then\n      we would have slots 9AM, 9:30AM, 10AM, 10:30AM etc. as the available times to book the 60 minute event."
+        },
+        {
+          "name": "slug",
+          "type": "string",
+          "location": "body",
+          "description": "Slug"
+        },
+        {
+          "name": "successRedirectUrl",
+          "type": "string",
+          "location": "body",
+          "description": "A valid URL where the booker will redirect to, once the booking is completed successfully"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "location": "body",
+          "description": "Title"
+        },
+        {
+          "name": "useDestinationCalendarEmail",
+          "type": "bool",
+          "location": "body",
+          "description": "Use destination calendar email"
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-create-team-webhook",
+      "description": "Create a webhook for a team event type",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active",
+          "required": true
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url",
+          "required": true
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-delete-all-team-webhooks",
+      "description": "Delete all webhooks for a team event type",
+      "method": "DELETE",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-delete-team-webhook",
+      "description": "Delete a webhook for a team event type",
+      "method": "DELETE",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-get-team-webhook",
+      "description": "Get a webhook for a team event type",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-get-team-webhooks",
+      "description": "Get all webhooks for a team event type",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks",
+      "params": [
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_event-types_teams-webhooks-update-team-webhook",
+      "description": "Update a webhook for a team event type",
+      "method": "PATCH",
+      "path": "/v2/teams/{teamId}/event-types/{eventTypeId}/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "eventTypeId",
+          "type": "float",
+          "location": "path",
+          "description": "Event type id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active"
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url"
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "teams_invite_teams-create",
+      "description": "Create team invite link",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/invite",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_memberships_teams-create-team",
+      "description": "Create a membership",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/memberships",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "Role"
+        },
+        {
+          "name": "userId",
+          "type": "float",
+          "location": "body",
+          "description": "User id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_memberships_teams-delete-team",
+      "description": "Delete a membership",
+      "method": "DELETE",
+      "path": "/v2/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_memberships_teams-get-team",
+      "description": "Get all memberships",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/memberships",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        },
+        {
+          "name": "emails",
+          "type": "array",
+          "location": "query",
+          "description": "Filter team memberships by email addresses. If you want to filter by multiple emails, separate them with a comma (max 20 emails for performance)."
+        }
+      ]
+    },
+    {
+      "name": "teams_memberships_teams-get-team-teams",
+      "description": "Get a membership",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_memberships_teams-update-team",
+      "description": "Update membership",
+      "method": "PATCH",
+      "path": "/v2/teams/{teamId}/memberships/{membershipId}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "membershipId",
+          "type": "float",
+          "location": "path",
+          "description": "Membership id",
+          "required": true
+        },
+        {
+          "name": "accepted",
+          "type": "bool",
+          "location": "body",
+          "description": "Accepted"
+        },
+        {
+          "name": "disableImpersonation",
+          "type": "bool",
+          "location": "body",
+          "description": "Disable impersonation"
+        },
+        {
+          "name": "role",
+          "type": "string",
+          "location": "body",
+          "description": "Role"
+        }
+      ]
+    },
+    {
+      "name": "teams_schedules_teams-get-team",
+      "description": "Get all team member schedules",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/schedules",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-get-verified-email-by-id",
+      "description": "Get verified email of a team by id",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/verified-resources/emails/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        },
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-get-verified-emails",
+      "description": "Get list of verified emails of a team",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/verified-resources/emails",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-get-verified-phone-by-id",
+      "description": "Get verified phone number of a team by id",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/verified-resources/phones/{id}",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-get-verified-phone-numbers",
+      "description": "Get list of verified phone numbers of a team",
+      "method": "GET",
+      "path": "/v2/teams/{teamId}/verified-resources/phones",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-request-email-verification-code",
+      "description": "Request email verification code",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/verified-resources/emails/verification-code/request",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-request-phone-verification-code",
+      "description": "Request phone number verification code",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/verified-resources/phones/verification-code/request",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "Phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-verify-email",
+      "description": "Verify an email for a team",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/verified-resources/emails/verification-code/verify",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the email to verify",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "teams_verified-resources_teams-verify-phone-number",
+      "description": "Verify a phone number for an org team",
+      "method": "POST",
+      "path": "/v2/teams/{teamId}/verified-resources/phones/verification-code/verify",
+      "params": [
+        {
+          "name": "teamId",
+          "type": "float",
+          "location": "path",
+          "description": "Team id",
+          "required": true
+        },
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the phone number to verify",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-get-verified-email-by-id",
+      "description": "Get verified email by id",
+      "method": "GET",
+      "path": "/v2/verified-resources/emails/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-get-verified-emails",
+      "description": "Get list of verified emails",
+      "method": "GET",
+      "path": "/v2/verified-resources/emails",
+      "params": [
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-get-verified-phone-by-id",
+      "description": "Get verified phone number by id",
+      "method": "GET",
+      "path": "/v2/verified-resources/phones/{id}",
+      "params": [
+        {
+          "name": "id",
+          "type": "float",
+          "location": "path",
+          "description": "Id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-get-verified-phone-numbers",
+      "description": "Get list of verified phone numbers",
+      "method": "GET",
+      "path": "/v2/verified-resources/phones",
+      "params": [
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-request-email-verification-code",
+      "description": "Request email verification code",
+      "method": "POST",
+      "path": "/v2/verified-resources/emails/verification-code/request",
+      "params": [
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-request-phone-verification-code",
+      "description": "Request phone number verification code",
+      "method": "POST",
+      "path": "/v2/verified-resources/phones/verification-code/request",
+      "params": [
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "Phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-verify-email",
+      "description": "Verify an email",
+      "method": "POST",
+      "path": "/v2/verified-resources/emails/verification-code/verify",
+      "params": [
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the email to verify",
+          "required": true
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "location": "body",
+          "description": "Email to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "verified-resources_user-verify-phone-number",
+      "description": "Verify a phone number",
+      "method": "POST",
+      "path": "/v2/verified-resources/phones/verification-code/verify",
+      "params": [
+        {
+          "name": "code",
+          "type": "string",
+          "location": "body",
+          "description": "verification code sent to the phone number to verify",
+          "required": true
+        },
+        {
+          "name": "phone",
+          "type": "string",
+          "location": "body",
+          "description": "phone number to verify.",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "webhooks_create",
+      "description": "Create a webhook",
+      "method": "POST",
+      "path": "/v2/webhooks",
+      "params": [
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active",
+          "required": true
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url",
+          "required": true
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers",
+          "required": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    },
+    {
+      "name": "webhooks_delete",
+      "description": "Delete a webhook",
+      "method": "DELETE",
+      "path": "/v2/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "webhooks_get",
+      "description": "Get all webhooks",
+      "method": "GET",
+      "path": "/v2/webhooks",
+      "params": [
+        {
+          "name": "take",
+          "type": "float",
+          "location": "query",
+          "description": "Maximum number of items to return"
+        },
+        {
+          "name": "skip",
+          "type": "float",
+          "location": "query",
+          "description": "Number of items to skip"
+        }
+      ]
+    },
+    {
+      "name": "webhooks_get-webhookid",
+      "description": "Get a webhook",
+      "method": "GET",
+      "path": "/v2/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "webhooks_update",
+      "description": "Update a webhook",
+      "method": "PATCH",
+      "path": "/v2/webhooks/{webhookId}",
+      "params": [
+        {
+          "name": "webhookId",
+          "type": "string",
+          "location": "path",
+          "description": "Webhook id",
+          "required": true
+        },
+        {
+          "name": "active",
+          "type": "bool",
+          "location": "body",
+          "description": "Active"
+        },
+        {
+          "name": "payloadTemplate",
+          "type": "string",
+          "location": "body",
+          "description": "The template of the payload that will be sent to the subscriberUrl, check cal.com/docs/core-features/webhooks for more information"
+        },
+        {
+          "name": "secret",
+          "type": "string",
+          "location": "body",
+          "description": "Secret"
+        },
+        {
+          "name": "subscriberUrl",
+          "type": "string",
+          "location": "body",
+          "description": "Subscriber url"
+        },
+        {
+          "name": "triggers",
+          "type": "array",
+          "location": "body",
+          "description": "Triggers"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "location": "body",
+          "description": "The version of the webhook"
+        }
+      ]
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -21,7 +21,10 @@
         "public_tool_count": 0,
         "auth_type": "api_key",
         "env_vars": ["DUB_TOKEN"],
-        "mcp_ready": "full"
+        "mcp_ready": "full",
+        "manifest_checksum": "sha256:c55f10f8cab350320609c2463dd83bf073d102661bd2b741dc5d6697f48fca8d",
+        "spec_format": "openapi3",
+        "manifest_url": "library/marketing/dub-pp-cli/tools-manifest.json"
       }
     },
     {
@@ -37,7 +40,10 @@
         "public_tool_count": 3,
         "auth_type": "none",
         "env_vars": [],
-        "mcp_ready": "full"
+        "mcp_ready": "full",
+        "manifest_checksum": "sha256:9ac1e69b66632589781e5386946ca9d6544c6ffacc117a28c635213e1e05d795",
+        "spec_format": "openapi3",
+        "manifest_url": "library/media-and-entertainment/espn-pp-cli/tools-manifest.json"
       }
     },
     {
@@ -69,7 +75,10 @@
         "public_tool_count": 10,
         "auth_type": "composed",
         "env_vars": [],
-        "mcp_ready": "partial"
+        "mcp_ready": "partial",
+        "manifest_checksum": "sha256:a091019421be7ba98f81894faec69400b2f2caf2c5d42d1beb1f26c8750867f1",
+        "spec_format": "openapi3",
+        "manifest_url": "library/other/pagliacci-pizza-pp-cli/tools-manifest.json"
       }
     },
     {
@@ -85,7 +94,10 @@
         "public_tool_count": 9,
         "auth_type": "none",
         "env_vars": [],
-        "mcp_ready": "full"
+        "mcp_ready": "full",
+        "manifest_checksum": "sha256:96bc481c9a47f57eeb494f39dcfc75265894eca19b675964ab61a4a1025b10bc",
+        "spec_format": "openapi3",
+        "manifest_url": "library/developer-tools/postman-explore-pp-cli/tools-manifest.json"
       }
     },
     {
@@ -101,7 +113,10 @@
         "public_tool_count": 29,
         "auth_type": "api_key",
         "env_vars": ["STEAM_WEB_API_KEY"],
-        "mcp_ready": "full"
+        "mcp_ready": "full",
+        "manifest_checksum": "sha256:d0020c2f50dfa9be7cd655e89d027dcde08aa868ac992b5cddf1e258ad745a2f",
+        "spec_format": "openapi3",
+        "manifest_url": "library/media-and-entertainment/steam-web-pp-cli/tools-manifest.json"
       }
     },
     {
@@ -117,7 +132,10 @@
         "public_tool_count": 0,
         "auth_type": "api_key",
         "env_vars": ["CAL_COM_TOKEN"],
-        "mcp_ready": "full"
+        "mcp_ready": "full",
+        "manifest_checksum": "sha256:dd568fada6bf4f8ba272b1075d6c1a6f0899c2deb15f4af954bf914f14a0e280",
+        "spec_format": "openapi3",
+        "manifest_url": "library/productivity/cal-com-pp-cli/tools-manifest.json"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Generate `tools-manifest.json` for 6 published CLIs from their original API specs
- Update `registry.json` with `manifest_checksum`, `spec_format`, and `manifest_url` fields

These manifests enable the mega MCP server (in cli-printing-press) to register tools at runtime without parsing OpenAPI specs.

| CLI | Tools | Source |
|-----|-------|--------|
| cal-com | 285 | spec.json in library |
| dub | 50 | manuscript OpenAPI spec |
| steam-web | 161 | manuscript OpenAPI spec |
| pagliacci-pizza | 38 | manuscript OpenAPI spec |
| postman-explore | 6 | manuscript OpenAPI spec |
| espn | 1 | reconstructed minimal spec |

**Skipped:** linear (no spec available), agent-capture (no MCP tools)

## Test plan

- [x] All 6 `tools-manifest.json` files are valid JSON with correct tool schemas
- [x] `registry.json` has `manifest_checksum`, `spec_format`, `manifest_url` for each CLI with a manifest
- [ ] Mega MCP server can fetch these manifests and register tools (verified after cli-printing-press PR merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)