### PR TITLE
fix(espn): replace broken CDN endpoints with site API, require --league on event commands

### DIFF
--- a/library/media-and-entertainment/espn/internal/cli/boxscore.go
+++ b/library/media-and-entertainment/espn/internal/cli/boxscore.go
@@ -31,6 +31,7 @@ func newBoxscoreCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&league, "league", "nfl", "League key")
+	cmd.Flags().StringVar(&league, "league", "", "League key (e.g. mlb, nfl, nba, nhl)")
+	_ = cmd.MarkFlagRequired("league")
 	return cmd
 }

--- a/library/media-and-entertainment/espn/internal/cli/plays.go
+++ b/library/media-and-entertainment/espn/internal/cli/plays.go
@@ -31,6 +31,7 @@ func newPlaysCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&league, "league", "nfl", "League key")
+	cmd.Flags().StringVar(&league, "league", "", "League key (e.g. mlb, nfl, nba, nhl)")
+	_ = cmd.MarkFlagRequired("league")
 	return cmd
 }

--- a/library/media-and-entertainment/espn/internal/espn/espn.go
+++ b/library/media-and-entertainment/espn/internal/espn/espn.go
@@ -122,17 +122,14 @@ func (e *ESPN) Summary(sport, league, eventID string) (json.RawMessage, error) {
 }
 
 func (e *ESPN) Boxscore(sport, league, eventID string) (json.RawMessage, error) {
-	// CDN uses just the league slug (nfl, nba) as the sport path component
-	return e.get(withQuery("https://cdn.espn.com/core/"+league+"/boxscore", map[string]string{
-		"gameId": eventID,
-		"xhr":    "1",
+	return e.get(withQuery(siteAPIURL(sport, league, "summary"), map[string]string{
+		"event": eventID,
 	}), 5*time.Minute)
 }
 
 func (e *ESPN) PlayByPlay(sport, league, eventID string) (json.RawMessage, error) {
-	return e.get(withQuery("https://cdn.espn.com/core/"+league+"/playbyplay", map[string]string{
-		"gameId": eventID,
-		"xhr":    "1",
+	return e.get(withQuery(siteAPIURL(sport, league, "summary"), map[string]string{
+		"event": eventID,
 	}), 5*time.Minute)
 }
 
@@ -315,10 +312,6 @@ func webAPIURL(segments ...string) string {
 	return joinURL(parts...)
 }
 
-func cdnURL(sport, league string, segments ...string) string {
-	parts := append([]string{"https://cdn.espn.com/core", sport, league}, segments...)
-	return joinURL(parts...)
-}
 
 func joinURL(parts ...string) string {
 	clean := make([]string, 0, len(parts))


### PR DESCRIPTION
## Summary

- `Boxscore()` and `PlayByPlay()` used `cdn.espn.com` endpoints that return HTML instead of JSON, causing `invalid character '<'` parse errors on every call. Switched both to the working `site.api.espn.com` summary endpoint.
- Made `--league` required on `boxscore` and `plays` commands. Event IDs are cross-sport, and the previous silent NFL default caused wrong-sport queries (e.g., querying NFL for an MLB event ID).
- Removed the now-unused `cdnURL()` helper function.

## Test plan

- [x] `espn-pp-cli boxscore <mlb-event> --league mlb --json` returns valid JSON boxscore data
- [x] `espn-pp-cli plays <mlb-event> --league mlb --json` returns valid JSON
- [x] `espn-pp-cli boxscore <event>` without `--league` gives clear "required flag" error
- [x] `go vet ./...` passes clean
- [x] `go build ./cmd/espn-pp-cli` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)