### PR TITLE
fix(espn): UX friction from real usage - team names, boxscore, provenance

### DIFF
--- a/library/media-and-entertainment/espn/internal/cli/boxscore.go
+++ b/library/media-and-entertainment/espn/internal/cli/boxscore.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type playerStat struct {
+	Name  string            `json:"name"`
+	Stats map[string]string `json:"stats"`
+}
+
+type teamBoxScore struct {
+	Team    string       `json:"team"`
+	Players []playerStat `json:"players"`
+}
+
+func newBoxScoreCmd(flags *rootFlags) *cobra.Command {
+	var flagEvent string
+	var flagTeam string
+	var flagLast int
+
+	cmd := &cobra.Command{
+		Use:   "boxscore <sport> <league>",
+		Short: "Box score with player stats for a game",
+		Long:  "Extract and display the box score from a game summary.\nUse --team to automatically find the most recent game, or --event for a specific game.",
+		Example: `  espn-pp-cli boxscore basketball nba --team warriors
+  espn-pp-cli boxscore basketball nba --team GS --last 2 --json
+  espn-pp-cli boxscore basketball nba --event 401811009`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hasEvent := cmd.Flags().Changed("event")
+			hasTeam := cmd.Flags().Changed("team")
+			if !hasEvent && !hasTeam && !flags.dryRun {
+				return fmt.Errorf("either --event or --team is required")
+			}
+			if len(args) < 1 {
+				return usageErr(fmt.Errorf("sport is required\nUsage: boxscore <sport> <league>"))
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: boxscore <sport> <league>"))
+			}
+			sport, league := args[0], args[1]
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			// Resolve event ID from --team if needed
+			if !hasEvent && hasTeam {
+				teamID, resolveErr := resolveTeamID(c, sport, league, flagTeam)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				eventID, eventErr := resolveLastEventID(c, sport, league, teamID, flagLast)
+				if eventErr != nil {
+					return eventErr
+				}
+				flagEvent = eventID
+			}
+
+			// Fetch summary
+			path := fmt.Sprintf("/%s/%s/summary", sport, league)
+			params := map[string]string{"event": flagEvent}
+			data, err := c.Get(path, params)
+			if err != nil {
+				return classifyAPIError(err)
+			}
+
+			// Parse box score
+			boxScores := parseBoxScores(data)
+			if len(boxScores) == 0 {
+				return fmt.Errorf("no box score data found for event %s", flagEvent)
+			}
+
+			// JSON output
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				filtered, _ := json.Marshal(boxScores)
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				}
+				return printOutput(cmd.OutOrStdout(), filtered, true)
+			}
+
+			// Table output
+			return printBoxScoreTable(cmd, boxScores)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagEvent, "event", "", "ESPN event or game ID")
+	cmd.Flags().StringVar(&flagTeam, "team", "", "Team name, abbreviation, or ID (resolves most recent game)")
+	cmd.Flags().IntVar(&flagLast, "last", 1, "Which completed game to show (1=most recent)")
+
+	return cmd
+}
+
+func parseBoxScores(data json.RawMessage) []teamBoxScore {
+	var summary struct {
+		Boxscore struct {
+			Players []struct {
+				Team struct {
+					DisplayName string `json:"displayName"`
+				} `json:"team"`
+				Statistics []struct {
+					Labels   []string `json:"labels"`
+					Athletes []struct {
+						Athlete struct {
+							DisplayName string `json:"displayName"`
+						} `json:"athlete"`
+						Stats []string `json:"stats"`
+					} `json:"athletes"`
+				} `json:"statistics"`
+			} `json:"players"`
+		} `json:"boxscore"`
+	}
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil
+	}
+
+	var result []teamBoxScore
+	for _, teamData := range summary.Boxscore.Players {
+		tbs := teamBoxScore{Team: teamData.Team.DisplayName}
+		if len(teamData.Statistics) == 0 {
+			continue
+		}
+		labels := teamData.Statistics[0].Labels
+		for _, athlete := range teamData.Statistics[0].Athletes {
+			if len(athlete.Stats) == 0 {
+				continue
+			}
+			ps := playerStat{
+				Name:  athlete.Athlete.DisplayName,
+				Stats: make(map[string]string),
+			}
+			for i, label := range labels {
+				if i < len(athlete.Stats) {
+					ps.Stats[label] = athlete.Stats[i]
+				}
+			}
+			tbs.Players = append(tbs.Players, ps)
+		}
+		result = append(result, tbs)
+	}
+	return result
+}
+
+func printBoxScoreTable(cmd *cobra.Command, boxScores []teamBoxScore) error {
+	w := cmd.OutOrStdout()
+	// Columns to display in order
+	columns := []string{"MIN", "PTS", "FG", "3PT", "FT", "REB", "AST", "TO", "STL", "BLK", "+/-"}
+
+	for i, tbs := range boxScores {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, bold(tbs.Team))
+		fmt.Fprintln(w, strings.Repeat("-", 90))
+
+		// Header
+		tw := newTabWriter(w)
+		header := bold("PLAYER")
+		for _, col := range columns {
+			header += "\t" + bold(col)
+		}
+		fmt.Fprintln(tw, header)
+
+		// Players
+		for _, p := range tbs.Players {
+			line := p.Name
+			for _, col := range columns {
+				val := p.Stats[col]
+				if val == "" {
+					val = "-"
+				}
+				line += "\t" + val
+			}
+			fmt.Fprintln(tw, line)
+		}
+		tw.Flush()
+	}
+	return nil
+}

--- a/library/media-and-entertainment/espn/internal/cli/helpers.go
+++ b/library/media-and-entertainment/espn/internal/cli/helpers.go
@@ -962,6 +962,17 @@ type DataProvenance struct {
 	ResourceType string     `json:"resource_type,omitempty"` // which resource type was queried
 }
 
+// countResponseItems returns the number of top-level items in a JSON response.
+// For arrays, returns the array length. For objects, returns 1.
+func countResponseItems(data json.RawMessage) int {
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) == nil {
+		return len(items)
+	}
+	// Single object, not an array
+	return 1
+}
+
 // printProvenance writes a one-line provenance message to stderr.
 func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	if prov.Source == "live" {

--- a/library/media-and-entertainment/espn/internal/cli/promoted_news.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_news.go
@@ -49,14 +49,7 @@ func newNewsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data = extractResponseData(data)
 
 			// Print provenance to stderr
-			{
-				var countItems []json.RawMessage
-				if json.Unmarshal(data, &countItems) != nil {
-					// Single object, not an array
-					countItems = []json.RawMessage{data}
-				}
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// CSV bypasses JSON pipe path so --csv works when piped
 			if flags.csv {
 				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)

--- a/library/media-and-entertainment/espn/internal/cli/promoted_rankings.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_rankings.go
@@ -44,14 +44,7 @@ func newRankingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data = extractResponseData(data)
 
 			// Print provenance to stderr
-			{
-				var countItems []json.RawMessage
-				if json.Unmarshal(data, &countItems) != nil {
-					// Single object, not an array
-					countItems = []json.RawMessage{data}
-				}
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// CSV bypasses JSON pipe path so --csv works when piped
 			if flags.csv {
 				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)

--- a/library/media-and-entertainment/espn/internal/cli/promoted_scoreboard.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_scoreboard.go
@@ -57,14 +57,7 @@ func newScoreboardPromotedCmd(flags *rootFlags) *cobra.Command {
 			data = extractResponseData(data)
 
 			// Print provenance to stderr
-			{
-				var countItems []json.RawMessage
-				if json.Unmarshal(data, &countItems) != nil {
-					// Single object, not an array
-					countItems = []json.RawMessage{data}
-				}
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// CSV bypasses JSON pipe path so --csv works when piped
 			if flags.csv {
 				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)

--- a/library/media-and-entertainment/espn/internal/cli/promoted_summary.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_summary.go
@@ -13,16 +13,22 @@ import (
 
 func newSummaryPromotedCmd(flags *rootFlags) *cobra.Command {
 	var flagEvent string
+	var flagTeam string
+	var flagLast int
 
 	cmd := &cobra.Command{
 		Use:   "summary <sport> <league>",
 		Short: "Get detailed game summary including box score, leaders, scoring plays, odds, and win probability",
-		Long:  "Shortcut for 'summary get'. Get detailed game summary including box score, leaders, scoring plays, odds, and win probability",
-		Example: `  espn-pp-cli summary football nfl --event 401547417
+		Long:  "Shortcut for 'summary get'. Get detailed game summary including box score, leaders, scoring plays, odds, and win probability.\nUse --team to look up the most recent game automatically instead of providing --event.",
+		Example: `  espn-pp-cli summary basketball nba --team warriors
+  espn-pp-cli summary basketball nba --team GS --last 2
+  espn-pp-cli summary football nfl --event 401547417
   espn-pp-cli summary basketball nba --event 401584793 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("event") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "event")
+			hasEvent := cmd.Flags().Changed("event")
+			hasTeam := cmd.Flags().Changed("team")
+			if !hasEvent && !hasTeam && !flags.dryRun {
+				return fmt.Errorf("either --event or --team is required")
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -33,11 +39,27 @@ func newSummaryPromotedCmd(flags *rootFlags) *cobra.Command {
 			if len(args) < 1 {
 				return usageErr(fmt.Errorf("sport is required\nUsage: %s %s <%s>", cmd.Root().Name(), cmd.CommandPath(), "sport"))
 			}
-			path = replacePathParam(path, "sport", args[0])
+			sport := args[0]
+			path = replacePathParam(path, "sport", sport)
 			if len(args) < 2 {
 				return usageErr(fmt.Errorf("league is required\nUsage: %s %s <%s>", cmd.Root().Name(), cmd.CommandPath(), "league"))
 			}
-			path = replacePathParam(path, "league", args[1])
+			league := args[1]
+			path = replacePathParam(path, "league", league)
+
+			// Resolve event ID from --team if --event not provided
+			if !hasEvent && hasTeam {
+				teamID, resolveErr := resolveTeamID(c, sport, league, flagTeam)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				eventID, eventErr := resolveLastEventID(c, sport, league, teamID, flagLast)
+				if eventErr != nil {
+					return eventErr
+				}
+				flagEvent = eventID
+			}
+
 			params := map[string]string{}
 			if flagEvent != "" {
 				params["event"] = fmt.Sprintf("%v", flagEvent)
@@ -51,14 +73,7 @@ func newSummaryPromotedCmd(flags *rootFlags) *cobra.Command {
 			data = extractResponseData(data)
 
 			// Print provenance to stderr
-			{
-				var countItems []json.RawMessage
-				if json.Unmarshal(data, &countItems) != nil {
-					// Single object, not an array
-					countItems = []json.RawMessage{data}
-				}
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// CSV bypasses JSON pipe path so --csv works when piped
 			if flags.csv {
 				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
@@ -94,6 +109,8 @@ func newSummaryPromotedCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagEvent, "event", "", "ESPN event or game ID")
+	cmd.Flags().StringVar(&flagTeam, "team", "", "Team name, abbreviation, or ID (resolves most recent game)")
+	cmd.Flags().IntVar(&flagLast, "last", 1, "Which completed game to show (1=most recent, 2=second most recent)")
 
 	// Wire sibling endpoints and sub-resources as subcommands
 

--- a/library/media-and-entertainment/espn/internal/cli/promoted_teams.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_teams.go
@@ -15,12 +15,13 @@ func newTeamsPromotedCmd(flags *rootFlags) *cobra.Command {
 	var flagSeason int
 
 	cmd := &cobra.Command{
-		Use:   "teams <sport> <league> <team_id>",
+		Use:   "teams <sport> <league> <team_name_or_id>",
 		Short: "Get past and upcoming schedule for a specific team",
-		Long:  "Shortcut for 'teams schedule'. Get past and upcoming schedule for a specific team",
-		Example: `  espn-pp-cli teams football nfl 12 --season 2025
-  espn-pp-cli teams list football nfl
-  espn-pp-cli teams get basketball nba 13 --json`,
+		Long:  "Shortcut for 'teams schedule'. Get past and upcoming schedule for a specific team.\nAccepts team name, abbreviation, or numeric ID.",
+		Example: `  espn-pp-cli teams basketball nba warriors
+  espn-pp-cli teams football nfl 12 --season 2025
+  espn-pp-cli teams basketball nba GS --json
+  espn-pp-cli teams list football nfl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := flags.newClient()
 			if err != nil {
@@ -37,9 +38,13 @@ func newTeamsPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 			path = replacePathParam(path, "league", args[1])
 			if len(args) < 3 {
-				return usageErr(fmt.Errorf("team_id is required\nUsage: %s %s <%s>", cmd.Root().Name(), cmd.CommandPath(), "team_id"))
+				return usageErr(fmt.Errorf("team name or ID is required\nUsage: %s %s <%s>", cmd.Root().Name(), cmd.CommandPath(), "team_name_or_id"))
 			}
-			path = replacePathParam(path, "team_id", args[2])
+			teamID, resolveErr := resolveTeamID(c, args[0], args[1], args[2])
+			if resolveErr != nil {
+				return resolveErr
+			}
+			path = replacePathParam(path, "team_id", teamID)
 			params := map[string]string{}
 			if flagSeason != 0 {
 				params["season"] = fmt.Sprintf("%v", flagSeason)
@@ -53,14 +58,7 @@ func newTeamsPromotedCmd(flags *rootFlags) *cobra.Command {
 			data = extractResponseData(data)
 
 			// Print provenance to stderr
-			{
-				var countItems []json.RawMessage
-				if json.Unmarshal(data, &countItems) != nil {
-					// Single object, not an array
-					countItems = []json.RawMessage{data}
-				}
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// CSV bypasses JSON pipe path so --csv works when piped
 			if flags.csv {
 				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)

--- a/library/media-and-entertainment/espn/internal/cli/root.go
+++ b/library/media-and-entertainment/espn/internal/cli/root.go
@@ -116,6 +116,7 @@ func Execute() error {
 	rootCmd.AddCommand(newWatchCmd(&flags))
 	rootCmd.AddCommand(newStreakCmd(&flags))
 	rootCmd.AddCommand(newRivalsCmd(&flags))
+	rootCmd.AddCommand(newBoxScoreCmd(&flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
 	err := rootCmd.Execute()

--- a/library/media-and-entertainment/espn/internal/cli/team_last_game.go
+++ b/library/media-and-entertainment/espn/internal/cli/team_last_game.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/client"
+)
+
+// resolveLastEventID fetches a team's schedule and returns the Nth most recent
+// completed game's event ID. n=1 means the most recent completed game.
+func resolveLastEventID(c *client.Client, sport, league, teamID string, n int) (string, error) {
+	if n < 1 {
+		n = 1
+	}
+
+	path := fmt.Sprintf("/%s/%s/teams/%s/schedule", sport, league, teamID)
+	data, err := c.Get(path, map[string]string{})
+	if err != nil {
+		return "", fmt.Errorf("fetching team schedule: %w", err)
+	}
+
+	var schedule struct {
+		Events []struct {
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			Competitions []struct {
+				Status struct {
+					Type struct {
+						Completed bool `json:"completed"`
+					} `json:"type"`
+				} `json:"status"`
+			} `json:"competitions"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(data, &schedule); err != nil {
+		return "", fmt.Errorf("parsing schedule: %w", err)
+	}
+
+	// Collect completed games in order (schedule is chronological)
+	var completed []string
+	for _, e := range schedule.Events {
+		if len(e.Competitions) > 0 && e.Competitions[0].Status.Type.Completed {
+			completed = append(completed, e.ID)
+		}
+	}
+
+	if len(completed) == 0 {
+		return "", fmt.Errorf("no completed games found for this team")
+	}
+	if n > len(completed) {
+		return "", fmt.Errorf("only %d completed games found, but --last %d requested", len(completed), n)
+	}
+
+	// Return the Nth from the end
+	return completed[len(completed)-n], nil
+}

--- a/library/media-and-entertainment/espn/internal/cli/team_resolve.go
+++ b/library/media-and-entertainment/espn/internal/cli/team_resolve.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/client"
+)
+
+// resolveTeamID resolves a team identifier to a numeric ESPN team ID.
+// Accepts numeric IDs (passthrough), team names ("warriors", "Golden State Warriors"),
+// abbreviations ("GS"), or slugs ("golden-state-warriors").
+func resolveTeamID(c *client.Client, sport, league, input string) (string, error) {
+	// Numeric ID passthrough
+	if isNumeric(input) {
+		return input, nil
+	}
+
+	// Fetch teams list
+	path := fmt.Sprintf("/%s/%s/teams", sport, league)
+	data, err := c.Get(path, map[string]string{})
+	if err != nil {
+		return "", fmt.Errorf("fetching teams list: %w", err)
+	}
+
+	teams := extractTeams(data)
+	if len(teams) == 0 {
+		return "", fmt.Errorf("no teams found for %s/%s", sport, league)
+	}
+
+	// Exact match (case-insensitive) against all name fields
+	lower := strings.ToLower(input)
+	var matches []teamInfo
+	for _, t := range teams {
+		if strings.EqualFold(t.DisplayName, input) ||
+			strings.EqualFold(t.ShortDisplayName, input) ||
+			strings.EqualFold(t.Name, input) ||
+			strings.EqualFold(t.Abbreviation, input) ||
+			strings.EqualFold(t.Slug, input) {
+			matches = append(matches, t)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("ambiguous team %q matches %d teams:\n%s", input, len(matches), formatTeamList(matches))
+	}
+
+	// Substring match as fallback
+	for _, t := range teams {
+		if strings.Contains(strings.ToLower(t.DisplayName), lower) ||
+			strings.Contains(strings.ToLower(t.ShortDisplayName), lower) ||
+			strings.Contains(strings.ToLower(t.Name), lower) {
+			matches = append(matches, t)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("ambiguous team %q matches %d teams:\n%s\nhint: use a more specific name or the numeric team ID", input, len(matches), formatTeamList(matches))
+	}
+
+	// No match - suggest closest
+	suggestion := suggestTeam(input, teams)
+	if suggestion != "" {
+		return "", fmt.Errorf("no team found matching %q\nhint: did you mean %s?", input, suggestion)
+	}
+	return "", fmt.Errorf("no team found matching %q\nhint: run 'espn-pp-cli teams list %s %s' to see available teams", input, sport, league)
+}
+
+type teamInfo struct {
+	ID               string
+	DisplayName      string
+	ShortDisplayName string
+	Name             string
+	Abbreviation     string
+	Slug             string
+}
+
+// extractTeams pulls team info from the ESPN teams list response.
+// The response structure is: {sports: [{leagues: [{teams: [{team: {...}}]}]}]}
+func extractTeams(data json.RawMessage) []teamInfo {
+	var resp struct {
+		Sports []struct {
+			Leagues []struct {
+				Teams []struct {
+					Team struct {
+						ID               string `json:"id"`
+						DisplayName      string `json:"displayName"`
+						ShortDisplayName string `json:"shortDisplayName"`
+						Name             string `json:"name"`
+						Abbreviation     string `json:"abbreviation"`
+						Slug             string `json:"slug"`
+					} `json:"team"`
+				} `json:"teams"`
+			} `json:"leagues"`
+		} `json:"sports"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil
+	}
+
+	var teams []teamInfo
+	for _, sport := range resp.Sports {
+		for _, league := range sport.Leagues {
+			for _, t := range league.Teams {
+				teams = append(teams, teamInfo{
+					ID:               t.Team.ID,
+					DisplayName:      t.Team.DisplayName,
+					ShortDisplayName: t.Team.ShortDisplayName,
+					Name:             t.Team.Name,
+					Abbreviation:     t.Team.Abbreviation,
+					Slug:             t.Team.Slug,
+				})
+			}
+		}
+	}
+	return teams
+}
+
+func isNumeric(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func formatTeamList(teams []teamInfo) string {
+	var lines []string
+	for _, t := range teams {
+		lines = append(lines, fmt.Sprintf("  %s: %s (%s)", t.ID, t.DisplayName, t.Abbreviation))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func suggestTeam(input string, teams []teamInfo) string {
+	best := ""
+	bestDist := 4
+	for _, t := range teams {
+		for _, name := range []string{t.Name, t.ShortDisplayName, t.Abbreviation} {
+			d := levenshteinDistance(strings.ToLower(input), strings.ToLower(name))
+			if d < bestDist {
+				bestDist = d
+				best = fmt.Sprintf("%q (ID: %s)", t.DisplayName, t.ID)
+			}
+		}
+	}
+	return best
+}

--- a/library/media-and-entertainment/espn/internal/cli/teams_get.go
+++ b/library/media-and-entertainment/espn/internal/cli/teams_get.go
@@ -42,11 +42,7 @@ func newTeamsGetCmd(flags *rootFlags) *cobra.Command {
 				return classifyAPIError(err)
 			}
 			// Print provenance to stderr for human-facing output
-			{
-				var countItems []json.RawMessage
-				_ = json.Unmarshal(data, &countItems)
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// For JSON output, wrap with provenance envelope before passing through flags
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				filtered := data

--- a/library/media-and-entertainment/espn/internal/cli/teams_list.go
+++ b/library/media-and-entertainment/espn/internal/cli/teams_list.go
@@ -42,11 +42,7 @@ func newTeamsListCmd(flags *rootFlags) *cobra.Command {
 				return classifyAPIError(err)
 			}
 			// Print provenance to stderr for human-facing output
-			{
-				var countItems []json.RawMessage
-				_ = json.Unmarshal(data, &countItems)
-				printProvenance(cmd, len(countItems), prov)
-			}
+			printProvenance(cmd, countResponseItems(data), prov)
 			// For JSON output, wrap with provenance envelope before passing through flags
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				filtered := data


### PR DESCRIPTION
## Summary
- Fix provenance count showing "0 results" for object responses (was breaking JSON pipe workflows)
- Add team name/abbreviation resolution - `teams basketball nba warriors` instead of needing numeric ID 9
- Add `--team` flag to `summary` command to auto-resolve most recent game instead of requiring `--event`
- Add `boxscore` command that extracts and formats player stats table from game summaries

## Context
These issues were all discovered during a real session using the CLI to pull Warriors box scores and track player stats. The 3-command chain to get a box score (find team ID, fetch schedule, parse event ID, call summary) is now a single command: `boxscore basketball nba --team warriors`.

## Testing
- `espn-pp-cli teams list basketball nba --json 2>/dev/null | python3 -c "import json,sys; json.load(sys.stdin)"` - valid JSON, no stderr leak
- `espn-pp-cli teams basketball nba warriors` - resolves to team ID 9
- `espn-pp-cli teams basketball nba GS` - abbreviation works
- `espn-pp-cli teams basketball nba cats` - "did you mean" suggestion
- `espn-pp-cli summary basketball nba --team warriors` - auto-resolves latest game
- `espn-pp-cli summary basketball nba --team warriors --last 2` - gets second most recent
- `espn-pp-cli boxscore basketball nba --team warriors --json` - full box score extraction
- `go vet ./...` passes clean

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CLI tool distributed via `go install`, no server-side component.

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)