### PR TITLE
fix(slack): resolve 12 CLI quality bugs from dogfooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,18 @@ The printing press generates both CLIs and MCP servers from the same spec. CLIs 
 | CLI | MCP | API | Tools | What it does |
 |-----|-----|-----|-------|-------------|
 | **[dub-pp-cli](library/marketing/dub/)** | dub-pp-mcp | Dub | 53 | Create short links, track analytics, manage domains, and run affiliate programs. |
+| **[hubspot-pp-cli](library/sales-and-crm/hubspot/)** | hubspot-pp-mcp | HubSpot | 50+ | CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics. |
 | **[linear-pp-cli](library/project-management/linear/)** | linear-pp-mcp | Linear | 63 | Issues, cycles, teams, projects via GraphQL. Local sync, stale detection, team health scoring. |
+| **[slack-pp-cli](library/productivity/slack/)** | slack-pp-mcp | Slack | 50+ | Send messages, search conversations, monitor channels, manage workspace. 8 transcendence analytics commands. |
 | **[steam-web-pp-cli](library/media-and-entertainment/steam-web/)** | steam-web-pp-mcp | Steam Web | 164 (29 public) | Look up Steam players, games, achievements, friends, and stats. 29 tools work without an API key. |
+| **[trigger-dev-pp-cli](library/developer-tools/trigger-dev/)** | trigger-dev-pp-mcp | Trigger.dev | 40+ | Monitor runs, trigger tasks, manage schedules, and detect failures. Real-time failure watch with desktop notifications. |
 | **[cal-com-pp-cli](library/productivity/cal-com/)** | cal-com-pp-mcp | Cal.com | 288 | Manage bookings, event types, schedules, and availability. |
+
+### Browser login required
+
+| CLI | MCP | API | Tools | What it does |
+|-----|-----|-----|-------|-------------|
+| **[dominos-pp-cli](library/commerce/dominos-pp-cli/)** | dominos-mcp | Domino's Pizza | 25+ | Order pizza, browse menus, track deliveries, manage rewards. Offline menu search, saved order templates, deal optimization. |
 
 ### Partial MCP (some tools work without auth)
 
@@ -60,6 +69,18 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 # Postman Explore — API network browser (no auth)
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@latest
+
+# HubSpot — CRM (set HUBSPOT_ACCESS_TOKEN env var)
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-cli@latest
+
+# Slack — workspace messaging (set SLACK_BOT_TOKEN env var)
+go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@latest
+
+# Trigger.dev — background jobs (set TRIGGER_SECRET_KEY env var)
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@latest
+
+# Domino's Pizza — pizza ordering (browser login)
+go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-pp-cli@latest
 
 # Pagliacci Pizza — pizza ordering (browser login for full access)
 go install github.com/mvanhorn/printing-press-library/library/other/pagliacci-pizza/cmd/pagliacci-pizza-pp-cli@latest

--- a/docs/plans/2026-04-10-001-fix-cli-quality-bugs-plan.md
+++ b/docs/plans/2026-04-10-001-fix-cli-quality-bugs-plan.md
@@ -1,0 +1,396 @@
+---
+title: "fix: Resolve 12 CLI quality bugs found during dogfooding"
+type: fix
+status: active
+date: 2026-04-10
+---
+
+# fix: Resolve 12 CLI quality bugs found during dogfooding
+
+## Overview
+
+The slack-pp-cli has 12 bugs discovered during real-world usage, ranging from fatal crashes to misleading output. This plan fixes all of them in the printing-press-library repo.
+
+## Problem Frame
+
+During hands-on testing of every command with a real Slack workspace, we found 2 crash bugs (panics/deadlocks), several data display issues (nil channel names, false credential validation), missing functionality (sync doesn't pull DMs/private channels, export only hits API), and input validation gaps (FTS5 query injection, negative limits).
+
+## Requirements Trace
+
+- R1. No command should panic or deadlock under any user input
+- R2. Channel names should display as human-readable names, not nil or raw IDs
+- R3. `doctor` should actually validate credentials against the API
+- R4. `sync` should pull DMs, group DMs, and private channels
+- R5. `search` should handle all user input without SQL errors
+- R6. `export` should work from local data, not just live API
+- R7. Invalid flag values (negative limits, bad types) should produce clear errors
+- R8. Health grading should reflect realistic workspace activity levels
+
+## Scope Boundaries
+
+- Fixes target the slack CLI in the library repo only, not the printing-press generator templates
+- No new features - only fixing broken existing behavior
+- No changes to the MCP server
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/store/store.go:236-248`: `Get()` does a `QueryRow` that conflicts with open cursors when `MaxOpenConns=1`
+- `internal/cli/search.go:220`: Slice bounds crash on negative limit
+- `internal/store/store.go:275-285`: FTS5 MATCH receives raw user input without escaping
+- `internal/cli/funny.go:51,75`: Reads `msg["channel"]` from message JSON, but channel is stored in the `channel_id` DB column, not in the message JSON body
+- `internal/cli/threads_stale.go:52`: Same channel resolution pattern as funny
+- `internal/cli/response_times.go:50-67`: Iterates `rows.Next()` while calling `resourceName()` which opens a nested query - deadlocks because `MaxOpenConns=1`
+- `internal/cli/doctor.go:103`: GETs the base URL instead of calling `auth.test`
+- `internal/cli/sync.go:490`: `conversations.list` called without `types=` param
+- `internal/cli/export.go:37,65`: Always creates an API client, never reads from local store
+- `internal/cli/health.go:198-207`: Grading thresholds assume very high-traffic channels
+- `internal/cli/analytics.go:106`: `obj[field]` on nonexistent field returns nil, printed as `<nil>`
+
+### Institutional Learnings
+
+- FTS5 query sanitization is a known gap in printing-press templates - no `sanitizeFTSQuery` exists anywhere. Standard fix: wrap each token in double quotes to neutralize FTS5 operators.
+- Belt-and-suspenders pattern from filepath traversal solution: sanitize input AND handle errors gracefully.
+- SQLite deadlock from nested queries with `MaxOpenConns=1` is a classic Go/SQLite pitfall. Fix: collect results into a slice before running dependent queries.
+
+## Key Technical Decisions
+
+- **FTS5 escaping via double-quoting**: Wrap each whitespace-delimited token in double quotes before passing to MATCH. This neutralizes `AND`, `OR`, `NOT`, `NEAR`, `*`, `(`, `)` without losing phrase matching. Chosen over stripping special chars because it preserves search intent.
+- **response-times deadlock fix via result collection**: Collect all rows into a slice first, close the cursor, then call `resourceName()`. Chosen over increasing MaxOpenConns because it's the correct Go pattern for SQLite.
+- **Channel name fix via channel_id column**: The message JSON body doesn't contain a `channel` field. The `channel_id` is stored in the messages table column. Fix the funny/threads-stale commands to extract channel_id from the DB row rather than from the JSON body.
+- **doctor credential validation via auth.test**: Slack's `auth.test` endpoint is the canonical way to validate a token. Replace the base URL GET with a POST to `auth.test`.
+- **sync types parameter**: Pass `types=public_channel,private_channel,mpim,im` to `conversations.list` so all conversation types are synced.
+- **Export from local data**: Add `--data-source` flag to export, defaulting to local. Read from the store when local, hit API when live.
+- **Health grading recalibration**: Lower thresholds to match typical small/medium workspace activity. A channel with 10+ msgs/day and 5+ posters should be an A, not a C.
+
+## Implementation Units
+
+- [ ] **Unit 1: Fix FTS5 query escaping in store**
+
+**Goal:** Prevent raw user input from crashing FTS5 MATCH queries
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/store/store.go`
+- Test: `internal/store/store_test.go`
+
+**Approach:**
+- Add a `sanitizeFTSQuery(query string) string` function that splits on whitespace, wraps each token in double quotes (escaping any embedded double quotes by doubling them), and rejoins
+- Empty queries should return `""` which the caller handles by returning empty results
+- Apply sanitization in `Search()`, `SearchUsergroups()`, and `SearchFiles()` before passing to MATCH
+
+**Patterns to follow:**
+- Existing `Search()` method at line 275
+
+**Test scenarios:**
+- Happy path: search "hello world" returns matching results
+- Edge case: empty string query returns empty results without error
+- Edge case: query with FTS5 operators "OR 1=1" is treated as literal text search
+- Edge case: query with special chars "a]b[c" is treated as literal text search
+- Edge case: query with semicolons "DROP TABLE;" is treated as literal text search
+- Edge case: query with embedded quotes 'say "hello"' properly escapes the quotes
+
+**Verification:**
+- `slack-pp-cli search "" --data-source local` returns "No results" instead of SQL error
+- `slack-pp-cli search "OR 1=1" --data-source local` returns results or "No results" without error
+
+- [ ] **Unit 2: Fix search panic on negative limit**
+
+**Goal:** Prevent slice bounds panic when limit is negative
+
+**Requirements:** R1, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/search.go`
+
+**Approach:**
+- In `outputSearchResults()` at line 220, guard the slice operation: if limit <= 0, skip the truncation
+- Validate limit in the command's RunE before calling search
+
+**Test scenarios:**
+- Edge case: `--limit -1` does not panic, returns results or error
+- Edge case: `--limit 0` returns empty results or all results
+
+**Verification:**
+- `slack-pp-cli search "hello" --data-source local --limit -1` exits cleanly
+
+- [ ] **Unit 3: Fix response-times deadlock**
+
+**Goal:** Eliminate goroutine deadlock from nested DB queries
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/response_times.go`
+
+**Approach:**
+- Collect all row data (channelID, avg, threads) into a struct slice during `rows.Next()` loop
+- Close rows (or let defer handle it)
+- Loop over the collected results to call `resourceName()` after the cursor is closed
+- The current code at lines 60-68 already builds an `out` slice but calls `resourceName` inside the scan loop - move the `resourceName` call to a second pass
+
+**Patterns to follow:**
+- The threads_stale.go pattern where items are collected first, then processed
+
+**Test scenarios:**
+- Happy path: `response-times` returns channel response time data without deadlock
+- Edge case: no thread data returns a helpful error message
+
+**Verification:**
+- `slack-pp-cli response-times` completes without panic or deadlock
+
+- [ ] **Unit 4: Fix channel name resolution in funny and threads-stale**
+
+**Goal:** Display channel names instead of `<nil>` in funny and threads-stale output
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/funny.go`
+- Modify: `internal/cli/threads_stale.go`
+
+**Approach:**
+- Root cause: message JSON from `m.data` doesn't contain a `channel` field. The channel_id is stored in the `channel_id` column of the messages table, not in the JSON body.
+- For funny.go: `TopReactedMessages` returns `m.data` which lacks channel. Either modify `TopReactedMessages` to also return `m.channel_id`, or have `TopReactedMessages` inject `channel_id` into the returned JSON before returning.
+- For threads-stale.go: same pattern - `StaleThreads` returns `m.data` without channel. Check that method too.
+- Simpler fix: modify `TopReactedMessages` and `StaleThreads` in store.go to SELECT `json_set(m.data, '$.channel', m.channel_id)` instead of plain `m.data`. This injects channel_id into the JSON at query time.
+
+**Files:**
+- Modify: `internal/store/store.go` (TopReactedMessages and StaleThreads methods)
+- Modify: `internal/cli/funny.go` (verify msg["channel"] works after store fix)
+- Modify: `internal/cli/threads_stale.go` (verify msg["channel"] works after store fix)
+
+**Patterns to follow:**
+- SQLite's `json_set()` function to inject fields into JSON at query time
+
+**Test scenarios:**
+- Happy path: `funny` output shows `#channel-name` instead of `<nil>`
+- Happy path: `threads-stale` output shows `#channel-name` instead of `<nil>`
+
+**Verification:**
+- `slack-pp-cli funny --period month` shows channel names in the Channel column
+- `slack-pp-cli threads-stale` shows channel names in the Channel column
+
+- [ ] **Unit 5: Fix doctor credential validation**
+
+**Goal:** Make `doctor` actually verify credentials work against the Slack API
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/doctor.go`
+
+**Approach:**
+- Replace the GET to base URL (line 103) with a POST to `/auth.test`, which is Slack's canonical credential validation endpoint
+- Parse the JSON response for `"ok": true` vs `"ok": false`
+- On `"ok": false`, report the error field from the response (e.g., "invalid_auth", "token_revoked")
+- Keep the existing reachability check (HEAD to base URL) for the API status line
+
+**Test scenarios:**
+- Happy path: valid token reports "Credentials: valid"
+- Error path: invalid/garbage token reports "Credentials: invalid (invalid_auth)"
+- Error path: empty token reports "Auth: not configured"
+
+**Verification:**
+- `SLACK_USER_TOKEN=bad-token slack-pp-cli doctor` shows credentials as invalid, not valid
+
+- [ ] **Unit 6: Add DM/private channel support to sync**
+
+**Goal:** Sync DMs, group DMs, and private channels alongside public channels
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/sync.go`
+
+**Approach:**
+- In `syncResourcePath()` at line 490, change the conversations path from `/conversations.list` to `/conversations.list?types=public_channel,private_channel,mpim,im`
+- Alternatively, modify the sync caller to pass the types parameter as a query param
+- The simpler approach is appending to the path since the sync infrastructure passes this directly to the API client
+
+**Test scenarios:**
+- Happy path: `sync` pulls DM and private channel conversations into the local store
+- Happy path: after sync, `search` finds content from DMs and private channels
+
+**Verification:**
+- After `slack-pp-cli sync`, the resources table contains conversations with `is_im: true` and `is_private: true`
+
+- [ ] **Unit 7: Add local data support to export**
+
+**Goal:** Allow export to read from synced local data instead of requiring API access
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/export.go`
+
+**Approach:**
+- Add `--data-source` flag matching the pattern used by other commands
+- When data-source is "local" or "auto" with local data available, read from `db.List(resource, limit)` instead of `c.Get(path, nil)`
+- When data-source is "live", keep the existing API path
+- Import the store package and use `openAnalyticsStore()` for local access
+
+**Patterns to follow:**
+- The search command's data-source routing pattern
+
+**Test scenarios:**
+- Happy path: `export messages --data-source local` exports locally synced messages
+- Happy path: `export messages --data-source live` hits the API as before
+- Error path: `export messages --data-source local` with no synced data returns a clear error
+
+**Verification:**
+- `slack-pp-cli export messages --data-source local --format jsonl` outputs JSONL from local store
+
+- [ ] **Unit 8: Recalibrate health grading thresholds**
+
+**Goal:** Make health grades reflect realistic workspace activity levels
+
+**Requirements:** R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/health.go`
+
+**Approach:**
+- Current thresholds (A: 100+ msgs/day or 25+ users, B: 40+/12+, C: 10+/5+, D: >0) are calibrated for very large workspaces
+- Recalibrate to: A: 10+ msgs/day AND 3+ unique posters, B: 5+ msgs/day AND 2+ posters, C: 1+ msgs/day, D: >0 but <1/day, F: no activity
+- Change OR logic to AND for A/B grades - a channel needs both volume and participation to be healthy
+- Keep single-poster channels capped at C regardless of volume (bot channels)
+
+**Test scenarios:**
+- Happy path: a channel with 12 msgs/day and 8 posters gets grade A
+- Edge case: a channel with 100 msgs/day but 1 poster (bot channel) gets grade C
+- Edge case: a channel with 0 messages gets grade F
+
+**Verification:**
+- `slack-pp-cli health` shows a distribution of grades, not all C/D
+
+- [ ] **Unit 9: Validate analytics group-by field and limit edge cases**
+
+**Goal:** Reject invalid group-by fields and handle edge case flag values
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/analytics.go`
+- Modify: `internal/cli/funny.go`
+
+**Approach:**
+- In `runGroupBy()`, after extracting values, check if all keys are `<nil>` - if so, the field doesn't exist. Return an error: "field %q not found in %s records"
+- In funny.go, validate that `--limit 0` and `--limit -1` are rejected with a clear error or clamped to 1
+
+**Test scenarios:**
+- Error path: `analytics --type messages --group-by nonexistent` returns "field not found" error
+- Edge case: `funny --limit 0` returns error or clamps to minimum
+- Edge case: `funny --limit -1` returns error or clamps to minimum
+
+**Verification:**
+- `slack-pp-cli analytics --type messages --group-by fake_field` shows a clear error
+
+- [ ] **Unit 10: Fix conversations history limit validation**
+
+**Goal:** Validate numeric flags before sending to API
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/promoted_conversations.go`
+
+**Approach:**
+- The `--limit` flag for `conversations history` is a string type. Validate it's a valid positive integer before making the API call
+- Return a clear error like "invalid --limit: expected a positive integer" instead of passing garbage to the API
+
+**Test scenarios:**
+- Error path: `conversations history --channel C123 --limit abc` returns validation error
+- Edge case: `conversations history --channel C123 --limit -1` returns validation error
+
+**Verification:**
+- `slack-pp-cli conversations history --channel C123 --limit abc` shows a local validation error, not an API error
+
+- [ ] **Unit 11: Handle missing scopes gracefully**
+
+**Goal:** Show user-friendly messages when Slack API returns missing_scope errors
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/cli/helpers.go` or wherever `classifyAPIError` lives
+
+**Approach:**
+- When the API returns `{"ok": false, "error": "missing_scope", "needed": "emoji:read"}`, the CLI currently dumps the raw JSON
+- Parse the response and show: "Missing Slack scope: emoji:read. Add it in your app's OAuth & Permissions settings and reinstall."
+- Apply this to the common response handling path so all commands benefit
+
+**Test scenarios:**
+- Error path: command requiring missing scope shows human-readable error with the needed scope name
+
+**Verification:**
+- `slack-pp-cli emoji` (without emoji:read scope) shows "Missing Slack scope: emoji:read" instead of raw JSON
+
+- [ ] **Unit 12: Fix export hitting API with wrong method name**
+
+**Goal:** Fix export so it constructs proper Slack API paths
+
+**Requirements:** R6
+
+**Dependencies:** Unit 7
+
+**Files:**
+- Modify: `internal/cli/export.go`
+
+**Approach:**
+- Currently export constructs path as `"/" + resource` (e.g., `/messages`), but Slack API endpoints use dot notation (e.g., `/conversations.history`)
+- For the live API path, reuse the `syncResourcePath()` mapping so export uses the same endpoints as sync
+- This ensures `export conversations` hits `/conversations.list`, not `/conversations`
+
+**Test scenarios:**
+- Happy path: `export conversations --data-source live` hits the correct Slack API endpoint
+- Error path: `export nonexistent --data-source live` returns a clear "unknown resource" error
+
+**Verification:**
+- `slack-pp-cli export conversations` returns conversation data instead of `unknown_method`
+
+## System-Wide Impact
+
+- **Interaction graph:** The FTS sanitization fix in store.go affects search, funny (indirectly via TopReactedMessages), and any future command that uses FTS. The channel name fix via json_set affects funny, threads-stale, and response-times.
+- **Error propagation:** Missing scope errors are currently swallowed as raw JSON - Unit 11 makes them user-friendly across all commands.
+- **State lifecycle risks:** The sync types change (Unit 6) will pull more data on next sync. Existing local data is unaffected - new data is additive.
+- **Unchanged invariants:** The MCP server is not modified. All API write commands (messages post, reactions add, etc.) are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| json_set may not be available in all SQLite builds | It's part of the JSON1 extension which is compiled in by default since SQLite 3.38.0 (2022). Go's mattn/go-sqlite3 includes it. |
+| Sync pulling DMs may hit rate limits on large workspaces | Slack's conversations.list handles all types in one paginated call, so no additional API calls beyond what sync already makes. |
+| Health grade recalibration may surprise users who rely on current grades | This is a cosmetic change with no downstream effects. Document the new thresholds in the help text. |
+
+## Sources & References
+
+- Related bugs: found during hands-on dogfooding session
+- Slack API docs: auth.test endpoint for credential validation
+- SQLite FTS5 docs: tokenize and MATCH query syntax
+- Go database/sql docs: cursor behavior with MaxOpenConns=1

--- a/library/productivity/slack/internal/cli/analytics.go
+++ b/library/productivity/slack/internal/cli/analytics.go
@@ -98,13 +98,22 @@ func runGroupBy(db *store.Store, resourceType, field string, limit int, flags *r
 	}
 
 	counts := make(map[string]int)
+	nilCount := 0
 	for _, item := range items {
 		var obj map[string]any
 		if err := json.Unmarshal(item, &obj); err != nil {
 			continue
 		}
-		val := fmt.Sprintf("%v", obj[field])
+		v, exists := obj[field]
+		if !exists || v == nil {
+			nilCount++
+			continue
+		}
+		val := fmt.Sprintf("%v", v)
 		counts[val]++
+	}
+	if len(counts) == 0 && nilCount > 0 {
+		return fmt.Errorf("field %q not found in %s records", field, resourceType)
 	}
 
 	type kv struct {

--- a/library/productivity/slack/internal/cli/conversations_history.go
+++ b/library/productivity/slack/internal/cli/conversations_history.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,9 @@ func newConversationsHistoryCmd(flags *rootFlags) *cobra.Command {
 				params["channel"] = fmt.Sprintf("%v", flagChannel)
 			}
 			if flagLimit != "" {
+				if _, parseErr := strconv.Atoi(flagLimit); parseErr != nil {
+					return fmt.Errorf("invalid --limit %q: expected a positive integer", flagLimit)
+				}
 				params["limit"] = fmt.Sprintf("%v", flagLimit)
 			}
 			if flagCursor != "" {

--- a/library/productivity/slack/internal/cli/data_source.go
+++ b/library/productivity/slack/internal/cli/data_source.go
@@ -88,11 +88,17 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if slackErr := checkSlackAPIError(data); slackErr != nil {
+			return nil, DataProvenance{}, slackErr
+		}
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			if slackErr := checkSlackAPIError(data); slackErr != nil {
+				return nil, DataProvenance{}, slackErr
+			}
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {

--- a/library/productivity/slack/internal/cli/doctor.go
+++ b/library/productivity/slack/internal/cli/doctor.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -93,29 +94,31 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = "reachable"
 				}
 
-				// Step 2: Validate credentials with an authenticated request
+				// Step 2: Validate credentials with Slack's auth.test endpoint
 				authHeader := cfg.AuthHeader()
 				if authHeader == "" {
 					// No auth configured — skip credential validation
 				} else if !apiReachable {
 					report["credentials"] = "skipped (API unreachable)"
 				} else {
-					authReq, _ := http.NewRequest("GET", baseURL, nil)
+					authReq, _ := http.NewRequest("POST", baseURL+"/auth.test", nil)
 					authReq.Header.Set("Authorization", authHeader)
 					authReq.Header.Set("User-Agent", "slack-pp-cli")
 					authResp, authErr := httpClient.Do(authReq)
 					if authErr != nil {
 						report["credentials"] = "error: could not reach API"
 					} else {
-						authResp.Body.Close()
-						switch {
-						case authResp.StatusCode >= 200 && authResp.StatusCode < 300:
+						defer authResp.Body.Close()
+						var result struct {
+							OK    bool   `json:"ok"`
+							Error string `json:"error"`
+						}
+						if json.NewDecoder(authResp.Body).Decode(&result) == nil && result.OK {
 							report["credentials"] = "valid"
-						case authResp.StatusCode == 401 || authResp.StatusCode == 403:
-							report["credentials"] = fmt.Sprintf("invalid (HTTP %d) — check your credentials", authResp.StatusCode)
-						default:
-							// Non-auth HTTP error (404, 500, etc.) — don't blame credentials
-							report["credentials"] = fmt.Sprintf("ok (HTTP %d from base URL, but auth was accepted)", authResp.StatusCode)
+						} else if result.Error != "" {
+							report["credentials"] = fmt.Sprintf("invalid (%s)", result.Error)
+						} else {
+							report["credentials"] = fmt.Sprintf("invalid (HTTP %d)", authResp.StatusCode)
 						}
 					}
 				}

--- a/library/productivity/slack/internal/cli/export.go
+++ b/library/productivity/slack/internal/cli/export.go
@@ -23,30 +23,20 @@ func newExportCmd(flags *rootFlags) *cobra.Command {
 		Short: "Export data to JSONL or JSON for backup, migration, or analysis",
 		Long: `Export paginated API data to a local file. Supports JSONL (one JSON object
 per line, streaming-friendly) and JSON (array). JSONL is recommended for
-large datasets as it has no memory pressure.`,
-		Example: `  # Export all items as JSONL (streaming, recommended for large datasets)
-  slack-pp-cli export <resource> --format jsonl --output data.jsonl
+large datasets as it has no memory pressure.
 
-  # Export with limit
-  slack-pp-cli export <resource> --format jsonl --limit 1000
+Supports --data-source: local (from synced SQLite), live (from API), auto (local first, API fallback).`,
+		Example: `  # Export from local sync data (recommended)
+  slack-pp-cli export messages --data-source local --format jsonl
+
+  # Export from live API
+  slack-pp-cli export conversations --data-source live --format jsonl --output data.jsonl
 
   # Pipe to another tool
-  slack-pp-cli export <resource> --format jsonl | jq '.id'`,
+  slack-pp-cli export messages --format jsonl | jq '.id'`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-			if noCache {
-				c.NoCache = true
-			}
-
 			resource := args[0]
-			path := "/" + resource
-			if len(args) > 1 {
-				path += "/" + args[1]
-			}
 
 			var writer *bufio.Writer
 			if outputFile != "" {
@@ -62,39 +52,67 @@ large datasets as it has no memory pressure.`,
 				defer writer.Flush()
 			}
 
+			// Try local data first when data-source is local or auto
+			if flags.dataSource == "local" || flags.dataSource == "auto" {
+				db, dbErr := openAnalyticsStore()
+				if dbErr == nil {
+					defer db.Close()
+					fetchLimit := limit
+					if fetchLimit <= 0 {
+						fetchLimit = 10000
+					}
+					// Messages are stored in a dedicated table, not the generic resources table.
+					var items []json.RawMessage
+					var listErr error
+					if resource == "messages" {
+						items, listErr = db.ListMessages(fetchLimit)
+					} else {
+						items, listErr = db.List(resource, fetchLimit)
+					}
+					if listErr == nil && len(items) > 0 {
+						return writeExport(writer, items, format, limit, outputFile)
+					}
+					if flags.dataSource == "local" {
+						if listErr != nil {
+							return fmt.Errorf("export from local store: %w", listErr)
+						}
+						return fmt.Errorf("no %s data in local store. Run 'slack-pp-cli sync' first", resource)
+					}
+				} else if flags.dataSource == "local" {
+					return fmt.Errorf("cannot open local store: %w\nRun 'slack-pp-cli sync' first", dbErr)
+				}
+			}
+
+			// Fall through to live API
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			if noCache {
+				c.NoCache = true
+			}
+
+			// Use the same endpoint mapping as sync
+			path := syncResourcePath(resource)
+			if len(args) > 1 {
+				path += "/" + args[1]
+			}
+
 			data, err := c.Get(path, nil)
 			if err != nil {
 				return classifyAPIError(err)
 			}
 
-			switch format {
-			case "jsonl":
-				var items []json.RawMessage
-				if err := json.Unmarshal(data, &items); err != nil {
-					fmt.Fprintln(writer, string(data))
-					return nil
-				}
-				count := 0
-				for _, item := range items {
-					if limit > 0 && count >= limit {
-						break
-					}
-					fmt.Fprintln(writer, string(item))
-					count++
-				}
+			var items []json.RawMessage
+			if json.Unmarshal(data, &items) != nil {
+				// Not an array - output as single item
+				fmt.Fprintln(writer, string(data))
 				if outputFile != "" {
-					fmt.Fprintf(os.Stderr, "Exported %d records to %s\n", count, outputFile)
+					fmt.Fprintf(os.Stderr, "Exported 1 record to %s\n", outputFile)
 				}
-			default:
-				enc := json.NewEncoder(writer)
-				enc.SetIndent("", "  ")
-				var parsed any
-				if err := json.Unmarshal(data, &parsed); err != nil {
-					return err
-				}
-				return enc.Encode(parsed)
+				return nil
 			}
-			return nil
+			return writeExport(writer, items, format, limit, outputFile)
 		},
 	}
 
@@ -104,4 +122,29 @@ large datasets as it has no memory pressure.`,
 	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Bypass response cache for fresh data")
 
 	return cmd
+}
+
+func writeExport(writer *bufio.Writer, items []json.RawMessage, format string, limit int, outputFile string) error {
+	switch format {
+	case "jsonl":
+		count := 0
+		for _, item := range items {
+			if limit > 0 && count >= limit {
+				break
+			}
+			fmt.Fprintln(writer, string(item))
+			count++
+		}
+		if outputFile != "" {
+			fmt.Fprintf(os.Stderr, "Exported %d records to %s\n", count, outputFile)
+		}
+	default:
+		enc := json.NewEncoder(writer)
+		enc.SetIndent("", "  ")
+		if limit > 0 && len(items) > limit {
+			items = items[:limit]
+		}
+		return enc.Encode(items)
+	}
+	return nil
 }

--- a/library/productivity/slack/internal/cli/funny.go
+++ b/library/productivity/slack/internal/cli/funny.go
@@ -27,6 +27,9 @@ func newFunnyCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			defer db.Close()
+			if limit <= 0 {
+				return fmt.Errorf("invalid --limit %d: must be a positive integer", limit)
+			}
 			days := map[string]int{"week": 7, "month": 30}[period]
 			if days == 0 {
 				return fmt.Errorf("invalid --period %q: must be week or month", period)

--- a/library/productivity/slack/internal/cli/health.go
+++ b/library/productivity/slack/internal/cli/health.go
@@ -196,12 +196,16 @@ func newHealthCmd(flags *rootFlags) *cobra.Command {
 				avg := math.Round((float64(msgs)/30)*10) / 10
 				grade := "F"
 				switch {
-				case avg >= 100 || users >= 25:
+				case avg >= 10 && users >= 3:
 					grade = "A"
-				case avg >= 40 || users >= 12:
+				case avg >= 5 && users >= 2:
 					grade = "B"
-				case avg >= 10 || users >= 5:
-					grade = "C"
+				case avg >= 1:
+					if users <= 1 {
+						grade = "C" // single-poster (bot) channels cap at C
+					} else {
+						grade = "C"
+					}
 				case avg > 0:
 					grade = "D"
 				}

--- a/library/productivity/slack/internal/cli/helpers.go
+++ b/library/productivity/slack/internal/cli/helpers.go
@@ -372,6 +372,26 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 // avoids false positives on APIs where "data" is a regular field (e.g., Stripe
 // returns {"data":[...],"has_more":true} where "data" is the list, not an
 // envelope wrapper).
+// checkSlackAPIError inspects the response for Slack's {"ok": false} pattern
+// and returns a user-friendly error when found. Returns nil if the response is ok.
+func checkSlackAPIError(data json.RawMessage) error {
+	var resp struct {
+		OK     bool   `json:"ok"`
+		Error  string `json:"error"`
+		Needed string `json:"needed"`
+	}
+	if json.Unmarshal(data, &resp) != nil {
+		return nil
+	}
+	if resp.OK || resp.Error == "" {
+		return nil
+	}
+	if resp.Error == "missing_scope" && resp.Needed != "" {
+		return fmt.Errorf("missing Slack scope: %s\nAdd it in your app's OAuth & Permissions settings at https://api.slack.com/apps and reinstall", resp.Needed)
+	}
+	return fmt.Errorf("Slack API error: %s", resp.Error)
+}
+
 func extractResponseData(data json.RawMessage) json.RawMessage {
 	var envelope struct {
 		Status string          `json:"status"`

--- a/library/productivity/slack/internal/cli/response_times.go
+++ b/library/productivity/slack/internal/cli/response_times.go
@@ -53,18 +53,23 @@ func newResponseTimesCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer rows.Close()
 			type row struct {
+				ChannelID          string  `json:"-"`
 				Channel            string  `json:"channel"`
 				AvgResponseMinutes float64 `json:"avg_response_minutes"`
 				Threads            int     `json:"threads"`
 			}
 			var out []row
 			for rows.Next() {
-				var channelID string
 				var item row
-				if rows.Scan(&channelID, &item.AvgResponseMinutes, &item.Threads) == nil {
-					item.Channel = resourceName(db, "conversations", channelID)
+				if rows.Scan(&item.ChannelID, &item.AvgResponseMinutes, &item.Threads) == nil {
 					out = append(out, item)
 				}
+			}
+			rows.Close()
+			// Resolve channel names after closing the cursor to avoid deadlock
+			// (resourceName opens a nested query, which deadlocks with MaxOpenConns=1).
+			for i := range out {
+				out[i].Channel = resourceName(db, "conversations", out[i].ChannelID)
 			}
 			if len(out) == 0 {
 				return fmt.Errorf("no thread reply data found. Run 'slack-pp-cli sync' first")

--- a/library/productivity/slack/internal/cli/search.go
+++ b/library/productivity/slack/internal/cli/search.go
@@ -217,7 +217,7 @@ func outputSearchResults(cmd *cobra.Command, flags *rootFlags, results []json.Ra
 	results = filtered
 
 	// Enforce limit across aggregated results.
-	if len(results) > limit {
+	if limit > 0 && len(results) > limit {
 		results = results[:limit]
 	}
 

--- a/library/productivity/slack/internal/cli/sync.go
+++ b/library/productivity/slack/internal/cli/sync.go
@@ -487,7 +487,7 @@ func defaultSyncResources() []string {
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) string {
 	paths := map[string]string{
-		"conversations": "/conversations.list",
+		"conversations": "/conversations.list?types=public_channel,private_channel,mpim,im",
 		"emoji":         "/emoji.list",
 		"files":         "/files.list",
 		"reactions":     "/reactions.list",

--- a/library/productivity/slack/internal/store/store.go
+++ b/library/productivity/slack/internal/store/store.go
@@ -272,9 +272,29 @@ func (s *Store) List(resourceType string, limit int) ([]json.RawMessage, error) 
 	return results, rows.Err()
 }
 
+// sanitizeFTSQuery wraps each whitespace-delimited token in double quotes
+// to prevent FTS5 operator injection (AND, OR, NOT, NEAR, *, etc.).
+// Empty input returns "" so callers can short-circuit to empty results.
+func sanitizeFTSQuery(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return ""
+	}
+	tokens := strings.Fields(query)
+	for i, t := range tokens {
+		t = strings.ReplaceAll(t, `"`, `""`)
+		tokens[i] = `"` + t + `"`
+	}
+	return strings.Join(tokens, " ")
+}
+
 func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 	if limit <= 0 {
 		limit = 50
+	}
+	q := sanitizeFTSQuery(query)
+	if q == "" {
+		return nil, nil
 	}
 	rows, err := s.db.Query(
 		`SELECT r.data FROM resources r
@@ -282,7 +302,7 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		 WHERE resources_fts MATCH ?
 		 ORDER BY rank
 		 LIMIT ?`,
-		query, limit,
+		q, limit,
 	)
 	if err != nil {
 		return nil, err
@@ -458,6 +478,21 @@ func (s *Store) UpsertMessage(channelID, userID, ts, threadTS, text string, repl
 	return nil
 }
 
+func (s *Store) ListMessages(limit int) ([]json.RawMessage, error) {
+	if limit <= 0 {
+		limit = 10000
+	}
+	rows, err := s.db.Query(
+		`SELECT data FROM messages ORDER BY CAST(ts AS REAL) DESC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return rawMessagesFromRows(rows)
+}
+
 func (s *Store) MessagesByChannel(channelID string, limit int) ([]json.RawMessage, error) {
 	if limit <= 0 {
 		limit = 200
@@ -526,7 +561,7 @@ func (s *Store) StaleThreads(days int, limit int) ([]json.RawMessage, error) {
 
 	cutoff := float64(time.Now().AddDate(0, 0, -days).Unix())
 	stmt, err := s.db.Prepare(
-		`SELECT parent.data
+		`SELECT json_set(parent.data, '$.channel', parent.channel_id)
 		 FROM messages parent
 		 JOIN messages reply ON reply.thread_ts = parent.ts
 		 WHERE parent.thread_ts IS NULL
@@ -559,14 +594,14 @@ func (s *Store) TopReactedMessages(channelID string, emoji string, limit int) ([
 		limit = 50
 	}
 
-	baseQuery := `SELECT m.data
+	baseQuery := `SELECT json_set(m.data, '$.channel', m.channel_id)
 		FROM messages m
 		LEFT JOIN json_each(COALESCE(m.reactions_json, '[]')) reaction
 		WHERE (? = '' OR m.channel_id = ?)
 		GROUP BY m.id`
 	args := []any{channelID, channelID}
 	if emoji != "" {
-		baseQuery = `SELECT m.data
+		baseQuery = `SELECT json_set(m.data, '$.channel', m.channel_id)
 			FROM messages m
 			JOIN json_each(COALESCE(m.reactions_json, '[]')) reaction
 			WHERE (? = '' OR m.channel_id = ?)
@@ -709,12 +744,16 @@ func (s *Store) SearchUsergroups(query string, limit int) ([]json.RawMessage, er
 	if limit <= 0 {
 		limit = 50
 	}
+	q := sanitizeFTSQuery(query)
+	if q == "" {
+		return nil, nil
+	}
 	rows, err := s.db.Query(
 		`SELECT t.data FROM usergroups t
 		 JOIN usergroups_fts ON usergroups_fts.rowid = t.rowid
 		 WHERE usergroups_fts MATCH ?
 		 ORDER BY rank LIMIT ?`,
-		query, limit,
+		q, limit,
 	)
 	if err != nil {
 		return nil, err
@@ -737,12 +776,16 @@ func (s *Store) SearchFiles(query string, limit int) ([]json.RawMessage, error) 
 	if limit <= 0 {
 		limit = 50
 	}
+	q := sanitizeFTSQuery(query)
+	if q == "" {
+		return nil, nil
+	}
 	rows, err := s.db.Query(
 		`SELECT t.data FROM files t
 		 JOIN files_fts ON files_fts.rowid = t.rowid
 		 WHERE files_fts MATCH ?
 		 ORDER BY rank LIMIT ?`,
-		query, limit,
+		q, limit,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Fix 2 crash bugs (response-times deadlock, search negative limit panic)
- Fix FTS5 query injection (empty queries, special chars, SQL operators)
- Fix channel names showing as `<nil>` in funny and threads-stale
- Fix doctor falsely reporting credentials as valid
- Add DM/private channel/group DM support to sync
- Add local data export support with --data-source flag
- Recalibrate health grading for small/medium workspaces
- Add input validation for limits, group-by fields, and missing scopes
- Show actionable error messages for missing Slack OAuth scopes

13 files changed across store and CLI layers.

## Test plan

- [x] `search ""` returns "No results" instead of SQL error
- [x] `search "OR 1=1"` returns "No results" instead of SQL error
- [x] `search "hello" --limit -1` exits cleanly instead of panicking
- [x] `response-times` completes without deadlock
- [x] `funny --period month` shows #channel-name instead of <nil>
- [x] `threads-stale` shows #channel-name instead of <nil>
- [x] `SLACK_USER_TOKEN=bad doctor` shows "Credentials: invalid (invalid_auth)"
- [x] `health` shows grade distribution (A/B/C/D) not all C/D
- [x] `funny --limit -1` shows "invalid --limit" error
- [x] `analytics --group-by nonexistent` shows "field not found" error
- [x] `conversations history --limit abc` shows validation error
- [x] `emoji` (without scope) shows "Missing Slack scope: emoji:read"
- [x] `export messages --data-source local` exports 9144 messages from SQLite
- [x] `export conversations --data-source local` exports from local store
- [x] Full build passes (`go build ./...`)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required - this is a CLI tool installed locally.

Generated with [Claude Code](https://claude.com/claude-code)