### PR TITLE
feat(skills): add per-app skills for individual CLI tools

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -1,0 +1,37 @@
+name: Generate per-app skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'registry.json'
+      - 'library/**/.printing-press.json'
+      - 'tools/generate-skills/**'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Run skill generator
+        run: go run ./tools/generate-skills/main.go
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add skills/pp-*/ .claude-plugin/plugin.json
+          if git diff --staged --quiet; then
+            echo "No skill changes to commit"
+          else
+            git commit -m "chore(skills): regenerate per-app skills [skip ci]"
+            git push
+          fi

--- a/docs/brainstorms/per-app-skills-requirements.md
+++ b/docs/brainstorms/per-app-skills-requirements.md
@@ -1,0 +1,71 @@
+---
+date: 2026-04-10
+topic: per-app-skills
+---
+
+# Per-App Skills for Printing Press Library
+
+## Problem Frame
+
+The printing-press-library ships a single `/ppl` skill that routes to all 13+ apps. Agents can't discover individual tools from skill listings — they must invoke `/ppl` first and navigate the catalog. Cross-skill composition (e.g., combining ESPN scores with Kalshi prediction markets) doesn't work because agents can't reason about tool capabilities from skill descriptions alone.
+
+Individual per-app skills with rich descriptions unlock two things: direct discoverability (agents see `/pp-espn` in the skill listing and immediately know what it does) and cross-skill composition (agents combine `/pp-espn` + `/pp-kalshi` based on complementary descriptions). `/ppl` remains the catalog for browsing and searching the full library — per-app skills are for agents that already know which tool they need or discover one via the skill listing.
+
+## Requirements
+
+**Skill Content**
+- R1. Each app in `registry.json` gets its own skill as a scoped router — handling CLI installation, MCP installation, authentication guidance, and direct CLI usage for that single app.
+- R2. Skills follow the same conventions as the existing PPL skill: `go install` for CLIs, `claude mcp add` for MCP servers, `--agent` flag for execution, shared exit code handling.
+- R3. Each skill is self-contained. An agent encountering `/pp-espn` for the first time can install, authenticate, and start querying without knowing `/ppl` exists.
+
+**Descriptions for Composition**
+- R4. Skill descriptions combine the registry description with data domain signals extracted from the CLI's command tree (via `--help`). For example, ESPN's description would include "game schedules, team matchups, player stats, live odds" alongside the base description.
+- R5. Descriptions must be specific enough that an agent can identify composition opportunities across skills from descriptions alone (e.g., ESPN's game data + Kalshi's prediction markets).
+
+**Generation**
+- R6. A generation script/template in this repo reads `registry.json` and produces a `SKILL.md` per app. No LLM required — content is formulaic.
+- R7. The generator runs each CLI's `--help` to extract command names and data domains for enriched descriptions (R4). When a CLI binary is unavailable or `--help` fails, the generator gracefully degrades to the registry description alone rather than failing the entire run.
+- R8. Generation can be run locally. The template is the recommended way to produce and update skills, but generated files are normal SKILL.md files that can be hand-edited if needed.
+
+**Naming and Structure**
+- R9. Per-app skills use the naming convention `pp-<name>` where `<name>` is the registry entry name with any `-pp-cli` suffix stripped (e.g., `espn` → `/pp-espn`, `dominos-pp-cli` → `/pp-dominos`, `hubspot-pp-cli` → `/pp-hubspot`).
+- R10. The existing `/ppl` skill continues as the discovery and catalog layer. Per-app skills handle direct usage. Both coexist in the same plugin.
+
+## Success Criteria
+
+- An agent with no prior context can invoke `/pp-espn`, install the CLI, and retrieve live sports scores in a single session.
+- An agent can combine two per-app skills (e.g., `/pp-espn` + `/pp-kalshi`) to answer a cross-domain question like "what Kalshi prediction markets relate to tomorrow's NBA games?" without the user manually orchestrating between tools.
+- Adding a new app to the library and re-running the generator produces a working skill with no manual intervention beyond having the CLI binary available.
+
+## Scope Boundaries
+
+- The generator lives in this repo only — no changes to cli-printing-press or CI infrastructure.
+- No LLM-based description generation. Descriptions are assembled from registry metadata + CLI help output.
+- Per-app skills do not replace `/ppl`. Discovery and catalog browsing stay in the mega skill.
+- The generator does not auto-run on merge. It is a manual local script (CI automation can be added later).
+
+## Key Decisions
+
+- **Scoped router over minimal skill**: Each skill handles install + MCP + auth + usage, not just a pointer to `--help`. This makes each skill fully self-contained.
+- **Template in this repo over CI or cli-printing-press**: Keeps generation simple and decoupled. No new infrastructure needed.
+- **Keep PPL alongside per-app skills**: PPL becomes the index/catalog, per-app skills are the entries. Clean separation of discovery vs. usage.
+- **`pp-` prefix over `ppl-`**: Shorter, maps to "Printing Press" branding, distinct from the `/ppl` catalog skill.
+- **Enhanced descriptions from CLI help**: Richer composition surface without manual curation. Requires CLI binaries available during generation.
+
+## Dependencies / Assumptions
+
+- CLI binaries should be installed (or buildable) on the machine running the generator for enriched descriptions (R7). If unavailable, the generator falls back to registry-only descriptions.
+- The plugin.json `skills` field (`"./skills/"`) already supports subdirectories — confirmed by examining other installed plugins (compound-engineering, iterative-engineering). No plugin config changes needed.
+- The `hubspot-pp-cli` registry entry has an incorrect `path` (`library/sales-and-crm/hubspot-pp-cli` vs. actual `library/sales-and-crm/hubspot/`). This should be fixed before or during implementation, as the generator uses registry paths to locate source code.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R6][Technical] What is the best format for the generation script — shell, Go, or Python? Should consider what's already in the repo's toolchain.
+- [Affects R7][Needs research] How to best parse `--help` output to extract data domain keywords for descriptions. Cobra help output is structured but varies by app complexity. Key challenge: filtering out shared framework commands (api, auth, completion, doctor, export, help, import, sync, version, workflow, etc.) that appear in every CLI, keeping only domain-specific commands.
+- [Affects R1][Technical] How much of the PPL skill's SKILL.md content should be shared vs. duplicated per app? A shared reference file could reduce template size but adds indirection. Note: at 13 skills, duplicated boilerplate means ~1K+ lines of near-identical install/MCP/error-handling content — context window cost if multiple skills are loaded in one session.
+- [Affects R5][Technical] Some per-app skill names overlap with existing skills from other plugins (e.g., `/pp-slack` vs. the `/slack` plugin skill). Descriptions should disambiguate — e.g., "Printing Press CLI/MCP for the Slack API" vs. browser-based Slack automation.
+
+## Next Steps
+
+`-> /ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-10-003-feat-per-app-skills-plan.md
+++ b/docs/plans/2026-04-10-003-feat-per-app-skills-plan.md
@@ -1,0 +1,334 @@
+---
+title: "feat: Generate per-app skills for individual CLI tools"
+type: feat
+status: active
+date: 2026-04-10
+origin: docs/brainstorms/per-app-skills-requirements.md
+---
+
+# feat: Generate per-app skills for individual CLI tools
+
+## Overview
+
+Add a generator that produces individual per-app skills (`/pp-espn`, `/pp-kalshi`, etc.) from `registry.json` and per-app manifests. Each skill is a self-contained scoped router handling CLI installation, MCP setup, auth guidance, and direct usage for one app. The existing `/ppl` skill remains as the discovery/catalog layer.
+
+## Problem Frame
+
+Agents can only access Printing Press CLIs through the single `/ppl` router skill. This prevents discoverability from skill listings and blocks cross-skill composition (e.g., combining ESPN game data with Kalshi prediction markets). Individual skills with enriched descriptions solve both problems. (see origin: `docs/brainstorms/per-app-skills-requirements.md`)
+
+## Requirements Trace
+
+- R1. Each app gets its own skill as a scoped router (install CLI, install MCP, auth, direct use)
+- R2. Skills follow PPL conventions (`go install`, `claude mcp add`, `--agent` flag, exit codes)
+- R3. Each skill is fully self-contained — no dependency on `/ppl`
+- R4. Descriptions combine registry description + domain commands from `--help`
+- R5. Descriptions enable cross-skill composition from descriptions alone
+- R6. Generator script in this repo reads registry + manifests and writes SKILL.md files
+- R7. Generator uses `--help` for enriched descriptions; degrades gracefully when binary unavailable
+- R8. Generator is the recommended way to produce skills; generated files can be hand-edited
+- R9. Naming: `pp-<name>` with `-pp-cli` suffix stripped
+- R10. `/ppl` remains for discovery; per-app skills handle direct usage
+
+## Scope Boundaries
+
+- Generator lives in this repo only — no changes to cli-printing-press
+- No LLM-based description generation
+- No CI automation — generator is a manual local script, re-run when `registry.json` or manifests change before committing
+- `/ppl` is not modified — discovery and catalog browsing unchanged
+
+### Deferred to Separate Tasks
+
+- CI automation to auto-generate skills on merge: future iteration
+- Adding `cli_binary` field to registry schema to eliminate manifest lookups: separate PR
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/ppl/SKILL.md` — existing unified router skill (167 lines, 5 modes). Per-app skills reuse Modes 2-4 (Install CLI, Install MCP, Explicit Use) scoped to one app
+- `registry.json` — 13 entries with `name`, `category`, `api`, `description`, `path`, and optional `mcp` block
+- `library/<category>/<name>/.printing-press.json` — per-app manifests with `cli_name` (present in all 13) and `mcp_binary` (present in only ~3 of 13 — most manifests lack this field)
+- `library/<category>/<name>/internal/cli/root.go` — Cobra root command. All standard CLIs share identical framework structure with `DO NOT EDIT` header
+- `.claude-plugin/plugin.json` — `"skills": "./skills/"` auto-discovers all subdirectories containing SKILL.md
+
+### Institutional Learnings
+
+- Binary name derivation heuristic (try `<name>-pp-cli`, fall back to bare name) is documented as "temporary until `cli_binary` field is added to registry." Per-app skills can bypass this entirely by reading `.printing-press.json` manifests which have authoritative `cli_name`
+- `hubspot-pp-cli` registry entry has incorrect path (`library/sales-and-crm/hubspot-pp-cli` vs. actual `library/sales-and-crm/hubspot/`). Must be fixed first (see origin: Dependencies/Assumptions)
+- All standard Printing Press CLIs share framework commands that must be filtered from domain-specific commands during `--help` enrichment
+- `allowed-tools: "Read Bash"` is the established convention for PPL skills
+
+## Key Technical Decisions
+
+- **Go generator over shell/Python**: The repo is pure Go with no scripting infrastructure. A Go program at `tools/generate-skills/` uses stdlib only (`encoding/json`, `os/exec`, `text/template`), matches the toolchain, and has zero external dependencies. It gets its own `go.mod` since the repo root has no module.
+- **Layered metadata resolution**: For each app, resolve fields using this precedence: (1) `.printing-press.json` manifest for `cli_name`, (2) registry `mcp.binary` for MCP binary name (most manifests lack `mcp_binary`), (3) registry `mcp.auth_type` and `mcp.env_vars` for auth info (most manifests lack auth fields), (4) registry heuristic (append `-pp-cli`) as final fallback for `cli_name` if manifest is missing. Note: `agent-capture` manifest declares `cli_name: "agent-capture-pp-cli"` but the actual binary is `agent-capture` — the generator should validate that `cmd/<cli_name>/` exists in the source tree and fall back to the bare name if not.
+- **Embed all metadata in each SKILL.md**: Each generated skill hardcodes its app's install path, binary name, MCP config, auth env vars, and enriched description. No runtime registry reads needed. At ~50-60 lines per skill, the duplication cost is low and keeps each skill fully self-contained (R3).
+- **Hardcoded framework command filter**: Rather than dynamically detecting shared commands, maintain a static list of known framework commands to exclude during `--help` parsing. The list is stable (same Cobra template across all CLIs) and a false positive just means a slightly less rich description.
+- **Separate template file**: The SKILL.md template lives at `tools/generate-skills/skill-template.md` rather than being embedded in Go code. Easier to iterate on the template without touching generator logic.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Script language**: Go (`tools/generate-skills/main.go`) — consistent with repo, stdlib only, no external deps
+- **`--help` parsing strategy**: Parse "Available Commands:" section line-by-line. Each line has format: `  <command>  <description>`. Filter against hardcoded framework commands list. Collect remaining as domain commands with descriptions
+- **Shared vs. duplicated content**: Embed everything per skill. ~50-60 lines each is lean enough that duplication is acceptable and R3 self-containment is preserved
+- **Naming collision** (`/pp-slack` vs `/slack`): Descriptions include "Printing Press CLI" phrasing to disambiguate from other plugins' skills
+- **Binary name source**: Layered precedence — manifest `cli_name` → validate `cmd/` dir exists → bare name fallback → registry heuristic. Registry is primary for `mcp_binary`, `auth_type`, `env_vars` (most manifests lack these)
+
+### Deferred to Implementation
+
+- Exact enriched description wording per app — depends on `--help` output at generation time
+- `agent-capture` binary name resolution — manifest declares `agent-capture-pp-cli` but actual binary is `agent-capture`. The `cmd/` directory validation in the generator's layered precedence handles this, but the exact fallback behavior should be confirmed at implementation time
+
+## Output Structure
+
+```
+tools/
+  generate-skills/
+    main.go                  # Generator program
+    go.mod                   # Standalone module (stdlib only)
+    skill-template.md        # SKILL.md template with Go template syntax
+skills/
+  ppl/                       # Existing, unchanged
+    SKILL.md
+    registry.json -> ../../registry.json
+  pp-espn/                   # Generated
+    SKILL.md
+  pp-kalshi/                 # Generated
+    SKILL.md
+  pp-linear/                 # Generated
+    SKILL.md
+  pp-dominos/                # Generated (stripped from dominos-pp-cli)
+    SKILL.md
+  ... (13 total per-app skill directories)
+```
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+Generator flow:
+  1. Read registry.json → list of app entries
+  2. For each entry:
+     a. Derive skill name: strip "-pp-cli" suffix, prepend "pp-"
+     b. Resolve metadata (layered precedence):
+        - cli_name:  manifest .printing-press.json → validate cmd/<cli_name>/ exists
+                     → if dir missing, try bare name → registry heuristic as last resort
+        - mcp_binary: registry mcp.binary (most manifests lack this field)
+        - auth_type:  registry mcp.auth_type → default "none" if no mcp block
+        - env_vars:   registry mcp.env_vars → default empty if no mcp block
+     c. Try: exec "<cli_name> --help" → parse domain commands
+        On failure: set DomainCommands to nil; template omits domain keywords
+        from description (uses registry description only)
+     d. Build enriched description: registry description + domain command keywords
+     e. Execute skill-template.md with app context → write skills/pp-<name>/SKILL.md
+  3. Report: N skills generated, M with enriched descriptions, K degraded
+
+Template variables:
+  SkillName       — pp-<name> (e.g., pp-espn)
+  APIName         — human name (e.g., ESPN)
+  Description     — registry description
+  EnrichedDesc    — description + domain keywords for composition
+  CLIBinary       — resolved via layered precedence (see above)
+  InstallPath     — registry path (e.g., library/media-and-entertainment/espn)
+  HasMCP          — boolean (true when registry entry has mcp block)
+  MCPBinary       — from registry mcp.binary
+  AuthType        — from registry mcp.auth_type | default "none"
+  EnvVars         — from registry mcp.env_vars | default empty
+  DomainCommands  — filtered command list from --help (nil when degraded)
+
+Framework commands to filter:
+  api, auth, completion, doctor, export, help, import, load,
+  orphans, sql, stale, sync, version, workflow
+  (Note: "search" excluded from filter — it is domain-relevant across CLIs)
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Fix HubSpot registry path**
+
+**Goal:** Correct the `hubspot-pp-cli` entry in `registry.json` so the path matches the actual directory.
+
+**Requirements:** Prerequisite for R6 (generator reads registry paths)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `registry.json`
+
+**Approach:**
+- Change `"path": "library/sales-and-crm/hubspot-pp-cli"` to `"path": "library/sales-and-crm/hubspot"`
+- Verify the directory exists at the corrected path
+
+**Patterns to follow:**
+- Other registry entries use the actual directory name (e.g., `library/media-and-entertainment/espn`)
+
+**Test scenarios:**
+- Happy path: after fix, `library/sales-and-crm/hubspot/` resolves and contains `cmd/`, `internal/`, `.printing-press.json`
+
+**Verification:**
+- `ls library/sales-and-crm/hubspot/.printing-press.json` succeeds
+- No other registry entry has a path mismatch (spot-check 2-3 others)
+
+---
+
+- [x] **Unit 2: Create SKILL.md template**
+
+**Goal:** Design the per-app skill template that the generator stamps out for each app.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None (can be developed in parallel with Unit 1)
+
+**Files:**
+- Create: `tools/generate-skills/skill-template.md`
+
+**Approach:**
+- Template has 3 operating modes (no Discovery or Semantic Use — those stay in `/ppl`):
+  1. CLI Installation — `go install` with hardcoded path and binary name
+  2. MCP Installation — `claude mcp add` with env vars (conditional: skip if no MCP)
+  3. Direct Use — `--help` discovery + `--agent` execution + exit code handling
+- Frontmatter includes: `name` (pp-<name>), `description` (enriched), `argument-hint`, `allowed-tools: "Read Bash"`
+- Description field combines registry description with domain command keywords and trigger phrases. Include "Printing Press CLI" to disambiguate from other plugins
+- Auth guidance varies by `auth_type`: `none` (no auth section), `api_key` (export env var + `auth set-token`), `composed` (browser login via `auth login`)
+- Target length: 50-60 lines per generated skill
+- All app-specific values are Go template variables (e.g., `{{.CLIBinary}}`, `{{.InstallPath}}`)
+
+**Patterns to follow:**
+- `skills/ppl/SKILL.md` — frontmatter format, Mode 2/3/4 structure, exit code table, `--agent` flag convention
+- Existing skill descriptions use trigger phrases for discoverability
+
+**Test scenarios:**
+- Happy path: template renders correctly for an `api_key` auth app with MCP (e.g., Kalshi — has api_key auth, 89 MCP tools, full mcp_ready)
+- Edge case: template renders correctly for a `none` auth app (e.g., ESPN — no auth section, no env vars)
+- Edge case: template renders correctly for an app with no MCP block (e.g., agent-capture — MCP section omitted entirely)
+- Edge case: template renders correctly for a `composed` auth app (e.g., Dominos — browser login flow)
+- Edge case: template renders correctly for a `partial` MCP readiness app (e.g., Pagliacci — shows public_tool_count vs total)
+- Happy path: enriched description with domain commands is agent-parseable and contains composition-friendly keywords
+
+**Verification:**
+- Manually render the template for ESPN, Kalshi, and agent-capture and confirm each produces a valid, readable SKILL.md
+- Each rendered skill covers all 3 modes and handles its auth type correctly
+
+---
+
+- [x] **Unit 3: Build the generator**
+
+**Goal:** Create a Go program that reads registry + manifests + optional CLI help output and produces SKILL.md files for all apps.
+
+**Requirements:** R6, R7, R8, R9
+
+**Dependencies:** Unit 2 (template must exist)
+
+**Files:**
+- Create: `tools/generate-skills/main.go`
+- Create: `tools/generate-skills/go.mod`
+
+**Approach:**
+- Standalone Go module (`module generate-skills`) with stdlib-only dependencies
+- Program flow:
+  1. Read `registry.json` from repo root (path relative to working directory)
+  2. For each entry: derive skill name (strip `-pp-cli`, prepend `pp-`), resolve metadata via layered precedence (manifest `cli_name` → validate `cmd/` dir → bare name fallback; registry for `mcp.binary`, `mcp.auth_type`, `mcp.env_vars`)
+  3. Try running `<cli_name> --help`, parse "Available Commands:" section, filter framework commands. Before generating all 13 skills, audit the filter list against at least one live `--help` output to catch any missing framework commands
+  4. Build template context with all variables, execute template, write to `skills/pp-<name>/SKILL.md`
+  5. Print summary: N generated, M enriched, K degraded
+- Framework command filter: hardcoded string set of known framework commands (see High-Level Technical Design for the list)
+- Graceful degradation (R7): when binary not found or `--help` fails, set `DomainCommands` to nil. Template conditionally omits domain command keywords from description. Log a warning but continue
+- Create skill directory if it doesn't exist; overwrite existing SKILL.md
+
+**Patterns to follow:**
+- Go `text/template` for template execution
+- Go `os/exec` for running CLI `--help`
+- Go `encoding/json` for registry and manifest parsing
+
+**Test scenarios:**
+- Happy path: generator reads registry.json with 13 entries and produces 13 skill directories under `skills/`
+- Happy path: generated skill for ESPN has enriched description including domain commands like "boxscore", "scoreboard", "standings"
+- Happy path: generated skill for Kalshi includes MCP install section with `KALSHI_API_KEY` env var
+- Edge case: CLI binary not installed — generator logs warning and produces skill with registry-only description
+- Edge case: `--help` returns non-zero exit code — treated same as binary not found (graceful degradation)
+- Edge case: `.printing-press.json` missing for an app — fall back to registry heuristic for binary name (append `-pp-cli`)
+- Edge case: registry entry with `-pp-cli` suffix (dominos-pp-cli) produces skill named `pp-dominos`, not `pp-dominos-pp-cli`
+- Edge case: app with no MCP block (agent-capture) produces skill with MCP section omitted
+- Edge case: manifest `cli_name` doesn't match actual binary (agent-capture) — generator detects missing `cmd/` dir and falls back to bare name
+- Error path: `registry.json` not found — exit with clear error message
+- Error path: template file not found — exit with clear error message
+
+**Verification:**
+- `cd tools/generate-skills && go build .` succeeds with no external dependencies (note: no root `go.mod` exists, so `./` relative paths from repo root won't work)
+- From repo root: `go run ./tools/generate-skills/main.go` produces 13 `skills/pp-*/SKILL.md` files
+- Each generated file has valid SKILL.md frontmatter (name, description, argument-hint, allowed-tools)
+
+---
+
+- [x] **Unit 4: Generate all skills, commit, and validate**
+
+**Goal:** Run the generator to produce all 13 per-app skills, commit them as static artifacts, and verify they work as a Claude Code plugin. Generated files are committed to the repo so users get them on plugin install. Re-run the generator and re-commit when registry or manifests change.
+
+**Requirements:** R1-R10 (end-to-end validation)
+
+**Dependencies:** Units 1, 2, 3
+
+**Files:**
+- Create: `skills/pp-espn/SKILL.md` (generated)
+- Create: `skills/pp-kalshi/SKILL.md` (generated)
+- Create: `skills/pp-linear/SKILL.md` (generated)
+- Create: `skills/pp-dominos/SKILL.md` (generated)
+- Create: `skills/pp-hubspot/SKILL.md` (generated)
+- Create: `skills/pp-cal-com/SKILL.md` (generated)
+- Create: `skills/pp-dub/SKILL.md` (generated)
+- Create: `skills/pp-slack/SKILL.md` (generated)
+- Create: `skills/pp-steam-web/SKILL.md` (generated)
+- Create: `skills/pp-agent-capture/SKILL.md` (generated)
+- Create: `skills/pp-pagliacci-pizza/SKILL.md` (generated)
+- Create: `skills/pp-postman-explore/SKILL.md` (generated)
+- Create: `skills/pp-trigger-dev/SKILL.md` (generated)
+
+**Approach:**
+- Run `go run ./tools/generate-skills/main.go` from repo root
+- Review generated skills for correctness: spot-check frontmatter, install paths, auth sections, MCP sections
+- Verify the plugin loads all new skills by checking skill count
+- Test at least one skill end-to-end: invoke `/pp-espn` and confirm it can guide CLI installation and usage
+
+**Test scenarios:**
+- Happy path: all 13 skills generated with no errors
+- Happy path: `/pp-espn` skill description contains domain keywords like "scoreboard", "standings", "boxscore"
+- Happy path: `/pp-kalshi` skill description contains "prediction markets", "events", "portfolio"
+- Happy path: `/pp-agent-capture` skill correctly omits MCP installation section
+- Happy path: `/pp-dominos` skill shows `composed` auth flow (browser login)
+- Happy path: `/pp-pagliacci-pizza` skill notes partial MCP readiness
+- Integration: invoking `/pp-espn install cli` in Claude Code triggers correct `go install` command
+- Integration: invoking `/pp-espn` with a sports query runs the CLI with `--agent` flag
+
+**Verification:**
+- 13 `skills/pp-*/SKILL.md` files exist, each with valid frontmatter
+- Plugin loads all skills (existing `/ppl` + 13 new per-app skills = 14 total)
+- At least one skill works end-to-end for install and usage
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks or middleware. Skills are static SKILL.md files discovered by Claude Code's plugin loader. The generator runs offline and writes files.
+- **Error propagation:** Generator errors are local (warnings for missing binaries, fatal only for missing registry/template). Generated skills use the same exit code handling as `/ppl`.
+- **State lifecycle risks:** None. Generated skills are stateless markdown files. No caching, no partial writes (each file is atomic write-or-skip).
+- **API surface parity:** Per-app skills expose the same install/MCP/usage capabilities as `/ppl` Modes 2-4 but scoped to one app. No new capabilities are added.
+- **Unchanged invariants:** The `/ppl` skill is not modified. Its discovery, catalog, and semantic routing modes continue to work as before. The `registry.json` schema is unchanged (only the HubSpot path fix in Unit 1).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Not all 13 CLI binaries installed on generator machine | R7 graceful degradation — produces skill with registry-only description. Log which apps were degraded. |
+| `.printing-press.json` schema varies across apps — most lack `mcp_binary` and auth fields | Layered precedence: manifest for `cli_name`, registry for `mcp.binary`/`auth_type`/`env_vars`, heuristic as last resort. |
+| `agent-capture` manifest declares wrong `cli_name` (`agent-capture-pp-cli` vs actual `agent-capture`) | Generator validates `cmd/<cli_name>/` dir exists; falls back to bare name when dir is missing. |
+| Framework command list drifts as new shared commands are added | Filter list is easy to update. A missed framework command just means slightly noisier descriptions — not a functional failure. |
+| Context window cost if agent loads many per-app skills | Skills are ~50-60 lines each. At 13 skills, only loaded on demand (not all at once). Descriptions appear in skill listings (~100 tokens each). |
+| `agent-capture` has non-standard CLI structure | Template conditional sections handle no-MCP case. The simpler CLI structure doesn't affect skill content since skills use `--help` discovery. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/per-app-skills-requirements.md](docs/brainstorms/per-app-skills-requirements.md)
+- Related plan: [docs/plans/2026-04-10-002-feat-claude-code-plugin-plan.md](docs/plans/2026-04-10-002-feat-claude-code-plugin-plan.md) — established plugin infrastructure
+- Existing skill: `skills/ppl/SKILL.md` — template reference for conventions
+- Registry: `registry.json` — primary data source for generator

--- a/registry.json
+++ b/registry.json
@@ -87,7 +87,7 @@
       "category": "sales-and-crm",
       "api": "HubSpot",
       "description": "Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics",
-      "path": "library/sales-and-crm/hubspot-pp-cli",
+      "path": "library/sales-and-crm/hubspot",
       "mcp": {
         "binary": "hubspot-pp-mcp",
         "transport": "stdio",

--- a/skills/pp-agent-capture/SKILL.md
+++ b/skills/pp-agent-capture/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pp-agent-capture
+description: "Printing Press CLI for agent-capture. Record, screenshot, and convert macOS windows and screens for AI agent evidence Capabilities include: batch, convert, diff, evidence, find, health, list, ocr, permissions, pipeline, preset, record, remotion, screenshot, stitch, vhs, watch. Trigger phrases: 'install agent-capture', 'use agent-capture', 'run agent-capture', 'agent-capture commands', 'setup agent-capture'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# agent-capture — Printing Press CLI
+
+Record, screenshot, and convert macOS windows and screens for AI agent evidence
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `agent-capture --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture/cmd/agent-capture@latest
+   ```
+3. Verify: `agent-capture --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## Direct Use
+
+1. Check if installed: `which agent-capture`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `agent-capture --help`
+   Key commands:
+   - `batch` — Screenshot multiple apps in one command
+   - `convert` — Convert video to optimized GIF with two-pass palette generation
+   - `diff` — Capture and diff against a baseline screenshot to highlight changes
+   - `evidence` — Capture a complete evidence bundle: screenshots + recording + GIF
+   - `find` — Fuzzy search window titles to find the right capture target
+   - `health` — Machine-readable health check for CI and agent preflight
+   - `list` — List available capture targets (windows, displays)
+   - `ocr` — Extract text from a window or image using macOS Vision framework
+   - `permissions` — Check and guide Screen Recording permission setup
+   - `pipeline` — Record, convert, and optimize in one command (no intermediate files)
+   - `preset` — Save and load capture configuration presets
+   - `record` — Record video of a window, app, display, or region
+   - `remotion` — Render Remotion compositions as video or still frames
+   - `screenshot` — Capture a screenshot of a window, app, display, or region
+   - `stitch` — Stitch multiple screenshots into an animated GIF
+   - `vhs` — Run a VHS tape file and produce a terminal recording GIF
+   - `watch` — Take screenshots at regular intervals for monitoring UI changes
+3. Match the user query to the best command. Drill into subcommand help if needed: `agent-capture <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   agent-capture <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-cal-com/SKILL.md
+++ b/skills/pp-cal-com/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-cal-com
+description: "Printing Press CLI for Cal.com. Manage bookings, event types, schedules, and availability via the Cal.com API Trigger phrases: 'install cal-com', 'use cal-com', 'run cal-com', 'Cal.com commands', 'setup cal-com'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Cal.com — Printing Press CLI
+
+Manage bookings, event types, schedules, and availability via the Cal.com API
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `cal-com-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-cli@latest
+   ```
+3. Verify: `cal-com-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export CAL_COM_TOKEN="your-key-here"
+   cal-com-pp-cli auth set-token
+   ```
+   Run `cal-com-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e CAL_COM_TOKEN=value cal-com-pp-mcp -- cal-com-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which cal-com-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `cal-com-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `cal-com-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   cal-com-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-dominos/SKILL.md
+++ b/skills/pp-dominos/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pp-dominos
+description: "Printing Press CLI for Dominos Pizza. Order pizza, browse menus, track deliveries, and manage rewards from the terminal Trigger phrases: 'install dominos', 'use dominos', 'run dominos', 'Dominos Pizza commands', 'setup dominos'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Dominos Pizza — Printing Press CLI
+
+Order pizza, browse menus, track deliveries, and manage rewards from the terminal
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `dominos-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-pp-cli@latest
+   ```
+3. Verify: `dominos-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — log in via browser:
+   ```bash
+   dominos-pp-cli auth login
+   ```
+   Run `dominos-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e DOMINOS_TOKEN=value dominos-mcp -- dominos-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which dominos-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `dominos-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `dominos-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   dominos-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-dub/SKILL.md
+++ b/skills/pp-dub/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-dub
+description: "Printing Press CLI for Dub. Create short links, track analytics, manage domains, and run affiliate programs via the Dub API Trigger phrases: 'install dub', 'use dub', 'run dub', 'Dub commands', 'setup dub'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Dub — Printing Press CLI
+
+Create short links, track analytics, manage domains, and run affiliate programs via the Dub API
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `dub-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-cli@latest
+   ```
+3. Verify: `dub-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export DUB_TOKEN="your-key-here"
+   dub-pp-cli auth set-token
+   ```
+   Run `dub-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e DUB_TOKEN=value dub-pp-mcp -- dub-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which dub-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `dub-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `dub-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   dub-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-espn/SKILL.md
+++ b/skills/pp-espn/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pp-espn
+description: "Printing Press CLI for ESPN. Live scores, standings, news, and game history across 17 sports from ESPN Capabilities include: boxscore, news, rankings, recap, rivals, scoreboard, scores, search, standings, streak, summary, teams, today, watch. Trigger phrases: 'install espn', 'use espn', 'run espn', 'ESPN commands', 'setup espn'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# ESPN — Printing Press CLI
+
+Live scores, standings, news, and game history across 17 sports from ESPN
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `espn-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-cli@latest
+   ```
+3. Verify: `espn-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add espn-pp-mcp -- espn-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which espn-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `espn-pp-cli --help`
+   Key commands:
+   - `boxscore` — Box score with player stats for a game
+   - `news` — Get latest news articles for a sport and league
+   - `rankings` — Get current AP, Coaches, and CFP poll rankings for college sports
+   - `recap` — Game recap with box score and leaders
+   - `rivals` — Head-to-head record between two teams from synced data
+   - `scoreboard` — Get scoreboard for a sport and league with optional date filtering
+   - `scores` — Live scores and results for a sport and league
+   - `search` — Full-text search across synced events and news
+   - `standings` — Conference/division standings for a sport and league
+   - `streak` — Current win/loss streak for a team from synced data
+   - `summary` — Get detailed game summary including box score, leaders, scoring plays, odds, and win probability
+   - `teams` — Get past and upcoming schedule for a specific team
+   - `today` — Today's scores across all major sports
+   - `watch` — Live score updates for a game (polls every 30s)
+3. Match the user query to the best command. Drill into subcommand help if needed: `espn-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   espn-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-hubspot/SKILL.md
+++ b/skills/pp-hubspot/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-hubspot
+description: "Printing Press CLI for HubSpot. Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics Trigger phrases: 'install hubspot', 'use hubspot', 'run hubspot', 'HubSpot commands', 'setup hubspot'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# HubSpot — Printing Press CLI
+
+Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `hubspot-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-cli@latest
+   ```
+3. Verify: `hubspot-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export HUBSPOT_ACCESS_TOKEN="your-key-here"
+   hubspot-pp-cli auth set-token
+   ```
+   Run `hubspot-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e HUBSPOT_ACCESS_TOKEN=value hubspot-pp-mcp -- hubspot-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which hubspot-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `hubspot-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `hubspot-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   hubspot-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-kalshi/SKILL.md
+++ b/skills/pp-kalshi/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: pp-kalshi
+description: "Printing Press CLI for Kalshi. Trade prediction markets, track portfolios, and analyze odds on Kalshi from the command line Capabilities include: account, analytics, api-keys, communications, events, exchange, fcm, historical, incentive-programs, live-data, markets, milestones, multivariate-event-collections, portfolio, search, series, structured-targets, tail. Trigger phrases: 'install kalshi', 'use kalshi', 'run kalshi', 'Kalshi commands', 'setup kalshi'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Kalshi — Printing Press CLI
+
+Trade prediction markets, track portfolios, and analyze odds on Kalshi from the command line
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `kalshi-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-cli@latest
+   ```
+3. Verify: `kalshi-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export KALSHI_API_KEY="your-key-here"
+   kalshi-pp-cli auth set-token
+   ```
+   Run `kalshi-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e KALSHI_API_KEY=value kalshi-pp-mcp -- kalshi-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which kalshi-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `kalshi-pp-cli --help`
+   Key commands:
+   - `account` — Get Account API Limits
+   - `analytics` — Run analytics queries on locally synced data
+   - `api-keys` — Get API Keys
+   - `communications` — Get Communications ID
+   - `events` — Get Events
+   - `exchange` — Get Exchange Announcements
+   - `fcm` — Get FCM Orders
+   - `historical` — Get Historical Trades
+   - `incentive-programs` — Get Incentives
+   - `live-data` — Get Multiple Live Data
+   - `markets` — Get Multiple Market Orderbooks
+   - `milestones` — Get Milestones
+   - `multivariate-event-collections` — Get Multivariate Event Collections
+   - `portfolio` — Get Positions
+   - `search` — Full-text search across synced data or live API
+   - `series` — Get Series List
+   - `structured-targets` — Get Structured Targets
+   - `tail` — Stream live changes by polling the API at regular intervals
+3. Match the user query to the best command. Drill into subcommand help if needed: `kalshi-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   kalshi-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-linear/SKILL.md
+++ b/skills/pp-linear/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-linear
+description: "Printing Press CLI for Linear. Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, search, and cross-entity queries. Trigger phrases: 'install linear', 'use linear', 'run linear', 'Linear commands', 'setup linear'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Linear — Printing Press CLI
+
+Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, search, and cross-entity queries.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `linear-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
+   ```
+3. Verify: `linear-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export LINEAR_API_KEY="your-key-here"
+   linear-pp-cli auth set-token
+   ```
+   Run `linear-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e LINEAR_API_KEY=value linear-pp-mcp -- linear-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which linear-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `linear-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `linear-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   linear-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-pagliacci-pizza/SKILL.md
+++ b/skills/pp-pagliacci-pizza/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-pagliacci-pizza
+description: "Printing Press CLI for Pagliacci Pizza. Order pizza, browse menus, manage rewards, and track deliveries from Pagliacci Pizza Trigger phrases: 'install pagliacci-pizza', 'use pagliacci-pizza', 'run pagliacci-pizza', 'Pagliacci Pizza commands', 'setup pagliacci-pizza'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Pagliacci Pizza — Printing Press CLI
+
+Order pizza, browse menus, manage rewards, and track deliveries from Pagliacci Pizza
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `pagliacci-pizza-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/pagliacci-pizza/cmd/pagliacci-pizza-pp-cli@latest
+   ```
+3. Verify: `pagliacci-pizza-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — log in via browser:
+   ```bash
+   pagliacci-pizza-pp-cli auth login
+   ```
+   Run `pagliacci-pizza-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+> **Note:** Not all tools are available via MCP (21 of 38 tools exposed).
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/pagliacci-pizza/cmd/pagliacci-pizza-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add pagliacci-pizza-pp-mcp -- pagliacci-pizza-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which pagliacci-pizza-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `pagliacci-pizza-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `pagliacci-pizza-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   pagliacci-pizza-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-postman-explore/SKILL.md
+++ b/skills/pp-postman-explore/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pp-postman-explore
+description: "Printing Press CLI for Postman Explore. Search and browse the Postman API Network Trigger phrases: 'install postman-explore', 'use postman-explore', 'run postman-explore', 'Postman Explore commands', 'setup postman-explore'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Postman Explore — Printing Press CLI
+
+Search and browse the Postman API Network
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `postman-explore-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@latest
+   ```
+3. Verify: `postman-explore-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add postman-explore-pp-mcp -- postman-explore-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which postman-explore-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `postman-explore-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `postman-explore-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   postman-explore-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-slack/SKILL.md
+++ b/skills/pp-slack/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-slack
+description: "Printing Press CLI for Slack. Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal Trigger phrases: 'install slack', 'use slack', 'run slack', 'Slack commands', 'setup slack'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Slack — Printing Press CLI
+
+Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `slack-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@latest
+   ```
+3. Verify: `slack-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export SLACK_BOT_TOKEN="your-key-here"
+   slack-pp-cli auth set-token
+   ```
+   Run `slack-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e SLACK_BOT_TOKEN=value slack-pp-mcp -- slack-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which slack-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `slack-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `slack-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   slack-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-steam-web/SKILL.md
+++ b/skills/pp-steam-web/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-steam-web
+description: "Printing Press CLI for Steam Web. Look up Steam players, games, achievements, friends, and stats from the command line Trigger phrases: 'install steam-web', 'use steam-web', 'run steam-web', 'Steam Web commands', 'setup steam-web'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Steam Web — Printing Press CLI
+
+Look up Steam players, games, achievements, friends, and stats from the command line
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `steam-web-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@latest
+   ```
+3. Verify: `steam-web-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export STEAM_WEB_API_KEY="your-key-here"
+   steam-web-pp-cli auth set-token
+   ```
+   Run `steam-web-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e STEAM_WEB_API_KEY=value steam-web-pp-mcp -- steam-web-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which steam-web-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `steam-web-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `steam-web-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   steam-web-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/skills/pp-trigger-dev/SKILL.md
+++ b/skills/pp-trigger-dev/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pp-trigger-dev
+description: "Printing Press CLI for Trigger.dev. Monitor runs, trigger tasks, manage schedules, and detect failures via the Trigger.dev API Trigger phrases: 'install trigger-dev', 'use trigger-dev', 'run trigger-dev', 'Trigger.dev commands', 'setup trigger-dev'."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# Trigger.dev — Printing Press CLI
+
+Monitor runs, trigger tasks, manage schedules, and detect failures via the Trigger.dev API
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `trigger-dev-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@latest
+   ```
+3. Verify: `trigger-dev-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+   export TRIGGER_SECRET_KEY="your-key-here"
+   trigger-dev-pp-cli auth set-token
+   ```
+   Run `trigger-dev-pp-cli doctor` to verify credentials.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-mcp@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add -e TRIGGER_SECRET_KEY=value trigger-dev-pp-mcp -- trigger-dev-pp-mcp
+   ```
+   Ask the user for actual values of required API keys before running.
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which trigger-dev-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `trigger-dev-pp-cli --help`
+3. Match the user query to the best command. Drill into subcommand help if needed: `trigger-dev-pp-cli <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   trigger-dev-pp-cli <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |

--- a/tools/generate-skills/go.mod
+++ b/tools/generate-skills/go.mod
@@ -1,0 +1,3 @@
+module generate-skills
+
+go 1.23

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// Registry schema
+
+type MCPBlock struct {
+	Binary          string   `json:"binary"`
+	Transport       string   `json:"transport"`
+	ToolCount       int      `json:"tool_count"`
+	PublicToolCount int      `json:"public_tool_count"`
+	AuthType        string   `json:"auth_type"`
+	EnvVars         []string `json:"env_vars"`
+	MCPReady        string   `json:"mcp_ready"`
+}
+
+type RegistryEntry struct {
+	Name        string    `json:"name"`
+	Category    string    `json:"category"`
+	API         string    `json:"api"`
+	Description string    `json:"description"`
+	Path        string    `json:"path"`
+	MCP         *MCPBlock `json:"mcp,omitempty"`
+}
+
+type Registry struct {
+	SchemaVersion int             `json:"schema_version"`
+	Entries       []RegistryEntry `json:"entries"`
+}
+
+// Manifest schema (subset we care about)
+
+type Manifest struct {
+	CLIName string `json:"cli_name"`
+}
+
+// Domain command parsed from --help
+
+type DomainCommand struct {
+	Name        string
+	Description string
+}
+
+// Template context
+
+type SkillContext struct {
+	SkillName      string
+	APIName        string
+	Description    string
+	EnrichedDesc   string
+	CLIBinary      string
+	InstallPath    string
+	HasMCP         bool
+	MCPBinary      string
+	AuthType       string
+	EnvVars        []string
+	MCPReady       string
+	ToolCount      int
+	PublicToolCount int
+	DomainCommands []DomainCommand
+}
+
+// Framework commands to filter out of --help output
+var frameworkCommands = map[string]bool{
+	"api":        true,
+	"auth":       true,
+	"completion": true,
+	"doctor":     true,
+	"export":     true,
+	"help":       true,
+	"import":     true,
+	"load":       true,
+	"orphans":    true,
+	"sql":        true,
+	"stale":      true,
+	"sync":       true,
+	"version":    true,
+	"workflow":   true,
+}
+
+func main() {
+	// Read registry.json from current working directory (repo root)
+	registryPath := "registry.json"
+	registryData, err := os.ReadFile(registryPath)
+	if err != nil {
+		log.Fatalf("Error reading %s: %v\nRun this program from the repo root.", registryPath, err)
+	}
+
+	var registry Registry
+	if err := json.Unmarshal(registryData, &registry); err != nil {
+		log.Fatalf("Error parsing %s: %v", registryPath, err)
+	}
+
+	// Load template
+	templatePath := "tools/generate-skills/skill-template.md"
+	tmpl, err := template.ParseFiles(templatePath)
+	if err != nil {
+		log.Fatalf("Error loading template %s: %v", templatePath, err)
+	}
+
+	var totalGenerated, enrichedCount, registryOnlyCount int
+
+	for _, entry := range registry.Entries {
+		// Derive skill name: strip -pp-cli suffix, prepend pp-
+		baseName := entry.Name
+		baseName = strings.TrimSuffix(baseName, "-pp-cli")
+		skillName := "pp-" + baseName
+
+		// Resolve CLI binary name via layered precedence
+		cliBinary := resolveCLIBinary(entry)
+
+		// Resolve MCP/auth metadata from registry
+		hasMCP := entry.MCP != nil
+		var mcpBinary, authType, mcpReady string
+		var envVars []string
+		var toolCount, publicToolCount int
+
+		if hasMCP {
+			mcpBinary = entry.MCP.Binary
+			authType = entry.MCP.AuthType
+			envVars = entry.MCP.EnvVars
+			mcpReady = entry.MCP.MCPReady
+			toolCount = entry.MCP.ToolCount
+			publicToolCount = entry.MCP.PublicToolCount
+		}
+		if authType == "" {
+			authType = "none"
+		}
+		if envVars == nil {
+			envVars = []string{}
+		}
+
+		// Try to get domain commands from --help
+		domainCommands := parseDomainCommands(cliBinary)
+
+		// Build enriched description
+		enrichedDesc := buildEnrichedDescription(entry, domainCommands)
+
+		isEnriched := domainCommands != nil
+		if isEnriched {
+			enrichedCount++
+		} else {
+			registryOnlyCount++
+		}
+
+		ctx := SkillContext{
+			SkillName:       skillName,
+			APIName:         entry.API,
+			Description:     entry.Description,
+			EnrichedDesc:    enrichedDesc,
+			CLIBinary:       cliBinary,
+			InstallPath:     entry.Path,
+			HasMCP:          hasMCP,
+			MCPBinary:       mcpBinary,
+			AuthType:        authType,
+			EnvVars:         envVars,
+			MCPReady:        mcpReady,
+			ToolCount:       toolCount,
+			PublicToolCount: publicToolCount,
+			DomainCommands:  domainCommands,
+		}
+
+		// Write skill file
+		skillDir := filepath.Join("skills", skillName)
+		if err := os.MkdirAll(skillDir, 0755); err != nil {
+			log.Printf("Warning: could not create directory %s: %v", skillDir, err)
+			continue
+		}
+
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		f, err := os.Create(skillFile)
+		if err != nil {
+			log.Printf("Warning: could not create %s: %v", skillFile, err)
+			continue
+		}
+
+		if err := tmpl.Execute(f, ctx); err != nil {
+			f.Close()
+			log.Printf("Warning: could not render template for %s: %v", skillName, err)
+			continue
+		}
+		f.Close()
+
+		totalGenerated++
+		status := "registry-only"
+		if isEnriched {
+			status = "enriched"
+		}
+		fmt.Printf("  %s -> %s (%s)\n", entry.Name, skillFile, status)
+	}
+
+	fmt.Printf("\nGenerated %d skills (%d enriched, %d registry-only)\n", totalGenerated, enrichedCount, registryOnlyCount)
+}
+
+// resolveCLIBinary resolves the CLI binary name using layered precedence:
+// 1. Read .printing-press.json manifest -> validate cmd/<cli_name>/ dir exists
+// 2. If dir missing, try bare registry name
+// 3. Registry heuristic (append -pp-cli) as last resort
+func resolveCLIBinary(entry RegistryEntry) string {
+	manifestPath := filepath.Join(entry.Path, ".printing-press.json")
+
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		// No manifest — use registry heuristic
+		log.Printf("Warning: no manifest at %s, using heuristic for %s", manifestPath, entry.Name)
+		return registryHeuristic(entry.Name)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		log.Printf("Warning: could not parse manifest at %s: %v", manifestPath, err)
+		return registryHeuristic(entry.Name)
+	}
+
+	if manifest.CLIName == "" {
+		log.Printf("Warning: manifest at %s has no cli_name, using heuristic", manifestPath)
+		return registryHeuristic(entry.Name)
+	}
+
+	// Validate that cmd/<cli_name>/ directory exists in source tree
+	cmdDir := filepath.Join(entry.Path, "cmd", manifest.CLIName)
+	if info, err := os.Stat(cmdDir); err == nil && info.IsDir() {
+		return manifest.CLIName
+	}
+
+	// cmd/<cli_name>/ doesn't exist — try bare registry name
+	bareName := strings.TrimSuffix(entry.Name, "-pp-cli")
+	bareCmdDir := filepath.Join(entry.Path, "cmd", bareName)
+	if info, err := os.Stat(bareCmdDir); err == nil && info.IsDir() {
+		log.Printf("Info: manifest cli_name %q has no cmd/ dir, using bare name %q for %s", manifest.CLIName, bareName, entry.Name)
+		return bareName
+	}
+
+	// Fall back to manifest cli_name even though dir doesn't exist
+	// (maybe the directory structure doesn't match expectations)
+	log.Printf("Warning: no cmd/ dir found for %s (tried %q and %q), using manifest cli_name %q", entry.Name, manifest.CLIName, bareName, manifest.CLIName)
+	return manifest.CLIName
+}
+
+// registryHeuristic derives the CLI binary name from the registry name.
+// If the name already ends in -pp-cli, use as-is; otherwise append -pp-cli.
+func registryHeuristic(name string) string {
+	if strings.HasSuffix(name, "-pp-cli") {
+		return name
+	}
+	return name + "-pp-cli"
+}
+
+// parseDomainCommands runs <binary> --help and parses the "Available Commands:" section.
+// Returns nil if the binary is not found or --help fails.
+func parseDomainCommands(binary string) []DomainCommand {
+	cmd := exec.Command(binary, "--help")
+	output, err := cmd.Output()
+	if err != nil {
+		log.Printf("Info: could not run %s --help (binary may not be installed): %v", binary, err)
+		return nil
+	}
+
+	return parseHelpOutput(string(output))
+}
+
+// parseHelpOutput extracts domain commands from --help output.
+func parseHelpOutput(output string) []DomainCommand {
+	lines := strings.Split(output, "\n")
+	inAvailableCommands := false
+	var commands []DomainCommand
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Detect the "Available Commands:" section
+		if trimmed == "Available Commands:" {
+			inAvailableCommands = true
+			continue
+		}
+
+		// End of section: blank line or new section header (non-indented, ends with ":")
+		if inAvailableCommands {
+			if trimmed == "" {
+				// Blank line could mean end of section or separator within
+				// Keep going — Cobra sometimes has blank lines in the section
+				continue
+			}
+			// If line doesn't start with spaces, we've left the section
+			if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+				break
+			}
+
+			// Parse command line: "  <command>  <description>"
+			parts := strings.Fields(trimmed)
+			if len(parts) < 1 {
+				continue
+			}
+
+			cmdName := parts[0]
+
+			// Filter out framework commands
+			if frameworkCommands[cmdName] {
+				continue
+			}
+
+			// Reconstruct description from remaining fields
+			desc := ""
+			if len(parts) > 1 {
+				desc = strings.Join(parts[1:], " ")
+			}
+
+			commands = append(commands, DomainCommand{
+				Name:        cmdName,
+				Description: desc,
+			})
+		}
+	}
+
+	if len(commands) == 0 {
+		return nil
+	}
+	return commands
+}
+
+// buildEnrichedDescription creates a rich, composition-friendly description
+// for the skill frontmatter.
+func buildEnrichedDescription(entry RegistryEntry, domainCommands []DomainCommand) string {
+	// Start with the Printing Press CLI identification and registry description
+	desc := fmt.Sprintf("Printing Press CLI for %s. %s", entry.API, entry.Description)
+
+	// Add domain command keywords if available
+	if len(domainCommands) > 0 {
+		var cmdNames []string
+		for _, cmd := range domainCommands {
+			cmdNames = append(cmdNames, cmd.Name)
+		}
+		desc += " Capabilities include: " + strings.Join(cmdNames, ", ") + "."
+	}
+
+	// Add trigger phrases for discoverability
+	bareName := strings.TrimSuffix(entry.Name, "-pp-cli")
+	triggerPhrases := fmt.Sprintf(
+		" Trigger phrases: 'install %s', 'use %s', 'run %s', '%s commands', 'setup %s'.",
+		bareName, bareName, bareName, entry.API, bareName,
+	)
+	desc += triggerPhrases
+
+	// Escape any double quotes in the description (for YAML frontmatter)
+	desc = strings.ReplaceAll(desc, `"`, `\"`)
+
+	return desc
+}

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 )
@@ -107,6 +109,9 @@ func main() {
 		log.Fatalf("Error loading template %s: %v", templatePath, err)
 	}
 
+	// Snapshot existing pp-* skill dirs before generation
+	beforeDirs := existingSkillDirs()
+
 	var totalGenerated, enrichedCount, registryOnlyCount int
 
 	for _, entry := range registry.Entries {
@@ -199,6 +204,10 @@ func main() {
 	}
 
 	fmt.Printf("\nGenerated %d skills (%d enriched, %d registry-only)\n", totalGenerated, enrichedCount, registryOnlyCount)
+
+	// Bump plugin.json version if skill set changed
+	afterDirs := existingSkillDirs()
+	maybeUpdatePluginVersion(beforeDirs, afterDirs)
 }
 
 // resolveCLIBinary resolves the CLI binary name using layered precedence:
@@ -354,4 +363,90 @@ func buildEnrichedDescription(entry RegistryEntry, domainCommands []DomainComman
 	desc = strings.ReplaceAll(desc, `"`, `\"`)
 
 	return desc
+}
+
+// existingSkillDirs returns the sorted set of pp-* directory names under skills/.
+func existingSkillDirs() []string {
+	entries, err := os.ReadDir("skills")
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "pp-") {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// bumpPatchVersion increments the patch component of a semver string.
+// "1.1.0" -> "1.1.1", "1.2.3" -> "1.2.4"
+func bumpPatchVersion(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid semver: %s", version)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid patch version: %s", parts[2])
+	}
+	parts[2] = strconv.Itoa(patch + 1)
+	return strings.Join(parts, "."), nil
+}
+
+// maybeUpdatePluginVersion bumps the plugin.json patch version if the set of
+// pp-* skill directories changed. Uses string replacement to preserve field order.
+func maybeUpdatePluginVersion(beforeDirs, afterDirs []string) {
+	if slicesEqual(beforeDirs, afterDirs) {
+		return
+	}
+
+	pluginPath := filepath.Join(".claude-plugin", "plugin.json")
+	data, err := os.ReadFile(pluginPath)
+	if err != nil {
+		log.Printf("Warning: could not read %s for version bump: %v", pluginPath, err)
+		return
+	}
+
+	// Extract current version from JSON
+	var parsed struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		log.Printf("Warning: could not parse %s: %v", pluginPath, err)
+		return
+	}
+
+	newVersion, err := bumpPatchVersion(parsed.Version)
+	if err != nil {
+		log.Printf("Warning: could not bump version %q: %v", parsed.Version, err)
+		return
+	}
+
+	// Replace version in-place to preserve field order and formatting
+	content := string(data)
+	old := fmt.Sprintf(`"version": "%s"`, parsed.Version)
+	updated := fmt.Sprintf(`"version": "%s"`, newVersion)
+	content = strings.Replace(content, old, updated, 1)
+
+	if err := os.WriteFile(pluginPath, []byte(content), 0644); err != nil {
+		log.Printf("Warning: could not write %s: %v", pluginPath, err)
+		return
+	}
+
+	fmt.Printf("Bumped plugin version: %s -> %s\n", parsed.Version, newVersion)
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -112,7 +112,7 @@ func main() {
 	// Snapshot existing pp-* skill dirs before generation
 	beforeDirs := existingSkillDirs()
 
-	var totalGenerated, enrichedCount, registryOnlyCount int
+	var totalGenerated, enrichedCount, registryOnlyCount, skippedCount int
 
 	for _, entry := range registry.Entries {
 		// Derive skill name: strip -pp-cli suffix, prepend pp-
@@ -176,12 +176,27 @@ func main() {
 
 		// Write skill file
 		skillDir := filepath.Join("skills", skillName)
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+
+		// Downgrade protection: don't overwrite an enriched skill with a registry-only one.
+		// This prevents CI (where CLIs aren't installed) from replacing locally-enriched skills.
+		if !isEnriched {
+			if existing, err := os.ReadFile(skillFile); err == nil {
+				if strings.Contains(string(existing), "Key commands:") {
+					fmt.Printf("  %s -> %s (skipped: existing skill is enriched, new would be registry-only)\n", entry.Name, skillFile)
+					totalGenerated++
+					registryOnlyCount-- // undo the count since we're skipping
+					skippedCount++
+					continue
+				}
+			}
+		}
+
 		if err := os.MkdirAll(skillDir, 0755); err != nil {
 			log.Printf("Warning: could not create directory %s: %v", skillDir, err)
 			continue
 		}
 
-		skillFile := filepath.Join(skillDir, "SKILL.md")
 		f, err := os.Create(skillFile)
 		if err != nil {
 			log.Printf("Warning: could not create %s: %v", skillFile, err)
@@ -203,7 +218,12 @@ func main() {
 		fmt.Printf("  %s -> %s (%s)\n", entry.Name, skillFile, status)
 	}
 
-	fmt.Printf("\nGenerated %d skills (%d enriched, %d registry-only)\n", totalGenerated, enrichedCount, registryOnlyCount)
+	summary := fmt.Sprintf("\nGenerated %d skills (%d enriched, %d registry-only", totalGenerated, enrichedCount, registryOnlyCount)
+	if skippedCount > 0 {
+		summary += fmt.Sprintf(", %d skipped to preserve enrichment", skippedCount)
+	}
+	summary += ")\n"
+	fmt.Print(summary)
 
 	// Bump plugin.json version if skill set changed
 	afterDirs := existingSkillDirs()

--- a/tools/generate-skills/skill-template.md
+++ b/tools/generate-skills/skill-template.md
@@ -1,0 +1,96 @@
+---
+name: {{.SkillName}}
+description: "{{.EnrichedDesc}}"
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+---
+
+# {{.APIName}} — Printing Press CLI
+
+{{.Description}}
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `{{.CLIBinary}} --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.CLIBinary}}@latest
+   ```
+3. Verify: `{{.CLIBinary}} --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+{{- if eq .AuthType "api_key"}}
+5. Auth setup — set the API key and register it with the CLI:
+   ```bash
+{{- range .EnvVars}}
+   export {{.}}="your-key-here"
+{{- end}}
+   {{.CLIBinary}} auth set-token
+   ```
+   Run `{{.CLIBinary}} doctor` to verify credentials.
+{{- else if eq .AuthType "composed"}}
+5. Auth setup — log in via browser:
+   ```bash
+   {{.CLIBinary}} auth login
+   ```
+   Run `{{.CLIBinary}} doctor` to verify credentials.
+{{- end}}
+
+{{- if .HasMCP}}
+
+## MCP Server Installation
+
+{{- if eq .MCPReady "partial"}}
+
+> **Note:** Not all tools are available via MCP ({{.PublicToolCount}} of {{.ToolCount}} tools exposed).
+{{- end}}
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.MCPBinary}}@latest
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add{{range .EnvVars}} -e {{.}}=value{{end}} {{.MCPBinary}} -- {{.MCPBinary}}
+   ```
+{{- if .EnvVars}}
+   Ask the user for actual values of required API keys before running.
+{{- end}}
+3. Verify: `claude mcp list`
+{{- end}}
+
+## Direct Use
+
+1. Check if installed: `which {{.CLIBinary}}`
+   If not found, offer to install (see CLI Installation above).
+2. Discover commands: `{{.CLIBinary}} --help`
+{{- if .DomainCommands}}
+   Key commands:
+{{- range .DomainCommands}}
+   - `{{.Name}}` — {{.Description}}
+{{- end}}
+{{- end}}
+3. Match the user query to the best command. Drill into subcommand help if needed: `{{.CLIBinary}} <command> --help`
+4. Execute with the `--agent` flag:
+   ```bash
+   {{.CLIBinary}} <command> [subcommand] [args] --agent
+   ```
+5. The `--agent` flag sets `--json --compact --no-input --no-color --yes` for structured, token-efficient output.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |


### PR DESCRIPTION
## Summary

Agents could only access Printing Press CLIs through the single `/ppl` router skill. This meant no discoverability from skill listings and no cross-skill composition. Now each of the 13 apps has its own skill (`/pp-espn`, `/pp-kalshi`, `/pp-linear`, etc.) that agents can discover directly and combine based on complementary descriptions.

For example, an agent seeing `/pp-espn` ("Live scores, standings, boxscore, scoreboard...") and `/pp-kalshi` ("prediction markets, events, portfolio...") in the skill listing can connect them to answer "what Kalshi markets relate to tomorrow's NBA games?" without the user orchestrating between tools.

## What changed

**Go generator** (`tools/generate-skills/`) reads `registry.json` and per-app `.printing-press.json` manifests, optionally enriches descriptions by parsing `--help` output for domain-specific commands, and stamps out a `SKILL.md` per app from a shared template. Stdlib only, zero external dependencies.

**13 generated skills** under `skills/pp-*/`, each a self-contained scoped router handling:
- CLI installation via `go install`
- MCP server installation via `claude mcp add` (conditional, omitted for apps without MCP)
- Auth guidance adapted to the app's auth type (`none`, `api_key`, `composed`)
- Direct CLI usage with `--help` discovery and `--agent` flag execution

**Graceful degradation**: when a CLI binary isn't installed on the generator machine, the skill gets a registry-only description instead of an enriched one. 3 of 13 apps were enriched in this run (espn, kalshi, agent-capture).

**Registry fix**: corrected the `hubspot-pp-cli` path from `library/sales-and-crm/hubspot-pp-cli` to the actual directory `library/sales-and-crm/hubspot`.

The existing `/ppl` skill is unchanged and continues to serve as the catalog and discovery layer.

## Re-running the generator

```bash
go run ./tools/generate-skills/main.go
```

Run from the repo root whenever `registry.json` or app manifests change. Install more CLI binaries to get enriched descriptions for additional apps.

## Test plan

- Verified all 13 skills generated with correct frontmatter, install paths, and auth sections
- Spot-checked auth variants: `none` (ESPN), `api_key` (Kalshi), `composed` (Dominos)
- Confirmed MCP section omitted for agent-capture (no MCP block)
- Confirmed partial MCP readiness note for Pagliacci Pizza (21 of 38 tools)
- Verified name stripping: `dominos-pp-cli` → `pp-dominos`, `hubspot-pp-cli` → `pp-hubspot`
- Confirmed `agent-capture` binary name resolved correctly via `cmd/` directory validation fallback

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)