### PR TITLE
fix(skill): move ppl registry.json into references directory

### DIFF
--- a/skills/ppl/SKILL.md
+++ b/skills/ppl/SKILL.md
@@ -11,7 +11,7 @@ Unified router for the Printing Press CLI library. Discover CLIs, install them, 
 
 ## Registry
 
-The registry is at `${CLAUDE_SKILL_DIR}/registry.json`. Read it only when the task requires it — do not read preemptively. Fallback: read `registry.json` from the repository root.
+The registry is at `${CLAUDE_SKILL_DIR}/references/registry.json`. Read it only when the task requires it — do not read preemptively. Fallback: read `registry.json` from the repository root.
 
 The registry contains entries with these fields:
 - `name` — short identifier (e.g., `espn`, `linear`, `dominos-pp-cli`)
@@ -37,7 +37,7 @@ Parse `$ARGUMENTS` to determine intent:
 
 ## Mode 1: Discovery
 
-Read `${CLAUDE_SKILL_DIR}/registry.json`.
+Read `${CLAUDE_SKILL_DIR}/references/registry.json`.
 
 **No arguments:** Show a summary table of all CLIs grouped by category. For each entry, show name, API, description, auth type (from `mcp.auth_type` or "CLI only"), and MCP tool count if available.
 
@@ -151,7 +151,7 @@ Triggered when the first word of `$ARGUMENTS` exactly matches a registry entry `
 
 Triggered when arguments don't match a CLI name and don't start with `install`.
 
-1. Read `${CLAUDE_SKILL_DIR}/registry.json`.
+1. Read `${CLAUDE_SKILL_DIR}/references/registry.json`.
 2. Scan each entry for relevance to the user's query. Prefer matches on `description` and `api` over `name` and `category` — a query like "track my short links" should match Dub (description: "Create short links, track analytics...") even though "short links" doesn't appear in the name or category. Use natural language understanding — e.g., "lakers score" matches ESPN ("Live scores, standings, news, and game history across 17 sports").
 3. **Single strong match:** Proceed as Explicit Use (Mode 4) with that CLI.
 4. **Multiple plausible matches:** Present the options with name, API, and description, and ask which the user wants.

--- a/skills/ppl/references/registry.json
+++ b/skills/ppl/references/registry.json
@@ -1,0 +1,1 @@
+../../../registry.json

--- a/skills/ppl/registry.json
+++ b/skills/ppl/registry.json
@@ -1,1 +1,0 @@
-../../registry.json


### PR DESCRIPTION
Move the `registry.json` symlink from `skills/ppl/` into `skills/ppl/references/` to follow skill conventions. Updates all 3 path references in SKILL.md to point to the new location.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)