### PR TITLE
chore: sweep retro patches and version bumps across 9 CLIs

### DIFF
--- a/library/commerce/dominos-pp-cli/internal/cli/root.go
+++ b/library/commerce/dominos-pp-cli/internal/cli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "1.0.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/commerce/instacart/internal/cli/root.go
+++ b/library/commerce/instacart/internal/cli/root.go
@@ -98,7 +98,7 @@ func (a *AppContext) RequireSession() error {
 func (a *AppContext) stderr() *os.File { return os.Stderr }
 
 // Version is set at build time via -ldflags or defaults to "dev".
-var Version = "0.1.0"
+var Version = "1.0.0"
 
 func Root() *cobra.Command {
 	root := &cobra.Command{

--- a/library/developer-tools/agent-capture/internal/cli/root.go
+++ b/library/developer-tools/agent-capture/internal/cli/root.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	jsonOutput bool
-	version    = "0.1.0"
+	version    = "1.0.0"
 )
 
 var rootCmd = &cobra.Command{

--- a/library/developer-tools/trigger-dev/internal/cli/data_source.go
+++ b/library/developer-tools/trigger-dev/internal/cli/data_source.go
@@ -88,11 +88,13 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -120,11 +122,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -135,6 +139,46 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'trigger-dev-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+// writeThroughCache upserts live API results into the local SQLite store.
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("trigger-dev-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items", "runs", "tasks", "schedules"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/developer-tools/trigger-dev/internal/cli/root.go
+++ b/library/developer-tools/trigger-dev/internal/cli/root.go
@@ -10,12 +10,12 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/internal/config"
+	"github.com/spf13/cobra"
 )
 
-var version = "4.4"
+var version = "4.5.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/developer-tools/trigger-dev/internal/cli/sync.go
+++ b/library/developer-tools/trigger-dev/internal/cli/sync.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/internal/store"
+	"github.com/spf13/cobra"
 )
 
 // syncResult holds the outcome of syncing a single resource.
@@ -32,6 +32,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var since string
 	var concurrency int
 	var dbPath string
+	var maxPages int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -107,7 +108,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full)
+						res := syncResource(c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -157,6 +158,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/trigger-dev-pp-cli/data.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 
 	return cmd
 }
@@ -166,7 +168,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -192,6 +194,7 @@ func syncResource(c interface {
 	pageSize := determinePaginationDefaults()
 
 	var progressCount int64
+	pagesFetched := 0
 
 	for {
 		params := map[string]string{}
@@ -264,6 +267,14 @@ func syncResource(c interface {
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+		}
+
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			}
+			break
 		}
 
 		// Determine if there are more pages

--- a/library/media-and-entertainment/archive-is/internal/cli/data_source.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/data_source.go
@@ -88,11 +88,13 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -120,11 +122,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -135,6 +139,45 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'archive-is-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("archive-is-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/media-and-entertainment/archive-is/internal/cli/root.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "1.1.0"
 
 type rootFlags struct {
 	asJSON        bool

--- a/library/media-and-entertainment/archive-is/internal/cli/sync.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/sync.go
@@ -32,6 +32,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var since string
 	var concurrency int
 	var dbPath string
+	var maxPages int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -107,7 +108,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full)
+						res := syncResource(c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -157,6 +158,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/archive-is-pp-cli/data.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 
 	return cmd
 }
@@ -166,7 +168,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -192,6 +194,7 @@ func syncResource(c interface {
 	pageSize := determinePaginationDefaults()
 
 	var progressCount int64
+	pagesFetched := 0
 
 	for {
 		params := map[string]string{}
@@ -264,6 +267,14 @@ func syncResource(c interface {
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+		}
+
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			}
+			break
 		}
 
 		// Determine if there are more pages

--- a/library/other/flightgoat/internal/cli/data_source.go
+++ b/library/other/flightgoat/internal/cli/data_source.go
@@ -88,11 +88,13 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -120,11 +122,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -135,6 +139,45 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'flightgoat-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("flightgoat-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items", "flights", "itineraries"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/other/flightgoat/internal/cli/root.go
+++ b/library/other/flightgoat/internal/cli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "4.17.1"
+var version = "4.18.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/other/flightgoat/internal/cli/sync.go
+++ b/library/other/flightgoat/internal/cli/sync.go
@@ -32,6 +32,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var since string
 	var concurrency int
 	var dbPath string
+	var maxPages int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -107,7 +108,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full)
+						res := syncResource(c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -157,6 +158,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/flightgoat-pp-cli/data.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 
 	return cmd
 }
@@ -166,7 +168,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -192,6 +194,7 @@ func syncResource(c interface {
 	pageSize := determinePaginationDefaults()
 
 	var progressCount int64
+	pagesFetched := 0
 
 	for {
 		params := map[string]string{}
@@ -264,6 +267,14 @@ func syncResource(c interface {
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+		}
+
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			}
+			break
 		}
 
 		// Determine if there are more pages

--- a/library/productivity/slack/internal/cli/data_source.go
+++ b/library/productivity/slack/internal/cli/data_source.go
@@ -91,6 +91,7 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if slackErr := checkSlackAPIError(data); slackErr != nil {
 			return nil, DataProvenance{}, slackErr
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
@@ -99,6 +100,7 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 			if slackErr := checkSlackAPIError(data); slackErr != nil {
 				return nil, DataProvenance{}, slackErr
 			}
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -126,11 +128,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -141,6 +145,45 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'slack-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("slack-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items", "messages", "channels", "members"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/productivity/slack/internal/cli/root.go
+++ b/library/productivity/slack/internal/cli/root.go
@@ -10,12 +10,12 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/productivity/slack/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/productivity/slack/internal/config"
+	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0"
+var version = "1.1.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/productivity/slack/internal/cli/sync.go
+++ b/library/productivity/slack/internal/cli/sync.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/productivity/slack/internal/store"
+	"github.com/spf13/cobra"
 )
 
 // syncResult holds the outcome of syncing a single resource.
@@ -32,6 +32,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var since string
 	var concurrency int
 	var dbPath string
+	var maxPages int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -117,7 +118,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full)
+						res := syncResource(c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -151,7 +152,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				}
 			}
 			if syncMessages {
-				res := syncResource(c, db, "messages", sinceTS, full)
+				res := syncResource(c, db, "messages", sinceTS, full, maxPages)
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
@@ -181,6 +182,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/slack-pp-cli/data.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 
 	return cmd
 }
@@ -190,7 +192,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -219,6 +221,7 @@ func syncResource(c interface {
 	pageSize := determinePaginationDefaults()
 
 	var progressCount int64
+	pagesFetched := 0
 
 	for {
 		params := map[string]string{}
@@ -291,6 +294,14 @@ func syncResource(c interface {
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+		}
+
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			}
+			break
 		}
 
 		// Determine if there are more pages

--- a/library/project-management/linear/internal/cli/data_source.go
+++ b/library/project-management/linear/internal/cli/data_source.go
@@ -88,11 +88,13 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -120,11 +122,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -135,6 +139,45 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'linear-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("linear-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items", "issues", "projects", "cycles", "teams"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/project-management/linear/internal/cli/root.go
+++ b/library/project-management/linear/internal/cli/root.go
@@ -10,12 +10,12 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/project-management/linear/internal/config"
+	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+var version = "1.0.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/project-management/linear/internal/cli/sync.go
+++ b/library/project-management/linear/internal/cli/sync.go
@@ -15,6 +15,7 @@ import (
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var full bool
 	var dbPath string
+	var maxPages int
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync Linear data to local SQLite store",
@@ -47,7 +48,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 
 			syncs := []struct {
 				name string
-				fn   func(*client.Client, *store.Store) (int, error)
+				fn   func(*client.Client, *store.Store, int) (int, error)
 			}{
 				{"teams", syncTeams},
 				{"users", syncUsers},
@@ -60,7 +61,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 
 			for _, s := range syncs {
 				fmt.Fprintf(os.Stderr, "Syncing %s... ", s.name)
-				n, err := s.fn(c, db)
+				n, err := s.fn(c, db, maxPages)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 					continue
@@ -75,10 +76,11 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&full, "full", false, "Full sync (ignore cursors, re-fetch everything)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/linear-pp-cli/store.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 	return cmd
 }
 
-func syncTeams(c *client.Client, db *store.Store) (int, error) {
+func syncTeams(c *client.Client, db *store.Store, _ int) (int, error) {
 	data, err := c.Query(client.TeamsQuery, nil)
 	if err != nil {
 		return 0, err
@@ -103,7 +105,7 @@ func syncTeams(c *client.Client, db *store.Store) (int, error) {
 	return len(result.Teams.Nodes), nil
 }
 
-func syncUsers(c *client.Client, db *store.Store) (int, error) {
+func syncUsers(c *client.Client, db *store.Store, _ int) (int, error) {
 	data, err := c.Query(client.UsersQuery, map[string]any{"first": 200})
 	if err != nil {
 		return 0, err
@@ -128,7 +130,7 @@ func syncUsers(c *client.Client, db *store.Store) (int, error) {
 	return len(result.Users.Nodes), nil
 }
 
-func syncWorkflowStates(c *client.Client, db *store.Store) (int, error) {
+func syncWorkflowStates(c *client.Client, db *store.Store, _ int) (int, error) {
 	data, err := c.Query(client.WorkflowStatesQuery, nil)
 	if err != nil {
 		return 0, err
@@ -153,8 +155,8 @@ func syncWorkflowStates(c *client.Client, db *store.Store) (int, error) {
 	return len(result.WorkflowStates.Nodes), nil
 }
 
-func syncLabels(c *client.Client, db *store.Store) (int, error) {
-	nodes, err := c.PaginatedQuery(client.IssueLabelsQuery, map[string]any{"first": 100}, "issueLabels", 100)
+func syncLabels(c *client.Client, db *store.Store, maxPages int) (int, error) {
+	nodes, err := c.PaginatedQueryMax(client.IssueLabelsQuery, map[string]any{"first": 100}, "issueLabels", 100, maxPages)
 	if err != nil {
 		return 0, err
 	}
@@ -170,8 +172,8 @@ func syncLabels(c *client.Client, db *store.Store) (int, error) {
 	return len(nodes), nil
 }
 
-func syncProjects(c *client.Client, db *store.Store) (int, error) {
-	nodes, err := c.PaginatedQuery(client.ProjectsQuery, nil, "projects", 50)
+func syncProjects(c *client.Client, db *store.Store, maxPages int) (int, error) {
+	nodes, err := c.PaginatedQueryMax(client.ProjectsQuery, nil, "projects", 50, maxPages)
 	if err != nil {
 		return 0, err
 	}
@@ -187,8 +189,8 @@ func syncProjects(c *client.Client, db *store.Store) (int, error) {
 	return len(nodes), nil
 }
 
-func syncCycles(c *client.Client, db *store.Store) (int, error) {
-	nodes, err := c.PaginatedQuery(client.CyclesQuery, nil, "cycles", 50)
+func syncCycles(c *client.Client, db *store.Store, maxPages int) (int, error) {
+	nodes, err := c.PaginatedQueryMax(client.CyclesQuery, nil, "cycles", 50, maxPages)
 	if err != nil {
 		return 0, err
 	}
@@ -204,8 +206,8 @@ func syncCycles(c *client.Client, db *store.Store) (int, error) {
 	return len(nodes), nil
 }
 
-func syncIssues(c *client.Client, db *store.Store) (int, error) {
-	nodes, err := c.PaginatedQuery(client.IssuesQuery, nil, "issues", 50)
+func syncIssues(c *client.Client, db *store.Store, maxPages int) (int, error) {
+	nodes, err := c.PaginatedQueryMax(client.IssuesQuery, nil, "issues", 50, maxPages)
 	if err != nil {
 		return 0, err
 	}

--- a/library/project-management/linear/internal/client/graphql.go
+++ b/library/project-management/linear/internal/client/graphql.go
@@ -67,6 +67,11 @@ func (c *Client) Mutate(query string, variables map[string]any) (json.RawMessage
 // queryFn returns the query string with $after variable; fieldPath is the dot-path to the connection
 // (e.g., "issues"). Returns all collected nodes.
 func (c *Client) PaginatedQuery(query string, variables map[string]any, fieldPath string, pageSize int) ([]json.RawMessage, error) {
+	return c.PaginatedQueryMax(query, variables, fieldPath, pageSize, 0)
+}
+
+// PaginatedQueryMax is like PaginatedQuery but stops after maxPages pages (0 = unlimited).
+func (c *Client) PaginatedQueryMax(query string, variables map[string]any, fieldPath string, pageSize int, maxPages int) ([]json.RawMessage, error) {
 	if variables == nil {
 		variables = map[string]any{}
 	}
@@ -77,6 +82,7 @@ func (c *Client) PaginatedQuery(query string, variables map[string]any, fieldPat
 
 	var all []json.RawMessage
 	hasNext := true
+	pagesFetched := 0
 	for hasNext {
 		data, err := c.Query(query, variables)
 		if err != nil {
@@ -107,6 +113,10 @@ func (c *Client) PaginatedQuery(query string, variables map[string]any, fieldPat
 
 		all = append(all, conn.Nodes...)
 		hasNext = conn.PageInfo.HasNextPage
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			break
+		}
 		if hasNext {
 			variables["after"] = conn.PageInfo.EndCursor
 		}

--- a/library/sales-and-crm/hubspot/internal/cli/data_source.go
+++ b/library/sales-and-crm/hubspot/internal/cli/data_source.go
@@ -88,11 +88,13 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := c.Get(path, params)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -120,11 +122,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		writeThroughCache(resourceType, data)
 		return data, DataProvenance{Source: "live"}, nil
 
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			writeThroughCache(resourceType, data)
 			return data, DataProvenance{Source: "live"}, nil
 		}
 		if !isNetworkError(err) {
@@ -135,6 +139,45 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'hubspot-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
 		return localData, prov, nil
+	}
+}
+
+func writeThroughCache(resourceType string, data json.RawMessage) {
+	db, err := store.Open(defaultDBPath("hubspot-pp-cli"))
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) != nil || len(items) == 0 {
+		items = nil
+		var envelope map[string]json.RawMessage
+		if json.Unmarshal(data, &envelope) == nil {
+			for _, key := range []string{"results", "data", "items", "contacts", "companies", "deals"} {
+				if raw, ok := envelope[key]; ok {
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+						items = arr
+						break
+					}
+				}
+			}
+			if items == nil {
+				if idRaw, ok := envelope["id"]; ok {
+					_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), data)
+					return
+				}
+			}
+		}
+	}
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		if idRaw, ok := obj["id"]; ok {
+			_ = db.Upsert(resourceType, strings.Trim(string(idRaw), "\""), item)
+		}
 	}
 }
 

--- a/library/sales-and-crm/hubspot/internal/cli/root.go
+++ b/library/sales-and-crm/hubspot/internal/cli/root.go
@@ -10,12 +10,12 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot-pp-cli/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot-pp-cli/internal/config"
+	"github.com/spf13/cobra"
 )
 
-var version = "3.0.0"
+var version = "3.1.0"
 
 type rootFlags struct {
 	asJSON       bool

--- a/library/sales-and-crm/hubspot/internal/cli/sync.go
+++ b/library/sales-and-crm/hubspot/internal/cli/sync.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot-pp-cli/internal/store"
+	"github.com/spf13/cobra"
 )
 
 // syncResult holds the outcome of syncing a single resource.
@@ -32,6 +32,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var since string
 	var concurrency int
 	var dbPath string
+	var maxPages int
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -107,7 +108,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full)
+						res := syncResource(c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -157,6 +158,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/hubspot-pp-cli/data.db)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 
 	return cmd
 }
@@ -166,7 +168,7 @@ Once synced, use the 'search' command for instant full-text search.`,
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, resource, sinceTS string, full bool) syncResult {
+}, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -192,6 +194,7 @@ func syncResource(c interface {
 	pageSize := determinePaginationDefaults()
 
 	var progressCount int64
+	pagesFetched := 0
 
 	for {
 		params := map[string]string{}
@@ -264,6 +267,14 @@ func syncResource(c interface {
 		if err := db.SaveSyncState(resource, nextCursor, totalCount); err != nil {
 			// Non-fatal: log and continue
 			fmt.Fprintf(os.Stderr, "\nwarning: failed to save sync state for %s: %v\n", resource, err)
+		}
+
+		pagesFetched++
+		if maxPages > 0 && pagesFetched >= maxPages {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			}
+			break
 		}
 
 		// Determine if there are more pages


### PR DESCRIPTION
## Summary

Write-through caching, sync page ceiling, and version bumps for the remaining 9 CLIs that weren't patched in the earlier per-CLI PRs.

### Patched (write-through + sync ceiling + version bump)

| CLI | Before | After | Notes |
|-----|--------|-------|-------|
| trigger-dev | 4.4 | 4.5.0 | Standard data layer |
| archive-is | 1.0.0 | 1.1.0 | Standard data layer |
| flightgoat | 4.17.1 | 4.18.0 | Standard data layer |
| slack | 1.0.0 | 1.1.0 | Adapted for Slack-specific error checks |
| linear | 0.1.0 | 1.0.0 | Non-standard GraphQL sync — added PaginatedQueryMax to graphql.go |
| hubspot | 3.0.0 | 3.1.0 | Standard data layer |

### Version only (no standard data layer to patch)

| CLI | Before | After | Why no patch |
|-----|--------|-------|-------------|
| dominos-pp-cli | 0.1.0 | 1.0.0 | GraphQL/custom architecture, no data_source.go |
| instacart | 0.1.0 | 1.0.0 | GraphQL/custom client, no data_source.go |
| agent-capture | 0.1.0 | 1.0.0 | Screen capture tool, no store |

All 9 CLIs build and vet clean.