### PR TITLE
feat: add OpenClaw metadata to generated skills

### DIFF
--- a/plugin/skills/pp-agent-capture/SKILL.md
+++ b/plugin/skills/pp-agent-capture/SKILL.md
@@ -3,6 +3,7 @@ name: pp-agent-capture
 description: "Printing Press CLI for agent-capture. Record, screenshot, and convert macOS windows and screens for AI agent evidence Capabilities include: batch, convert, diff, evidence, find, health, list, ocr, permissions, pipeline, preset, record, remotion, screenshot, stitch, vhs, watch. Trigger phrases: 'install agent-capture', 'use agent-capture', 'run agent-capture', 'agent-capture commands', 'setup agent-capture'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["agent-capture"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture/cmd/agent-capture@latest","bins":["agent-capture"],"label":"Install via go install"}]}}'
 ---
 
 # agent-capture — Printing Press CLI

--- a/plugin/skills/pp-archive-is/SKILL.md
+++ b/plugin/skills/pp-archive-is/SKILL.md
@@ -3,6 +3,7 @@ name: pp-archive-is
 description: "Printing Press CLI for Archive.today. Bypass paywalls and look up web archives via archive.today. Hero command: find or create an archive for any URL with lookup-before-submit, Wayback Machine fallback, and agent-hints on stderr when called non-interactively. Trigger phrases: 'install archive-is', 'use archive-is', 'run archive-is', 'Archive.today commands', 'setup archive-is'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["archive-is-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-cli@latest","bins":["archive-is-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Archive.today — Printing Press CLI

--- a/plugin/skills/pp-cal-com/SKILL.md
+++ b/plugin/skills/pp-cal-com/SKILL.md
@@ -3,6 +3,7 @@ name: pp-cal-com
 description: "Printing Press CLI for Cal.com. Manage bookings, event types, schedules, and availability via the Cal.com API Trigger phrases: 'install cal-com', 'use cal-com', 'run cal-com', 'Cal.com commands', 'setup cal-com'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["cal-com-pp-cli"],"env":["CAL_COM_TOKEN"]},"primaryEnv":"CAL_COM_TOKEN","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-cli@latest","bins":["cal-com-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Cal.com — Printing Press CLI

--- a/plugin/skills/pp-dominos/SKILL.md
+++ b/plugin/skills/pp-dominos/SKILL.md
@@ -3,6 +3,7 @@ name: pp-dominos
 description: "Printing Press CLI for Dominos Pizza. Order pizza, browse menus, track deliveries, and manage rewards from the terminal Trigger phrases: 'install dominos', 'use dominos', 'run dominos', 'Dominos Pizza commands', 'setup dominos'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["dominos-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-pp-cli@latest","bins":["dominos-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Dominos Pizza — Printing Press CLI

--- a/plugin/skills/pp-dub/SKILL.md
+++ b/plugin/skills/pp-dub/SKILL.md
@@ -3,6 +3,7 @@ name: pp-dub
 description: "Printing Press CLI for Dub. Create short links, track analytics, manage domains, and run affiliate programs via the Dub API Trigger phrases: 'install dub', 'use dub', 'run dub', 'Dub commands', 'setup dub'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["dub-pp-cli"],"env":["DUB_TOKEN"]},"primaryEnv":"DUB_TOKEN","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-cli@latest","bins":["dub-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Dub — Printing Press CLI

--- a/plugin/skills/pp-flightgoat/SKILL.md
+++ b/plugin/skills/pp-flightgoat/SKILL.md
@@ -3,6 +3,7 @@ name: pp-flightgoat
 description: "Printing Press CLI for flightgoat. Free Google Flights search, Kayak nonstop route explorer, and optional FlightAware live tracking in one CLI. No API key required for search. Trigger phrases: 'install flightgoat', 'use flightgoat', 'run flightgoat', 'flightgoat commands', 'setup flightgoat'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["flightgoat-pp-cli"],"env":["FLIGHTGOAT_API_KEY_AUTH"]},"primaryEnv":"FLIGHTGOAT_API_KEY_AUTH","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/flightgoat/cmd/flightgoat-pp-cli@latest","bins":["flightgoat-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # flightgoat — Printing Press CLI

--- a/plugin/skills/pp-hackernews/SKILL.md
+++ b/plugin/skills/pp-hackernews/SKILL.md
@@ -3,6 +3,7 @@ name: pp-hackernews
 description: "Printing Press CLI for Hacker News. Browse, search, and analyze Hacker News — front page, Show HN, Ask HN, Who is Hiring, topic pulse, and pipe-friendly output Trigger phrases: 'install hackernews', 'use hackernews', 'run hackernews', 'Hacker News commands', 'setup hackernews'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["hackernews-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli@latest","bins":["hackernews-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Hacker News — Printing Press CLI

--- a/plugin/skills/pp-hubspot/SKILL.md
+++ b/plugin/skills/pp-hubspot/SKILL.md
@@ -3,6 +3,7 @@ name: pp-hubspot
 description: "Printing Press CLI for HubSpot. Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics Trigger phrases: 'install hubspot', 'use hubspot', 'run hubspot', 'HubSpot commands', 'setup hubspot'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["hubspot-pp-cli"],"env":["HUBSPOT_ACCESS_TOKEN"]},"primaryEnv":"HUBSPOT_ACCESS_TOKEN","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-cli@latest","bins":["hubspot-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # HubSpot — Printing Press CLI

--- a/plugin/skills/pp-instacart/SKILL.md
+++ b/plugin/skills/pp-instacart/SKILL.md
@@ -3,6 +3,7 @@ name: pp-instacart
 description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'Instacart commands', 'setup instacart'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["instacart-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@latest","bins":["instacart-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Instacart — Printing Press CLI

--- a/plugin/skills/pp-kalshi/SKILL.md
+++ b/plugin/skills/pp-kalshi/SKILL.md
@@ -3,6 +3,7 @@ name: pp-kalshi
 description: "Printing Press CLI for Kalshi. Trade prediction markets, track portfolios, and analyze odds on Kalshi from the command line Capabilities include: account, analytics, api-keys, communications, events, exchange, fcm, historical, incentive-programs, live-data, markets, milestones, multivariate-event-collections, portfolio, search, series, structured-targets, tail. Trigger phrases: 'install kalshi', 'use kalshi', 'run kalshi', 'Kalshi commands', 'setup kalshi'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["kalshi-pp-cli"],"env":["KALSHI_API_KEY"]},"primaryEnv":"KALSHI_API_KEY","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-cli@latest","bins":["kalshi-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Kalshi — Printing Press CLI

--- a/plugin/skills/pp-linear/SKILL.md
+++ b/plugin/skills/pp-linear/SKILL.md
@@ -3,6 +3,7 @@ name: pp-linear
 description: "Printing Press CLI for Linear. Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, search, and cross-entity queries. Trigger phrases: 'install linear', 'use linear', 'run linear', 'Linear commands', 'setup linear'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["linear-pp-cli"],"env":["LINEAR_API_KEY"]},"primaryEnv":"LINEAR_API_KEY","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest","bins":["linear-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Linear — Printing Press CLI

--- a/plugin/skills/pp-movie-goat/SKILL.md
+++ b/plugin/skills/pp-movie-goat/SKILL.md
@@ -3,6 +3,7 @@ name: pp-movie-goat
 description: "Printing Press CLI for TMDb + OMDb. Multi-source movie ratings (TMDb + OMDb), streaming availability, and cross-taste recommendations Trigger phrases: 'install movie-goat', 'use movie-goat', 'run movie-goat', 'TMDb + OMDb commands', 'setup movie-goat'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["movie-goat-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest","bins":["movie-goat-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # TMDb + OMDb — Printing Press CLI

--- a/plugin/skills/pp-pagliacci-pizza/SKILL.md
+++ b/plugin/skills/pp-pagliacci-pizza/SKILL.md
@@ -3,6 +3,7 @@ name: pp-pagliacci-pizza
 description: "Printing Press CLI for Pagliacci Pizza. Order pizza, browse menus, manage rewards, and track deliveries from Pagliacci Pizza Trigger phrases: 'install pagliacci-pizza', 'use pagliacci-pizza', 'run pagliacci-pizza', 'Pagliacci Pizza commands', 'setup pagliacci-pizza'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["pagliacci-pizza-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/pagliacci-pizza/cmd/pagliacci-pizza-pp-cli@latest","bins":["pagliacci-pizza-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Pagliacci Pizza — Printing Press CLI

--- a/plugin/skills/pp-postman-explore/SKILL.md
+++ b/plugin/skills/pp-postman-explore/SKILL.md
@@ -3,6 +3,7 @@ name: pp-postman-explore
 description: "Printing Press CLI for Postman Explore. Search and browse the Postman API Network Trigger phrases: 'install postman-explore', 'use postman-explore', 'run postman-explore', 'Postman Explore commands', 'setup postman-explore'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["postman-explore-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@latest","bins":["postman-explore-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Postman Explore — Printing Press CLI

--- a/plugin/skills/pp-slack/SKILL.md
+++ b/plugin/skills/pp-slack/SKILL.md
@@ -3,6 +3,7 @@ name: pp-slack
 description: "Printing Press CLI for Slack. Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal Trigger phrases: 'install slack', 'use slack', 'run slack', 'Slack commands', 'setup slack'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["slack-pp-cli"],"env":["SLACK_BOT_TOKEN"]},"primaryEnv":"SLACK_BOT_TOKEN","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@latest","bins":["slack-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Slack — Printing Press CLI

--- a/plugin/skills/pp-steam-web/SKILL.md
+++ b/plugin/skills/pp-steam-web/SKILL.md
@@ -3,6 +3,7 @@ name: pp-steam-web
 description: "Printing Press CLI for Steam Web. Look up Steam players, games, achievements, friends, and stats from the command line Trigger phrases: 'install steam-web', 'use steam-web', 'run steam-web', 'Steam Web commands', 'setup steam-web'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["steam-web-pp-cli"],"env":["STEAM_WEB_API_KEY"]},"primaryEnv":"STEAM_WEB_API_KEY","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@latest","bins":["steam-web-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Steam Web — Printing Press CLI

--- a/plugin/skills/pp-trigger-dev/SKILL.md
+++ b/plugin/skills/pp-trigger-dev/SKILL.md
@@ -3,6 +3,7 @@ name: pp-trigger-dev
 description: "Printing Press CLI for Trigger.dev. Monitor runs, trigger tasks, manage schedules, and detect failures via the Trigger.dev API Trigger phrases: 'install trigger-dev', 'use trigger-dev', 'run trigger-dev', 'Trigger.dev commands', 'setup trigger-dev'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["trigger-dev-pp-cli"],"env":["TRIGGER_SECRET_KEY"]},"primaryEnv":"TRIGGER_SECRET_KEY","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@latest","bins":["trigger-dev-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Trigger.dev — Printing Press CLI

--- a/plugin/skills/pp-weather-goat/SKILL.md
+++ b/plugin/skills/pp-weather-goat/SKILL.md
@@ -3,6 +3,7 @@ name: pp-weather-goat
 description: "Printing Press CLI for Open-Meteo + NWS. Weather forecasts, severe weather alerts, air quality, and GO/CAUTION/STOP activity verdicts for walk, bike, hike, commute, and drive Trigger phrases: 'install weather-goat', 'use weather-goat', 'run weather-goat', 'Open-Meteo + NWS commands', 'setup weather-goat'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["weather-goat-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-cli@latest","bins":["weather-goat-pp-cli"],"label":"Install via go install"}]}}'
 ---
 
 # Open-Meteo + NWS — Printing Press CLI

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -55,20 +55,21 @@ type DomainCommand struct {
 // Template context
 
 type SkillContext struct {
-	SkillName      string
-	APIName        string
-	Description    string
-	EnrichedDesc   string
-	CLIBinary      string
-	InstallPath    string
-	HasMCP         bool
-	MCPBinary      string
-	AuthType       string
-	EnvVars        []string
-	MCPReady       string
-	ToolCount      int
+	SkillName       string
+	APIName         string
+	Description     string
+	EnrichedDesc    string
+	CLIBinary       string
+	InstallPath     string
+	HasMCP          bool
+	MCPBinary       string
+	AuthType        string
+	EnvVars         []string
+	MCPReady        string
+	ToolCount       int
 	PublicToolCount int
-	DomainCommands []DomainCommand
+	DomainCommands  []DomainCommand
+	OpenClawMeta    string
 }
 
 // Framework commands to filter out of --help output
@@ -173,6 +174,7 @@ func main() {
 			PublicToolCount: publicToolCount,
 			DomainCommands:  domainCommands,
 		}
+		ctx.OpenClawMeta = buildOpenClawMetadata(ctx)
 
 		// Write skill file
 		skillDir := filepath.Join("plugin", "skills", skillName)
@@ -457,6 +459,67 @@ func maybeUpdatePluginVersion(beforeDirs, afterDirs []string) {
 	}
 
 	fmt.Printf("Bumped plugin version: %s -> %s\n", parsed.Version, newVersion)
+}
+
+// buildOpenClawMetadata constructs the single-line JSON for the metadata frontmatter field.
+// This gives OpenClaw dependency gating, auto-install, and API key prompting.
+func buildOpenClawMetadata(ctx SkillContext) string {
+	type installBlock struct {
+		ID      string   `json:"id"`
+		Kind    string   `json:"kind"`
+		Command string   `json:"command"`
+		Bins    []string `json:"bins"`
+		Label   string   `json:"label"`
+	}
+
+	type requires struct {
+		Bins []string `json:"bins"`
+		Env  []string `json:"env,omitempty"`
+	}
+
+	type openclawBlock struct {
+		Requires   requires       `json:"requires"`
+		PrimaryEnv string         `json:"primaryEnv,omitempty"`
+		Install    []installBlock `json:"install"`
+	}
+
+	type metadataWrapper struct {
+		OpenClaw openclawBlock `json:"openclaw"`
+	}
+
+	goInstallCmd := fmt.Sprintf("go install github.com/mvanhorn/printing-press-library/%s/cmd/%s@latest", ctx.InstallPath, ctx.CLIBinary)
+
+	req := requires{
+		Bins: []string{ctx.CLIBinary},
+	}
+	if len(ctx.EnvVars) > 0 && ctx.AuthType == "api_key" {
+		req.Env = ctx.EnvVars
+	}
+
+	oc := openclawBlock{
+		Requires: req,
+		Install: []installBlock{
+			{
+				ID:      "go",
+				Kind:    "shell",
+				Command: goInstallCmd,
+				Bins:    []string{ctx.CLIBinary},
+				Label:   "Install via go install",
+			},
+		},
+	}
+
+	if len(ctx.EnvVars) > 0 && ctx.AuthType == "api_key" {
+		oc.PrimaryEnv = ctx.EnvVars[0]
+	}
+
+	wrapper := metadataWrapper{OpenClaw: oc}
+	data, err := json.Marshal(wrapper)
+	if err != nil {
+		log.Printf("Warning: could not marshal OpenClaw metadata for %s: %v", ctx.SkillName, err)
+		return ""
+	}
+	return string(data)
 }
 
 func slicesEqual(a, b []string) bool {

--- a/tools/generate-skills/skill-template.md
+++ b/tools/generate-skills/skill-template.md
@@ -3,6 +3,9 @@ name: {{.SkillName}}
 description: "{{.EnrichedDesc}}"
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
+{{- if .OpenClawMeta}}
+metadata: '{{.OpenClawMeta}}'
+{{- end}}
 ---
 
 # {{.APIName}} — Printing Press CLI


### PR DESCRIPTION
## Summary

- Generator now emits `metadata` frontmatter with OpenClaw-compatible JSON for dependency gating, auto-install, and API key prompting
- Claude Code ignores the `metadata` field, so this is backwards-compatible
- Three auth patterns handled correctly:
  - **No auth** (espn, archive-is): `requires.bins` only
  - **API key** (linear, kalshi, dub): `requires.bins` + `requires.env` + `primaryEnv`
  - **Browser/composed** (dominos): `requires.bins` only (no env vars to gate on)
- Also adds standalone `marketplace.json` for independent plugin install (decoupled from cli-printing-press marketplace)

## Changes

- `tools/generate-skills/main.go` — added `buildOpenClawMetadata()` and `OpenClawMeta` field on `SkillContext`
- `tools/generate-skills/skill-template.md` — conditional `metadata` line in frontmatter
- 17 per-CLI skill `SKILL.md` files regenerated with metadata

## Test plan

- [x] Generator builds and runs successfully
- [x] Verified no-auth, api_key, and composed auth patterns all render correct JSON
- [x] ESPN skill preserved by downgrade protection (enriched, binary not installed)
- [ ] Verify OpenClaw loads skills and respects `requires.bins` gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)