### PR TITLE
feat(skills): prefer upstream SKILL.md from printed CLIs

### DIFF
--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -152,11 +152,6 @@ func main() {
 		enrichedDesc := buildEnrichedDescription(entry, domainCommands)
 
 		isEnriched := domainCommands != nil
-		if isEnriched {
-			enrichedCount++
-		} else {
-			registryOnlyCount++
-		}
 
 		ctx := SkillContext{
 			SkillName:       skillName,
@@ -203,7 +198,6 @@ func main() {
 				if strings.Contains(string(existing), "Key commands:") {
 					fmt.Printf("  %s -> %s (skipped: existing skill is enriched, new would be registry-only)\n", entry.Name, skillFile)
 					totalGenerated++
-					registryOnlyCount-- // undo the count since we're skipping
 					skippedCount++
 					continue
 				}
@@ -232,6 +226,9 @@ func main() {
 		status := "registry-only"
 		if isEnriched {
 			status = "enriched"
+			enrichedCount++
+		} else {
+			registryOnlyCount++
 		}
 		fmt.Printf("  %s -> %s (%s)\n", entry.Name, skillFile, status)
 	}
@@ -248,9 +245,10 @@ func main() {
 	maybeUpdatePluginVersion(beforeDirs, afterDirs)
 }
 
-// copyUpstreamSkill copies <entryPath>/SKILL.md to skillFile if it exists.
-// Returns (true, nil) on successful copy, (false, nil) if no upstream SKILL.md,
-// (false, err) on filesystem errors.
+// copyUpstreamSkill copies <entryPath>/SKILL.md to skillFile if it exists and
+// is non-empty. Returns (true, nil) on successful copy, (false, nil) when
+// upstream is missing or empty (so the caller can fall through to synthesis),
+// (false, err) on other filesystem errors.
 func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
 	upstreamPath := filepath.Join(entryPath, "SKILL.md")
 	data, err := os.ReadFile(upstreamPath)
@@ -259,6 +257,13 @@ func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
 			return false, nil
 		}
 		return false, fmt.Errorf("read %s: %w", upstreamPath, err)
+	}
+	// Empty or whitespace-only upstream almost always signals a generator bug
+	// (failed write mid-pipeline). Prefer thin synthesis over shipping a blank
+	// SKILL.md. Log loudly so the upstream regression is visible.
+	if len(strings.TrimSpace(string(data))) == 0 {
+		log.Printf("Warning: upstream SKILL.md at %s is empty; falling through to synthesis", upstreamPath)
+		return false, nil
 	}
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", skillDir, err)

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -113,7 +113,7 @@ func main() {
 	// Snapshot existing pp-* skill dirs before generation
 	beforeDirs := existingSkillDirs()
 
-	var totalGenerated, enrichedCount, registryOnlyCount, skippedCount int
+	var totalGenerated, enrichedCount, registryOnlyCount, skippedCount, upstreamCount int
 
 	for _, entry := range registry.Entries {
 		// Derive skill name: strip -pp-cli suffix, prepend pp-
@@ -180,6 +180,22 @@ func main() {
 		skillDir := filepath.Join("plugin", "skills", skillName)
 		skillFile := filepath.Join(skillDir, "SKILL.md")
 
+		// Upstream wins: if the printed CLI ships its own SKILL.md, copy it
+		// verbatim. The generator has research context (novel features,
+		// narrative, trigger phrases) that this tool can't reconstruct, so
+		// upstream is strictly better than enriched or registry-only synthesis.
+		copied, err := copyUpstreamSkill(entry.Path, skillDir, skillFile)
+		if err != nil {
+			log.Printf("Warning: could not copy upstream SKILL.md for %s: %v", entry.Name, err)
+			continue
+		}
+		if copied {
+			totalGenerated++
+			upstreamCount++
+			fmt.Printf("  %s -> %s (upstream)\n", entry.Name, skillFile)
+			continue
+		}
+
 		// Downgrade protection: don't overwrite an enriched skill with a registry-only one.
 		// This prevents CI (where CLIs aren't installed) from replacing locally-enriched skills.
 		if !isEnriched {
@@ -220,7 +236,7 @@ func main() {
 		fmt.Printf("  %s -> %s (%s)\n", entry.Name, skillFile, status)
 	}
 
-	summary := fmt.Sprintf("\nGenerated %d skills (%d enriched, %d registry-only", totalGenerated, enrichedCount, registryOnlyCount)
+	summary := fmt.Sprintf("\nGenerated %d skills (%d upstream, %d enriched, %d registry-only", totalGenerated, upstreamCount, enrichedCount, registryOnlyCount)
 	if skippedCount > 0 {
 		summary += fmt.Sprintf(", %d skipped to preserve enrichment", skippedCount)
 	}
@@ -230,6 +246,27 @@ func main() {
 	// Bump plugin.json version if skill set changed
 	afterDirs := existingSkillDirs()
 	maybeUpdatePluginVersion(beforeDirs, afterDirs)
+}
+
+// copyUpstreamSkill copies <entryPath>/SKILL.md to skillFile if it exists.
+// Returns (true, nil) on successful copy, (false, nil) if no upstream SKILL.md,
+// (false, err) on filesystem errors.
+func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
+	upstreamPath := filepath.Join(entryPath, "SKILL.md")
+	data, err := os.ReadFile(upstreamPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", upstreamPath, err)
+	}
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", skillDir, err)
+	}
+	if err := os.WriteFile(skillFile, data, 0644); err != nil {
+		return false, fmt.Errorf("write %s: %w", skillFile, err)
+	}
+	return true, nil
 }
 
 // resolveCLIBinary resolves the CLI binary name using layered precedence:

--- a/tools/generate-skills/main_test.go
+++ b/tools/generate-skills/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -99,5 +103,222 @@ func TestCopyUpstreamSkill_OverwritesExisting(t *testing.T) {
 	}
 	if string(got) != string(upstream) {
 		t.Errorf("upstream should overwrite stale synthesis\nwant: %q\ngot:  %q", upstream, got)
+	}
+}
+
+func TestCopyUpstreamSkill_EmptyFallsThrough(t *testing.T) {
+	tmp := t.TempDir()
+	entryPath := filepath.Join(tmp, "library", "commerce", "blank")
+	if err := os.MkdirAll(entryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entryPath, "SKILL.md"), []byte("   \n\t\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(tmp, "plugin", "skills", "pp-blank")
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+
+	copied, err := copyUpstreamSkill(entryPath, skillDir, skillFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if copied {
+		t.Error("expected copied=false for empty/whitespace upstream so synthesis can take over")
+	}
+	if _, err := os.Stat(skillFile); !os.IsNotExist(err) {
+		t.Errorf("expected destination not to exist when upstream is empty, stat err=%v", err)
+	}
+}
+
+// buildTool compiles the generate-skills binary into a tempdir and returns its path.
+func buildTool(t *testing.T) string {
+	t.Helper()
+	srcDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binName := "generate-skills"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(t.TempDir(), binName)
+	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = srcDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+// setupFixture writes a minimal working tree that main() expects:
+//   - registry.json at root
+//   - tools/generate-skills/skill-template.md (copied from the real template)
+//   - plugin/.claude-plugin/plugin.json (so version bump can run without a warning)
+//   - plugin/skills/ (output dir)
+func setupFixture(t *testing.T, root string, entries []RegistryEntry) {
+	t.Helper()
+
+	registry := Registry{SchemaVersion: 1, Entries: entries}
+	regJSON := fmt.Sprintf(`{"schema_version":1,"entries":[`)
+	for i, e := range entries {
+		if i > 0 {
+			regJSON += ","
+		}
+		regJSON += fmt.Sprintf(`{"name":%q,"category":%q,"api":%q,"description":%q,"path":%q}`,
+			e.Name, e.Category, e.API, e.Description, e.Path)
+	}
+	regJSON += `]}`
+	_ = registry // silence unused warning when fields unused
+	if err := os.WriteFile(filepath.Join(root, "registry.json"), []byte(regJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy the real template so the synthesis path works.
+	srcDir, _ := os.Getwd()
+	tmplSrc, err := os.ReadFile(filepath.Join(srcDir, "skill-template.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmplDir := filepath.Join(root, "tools", "generate-skills")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "skill-template.md"), tmplSrc, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Minimal plugin.json so the version-bump path doesn't warn.
+	pluginDir := filepath.Join(root, "plugin", ".claude-plugin")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"version": "1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, "plugin", "skills"), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegration_UpstreamPreferredOverSynthesis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	bin := buildTool(t)
+	root := t.TempDir()
+
+	entries := []RegistryEntry{
+		{Name: "with-upstream-pp-cli", Category: "commerce", API: "With Upstream",
+			Description: "Has upstream skill", Path: "library/commerce/with-upstream"},
+		{Name: "no-upstream-pp-cli", Category: "commerce", API: "No Upstream",
+			Description: "No upstream skill", Path: "library/commerce/no-upstream"},
+	}
+	setupFixture(t, root, entries)
+
+	// Only the first entry ships an upstream SKILL.md.
+	upstreamDir := filepath.Join(root, "library", "commerce", "with-upstream")
+	if err := os.MkdirAll(upstreamDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	upstreamContent := "---\nname: pp-with-upstream\ndescription: \"Authored upstream with research context.\"\n---\n\n# Upstream Skill\n\nNovel features and narrative.\n"
+	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte(upstreamContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	noUpstreamDir := filepath.Join(root, "library", "commerce", "no-upstream")
+	if err := os.MkdirAll(noUpstreamDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tool exited with error: %v\n%s", err, out)
+	}
+	outStr := string(out)
+
+	// Upstream entry should be copied byte-for-byte.
+	upstreamSkill, err := os.ReadFile(filepath.Join(root, "plugin", "skills", "pp-with-upstream", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading upstream-copied skill: %v", err)
+	}
+	if string(upstreamSkill) != upstreamContent {
+		t.Errorf("upstream skill not copied byte-for-byte\nwant: %q\ngot:  %q", upstreamContent, upstreamSkill)
+	}
+	if !strings.Contains(outStr, "(upstream)") {
+		t.Errorf("expected (upstream) status in output, got:\n%s", outStr)
+	}
+
+	// Non-upstream entry should be synthesized from the template.
+	synthSkill, err := os.ReadFile(filepath.Join(root, "plugin", "skills", "pp-no-upstream", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading synthesized skill: %v", err)
+	}
+	synthStr := string(synthSkill)
+	if !strings.Contains(synthStr, "name: pp-no-upstream") {
+		t.Errorf("synthesized skill missing expected frontmatter name:\n%s", synthStr)
+	}
+	if !strings.Contains(synthStr, "Printing Press CLI for No Upstream") {
+		t.Errorf("synthesized skill missing expected description:\n%s", synthStr)
+	}
+	if strings.Contains(synthStr, "Authored upstream") {
+		t.Errorf("synthesized skill should not leak upstream content:\n%s", synthStr)
+	}
+
+	// Summary should count one upstream and one registry-only.
+	if !strings.Contains(outStr, "1 upstream") {
+		t.Errorf("expected summary to report 1 upstream, got:\n%s", outStr)
+	}
+	if !strings.Contains(outStr, "1 registry-only") {
+		t.Errorf("expected summary to report 1 registry-only, got:\n%s", outStr)
+	}
+}
+
+func TestIntegration_UpstreamOverwritesStaleSynthesis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	bin := buildTool(t)
+	root := t.TempDir()
+
+	entries := []RegistryEntry{
+		{Name: "api-pp-cli", Category: "commerce", API: "API",
+			Description: "Has upstream skill", Path: "library/commerce/api"},
+	}
+	setupFixture(t, root, entries)
+
+	// Pre-seed a stale synthesized skill.
+	staleDir := filepath.Join(root, "plugin", "skills", "pp-api")
+	if err := os.MkdirAll(staleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "SKILL.md"), []byte("STALE SYNTHESIZED CONTENT"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ship a fresh upstream SKILL.md.
+	upstreamDir := filepath.Join(root, "library", "commerce", "api")
+	if err := os.MkdirAll(upstreamDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	upstreamContent := "---\nname: pp-api\ndescription: \"Fresh upstream.\"\n---\n\n# Fresh\n"
+	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte(upstreamContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("tool exited with error: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(staleDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != upstreamContent {
+		t.Errorf("upstream should overwrite stale synthesis\nwant: %q\ngot:  %q", upstreamContent, got)
 	}
 }

--- a/tools/generate-skills/main_test.go
+++ b/tools/generate-skills/main_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyUpstreamSkill_Present(t *testing.T) {
+	tmp := t.TempDir()
+
+	entryPath := filepath.Join(tmp, "library", "commerce", "yahoo-finance")
+	if err := os.MkdirAll(entryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	upstream := []byte("---\nname: pp-yahoo-finance\ndescription: \"Upstream content with `backticks` and \\\"quotes\\\"\"\n---\n\n# Yahoo Finance\n\nNarrative content.\n")
+	if err := os.WriteFile(filepath.Join(entryPath, "SKILL.md"), upstream, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(tmp, "plugin", "skills", "pp-yahoo-finance")
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+
+	copied, err := copyUpstreamSkill(entryPath, skillDir, skillFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !copied {
+		t.Fatal("expected copied=true when upstream SKILL.md exists")
+	}
+
+	got, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatalf("reading destination: %v", err)
+	}
+	if string(got) != string(upstream) {
+		t.Errorf("destination content does not match upstream byte-for-byte\nwant: %q\ngot:  %q", upstream, got)
+	}
+}
+
+func TestCopyUpstreamSkill_Absent(t *testing.T) {
+	tmp := t.TempDir()
+
+	entryPath := filepath.Join(tmp, "library", "commerce", "no-upstream")
+	if err := os.MkdirAll(entryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(tmp, "plugin", "skills", "pp-no-upstream")
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+
+	copied, err := copyUpstreamSkill(entryPath, skillDir, skillFile)
+	if err != nil {
+		t.Fatalf("unexpected error when upstream missing: %v", err)
+	}
+	if copied {
+		t.Error("expected copied=false when upstream SKILL.md missing")
+	}
+	if _, err := os.Stat(skillFile); !os.IsNotExist(err) {
+		t.Errorf("expected destination not to exist, stat err=%v", err)
+	}
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		t.Errorf("expected skill dir not to be created when no upstream, stat err=%v", err)
+	}
+}
+
+func TestCopyUpstreamSkill_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+
+	entryPath := filepath.Join(tmp, "library", "commerce", "yahoo-finance")
+	if err := os.MkdirAll(entryPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	upstream := []byte("UPSTREAM CONTENT")
+	if err := os.WriteFile(filepath.Join(entryPath, "SKILL.md"), upstream, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	skillDir := filepath.Join(tmp, "plugin", "skills", "pp-yahoo-finance")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillFile, []byte("STALE SYNTHESIS"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	copied, err := copyUpstreamSkill(entryPath, skillDir, skillFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !copied {
+		t.Fatal("expected copied=true")
+	}
+
+	got, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(upstream) {
+		t.Errorf("upstream should overwrite stale synthesis\nwant: %q\ngot:  %q", upstream, got)
+	}
+}


### PR DESCRIPTION
## What this PR does

Teaches the `generate-skills` tool to prefer an upstream-authored `SKILL.md` (shipped by the printed CLI itself) over its own template-based synthesis. When a printed CLI in the library ships `library/<cat>/<api>/SKILL.md`, that file is copied byte-for-byte to `plugin/skills/pp-<api>/SKILL.md`. When no upstream file exists, the tool falls back to its current synthesis path unchanged.

This is the library-repo half of a two-repo change. The upstream half is [`mvanhorn/cli-printing-press#186`](https://github.com/mvanhorn/cli-printing-press/pull/186), which teaches the printing press generator to emit a `SKILL.md` alongside `README.md` for every printed CLI, authored from the same research context (brief, novel features, trigger phrases, recipes) the generator already uses for the README.

## Why this matters

The `plugin/skills/pp-<api>/SKILL.md` files are what agents load when users say "use yahoo-finance" or similar. Today they're synthesized by this tool from registry metadata + the CLI's `--help` output, because those are the only inputs this tool has. That produces thin, generic skill files.

Concrete example — today's downstream-synthesized `pp-yahoo-finance/SKILL.md`:

```
## Direct Use

1. Check if installed: `which yahoo-finance-pp-cli`
2. Discover commands: `yahoo-finance-pp-cli --help`
3. Match the user query to the best command.
```

Step 2 ("discover commands via `--help`") is the exact agent-discovery loop that wastes tokens — the agent has to call `--help` on the CLI, then `--help` on each subcommand to understand what exists. Skills are supposed to give agents the capability map upfront.

The printing press generator has that map at print time: it just ran research, it knows the novel features, it knows the API-specific auth story, it knows realistic trigger phrases. #186 captures that into a `SKILL.md` artifact. This PR makes this tool consume that artifact when available instead of re-synthesizing a less-informed version.

## Precedence order

1. **Upstream** — `<entry.Path>/SKILL.md` present and non-empty → copy verbatim (always wins; has research context)
2. **Enriched** — CLI installed locally, `--help` parsed → synthesize with domain commands
3. **Registry-only** — no `--help` available → synthesize from registry data only

The existing enriched-beats-registry-only downgrade protection is preserved for the synthesis fallback path.

## Safety guards

- **Empty upstream** (0-byte or whitespace-only `SKILL.md`) almost always signals a generator crash mid-write. Log loudly and fall through to synthesis rather than shipping a blank skill.

## Intentionally deferred

**Inverse downgrade guard** (a sidecar provenance marker that refuses to overwrite a previously-upstream-copied skill with registry-only synthesis when upstream suddenly disappears). Considered but not implemented — it defends against a hypothetical failure mode (upstream regresses mid-cycle) that hasn't been observed. Will revisit if upstream churn appears in practice.

Current behavior on upstream disappearance: if upstream `SKILL.md` is intentionally removed, re-synthesis is correct. If it's transiently unreadable, a loud warning fires and the next successful run restores the upstream copy.

## Tests (6 total, all pass)

**Unit (4)** — test the `copyUpstreamSkill` helper in isolation:
- upstream present → copied byte-for-byte
- upstream absent → helper returns `(false, nil)`, no destination written
- upstream overwrites stale content at destination
- empty/whitespace upstream → helper returns `(false, nil)` so synthesis can take over

**Integration (2)** — build and exec the real binary against a tmpdir fixture (registry.json + library tree + template):
- mixed registry (one entry with upstream, one without) → upstream entry copied byte-for-byte, non-upstream entry synthesized from template in the same run, summary counts 1 upstream and 1 registry-only
- upstream present + stale synthesized file already at destination → upstream content overwrites

**A real bug was caught during integration-test development.** `enrichedCount` / `registryOnlyCount` were being incremented speculatively before the upstream short-circuit, so a mixed run reported the upstream entry in the registry-only bucket. Fixed in this PR by moving the increment into the synthesis branch where it belongs. Unit tests on the helper alone would not have caught this.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 6 tests pass
- [ ] After #186 merges and a library CLI regenerates with the new upstream `SKILL.md`: run `go run ./tools/generate-skills` and verify `plugin/skills/pp-<api>/SKILL.md` matches `library/<cat>/<api>/SKILL.md` byte-for-byte
- [ ] Verify the run summary reports a non-zero `upstream` count for CLIs shipping the new artifact

## Merge order and blast radius

Safe to merge before or after [`mvanhorn/cli-printing-press#186`](https://github.com/mvanhorn/cli-printing-press/pull/186). This PR is a **no-op until a printed CLI actually ships a `SKILL.md`** — every existing library entry will continue to go through the synthesis path unchanged because none of them carry an upstream `SKILL.md` today. The only behavioral change is: the first CLI that does ship one will be copied instead of synthesized.

Related: [`mvanhorn/cli-printing-press#186`](https://github.com/mvanhorn/cli-printing-press/pull/186)

🤖 Generated with [Claude Code](https://claude.com/claude-code)