### PR TITLE
fix(weather-goat): doctor shows OK for no-auth state (was WARN), v1.0.1

### DIFF
--- a/library/other/weather-goat/internal/cli/doctor.go
+++ b/library/other/weather-goat/internal/cli/doctor.go
@@ -119,9 +119,16 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				}
 				s := fmt.Sprintf("%v", v)
 				indicator := green("OK")
-				if strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") {
+				switch {
+				case strings.HasPrefix(s, "optional"):
+					// Optional-auth CLI with no key set — informational, not a failure.
+					indicator = yellow("INFO")
+				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid"):
 					indicator = red("FAIL")
-				} else if strings.Contains(s, "not ") || strings.Contains(s, "skipped") || strings.Contains(s, "inferred") {
+				case s == "not required":
+					// Public APIs: no auth needed is a healthy state, not a warning.
+					indicator = green("OK")
+				case strings.Contains(s, "not ") || strings.Contains(s, "skipped") || strings.Contains(s, "inferred"):
 					indicator = yellow("WARN")
 				}
 				fmt.Fprintf(w, "  %s %s: %s\n", indicator, ck.label, s)

--- a/library/other/weather-goat/internal/cli/root.go
+++ b/library/other/weather-goat/internal/cli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/other/weather-goat/internal/config"
 )
 
-var version = "1.0.0"
+var version = "1.0.1"
 
 type rootFlags struct {
 	asJSON       bool


### PR DESCRIPTION
## Summary

Weather GOAT is a fully public-API CLI (Open-Meteo + NWS). Its auth state is legitimately \"not required\", but the doctor was emitting a misleading WARN:

\`\`\`
WARN Auth: not required
\`\`\`

Root cause: the status-indicator switch matched the generic \`\"not \"\` substring before the \`\"not required\"\` special case. Fix reorders the switch so healthy states read as healthy:

\`\`\`
OK Auth: not required
\`\`\`

## What changed

\`internal/cli/doctor.go\` — status-indicator logic now evaluates \`s == \"not required\"\` before the generic \`strings.Contains(s, \"not \")\` branch. Also adds an \`strings.HasPrefix(s, \"optional\")\` → INFO case for the optional-auth pattern (Weather GOAT doesn't use it, but the switch was restructured to support both patterns consistently — this matches the upstream machine fix in mvanhorn/cli-printing-press#211).

Version bumped to 1.0.1.

## Upstream

mvanhorn/cli-printing-press#211 is the machine-level fix. Regenerating Weather GOAT with that merged will produce the same result as this hand-patch — this PR just ships the fix earlier so users stop seeing the misleading WARN.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`weather-goat-pp-cli doctor\` shows \`OK Auth: not required\` locally
- [ ] Smoke-check once PR CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)