### PR TITLE
fix(recipe-goat): html entities, sub matching, trending warnings, stopwords

### DIFF
--- a/library/food-and-dining/recipe-goat/internal/cli/trending_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/trending_cmd.go
@@ -36,6 +36,8 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 
 			var mu sync.Mutex
 			all := []trendingEntry{}
+			siteErrors := map[string]string{} // hostname -> short reason
+			emptySites := []string{}          // reached but returned no recipes
 			var wg sync.WaitGroup
 			sem := make(chan struct{}, 4)
 			for _, s := range sites {
@@ -47,17 +49,33 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 					defer func() { <-sem }()
 					body, err := recipes.FetchHTML(ctx, client, "https://www."+s.Hostname+"/")
 					if err != nil {
+						mu.Lock()
+						siteErrors[s.Hostname] = shortErr(err)
+						mu.Unlock()
 						return
 					}
 					// Candidates are permissive (up to limit*4). Validate each
 					// by fetching its JSON-LD; keep only real Recipe pages.
 					res := validateTrendingCandidates(ctx, client, body, s, limit)
 					mu.Lock()
+					if len(res) == 0 {
+						emptySites = append(emptySites, s.Hostname)
+					}
 					all = append(all, res...)
 					mu.Unlock()
 				}()
 			}
 			wg.Wait()
+
+			// Surface per-site failures on stderr so partial runs are obvious.
+			// JSON output keeps stderr silent-free? No — warnings go to stderr
+			// either way so scripts can still capture JSON on stdout cleanly.
+			for host, why := range siteErrors {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warn: %s unreachable: %s\n", host, why)
+			}
+			for _, host := range emptySites {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warn: %s reachable but no recipes found on homepage\n", host)
+			}
 
 			if flags.asJSON {
 				return flags.printJSON(cmd, all)
@@ -77,6 +95,23 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&siteFilter, "site", "all", "Sites to query (CSV or 'all')")
 	cmd.Flags().IntVar(&limit, "limit", 5, "Max per site")
 	return cmd
+}
+
+// shortErr condenses an error to a single-line reason tag for stderr warnings.
+// Full error chains are too noisy when we're already listing 15 sites.
+func shortErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	if i := strings.Index(s, "\n"); i >= 0 {
+		s = s[:i]
+	}
+	const max = 80
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
 }
 
 // validateTrendingCandidates pulls candidate links from homepage HTML (using

--- a/library/food-and-dining/recipe-goat/internal/recipes/jsonld.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/jsonld.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -165,17 +166,17 @@ func recipeFromNode(n map[string]any, sourceURL string) *Recipe {
 func asString(v any) string {
 	switch x := v.(type) {
 	case string:
-		return strings.TrimSpace(x)
+		return html.UnescapeString(strings.TrimSpace(x))
 	case []any:
 		if len(x) > 0 {
 			return asString(x[0])
 		}
 	case map[string]any:
 		if s, ok := x["@value"].(string); ok {
-			return s
+			return html.UnescapeString(s)
 		}
 		if s, ok := x["name"].(string); ok {
-			return s
+			return html.UnescapeString(s)
 		}
 	case float64:
 		return strconv.FormatFloat(x, 'f', -1, 64)
@@ -188,7 +189,7 @@ func asString(v any) string {
 func extractAuthor(v any) string {
 	switch x := v.(type) {
 	case string:
-		return strings.TrimSpace(x)
+		return html.UnescapeString(strings.TrimSpace(x))
 	case map[string]any:
 		return asString(x["name"])
 	case []any:
@@ -249,19 +250,19 @@ func extractStringList(v any) []string {
 			out := make([]string, 0, len(lines))
 			for _, l := range lines {
 				if t := strings.TrimSpace(l); t != "" {
-					out = append(out, t)
+					out = append(out, html.UnescapeString(t))
 				}
 			}
 			return out
 		}
-		return []string{s}
+		return []string{html.UnescapeString(s)}
 	case []any:
 		out := make([]string, 0, len(x))
 		for _, it := range x {
 			switch v2 := it.(type) {
 			case string:
 				if s := strings.TrimSpace(v2); s != "" {
-					out = append(out, s)
+					out = append(out, html.UnescapeString(s))
 				}
 			case map[string]any:
 				if s := asString(v2["name"]); s != "" {
@@ -354,7 +355,7 @@ func CleanInstructions(raw any) []string {
 		out := make([]string, 0, len(lines))
 		for _, l := range lines {
 			if t := strings.TrimSpace(l); t != "" {
-				out = append(out, t)
+				out = append(out, html.UnescapeString(t))
 			}
 		}
 		return out
@@ -364,7 +365,7 @@ func CleanInstructions(raw any) []string {
 			switch x := item.(type) {
 			case string:
 				if s := strings.TrimSpace(x); s != "" {
-					out = append(out, s)
+					out = append(out, html.UnescapeString(s))
 				}
 			case map[string]any:
 				t, _ := x["@type"].(string)

--- a/library/food-and-dining/recipe-goat/internal/recipes/search.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/search.go
@@ -182,7 +182,7 @@ func looksLikeRecipeLink(href string, site Site) bool {
 		return false
 	}
 	// Skip obvious non-recipe paths.
-	for _, bad := range []string{"/search", "/tag/", "/category/", "/categories/", "/about", "/contact", "/privacy", "/subscribe", "/newsletter", "/author/", "/authors/", "/page/", "/collection/", "/collections/", "/topics/", "/gallery/", "/galleries/", "/video/", "/videos/", "/shop", "/store/", ".jpg", ".png", ".webp", ".gif", ".svg", ".pdf", ".css", ".js"} {
+	for _, bad := range []string{"/search", "/tag/", "/category/", "/categories/", "/about", "/contact", "/privacy", "/subscribe", "/newsletter", "/author/", "/authors/", "/page/", "/collection/", "/collections/", "/topics/", "/gallery/", "/galleries/", "/video/", "/videos/", "/shop", "/store/", "/random", "/feed", "/feeds", ".jpg", ".png", ".webp", ".gif", ".svg", ".pdf", ".css", ".js"} {
 		if strings.Contains(l, bad) {
 			return false
 		}

--- a/library/food-and-dining/recipe-goat/internal/recipes/subs.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/subs.go
@@ -1,6 +1,9 @@
 package recipes
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // Sub is one suggested substitution for an ingredient.
 type Sub struct {
@@ -73,8 +76,13 @@ var subTable = []Sub{
 
 // LookupSubs returns substitutions for `ingredient` whose Context matches
 // `contextFilter` (case-insensitive) or is "any". Pass "" or "any" to return
-// all contexts. Matching on ingredient is case-insensitive substring so
-// "buttermilk" matches and so would "2 cups buttermilk".
+// all contexts.
+//
+// Matching is word-boundary aware: table ingredients are matched as whole
+// tokens against the user's query, so "butter" will not match "buttermilk"
+// (a previous bug). The needle itself is still allowed to be a phrase like
+// "2 cups buttermilk" — we tokenize it and look for the table ingredient as a
+// contiguous token sequence.
 func LookupSubs(ingredient string, contextFilter string) []Sub {
 	needle := strings.ToLower(strings.TrimSpace(ingredient))
 	if needle == "" {
@@ -83,7 +91,7 @@ func LookupSubs(ingredient string, contextFilter string) []Sub {
 	cf := strings.ToLower(strings.TrimSpace(contextFilter))
 	out := []Sub{}
 	for _, s := range subTable {
-		if !strings.Contains(needle, strings.ToLower(s.Ingredient)) && !strings.Contains(strings.ToLower(s.Ingredient), needle) {
+		if !ingredientMatches(needle, strings.ToLower(s.Ingredient)) {
 			continue
 		}
 		if cf != "" && cf != "any" && s.Context != "any" && s.Context != cf {
@@ -92,6 +100,34 @@ func LookupSubs(ingredient string, contextFilter string) []Sub {
 		out = append(out, s)
 	}
 	return out
+}
+
+// ingredientTokenRe splits on non-alphanumerics so "buttermilk" stays one
+// token and "brown sugar" becomes two.
+var ingredientTokenRe = regexp.MustCompile(`[a-z0-9]+`)
+
+// ingredientMatches returns true when the table ingredient `target` appears
+// as a contiguous sequence of whole tokens inside the user's query `needle`.
+// Both inputs are expected already lowercased.
+func ingredientMatches(needle, target string) bool {
+	needleToks := ingredientTokenRe.FindAllString(needle, -1)
+	targetToks := ingredientTokenRe.FindAllString(target, -1)
+	if len(targetToks) == 0 || len(needleToks) < len(targetToks) {
+		return false
+	}
+	for i := 0; i <= len(needleToks)-len(targetToks); i++ {
+		match := true
+		for j, t := range targetToks {
+			if needleToks[i+j] != t {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // AllSubs returns the built-in sub table (used by 'sub --list' or similar).

--- a/library/food-and-dining/recipe-goat/internal/store/recipes.go
+++ b/library/food-and-dining/recipe-goat/internal/store/recipes.go
@@ -502,9 +502,35 @@ func (s *Store) KidExcludedRemove(ing string) error {
 	return err
 }
 
+// pantryStaples are ingredients the matcher treats as "everyone has" so that
+// recipes aren't reported as missing water, salt, or garnish. Keep this short
+// and obvious — these are the items a cook should not need to list in --have.
+var pantryStaples = []string{
+	"water", "ice", "ice cube", "ice cubes",
+	"salt", "kosher salt", "sea salt", "table salt", "coarse salt",
+	"pepper", "black pepper", "ground pepper",
+	"for garnish", "to taste", "to serve", "for serving", "for dusting",
+}
+
+// isPantryStaple returns true when an ingredient line is satisfied by
+// something every kitchen has on hand. Checked case-insensitively on the full
+// line so "Coarse sea salt, for garnish" matches on both "sea salt" and
+// "for garnish".
+func isPantryStaple(line string) bool {
+	lower := strings.ToLower(line)
+	for _, s := range pantryStaples {
+		if strings.Contains(lower, s) {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchByIngredients returns recipes whose ingredient list can be assembled
 // from `have` with at most `missingMax` missing items. Matching is
-// case-insensitive substring per ingredient line.
+// case-insensitive substring per ingredient line. Pantry staples (water,
+// salt, pepper, ice, "for garnish" tags) are treated as always-available and
+// never counted as missing.
 func (s *Store) MatchByIngredients(have []string, missingMax int) ([]RecipeMatch, error) {
 	if missingMax < 0 {
 		missingMax = 0
@@ -527,6 +553,9 @@ func (s *Store) MatchByIngredients(have []string, missingMax int) ([]RecipeMatch
 		}
 		missing := []string{}
 		for _, line := range r.Ingredients {
+			if isPantryStaple(line) {
+				continue
+			}
 			lower := strings.ToLower(line)
 			matched := false
 			for _, h := range haveLower {


### PR DESCRIPTION
## Summary

Five bugs surfaced during hands-on dogfooding of \`recipe-goat-pp-cli\` — all surgical printed-CLI fixes, no machine changes.

| # | Before | After |
|---|---|---|
| 1 | Titles rendered \`The Food Lab&#39;s Chocolate Chip Cookies\` | \`The Food Lab's Chocolate Chip Cookies\` |
| 2 | \`sub buttermilk\` returned butter subs (oil, coconut oil) | Only buttermilk subs |
| 3 | \`trending\` silently dropped unreachable sites | Emits stderr warnings per site |
| 4 | \`trending --site budgetbytes\` returned \`/random/\` as a "recipe" | \`/random\` now in deny-list |
| 5 | \`cookbook match\` counted "1 ice cube" as missing | Pantry staples auto-satisfied |

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean on the 5 touched files
- [x] Re-ran each failing scenario against a locally-built binary:
  - \`goat "chocolate chip cookies"\` → titles decoded
  - \`sub buttermilk\` → 3 entries, all buttermilk
  - \`sub butter\` → still returns butter subs (regression check)
  - \`sub "1 cup buttermilk"\` → still resolves to buttermilk (phrase query)
  - \`trending --site smittenkitchen,budgetbytes\` → warning printed; no \`/random/\` URL
  - \`cookbook match --have "butter,flour,sugar,eggs,chocolate,vanilla,baking soda"\` → 0 missing

## Follow-up

A companion retro on the Printing Press will capture the systemic patterns that let these ship:
- HTML-entity decoding should be a default in any HTML-scraping generator output
- Aggregating commands should have a shared pattern for per-source warnings on partial failure (\`goat\` had it; \`trending\` didn't)
- Site URL-pattern regexes are too permissive without a deny-list
- Printed CLIs ship with zero tests; the generator should seed baseline unit tests for pure logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)