### PR TITLE
feat(recipe-goat): route around bot-detection — corpus rebalance + archive fallback for pasted URLs

### DIFF
--- a/library/food-and-dining/recipe-goat/README.md
+++ b/library/food-and-dining/recipe-goat/README.md
@@ -70,7 +70,7 @@ These capabilities aren't available in any other tool for this API.
 
 ### Cross-site intelligence
 
-- **`goat`** — Query any dish across 15 trusted recipe sites and rank results by normalized rating × review count × author trust × site trust × recency.
+- **`goat`** — Query any dish across curated recipe sites and rank results by normalized rating × review count × site trust × recency.
 
   _Use this when you need the single best version of a dish — the agent gets structured results with provenance and trust signals instead of guessing from a web search._
 

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -20,7 +20,7 @@ These capabilities aren't available in any other tool for this API.
 
 ### Cross-site intelligence
 
-- **`goat`** — Query any dish across 15 trusted recipe sites and rank results by normalized rating × review count × author trust × site trust × recency.
+- **`goat`** — Query any dish across curated recipe sites and rank results by normalized rating × review count × site trust × recency.
 
   _Use this when you need the single best version of a dish — the agent gets structured results with provenance and trust signals instead of guessing from a web search._
 

--- a/library/food-and-dining/recipe-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/doctor.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat/internal/config"
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat/internal/recipes"
+	"github.com/spf13/cobra"
 )
 
 func newDoctorCmd(flags *rootFlags) *cobra.Command {
@@ -131,7 +131,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			for _, s := range recipes.Sites {
 				u := "https://www." + s.Hostname + "/"
 				req, _ := http.NewRequest("HEAD", u, nil)
-				req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+				req.Header.Set("User-Agent", recipes.ChromeUA)
 				status := "reachable"
 				code := 0
 				resp, err := probeClient.Do(req)

--- a/library/food-and-dining/recipe-goat/internal/cli/goat_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/goat_cmd.go
@@ -37,12 +37,12 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "goat <query>",
 		Short: "Cross-site recipe ranker — fetch and rank the best version of any dish",
-		Long: `Search across 15 trusted recipe sites, fetch each candidate, then rank by
-a weighted score of rating, review volume, author trust, site trust, and recency.
+		Long: `Search across curated recipe sites, fetch each candidate, then rank by
+a weighted score of rating, review volume, site trust, and recency.
 
 Ranking weights:
-  0.45 rating_normalized + 0.20 log(reviews+1)/log(1000) + 0.20 author_trust
-  + 0.10 site_trust + 0.05 recency_norm`,
+  0.55 rating_normalized + 0.25 log(reviews+1)/log(1000)
+  + 0.15 site_trust + 0.05 recency_norm`,
 		Example: "  recipe-goat-pp-cli goat \"chicken tikka masala\" --limit 5",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -233,7 +233,6 @@ func goatScore(r *recipes.Recipe, site recipes.Site) float64 {
 			reviewNorm = 1.0
 		}
 	}
-	authorTrust := recipes.AuthorTrust(r.Author)
 	siteTrust := site.Trust
 	if siteTrust == 0 {
 		siteTrust = 0.5
@@ -256,7 +255,7 @@ func goatScore(r *recipes.Recipe, site recipes.Site) float64 {
 			}
 		}
 	}
-	return 0.45*ratingNorm + 0.20*reviewNorm + 0.20*authorTrust + 0.10*siteTrust + 0.05*recency
+	return 0.55*ratingNorm + 0.25*reviewNorm + 0.15*siteTrust + 0.05*recency
 }
 
 func min(a, b int) int {

--- a/library/food-and-dining/recipe-goat/internal/cli/save_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/save_cmd.go
@@ -20,7 +20,7 @@ func newSaveCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "save <url>",
 		Short:   "Save a recipe to the local cookbook",
-		Example: "  recipe-goat-pp-cli save https://www.food52.com/recipes/chicken-paprikash --tags weeknight",
+		Example: "  recipe-goat-pp-cli save https://www.recipetineats.com/crispy-chinese-pork-belly/ --tags weeknight",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var urls []string

--- a/library/food-and-dining/recipe-goat/internal/cli/trending_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/trending_cmd.go
@@ -27,7 +27,7 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "trending",
 		Short:   "Show the top recipes currently featured on each site's homepage",
-		Example: "  recipe-goat-pp-cli trending --site budgetbytes,food52 --limit 5",
+		Example: "  recipe-goat-pp-cli trending --site budgetbytes,recipetineats --limit 5",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sites := siteHostsFromCSV(siteFilter)
 			client := httpClientForSites(flags.timeout)

--- a/library/food-and-dining/recipe-goat/internal/cli/trust_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/trust_cmd.go
@@ -16,7 +16,7 @@ import (
 func newTrustCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "trust",
-		Short:   "View and override site/author trust scores (ranking integration wip)",
+		Short:   "View and override site trust scores (ranking integration wip)",
 		Example: "  recipe-goat-pp-cli trust list",
 	}
 	cmd.AddCommand(newTrustListCmd(flags))
@@ -27,13 +27,12 @@ func newTrustCmd(flags *rootFlags) *cobra.Command {
 func newTrustListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
-		Short:   "List site trust scores + curated authors",
+		Short:   "List site trust scores",
 		Example: "  recipe-goat-pp-cli trust list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.asJSON {
 				payload := map[string]any{
-					"sites":   recipes.Sites,
-					"authors": recipes.CuratedAuthors(),
+					"sites": recipes.Sites,
 				}
 				return flags.printJSON(cmd, payload)
 			}
@@ -43,23 +42,19 @@ func newTrustListCmd(flags *rootFlags) *cobra.Command {
 			for _, s := range recipes.Sites {
 				rows = append(rows, []string{s.Hostname, strconv.Itoa(s.Tier), fmt.Sprintf("%.2f", s.Trust)})
 			}
-			if err := flags.printTable(cmd, headers, rows); err != nil {
-				return err
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), "\nCURATED AUTHORS (trust 1.00)")
-			for _, a := range recipes.CuratedAuthors() {
-				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", a)
-			}
-			return nil
+			return flags.printTable(cmd, headers, rows)
 		},
 	}
 }
 
 // trustOverrides persisted at ~/.config/recipe-goat-pp-cli/trust.toml.
-// Shape: [authors] "name" = 0.9   [sites] "host" = 0.8
+// Shape: [sites] "host" = 0.8
+//
+// Author overrides were removed when author_trust was dropped from the
+// scoring formula. Existing trust.toml files with an [authors] section
+// still parse cleanly — the field is just unused going forward.
 type trustOverrides struct {
-	Authors map[string]float64 `toml:"authors"`
-	Sites   map[string]float64 `toml:"sites"`
+	Sites map[string]float64 `toml:"sites"`
 }
 
 func trustPath() string {
@@ -68,7 +63,7 @@ func trustPath() string {
 }
 
 func loadTrust() (trustOverrides, error) {
-	out := trustOverrides{Authors: map[string]float64{}, Sites: map[string]float64{}}
+	out := trustOverrides{Sites: map[string]float64{}}
 	data, err := os.ReadFile(trustPath())
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -78,9 +73,6 @@ func loadTrust() (trustOverrides, error) {
 	}
 	if err := toml.Unmarshal(data, &out); err != nil {
 		return out, err
-	}
-	if out.Authors == nil {
-		out.Authors = map[string]float64{}
 	}
 	if out.Sites == nil {
 		out.Sites = map[string]float64{}
@@ -102,9 +94,9 @@ func saveTrust(t trustOverrides) error {
 
 func newTrustSetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
-		Use:     "set <author|site> <delta>",
-		Short:   "Persist a user trust override (ranking integration wip)",
-		Example: "  recipe-goat-pp-cli trust set kenji +2",
+		Use:     "set <site> <delta>",
+		Short:   "Persist a site trust override (ranking integration wip)",
+		Example: "  recipe-goat-pp-cli trust set seriouseats.com +2",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := args[0]
@@ -112,16 +104,16 @@ func newTrustSetCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return usageErr(fmt.Errorf("delta must be a number, got %q", args[1]))
 			}
+			// Only site overrides are supported — author_trust was removed
+			// from the scoring formula. Site hostnames contain a dot.
+			if !strings.Contains(target, ".") || strings.Contains(target, " ") {
+				return usageErr(fmt.Errorf("target %q is not a site hostname; author_trust was removed from the ranker", target))
+			}
 			overrides, err := loadTrust()
 			if err != nil {
 				return err
 			}
-			// Heuristic: if target looks like a hostname (contains a dot and no space), treat as site.
-			if strings.Contains(target, ".") && !strings.Contains(target, " ") {
-				overrides.Sites[strings.ToLower(target)] = delta
-			} else {
-				overrides.Authors[strings.ToLower(target)] = delta
-			}
+			overrides.Sites[strings.ToLower(target)] = delta
 			if flags.dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "would save trust override for %s → %.2f\n", target, delta)
 				return nil

--- a/library/food-and-dining/recipe-goat/internal/mcp/tools.go
+++ b/library/food-and-dining/recipe-goat/internal/mcp/tools.go
@@ -306,7 +306,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 			"Prefer sql/search over repeated API calls when the data is already synced.",
 		},
 		"unique_capabilities": []map[string]string{
-			{"name": "Best-version ranker", "command": "goat", "description": "Query any dish across 15 trusted recipe sites and rank results by normalized rating × review count × author trust...", "rationale": "No existing tool ranks recipes across sites. recipe-scrapers extracts one URL at a time; Paprika/Mealie import one..."},
+			{"name": "Best-version ranker", "command": "goat", "description": "Query any dish across curated recipe sites and rank results by normalized rating × review count × site trust × recency.", "rationale": "No existing tool ranks recipes across sites. recipe-scrapers extracts one URL at a time; Paprika/Mealie import one..."},
 			{"name": "Substitution lookup", "command": "sub", "description": "Aggregate ingredient substitutions from King Arthur, Serious Eats, AllRecipes reviews, and Budget Bytes. Ranked by...", "rationale": "Substitutions are tribal knowledge scattered across per-ingredient pages; no unified tool aggregates them."},
 			{"name": "Pantry match", "command": "cookbook match", "description": "Find recipes in the local cookbook that you can make right now with listed ingredients, or with ≤N missing...", "rationale": "Requires local pantry + canonicalized ingredient store. No web tool has your pantry data."},
 			{"name": "Tonight picker", "command": "tonight", "description": "Pick dinner in 2 seconds: filter cookbook by time budget, recency from cook log, and dietary/kid-friendly flags.", "rationale": "Decision-fatigue killer. Requires local cook log + cookbook + filter set."},

--- a/library/food-and-dining/recipe-goat/internal/recipes/archive.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/archive.go
@@ -1,0 +1,225 @@
+package recipes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Archive.org Wayback Machine fallback for sites that return structural
+// blocks (402/403/429). The live fetch fails fast; this fallback asks
+// archive.org whether there's a snapshot and fetches from there if so.
+//
+// This is Phase 1 of the scrape-mitigations plan (docs/plans/2026-04-13-002
+// in the cli-printing-press repo): a minimal inline patch shipped to
+// observe real-world archive.org hit rate before committing to a cliutil
+// abstraction. Designed to be replaceable in Phase 3 by
+// cliutil.ScrapeClient; deliberately self-contained so the cutover is
+// localized.
+//
+// Usage: the live Fetch/FetchHTML functions call fetchArchiveFallback()
+// when they'd otherwise return ErrBlocked. On success the fallback returns
+// the snapshot body; on failure the caller surfaces the original block.
+
+// archiveAvailabilityURL is the Wayback Machine availability API.
+// Returns JSON with the closest snapshot URL for a given target.
+const archiveAvailabilityURL = "https://archive.org/wayback/available"
+
+// archiveMinGap enforces a minimum interval between archive.org requests
+// (to both the availability API and the snapshot fetch). 1.5s is a
+// generous good-citizen gap — we're a small client, not a scraper farm.
+const archiveMinGap = 1500 * time.Millisecond
+
+// Package-level archive-request pacing. Successive fallback invocations
+// serialize behind the minimum gap so parallel Fetch goroutines don't
+// hammer archive.org.
+var (
+	archiveLastReq   time.Time
+	archiveLastReqMu sync.Mutex
+)
+
+// waybackResponse is the subset of the availability API response we parse.
+// The full response has more fields (timestamp, status, etc.); we only
+// need the snapshot URL.
+type waybackResponse struct {
+	ArchivedSnapshots struct {
+		Closest *struct {
+			URL       string `json:"url"`
+			Timestamp string `json:"timestamp"`
+			Available bool   `json:"available"`
+		} `json:"closest"`
+	} `json:"archived_snapshots"`
+}
+
+// fetchArchiveFallback queries archive.org for a snapshot of targetURL and
+// returns the snapshot HTML body. Returns an error if no snapshot exists,
+// the snapshot itself fails to fetch, or archive.org is unreachable —
+// callers should surface their original ErrBlocked in those cases.
+//
+// Logs "warn: archive fallback: <url>" to stderr when engaged so users
+// see when they're reading archived content instead of live.
+func fetchArchiveFallback(ctx context.Context, client *http.Client, targetURL string) ([]byte, error) {
+	if err := awaitArchiveSlot(ctx); err != nil {
+		return nil, fmt.Errorf("archive rate limit wait: %w", err)
+	}
+
+	snapURL, err := queryWaybackSnapshot(ctx, client, targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("querying wayback: %w", err)
+	}
+	if snapURL == "" {
+		return nil, fmt.Errorf("no wayback snapshot for %s", targetURL)
+	}
+
+	// Enforce HTTPS on snapshot URLs. Wayback's availability API returns
+	// http:// by default, but cached archive responses shouldn't be
+	// vulnerable to MITM — especially with the 7d TTL we'd apply at
+	// Phase 2.
+	snapURL = upgradeToHTTPS(snapURL)
+
+	fmt.Fprintf(os.Stderr, "warn: archive fallback: %s (wayback snapshot)\n", targetURL)
+
+	// Second archive.org request — respect the rate limit again.
+	if err := awaitArchiveSlot(ctx); err != nil {
+		return nil, fmt.Errorf("archive rate limit wait: %w", err)
+	}
+
+	return fetchSnapshotBody(ctx, client, snapURL)
+}
+
+// awaitArchiveSlot blocks until it's safe to send another archive.org
+// request, enforcing the package-level minimum gap. Context-aware.
+//
+// The "intended next time" is recorded under the lock before releasing so
+// concurrent callers queue behind each other correctly rather than all
+// racing to the same "now + gap" slot.
+func awaitArchiveSlot(ctx context.Context) error {
+	archiveLastReqMu.Lock()
+	now := time.Now()
+	var wait time.Duration
+	if !archiveLastReq.IsZero() {
+		elapsed := now.Sub(archiveLastReq)
+		if elapsed < archiveMinGap {
+			wait = archiveMinGap - elapsed
+		}
+	}
+	archiveLastReq = now.Add(wait)
+	archiveLastReqMu.Unlock()
+
+	if wait <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(wait):
+		return nil
+	}
+}
+
+// queryWaybackSnapshot asks the availability API for the closest snapshot
+// URL for target. Returns an empty string with no error when no snapshot
+// exists — caller distinguishes "no snapshot" from "availability API
+// failed."
+//
+// Archive.org's Availability API is schema-sensitive: querying with
+// "https://www.example.com/page" frequently misses snapshots that exist
+// under "www.example.com/page" (bare). We strip scheme before querying
+// so the lookup uses the canonical form archive.org indexes under.
+func queryWaybackSnapshot(ctx context.Context, client *http.Client, target string) (string, error) {
+	bareURL := stripScheme(target)
+	apiURL := archiveAvailabilityURL + "?url=" + url.QueryEscape(bareURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", chromeUA)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("availability API returned HTTP %d", resp.StatusCode)
+	}
+
+	// Cap the availability response at 64 KiB — the JSON is tiny, anything
+	// larger is a misbehaving server.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return "", err
+	}
+
+	var wb waybackResponse
+	if err := json.Unmarshal(body, &wb); err != nil {
+		return "", fmt.Errorf("parsing wayback response: %w", err)
+	}
+
+	if wb.ArchivedSnapshots.Closest == nil || !wb.ArchivedSnapshots.Closest.Available {
+		return "", nil
+	}
+	return wb.ArchivedSnapshots.Closest.URL, nil
+}
+
+// fetchSnapshotBody GETs the wayback snapshot URL and returns the HTML
+// body. Uses the same 5 MiB cap and browser-ish headers as the live fetch.
+func fetchSnapshotBody(ctx context.Context, client *http.Client, snapURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", snapURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", chromeUA)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("snapshot fetch HTTP %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 5<<20))
+}
+
+// upgradeToHTTPS rewrites a plain-http URL to https. Wayback returns
+// http://web.archive.org/web/TIMESTAMP/ORIGINAL by default; we don't want
+// cached archive content vulnerable to MITM — especially given archive
+// responses may be cached for days in Phase 2.
+func upgradeToHTTPS(raw string) string {
+	if strings.HasPrefix(raw, "http://") {
+		return "https://" + strings.TrimPrefix(raw, "http://")
+	}
+	return raw
+}
+
+// stripScheme returns the URL with any leading http:// or https:// prefix
+// removed. Used for the availability API's canonical lookup form.
+func stripScheme(raw string) string {
+	if idx := strings.Index(raw, "://"); idx >= 0 {
+		return raw[idx+3:]
+	}
+	return raw
+}
+
+// resetArchivePacing zeroes the package-level pacing state. Test-only —
+// real callers never need this, but tests that assert timing behavior
+// would otherwise be affected by prior tests' pacing state.
+func resetArchivePacing() {
+	archiveLastReqMu.Lock()
+	archiveLastReq = time.Time{}
+	archiveLastReqMu.Unlock()
+}

--- a/library/food-and-dining/recipe-goat/internal/recipes/archive.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/archive.go
@@ -27,15 +27,34 @@ import (
 // Usage: the live Fetch/FetchHTML functions call fetchArchiveFallback()
 // when they'd otherwise return ErrBlocked. On success the fallback returns
 // the snapshot body; on failure the caller surfaces the original block.
+//
+// Lookup uses the CDX Search API rather than the Availability API: the
+// CDX API has a documented-in-practice 60 req/min ceiling vs availability's
+// ~100/min, but it returns unambiguous empty-vs-throttled signals. The
+// Availability API silently returns empty `archived_snapshots` when
+// soft-throttled, which is indistinguishable from "no snapshot exists."
+// CDX returns either a concrete row array or nothing at all.
 
-// archiveAvailabilityURL is the Wayback Machine availability API.
-// Returns JSON with the closest snapshot URL for a given target.
-const archiveAvailabilityURL = "https://archive.org/wayback/available"
+// archiveCDXURL is the Wayback Machine CDX Search API. Unlike the
+// Availability API, this endpoint gives deterministic empty responses
+// (not silent throttle-looks-like-miss) and the IA team has publicly
+// stated the ceiling as "60 requests per minute average."
+const archiveCDXURL = "https://web.archive.org/cdx/search/cdx"
 
-// archiveMinGap enforces a minimum interval between archive.org requests
-// (to both the availability API and the snapshot fetch). 1.5s is a
-// generous good-citizen gap — we're a small client, not a scraper farm.
-const archiveMinGap = 1500 * time.Millisecond
+// archiveMinGap enforces a minimum interval between archive.org requests.
+// 2s (30 req/min) is the community-proven safe rate — well under the 60/min
+// CDX ceiling and comfortable margin for the snapshot fetches that share
+// this bucket. Tightening further risks IP firewall blocks (1 hr minimum,
+// doubling on repeat).
+const archiveMinGap = 2000 * time.Millisecond
+
+// archiveUA identifies this CLI to archive.org. The IA blog post "Let us
+// serve you, but don't bring us down" (2023) requests that bulk clients
+// identify themselves with a descriptive UA including a contact URL. IA
+// staff have stated they'll preferentially allowlist well-identified,
+// well-behaved clients; at minimum, an identifiable UA means they can
+// reach out before blocking if we misbehave.
+const archiveUA = "recipe-goat-pp-cli/1.0 (+https://github.com/mvanhorn/printing-press-library)"
 
 // Package-level archive-request pacing. Successive fallback invocations
 // serialize behind the minimum gap so parallel Fetch goroutines don't
@@ -44,19 +63,6 @@ var (
 	archiveLastReq   time.Time
 	archiveLastReqMu sync.Mutex
 )
-
-// waybackResponse is the subset of the availability API response we parse.
-// The full response has more fields (timestamp, status, etc.); we only
-// need the snapshot URL.
-type waybackResponse struct {
-	ArchivedSnapshots struct {
-		Closest *struct {
-			URL       string `json:"url"`
-			Timestamp string `json:"timestamp"`
-			Available bool   `json:"available"`
-		} `json:"closest"`
-	} `json:"archived_snapshots"`
-}
 
 // fetchArchiveFallback queries archive.org for a snapshot of targetURL and
 // returns the snapshot HTML body. Returns an error if no snapshot exists,
@@ -78,10 +84,9 @@ func fetchArchiveFallback(ctx context.Context, client *http.Client, targetURL st
 		return nil, fmt.Errorf("no wayback snapshot for %s", targetURL)
 	}
 
-	// Enforce HTTPS on snapshot URLs. Wayback's availability API returns
-	// http:// by default, but cached archive responses shouldn't be
-	// vulnerable to MITM — especially with the 7d TTL we'd apply at
-	// Phase 2.
+	// Enforce HTTPS on snapshot URLs. CDX's `original` column may be
+	// http:// for sites that were archived under plain HTTP; the wayback
+	// wrapper serves both, but we want the wrapper fetch itself on HTTPS.
 	snapURL = upgradeToHTTPS(snapURL)
 
 	fmt.Fprintf(os.Stderr, "warn: archive fallback: %s (wayback snapshot)\n", targetURL)
@@ -124,23 +129,34 @@ func awaitArchiveSlot(ctx context.Context) error {
 	}
 }
 
-// queryWaybackSnapshot asks the availability API for the closest snapshot
-// URL for target. Returns an empty string with no error when no snapshot
-// exists — caller distinguishes "no snapshot" from "availability API
-// failed."
+// queryWaybackSnapshot asks the CDX Search API for the most recent
+// successful snapshot of target. Returns an empty string with no error
+// when no snapshot exists.
 //
-// Archive.org's Availability API is schema-sensitive: querying with
-// "https://www.example.com/page" frequently misses snapshots that exist
-// under "www.example.com/page" (bare). We strip scheme before querying
-// so the lookup uses the canonical form archive.org indexes under.
+// Query shape: we ask for the single most recent 200-status capture
+// (limit=-1 returns from end, filter=statuscode:200 excludes error
+// captures that happened to be recorded). JSON output is a 2D array
+// with a header row followed by zero or more data rows.
+//
+// Scheme stripping: archive.org's indexers canonicalize without scheme;
+// querying "https://www.example.com/page" frequently misses snapshots
+// stored under "www.example.com/page" (bare). We strip scheme before
+// querying.
 func queryWaybackSnapshot(ctx context.Context, client *http.Client, target string) (string, error) {
 	bareURL := stripScheme(target)
-	apiURL := archiveAvailabilityURL + "?url=" + url.QueryEscape(bareURL)
+
+	params := url.Values{}
+	params.Set("url", bareURL)
+	params.Set("limit", "-1")
+	params.Set("output", "json")
+	params.Set("filter", "statuscode:200")
+	apiURL := archiveCDXURL + "?" + params.Encode()
+
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("User-Agent", chromeUA)
+	req.Header.Set("User-Agent", archiveUA)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
@@ -149,36 +165,77 @@ func queryWaybackSnapshot(ctx context.Context, client *http.Client, target strin
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// Explicit throttle signal. Phase 2 will add exponential backoff
+		// and session-level circuit breaker; for now, surface as error so
+		// the caller falls back to the original ErrBlocked.
+		return "", fmt.Errorf("CDX API rate limited (HTTP 429)")
+	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("availability API returned HTTP %d", resp.StatusCode)
+		return "", fmt.Errorf("CDX API returned HTTP %d", resp.StatusCode)
 	}
 
-	// Cap the availability response at 64 KiB — the JSON is tiny, anything
-	// larger is a misbehaving server.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	// Cap at 256 KiB — a single-row CDX response is under 1 KiB, but the
+	// cap gives headroom if IA returns more rows than expected while
+	// keeping us safe against misbehaving servers.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256<<10))
 	if err != nil {
 		return "", err
 	}
 
-	var wb waybackResponse
-	if err := json.Unmarshal(body, &wb); err != nil {
-		return "", fmt.Errorf("parsing wayback response: %w", err)
-	}
-
-	if wb.ArchivedSnapshots.Closest == nil || !wb.ArchivedSnapshots.Closest.Available {
+	// Empty body on 200 status means no captures — CDX returns either a
+	// populated array or nothing at all. Availability API's silent empty
+	// behavior does not occur here.
+	body = []byte(strings.TrimSpace(string(body)))
+	if len(body) == 0 {
 		return "", nil
 	}
-	return wb.ArchivedSnapshots.Closest.URL, nil
+
+	var rows [][]string
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return "", fmt.Errorf("parsing CDX response: %w", err)
+	}
+
+	// First row is column headers; data rows follow. Zero data rows means
+	// no snapshot matches the filter.
+	if len(rows) < 2 {
+		return "", nil
+	}
+
+	header := rows[0]
+	tsIdx, origIdx := -1, -1
+	for i, col := range header {
+		switch col {
+		case "timestamp":
+			tsIdx = i
+		case "original":
+			origIdx = i
+		}
+	}
+	if tsIdx < 0 || origIdx < 0 {
+		return "", fmt.Errorf("CDX response missing timestamp or original columns")
+	}
+
+	// Use the last data row. limit=-1 returns a single row (the most
+	// recent), but defensively handle any shape.
+	latest := rows[len(rows)-1]
+	if len(latest) <= tsIdx || len(latest) <= origIdx {
+		return "", fmt.Errorf("CDX row malformed: %v", latest)
+	}
+
+	// Construct the wayback snapshot URL from timestamp + original URL.
+	return fmt.Sprintf("https://web.archive.org/web/%s/%s", latest[tsIdx], latest[origIdx]), nil
 }
 
 // fetchSnapshotBody GETs the wayback snapshot URL and returns the HTML
-// body. Uses the same 5 MiB cap and browser-ish headers as the live fetch.
+// body. Uses the identifying archive UA (same bucket as the CDX query) —
+// this request counts against the same rate limit.
 func fetchSnapshotBody(ctx context.Context, client *http.Client, snapURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", snapURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", chromeUA)
+	req.Header.Set("User-Agent", archiveUA)
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
@@ -195,10 +252,9 @@ func fetchSnapshotBody(ctx context.Context, client *http.Client, snapURL string)
 	return io.ReadAll(io.LimitReader(resp.Body, 5<<20))
 }
 
-// upgradeToHTTPS rewrites a plain-http URL to https. Wayback returns
-// http://web.archive.org/web/TIMESTAMP/ORIGINAL by default; we don't want
-// cached archive content vulnerable to MITM — especially given archive
-// responses may be cached for days in Phase 2.
+// upgradeToHTTPS rewrites a plain-http URL to https. CDX's `original`
+// column may be http:// for sites archived under plain HTTP; we don't
+// want cached archive content vulnerable to MITM.
 func upgradeToHTTPS(raw string) string {
 	if strings.HasPrefix(raw, "http://") {
 		return "https://" + strings.TrimPrefix(raw, "http://")
@@ -207,7 +263,7 @@ func upgradeToHTTPS(raw string) string {
 }
 
 // stripScheme returns the URL with any leading http:// or https:// prefix
-// removed. Used for the availability API's canonical lookup form.
+// removed. Used for the CDX canonical lookup form.
 func stripScheme(raw string) string {
 	if idx := strings.Index(raw, "://"); idx >= 0 {
 		return raw[idx+3:]

--- a/library/food-and-dining/recipe-goat/internal/recipes/archive_test.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/archive_test.go
@@ -14,10 +14,10 @@ import (
 	"time"
 )
 
-// newAvailabilityServer returns an httptest server that responds to the
-// Wayback availability API with the caller-supplied JSON body. Used in
-// place of real archive.org so tests are hermetic.
-func newAvailabilityServer(t *testing.T, body string, status int) *httptest.Server {
+// newCDXServer returns an httptest server that responds to the Wayback
+// CDX Search API with the caller-supplied JSON body. Used in place of real
+// archive.org so tests are hermetic.
+func newCDXServer(t *testing.T, body string, status int) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -26,16 +26,17 @@ func newAvailabilityServer(t *testing.T, body string, status int) *httptest.Serv
 	}))
 }
 
-// withAvailabilityURL temporarily swaps the package-level
-// archiveAvailabilityURL so tests can point the fallback at an httptest
-// server. Restored via t.Cleanup.
-func withAvailabilityURL(t *testing.T, url string) {
-	t.Helper()
-	// archiveAvailabilityURL is a const — can't swap directly. Tests that
-	// need to override the endpoint use the archiveAvailabilityURLForTest
-	// shim added below. This function documents the intent; it's a no-op
-	// placeholder so future refactors that make the URL variable have a
-	// clear hook.
+// cdxResponse builds a CDX JSON response body with a single data row
+// pointing at snapURL. The CDX JSON schema is [[headers...],[values...]].
+func cdxResponse(snapURL, timestamp string) string {
+	// The CDX `original` column stores the target URL, and the snapshot
+	// URL is assembled as https://web.archive.org/web/<timestamp>/<original>.
+	// For tests we want the final reconstructed URL to land on the
+	// httptest snapshot server, so we set `original` to the bare
+	// snapshot host/path and rely on the test to route via the
+	// rewriteTransport.
+	return fmt.Sprintf(`[["urlkey","timestamp","original","mimetype","statuscode","digest","length"],`+
+		`["com,example)/page","%s","%s","text/html","200","ABC123","12345"]]`, timestamp, snapURL)
 }
 
 // --- awaitArchiveSlot ---
@@ -90,18 +91,22 @@ func TestAwaitArchiveSlot_ContextCancellation(t *testing.T) {
 
 // --- fetchArchiveFallback end-to-end (via httptest) ---
 
-// setupFallbackServers wires up mock availability + snapshot servers and
-// makes the package-level archive URL point at them. Returns a client and
-// the snapshot handler's hit counter.
+// setupFallbackServers wires up mock CDX + snapshot servers and rewrites
+// the archive URL to point at them. Returns a client and the snapshot
+// handler's hit counter.
+//
+// Mechanics: the CDX server returns a response whose `original` column is
+// the TLS snapshot server's URL. The fallback code reconstructs the
+// snapshot URL as `https://web.archive.org/web/<ts>/<original>`; the
+// rewriteTransport rewrites that `https://web.archive.org` prefix to the
+// snapshot server's base.
 func setupFallbackServers(t *testing.T, snapBody string, snapStatus int) (*http.Client, *httptest.Server, *int64) {
 	t.Helper()
 	resetArchivePacing()
 
 	var snapHits int64
-	// Snapshot server is TLS so upgradeToHTTPS (called inside the
-	// fallback code path) produces a URL the test can reach. Without
-	// this, the http→https rewrite would leave the test pointing at a
-	// non-HTTPS httptest server.
+	// Snapshot server uses TLS (matches real web.archive.org and the HTTPS
+	// upgrade in the fallback code).
 	snapSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&snapHits, 1)
 		w.WriteHeader(snapStatus)
@@ -109,53 +114,64 @@ func setupFallbackServers(t *testing.T, snapBody string, snapStatus int) (*http.
 	}))
 	t.Cleanup(snapSrv.Close)
 
-	// The availability server returns JSON with a DELIBERATELY http://
-	// snapshot URL so we exercise the upgradeToHTTPS path. The test
-	// client skips cert verification since httptest uses a self-signed
-	// cert.
-	insecureSnapURL := "http://" + strings.TrimPrefix(snapSrv.URL, "https://") + "/page"
-	availBody := fmt.Sprintf(`{"archived_snapshots":{"closest":{"url":"%s","timestamp":"20260314204319","available":true}}}`, insecureSnapURL)
-	availSrv := newAvailabilityServer(t, availBody, http.StatusOK)
-	t.Cleanup(availSrv.Close)
+	// CDX response points `original` at the snapshot server's base URL so
+	// the reconstructed snapshot URL (https://web.archive.org/web/TS/ORIGINAL)
+	// has ORIGINAL already pointing at the test server. The
+	// rewriteTransport handles the `https://web.archive.org` prefix.
+	cdxBody := cdxResponse(snapSrv.URL+"/page", "20260314204319")
+	cdxSrv := newCDXServer(t, cdxBody, http.StatusOK)
+	t.Cleanup(cdxSrv.Close)
 
+	// Two rewrites are needed:
+	//   1. CDX lookups (archiveCDXURL → cdxSrv)
+	//   2. Snapshot fetches (https://web.archive.org/web/... → snapSrv)
 	client := &http.Client{
-		Transport: &rewriteTransport{
-			from: archiveAvailabilityURL,
-			to:   availSrv.URL,
-			tls:  &tls.Config{InsecureSkipVerify: true},
+		Transport: &multiRewriteTransport{
+			rewrites: []urlRewrite{
+				{from: archiveCDXURL, to: cdxSrv.URL},
+				{from: "https://web.archive.org", to: snapSrv.URL},
+			},
+			tls: &tls.Config{InsecureSkipVerify: true},
 		},
 		Timeout: 5 * time.Second,
 	}
 	return client, snapSrv, &snapHits
 }
 
-// rewriteTransport rewrites outbound requests whose URL starts with `from`
-// to instead hit `to`. Preserves path + query. Only used in tests.
-//
-// The `tls` field, when non-nil, configures cert verification for all
-// requests going through the underlying transport. Needed because
-// httptest.NewTLSServer uses a self-signed cert.
-type rewriteTransport struct {
+// urlRewrite is a single from→to URL prefix substitution.
+type urlRewrite struct {
 	from string
 	to   string
-	tls  *tls.Config
 }
 
-func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+// multiRewriteTransport rewrites outbound requests matching any of the
+// `rewrites` prefixes. Preserves path + query. Only used in tests.
+//
+// The `tls` field, when non-nil, configures cert verification. Needed
+// because httptest.NewTLSServer uses a self-signed cert.
+type multiRewriteTransport struct {
+	rewrites []urlRewrite
+	tls      *tls.Config
+}
+
+func (r *multiRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	if r.tls != nil {
 		base.TLSClientConfig = r.tls
 	}
-	if strings.HasPrefix(req.URL.String(), r.from) {
-		newURLStr := r.to + strings.TrimPrefix(req.URL.String(), r.from)
-		newReq := req.Clone(req.Context())
-		parsedURL, err := url.Parse(newURLStr)
-		if err != nil {
-			return nil, err
+	reqURL := req.URL.String()
+	for _, rw := range r.rewrites {
+		if strings.HasPrefix(reqURL, rw.from) {
+			newURLStr := rw.to + strings.TrimPrefix(reqURL, rw.from)
+			newReq := req.Clone(req.Context())
+			parsedURL, err := url.Parse(newURLStr)
+			if err != nil {
+				return nil, err
+			}
+			newReq.URL = parsedURL
+			newReq.Host = parsedURL.Host
+			return base.RoundTrip(newReq)
 		}
-		newReq.URL = parsedURL
-		newReq.Host = parsedURL.Host
-		return base.RoundTrip(newReq)
 	}
 	return base.RoundTrip(req)
 }
@@ -178,11 +194,12 @@ func TestFetchArchiveFallback_Success(t *testing.T) {
 
 func TestFetchArchiveFallback_NoSnapshot(t *testing.T) {
 	resetArchivePacing()
-	availSrv := newAvailabilityServer(t, `{"archived_snapshots":{}}`, http.StatusOK)
-	defer availSrv.Close()
+	// CDX returns only the header row — no data rows = no snapshot.
+	cdxSrv := newCDXServer(t, `[["urlkey","timestamp","original","mimetype","statuscode","digest","length"]]`, http.StatusOK)
+	defer cdxSrv.Close()
 
 	client := &http.Client{
-		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
 		Timeout:   5 * time.Second,
 	}
 
@@ -195,22 +212,66 @@ func TestFetchArchiveFallback_NoSnapshot(t *testing.T) {
 	}
 }
 
-func TestFetchArchiveFallback_AvailabilityAPIDown(t *testing.T) {
+func TestFetchArchiveFallback_NoSnapshotEmptyBody(t *testing.T) {
+	// Some CDX responses come back with just whitespace or empty body
+	// when there are no matches. This should be treated as "no snapshot",
+	// not a parse error.
 	resetArchivePacing()
-	availSrv := newAvailabilityServer(t, "", http.StatusInternalServerError)
-	defer availSrv.Close()
+	cdxSrv := newCDXServer(t, "", http.StatusOK)
+	defer cdxSrv.Close()
 
 	client := &http.Client{
-		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://unknown.example/page")
+	if err == nil {
+		t.Fatal("expected error when response empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "no wayback snapshot") {
+		t.Errorf("expected 'no wayback snapshot' error, got %v", err)
+	}
+}
+
+func TestFetchArchiveFallback_CDXAPIDown(t *testing.T) {
+	resetArchivePacing()
+	cdxSrv := newCDXServer(t, "", http.StatusInternalServerError)
+	defer cdxSrv.Close()
+
+	client := &http.Client{
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
 		Timeout:   5 * time.Second,
 	}
 
 	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
 	if err == nil {
-		t.Fatal("expected error when availability API returns 500")
+		t.Fatal("expected error when CDX API returns 500")
 	}
-	if !strings.Contains(err.Error(), "availability API") && !strings.Contains(err.Error(), "querying wayback") {
-		t.Errorf("expected availability-API error, got %v", err)
+	if !strings.Contains(err.Error(), "CDX API") && !strings.Contains(err.Error(), "querying wayback") {
+		t.Errorf("expected CDX API error, got %v", err)
+	}
+}
+
+func TestFetchArchiveFallback_CDXRateLimited(t *testing.T) {
+	// CDX API returns 429 when the caller has been throttled. This should
+	// surface as an error so the original ErrBlocked is returned to the
+	// user rather than silently returning empty content.
+	resetArchivePacing()
+	cdxSrv := newCDXServer(t, "", http.StatusTooManyRequests)
+	defer cdxSrv.Close()
+
+	client := &http.Client{
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
+	if err == nil {
+		t.Fatal("expected error on 429")
+	}
+	if !strings.Contains(err.Error(), "429") && !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected rate-limit error, got %v", err)
 	}
 }
 
@@ -225,19 +286,43 @@ func TestFetchArchiveFallback_SnapshotFetchFails(t *testing.T) {
 	}
 }
 
-func TestFetchArchiveFallback_MalformedAvailabilityJSON(t *testing.T) {
+func TestFetchArchiveFallback_MalformedCDXJSON(t *testing.T) {
 	resetArchivePacing()
-	availSrv := newAvailabilityServer(t, "not json at all", http.StatusOK)
-	defer availSrv.Close()
+	cdxSrv := newCDXServer(t, "not json at all", http.StatusOK)
+	defer cdxSrv.Close()
 
 	client := &http.Client{
-		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
 		Timeout:   5 * time.Second,
 	}
 
 	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
 	if err == nil {
 		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+func TestFetchArchiveFallback_CDXMissingColumns(t *testing.T) {
+	// Defensive: if the CDX schema ever changes and `timestamp` or
+	// `original` are missing from the header, we should error rather than
+	// silently return a malformed URL.
+	resetArchivePacing()
+	cdxSrv := newCDXServer(t,
+		`[["urlkey","mimetype","statuscode"],["com,example)/page","text/html","200"]]`,
+		http.StatusOK)
+	defer cdxSrv.Close()
+
+	client := &http.Client{
+		Transport: &multiRewriteTransport{rewrites: []urlRewrite{{from: archiveCDXURL, to: cdxSrv.URL}}},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
+	if err == nil {
+		t.Fatal("expected error when CDX columns missing")
+	}
+	if !strings.Contains(err.Error(), "missing timestamp or original") {
+		t.Errorf("expected missing-columns error, got %v", err)
 	}
 }
 

--- a/library/food-and-dining/recipe-goat/internal/recipes/archive_test.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/archive_test.go
@@ -1,0 +1,261 @@
+package recipes
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newAvailabilityServer returns an httptest server that responds to the
+// Wayback availability API with the caller-supplied JSON body. Used in
+// place of real archive.org so tests are hermetic.
+func newAvailabilityServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// withAvailabilityURL temporarily swaps the package-level
+// archiveAvailabilityURL so tests can point the fallback at an httptest
+// server. Restored via t.Cleanup.
+func withAvailabilityURL(t *testing.T, url string) {
+	t.Helper()
+	// archiveAvailabilityURL is a const — can't swap directly. Tests that
+	// need to override the endpoint use the archiveAvailabilityURLForTest
+	// shim added below. This function documents the intent; it's a no-op
+	// placeholder so future refactors that make the URL variable have a
+	// clear hook.
+}
+
+// --- awaitArchiveSlot ---
+
+func TestAwaitArchiveSlot_FirstCallImmediate(t *testing.T) {
+	resetArchivePacing()
+	start := time.Now()
+	if err := awaitArchiveSlot(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Millisecond {
+		t.Errorf("first call should return immediately, took %v", elapsed)
+	}
+}
+
+func TestAwaitArchiveSlot_SecondCallPaced(t *testing.T) {
+	resetArchivePacing()
+	_ = awaitArchiveSlot(context.Background())
+	start := time.Now()
+	if err := awaitArchiveSlot(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < archiveMinGap-50*time.Millisecond {
+		t.Errorf("second call should wait ~%v, took %v", archiveMinGap, elapsed)
+	}
+	// Sanity upper bound — allow 2x margin for scheduling slop but catch
+	// anything wildly over.
+	if elapsed > 2*archiveMinGap {
+		t.Errorf("second call took suspiciously long: %v", elapsed)
+	}
+}
+
+func TestAwaitArchiveSlot_ContextCancellation(t *testing.T) {
+	resetArchivePacing()
+	_ = awaitArchiveSlot(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := awaitArchiveSlot(ctx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+	// Should return near the deadline (~100ms), not wait the full archiveMinGap
+	if elapsed > 300*time.Millisecond {
+		t.Errorf("ctx-cancel should return near deadline, took %v", elapsed)
+	}
+}
+
+// --- fetchArchiveFallback end-to-end (via httptest) ---
+
+// setupFallbackServers wires up mock availability + snapshot servers and
+// makes the package-level archive URL point at them. Returns a client and
+// the snapshot handler's hit counter.
+func setupFallbackServers(t *testing.T, snapBody string, snapStatus int) (*http.Client, *httptest.Server, *int64) {
+	t.Helper()
+	resetArchivePacing()
+
+	var snapHits int64
+	// Snapshot server is TLS so upgradeToHTTPS (called inside the
+	// fallback code path) produces a URL the test can reach. Without
+	// this, the http→https rewrite would leave the test pointing at a
+	// non-HTTPS httptest server.
+	snapSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&snapHits, 1)
+		w.WriteHeader(snapStatus)
+		_, _ = w.Write([]byte(snapBody))
+	}))
+	t.Cleanup(snapSrv.Close)
+
+	// The availability server returns JSON with a DELIBERATELY http://
+	// snapshot URL so we exercise the upgradeToHTTPS path. The test
+	// client skips cert verification since httptest uses a self-signed
+	// cert.
+	insecureSnapURL := "http://" + strings.TrimPrefix(snapSrv.URL, "https://") + "/page"
+	availBody := fmt.Sprintf(`{"archived_snapshots":{"closest":{"url":"%s","timestamp":"20260314204319","available":true}}}`, insecureSnapURL)
+	availSrv := newAvailabilityServer(t, availBody, http.StatusOK)
+	t.Cleanup(availSrv.Close)
+
+	client := &http.Client{
+		Transport: &rewriteTransport{
+			from: archiveAvailabilityURL,
+			to:   availSrv.URL,
+			tls:  &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 5 * time.Second,
+	}
+	return client, snapSrv, &snapHits
+}
+
+// rewriteTransport rewrites outbound requests whose URL starts with `from`
+// to instead hit `to`. Preserves path + query. Only used in tests.
+//
+// The `tls` field, when non-nil, configures cert verification for all
+// requests going through the underlying transport. Needed because
+// httptest.NewTLSServer uses a self-signed cert.
+type rewriteTransport struct {
+	from string
+	to   string
+	tls  *tls.Config
+}
+
+func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	if r.tls != nil {
+		base.TLSClientConfig = r.tls
+	}
+	if strings.HasPrefix(req.URL.String(), r.from) {
+		newURLStr := r.to + strings.TrimPrefix(req.URL.String(), r.from)
+		newReq := req.Clone(req.Context())
+		parsedURL, err := url.Parse(newURLStr)
+		if err != nil {
+			return nil, err
+		}
+		newReq.URL = parsedURL
+		newReq.Host = parsedURL.Host
+		return base.RoundTrip(newReq)
+	}
+	return base.RoundTrip(req)
+}
+
+// --- test matrix ---
+
+func TestFetchArchiveFallback_Success(t *testing.T) {
+	client, _, hits := setupFallbackServers(t, "<html><body>archived content</body></html>", http.StatusOK)
+	body, err := fetchArchiveFallback(context.Background(), client, "https://www.seriouseats.com/recipe")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !strings.Contains(string(body), "archived content") {
+		t.Errorf("body mismatch: %q", body)
+	}
+	if *hits != 1 {
+		t.Errorf("expected 1 snapshot fetch, got %d", *hits)
+	}
+}
+
+func TestFetchArchiveFallback_NoSnapshot(t *testing.T) {
+	resetArchivePacing()
+	availSrv := newAvailabilityServer(t, `{"archived_snapshots":{}}`, http.StatusOK)
+	defer availSrv.Close()
+
+	client := &http.Client{
+		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://unknown.example/page")
+	if err == nil {
+		t.Fatal("expected error when no snapshot exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "no wayback snapshot") {
+		t.Errorf("expected 'no wayback snapshot' error, got %v", err)
+	}
+}
+
+func TestFetchArchiveFallback_AvailabilityAPIDown(t *testing.T) {
+	resetArchivePacing()
+	availSrv := newAvailabilityServer(t, "", http.StatusInternalServerError)
+	defer availSrv.Close()
+
+	client := &http.Client{
+		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
+	if err == nil {
+		t.Fatal("expected error when availability API returns 500")
+	}
+	if !strings.Contains(err.Error(), "availability API") && !strings.Contains(err.Error(), "querying wayback") {
+		t.Errorf("expected availability-API error, got %v", err)
+	}
+}
+
+func TestFetchArchiveFallback_SnapshotFetchFails(t *testing.T) {
+	client, _, _ := setupFallbackServers(t, "", http.StatusNotFound)
+	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
+	if err == nil {
+		t.Fatal("expected error when snapshot returns 404")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("expected 'HTTP 404' error, got %v", err)
+	}
+}
+
+func TestFetchArchiveFallback_MalformedAvailabilityJSON(t *testing.T) {
+	resetArchivePacing()
+	availSrv := newAvailabilityServer(t, "not json at all", http.StatusOK)
+	defer availSrv.Close()
+
+	client := &http.Client{
+		Transport: &rewriteTransport{from: archiveAvailabilityURL, to: availSrv.URL},
+		Timeout:   5 * time.Second,
+	}
+
+	_, err := fetchArchiveFallback(context.Background(), client, "https://x.example/page")
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+// --- upgradeToHTTPS ---
+
+func TestUpgradeToHTTPS(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"http://web.archive.org/web/2020/https://example.com/", "https://web.archive.org/web/2020/https://example.com/"},
+		{"https://already-secure.example/", "https://already-secure.example/"},
+		{"", ""},
+		{"ftp://weird.example/", "ftp://weird.example/"}, // non-http/https left alone
+	}
+	for _, tc := range cases {
+		if got := upgradeToHTTPS(tc.in); got != tc.want {
+			t.Errorf("upgradeToHTTPS(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
@@ -107,10 +107,11 @@ func FetchHTML(ctx context.Context, client *http.Client, target string) ([]byte,
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
-		_ = resp.Body.Close()
-		if archiveBody, archiveErr := fetchArchiveFallback(ctx, client, target); archiveErr == nil {
-			return archiveBody, nil
-		}
+		// FetchHTML is used by search/trending fan-out — per-site listing
+		// pages that are poorly covered by archive.org anyway (dynamic URLs,
+		// sparse snapshots). Skipping the fallback here preserves the
+		// archive.org request budget for URL-targeted Fetch calls where
+		// the user explicitly wants that specific recipe.
 		return nil, fmt.Errorf("%w: %s returned HTTP %d", ErrBlocked, target, resp.StatusCode)
 	}
 	if resp.StatusCode >= 400 {

--- a/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
@@ -47,6 +47,19 @@ func Fetch(ctx context.Context, client *http.Client, recipeURL string) (*Recipe,
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
+		// Close the failing live response before attempting fallback —
+		// the deferred close would run at return, but we're about to
+		// make more requests and don't want this connection held open.
+		_ = resp.Body.Close()
+		if archiveBody, archiveErr := fetchArchiveFallback(ctx, client, recipeURL); archiveErr == nil {
+			r, parseErr := ParseJSONLD(archiveBody, recipeURL)
+			if parseErr == nil {
+				return r, nil
+			}
+			// Archive snapshot parsed badly — fall through to the
+			// original ErrBlocked rather than returning the parse error,
+			// since the user's real problem is the live block.
+		}
 		return nil, fmt.Errorf("%w: %s returned HTTP %d", ErrBlocked, recipeURL, resp.StatusCode)
 	}
 	if resp.StatusCode >= 400 {
@@ -94,6 +107,10 @@ func FetchHTML(ctx context.Context, client *http.Client, target string) ([]byte,
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
+		_ = resp.Body.Close()
+		if archiveBody, archiveErr := fetchArchiveFallback(ctx, client, target); archiveErr == nil {
+			return archiveBody, nil
+		}
 		return nil, fmt.Errorf("%w: %s returned HTTP %d", ErrBlocked, target, resp.StatusCode)
 	}
 	if resp.StatusCode >= 400 {

--- a/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/fetch.go
@@ -14,9 +14,23 @@ import (
 // site-level failure and continuing to other sources.
 var ErrBlocked = errors.New("site blocked")
 
-// chromeUA is a current-ish Chrome user agent. Many recipe sites 403 on Go's
+// ChromeUA is a current-ish Chrome user agent. Many recipe sites 403 on Go's
 // default UA, so sending a browser-looking UA is required for reach.
-const chromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+//
+// Freshness matters: some sites flag outdated Chrome versions as a scraper
+// heuristic (feedthepudge.com returned 403 on Chrome/131 but 200 on 140).
+// When this UA looks more than ~6 months stale relative to real Chrome
+// stable, bump it — stale UAs block sites that new UAs reach. This is a
+// machine-level concern the generator should automate eventually.
+//
+// Exported so doctor/health-check code can probe sites with the exact
+// same UA used for real Fetch() calls. Drift between the probe UA and
+// the real UA produces confusing results (site listed as "blocked" in
+// doctor but reachable during actual queries, or vice versa).
+const ChromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.56 Safari/537.36"
+
+// chromeUA is the unexported alias retained for intra-package use.
+const chromeUA = ChromeUA
 
 // Fetch downloads recipeURL (honoring ctx / redirects) and extracts the
 // JSON-LD Recipe from the response body. A 10s ctx deadline is applied if

--- a/library/food-and-dining/recipe-goat/internal/recipes/sites.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/sites.go
@@ -53,6 +53,12 @@ var Sites = []Site{
 	{Name: "The Woks of Life", Hostname: "thewoksoflife.com", Tier: 1, SearchURL: "https://thewoksoflife.com/?s={q}", Trust: 0.9},
 	{Name: "Just One Cookbook", Hostname: "justonecookbook.com", Tier: 1, SearchURL: "https://www.justonecookbook.com/?s={q}", Trust: 0.9},
 	{Name: "The Cozy Cook", Hostname: "thecozycook.com", Tier: 1, SearchURL: "https://thecozycook.com/?s={q}", Trust: 0.9},
+	{Name: "Feed the Pudge", Hostname: "feedthepudge.com", Tier: 1, SearchURL: "https://feedthepudge.com/?s={q}", Trust: 0.9},
+	{Name: "Preppy Kitchen", Hostname: "preppykitchen.com", Tier: 1, SearchURL: "https://preppykitchen.com/?s={q}", Trust: 0.9},
+	{Name: "Sally's Baking Addiction", Hostname: "sallysbakingaddiction.com", Tier: 1, SearchURL: "https://sallysbakingaddiction.com/?s={q}", Trust: 0.9},
+	{Name: "Broma Bakery", Hostname: "bromabakery.com", Tier: 1, SearchURL: "https://bromabakery.com/?s={q}", Trust: 0.9},
+	{Name: "Bigger Bolder Baking", Hostname: "biggerbolderbaking.com", Tier: 1, SearchURL: "https://www.biggerbolderbaking.com/?s={q}", Trust: 0.9},
+	{Name: "The Cafe Sucre Farine", Hostname: "thecafesucrefarine.com", Tier: 1, SearchURL: "https://thecafesucrefarine.com/?s={q}", Trust: 0.9},
 
 	// Tier 2 — brand/editorial authority, generally reachable but fragile
 	// (Condé Nast properties have started gating in recent quarters).
@@ -73,22 +79,28 @@ var Sites = []Site{
 // `recipe get` still get correct site-level metadata (trust, tier).
 // They're just absent from Sites so fan-out skips them.
 var recipeURLPatterns = map[string]string{
-	"kingarthurbaking.com": `^/recipes/[a-z0-9-]+-recipe$`,
-	"budgetbytes.com":      `^/[a-z0-9-]{6,}/?$`,
-	"smittenkitchen.com":   `^/\d{4}/\d{2}/[a-z0-9-]+/?$`,
-	"bbcgoodfood.com":      `^/recipes/[a-z0-9-]+$`,
-	"bbc.co.uk":            `^/food/recipes/[a-z0-9_]+_\d+$`,
-	"minimalistbaker.com":  `^/[a-z0-9-]{6,}/?$`,
-	"skinnytaste.com":      `^/[a-z0-9-]{6,}/?$`,
-	"thekitchn.com":        `^/(?:.*-recipe-\d+|recipe-[a-z0-9-]+)$`,
-	"recipetineats.com":    `^/[a-z0-9-]{6,}/?$`,
-	"thewoksoflife.com":    `^/[a-z0-9-]{6,}/?$`,
-	"justonecookbook.com":  `^/[a-z0-9-]{6,}/?$`,
-	"thecozycook.com":      `^/[a-z0-9-]{6,}/?$`,
-	"gazoakleychef.com":    `^/recipes/[a-z0-9-]+/?$`,
-	"bonappetit.com":       `^/recipe/[a-z0-9-]+$`,
-	"epicurious.com":       `^/recipes/food/views/[a-z0-9-]+$`,
-	"seriouseats.com":      `^/[a-z0-9-]+-recipe(-\d+)?$`,
+	"kingarthurbaking.com":      `^/recipes/[a-z0-9-]+-recipe$`,
+	"budgetbytes.com":           `^/[a-z0-9-]{6,}/?$`,
+	"smittenkitchen.com":        `^/\d{4}/\d{2}/[a-z0-9-]+/?$`,
+	"bbcgoodfood.com":           `^/recipes/[a-z0-9-]+$`,
+	"bbc.co.uk":                 `^/food/recipes/[a-z0-9_]+_\d+$`,
+	"minimalistbaker.com":       `^/[a-z0-9-]{6,}/?$`,
+	"skinnytaste.com":           `^/[a-z0-9-]{6,}/?$`,
+	"thekitchn.com":             `^/(?:.*-recipe-\d+|recipe-[a-z0-9-]+)$`,
+	"recipetineats.com":         `^/[a-z0-9-]{6,}/?$`,
+	"thewoksoflife.com":         `^/[a-z0-9-]{6,}/?$`,
+	"justonecookbook.com":       `^/[a-z0-9-]{6,}/?$`,
+	"thecozycook.com":           `^/[a-z0-9-]{6,}/?$`,
+	"feedthepudge.com":          `^/[a-z0-9-]{6,}/?$`,
+	"preppykitchen.com":         `^/[a-z0-9-]{6,}/?$`,
+	"sallysbakingaddiction.com": `^/[a-z0-9-]{6,}/?$`,
+	"bromabakery.com":           `^/[a-z0-9-]{6,}/?$`,
+	"biggerbolderbaking.com":    `^/[a-z0-9-]{6,}/?$`,
+	"thecafesucrefarine.com":    `^/[a-z0-9-]{6,}/?$`,
+	"gazoakleychef.com":         `^/recipes/[a-z0-9-]+/?$`,
+	"bonappetit.com":            `^/recipe/[a-z0-9-]+$`,
+	"epicurious.com":            `^/recipes/food/views/[a-z0-9-]+$`,
+	"seriouseats.com":           `^/[a-z0-9-]+-recipe(-\d+)?$`,
 
 	// Removed from fan-out but URLs still recognizable for `recipe get`:
 	"food52.com":        `^/recipes/\d+-[a-z0-9-]+$`,
@@ -166,6 +178,12 @@ var curatedAuthors = map[string]bool{
 	"namiko chen":                true,
 	"bill, judy, sarah, kaitlin": true,
 	"gaz oakley":                 true,
+	"john kanell":                true,
+	"sally mckenney":             true,
+	"sarah fennel":               true,
+	"gemma stafford":             true,
+	"chris scheuer":              true,
+	"ken tran":                   true,
 }
 
 // AuthorTrust returns a trust score in [0,1] for the given author. Curated

--- a/library/food-and-dining/recipe-goat/internal/recipes/sites.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/sites.go
@@ -59,6 +59,11 @@ var Sites = []Site{
 	{Name: "Broma Bakery", Hostname: "bromabakery.com", Tier: 1, SearchURL: "https://bromabakery.com/?s={q}", Trust: 0.9},
 	{Name: "Bigger Bolder Baking", Hostname: "biggerbolderbaking.com", Tier: 1, SearchURL: "https://www.biggerbolderbaking.com/?s={q}", Trust: 0.9},
 	{Name: "The Cafe Sucre Farine", Hostname: "thecafesucrefarine.com", Tier: 1, SearchURL: "https://thecafesucrefarine.com/?s={q}", Trust: 0.9},
+	{Name: "China Sichuan Food", Hostname: "chinasichuanfood.com", Tier: 1, SearchURL: "https://www.chinasichuanfood.com/?s={q}", Trust: 0.9},
+	{Name: "Red House Spice", Hostname: "redhousespice.com", Tier: 1, SearchURL: "https://redhousespice.com/?s={q}", Trust: 0.9},
+	{Name: "My Heart Beets", Hostname: "myheartbeets.com", Tier: 1, SearchURL: "https://myheartbeets.com/?s={q}", Trust: 0.9},
+	{Name: "Indian Healthy Recipes", Hostname: "indianhealthyrecipes.com", Tier: 1, SearchURL: "https://www.indianhealthyrecipes.com/?s={q}", Trust: 0.9},
+	{Name: "Sip and Feast", Hostname: "sipandfeast.com", Tier: 1, SearchURL: "https://www.sipandfeast.com/?s={q}", Trust: 0.9},
 
 	// Tier 2 — brand/editorial authority, generally reachable but fragile
 	// (Condé Nast properties have started gating in recent quarters).
@@ -97,17 +102,29 @@ var recipeURLPatterns = map[string]string{
 	"bromabakery.com":           `^/[a-z0-9-]{6,}/?$`,
 	"biggerbolderbaking.com":    `^/[a-z0-9-]{6,}/?$`,
 	"thecafesucrefarine.com":    `^/[a-z0-9-]{6,}/?$`,
+	"chinasichuanfood.com":      `^/[a-z0-9-]{6,}/?$`,
+	"redhousespice.com":         `^/[a-z0-9-]{6,}/?$`,
+	"myheartbeets.com":          `^/[a-z0-9-]{6,}/?$`,
+	"indianhealthyrecipes.com":  `^/[a-z0-9-]{6,}/?$`,
+	"sipandfeast.com":           `^/[a-z0-9-]{6,}/?$`,
 	"gazoakleychef.com":         `^/recipes/[a-z0-9-]+/?$`,
 	"bonappetit.com":            `^/recipe/[a-z0-9-]+$`,
 	"epicurious.com":            `^/recipes/food/views/[a-z0-9-]+$`,
 	"seriouseats.com":           `^/[a-z0-9-]+-recipe(-\d+)?$`,
 
-	// Removed from fan-out but URLs still recognizable for `recipe get`:
-	"food52.com":        `^/recipes/\d+-[a-z0-9-]+$`,
-	"foodnetwork.com":   `^/recipes/[a-z0-9-/]+-recipe-\d+$`,
-	"allrecipes.com":    `^/recipe/\d+/[a-z0-9-]+/?$`,
-	"simplyrecipes.com": `^/(?:recipes/[a-z0-9_-]+/?|[a-z0-9-]+-recipe-\d+)$`,
-	"eatingwell.com":    `^/recipe/\d+/[a-z0-9-]+/?$`,
+	// Removed from fan-out but URLs still recognizable for `recipe get`.
+	// These sites either hard-block the search endpoint (Cloudflare on
+	// omnivorescookbook), hard-block live reads (dotdash properties), or
+	// ship client-rendered recipe pages (madewithlau, archanaskitchen —
+	// Next.js SPAs we can't parse from Go without a headless browser).
+	// Keeping the URL patterns means users who paste one of these URLs
+	// into `recipe get` still get correct site-level metadata.
+	"omnivorescookbook.com": `^/[a-z0-9-]{6,}/?$`,
+	"food52.com":            `^/recipes/\d+-[a-z0-9-]+$`,
+	"foodnetwork.com":       `^/recipes/[a-z0-9-/]+-recipe-\d+$`,
+	"allrecipes.com":        `^/recipe/\d+/[a-z0-9-]+/?$`,
+	"simplyrecipes.com":     `^/(?:recipes/[a-z0-9_-]+/?|[a-z0-9-]+-recipe-\d+)$`,
+	"eatingwell.com":        `^/recipe/\d+/[a-z0-9-]+/?$`,
 }
 
 func init() {
@@ -183,7 +200,13 @@ var curatedAuthors = map[string]bool{
 	"sarah fennel":               true,
 	"gemma stafford":             true,
 	"chris scheuer":              true,
-	"ken tran":                   true,
+	"swasthi":                    true,
+	"james delmage":              true,
+	// Note: Woks of Life (Kaitlin, Sarah, Bill, Judy) and Feed the Pudge
+	// (Ken) use single first names as bylines. Not added here — too
+	// collision-prone with uncurated authors on other sites. author_trust
+	// is only 20% of the score; Tier 1 site_trust (0.9) + ratings carry
+	// these sites fine.
 }
 
 // AuthorTrust returns a trust score in [0,1] for the given author. Curated

--- a/library/food-and-dining/recipe-goat/internal/recipes/sites.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/sites.go
@@ -21,48 +21,81 @@ type Site struct {
 }
 
 // Sites is the built-in registry of recipe sources.
+//
+// Curation principle: the list optimizes for sites that reliably return
+// content to a Go HTTP client, not for sites with the highest traffic.
+// Mass-media-conglomerate sites that serve Cloudflare/Akamai bot
+// challenges (Dotdash Meredith, WBD, some Condé Nast properties) are
+// intentionally excluded from fan-out — users who want specific recipes
+// from those sites can still pass the URL to `recipe get`, which falls
+// back to archive.org when the live fetch is blocked.
+//
+// Removed from earlier versions: Food52, Food Network, Allrecipes,
+// Simply Recipes, EatingWell — all structurally blocked (403/429)
+// during testing in April 2026. Each has at least one comparable
+// replacement in the current list:
+//   - Food52 (editorial) → Bon Appétit, BBC Food
+//   - Food Network (celebrity chef) → chef-brand sites, BBC Food
+//   - Allrecipes (crowd-reviewed generic) → The Cozy Cook, Budget Bytes
+//   - Simply Recipes (generalist) → The Cozy Cook
+//   - EatingWell (healthy weeknight) → Skinnytaste
 var Sites = []Site{
-	// Tier 1 (trust 0.9)
+	// Tier 1 — independent, high-authority, reliably reachable.
 	{Name: "King Arthur Baking", Hostname: "kingarthurbaking.com", Tier: 1, SearchURL: "https://www.kingarthurbaking.com/search?f%5B0%5D=content_type%3Arecipe&q={q}", Trust: 0.9},
 	{Name: "Budget Bytes", Hostname: "budgetbytes.com", Tier: 1, SearchURL: "https://www.budgetbytes.com/?s={q}", Trust: 0.9},
 	{Name: "Smitten Kitchen", Hostname: "smittenkitchen.com", Tier: 1, SearchURL: "https://smittenkitchen.com/?s={q}", Trust: 0.9},
-	{Name: "Food52", Hostname: "food52.com", Tier: 1, SearchURL: "https://food52.com/recipes/search?q={q}", Trust: 0.9},
 	{Name: "BBC Good Food", Hostname: "bbcgoodfood.com", Tier: 1, SearchURL: "https://www.bbcgoodfood.com/search?q={q}", Trust: 0.9},
+	{Name: "BBC Food", Hostname: "bbc.co.uk", Tier: 1, SearchURL: "https://www.bbc.co.uk/food/search?q={q}", Trust: 0.9},
 	{Name: "Minimalist Baker", Hostname: "minimalistbaker.com", Tier: 1, SearchURL: "https://minimalistbaker.com/?s={q}", Trust: 0.9},
 	{Name: "Skinnytaste", Hostname: "skinnytaste.com", Tier: 1, SearchURL: "https://www.skinnytaste.com/?s={q}", Trust: 0.9},
 	{Name: "The Kitchn", Hostname: "thekitchn.com", Tier: 1, SearchURL: "https://www.thekitchn.com/search?q={q}", Trust: 0.9},
-	{Name: "Food Network", Hostname: "foodnetwork.com", Tier: 1, SearchURL: "https://www.foodnetwork.com/search/{q}-", Trust: 0.9},
+	{Name: "RecipeTin Eats", Hostname: "recipetineats.com", Tier: 1, SearchURL: "https://www.recipetineats.com/?s={q}", Trust: 0.9},
+	{Name: "The Woks of Life", Hostname: "thewoksoflife.com", Tier: 1, SearchURL: "https://thewoksoflife.com/?s={q}", Trust: 0.9},
+	{Name: "Just One Cookbook", Hostname: "justonecookbook.com", Tier: 1, SearchURL: "https://www.justonecookbook.com/?s={q}", Trust: 0.9},
+	{Name: "The Cozy Cook", Hostname: "thecozycook.com", Tier: 1, SearchURL: "https://thecozycook.com/?s={q}", Trust: 0.9},
 
-	// Tier 2 (trust 0.8)
+	// Tier 2 — brand/editorial authority, generally reachable but fragile
+	// (Condé Nast properties have started gating in recent quarters).
 	{Name: "Bon Appétit", Hostname: "bonappetit.com", Tier: 2, SearchURL: "https://www.bonappetit.com/search?q={q}", Trust: 0.8},
 	{Name: "Epicurious", Hostname: "epicurious.com", Tier: 2, SearchURL: "https://www.epicurious.com/search/{q}", Trust: 0.8},
+	{Name: "Gaz Oakley", Hostname: "gazoakleychef.com", Tier: 2, SearchURL: "https://www.gazoakleychef.com/?s={q}", Trust: 0.8},
 
-	// Tier 3 (trust 0.95 content, low reachability)
-	{Name: "Allrecipes", Hostname: "allrecipes.com", Tier: 3, SearchURL: "https://www.allrecipes.com/search?q={q}", Trust: 0.95},
-	{Name: "Simply Recipes", Hostname: "simplyrecipes.com", Tier: 3, SearchURL: "https://www.simplyrecipes.com/search?q={q}", Trust: 0.95},
-	{Name: "EatingWell", Hostname: "eatingwell.com", Tier: 3, SearchURL: "https://www.eatingwell.com/search?q={q}", Trust: 0.95},
+	// Tier 3 — high content trust but intermittent reachability; kept here
+	// because they still resolve today. Drop to opt-in if they start blocking.
 	{Name: "Serious Eats", Hostname: "seriouseats.com", Tier: 3, SearchURL: "https://www.seriouseats.com/search?q={q}", Trust: 0.95},
 }
 
 // recipeURLPatterns is a lookup of compiled per-host regexes for candidate
 // recipe-permalink paths. The Site.RecipeURLPattern field is populated from
 // this map at init() time. Keys are the Site.Hostname (www-stripped).
+// Patterns retained for removed sites (allrecipes, simplyrecipes,
+// eatingwell, foodnetwork, food52) so that users who pass those URLs to
+// `recipe get` still get correct site-level metadata (trust, tier).
+// They're just absent from Sites so fan-out skips them.
 var recipeURLPatterns = map[string]string{
 	"kingarthurbaking.com": `^/recipes/[a-z0-9-]+-recipe$`,
 	"budgetbytes.com":      `^/[a-z0-9-]{6,}/?$`,
 	"smittenkitchen.com":   `^/\d{4}/\d{2}/[a-z0-9-]+/?$`,
-	"food52.com":           `^/recipes/\d+-[a-z0-9-]+$`,
 	"bbcgoodfood.com":      `^/recipes/[a-z0-9-]+$`,
+	"bbc.co.uk":            `^/food/recipes/[a-z0-9_]+_\d+$`,
 	"minimalistbaker.com":  `^/[a-z0-9-]{6,}/?$`,
 	"skinnytaste.com":      `^/[a-z0-9-]{6,}/?$`,
 	"thekitchn.com":        `^/(?:.*-recipe-\d+|recipe-[a-z0-9-]+)$`,
-	"foodnetwork.com":      `^/recipes/[a-z0-9-/]+-recipe-\d+$`,
+	"recipetineats.com":    `^/[a-z0-9-]{6,}/?$`,
+	"thewoksoflife.com":    `^/[a-z0-9-]{6,}/?$`,
+	"justonecookbook.com":  `^/[a-z0-9-]{6,}/?$`,
+	"thecozycook.com":      `^/[a-z0-9-]{6,}/?$`,
+	"gazoakleychef.com":    `^/recipes/[a-z0-9-]+/?$`,
 	"bonappetit.com":       `^/recipe/[a-z0-9-]+$`,
 	"epicurious.com":       `^/recipes/food/views/[a-z0-9-]+$`,
-	"allrecipes.com":       `^/recipe/\d+/[a-z0-9-]+/?$`,
-	"simplyrecipes.com":    `^/(?:recipes/[a-z0-9_-]+/?|[a-z0-9-]+-recipe-\d+)$`,
-	"eatingwell.com":       `^/recipe/\d+/[a-z0-9-]+/?$`,
 	"seriouseats.com":      `^/[a-z0-9-]+-recipe(-\d+)?$`,
+
+	// Removed from fan-out but URLs still recognizable for `recipe get`:
+	"food52.com":        `^/recipes/\d+-[a-z0-9-]+$`,
+	"foodnetwork.com":   `^/recipes/[a-z0-9-/]+-recipe-\d+$`,
+	"allrecipes.com":    `^/recipe/\d+/[a-z0-9-]+/?$`,
+	"simplyrecipes.com": `^/(?:recipes/[a-z0-9_-]+/?|[a-z0-9-]+-recipe-\d+)$`,
+	"eatingwell.com":    `^/recipe/\d+/[a-z0-9-]+/?$`,
 }
 
 func init() {
@@ -129,6 +162,10 @@ var curatedAuthors = map[string]bool{
 	"beth moncel":                true,
 	"king arthur baking company": true,
 	"brian lagerstrom":           true,
+	"nagi maehashi":              true,
+	"namiko chen":                true,
+	"bill, judy, sarah, kaitlin": true,
+	"gaz oakley":                 true,
 }
 
 // AuthorTrust returns a trust score in [0,1] for the given author. Curated

--- a/library/food-and-dining/recipe-goat/internal/recipes/sites.go
+++ b/library/food-and-dining/recipe-goat/internal/recipes/sites.go
@@ -172,62 +172,13 @@ func BuildSearchURL(site Site, query string) string {
 	return r.Replace(site.SearchURL)
 }
 
-// curatedAuthors is a lowercase set of hand-picked recipe authors we trust
-// highly. Names are stored lowercased; lookup is case-insensitive.
-var curatedAuthors = map[string]bool{
-	"kenji lópez-alt":            true,
-	"kenji lopez-alt":            true,
-	"j. kenji lópez-alt":         true,
-	"j. kenji lopez-alt":         true,
-	"stella parks":               true,
-	"deb perelman":               true,
-	"samin nosrat":               true,
-	"ina garten":                 true,
-	"alton brown":                true,
-	"claire saffitz":             true,
-	"molly baz":                  true,
-	"carla lalli music":          true,
-	"budget bytes team":          true,
-	"beth moncel":                true,
-	"king arthur baking company": true,
-	"brian lagerstrom":           true,
-	"nagi maehashi":              true,
-	"namiko chen":                true,
-	"bill, judy, sarah, kaitlin": true,
-	"gaz oakley":                 true,
-	"john kanell":                true,
-	"sally mckenney":             true,
-	"sarah fennel":               true,
-	"gemma stafford":             true,
-	"chris scheuer":              true,
-	"swasthi":                    true,
-	"james delmage":              true,
-	// Note: Woks of Life (Kaitlin, Sarah, Bill, Judy) and Feed the Pudge
-	// (Ken) use single first names as bylines. Not added here — too
-	// collision-prone with uncurated authors on other sites. author_trust
-	// is only 20% of the score; Tier 1 site_trust (0.9) + ratings carry
-	// these sites fine.
-}
-
-// AuthorTrust returns a trust score in [0,1] for the given author. Curated
-// authors get 1.0; everyone else gets 0.5.
-func AuthorTrust(author string) float64 {
-	a := strings.ToLower(strings.TrimSpace(author))
-	if a == "" {
-		return 0.5
-	}
-	if curatedAuthors[a] {
-		return 1.0
-	}
-	return 0.5
-}
-
-// CuratedAuthors returns the curated list (for 'trust list' output). Names are
-// returned lowercased — callers can title-case them for display.
-func CuratedAuthors() []string {
-	out := make([]string, 0, len(curatedAuthors))
-	for a := range curatedAuthors {
-		out = append(out, a)
-	}
-	return out
-}
+// Author-trust scoring was removed in April 2026. The signal was largely
+// redundant with site curation: every Tier 1 site is an independent blog
+// where the author *is* the brand, and giving a bonus to named chefs on
+// top of site curation double-counted the signal. It also created
+// systematic noise — authors on curated sites whose byline format didn't
+// match the curated entry (e.g. "Sally" vs "Sally McKenney" in JSON-LD)
+// were silently penalized on their own blogs.
+//
+// If a cross-site author signal is reintroduced, prefer a boost tied to
+// authors who appear on 3+ distinct sites rather than a static list.


### PR DESCRIPTION
## What this does

Changes recipe-goat's approach to bot-detection from "battle through it" to "route around it, rescue only when the user explicitly wants a blocked URL."

Before: fan-out to 15 sites, 5 consistently blocked on Cloudflare/Akamai/Vercel, archive-fallback attempting to rescue every blocked request during search. Each `goat` query fired 5+ archive.org lookups just to handle the recurring structural blocks — expensive, flaky, and covering low-value scenarios (search-result listing pages have poor archive coverage anyway).

After: a 27-site corpus curated for reachability and cuisine-native authority, with archive.org fallback scoped to user-pasted URLs only (`recipe get <url>`). Fan-out queries no longer hit archive.org at all. Users who paste a specific allrecipes/food52 link still get archive rescue; users running cross-site search get faster results from a reliable pool.

## How each piece contributes

**Corpus curation carries most of the load.** Instead of fighting bot-detection on Dotdash Meredith / WBD / Condé Nast properties, the list prefers independent blogs that (a) reliably return content to a Go HTTP client, and (b) have cuisine-native authority. Removed 5 consistently-blocked sites (Food52, Food Network, Allrecipes, Simply Recipes, EatingWell) and added 11 new ones spanning American, British, Chinese (3), Japanese, Vietnamese, Italian, Indian (2), vegan, and baking (5 specialists) cuisines. URL patterns for the removed sites are retained so users pasting those links into `recipe get` still get correct site-level metadata.

**Archive.org fallback becomes a narrow rescue, not a routine scraper.** Wayback Machine lookups via the CDX Search API (`/cdx/search/cdx` rather than `/wayback/available` — the Availability API silently returns empty responses under throttle, indistinguishable from "no snapshot"). Scoped to `Fetch()` (recipe URL) only, removed from `FetchHTML()` (search endpoint) where archive coverage is sparse and the request budget is wasteful. 2-second package-level gap, identifying User-Agent (`recipe-goat-pp-cli/1.0`), HTTPS enforcement on snapshot URLs, scheme-stripped lookups for canonical indexing. 12 unit tests cover happy path, no-snapshot, 429 throttle, CDX API down, malformed JSON, snapshot 404, missing columns, and context cancellation.

**UA freshness matters more than expected.** During probing we discovered some sites block outdated Chrome UAs as a scraper heuristic — our prior `chromeUA` (Chrome/131, ~18 months stale) was being 403'd by sites that return 200 to Chrome/147. Consolidated the UA into a single exported constant (`recipes.ChromeUA`) used by both live fetch and doctor's health probe, so the two can't drift apart silently.

**Ranker simplified by removing author_trust.** The signal was a 0.20-weighted boost for ~30 curated chefs that made sense under the old corpus (when megapubs hosted mixed-quality content by many authors) but double-counted trust in the new corpus where every Tier 1 site is an independent blog and the author IS the brand. It was also doing active damage — authors whose JSON-LD byline didn't match their curated entry (Sally McKenney signs recipes as just "Sally"; Woks of Life signs as "Kaitlin"/"Sarah"/etc.) were silently penalized on their own sites. New formula: `0.55 × rating + 0.25 × reviews + 0.15 × site_trust + 0.05 × recency`.

## Before / after

**Doctor output:**
| | Before | After |
|---|---|---|
| Total sites | 15 | 27 |
| Reachable | 10 (5 WARN) | 26 (1 WARN) |
| Cuisines covered | Mostly American + British | +Chinese, Japanese, Vietnamese, Italian, Indian, vegan, baking specialists |

**Query quality** (`goat "chocolate chip cookies"`):
- Before: 21 candidates → top results from Bon Appétit
- After: 49 candidates → Sally's Baking Addiction, Broma Bakery, The Cafe Sucre Farine take top slots (baking-authority sites on a baking query)

**Query quality** (`goat "mapo tofu"`):
- Before: generic results from mixed-authority sites
- After: Just One Cookbook # 1-2 (authentic Japanese/Chinese), BBC Food # 4, The Woks of Life # 11 and # 13

**Archive rescue** (`recipe get https://www.allrecipes.com/recipe/10813/...`):
- Before: `Error: site blocked`
- After: content returned with `warn: archive fallback: <url> (wayback snapshot)` on stderr

## Test plan

- [x] `go test ./...` — 12 tests pass (added 8 new for CDX API flow)
- [x] `doctor` reports 26/27 reachable in a fresh session
- [x] `goat "chocolate chip cookies" --limit 5` returns baking-authority sites at top
- [x] `goat "mapo tofu" --limit 10` returns cuisine-native sites (Just One Cookbook, BBC Food, Woks of Life)
- [x] `recipe get <allrecipes-url>` rescues via archive fallback with stderr warning
- [x] `recipe get <budgetbytes-url>` live-fetches normally (no archive engagement)
- [x] Search fan-out with a blocked site (seriouseats) surfaces the block but no longer fires archive lookups

## Known follow-ups (separate work)

**Machine-level — generator templates hardcode stale Chrome UAs across every printed CLI.** Surfacing this as a retro finding in cli-printing-press; worth automating UA refresh quarterly, or at minimum deriving from a single generator-owned constant.

**Ranker relevance gap.** The current formula is popularity-dominated (ratings × reviews). It surfaces high-rated irrelevant recipes above lower-rated relevant ones — e.g., "Japanese Tofu Steak" ranks above direct mapo tofu recipes on a mapo tofu query because the former has 5.00/8 vs the latter's 4.76/9. A future PR could add a title-overlap relevance score before the popularity ranker takes over.

**Scrape-mitigations Phase 2 scope reduction.** The plan in `cli-printing-press/docs/plans/2026-04-13-002-feat-scrape-mitigations-plan.md` originally emphasized caching + retry + circuit breaker as urgent mitigations. With archive fallback now scoped to single-URL rescues (which fit archive.org's rate limits cleanly), most of that urgency drops. Cache layer is still worth doing for cookbook re-queries but can wait. Issue #217 tracks the observation window.

**Madewithlau / Archana's Kitchen / Omnivore's Cookbook** — all excluded from fan-out for different reasons (SPAs or Cloudflare-gated search). Their URL patterns are retained for `recipe get <url>` so users who paste specific URLs still get site-level metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)