### PR TITLE
fix(recipe-goat): remove stale "15 trusted sites" references in SKILL/README/help

### DIFF
--- a/library/food-and-dining/recipe-goat/README.md
+++ b/library/food-and-dining/recipe-goat/README.md
@@ -1,8 +1,8 @@
 # Recipe Goat CLI
 
-**Find the best version of any recipe across 15 trusted sites — then plan, shop, and cook with a local kitchen companion.**
+**Find the best version of any recipe across curated cuisine-authority sites — then plan, shop, and cook with a local kitchen companion.**
 
-Recipe GOAT aggregates 15 of the web's most trusted recipe sites (King Arthur, Serious Eats, Budget Bytes, Smitten Kitchen, Food52, BBC Good Food, and more), ranks results by merged trust + rating + review-count signals, and builds a local SQLite cookbook that powers pantry match, cook log, meal plans, and aisle-grouped shopping lists. Unique commands like `goat` (best-version ranker), `sub` (cross-site substitution aggregation), `tonight` (decision-fatigue killer), and `cookbook match --have` (pantry match) solve problems no single recipe site can.
+Recipe GOAT aggregates a curated set of independent, cuisine-authoritative recipe sites — Nagi (RecipeTin Eats), Swasthi (Indian Healthy Recipes), Elaine (China Sichuan Food), The Woks of Life, Just One Cookbook, Sally's Baking Addiction, King Arthur Baking, Budget Bytes, BBC Food, and more — ranks results by merged trust + rating + review-count signals, and builds a local SQLite cookbook that powers pantry match, cook log, meal plans, and aisle-grouped shopping lists. When users paste URLs from bot-detection-gated sites (allrecipes, food52, etc.), archive.org's Wayback Machine is used to recover the content. Unique commands like `goat` (best-version ranker), `sub` (cross-site substitution aggregation), `tonight` (decision-fatigue killer), and `cookbook match --have` (pantry match) solve problems no single recipe site can.
 
 ## Install
 
@@ -43,7 +43,7 @@ Verify with `recipe-goat-pp-cli doctor` — Auth should show `INFO Auth: optiona
 recipe-goat-pp-cli doctor
 
 
-# Rank the best version across 15 sites
+# Rank the best version across the curated corpus
 recipe-goat-pp-cli goat "chicken tikka masala" --limit 5
 
 
@@ -77,7 +77,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   recipe-goat-pp-cli goat "chicken tikka masala" --limit 5 --json
   ```
-- **`sub`** — Aggregate ingredient substitutions from King Arthur, Serious Eats, AllRecipes reviews, and Budget Bytes. Ranked by source trust with ratios and context.
+- **`sub`** — Aggregate ingredient substitutions from King Arthur Baking and other trusted baking-science sources. Ranked by source trust with ratios and context.
 
   _When a recipe needs a sub, agents can pick the best one given the cooking context (baking vs marinade) instead of suggesting the first hit on Google._
 
@@ -253,7 +253,8 @@ Environment variables:
 
 ### API-specific
 
-- **HTTP 402 or 403 on AllRecipes / Simply Recipes / EatingWell / Serious Eats fetches** — These are Dotdash Meredith sites with TLS-fingerprint bot detection. Run `recipe-goat-pp-cli doctor` to see per-site reachability. The CLI falls back to other sources automatically; your `goat` ranking will show results from reachable sites.
+- **HTTP 402 or 403 on AllRecipes / Simply Recipes / EatingWell / Food52 / FoodNetwork fetches** — These sites serve Cloudflare/Akamai bot-detection challenges to non-browser clients and are not in the default `goat` fan-out. When you paste a URL from one of them into `recipe get`, the CLI automatically falls back to archive.org's Wayback Machine and prints `warn: archive fallback: <url>` on stderr so you know the content came from an archived snapshot rather than live.
+- **HTTP 403 on Serious Eats fetches** — Still in the default corpus but intermittently Akamai-gated. Run `recipe-goat-pp-cli doctor` to see current reachability; your `goat` ranking still ranks across reachable sites.
 - **Nutrition missing or marked `[source: site]` with obviously wrong numbers** — Pass `--nutrition` to force USDA backfill. Requires USDA_FDC_API_KEY. Mark suspect recipes with `cookbook tag <id> nutrition-suspect`.
 - **`goat` query returns nothing** — Check `--site` filter if set. Try broader terms. Use `search --debug` to see per-site fetch attempts and which sites fell back to cache or failed.
 - **Shopping list has duplicate entries with different units** — Run `cookbook ingredients canonicalize` to re-run the parser. If an ingredient consistently fails, add to `~/.config/recipe-goat-pp-cli/ingredient-aliases.toml`.

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-recipe-goat
-description: "Find the best version of any recipe across 15 trusted sites — then plan, shop, and cook with a local kitchen companion. Trigger phrases: `find me the best recipe for`, `what can I make with`, `substitute for`, `plan meals for the week`, `shopping list from my meal plan`, `use recipe-goat`, `run recipe-goat`."
+description: "Find the best version of any recipe across curated cuisine-authority sites — then plan, shop, and cook with a local kitchen companion. Trigger phrases: `find me the best recipe for`, `what can I make with`, `substitute for`, `plan meals for the week`, `shopping list from my meal plan`, `use recipe-goat`, `run recipe-goat`."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata: '{"openclaw":{"requires":{"bins":["recipe-goat-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat-pp-cli/cmd/recipe-goat-pp-cli@latest","bins":["recipe-goat-pp-cli"],"label":"Install via go install"}]}}'
@@ -8,7 +8,7 @@ metadata: '{"openclaw":{"requires":{"bins":["recipe-goat-pp-cli"]},"install":[{"
 
 # Recipe Goat — Printing Press CLI
 
-Recipe GOAT aggregates 15 of the web's most trusted recipe sites (King Arthur, Serious Eats, Budget Bytes, Smitten Kitchen, Food52, BBC Good Food, and more), ranks results by merged trust + rating + review-count signals, and builds a local SQLite cookbook that powers pantry match, cook log, meal plans, and aisle-grouped shopping lists. Unique commands like `goat` (best-version ranker), `sub` (cross-site substitution aggregation), `tonight` (decision-fatigue killer), and `cookbook match --have` (pantry match) solve problems no single recipe site can.
+Recipe GOAT aggregates a curated set of independent, cuisine-authoritative recipe sites — Nagi (RecipeTin Eats), Swasthi (Indian Healthy Recipes), Elaine (China Sichuan Food), The Woks of Life, Just One Cookbook, Sally's Baking Addiction, King Arthur Baking, Budget Bytes, BBC Food, and more — ranks results by merged trust + rating + review-count signals, and builds a local SQLite cookbook that powers pantry match, cook log, meal plans, and aisle-grouped shopping lists. When users paste URLs from bot-detection-gated sites (allrecipes, food52, etc.), archive.org's Wayback Machine is used to recover the content. Unique commands like `goat` (best-version ranker), `sub` (cross-site substitution aggregation), `tonight` (decision-fatigue killer), and `cookbook match --have` (pantry match) solve problems no single recipe site can.
 
 ## When to Use This CLI
 
@@ -27,7 +27,7 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   recipe-goat-pp-cli goat "chicken tikka masala" --limit 5 --json
   ```
-- **`sub`** — Aggregate ingredient substitutions from King Arthur, Serious Eats, AllRecipes reviews, and Budget Bytes. Ranked by source trust with ratios and context.
+- **`sub`** — Aggregate ingredient substitutions from King Arthur Baking and other trusted baking-science sources. Ranked by source trust with ratios and context.
 
   _When a recipe needs a sub, agents can pick the best one given the cooking context (baking vs marinade) instead of suggesting the first hit on Google._
 
@@ -112,7 +112,7 @@ These capabilities aren't available in any other tool for this API.
 recipe-goat-pp-cli goat "carbonara" --limit 5
 ```
 
-Query 15 sites, return the top 5 ranked by trust + rating + reviews with source attribution.
+Query the curated corpus, return the top 5 ranked by trust + rating + reviews with source attribution.
 
 ### Save and tag for weeknight
 

--- a/library/food-and-dining/recipe-goat/internal/cli/recipe_cmd.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/recipe_cmd.go
@@ -16,7 +16,7 @@ import (
 func newRecipeCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "recipe",
-		Short:   "Fetch, open, and inspect recipes from 15 trusted sites",
+		Short:   "Fetch, open, and inspect recipes from curated sites",
 		Long:    "Subcommands to fetch a recipe by URL, open a saved recipe in the browser, or inspect reviews/cost.",
 		Example: "  recipe-goat-pp-cli recipe get https://www.seriouseats.com/the-best-chili-recipe",
 	}

--- a/library/food-and-dining/recipe-goat/internal/cli/root.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/root.go
@@ -10,9 +10,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var version = "1.0.0"
@@ -41,12 +41,12 @@ func Execute() error {
 
 	rootCmd := &cobra.Command{
 		Use:   "recipe-goat-pp-cli",
-		Short: `Recipe Goat CLI — Find the best version of any recipe across 15 trusted sites — then plan, shop, and cook with a local kitchen companion.`,
-		Long: `Recipe Goat CLI — Find the best version of any recipe across 15 trusted sites — then plan, shop, and cook with a local kitchen companion.
+		Short: `Recipe Goat CLI — Find the best version of any recipe across curated sites — then plan, shop, and cook with a local kitchen companion.`,
+		Long: `Recipe Goat CLI — Find the best version of any recipe across curated sites — then plan, shop, and cook with a local kitchen companion.
 
 Highlights (not in the official API docs):
-  • goat   Query any dish across 15 trusted recipe sites and rank results by normalized ra…
-  • sub   Aggregate ingredient substitutions from King Arthur, Serious Eats, AllRecipes r…
+  • goat   Query any dish across curated recipe sites and rank results by normalized ra…
+  • sub   Aggregate ingredient substitutions from King Arthur, Serious Eats, and Budge…
   • cookbook match   Find recipes in the local cookbook that you can make right now with listed ingr…
   • tonight   Pick dinner in 2 seconds: filter cookbook by time budget, recency from cook log…
   • recipe reviews   Surface the top modifications cooks actually made to a recipe ("added an egg: 2…

--- a/library/food-and-dining/recipe-goat/internal/mcp/tools.go
+++ b/library/food-and-dining/recipe-goat/internal/mcp/tools.go
@@ -282,7 +282,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	ctx := map[string]any{
 		"api":         "recipe-goat",
-		"description": "Recipe GOAT — find the best version of any recipe across 15 trusted sites, with offline cookbook, pantry match,...",
+		"description": "Recipe GOAT — find the best version of any recipe across curated sites, with offline cookbook, pantry match,...",
 		"archetype":   "generic",
 		"tool_count":  3,
 		"auth": map[string]any{


### PR DESCRIPTION
## What this does

Follow-up to PR #69 (merged). That PR rebalanced the corpus to 27 cuisine-authority sites and added archive fallback for user-pasted URLs, but several user-facing surfaces still said "15 trusted sites" and referenced removed sites (Food52, AllRecipes). This PR fixes those.

## Why it matters

The stale copy was load-bearing in three ways:

1. **SKILL.md trigger description** is what the agent sees when deciding whether to invoke the skill — it needs to reflect actual capability (cuisine-authority corpus + archive rescue), not the old single-sentence positioning.
2. **`recipe-goat-pp-cli --help`** output (from `root.go`) is the first thing new users see — describing 15 sites when `doctor` shows 27 confuses more than it orients.
3. **Troubleshooting guidance for HTTP 402/403** previously said "falls back to other sources" — but after PR #69 the actual mechanism is archive.org Wayback fallback scoped to `recipe get <url>`. Users hitting that error deserve to know what's happening.

## What changed

| Surface | Before | After |
|---|---|---|
| SKILL.md frontmatter description | "across 15 trusted sites" | "across curated cuisine-authority sites" |
| SKILL.md + README.md intro paragraph | Fabricated "15 of the web's most trusted" + named Food52 (removed) | Names the actual cuisine authorities (Nagi, Swasthi, Elaine, Woks of Life, Just One Cookbook, etc.) + mentions archive fallback |
| SKILL.md + README.md `sub` description | "King Arthur, Serious Eats, AllRecipes reviews, Budget Bytes" | "King Arthur Baking and other trusted baking-science sources" |
| README.md troubleshooting entry | "CLI falls back to other sources automatically" (wrong) | Explains the Wayback archive fallback + the `warn: archive fallback:` stderr signal |
| `root.go` Short + Long help text | "15 trusted sites" | "curated sites" |
| `recipe_cmd.go` Short | "from 15 trusted sites" | "from curated sites" |
| `internal/mcp/tools.go` description | "across 15 trusted sites" | "across curated sites" |

Historical manuscripts in `.manuscripts/` deliberately left unchanged — they're archived research from generation time.

## Test plan

- [x] `go build ./...` — success
- [x] `go test ./...` — all tests pass
- [x] `recipe-goat-pp-cli --help` reads coherently with current doctor output (27 sites)
- [x] No remaining hits for `grep -rn "15 trusted"` in non-manuscript files

🤖 Generated with [Claude Code](https://claude.com/claude-code)