### PR TITLE
docs: refresh Movie GOAT README and SKILL

### DIFF
--- a/library/media-and-entertainment/movie-goat/README.md
+++ b/library/media-and-entertainment/movie-goat/README.md
@@ -1,8 +1,16 @@
 # Movie Goat CLI
 
-The only movie CLI with multi-source ratings (TMDb + IMDb + Rotten Tomatoes + Metacritic), streaming availability, and cross-taste recommendations. Powered by TMDb and OMDb.
+**Find the best thing to watch with one CLI for multi-source ratings, streaming availability, franchise planning, and taste-bridging recommendations.**
 
-Look up any movie and see ratings from four sources in one view. Find where to stream it. Get recommendations by telling it movies you like. Plan a franchise marathon. Discover hidden gems by genre and decade. Compare two movies head-to-head.
+Movie GOAT combines TMDb discovery, search, credits, collections, and watch-provider data with optional OMDb enrichment so one tool can answer practical movie-night questions fast:
+
+- "What should I watch tonight?"
+- "Which movie actually wins when I compare them side by side?"
+- "Where can I stream this in the US or another region?"
+- "What bridges the gap between my partner's taste and mine?"
+- "How long would a full franchise marathon take?"
+
+It also keeps a local SQLite archive for offline search and analytics, so the CLI is useful both as an interactive tool and as a reusable data source for scripts and agents.
 
 ## Install
 
@@ -16,294 +24,406 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
 
-## Authentication
+## Required: TMDb API key
 
-Get a free TMDb API key at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api), then set it:
+**All core commands require TMDb credentials.**
+
+### What the key unlocks
+
+TMDb powers the main CLI experience:
+
+- `movies get`, `movies search`, `tv get`, `tv search`
+- `watch` for region-specific streaming, rental, and purchase options
+- `tonight`, `blind`, `discover`, and `trending`
+- `recommend-for-me`, `versus`, `career`, and `marathon`
+- `sync`, `search`, and `analytics` against a local archive
+
+### Get a key
+
+1. Create a free account at https://www.themoviedb.org/.
+2. Request an API key or read token at https://www.themoviedb.org/settings/api.
+3. Export it:
 
 ```bash
-export TMDB_API_KEY="your-api-key"
+export TMDB_API_KEY="<your-key>"
 ```
 
-Or store it persistently:
+Or persist credentials in the CLI config:
 
 ```bash
-movie-goat-pp-cli auth set-token YOUR_API_KEY
+movie-goat-pp-cli auth set-token <your-key>
 ```
 
-### OMDb (optional — enables Rotten Tomatoes & Metacritic)
-
-OMDb provides Rotten Tomatoes and Metacritic ratings that TMDb doesn't have. Without it, everything works — you just see TMDb ratings only. With it, `movies get`, `versus`, and other commands show all four rating sources.
-
-Get a free key (1,000 requests/day) at [omdbapi.com/apikey.aspx](http://www.omdbapi.com/apikey.aspx). For heavier use, [Patreon supporters](https://www.patreon.com/join/omdb) get 100,000 requests/day starting at $1/month.
+Verify with:
 
 ```bash
-export OMDB_API_KEY="your-omdb-key"
+movie-goat-pp-cli doctor
 ```
+
+`Auth` should move from `not configured` to `configured`.
+
+## Optional: OMDb API key
+
+**Movie GOAT works without OMDb.** OMDb adds the extra ratings and metadata that TMDb does not provide directly.
+
+### What the key unlocks
+
+When `OMDB_API_KEY` is set, Movie GOAT can enrich results with:
+
+- IMDb rating
+- Rotten Tomatoes score
+- Metacritic score
+- awards
+- box office
+
+This matters most for:
+
+- `movies get`
+- `blind`
+- `versus`
+
+### Get a key
+
+Get a free key at http://www.omdbapi.com/apikey.aspx.
+
+```bash
+export OMDB_API_KEY="<your-omdb-key>"
+```
+
+If you do not set it, the CLI still works. You just get TMDb-only results where OMDb enrichment would otherwise appear.
 
 ## Quick Start
 
 ```bash
-# Check your setup
+# Check config, auth, and API reachability
 movie-goat-pp-cli doctor
 
 # What should I watch tonight?
 movie-goat-pp-cli tonight
 
-# Random surprise pick
+# Random sci-fi pick above 7.5/10
 movie-goat-pp-cli blind --genre 878 --min-rating 7.5
 
 # Compare two movies head-to-head
 movie-goat-pp-cli versus "The Dark Knight" "Inception"
 
-# Where can I stream this?
-movie-goat-pp-cli watch "Breaking Bad" --type tv
+# Find where to stream a show
+movie-goat-pp-cli watch "Breaking Bad" --type tv --region US
+
+# Get recommendations from multiple taste anchors
+movie-goat-pp-cli recommend-for-me "Parasite" "Oldboy" "The Handmaiden"
+
+# Plan a franchise marathon
+movie-goat-pp-cli marathon "Lord of the Rings"
+
+# Build a local archive for offline search
+movie-goat-pp-cli sync
+movie-goat-pp-cli search "time travel" --data-source local
 ```
 
 ## Unique Features
 
-These capabilities aren't available in any other tool for this API.
+These are the workflows that make Movie GOAT more useful than a thin TMDb wrapper.
 
-- **`movies get`** -- See TMDb, IMDb, Rotten Tomatoes, and Metacritic ratings for any movie in one view
-- **`watch`** -- Find every streaming platform, rental option, and purchase option for any movie or show
-- **`career`** -- Explore any actor or director's complete filmography with ratings and career trajectory
-- **`tonight`** -- Get a smart recommendation for what to watch tonight based on trending and your streaming services
-- **`versus`** -- Compare two movies or shows side-by-side across every metric: ratings, cast, box office, streaming
-- **`marathon`** -- Plan a franchise movie marathon with watch order, total runtime, and suggested breaks
+### `movies get`
+
+Get a movie's core record plus appended credits, videos, recommendations, watch providers, and external IDs. With OMDb configured, the command can also attach IMDb, Rotten Tomatoes, and Metacritic ratings in the same result.
+
+_Use this when you need one canonical view of a movie instead of checking TMDb, IMDb, and streaming apps separately._
+
+```bash
+movie-goat-pp-cli movies get 550
+movie-goat-pp-cli movies get 550 --json
+```
+
+### `watch`
+
+Look up where a movie or TV show is available to stream, rent, buy, or watch free with ads in a specific region.
+
+_Useful when the real question is not "is this good?" but "can I actually watch it tonight in my country?"_
+
+```bash
+movie-goat-pp-cli watch "Inception" --region US
+movie-goat-pp-cli watch "Breaking Bad" --type tv --region GB
+```
+
+### `recommend-for-me`
+
+Takes two or more movies you already love, fetches recommendations and similars for each, then scores candidates by how well they bridge the input tastes.
+
+_This is stronger than "more like this" because it tries to find overlap across multiple taste anchors instead of extending a single seed._
+
+```bash
+movie-goat-pp-cli recommend-for-me "The Matrix" "Mad Max: Fury Road" "Arrival"
+```
+
+### `versus`
+
+Compares two movies side by side across ratings, runtime, genres, streaming, and, when OMDb is configured, additional review-score and box-office context.
+
+_Use this when you are deciding between two options and want a direct answer, not two disconnected pages._
+
+```bash
+movie-goat-pp-cli versus "Barbie" "Oppenheimer"
+```
+
+### `blind`
+
+The "surprise me" command. It discovers a random well-rated movie using filters for genre, decade, minimum rating, and streaming provider.
+
+_Good when the bottleneck is decision fatigue, not lack of options._
+
+```bash
+movie-goat-pp-cli blind --genre 35 --decade 1990s --min-rating 7.0
+```
+
+### `tonight`
+
+Builds a short ranked list from trending and popular titles, then sorts by a weighted popularity and rating score.
+
+_This is the fast answer to "just give me a few strong picks right now."_
+
+```bash
+movie-goat-pp-cli tonight
+movie-goat-pp-cli tonight --type tv
+movie-goat-pp-cli tonight --genre 28
+```
+
+### `career`
+
+Looks up a person's combined credits and turns them into a sortable filmography with summary stats.
+
+_Useful for questions like "what are this director's best-rated works?" or "what was their busiest period?"_
+
+```bash
+movie-goat-pp-cli career "Denis Villeneuve" --sort rating
+```
+
+### `marathon`
+
+Finds a TMDb collection, orders the films by release date, totals runtime, and suggests break points.
+
+_Great for franchise planning because it turns "should we do this?" into a concrete time commitment._
+
+```bash
+movie-goat-pp-cli marathon "Harry Potter"
+```
+
+### `sync` + `search` + `analytics`
+
+Movie GOAT can archive TMDb data locally into SQLite, then search it with FTS and run simple analytics on top.
+
+_This is what turns the CLI from a one-shot API client into a reusable local movie dataset._
+
+```bash
+movie-goat-pp-cli sync
+movie-goat-pp-cli search "time travel" --data-source local
+movie-goat-pp-cli analytics --json
+```
+
+## Usage
+
+Run `movie-goat-pp-cli --help` for the full command tree and all flags.
 
 ## Commands
 
-### Discovery and Recommendations
+### Discovery and recommendations
 
 | Command | Description |
-|---------|-------------|
-| `tonight` | Smart "what should I watch tonight?" recommendation |
-| `blind` | Random high-quality movie pick with genre, decade, and streaming filters |
-| `recommend-for-me` | Consensus recommendations based on movies you love |
-| `discover` | Discover movies by genre, year, rating, certification, cast, crew, streaming provider |
-| `discover tv` | Discover TV shows by genre, year, rating, network, streaming provider |
-| `trending` | Trending movies, TV shows, and people |
+| --- | --- |
+| `tonight` | Shortlist strong picks for tonight |
+| `blind` | Random high-quality movie pick with filters |
+| `recommend-for-me` | Blend multiple favorites into one recommendation set |
+| `discover` | Discover movies with genre, year, rating, certification, and provider filters |
+| `discover tv` | Discover TV shows with TV-specific filters |
+| `trending` | Trending movies, TV, and people |
 
-### Movies
+### Title and person lookup
 
 | Command | Description |
-|---------|-------------|
-| `movies get <id>` | Full movie detail with cast, ratings, streaming, and recommendations |
+| --- | --- |
+| `movies get <id>` | Detailed movie record with appended context |
 | `movies search <query>` | Search movies by title |
-| `movies now-playing` | Movies currently in theaters |
-| `movies upcoming` | Movies coming soon |
-| `movies top-rated` | Highest rated movies |
-
-### TV Shows
-
-| Command | Description |
-|---------|-------------|
-| `tv get <id>` | Full TV show detail |
+| `movies now-playing` | Movies in theaters now |
+| `movies upcoming` | Upcoming movies |
+| `movies top-rated` | Top-rated movies |
+| `tv get <id>` | Detailed TV show record |
 | `tv search <query>` | Search TV shows by title |
-| `tv airing-today` | Shows with episodes airing today |
+| `tv airing-today` | Shows airing today |
 | `tv on-the-air` | Shows currently on the air |
-| `tv top-rated` | Highest rated TV shows |
-
-### People
-
-| Command | Description |
-|---------|-------------|
-| `people` | Popular people in entertainment |
-| `people get <id>` | Person detail with filmography |
+| `tv top-rated` | Top-rated TV shows |
+| `people` | Popular people |
+| `people get <id>` | Person detail |
 | `people search <query>` | Search people by name |
-| `career <name-or-id>` | Full career filmography with stats and highlights |
+| `career <name-or-id>` | Full career summary and filmography |
 
-### Comparison and Planning
-
-| Command | Description |
-|---------|-------------|
-| `versus <title1> <title2>` | Side-by-side comparison of two movies |
-| `marathon <collection>` | Franchise marathon planner with watch order and runtime |
-| `watch <title-or-id>` | Streaming availability by region |
-
-### Data and Utilities
+### Planning and comparison
 
 | Command | Description |
-|---------|-------------|
-| `search <query>` | Full-text search across synced data or live API |
-| `sync` | Sync API data to local SQLite for offline search |
-| `analytics` | Analyze synced data with count, group-by, and summary |
-| `export` | Export data to JSONL or JSON |
-| `import` | Import data from JSONL file |
-| `genres` | Genre lists for movies and TV |
-| `doctor` | Check CLI health, auth, and API connectivity |
-| `auth` | Manage authentication tokens |
+| --- | --- |
+| `watch <title-or-id>` | Watch providers by region |
+| `versus <title1> <title2>` | Side-by-side movie comparison |
+| `marathon <collection>` | Franchise marathon planner |
+
+### Local archive and power-user tools
+
+| Command | Description |
+| --- | --- |
+| `sync` | Archive API data to local SQLite |
+| `search <query>` | Search live API or local archive |
+| `analytics` | Summaries over synced local data |
+| `workflow archive` | Sync all resources for offline access |
+| `workflow status` | Show local archive status |
+| `export` | Export API data to JSONL or JSON |
+| `import` | Import JSONL via API create/upsert calls |
+| `tail <resource>` | Poll a resource and emit NDJSON events |
+| `api` | Browse raw interface coverage |
+| `doctor` | Check config, auth, and API reachability |
+| `auth` | Show, set, or clear credentials |
 
 ## Output Formats
 
 ```bash
-# Human-readable table (default in terminal, JSON when piped)
+# Human-readable output in a terminal
 movie-goat-pp-cli trending movies
 
 # JSON for scripting and agents
 movie-goat-pp-cli trending movies --json
 
-# Filter to specific fields
-movie-goat-pp-cli trending movies --json --select title,vote_average
+# Select only the fields you need
+movie-goat-pp-cli trending movies --json --select id,title,vote_average
 
 # CSV output
 movie-goat-pp-cli trending movies --csv
 
-# Compact output (key fields only, minimal tokens)
+# Plain tab-separated text
+movie-goat-pp-cli trending movies --plain
+
+# Compact output for lower token usage
 movie-goat-pp-cli trending movies --compact
 
-# Dry run -- show the request without sending
+# Show the request without sending it
 movie-goat-pp-cli movies get 550 --dry-run
 
-# Agent mode -- JSON + compact + no prompts in one flag
+# Force local or live reads
+movie-goat-pp-cli search "noir" --data-source local
+movie-goat-pp-cli search "noir" --data-source live
+
+# Agent mode = --json --compact --no-input --no-color --yes
 movie-goat-pp-cli tonight --agent
 ```
 
 ## Agent Usage
 
-This CLI is designed for AI agent consumption:
+This CLI is designed to behave well in scripts, MCP clients, and non-interactive agent runs:
 
-- **Non-interactive** -- never prompts, every input is a flag
-- **Pipeable** -- `--json` output to stdout, errors to stderr
-- **Filterable** -- `--select id,name` returns only fields you need
-- **Previewable** -- `--dry-run` shows the request without sending
-- **Confirmable** -- `--yes` for explicit confirmation of destructive actions
-- **Cacheable** -- GET responses cached for 5 minutes, bypass with `--no-cache`
-- **Agent-safe by default** -- no colors or formatting unless `--human-friendly` is set
-- **Progress events** -- paginated commands emit NDJSON events to stderr
+- Non-interactive: every input can be provided via args, flags, or stdin
+- Pipeable: data goes to stdout, operational messages go to stderr
+- Filterable: `--select` reduces payload size
+- Compactable: `--compact` keeps only key fields
+- Previewable: `--dry-run` shows the request shape without sending it
+- Cacheable: GET requests are cached unless `--no-cache` is set
+- Source-aware: `--data-source auto|live|local` makes live/local behavior explicit
+- Agent mode: `--agent` bundles the sane defaults for machine consumption
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
 
 ## Use as MCP Server
 
-This CLI ships a companion MCP server for use with Claude Desktop, Cursor, and other MCP-compatible tools.
+This project also ships a companion MCP server.
 
 ### Claude Code
 
 ```bash
-claude mcp add movie movie-goat-pp-mcp -e TMDB_API_KEY=<your-token>
+claude mcp add movie-goat movie-goat-pp-mcp -e TMDB_API_KEY=<your-key>
 ```
+
+If you want OMDb enrichment there too, add `-e OMDB_API_KEY=<your-omdb-key>` as well.
 
 ### Claude Desktop
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
-    "movie": {
+    "movie-goat": {
       "command": "movie-goat-pp-mcp",
       "env": {
-        "TMDB_API_KEY": "<your-key>"
+        "TMDB_API_KEY": "<your-key>",
+        "OMDB_API_KEY": "<optional-omdb-key>"
       }
     }
   }
 }
 ```
 
-## Cookbook
-
-```bash
-# What should I watch tonight?
-movie-goat-pp-cli tonight
-
-# Tonight picks filtered to sci-fi
-movie-goat-pp-cli tonight --genre 878
-
-# Random surprise movie
-movie-goat-pp-cli blind --min-rating 7.5
-
-# Random 90s comedy on Netflix
-movie-goat-pp-cli blind --genre 35 --decade 1990s --streaming 8
-
-# Compare two movies side-by-side
-movie-goat-pp-cli versus "Barbie" "Oppenheimer"
-
-# Plan a Lord of the Rings marathon
-movie-goat-pp-cli marathon "Lord of the Rings"
-
-# Where to stream a specific movie
-movie-goat-pp-cli watch "Inception" --region US
-
-# Full career of a director, sorted by rating
-movie-goat-pp-cli career "Denis Villeneuve" --sort rating
-
-# Get recommendations based on your favorites
-movie-goat-pp-cli recommend-for-me "Parasite" "Oldboy" "The Handmaiden"
-
-# Discover highly-rated action movies from 2024
-movie-goat-pp-cli discover --with-genres 28 --primary-release-year 2024 --vote-average-gte 7.0
-
-# Find all R-rated horror
-movie-goat-pp-cli discover --with-genres 27 --certification R --certification-country US
-
-# Sync data for offline search
-movie-goat-pp-cli sync
-
-# Search synced data
-movie-goat-pp-cli search "time travel"
-
-# Export trending movies as JSONL for scripting
-movie-goat-pp-cli trending movies --json | jq -c '.[]'
-```
-
 ## Health Check
 
 ```bash
-$ movie-goat-pp-cli doctor
-  OK Config: ok
-  FAIL Auth: not configured
-  OK API: reachable
-  config_path: /Users/you/.config/movie-goat-pp-cli/config.toml
-  base_url: https://api.themoviedb.org/3
-  version: 1.0.0
-  hint: export TMDB_API_KEY=<your-key>
-  Get a key at: https://www.themoviedb.org/settings/api
+movie-goat-pp-cli doctor
 ```
+
+This verifies:
+
+- config loading
+- auth presence
+- API reachability
+- version
 
 ## Configuration
 
-Config file: `~/.config/movie-goat-pp-cli/config.toml`
+Config file:
+
+```text
+~/.config/movie-goat-pp-cli/config.toml
+```
+
+Local archive database:
+
+```text
+~/.local/share/movie-goat-pp-cli/data.db
+```
 
 Environment variables:
 
-| Variable | Description |
-|----------|-------------|
-| `TMDB_API_KEY` | TMDb API key (required) |
-| `OMDB_API_KEY` | OMDb API key (optional, enables multi-source ratings) |
-| `MOVIE_GOAT_BASE_URL` | Override API base URL (for self-hosted or testing) |
-| `MOVIE_GOAT_CONFIG` | Override config file path |
+- `TMDB_API_KEY`
+- `OMDB_API_KEY`
+- `MOVIE_GOAT_CONFIG`
+- `MOVIE_GOAT_BASE_URL`
 
 ## Troubleshooting
 
-**Authentication errors (exit code 4)**
-- Run `movie-goat-pp-cli doctor` to check credentials
-- Verify the environment variable is set: `echo $TMDB_API_KEY`
-- Get a key at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api)
+**`doctor` says auth is not configured**
 
-**Not found errors (exit code 3)**
-- Check the resource ID is correct
-- Try searching by name instead of ID: `movie-goat-pp-cli movies search "title"`
+- Export `TMDB_API_KEY`
+- Or run `movie-goat-pp-cli auth set-token <your-key>`
+- Re-run `movie-goat-pp-cli doctor`
 
-**Rate limit errors (exit code 7)**
-- The CLI auto-retries with exponential backoff
-- Use `--rate-limit 2` to throttle requests
-- If persistent, wait a few minutes and try again
+**I only see TMDb ratings**
 
-**Config errors (exit code 10)**
-- Check config file syntax: `cat ~/.config/movie-goat-pp-cli/config.toml`
-- Reset with `movie-goat-pp-cli auth set-token YOUR_KEY`
+- Set `OMDB_API_KEY`
+- Re-run `movies get`, `blind`, or `versus`
+- If the title has no IMDb mapping, OMDb enrichment may still be unavailable
 
----
+**`watch` returns no providers for my region**
 
-## Sources & Inspiration
+- Try another region with `--region`, for example `US`, `GB`, or `DE`
+- Some titles have provider data only for a subset of regions
 
-This CLI was built by studying these projects and resources:
+**Local search fails**
 
-- [**tmdb-mcp**](https://github.com/xdwanj/tmdb-mcp) -- Go
-- [**imdb-mcp-server**](https://github.com/uzaysozen/imdb-mcp-server) -- Python
-- [**mediascore**](https://github.com/dkorunic/mediascore) -- Go
-- [**TMDB_CLI**](https://github.com/illegalbyte/TMDB_CLI) -- Python
-- [**tmdb-cli (bhantsi)**](https://github.com/bhantsi/tmdb-cli) -- JavaScript
-- [**imdb-rename**](https://github.com/BurntSushi/imdb-rename) -- Rust
+- Run `movie-goat-pp-cli sync` first
+- Then search with `--data-source local`
+- Confirm the DB exists at `~/.local/share/movie-goat-pp-cli/data.db`
 
-Generated by [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press)
+**Search results are inconsistent**
+
+- `--data-source auto` prefers live API search and falls back to local on network failure
+- Use `--data-source live` or `--data-source local` when you need deterministic behavior
+
+**You are hitting API limits or repeated network failures**
+
+- Reduce request volume
+- Use the built-in cache instead of `--no-cache`
+- Use `--rate-limit` for gentler scripted runs

--- a/library/media-and-entertainment/movie-goat/SKILL.md
+++ b/library/media-and-entertainment/movie-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-movie-goat
-description: "Use this skill whenever the user asks about movies, TV shows, actors, directors, ratings, where to stream something, what to watch tonight, franchise marathons, hidden gems, or cross-taste recommendations. Multi-source movie CLI combining TMDb + OMDb for ratings from four critics at once plus streaming availability. Requires a free TMDb API key. Triggers on phrasings like 'what should I watch tonight', 'where can I stream Oppenheimer', 'compare Dune and Blade Runner', 'best movies from Denis Villeneuve', 'plan a Marvel marathon', 'what's trending on TMDb this week'."
+description: "Find what to watch with Movie GOAT: movie and TV lookup, region-specific streaming availability, side-by-side comparisons, franchise marathons, people filmographies, and taste-bridging recommendations. Use when the user asks what to watch tonight, where something streams, how two movies compare, what else they might like based on favorites, or wants movie/TV data from TMDb with optional OMDb enrichment."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata: '{"openclaw":{"requires":{"bins":["movie-goat-pp-cli"],"env":["TMDB_API_KEY"]},"primaryEnv":"TMDB_API_KEY","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest","bins":["movie-goat-pp-cli"],"label":"Install via go install"}]}}'
@@ -8,105 +8,179 @@ metadata: '{"openclaw":{"requires":{"bins":["movie-goat-pp-cli"],"env":["TMDB_AP
 
 # Movie Goat — Printing Press CLI
 
-Multi-source movie ratings (TMDb + OMDb), streaming availability, and cross-taste recommendations. Look up any movie and see ratings from four sources in one view. Find where to stream it. Get recommendations by telling the CLI movies you love. Plan a franchise marathon with total runtime. Discover hidden gems by genre and decade. Compare two movies head-to-head.
+Movie GOAT is a movie and TV CLI built on TMDb, with optional OMDb enrichment for extra ratings and metadata. It is strongest when the user needs one of these workflows:
+
+- a fast shortlist for tonight
+- where a movie or show streams in a specific region
+- a direct side-by-side comparison between two movies
+- recommendations that bridge multiple favorites
+- a franchise marathon plan with total runtime
+- a sortable filmography for an actor or director
+
+It can also sync data into a local SQLite archive for offline search and analytics.
 
 ## When to Use This CLI
 
-Reach for this when a user wants movie or TV information — ratings, where to watch, recommendations, franchise planning, or cross-comparisons — and prefers a terminal-native flow over opening IMDB/Rotten Tomatoes/Letterboxd tabs one by one. Particularly valuable when a user can express taste as "I liked X and Y" and wants suggestions that bridge those.
+Use Movie GOAT when the user asks about:
 
-Don't reach for this if the user wants real-time reviews from a specific critic (Roger Ebert etc.) or currently-showing-in-theaters data beyond what TMDb's release-date feeds provide.
+- movies or TV shows
+- ratings or cross-source score comparisons
+- streaming, rental, or purchase availability
+- actors, directors, and filmographies
+- what to watch next
+- franchise watch order or marathon planning
+- discovering titles by genre, year, rating, or provider
+
+Do not use it when the user specifically needs:
+
+- current critic-review text from a named publication or critic
+- theatrical showtimes by local theater
+- live box-office reporting beyond what OMDb/TMDb metadata can provide
+
+## Best Command Mapping
+
+- "What should I watch tonight?" → `movie-goat-pp-cli tonight --agent`
+- "Give me a random good sci-fi movie" → `movie-goat-pp-cli blind --genre 878 --min-rating 7.5 --agent`
+- "Where can I stream Oppenheimer?" → `movie-goat-pp-cli watch "Oppenheimer" --region US --agent`
+- "Compare Dune and Blade Runner 2049" → `movie-goat-pp-cli versus "Dune" "Blade Runner 2049" --agent`
+- "I liked Parasite and Oldboy, what else?" → `movie-goat-pp-cli recommend-for-me "Parasite" "Oldboy" --agent`
+- "Show Denis Villeneuve's best work" → `movie-goat-pp-cli career "Denis Villeneuve" --sort rating --agent`
+- "Plan a Lord of the Rings marathon" → `movie-goat-pp-cli marathon "Lord of the Rings" --agent`
+- "Find action movies from 2024 on Netflix" → `movie-goat-pp-cli discover --with-genres 28 --primary-release-year 2024 --with-watch-providers 8 --watch-region US --agent`
 
 ## Unique Capabilities
 
-Commands that combine TMDb + OMDb data or derive from streaming/watch-taste data.
+### `movies get`
 
-### Multi-source ratings in one shot
+Get one detailed movie record with appended credits, videos, recommendations, watch providers, and external IDs. If `OMDB_API_KEY` is set and the title has an IMDb ID, the response can also include IMDb, Rotten Tomatoes, and Metacritic data.
 
-- **`movies get <movieId>`** — Returns TMDb user score, IMDB rating, Metacritic, Rotten Tomatoes — all in one response.
+```bash
+movie-goat-pp-cli movies get 550 --agent
+```
 
-  _Skips four tab-switches. Gives the agent a clean multi-source comparison to summarize._
+### `watch`
 
-- **`versus <movie1> <movie2>`** — Side-by-side rating comparison, box office, cast overlap, streaming availability. For "better movie" arguments and curation.
+Look up where a movie or TV show is available to stream, rent, buy, or watch free/ad-supported in a given region. Accepts either a title or a TMDb ID.
 
-### Taste-aware recommendations
+```bash
+movie-goat-pp-cli watch "Breaking Bad" --type tv --region US --agent
+```
 
-- **`recommend-for-me <movie> [<movie>...]`** — Give it 2-4 movies you love; it returns picks that bridge their shared tastes via TMDb's recommendation graph + genre/director overlap.
+### `recommend-for-me`
 
-  _Solves "I liked Inception and Dune, what next?" better than Netflix homepage._
+Takes two or more movie titles, fetches recommendations and similar titles for each, and ranks candidates by how well they bridge the combined tastes.
 
-- **`tonight`** — Smart "what should I watch" — uses time of day, recent browsing patterns in the local cache, and currently-streaming availability on your providers to pick one film.
+```bash
+movie-goat-pp-cli recommend-for-me "The Matrix" "Arrival" "Mad Max: Fury Road" --agent
+```
 
-- **`blind`** — Random high-quality pick (rating >= 7.5, vote count >= 1000). Anti-decision-fatigue tool.
+### `versus`
 
-### Structured discovery
+Compares two movies side by side across TMDb data and, when configured, OMDb enrichment such as IMDb, Rotten Tomatoes, Metacritic, awards, and box office.
 
-- **`discover [--with-genres <ids>] [--year <y>] [--vote-average-gte N] [--with-watch-providers <ids>]`** — Browse with structured filters. Combine genre IDs, year, rating floor, cast, and streaming provider IDs (e.g. `8`=Netflix, `337`=Disney+) in one query. Use `movies genres` to look up genre IDs.
+```bash
+movie-goat-pp-cli versus "Barbie" "Oppenheimer" --agent
+```
 
-- **`marathon <franchise>`** — Plan a franchise marathon with chronological or release order, total runtime, and where-to-stream for each title.
+### `blind`
 
-  _"Schedule a Star Wars weekend" → ordered list with total hours and streaming mix._
+Picks a random high-quality movie using TMDb discover filters such as genre, decade, minimum rating, and watch provider.
 
-- **`career <person-name-or-id>`** — Complete filmography with genre breakdown, decades active, average rating, most-acclaimed titles.
+```bash
+movie-goat-pp-cli blind --genre 35 --decade 1990s --min-rating 7.0 --agent
+```
 
-- **`trending`** — TMDb's real-time trending list — movies, TV, and people.
+### `tonight`
 
-### Streaming availability
+Builds a short ranked list from TMDb trending and popular results, optionally filtered by genre or media type.
 
-- **`watch <movieId>`** — Where to stream, rent, or buy. Uses TMDb's JustWatch-powered provider data; scoped by region (defaults to US).
+```bash
+movie-goat-pp-cli tonight --genre 28 --agent
+movie-goat-pp-cli tonight --type tv --agent
+```
+
+### `career`
+
+Returns a person's combined filmography with sortable output and summary stats.
+
+```bash
+movie-goat-pp-cli career "Cate Blanchett" --sort rating --agent
+```
+
+### `marathon`
+
+Finds a TMDb collection, sorts its films by release date, totals runtime, and suggests break points.
+
+```bash
+movie-goat-pp-cli marathon "Harry Potter" --agent
+```
+
+### `sync` + `search` + `analytics`
+
+Sync TMDb data into the local SQLite archive, then search or analyze it without re-hitting the API every time.
+
+```bash
+movie-goat-pp-cli sync
+movie-goat-pp-cli search "time travel" --data-source local --agent
+movie-goat-pp-cli analytics --agent
+```
 
 ## Command Reference
 
-Movies:
+Discovery and recommendations:
 
-- `movie-goat-pp-cli movies` — Browse (popular, top-rated, upcoming, now-playing)
-- `movie-goat-pp-cli movies search "<title>"` — Search by title
-- `movie-goat-pp-cli movies get <movieId>` — Detail with multi-source ratings
+- `movie-goat-pp-cli tonight`
+- `movie-goat-pp-cli blind`
+- `movie-goat-pp-cli recommend-for-me <title1> [title2] [title3...]`
+- `movie-goat-pp-cli discover [filters]`
+- `movie-goat-pp-cli discover tv [filters]`
+- `movie-goat-pp-cli trending`
 
-TV:
+Movie and TV lookup:
 
-- `movie-goat-pp-cli tv` — Browse TV shows
-- `movie-goat-pp-cli tv get <seriesId>` — Series detail
-- `movie-goat-pp-cli tv get <seriesId> <seasonNumber>` — Season detail
-- `movie-goat-pp-cli tv airing-today` — Today's airings
+- `movie-goat-pp-cli movies`
+- `movie-goat-pp-cli movies search "<title>"`
+- `movie-goat-pp-cli movies get <movieId>`
+- `movie-goat-pp-cli tv`
+- `movie-goat-pp-cli tv search "<title>"`
+- `movie-goat-pp-cli tv get <seriesId>`
+- `movie-goat-pp-cli tv seasons get <seriesId> <seasonNumber>`
+- `movie-goat-pp-cli genres`
+- `movie-goat-pp-cli genres tv`
 
-People:
+People and planning:
 
-- `movie-goat-pp-cli people` — Browse/search
-- `movie-goat-pp-cli people get <personId>` — Person detail
-- `movie-goat-pp-cli career <person>` — Complete filmography with stats
+- `movie-goat-pp-cli people`
+- `movie-goat-pp-cli people search "<name>"`
+- `movie-goat-pp-cli people get <personId>`
+- `movie-goat-pp-cli career <person-name-or-id>`
+- `movie-goat-pp-cli watch <title-or-id>`
+- `movie-goat-pp-cli versus <movie1> <movie2>`
+- `movie-goat-pp-cli marathon <collection-name>`
 
-Discovery / recommendations:
+Local and power-user commands:
 
-- `movie-goat-pp-cli discover [filters]` — Structured filtered browse
-- `movie-goat-pp-cli trending` — Real-time trending
-- `movie-goat-pp-cli recommend-for-me <titles>` — Taste-based recs
-- `movie-goat-pp-cli tonight` — Smart single pick
-- `movie-goat-pp-cli blind` — Random high-quality pick
+- `movie-goat-pp-cli sync`
+- `movie-goat-pp-cli search "<query>"`
+- `movie-goat-pp-cli analytics`
+- `movie-goat-pp-cli workflow archive`
+- `movie-goat-pp-cli workflow status`
+- `movie-goat-pp-cli export`
+- `movie-goat-pp-cli import`
+- `movie-goat-pp-cli tail <resource>`
+- `movie-goat-pp-cli api`
+- `movie-goat-pp-cli doctor`
+- `movie-goat-pp-cli auth status|set-token|logout`
 
-Planning / comparison:
+## Practical Recipes
 
-- `movie-goat-pp-cli marathon <franchise>` — Franchise watch-order
-- `movie-goat-pp-cli versus <movie1> <movie2>` — Head-to-head
-- `movie-goat-pp-cli watch <movieId>` — Streaming providers
-- `movie-goat-pp-cli genres` — List genre IDs
-
-Local / auth:
-
-- `movie-goat-pp-cli sync` / `export` / `import` / `archive` — Local store
-- `movie-goat-pp-cli auth set-token <TMDB_KEY>` — Save API key
-- `movie-goat-pp-cli doctor` — Verify
-
-## Recipes
-
-### "What should I watch tonight?"
+### What should I watch tonight?
 
 ```bash
 movie-goat-pp-cli tonight --agent
-# or: bias toward recent favorites
-movie-goat-pp-cli recommend-for-me "Dune: Part Two" "Oppenheimer" --limit 5 --agent
 ```
 
-`tonight` picks one film considering time of day and streaming. `recommend-for-me` with 2-4 titles you liked returns a ranked shortlist that blends those tastes.
+Use `--genre` or `--type tv` when the user already has a narrower intent.
 
 ### Compare two movies before committing
 
@@ -114,91 +188,113 @@ movie-goat-pp-cli recommend-for-me "Dune: Part Two" "Oppenheimer" --limit 5 --ag
 movie-goat-pp-cli versus "Inception" "Tenet" --agent
 ```
 
-Returns: TMDb score, IMDB, Metacritic, RT scores for each; box office; shared cast/crew; where each streams. Settles "which should I watch first" without five Google searches.
+Good for "which should I watch first?" or "which one wins on ratings and box office?"
 
-### Plan a weekend marathon
-
-```bash
-movie-goat-pp-cli marathon "Lord of the Rings" --agent
-movie-goat-pp-cli marathon "Alien" --agent
-```
-
-Pass a TMDb collection name; returns titles in watch order, runtime per film, total weekend duration, and streaming mix so you know if one movie's only on a provider you don't have. Watch order follows TMDb's collection sequence.
-
-### Research a director's full career
+### Find where something streams
 
 ```bash
-movie-goat-pp-cli career "Denis Villeneuve" --agent
+movie-goat-pp-cli watch "The Dark Knight" --region US --agent
+movie-goat-pp-cli watch "Breaking Bad" --type tv --region GB --agent
 ```
 
-Complete filmography, decades active, genres, average rating, highlights. Used as prep for deeper research or "what to watch next from them" picks.
+Use titles when the user does not know IDs. Use `--type tv` when the title is a show.
 
-### Discover-by-filter
+### Discover by structured filters
 
 ```bash
-movie-goat-pp-cli movies genres --agent                           # look up genre IDs first
-# 878 = sci-fi, 8 = Netflix provider ID
-movie-goat-pp-cli discover \
-  --with-genres 878 --primary-release-year 2005 \
-  --vote-average-gte 7.5 \
-  --with-watch-providers 8 --watch-region US \
-  --agent
+movie-goat-pp-cli genres --agent
+movie-goat-pp-cli discover --with-genres 878 --primary-release-year 2005 --vote-average-gte 7.5 --with-watch-providers 8 --watch-region US --agent
 ```
 
-TMDb's discover endpoint uses numeric IDs for genres and providers — look them up first via `movies genres`. Structured search beats search-by-title when the question is "what 2000s sci-fi with 7.5+ rating is on Netflix."
+Use `genres` first if the user gives natural-language genre names and you need the TMDb numeric IDs.
+
+### Research a director or actor
+
+```bash
+movie-goat-pp-cli career "Denis Villeneuve" --sort rating --agent
+```
+
+Use `--sort popularity` for broader career overview and `--limit` when the answer should stay short.
 
 ## Auth Setup
 
-Requires a free TMDb API key. OMDb enrichment is optional.
+TMDb credentials are required for core usage.
 
 ```bash
-# 1. Get a key: https://www.themoviedb.org/settings/api
-export TMDB_API_KEY="your-tmdb-key"
-movie-goat-pp-cli auth set-token "$TMDB_API_KEY"  # also persists to config
+export TMDB_API_KEY="<your-key>"
+movie-goat-pp-cli auth set-token <your-key>
 movie-goat-pp-cli doctor
 ```
 
 Optional:
-- `OMDB_API_KEY` — enables extra rating sources (IMDB, Metacritic, RT via OMDb)
-- `MOVIE_GOAT_REGION` — streaming region (default `US`)
+
+- `OMDB_API_KEY` adds IMDb, Rotten Tomatoes, Metacritic, awards, and box-office enrichment where available.
 
 ## Agent Mode
 
-Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes`. Supports `--select <fields>`, `--dry-run`, `--rate-limit N` (throttle requests), `--no-cache`.
+Add `--agent` to commands you want optimized for machine consumption.
+
+It expands to:
+
+- `--json`
+- `--compact`
+- `--no-input`
+- `--no-color`
+- `--yes`
+
+Useful companion flags:
+
+- `--select <fields>`
+- `--dry-run`
+- `--no-cache`
+- `--rate-limit <n>`
+- `--data-source auto|live|local`
 
 ## Exit Codes
 
 | Code | Meaning |
-|------|---------|
+| --- | --- |
 | 0 | Success |
 | 2 | Usage error |
-| 3 | Not found (movie, person, series) |
-| 4 | Auth required (missing TMDB_API_KEY) |
-| 5 | API error (upstream TMDb or OMDb) |
+| 3 | Not found |
+| 4 | Auth error |
+| 5 | API error |
 | 7 | Rate limited |
 | 10 | Config error |
-
-## Installation
-
-### CLI
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest
-movie-goat-pp-cli auth set-token YOUR_TMDB_KEY
-movie-goat-pp-cli doctor
-```
-
-### MCP Server
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-mcp@latest
-claude mcp add -e TMDB_API_KEY=<key> movie-goat-pp-mcp -- movie-goat-pp-mcp
-```
 
 ## Argument Parsing
 
 Given `$ARGUMENTS`:
 
-1. **Empty, `help`, or `--help`** → run `movie-goat-pp-cli --help`
-2. **`install`** → CLI; **`install mcp`** → MCP
-3. **Anything else** → check `which movie-goat-pp-cli` (offer install if missing), verify `TMDB_API_KEY` is set (prompt for setup if not), match intent to a command (taste queries → `recommend-for-me`, comparison → `versus`, franchise → `marathon`, single pick → `tonight`), run with `--agent`.
+1. Empty, `help`, or `--help` → run `movie-goat-pp-cli --help`
+2. `install` → install CLI
+3. `install mcp` → install MCP server
+4. Anything else → map the user request to the best command above and run it with `--agent`
+
+## CLI Installation
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest
+movie-goat-pp-cli --version
+```
+
+## MCP Server Installation
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-mcp@latest
+claude mcp add movie-goat movie-goat-pp-mcp -e TMDB_API_KEY=<your-key>
+```
+
+If OMDb enrichment is desired in MCP clients too:
+
+```bash
+claude mcp add movie-goat movie-goat-pp-mcp -e TMDB_API_KEY=<your-key> -e OMDB_API_KEY=<your-omdb-key>
+```
+
+## Direct Use
+
+1. Check whether `movie-goat-pp-cli` is installed.
+2. If not installed, offer CLI installation.
+3. If `TMDB_API_KEY` is missing, guide the user through auth setup before trying to use the CLI.
+4. Choose the command that matches the user's intent most directly.
+5. Run with `--agent` unless the user explicitly wants human-formatted output.


### PR DESCRIPTION
## Summary
- rewrite the Movie GOAT README to match the stronger Recipe GOAT documentation standard
- clarify required TMDb auth vs optional OMDb enrichment and add practical config and troubleshooting guidance
- replace the Movie GOAT SKILL with an agent-focused version that matches the real CLI surface and removes inaccurate claims

## Testing
- not run (docs only)