### PR TITLE
docs: fix plugin install instructions for marketplace flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This repository currently includes 21 CLIs, 19 MCP servers, one mega-skill (`/pp
 
 ## Start Here
 
-If you are using the plugin, install the repository by name:
+This repo is its own Claude Code plugin marketplace. Add the marketplace, then install the plugin:
 
 ```text
-/install mvanhorn/printing-press-library
+/plugin marketplace add mvanhorn/printing-press-library
+/plugin install printing-press-library@printing-press-library
 ```
 
 After install, the main router skill is:
@@ -26,7 +27,8 @@ That naming split is intentional:
 If you also want to generate new tools from API specs, install the source project too:
 
 ```text
-/install mvanhorn/cli-printing-press
+/plugin marketplace add mvanhorn/cli-printing-press
+/plugin install cli-printing-press@cli-printing-press
 ```
 
 ## Quick Examples


### PR DESCRIPTION
The README's install snippets used `/install <repo>`, which isn't a real Claude Code command. Since this repo now ships its own `.claude-plugin/marketplace.json`, the correct flow is to add the marketplace and then install the plugin by name:

```text
/plugin marketplace add mvanhorn/printing-press-library
/plugin install printing-press-library@printing-press-library
```

Same fix applied to the optional `cli-printing-press` block, which is also its own marketplace.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)