### PR TITLE
feat(cli): make instacart history backfill a one-command end-user flow

### DIFF
--- a/docs/patterns/authenticated-session-scraping.md
+++ b/docs/patterns/authenticated-session-scraping.md
@@ -127,18 +127,28 @@ If you see this pattern:
 
 ## The Instacart worked example
 
-The `pp-instacart` CLI uses the full tier-1 pattern. Sketch of the flow:
+The `pp-instacart` CLI uses the full tier-1 pattern, wrapped in a one-command skill flow so end users do not need to understand the plumbing.
 
-1. **User dumps.** Opens `/store/account/orders` in Chrome with claude-in-chrome MCP connected, runs the agent-provided JS snippets (`library/commerce/instacart/docs/dumper.js` + `extract-one.js`) to walk order pages and collect the Apollo cache's `OrderManagerOrderDelivery` entries into `localStorage`.
-2. **User exports.** Triggers a `Blob` + `<a download>` click. Browser saves `instacart-orders.jsonl` to `~/Downloads/`.
-3. **CLI imports.** User runs `instacart history import ~/Downloads/instacart-orders.jsonl`. The CLI upserts orders, items, and the aggregated `purchased_items` table.
-4. **`add` resolves via history.** `instacart add qfc "limoncello sorbet"` now returns `resolved_via: "history"` with the exact Alden's Organic Limoncello Sorbet Bars SKU the user previously bought, instead of the three-call live search picking Talenti.
+End-user invocation:
+
+> "backfill my instacart orders"
+
+The `/pp-instacart` skill's argument parser matches any of several backfill intents ("sync my history", "download my orders", etc.) and drives the Chrome MCP loop end to end:
+
+1. **Skill probes.** Reads the user's existing `instacart history stats` to decide full backfill vs top-up. Confirms `claude-in-chrome` MCP tools are loaded; falls through to the DevTools copy-paste path in `library/commerce/instacart/docs/backfill-devtools-fallback.md` if not.
+2. **Dumper walks the orders page.** Injects `library/commerce/instacart/docs/dumper.js` into the logged-in Chrome tab. The dumper scrolls, clicks "Load more" with bounded retries, and accumulates order IDs into `localStorage.__ic_backfill_state` so interrupted sessions resume.
+3. **Extractor pulls per-order detail.** For each pending order, the skill navigates to `/store/orders/<id>` and injects `extract-one.js`. That script polls the Apollo cache up to 10s for the `OrderManagerOrderDelivery` entry with `includeOrderItems:true`, then normalizes the record and appends to `localStorage.__ic_dumped`. Failures push structured skip records instead of silently losing orders.
+4. **Exporter downloads JSONL.** `export-jsonl.js` filters skip records, writes the rest as JSONL, and triggers a browser download of `instacart-orders.jsonl`.
+5. **CLI imports.** Skill shells out to `instacart history import ~/Downloads/instacart-orders.jsonl --agent`. Upsert is idempotent, so re-runs are safe.
+6. **`add` resolves via history.** `instacart add qfc "limoncello sorbet"` now returns `resolved_via: "history"` with the exact Alden's Organic Limoncello Sorbet Bars SKU the user previously bought, instead of the three-call live search picking Talenti.
 
 Observed calibration from the first real run (2026-04-18):
 
 - Dump phase: ~60 seconds to walk and extract 10 orders from the user's Instacart
 - Import phase: ~1 second for 10 orders × 87 items total
 - Resolver impact: history-first fires for queries the user has bought before at the retailer in question, falls through to live search otherwise (as designed)
+
+The end-user-facing entry points are documented in `library/commerce/instacart/docs/backfill-walkthrough.md` (skill-driven) and `library/commerce/instacart/docs/backfill-devtools-fallback.md` (manual). This playbook's tier model is unchanged; the skill is simply the packaged tier-1 outcome for this CLI.
 
 ## Checklist for adding this pattern to a new printed CLI
 
@@ -160,13 +170,16 @@ Then:
 
 ## Used in the wild
 
-- `pp-instacart` — order history + purchased-items backfill (this document's worked example)
+- `pp-instacart` — order history + purchased-items backfill, wrapped in a one-command skill flow end users can invoke with "backfill my instacart orders" (this document's worked example)
 
 Add your CLI here when you adopt the pattern.
 
 ## Further reading
 
-- `library/commerce/instacart/docs/dumper.js` — the working reference implementation
-- `library/commerce/instacart/docs/extract-one.js` — the per-order extractor + exporter
+- `library/commerce/instacart/docs/dumper.js` — the working reference implementation of the order-list walker
+- `library/commerce/instacart/docs/extract-one.js` — the per-order Apollo-cache extractor
+- `library/commerce/instacart/docs/export-jsonl.js` — the Blob-download exporter
+- `library/commerce/instacart/docs/backfill-walkthrough.md` — end-user walkthrough for the skill-driven flow
+- `library/commerce/instacart/docs/backfill-devtools-fallback.md` — manual DevTools flow for users without Chrome MCP
 - `library/commerce/instacart/internal/cli/history_import.go` — the Go-side importer
 - `docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md` — the architecture-gap finding that motivated this playbook

--- a/docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md
+++ b/docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md
@@ -21,6 +21,8 @@ Future contributors searching for "instacart order history graphql" or "instacar
 
 Navigate to each `/store/orders/<id>` page in a logged-in browser, wait for Apollo to populate, then read `window.__APOLLO_CLIENT__.cache.extract().OrderManagerOrderDelivery`. The reference implementation lives at `library/commerce/instacart/docs/extract-one.js` and is tier-1 (Chrome MCP driven) per the authenticated-session-scraping playbook.
 
+For end users, the flow is wrapped into the `/pp-instacart` skill: typing "backfill my instacart orders" into a Claude Code session drives the full loop. See `library/commerce/instacart/docs/backfill-walkthrough.md`.
+
 ## Multi-profile redirect catch
 
 Plain HTTP scraping of `/store/account/orders` with extracted cookies redirects to `/store/profiles?next=...` because the user has multi-profile on their Instacart account. A selected-profile cookie is required, and it's set via a browser-side flow that doesn't survive plain-cookie extraction. Only a browser tab that has interactively cleared the profile picker can access the orders page.

--- a/library/commerce/instacart/README.md
+++ b/library/commerce/instacart/README.md
@@ -42,6 +42,20 @@ go build -o instacart ./cmd/instacart
 ./instacart doctor
 ```
 
+## First-time history backfill
+
+Optional but recommended. Once backfilled, `add` resolves items from your real purchase history ("Alden's Organic Limoncello Sorbet Bars" instead of whatever live search ranks first for "limoncello sorbet") and runs about 5x faster on repeated items.
+
+The fastest path is the pp-instacart skill. In a Claude Code session with `claude-in-chrome` MCP tools loaded, tell the agent:
+
+> backfill my instacart orders
+
+The skill walks your logged-in Chrome tab through every order, extracts the data, and runs `instacart history import` for you. Typical full backfill: 5-10 minutes for a ~180-order history. Subsequent top-ups: under a minute.
+
+If you do not have `claude-in-chrome` MCP available, run the flow manually: see [`docs/backfill-devtools-fallback.md`](docs/backfill-devtools-fallback.md). Same three JS files, same import command, different driver.
+
+More detail: [`docs/backfill-walkthrough.md`](docs/backfill-walkthrough.md) (full procedure) and [`docs/patterns/authenticated-session-scraping.md`](../../../docs/patterns/authenticated-session-scraping.md) (why this pattern exists).
+
 ## Agent Usage
 
 Every command supports `--json` for structured output and typed exit codes

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pp-instacart
-description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco'."
-argument-hint: "<command> [args] | install cli|mcp"
-allowed-tools: "Read Bash"
+description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco', 'backfill my instacart history', 'sync my instacart orders', 'download my order history', 'save my instacart history locally'."
+argument-hint: "<command> [args] | install cli|mcp | backfill"
+allowed-tools: "Read Bash WebFetch"
 ---
 
 # Instacart - Printing Press CLI
@@ -36,17 +36,20 @@ Falls through to today's live-search behavior when any condition fails. Pass `--
 
 Every successful `add` (history-resolved or live-resolved) writes back to `purchased_items` so the signal gets warmer without a full re-sync.
 
-### Purchase history import + inspection
+### One-command history backfill
 
-**Use `history import`, not `history sync`.** Instacart does not expose a clean order-history GraphQL op, so `sync` cannot work — it surfaces a clear error pointing at the working path. The working path is:
+Typing "backfill my instacart orders" (or similar, see Argument Parsing) kicks off a Chrome-MCP-driven flow that walks the user's logged-in Instacart tab, extracts their order history into JSONL, and imports it into the local DB. After backfill, `add` resolves from real purchase history instead of live-search guesses.
 
-1. Run the browser-side dumper (see `docs/dumper.js` + `docs/extract-one.js`) against a logged-in Chrome tab
-2. Download the resulting `instacart-orders.jsonl`
-3. `instacart history import <path>` — upserts orders + items into the local DB
+Primary path: Chrome MCP. Fallback: paste three JS files into DevTools by hand.
 
-See the full playbook at [`docs/patterns/authenticated-session-scraping.md`](https://github.com/mvanhorn/printing-press-library/blob/main/docs/patterns/authenticated-session-scraping.md) (repo root).
+Full walkthrough below under "Backfill Flow". Reference docs with more detail:
+
+- [`docs/backfill-walkthrough.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-walkthrough.md) — Chrome MCP flow
+- [`docs/backfill-devtools-fallback.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-devtools-fallback.md) — manual DevTools flow
 
 `history list` / `history search` / `history stats` inspect whatever has been loaded.
+
+Instacart does not expose a clean order-history GraphQL op, so the legacy `history sync` command cannot work. See [`docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md`](https://github.com/mvanhorn/printing-press-library/blob/main/docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md) for why.
 
 ### Natural-language `add`
 
@@ -107,12 +110,13 @@ Maintenance:
 instacart auth login                # extract cookies from Chrome
 instacart doctor                    # verify auth + live ping
 instacart capture                   # seed built-in op hashes
-# History backfill: browser-side dump, then import. See
-# docs/patterns/authenticated-session-scraping.md for the full walkthrough.
-# After you have instacart-orders.jsonl:
-instacart history import ~/Downloads/instacart-orders.jsonl
-instacart history stats             # confirm what landed
 ```
+
+Then backfill history (optional but recommended; unlocks history-first `add`):
+
+> Tell the agent: "backfill my instacart orders"
+
+The skill drives the rest. See the "Backfill Flow" section below.
 
 ### Add something you buy all the time
 
@@ -169,7 +173,37 @@ Given a free-form natural-language request:
 
 1. Empty, `help`, or `--help` -> run `instacart --help`
 2. Starts with `install` -> CLI install; ends with `mcp` -> MCP install
-3. Anything else -> map to the best subcommand and run with `--json` when invoked from an agent
+3. Matches a **backfill intent** -> run the Backfill Flow below. Trigger phrases include: "backfill my orders", "backfill my history", "sync my instacart history", "sync my instacart orders", "download my order history", "save my instacart history locally", "pull in my past orders", "import my recent orders".
+4. Anything else -> map to the best subcommand and run with `--json` when invoked from an agent
+
+## Backfill Flow
+
+Drive this when the user hits a backfill intent. Read [`docs/backfill-walkthrough.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-walkthrough.md) via WebFetch for the full procedure; summary below.
+
+Setup check:
+
+1. Confirm `instacart-pp-cli` is on PATH. If not, install: `go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@latest`.
+2. Probe `mcp__claude-in-chrome__tabs_context_mcp`. If the tool is unavailable, route to the DevTools fallback: fetch [`docs/backfill-devtools-fallback.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-devtools-fallback.md) and walk the user through it. Stop.
+3. Run `instacart-pp-cli history stats --agent`. If orders > 0, this is a top-up run; the resume state will skip already-dumped orders automatically.
+
+Chrome MCP loop:
+
+1. WebFetch the three JS files (cache each in the current session):
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/dumper.js`
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/extract-one.js`
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/export-jsonl.js`
+2. Open or reuse a tab at `https://www.instacart.com/store/account/orders`. If the dumper returns `profile_picker: true`, ask the user to pick a profile in the tab, then re-run.
+3. Inject `dumper.js` via `mcp__claude-in-chrome__javascript_tool`. Read back `total_ids` and `pending_extract`.
+4. For each order ID in the pending set, navigate to `/store/orders/<id>` then inject `extract-one.js`. Report progress to the user every 10 orders.
+5. When pending reaches 0, inject `export-jsonl.js`. It downloads `instacart-orders.jsonl` to the user's default Downloads folder.
+6. Run `instacart-pp-cli history import ~/Downloads/instacart-orders.jsonl --agent` in a Bash tool. Show the summary JSON to the user.
+7. Verify: `instacart-pp-cli history stats --agent`. Offer a follow-up sanity check: `instacart-pp-cli add <retailer> "<something they've bought>" --dry-run --json` and flag `resolved_via: "history"` when it appears.
+
+Error surfaces worth translating for the user:
+
+- Extractor `cache_key_missing` on every order -> Instacart rotated their web bundle. Report the observed cache keys and point at the rotation-recovery section of the walkthrough doc.
+- Dumper reports fewer IDs than the user expected -> probably on a multi-profile account; ensure the selected profile is the one with purchase history.
+- `history import` shows 0 orders imported -> the JSONL is empty (only skip records). Re-run the extractor loop with fresh tabs.
 
 ## CLI Installation
 
@@ -185,5 +219,5 @@ Ensure `$HOME/go/bin` is on `$PATH`.
 1. Check installed: `which instacart-pp-cli`
 2. Check auth: `instacart doctor`
 3. Capture GraphQL hashes: `instacart capture`
-4. (Optional but recommended) Sync history: follow `docs/history-ops-capture.md` then `instacart history sync`
+4. (Optional but recommended) Backfill history — run the Backfill Flow above. Unlocks history-first `add` resolution.
 5. Run your command with `--json` if invoked from an agent

--- a/library/commerce/instacart/docs/backfill-devtools-fallback.md
+++ b/library/commerce/instacart/docs/backfill-devtools-fallback.md
@@ -1,0 +1,101 @@
+# Instacart history backfill — DevTools fallback
+
+Use this flow when you do not have `claude-in-chrome` MCP tools in your Claude Code session, or when you just want to drive the backfill by hand.
+
+Same result as the skill-driven flow: a JSONL file that `instacart history import` ingests. Just you in the driver seat instead of the skill.
+
+Works only in Chrome or Chromium. Firefox/Safari lack the `window.__APOLLO_CLIENT__` global the extractor depends on.
+
+## Prerequisites
+
+- `instacart-pp-cli` installed and authenticated.
+- Chrome logged in at https://www.instacart.com with the correct profile selected.
+
+## Step 1 — Open the orders page + DevTools
+
+1. Open https://www.instacart.com/store/account/orders in Chrome.
+2. If redirected to `/store/profiles`, pick a profile first.
+3. Open DevTools (Cmd+Option+I on macOS, Ctrl+Shift+I on Linux/Windows).
+4. Switch to the Console tab.
+
+## Step 2 — Collect your order IDs (dumper)
+
+Paste the entire contents of [`dumper.js`](dumper.js) into the console and press Enter. Wait for the return value. It looks like:
+
+```json
+{
+  "total_ids": 183,
+  "new_ids_this_run": 183,
+  "already_dumped": 0,
+  "pending_extract": 183,
+  "resumed": false,
+  "state_key": "__ic_backfill_state",
+  "pending_sample": ["123...", "456..."]
+}
+```
+
+Note `total_ids` (how many orders the dumper found) and `pending_extract` (how many still need per-order extraction). If you see `"profile_picker": true`, pick a profile in the tab and paste the dumper again.
+
+## Step 3 — Pull each order's detail (extractor)
+
+For every order ID in `pending_extract`:
+
+1. Navigate the tab to `https://www.instacart.com/store/orders/<order-id>`.
+2. Paste the contents of [`extract-one.js`](extract-one.js) into the console. Press Enter. The extractor polls for the Apollo cache and normalizes the record; return value names the retailer + item count.
+
+Do this for every pending order. The accumulator persists in `localStorage.__ic_dumped` so navigation between orders does not lose progress.
+
+If you have 50+ orders, this is tedious by hand. Consider:
+
+- A DevTools snippet (Sources -> Snippets) so you can double-click to run extract-one instead of pasting.
+- A short `fetch` loop that navigates via `window.location.href = "/store/orders/" + id; await new Promise(r => setTimeout(r, 4500));` and then runs the extractor. Not included here because navigation tears down the JS context, so the loop has to be two snippets cooperating via localStorage.
+- Or just use the skill-driven flow — `claude-in-chrome` MCP is free and handles the navigation loop for you. See [`backfill-walkthrough.md`](backfill-walkthrough.md).
+
+## Step 4 — Export JSONL
+
+Paste the contents of [`export-jsonl.js`](export-jsonl.js) into the console. Chrome downloads `instacart-orders.jsonl` to your default Downloads folder. The return value summarizes what was exported:
+
+```json
+{
+  "downloaded": true,
+  "filename": "instacart-orders.jsonl",
+  "bytes": 48213,
+  "orders": 183,
+  "skipped_count": 0,
+  "next_command": "instacart history import ~/Downloads/instacart-orders.jsonl"
+}
+```
+
+If `skipped_count > 0`, some orders failed to extract. You can re-navigate to those (check `localStorage.__ic_dumped` for `skipped: true` entries) and re-run the extractor. Re-running the exporter overwrites the download with the new set.
+
+## Step 5 — Import
+
+In your terminal:
+
+```bash
+instacart history import ~/Downloads/instacart-orders.jsonl
+```
+
+Idempotent by primary key — safe to re-run. Output names how many orders and items landed.
+
+Verify:
+
+```bash
+instacart history stats
+instacart add <retailer> "<something you buy>" --dry-run --json
+```
+
+Look for `"resolved_via": "history"` in the dry-run output.
+
+## Top-up later
+
+Re-running `dumper.js` skips orders already in `__ic_backfill_state.seen_ids`. Re-running `extract-one.js` on an order already in `__ic_dumped` dedupes (the push is guarded). Re-running the exporter produces a superset. Re-running `history import` is idempotent. So the full loop is safe to repeat monthly for top-ups.
+
+If you want to start over from zero, clear the browser-side state in DevTools:
+
+```js
+localStorage.removeItem('__ic_dumped');
+localStorage.removeItem('__ic_backfill_state');
+```
+
+Then delete your local history tables with `instacart history import --dry-run` on a corrupt file (there is no first-class wipe command yet; open an issue if you need one).

--- a/library/commerce/instacart/docs/backfill-walkthrough.md
+++ b/library/commerce/instacart/docs/backfill-walkthrough.md
@@ -1,0 +1,56 @@
+# Instacart history backfill — the one-command walkthrough
+
+This is the canonical end-to-end backfill flow. A user types "backfill my instacart orders" (or a near-variant) into a Claude Code session and the `/pp-instacart` skill drives the rest.
+
+The short version: Chrome MCP walks your logged-in Instacart tab, extracts each order's Apollo cache entry, downloads `instacart-orders.jsonl`, and then `instacart history import` upserts it into your local SQLite store. After that, `instacart add <retailer> "<thing you've bought>"` resolves via history instead of live search.
+
+## Before you start
+
+You need:
+
+- `instacart-pp-cli` installed and authenticated (`instacart doctor` should show session OK, at least one op-hash cached, history warn is fine).
+- A Chrome tab signed in to https://www.instacart.com with the correct profile selected (multi-profile accounts redirect through `/store/profiles` on a fresh session).
+- The `claude-in-chrome` MCP tools available in Claude Code. Run `/pp-instacart backfill my orders` from a session where you have those tools.
+
+If you do not have Chrome MCP available, follow [`backfill-devtools-fallback.md`](backfill-devtools-fallback.md) instead. Same JS files, same import command, different driver.
+
+## The loop
+
+The skill drives Chrome MCP to run three JS files in order. You can read them on GitHub:
+
+- Dumper: [`library/commerce/instacart/docs/dumper.js`](dumper.js)
+- Per-order extractor: [`library/commerce/instacart/docs/extract-one.js`](extract-one.js)
+- JSONL exporter: [`library/commerce/instacart/docs/export-jsonl.js`](export-jsonl.js)
+
+The flow:
+
+1. Navigate to `https://www.instacart.com/store/account/orders`. If the tab redirects to `/store/profiles`, pick a profile and try again.
+2. Inject `dumper.js` into the page via `mcp__claude-in-chrome__javascript_tool`. It scrolls + clicks "Load more" until no new order IDs appear, then writes progress into `localStorage.__ic_backfill_state`.
+3. Read the dumper output. `total_ids` is how many orders were seen. `pending_extract` is how many still need per-order extraction.
+4. For each pending order ID, navigate to `/store/orders/<id>` then inject `extract-one.js`. The extractor polls for Apollo cache hydration (up to 10s), pulls the `OrderManagerOrderDelivery` entry, and appends the record to `localStorage.__ic_dumped`.
+5. After the per-order loop finishes, inject `export-jsonl.js`. It filters skip records, writes the rest as JSONL, and triggers a browser download of `instacart-orders.jsonl` into your Downloads folder.
+6. Run `instacart history import ~/Downloads/instacart-orders.jsonl` (use `--json` for agent output). Upsert is idempotent so re-runs are safe.
+7. Verify with `instacart history stats` and a sanity-check `instacart add <retailer> "<something you buy>" --dry-run --json`. Look for `"resolved_via": "history"`.
+
+## Resume and top-up
+
+Both `dumper.js` and `extract-one.js` are designed to resume. Interrupted sessions (tab closed, MFA kicked in, computer slept) do not lose progress:
+
+- `localStorage.__ic_backfill_state.seen_ids` — every order ID the dumper has seen on the orders page.
+- `localStorage.__ic_dumped` — every order record the extractor has produced (valid records and structured skip records).
+
+Re-running the skill reads both, cross-checks, and only navigates to orders that are still pending. If no orders are pending, it jumps straight to the exporter so `history import` can merge any newer orders.
+
+For monthly top-ups (you have backfilled before and just want to catch new orders since then), the skill detects the populated store via `instacart history stats` and takes the top-up path: it walks the orders page to find any new IDs, extracts only those, and imports. Typically completes in under 30 seconds when nothing is new.
+
+## Troubleshooting
+
+- **`instacart doctor` warns "session: fail"** — cookies are stale. Run `instacart auth login` to re-extract from Chrome.
+- **Dumper reports `profile_picker: true`** — the tab is at `/store/profiles`. Click a profile in your browser, then re-run.
+- **Extractor reports `cache_not_hydrated` or `cache_key_missing` for every order** — Instacart probably rotated their web bundle. The extractor's fallback scan looks for any cache entry with `"includeOrderItems":true` in its key; if even that fails, the cache shape has changed materially. File an issue with the first few `Object.keys(window.__APOLLO_CLIENT__.cache.extract())` output from one of your order detail pages.
+- **`history import` succeeds but `add` still falls through to live search** — check `instacart history search "<query>" --store <retailer>` to see whether the item is actually in your local store. The FTS match has to clear a confidence threshold (recent purchase, in stock on last purchase). Pass `--no-history` to force live search and compare.
+- **Exporter says `only_skip_records`** — every extract failed. Usually means the tab got signed out mid-loop. Check `instacart doctor`, re-auth, and re-run.
+
+## Why this flow exists
+
+Instacart does not expose a clean GraphQL operation for order history. The orders index page is server-rendered HTML; per-order data lives in the client-side Apollo cache after the order detail page hydrates. See [`docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md`](../../../docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md) for the full architecture finding and [`docs/patterns/authenticated-session-scraping.md`](../../../docs/patterns/authenticated-session-scraping.md) for the tiered decision tree on when Chrome-MCP-driven scraping is the right tool for a printed CLI.

--- a/library/commerce/instacart/docs/dumper.js
+++ b/library/commerce/instacart/docs/dumper.js
@@ -1,67 +1,149 @@
 // Instacart order-history dumper. Paste this into DevTools console on a
-// logged-in Instacart tab (starting from https://www.instacart.com/store/account/orders)
-// to extract your order history as JSONL, then feed the download to
-// `instacart history import <file>`.
+// logged-in Instacart tab (starting from
+// https://www.instacart.com/store/account/orders) or run it from Chrome
+// MCP via the /pp-instacart backfill skill flow.
 //
-// This works because Instacart's Apollo cache exposes the full order detail
-// (retailer + items + quantities) under the OrderManagerOrderDelivery key
-// once each order's detail page has been loaded. Plain HTTP scraping does
-// NOT work on multi-profile accounts -- the user's selected-profile session
-// is required, and only the live browser carries it.
+// What it does:
+//   1. Scrolls the orders page to force infinite-scroll / clicks "Load
+//      more" until no new order IDs appear.
+//   2. Accumulates the IDs into localStorage.__ic_backfill_state.seen_ids
+//      so that re-runs after a tab crash or interrupted session resume
+//      instead of re-walking.
+//   3. Returns a JSON summary the skill (or a human) can read to decide
+//      whether to proceed to the per-order extract loop.
 //
-// See docs/patterns/authenticated-session-scraping.md for why Chrome MCP /
-// interactive DevTools is the right tier for this type of scraping.
+// This script does NOT pull order contents. The per-order detail (items,
+// retailer, delivery timestamp) lives in the Apollo cache on each order's
+// /store/orders/<id> page and is captured by extract-one.js.
+//
+// Profile-picker handling: if Instacart redirected the tab to
+// /store/profiles (multi-profile accounts do this before serving private
+// data), the script exits early and returns a sentinel. The caller is
+// expected to prompt the user to pick a profile and re-run.
+//
+// See docs/patterns/authenticated-session-scraping.md for why Chrome MCP
+// or interactive DevTools is the right tier for this type of scraping.
 
 (async () => {
-  // -- Step 1: collect every order ID from the Orders page via infinite scroll
-  //    + "Load more" button clicks.
-  const ids = await (async () => {
-    const seen = new Set();
-    const collect = () =>
-      Array.from(document.querySelectorAll('a[href^="/store/orders/"]')).forEach(a => {
-        const id = (a.getAttribute('href').match(/\/store\/orders\/(\d+)/) || [])[1];
-        if (id) seen.add(id);
-      });
-    collect();
-    let stable = 0;
-    for (let i = 0; i < 30 && stable < 3; i++) {
-      window.scrollTo(0, document.body.scrollHeight);
-      await new Promise(r => setTimeout(r, 1400));
-      const before = seen.size;
-      collect();
-      if (seen.size === before) stable++;
-      else stable = 0;
+  const STATE_KEY = '__ic_backfill_state';
+  const MAX_SEEN_IDS = 2000; // hard cap to prevent runaway localStorage
+
+  // --- Profile-picker short-circuit --------------------------------------
+  if (window.location.pathname.startsWith('/store/profiles')) {
+    return JSON.stringify({
+      profile_picker: true,
+      reason: 'tab_redirected_to_profile_picker',
+      action: 'pick a profile manually, then re-run the dumper',
+    });
+  }
+
+  // --- Load / init resume state ------------------------------------------
+  const loadState = () => {
+    try {
+      const raw = localStorage.getItem(STATE_KEY);
+      if (!raw) return { seen_ids: [], started_at: new Date().toISOString() };
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed.seen_ids)) parsed.seen_ids = [];
+      return parsed;
+    } catch (e) {
+      return { seen_ids: [], started_at: new Date().toISOString() };
     }
-    // Click "Load more" button until it is gone, with a cap for safety.
-    for (let i = 0; i < 30; i++) {
-      const btn = Array.from(document.querySelectorAll('button')).find(b =>
-        /^load more/i.test((b.innerText || '').trim())
-      );
-      if (!btn) break;
-      btn.scrollIntoView({ block: 'center' });
-      await new Promise(r => setTimeout(r, 400));
+  };
+  const saveState = (s) => {
+    // Trim to MAX_SEEN_IDS most-recent to prevent unbounded growth over
+    // months of backfill use. Order is preserved (most-recently-added last).
+    if (s.seen_ids.length > MAX_SEEN_IDS) {
+      s.seen_ids = s.seen_ids.slice(-MAX_SEEN_IDS);
+    }
+    s.updated_at = new Date().toISOString();
+    localStorage.setItem(STATE_KEY, JSON.stringify(s));
+  };
+
+  const state = loadState();
+  const resumedFromCount = state.seen_ids.length;
+  const seen = new Set(state.seen_ids);
+
+  // --- ID collection helpers ---------------------------------------------
+  const collect = () => {
+    const found = new Set();
+    for (const a of document.querySelectorAll('a[href^="/store/orders/"]')) {
+      const href = a.getAttribute('href') || '';
+      const m = href.match(/\/store\/orders\/(\d+)/);
+      if (m) found.add(m[1]);
+    }
+    let added = 0;
+    for (const id of found) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        added++;
+      }
+    }
+    return added;
+  };
+
+  // --- Infinite-scroll phase ---------------------------------------------
+  // Loop until scroll position stabilizes for 3 consecutive iterations
+  // OR we hit the page cap. Each iteration waits 1.4s for lazy-load.
+  collect();
+  let stableScroll = 0;
+  const SCROLL_ITERS = 40;
+  for (let i = 0; i < SCROLL_ITERS && stableScroll < 3; i++) {
+    window.scrollTo(0, document.body.scrollHeight);
+    await new Promise((r) => setTimeout(r, 1400));
+    const added = collect();
+    if (added === 0) stableScroll++;
+    else stableScroll = 0;
+  }
+
+  // --- "Load more" click phase -------------------------------------------
+  // Bounded retries with linear backoff. CDP gets upset if you click the
+  // same button too aggressively -- 400ms scroll-into-view, 2s post-click
+  // wait, and a backoff factor of +500ms per successful click.
+  const LOAD_MORE_ITERS = 40;
+  let loadMoreDelay = 2000;
+  for (let i = 0; i < LOAD_MORE_ITERS; i++) {
+    const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+      /^load more/i.test((b.innerText || '').trim())
+    );
+    if (!btn) break;
+    btn.scrollIntoView({ block: 'center' });
+    await new Promise((r) => setTimeout(r, 400));
+    try {
       btn.click();
-      await new Promise(r => setTimeout(r, 2200));
-      const before = seen.size;
-      collect();
-      if (seen.size === before) break;
+    } catch (e) {
+      // Button was removed between find and click. Not fatal; loop will
+      // refind on the next iteration (or exit if it is truly gone).
+      continue;
     }
-    return Array.from(seen);
-  })();
+    await new Promise((r) => setTimeout(r, loadMoreDelay));
+    const added = collect();
+    if (added === 0) break;
+    loadMoreDelay = Math.min(loadMoreDelay + 500, 5000);
+  }
 
-  console.log(`[dumper] found ${ids.length} order IDs`);
+  // --- Persist state -----------------------------------------------------
+  state.seen_ids = Array.from(seen);
+  state.last_page_height = document.body.scrollHeight;
+  saveState(state);
 
-  // -- Step 2: for each order, navigate to its detail page via window.location,
-  //    wait for Apollo cache to populate, and pull the OrderManagerOrderDelivery
-  //    entry. Results persist in localStorage across navigations.
-  //
-  //    NOTE: This function relies on being RE-RUN after each navigation because
-  //    changing window.location tears down the JS context. In practice you run
-  //    the per-order extract snippet separately for each order (the companion
-  //    extract-one.js). This block is for discovery of order IDs; iterating
-  //    through them is done via Chrome MCP driver or a DevTools macro.
+  // --- Cross-check dumped set to report what is still pending ------------
+  let dumpedIds = new Set();
+  try {
+    const dumped = JSON.parse(localStorage.getItem('__ic_dumped') || '[]');
+    for (const r of dumped) if (r && r.order_id) dumpedIds.add(r.order_id);
+  } catch (e) {
+    // corrupt __ic_dumped; leave dumpedIds empty so the caller treats
+    // everything as pending and re-extracts.
+  }
+  const pending = state.seen_ids.filter((id) => !dumpedIds.has(id));
 
-  const result = { order_ids: ids, collected_at: new Date().toISOString() };
-  window.__ic_order_ids = ids;
-  return JSON.stringify(result, null, 2);
+  return JSON.stringify({
+    total_ids: state.seen_ids.length,
+    new_ids_this_run: state.seen_ids.length - resumedFromCount,
+    already_dumped: dumpedIds.size,
+    pending_extract: pending.length,
+    resumed: resumedFromCount > 0,
+    state_key: STATE_KEY,
+    pending_sample: pending.slice(0, 5),
+  });
 })();

--- a/library/commerce/instacart/docs/export-jsonl.js
+++ b/library/commerce/instacart/docs/export-jsonl.js
@@ -1,0 +1,56 @@
+// Instacart dumped-orders exporter. Run this after extract-one.js has
+// walked every pending order (check dumper.js output for pending_extract
+// reaching 0). Triggers a browser download of instacart-orders.jsonl to
+// the user's default Downloads directory.
+//
+// Then run:
+//     instacart history import ~/Downloads/instacart-orders.jsonl
+//
+// Skip records (from extract-one.js failures) are filtered out of the
+// JSONL but counted in the return summary so the caller can warn the
+// user about coverage gaps.
+
+(() => {
+  const DUMPED_KEY = '__ic_dumped';
+
+  let data;
+  try {
+    data = JSON.parse(localStorage.getItem(DUMPED_KEY) || '[]');
+  } catch (e) {
+    return JSON.stringify({ err: 'dumped_store_corrupt', detail: String(e) });
+  }
+  if (!Array.isArray(data) || data.length === 0) {
+    return JSON.stringify({ err: 'no_dumped_records', hint: 'run dumper.js + extract-one.js first' });
+  }
+
+  const valid = data.filter((r) => r && !r.skipped && r.order_id);
+  const skipped = data.length - valid.length;
+
+  if (valid.length === 0) {
+    return JSON.stringify({
+      err: 'only_skip_records',
+      skipped_count: skipped,
+      hint: 'every extract-one.js run failed; check cache key and re-run',
+    });
+  }
+
+  const jsonl = valid.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const blob = new Blob([jsonl], { type: 'application/x-ndjson' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'instacart-orders.jsonl';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+
+  return JSON.stringify({
+    downloaded: true,
+    filename: 'instacart-orders.jsonl',
+    bytes: jsonl.length,
+    orders: valid.length,
+    skipped_count: skipped,
+    next_command: 'instacart history import ~/Downloads/instacart-orders.jsonl',
+  });
+})();

--- a/library/commerce/instacart/docs/extract-one.js
+++ b/library/commerce/instacart/docs/extract-one.js
@@ -1,60 +1,166 @@
-// Per-order extractor. Run this after navigating to a
-// /store/orders/<id> page. Reads the OrderManagerOrderDelivery cache
-// entry (populated after Apollo finishes loading the page) and appends
-// the order to localStorage['__ic_dumped'].
+// Instacart per-order extractor. Run this AFTER navigating to a
+// /store/orders/<id> page in the logged-in Instacart tab.
 //
-// After iterating through all orders, run the exporter snippet below
-// to download a JSONL file for `instacart history import`.
+// How it works:
+//   1. Polls the Apollo cache for up to 10s waiting for the
+//      OrderManagerOrderDelivery entry to hydrate with
+//      "includeOrderItems":true. Hydration is async; running the
+//      extractor on page load without polling drops records silently.
+//   2. If the expected cache key is missing (bundle rotation renamed
+//      it), falls back to scanning cache keys for the first entry whose
+//      key contains "includeOrderItems":true. Reports the fallback in
+//      the result so the caller can alert on bundle drift.
+//   3. Normalizes the order into the JSONL schema consumed by
+//      `instacart history import`.
+//   4. Appends the record to localStorage.__ic_dumped (persistent across
+//      navigation). Dedups by order_id on push.
+//
+// Skip records: if polling times out OR the entry holds no orderItems,
+// a structured {order_id, skipped: true, reason} record is pushed so a
+// partial backfill is visible instead of silently losing records.
+//
+// Run export-jsonl.js after the per-order loop to trigger a download of
+// the collected JSONL for `instacart history import`.
 
 (async () => {
-  await new Promise(r => setTimeout(r, 3500));
-  const v = window.__APOLLO_CLIENT__.cache.extract().OrderManagerOrderDelivery;
-  const k = v && Object.keys(v).find(k => k.includes('"includeOrderItems":true'));
-  if (!k) return JSON.stringify({ skipped: true, reason: 'no items-bearing cache entry yet' });
-  const od = v[k].orderDelivery;
-  const orderId = JSON.parse(k).orderId;
-  const items = (od.orderItems || []).map(oi => ({
-    item_id: oi?.currentItem?.legacyId
-      ? 'items_' + (od.retailer?.id || '?') + '-' + oi.currentItem.legacyId.replace(/^item_/, '')
+  const DUMPED_KEY = '__ic_dumped';
+  const MAX_POLL_MS = 10000;
+  const POLL_INTERVAL_MS = 200;
+
+  const loadDumped = () => {
+    try {
+      return JSON.parse(localStorage.getItem(DUMPED_KEY) || '[]');
+    } catch (e) {
+      return [];
+    }
+  };
+  const saveDumped = (arr) => {
+    localStorage.setItem(DUMPED_KEY, JSON.stringify(arr));
+  };
+  const pushDumped = (record) => {
+    const arr = loadDumped();
+    if (!arr.find((r) => r && r.order_id === record.order_id)) arr.push(record);
+    saveDumped(arr);
+    return arr.length;
+  };
+
+  // Derive the order ID from the URL so the caller does not have to
+  // pass it explicitly. Matches /store/orders/<digits>.
+  const urlMatch = window.location.pathname.match(/\/store\/orders\/(\d+)/);
+  const urlOrderId = urlMatch ? urlMatch[1] : null;
+
+  // --- Profile-picker redirect ------------------------------------------
+  if (window.location.pathname.startsWith('/store/profiles')) {
+    return JSON.stringify({
+      profile_picker: true,
+      reason: 'tab_redirected_to_profile_picker',
+    });
+  }
+
+  // --- Locate the cache entry with includeOrderItems:true ---------------
+  // The primary path is the OrderManagerOrderDelivery key. Fallback path
+  // scans cache keys for the substring, in case Instacart renames the
+  // key in a future bundle.
+  const findOrderDeliveryEntry = () => {
+    const client = window.__APOLLO_CLIENT__;
+    if (!client || !client.cache || typeof client.cache.extract !== 'function') {
+      return { err: 'no_apollo_client' };
+    }
+    const snapshot = client.cache.extract();
+    const primary = snapshot && snapshot.OrderManagerOrderDelivery;
+    if (primary && typeof primary === 'object') {
+      for (const k of Object.keys(primary)) {
+        if (k.includes('"includeOrderItems":true')) {
+          return { path: ['OrderManagerOrderDelivery', k], entry: primary[k], fallback: false };
+        }
+      }
+    }
+    // Fallback: scan every top-level cache entry for an items-bearing sub-key.
+    for (const topKey of Object.keys(snapshot || {})) {
+      const bucket = snapshot[topKey];
+      if (!bucket || typeof bucket !== 'object') continue;
+      for (const k of Object.keys(bucket)) {
+        if (k.includes('"includeOrderItems":true') && bucket[k] && bucket[k].orderDelivery) {
+          return { path: [topKey, k], entry: bucket[k], fallback: true };
+        }
+      }
+    }
+    return { err: 'cache_key_missing' };
+  };
+
+  // --- Poll for hydration -----------------------------------------------
+  const deadline = Date.now() + MAX_POLL_MS;
+  let located = null;
+  let lastErr = null;
+  while (Date.now() < deadline) {
+    const attempt = findOrderDeliveryEntry();
+    if (attempt.entry && attempt.entry.orderDelivery) {
+      located = attempt;
+      break;
+    }
+    lastErr = attempt.err || 'entry_without_orderDelivery';
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  if (!located) {
+    // Push a skip record so the missing order is visible in the dumped set.
+    const skip = {
+      order_id: urlOrderId || 'unknown',
+      skipped: true,
+      reason: lastErr || 'cache_not_hydrated',
+      url: window.location.pathname,
+    };
+    pushDumped(skip);
+    return JSON.stringify(skip);
+  }
+
+  // --- Normalize into JSONL shape ---------------------------------------
+  const od = located.entry.orderDelivery;
+
+  // Prefer the orderId encoded in the cache key JSON -- it matches URL.
+  let keyOrderId = urlOrderId;
+  try {
+    const keyStr = located.path[1];
+    const parsed = JSON.parse(keyStr);
+    if (parsed && parsed.orderId) keyOrderId = parsed.orderId;
+  } catch (e) {
+    // Not JSON; rely on URL match.
+  }
+
+  const items = (od.orderItems || []).map((oi) => ({
+    item_id: oi && oi.currentItem && oi.currentItem.legacyId
+      ? 'items_' + (od.retailer && od.retailer.id ? od.retailer.id : '?') + '-' +
+        oi.currentItem.legacyId.replace(/^item_/, '')
       : null,
-    product_id: oi?.currentItem?.basketProduct?.item?.productId,
-    name: oi?.currentItem?.name,
-    quantity: oi?.selectedQuantityValue,
-    quantity_type: oi?.selectedQuantityType,
+    product_id:
+      oi && oi.currentItem && oi.currentItem.basketProduct && oi.currentItem.basketProduct.item
+        ? oi.currentItem.basketProduct.item.productId
+        : null,
+    name: oi && oi.currentItem ? oi.currentItem.name : null,
+    quantity: oi ? oi.selectedQuantityValue : null,
+    quantity_type: oi ? oi.selectedQuantityType : null,
   }));
-  const rec = {
-    order_id: orderId,
-    retailer_id: od.retailer?.id,
-    retailer_slug: od.retailer?.slug,
-    retailer_name: od.retailer?.name,
-    delivered_at: od.deliveredAt,
+
+  const record = {
+    order_id: keyOrderId,
+    retailer_id: od.retailer ? od.retailer.id : null,
+    retailer_slug: od.retailer ? od.retailer.slug : null,
+    retailer_name: od.retailer ? od.retailer.name : null,
+    delivered_at: od.deliveredAt || null,
     item_count: items.length,
     items,
   };
-  const existing = JSON.parse(localStorage.getItem('__ic_dumped') || '[]');
-  if (!existing.find(r => r.order_id === orderId)) existing.push(rec);
-  localStorage.setItem('__ic_dumped', JSON.stringify(existing));
-  return JSON.stringify({ order_id: orderId, retailer: od.retailer?.slug, items: items.length, total: existing.length });
-})();
 
-// ---- Exporter (run after all per-order extracts complete) ----
-// Triggers a browser download of instacart-orders.jsonl. Drop it somewhere
-// the CLI can find, then run:
-//     instacart history import ~/Downloads/instacart-orders.jsonl
+  if (located.fallback) {
+    record.extraction_note = 'fallback_cache_scan';
+  }
 
-/*
-(() => {
-  const data = JSON.parse(localStorage.getItem('__ic_dumped') || '[]');
-  const jsonl = data.map(r => JSON.stringify(r)).join('\n');
-  const blob = new Blob([jsonl], { type: 'application/x-ndjson' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'instacart-orders.jsonl';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-  return JSON.stringify({ downloaded: true, bytes: jsonl.length, orders: data.length });
+  const total = pushDumped(record);
+  return JSON.stringify({
+    order_id: record.order_id,
+    retailer: record.retailer_slug,
+    items: items.length,
+    fallback_scan: located.fallback,
+    total_in_store: total,
+  });
 })();
-*/

--- a/library/commerce/instacart/docs/history-ops-capture.md
+++ b/library/commerce/instacart/docs/history-ops-capture.md
@@ -6,19 +6,14 @@ The original PR #78 assumed Instacart exposed dedicated GraphQL ops named `BuyIt
 
 ## Use this instead
 
-For the working path to backfill your Instacart purchase history, see:
+For the working end-user flow:
 
-- **Playbook:** [`docs/patterns/authenticated-session-scraping.md`](../../../docs/patterns/authenticated-session-scraping.md) — the canonical reference for this class of problem across any printed CLI.
-- **Dumper:** `docs/dumper.js` + `docs/extract-one.js` — the browser-side JS to walk orders and export JSONL.
-- **Importer:** `instacart history import <path>` — the CLI-side command that reads the JSONL and populates the history tables.
+- **One command:** Tell the `/pp-instacart` skill "backfill my instacart orders". It drives the full Chrome MCP + import loop for you.
+- **Walkthrough:** [`backfill-walkthrough.md`](backfill-walkthrough.md) covers the skill-driven path end to end.
+- **Manual fallback:** [`backfill-devtools-fallback.md`](backfill-devtools-fallback.md) for users without `claude-in-chrome` MCP.
 
-## Quick-start (10 minutes end-to-end)
+Technical reference:
 
-1. Open `https://www.instacart.com/store/account/orders` in Chrome, logged in.
-2. Run `dumper.js` to collect order IDs (via DevTools console or agent-driven Chrome MCP).
-3. For each order ID, navigate to `/store/orders/<id>` and run `extract-one.js`.
-4. Run the exporter snippet at the bottom of `extract-one.js` to download `instacart-orders.jsonl`.
-5. `instacart history import ~/Downloads/instacart-orders.jsonl`.
-6. `instacart add <retailer> "<something you've bought>" --dry-run --json` → look for `"resolved_via": "history"`.
-
-The full walkthrough with tooling rationale is in the playbook.
+- **Playbook:** [`docs/patterns/authenticated-session-scraping.md`](../../../docs/patterns/authenticated-session-scraping.md) — tiered decision tree for this class of problem across any printed CLI.
+- **Scripts:** `docs/dumper.js`, `docs/extract-one.js`, `docs/export-jsonl.js` — the browser-side JS.
+- **Importer:** `instacart history import <path>` — the CLI-side command.

--- a/library/commerce/instacart/internal/cli/add.go
+++ b/library/commerce/instacart/internal/cli/add.go
@@ -126,6 +126,9 @@ Instacart app or web UI.`,
 					"quantity": qty,
 					"status":   "dry-run (mutation not fired)",
 				}
+				if resolvedVia != "history" && historyIsEmpty(app) {
+					preview["hint"] = backfillHint()
+				}
 				if app.JSON {
 					return json.NewEncoder(cmd.OutOrStdout()).Encode(preview)
 				}
@@ -184,12 +187,16 @@ Instacart app or web UI.`,
 			}
 
 			if app.JSON {
-				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+				envelope := map[string]any{
 					"added":        pick,
 					"cart_id":      cartID,
 					"resolved_via": resolvedVia,
 					"result":       parsed.Data.UpdateCartItems,
-				})
+				}
+				if resolvedVia != "history" && historyIsEmpty(app) {
+					envelope["hint"] = backfillHint()
+				}
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(envelope)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "added to %s cart:\n  %s (via %s)\n  item_id=%s\n", retailer, pick.Name, resolvedVia, pick.ItemID)
 			if parsed.Data.UpdateCartItems.Cart != nil {

--- a/library/commerce/instacart/internal/cli/doctor.go
+++ b/library/commerce/instacart/internal/cli/doctor.go
@@ -63,27 +63,18 @@ Exit codes:
 				}
 			}
 
-			// 4. History sync state
+			// 4. History store state. Instacart has no clean GraphQL op for
+			// order history (see docs/solutions/best-practices/
+			// instacart-orders-no-clean-graphql-op.md), so the only working
+			// backfill path is the Chrome-MCP-driven `/pp-instacart backfill`
+			// skill flow which dumps + imports JSONL.
 			orderCount, _ := app.Store.CountOrders()
 			itemCount, _, _ := app.Store.CountPurchasedItems()
-			historyEnabled := true
-			for _, opName := range instacart.HistoryOpNames() {
-				if h, _ := app.Store.LookupOp(opName); h == "" {
-					historyEnabled = false
-					break
-				}
-			}
-			if !historyEnabled {
+			if orderCount == 0 && itemCount == 0 {
 				results = append(results, checkResult{
 					Name:   "history",
 					Status: "warn",
-					Detail: "hashes not yet captured -- see docs/history-ops-capture.md",
-				})
-			} else if orderCount == 0 && itemCount == 0 {
-				results = append(results, checkResult{
-					Name:   "history",
-					Status: "warn",
-					Detail: "not synced yet -- run `instacart history sync`",
+					Detail: backfillHint(),
 				})
 			} else {
 				results = append(results, checkResult{

--- a/library/commerce/instacart/internal/cli/history.go
+++ b/library/commerce/instacart/internal/cli/history.go
@@ -177,7 +177,7 @@ Use --store to filter to one retailer. Default limit is 25.`,
 				return err
 			}
 			if len(rows) == 0 {
-				fmt.Fprintln(cmd.OutOrStderr(), "no purchase history yet -- run `instacart history sync` to populate")
+				fmt.Fprintln(cmd.OutOrStderr(), backfillHint())
 				if app.JSON {
 					return json.NewEncoder(cmd.OutOrStdout()).Encode([]any{})
 				}

--- a/library/commerce/instacart/internal/cli/history_hints.go
+++ b/library/commerce/instacart/internal/cli/history_hints.go
@@ -1,0 +1,28 @@
+package cli
+
+// backfillHint returns the canonical one-line nudge shown to users whose
+// local Instacart history store is empty. Surfaced by `doctor` and by
+// `add --json` when live-search fallthrough happens on an empty store.
+//
+// Keep the message short. It is meant to be a pointer, not a tutorial.
+// Full walkthrough lives in the pp-instacart skill (backfill intent) and
+// in docs/patterns/authenticated-session-scraping.md.
+func backfillHint() string {
+	return "no local order history. run `/pp-instacart backfill my orders` to populate so `add` can resolve from your real purchases."
+}
+
+// historyIsEmpty reports whether the local purchase-history store has any
+// orders or purchased_items rows. Used to gate first-run discovery hints.
+// Errors from the store are treated as non-empty so the hint does not fire
+// on a corrupt or locked database.
+func historyIsEmpty(app *AppContext) bool {
+	orderCount, err := app.Store.CountOrders()
+	if err != nil || orderCount > 0 {
+		return false
+	}
+	itemCount, _, err := app.Store.CountPurchasedItems()
+	if err != nil {
+		return false
+	}
+	return itemCount == 0
+}

--- a/library/commerce/instacart/internal/cli/history_hints_test.go
+++ b/library/commerce/instacart/internal/cli/history_hints_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBackfillHint_ReferencesSkill ensures the hint string points users at
+// the canonical skill invocation. Downstream UX (README, doctor, add) all
+// reuse this string, so regressing the wording is a single-source change.
+func TestBackfillHint_ReferencesSkill(t *testing.T) {
+	hint := backfillHint()
+	if !strings.Contains(hint, "/pp-instacart backfill") {
+		t.Errorf("hint should name the skill invocation; got %q", hint)
+	}
+	if !strings.Contains(hint, "order history") {
+		t.Errorf("hint should mention what gets populated; got %q", hint)
+	}
+}
+
+func TestHistoryIsEmpty_FreshStore(t *testing.T) {
+	app := newTestApp(t)
+	if !historyIsEmpty(app) {
+		t.Fatal("fresh store should be reported empty")
+	}
+}
+
+func TestHistoryIsEmpty_WithOrder(t *testing.T) {
+	app := newTestApp(t)
+	// Seeding a purchased_item is the cheapest way to make the store
+	// non-empty without wiring a full order through the upsert path.
+	seedPurchase(t, app.Store, "qfc", "items_42-111", "Test Item", 3, true)
+	if historyIsEmpty(app) {
+		t.Fatal("store with a purchased_item should not be reported empty")
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-instacart/SKILL.md
+++ b/plugin/skills/pp-instacart/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pp-instacart
-description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco'."
-argument-hint: "<command> [args] | install cli|mcp"
-allowed-tools: "Read Bash"
+description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco', 'backfill my instacart history', 'sync my instacart orders', 'download my order history', 'save my instacart history locally'."
+argument-hint: "<command> [args] | install cli|mcp | backfill"
+allowed-tools: "Read Bash WebFetch"
 ---
 
 # Instacart - Printing Press CLI
@@ -36,17 +36,20 @@ Falls through to today's live-search behavior when any condition fails. Pass `--
 
 Every successful `add` (history-resolved or live-resolved) writes back to `purchased_items` so the signal gets warmer without a full re-sync.
 
-### Purchase history import + inspection
+### One-command history backfill
 
-**Use `history import`, not `history sync`.** Instacart does not expose a clean order-history GraphQL op, so `sync` cannot work — it surfaces a clear error pointing at the working path. The working path is:
+Typing "backfill my instacart orders" (or similar, see Argument Parsing) kicks off a Chrome-MCP-driven flow that walks the user's logged-in Instacart tab, extracts their order history into JSONL, and imports it into the local DB. After backfill, `add` resolves from real purchase history instead of live-search guesses.
 
-1. Run the browser-side dumper (see `docs/dumper.js` + `docs/extract-one.js`) against a logged-in Chrome tab
-2. Download the resulting `instacart-orders.jsonl`
-3. `instacart history import <path>` — upserts orders + items into the local DB
+Primary path: Chrome MCP. Fallback: paste three JS files into DevTools by hand.
 
-See the full playbook at [`docs/patterns/authenticated-session-scraping.md`](https://github.com/mvanhorn/printing-press-library/blob/main/docs/patterns/authenticated-session-scraping.md) (repo root).
+Full walkthrough below under "Backfill Flow". Reference docs with more detail:
+
+- [`docs/backfill-walkthrough.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-walkthrough.md) — Chrome MCP flow
+- [`docs/backfill-devtools-fallback.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-devtools-fallback.md) — manual DevTools flow
 
 `history list` / `history search` / `history stats` inspect whatever has been loaded.
+
+Instacart does not expose a clean order-history GraphQL op, so the legacy `history sync` command cannot work. See [`docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md`](https://github.com/mvanhorn/printing-press-library/blob/main/docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md) for why.
 
 ### Natural-language `add`
 
@@ -107,12 +110,13 @@ Maintenance:
 instacart auth login                # extract cookies from Chrome
 instacart doctor                    # verify auth + live ping
 instacart capture                   # seed built-in op hashes
-# History backfill: browser-side dump, then import. See
-# docs/patterns/authenticated-session-scraping.md for the full walkthrough.
-# After you have instacart-orders.jsonl:
-instacart history import ~/Downloads/instacart-orders.jsonl
-instacart history stats             # confirm what landed
 ```
+
+Then backfill history (optional but recommended; unlocks history-first `add`):
+
+> Tell the agent: "backfill my instacart orders"
+
+The skill drives the rest. See the "Backfill Flow" section below.
 
 ### Add something you buy all the time
 
@@ -169,7 +173,37 @@ Given a free-form natural-language request:
 
 1. Empty, `help`, or `--help` -> run `instacart --help`
 2. Starts with `install` -> CLI install; ends with `mcp` -> MCP install
-3. Anything else -> map to the best subcommand and run with `--json` when invoked from an agent
+3. Matches a **backfill intent** -> run the Backfill Flow below. Trigger phrases include: "backfill my orders", "backfill my history", "sync my instacart history", "sync my instacart orders", "download my order history", "save my instacart history locally", "pull in my past orders", "import my recent orders".
+4. Anything else -> map to the best subcommand and run with `--json` when invoked from an agent
+
+## Backfill Flow
+
+Drive this when the user hits a backfill intent. Read [`docs/backfill-walkthrough.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-walkthrough.md) via WebFetch for the full procedure; summary below.
+
+Setup check:
+
+1. Confirm `instacart-pp-cli` is on PATH. If not, install: `go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@latest`.
+2. Probe `mcp__claude-in-chrome__tabs_context_mcp`. If the tool is unavailable, route to the DevTools fallback: fetch [`docs/backfill-devtools-fallback.md`](https://github.com/mvanhorn/printing-press-library/blob/main/library/commerce/instacart/docs/backfill-devtools-fallback.md) and walk the user through it. Stop.
+3. Run `instacart-pp-cli history stats --agent`. If orders > 0, this is a top-up run; the resume state will skip already-dumped orders automatically.
+
+Chrome MCP loop:
+
+1. WebFetch the three JS files (cache each in the current session):
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/dumper.js`
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/extract-one.js`
+   - `https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/library/commerce/instacart/docs/export-jsonl.js`
+2. Open or reuse a tab at `https://www.instacart.com/store/account/orders`. If the dumper returns `profile_picker: true`, ask the user to pick a profile in the tab, then re-run.
+3. Inject `dumper.js` via `mcp__claude-in-chrome__javascript_tool`. Read back `total_ids` and `pending_extract`.
+4. For each order ID in the pending set, navigate to `/store/orders/<id>` then inject `extract-one.js`. Report progress to the user every 10 orders.
+5. When pending reaches 0, inject `export-jsonl.js`. It downloads `instacart-orders.jsonl` to the user's default Downloads folder.
+6. Run `instacart-pp-cli history import ~/Downloads/instacart-orders.jsonl --agent` in a Bash tool. Show the summary JSON to the user.
+7. Verify: `instacart-pp-cli history stats --agent`. Offer a follow-up sanity check: `instacart-pp-cli add <retailer> "<something they've bought>" --dry-run --json` and flag `resolved_via: "history"` when it appears.
+
+Error surfaces worth translating for the user:
+
+- Extractor `cache_key_missing` on every order -> Instacart rotated their web bundle. Report the observed cache keys and point at the rotation-recovery section of the walkthrough doc.
+- Dumper reports fewer IDs than the user expected -> probably on a multi-profile account; ensure the selected profile is the one with purchase history.
+- `history import` shows 0 orders imported -> the JSONL is empty (only skip records). Re-run the extractor loop with fresh tabs.
 
 ## CLI Installation
 
@@ -185,5 +219,5 @@ Ensure `$HOME/go/bin` is on `$PATH`.
 1. Check installed: `which instacart-pp-cli`
 2. Check auth: `instacart doctor`
 3. Capture GraphQL hashes: `instacart capture`
-4. (Optional but recommended) Sync history: follow `docs/history-ops-capture.md` then `instacart history sync`
+4. (Optional but recommended) Backfill history — run the Backfill Flow above. Unlocks history-first `add` resolution.
 5. Run your command with `--json` if invoked from an agent


### PR DESCRIPTION
## Summary

- Typing "backfill my instacart orders" into the `/pp-instacart` skill now drives the full Chrome MCP + import loop end to end. No more hand-walking users through DevTools-console JS.
- Dumper + extractor hardened with resume state, cache-hydration polling, and bundle-rotation fallback so the flow works for 100+ order histories without silent drops.
- `doctor` and `add --json` surface a one-line hint when history is empty so users discover the capability.
- Docs and playbook cross-links reflect the new entry point.

Executes plan `~/docs/plans/2026-04-18-007-feat-instacart-end-user-backfill-ux-plan.md`.

## Commits

1. `feat(instacart): surface /pp-instacart backfill hint on empty history` — Unit 3. Hints in `doctor`, `add --json`, and `history list`. New `history_hints.go` with shared helpers + tests.
2. `feat(instacart): harden browser-side dumper/extractor for full-history backfill` — Unit 1. `__ic_backfill_state` resume, bounded Load-more retries, cache polling loop, fallback key scan, structured skip records. Extracts exporter into `export-jsonl.js`.
3. `feat(cli): add one-command backfill skill flow for instacart end users` — Unit 2. Skill argument-parser intent + inline Backfill Flow section + WebFetch URLs for the three JS files. Adds `docs/backfill-walkthrough.md` and `docs/backfill-devtools-fallback.md`. Plugin version 1.1.12 -> 1.1.13.
4. `docs: reflect one-command backfill flow in README, playbook, and supersede notes` — Unit 4. README "First-time history backfill" section, updates to `authenticated-session-scraping.md` worked example + further reading, cross-links in `history-ops-capture.md` and `instacart-orders-no-clean-graphql-op.md`.

## Scope boundaries respected

- No changes to `add` resolver logic or SQLite schema. Import contract unchanged.
- No tier-2 (cookie-imported headless) or tier-3 (chromedp-in-Go) implementation.
- No cross-CLI generalization. The parallel deep plan for other CLIs is shelved until a second driver exists.

## Test plan

- [x] `go test ./...` passes in `library/commerce/instacart`
- [x] `gofmt -l` clean
- [x] `go vet` clean
- [x] All three JS files parse with `node --check`
- [x] `.github/scripts/verify-skill/verify_skill.py --dir library/commerce/instacart` passes
- [ ] End-to-end manual test: typing "backfill my instacart orders" from a Claude Code session with `claude-in-chrome` loaded completes against Matt's real Instacart account
- [ ] DevTools fallback test: following `docs/backfill-devtools-fallback.md` cold produces a working JSONL

The last two require a live Claude Code session with the plugin installed from this branch. Worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)