### PR TITLE
docs: refresh plan with PR #83 learnings + mark Unit 1 done (#227)

### DIFF
--- a/docs/plans/2026-04-19-002-feat-espn-movie-goat-missing-commands-plan.md
+++ b/docs/plans/2026-04-19-002-feat-espn-movie-goat-missing-commands-plan.md
@@ -1,410 +1,459 @@
 ---
-title: "feat: Add missing CLI commands to ESPN and audit Movie Goat surface"
+title: "feat: Implement missing ESPN CLI commands and generator extra_commands support"
 type: feat
 status: active
 date: 2026-04-19
+deepened: 2026-04-19
 ---
 
-# feat: Add missing CLI commands to ESPN and audit Movie Goat surface
+# feat: Implement missing ESPN CLI commands and generator extra_commands support
 
 ## Overview
 
-Two Printing Press CLIs ship SKILL.md docs that promise commands the binary does not implement. The agent reads SKILL.md, calls the documented command, and gets `unknown command`. Today's session hit four such failures inside a single MLB query (`boxscore`, `leaders`, `summary <id>`, `team get`).
+Two PRs already shipped from this work stream:
 
-This plan closes the gap by implementing the genuinely useful missing commands in the two CLIs and updating SKILL.md to match the real surface. ESPN gets the bulk of the work because most documented-but-missing commands map to real public ESPN endpoints. Movie Goat needs an audit and small additions (TV `airing-today`, `on-the-air`, `top-rated` are real but undocumented; `discover tv` is real and documented but the SKILL.md example is wrong).
+- #82: original plan capturing the SKILL.md drift evidence.
+- #83: added `unknown-command` check to verify-skill (so the bug class can't reintroduce silently) and truthed-up SKILL.md docs for ESPN, cal-com, flightgoat. Plugin bumped to 1.1.14.
+
+This refresh focuses on the actual user goal: make the ESPN commands work for real, not just remove them from the docs. Eleven commands need implementation: `boxscore`, `leaders`, `plays`, `injuries`, `odds`, `transactions`, `sos`, `h2h`, `compare`, `trending`, `dashboard`. Plus a prerequisite generator change in cli-printing-press so SKILL.md regenerates with the new commands instead of needing hand-edits.
+
+Movie Goat audit is deferred to a separate plan to keep this one focused. Skill-doctor / drift detection is DONE in a different form: PR #83's `unknown-command` check covers the territory the original Unit 5 was scoped for.
 
 ## Problem Frame
 
-The pp-espn SKILL.md cache (`/Users/mvanhorn/.claude/plugins/cache/printing-press-library/printing-press-library/1.1.10/skills/pp-espn/SKILL.md`) lists the following commands in its "Command Reference":
+ESPN's pp-cli currently exposes 25 commands. Eleven more are useful, were previously documented as if they existed, were removed from the docs in #83 to restore truth, and are now intentionally being added back. Each maps to a real public ESPN endpoint or a derivable cross-endpoint composition:
 
-- `boxscore <game_id>`
-- `plays <game_id>`
-- `preview <game_id>`
-- `leaders <sport> <league>`
-- `injuries <sport> <league>`
-- `odds <sport> <league>`
-- `transactions <sport> <league>`
-- `sos <sport> <league>`
-- `h2h <team1> <team2>`
-- `compare <athlete1> <athlete2>`
-- `trending`
-- `dashboard`
-- `team get|list <sport> <league> <team_id>` (real cmd is `teams get|list`)
-- `athlete <sport> <league>`
+| Command | Endpoint family | Style |
+|---|---|---|
+| `boxscore <event_id>` | `summary` payload subtree | hand-written (composes `summary`) |
+| `plays <event_id>` | `sports.core.api.espn.com/v2/.../events/{id}/competitions/{id}/plays` | spec-driven |
+| `leaders <sport> <league>` | `site.web.api.espn.com/apis/common/v3/.../statistics/byathlete` | spec-driven |
+| `injuries <sport> <league>` | `site.web.api.espn.com/apis/site/v2/.../injuries` | spec-driven |
+| `transactions <sport> <league>` | `sports.core.api.espn.com/v2/.../transactions` | spec-driven (needs base-url override) |
+| `odds <sport> <league>` | scoreboard `competitions[].odds` aggregation | hand-written |
+| `sos <sport> <league>` | standings `strengthOfSchedule` derivation | hand-written |
+| `h2h <team1> <team2>` | derived from synced data | hand-written (close to existing `rivals`) |
+| `compare <athlete1> <athlete2>` | athlete search + per-athlete stats | hand-written |
+| `trending` | `site.api.espn.com/apis/site/v2/trending` | hand-written (cross-league) |
+| `dashboard` | reads `~/.config/espn-pp-cli/config.toml` `[favorites]` + scores/standings | hand-written (config + cliutil.FanoutRun) |
 
-None of these resolve in `espn-pp-cli --help` (verified 2026-04-19, version current as of commit d23db1f). The real CLI exposes `summary`, `recap`, `scores`, `scoreboard`, `standings`, `schedule`, `streak`, `rivals`, `today`, `watch`, `news`, `search`, `sync`, `rankings`, `teams`, plus power-user commands `sql`, `workflow`, `load`, `orphans`, `stale`. SKILL.md never mentions `today`, `scoreboard`, `streak`, `rivals`, `workflow`, `sql`.
-
-The Movie Goat SKILL.md is mostly accurate but:
-
-- Promotes `discover tv` as a recipe, real command exists as `discover tv` subcommand (good), but no examples elsewhere reflect that subcommand structure.
-- Does not document real subcommands `tv airing-today`, `tv on-the-air`, `tv top-rated`.
-- Lists `tv seasons get <seriesId> <seasonNumber>` which exists as `tv get` subcommand named `get` (Cobra collision: `tv get <id>` and `tv seasons get <id> <season>` both share `get`). Behavior needs verification.
-- Lists `genres tv` - need to verify subcommand exists.
-
-The cost of leaving this is steady agent-side friction: every retry burns context, every wrong command erodes user trust, and the SKILL.md keeps shipping promises the CLI cannot keep.
+Generator constraint surfaced in #83: `internal/generator/templates/skill.md.tmpl` `## Command Reference` block iterates `.Resources` only. Hand-written commands like `today`, `streak`, `rivals` never appear in regenerated SKILL.md. That's why prior SKILL.md hand-edits drifted - they were the only way to document hand-written commands. Solution: add an `extra_commands:` array to spec.yaml so authors declare hand-written commands once and the template iterates them too.
 
 ## Requirements Trace
 
-- R1. Every command listed in pp-espn SKILL.md `## Command Reference` resolves successfully against `espn-pp-cli --help` after this PR lands, OR is removed from SKILL.md with no replacement claim.
-- R2. Each new ESPN command returns valid live data against a public ESPN endpoint with `--agent` mode for an in-season league at the time of merge.
-- R3. The pp-movie-goat SKILL.md `## Command Reference` matches `movie-goat-pp-cli --help` exactly (no documented-missing or real-undocumented commands).
-- R4. Existing ESPN commands (`scores`, `summary`, `teams`, `standings`, `news`, `recap`, `rankings`, `today`, `scoreboard`, `streak`, `rivals`, `watch`, `search`, `sync`) continue to work without regression.
-- R5. SKILL.md updates land in both the canonical per-CLI SKILL.md (`library/media-and-entertainment/<cli>/SKILL.md`) and the plugin-cached copy (`plugin/skills/pp-<cli>/SKILL.md`) so plugin users and openclaw users see consistent docs.
-- R6. New ESPN commands have at least one example in SKILL.md and one in the command's `--help` examples block.
-- R7. Each new command writes domain-specific store records (or explicitly opts out) so `sync` and `search` can pick it up where applicable.
+- R1. All eleven listed ESPN commands resolve in `espn-pp-cli --help` after this work lands and return live data via `--agent` for an in-season league.
+- R2. The cli-printing-press generator accepts an `extra_commands:` array in spec.yaml and includes those entries in the generated SKILL.md `## Command Reference` block, in declaration order, after the spec-driven resources.
+- R3. Regenerating ESPN through the new generator preserves all hand-tuned content currently in `library/media-and-entertainment/espn/SKILL.md` that is NOT inside `## Command Reference`. Use `printing-press patch` if full regen would lose context.
+- R4. The verify-skill `unknown-command` check (shipped in #83) reports zero errors for ESPN after each new command lands.
+- R5. Existing ESPN commands and the existing SKILL.md sections (`## Unique Capabilities`, `## Recipes`, `## Auth Setup`, `## Agent Mode`, `## Exit Codes`, `## Installation`, `## Argument Parsing`, `## Agent Workflow Features`) continue to work without regression.
+- R6. Per AGENTS.md, every SKILL.md change is paired with a `tools/generate-skills/main.go` rerun and a `plugin/.claude-plugin/plugin.json` patch bump in the same commit.
+- R7. New commands write to local SQLite via `internal/store/` upserts where the response is naturally row-shaped (leaders, plays, injuries, transactions). Aggregations and read-only views (boxscore, odds, sos, h2h, trending, dashboard) skip the store.
+- R8. Commands that hit endpoints behind the optional API tier (none today for ESPN) document that gracefully. Today all ESPN endpoints are no-auth.
 
 ## Scope Boundaries
 
 In scope:
 
-- Add ESPN commands: `boxscore`, `plays`, `leaders`, `injuries`, `odds`, `transactions`, `sos`, `h2h`, `compare`, `trending`, `dashboard`. Some land via spec.yaml extensions (auto-generated), others as hand-written promoted commands.
-- Rename or alias `team get|list` to `teams get|list` per real CLI naming, with the documented `team` form kept as a deprecated alias for one minor version.
-- Drop `athlete <sport> <league>` from docs (no real ESPN public endpoint matches; subsumed by `compare` and team rosters).
-- Add `today`, `scoreboard`, `streak`, `rivals`, `sql`, `workflow` to ESPN SKILL.md command reference and recipes.
-- Movie Goat: add `tv airing-today`, `tv on-the-air`, `tv top-rated` to SKILL.md. Verify `tv seasons get` and `genres tv` resolve and either fix the docs or fix the binary.
+- cli-printing-press: extend `internal/spec/spec.go`, `internal/generator/templates/skill.md.tmpl`, and the existing skill_test.go coverage to support `extra_commands:`.
+- printing-press-library: extend `library/media-and-entertainment/espn/spec.yaml` with the four spec-driven resources, hand-write the seven composition/aggregation commands, declare all eleven in `extra_commands:` for SKILL.md regen.
+- printing-press-library: regenerate plugin/skills/pp-espn/SKILL.md, bump plugin.json.
+- Tests: per-command `_test.go` for hand-written commands; spec_test.go coverage for the new generator field; verify-skill check stays green.
 
-Out of scope:
+Out of scope (explicit non-goals):
 
-- Authentication changes - ESPN stays no-auth, Movie Goat keeps TMDb + optional OMDb.
-- Schema changes to existing tables in `internal/store`.
-- New MCP tools (the MCP server picks up new resources automatically when spec.yaml grows; no hand-written MCP code in this PR).
-- Cross-CLI shared library work (e.g., shared `agent-mode` flags) - covered elsewhere by PR #218.
-- Dashboard config UI; `dashboard` command reads `~/.config/espn-pp-cli/config.toml` `[favorites]` table only.
-- Live websocket streaming. ESPN endpoints stay polling-only.
+- Movie Goat audit and additions. Splits into its own plan.
+- Per-command MCP tool wrappers beyond what spec-driven resources auto-generate. Hand-written commands stay CLI-only this round.
+- Schema migrations to existing tables. New tables only via `CREATE TABLE IF NOT EXISTS` in the existing store package.
+- Cross-CLI shared library work (e.g., shared agent-mode flags). Covered by PR #218.
+- Live-polling (websocket) variants. ESPN endpoints stay polling-only; `watch` is the existing live path.
+- A new dashboard config UI. The `[favorites]` TOML table is hand-edited.
+- Backfilling SKILL.md drift fixes for any other CLI - hubspot's two false-positives, etc., stay in the verify-skill `[likely false positive]` bucket.
 
 ## Context and Research
 
 ### Relevant Code and Patterns
 
-ESPN package layout:
+cli-printing-press generator:
 
-- `library/media-and-entertainment/espn/spec.yaml` - declarative API spec, 5 resources today (`scoreboard`, `teams`, `news`, `summary`, `rankings`). Generator produces resource-bound commands as `internal/cli/promoted_<resource>.go`.
-- `library/media-and-entertainment/espn/internal/cli/` - hand-written command files for non-spec commands. Pattern: see `today.go`, `streak.go`, `rivals.go`, `recap.go`, `watch.go`, `scores.go`. These read from `internal/client/` for HTTP calls and `internal/store/` for sync/search.
-- `library/media-and-entertainment/espn/internal/client/` - HTTP client wrapping ESPN's site, sports.core, and site.web API surfaces.
-- `library/media-and-entertainment/espn/internal/store/` - SQLite domain tables.
-- `library/media-and-entertainment/espn/internal/types/` - response types.
-- `library/media-and-entertainment/espn/cmd/espn-pp-cli/main.go` - main entrypoint, calls `cli.Execute()`.
+- `internal/spec/spec.go:21` `APISpec` struct - top-level YAML model, add `ExtraCommands` field here.
+- `internal/spec/spec.go:95` `Resource` struct - shape to mirror loosely for `ExtraCommand` if we need richer fields.
+- `internal/generator/templates/skill.md.tmpl:65` `## Command Reference` block iterates `.Resources` - extend to also iterate `.ExtraCommands`.
+- `internal/generator/skill_test.go` - test pattern for skill template expectations; add a new test that asserts extra_commands appear in the rendered SKILL.md.
+- `internal/generator/generator.go:681` template-to-output mapping (`skill.md.tmpl` → `SKILL.md`) - already wired, no change needed.
 
-Movie Goat package layout:
+ESPN package:
 
-- `library/media-and-entertainment/movie-goat/spec.yaml` - 7 resources: `movies`, `tv`, `people`, `discover`, `trending`, `genres`, `search`.
-- `library/media-and-entertainment/movie-goat/internal/cli/` - same generator + hand-written split as ESPN.
-- `library/media-and-entertainment/movie-goat/internal/omdb/` - OMDb enrichment client.
+- `library/media-and-entertainment/espn/spec.yaml` - 5 existing resources: `scoreboard`, `teams`, `news`, `summary`, `rankings`. Pattern for adding new ones is `news:` and `summary:` blocks (clean, single-endpoint shape).
+- `library/media-and-entertainment/espn/internal/cli/today.go` - hand-written cross-league fetch, single-shot. Pattern for `trending` and `dashboard`.
+- `library/media-and-entertainment/espn/internal/cli/rivals.go` - hand-written team-vs-team derivation from synced data. Pattern for `h2h`.
+- `library/media-and-entertainment/espn/internal/cli/streak.go` - hand-written derivation from synced data. Pattern for `sos`.
+- `library/media-and-entertainment/espn/internal/cli/recap.go` - hand-written sport+league argument parsing. Pattern for `boxscore` argument shape.
+- `library/media-and-entertainment/espn/internal/client/` - HTTP client wrapping ESPN's three API surfaces (`site.api`, `sports.core.api`, `site.web.api`). Already covers all the bases needed.
+- `library/media-and-entertainment/espn/internal/store/` - SQLite upsert pattern for new domain tables.
+- `library/media-and-entertainment/espn/internal/cliutil/fanout.go` (likely) - per cli-printing-press AGENTS.md, `cliutil.FanoutRun` is the canonical aggregation pattern with per-source error collection and bounded concurrency. `dashboard` and `trending` should use it.
 
-Add-a-command pattern (verified by reading `today.go`, `recap.go`, `rivals.go`):
+Repo plumbing:
 
-- New command file `internal/cli/<verb>.go`
-- `init()` registers a `*cobra.Command` with rootCmd
-- Handler reads positional args + flags, calls `client.<Method>()`, prints via `helpers.PrintJSON()` or `helpers.PrintTable()`
-- For commands that should also feed the local store, call `store.Upsert<Domain>()` after fetch
-
-ESPN endpoint discovery:
-
-- Many ESPN endpoints are undocumented but stable: `site.api.espn.com/apis/site/v2/sports/{sport}/{league}/{resource}`, `sports.core.api.espn.com/v2/sports/{sport}/leagues/{league}/...`, `site.web.api.espn.com/apis/common/v3/sports/{sport}/{league}/...`. The existing client already hits all three.
-- Confirmed live endpoints used by real ESPN web app:
-  - Boxscore: covered by existing `summary` command's response payload (key: `boxscore`)
-  - Plays: `sports.core.api.espn.com/v2/sports/{sport}/leagues/{league}/events/{eventId}/competitions/{eventId}/plays?limit=1000`
-  - Injuries: `site.web.api.espn.com/apis/site/v2/sports/{sport}/{league}/injuries`
-  - Odds: contained in `summary` payload under `pickcenter`/`againstTheSpread`
-  - Transactions: `sports.core.api.espn.com/v2/sports/{sport}/leagues/{league}/transactions`
-  - Leaders: `site.web.api.espn.com/apis/common/v3/sports/{sport}/{league}/statistics/byathlete?limit=N&category=<cat>`
-  - Athletes by team: `site.web.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams/{teamId}/roster`
-
-Verification strategy: dogfood-results.json already exists per CLI. Adding a command means appending to its example_check coverage.
+- `tools/generate-skills/main.go` - regenerates `plugin/skills/pp-*/SKILL.md` from `library/<cat>/<cli>/SKILL.md` plus `--help` enrichment. Run after every library SKILL.md change.
+- `plugin/.claude-plugin/plugin.json` - bump `version` patch component in same commit as SKILL changes.
+- `.github/scripts/verify-skill/verify_skill.py` - now includes `unknown-command` check (PR #83). Will fail any PR that documents commands missing from `internal/cli/*.go`.
+- `.github/workflows/verify-skills.yml` - triggers on `library/**/SKILL.md`, `library/**/internal/cli/**`, and `.github/scripts/verify-skill/**`.
 
 ### Institutional Learnings
 
-- 2026-04-10-001 fix-cli-quality-bugs plan: previous round of CLI hygiene fixes. Pattern was small atomic commits per binary, dogfood verification before merge. Worth following here.
-- Memory `feedback_pp_go_install_goprivate.md`: PP CLIs need `GOPRIVATE='github.com/mvanhorn/*'` for fresh installs. Local verification commands in this plan must include that prefix.
-- Memory `feedback_evidence_every_pr.md`: every PR in a batch needs evidence. This plan splits into separate PRs per CLI for that reason.
+- PR #83 (this work stream): generator-side fix is the durable solution. Hand-edits to SKILL.md silently invalidate on regen. The `extra_commands:` declaration closes that loop.
+- cli-printing-press AGENTS.md: "Default to machine changes." Generator extension lands first; ESPN consumes it.
+- cli-printing-press AGENTS.md: `cliutil` namespace is generator-reserved. Hand-written code must not collide with `cliutil.FanoutRun` or `cliutil.CleanText` exports.
+- cli-printing-press AGENTS.md: dogfood marks path-validity skipped when `kind: synthetic`. ESPN is currently `kind: rest` (default) - new endpoints will run path-validity checks. Verify each spec.yaml endpoint URL with a real curl before merging.
+- printing-press-library AGENTS.md: SKILL.md content changes do NOT trigger automatic plugin.json bump. Manual patch bump every time.
+- 2026-04-10 fix-cli-quality-bugs plan: prior round of CLI hygiene. Pattern was small atomic commits per binary, dogfood verification before merge.
+- Memory `feedback_pp_go_install_goprivate.md`: PP CLIs need `GOPRIVATE='github.com/mvanhorn/*'` for fresh installs. Local verification commands need that prefix.
+- Memory `feedback_evidence_every_pr.md`: every PR in a batch needs evidence. Splits this plan into separate PRs by repo and by command cluster.
 
 ### External References
 
-- ESPN unofficial API reference: https://github.com/pseudo-r/Public-ESPN-API (community-maintained list of working endpoints, current as of 2025-12).
-- TMDb API docs: https://developer.themoviedb.org/reference/intro/getting-started.
-- Cobra subcommand collision rules: https://pkg.go.dev/github.com/spf13/cobra (relevant for the `tv get` vs `tv seasons get` overlap question in Movie Goat).
+- ESPN unofficial API reference: https://github.com/pseudo-r/Public-ESPN-API - community-maintained list of working endpoints, current as of 2025-12.
+- ESPN trending endpoint sample response (verified 2026-04-19): `https://site.api.espn.com/apis/site/v2/trending` returns athletes and teams with `entity_type`, `name`, `league`, `popularity` fields.
+- Cobra subcommand registration: https://pkg.go.dev/github.com/spf13/cobra - referenced for `rootCmd.AddCommand` patterns when wiring new commands into root.go.
 
 ## Key Technical Decisions
 
-- Spec-driven vs hand-written for new ESPN commands. Decision: spec.yaml for `injuries`, `transactions`, `leaders`, `plays` (single endpoint, predictable response shape, MCP server gets them for free). Hand-written for `boxscore`, `odds`, `sos`, `h2h`, `compare`, `trending`, `dashboard` (multi-endpoint composition or local-state computation, no clean spec fit). Rationale: spec.yaml gives free MCP exposure but pays cost in flexibility; commands that compose multiple endpoints or read local config want raw Go.
-- `boxscore` semantics. Decision: alias `boxscore <event_id>` to `summary <sport> <league> --event <event_id>` filtered to the boxscore subtree. Sport+league inferred from the cached scores response when possible, required as flag otherwise. Rationale: user mental model is "boxscore for a game id"; making them remember sport+league + use a flag is the friction we are removing.
-- `team` vs `teams` naming. Decision: keep `teams` as canonical, add `team` as a hidden alias that prints a deprecation note on stderr. Drop `team` references from SKILL.md immediately. Rationale: SKILL.md `team` is a docs bug; renaming the real command would break users on old SKILL.md.
-- Dashboard config schema. Decision: `[favorites]` TOML table with `nfl = ["KC", "BAL"]`, `nba = ["OKC", "BOS"]` keyed by league abbreviation. Reuses existing config file `~/.config/espn-pp-cli/config.toml`. Rationale: smallest config surface that supports per-league favorites; matches how scores/standings already key on league.
-- Movie Goat `tv get` collision. Decision: keep `tv get <seriesId>` as the series-detail call, rename the season detail to `tv seasons get <seriesId> <seasonNumber>` (verified to be the existing signature, just under-promoted). Update SKILL.md to use the explicit `tv seasons get` form so no example collides.
-- SKILL.md sync. Decision: write a small repo-level `tools/skill-doctor.go` that diffs each `library/<area>/<cli>/SKILL.md` against `<binary> --help` output and fails CI if drift exceeds zero documented-missing commands. Adds it as the last unit. Rationale: the only durable way to prevent this class of bug from coming back. If the unit slips, the rest of the plan still ships value.
+- Generator change first, ESPN second. The generator extension is small and unblocks SKILL.md regen for ESPN. Doing ESPN first would force another round of hand-edits that re-trigger the drift class. Sequence: cli-printing-press PR → release → printing-press-library bumps generator dep → ESPN consumes.
+- `extra_commands:` shape is intentionally minimal. Each entry has `name`, `description`, optional `subcommands` for parent commands with leaves. No `endpoint` field - extra_commands are by definition non-endpoint-driven. Avoids overlap with `Resource` while staying YAML-readable.
+- Spec-driven for `injuries`, `transactions`, `leaders`, `plays`. These have predictable single-endpoint response shapes, good upsert candidates for the local store, and they get free MCP tool exposure via the existing spec→mcp generator path. Hand-written would deny MCP coverage.
+- Hand-written for `boxscore`, `odds`, `sos`, `h2h`, `compare`, `trending`, `dashboard`. These compose multiple endpoints, derive from synced data, or read local config. Spec representation would either fail to express the composition or force a contrived single-endpoint shim.
+- `boxscore <event_id>` defaults to inferring `--sport`/`--league` from a recent scores cache; falls back to required flags when cache misses. Avoids forcing the user to remember sport+league for an event ID they just got from `scores`.
+- `transactions` needs a per-resource `base_url_override` because it lives on `sports.core.api.espn.com` while ESPN's default `base_url` in spec.yaml is `site.api.espn.com`. Generator already supports this via the `base_url` field on the Endpoint type? Verify in implementation; if not, this is part of the generator PR's scope.
+- `dashboard` reads `[favorites]` from existing config file. Schema: `nfl = ["KC", "BAL"]`, keyed by league abbreviation. Simplest TOML shape that supports per-league favorites; matches how scores/standings already key on league.
+- `h2h <team1> <team2>` versus existing `rivals <sport> <league>`. Decision: keep both. `rivals` returns league-wide pairwise records; `h2h` returns one specific pair with deeper detail (recent meetings, score history, key players). Different question, different command.
+- Per-CLI versus combined PRs. Splits into three PRs:
+  1. cli-printing-press: `extra_commands:` support.
+  2. printing-press-library: ESPN spec-driven additions (Unit 2) + extra_commands declaration + regen.
+  3. printing-press-library: ESPN hand-written commands (Unit 3) + regen.
+  Lets each merge on its own evidence trail; matches `feedback_evidence_every_pr.md`.
 
 ## Open Questions
 
 ### Resolved During Planning
 
-- Q: Are the ESPN endpoints for plays/injuries/transactions stable enough to ship? A: Yes, used by ESPN's own scoreboard frontend; community-maintained reference confirms 2025+ stability.
-- Q: Should `boxscore` print everything or be summarized? A: Default to a leaders + line score view in human mode, full structured payload in `--agent` mode. Matches the user-vs-agent mode pattern already used by `summary`.
-- Q: Per-CLI PR or one combined PR? A: Per-CLI PRs. Smaller diff, easier review, matches `feedback_evidence_every_pr.md` rule.
+- Should SKILL.md remain hand-edited or become regenerable? Regenerable, gated by `extra_commands:`. Resolved by PR #83's discovery and the cli-printing-press AGENTS.md "default to machine changes" rule.
+- Spec.yaml or hand-written for each of the eleven? Decided per-command in the table above.
+- Add MCP coverage for hand-written commands? No, not this round. Spec-driven commands get MCP for free via existing spec→mcp path; hand-written stay CLI-only until users request MCP.
+- Per-CLI versus combined PR? Three PRs, sequenced as listed.
+- ESPN endpoint stability for plays/leaders/transactions/injuries? Confirmed via community reference and ESPN's own scoreboard frontend usage. Acceptable risk.
+- Should `dashboard` poll-refresh? No, one-shot. `watch` is the existing live-poll path.
 
 ### Deferred to Implementation
 
-- Exact response field selection for `--compact` output of each new command (pick during implementation by inspecting one live response).
-- Whether `leaders` should support `--category passing,rushing,receiving` filters at launch or in a follow-up. Probable: add minimal `--category <name>` and let the user discover via help.
-- Whether `dashboard` should poll-refresh or be one-shot. Probable: one-shot, with `watch` available as the existing live-poll path.
-- Sequencing inside the ESPN PR: probably ship spec-driven commands together, then hand-written ones as separate commits. Decide at implementation time based on diff size.
+- Whether the generator already supports per-endpoint `base_url_override` for the `transactions` endpoint living on `sports.core.api.espn.com`. Resolve by reading `internal/spec/spec.go` Endpoint definition during Unit 1.
+- Exact response field selection for `--compact` output of each new command. Pick during implementation by inspecting one live response.
+- Whether `leaders` ships with `--category passing,rushing,receiving` filters at launch or in a follow-up. Probable: minimal `--category <name>` flag; let users discover via help.
+- For `compare`, how to disambiguate athlete name searches that return multiple matches. Probable: list candidates and exit 2.
+- Whether `h2h` should auto-sync if no local data exists. Probable: yes, with a one-line "syncing first" notice on stderr.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+The shape of the `extra_commands:` declaration in spec.yaml:
+
+```yaml
+extra_commands:
+  - name: boxscore
+    description: "Full box score for a specific event id"
+    args: "<event_id>"
+  - name: trending
+    description: "Most-followed athletes and teams across all leagues"
+  - name: dashboard
+    description: "Your favorite teams' status at a glance"
+  - name: h2h
+    description: "Head-to-head detail between two teams"
+    args: "<team1> <team2>"
+  - name: compare
+    description: "Side-by-side athlete stat comparison"
+    args: "<athlete1> <athlete2>"
+  - name: sos
+    description: "Strength-of-schedule derivation from standings"
+    args: "<sport> <league>"
+  - name: odds
+    description: "Spread/total/moneyline lines for tonight's slate"
+    args: "<sport> <league>"
+```
+
+The generated `## Command Reference` block becomes:
+
+```
+## Command Reference
+
+scoreboard - Live and historical game scores
+- espn-pp-cli scoreboard get - Get scoreboard for a sport and league
+... (other resources)
+
+Hand-written commands:
+- espn-pp-cli boxscore <event_id> - Full box score for a specific event id
+- espn-pp-cli trending - Most-followed athletes and teams across all leagues
+... (other extra_commands)
+```
+
+End-to-end flow for one new ESPN command (e.g. `injuries`):
+
+```
+spec.yaml resource declaration
+  -> printing-press generate (spec-driven)
+  -> internal/cli/promoted_injuries.go appears
+  -> internal/store/injuries_store.go appears (if upsertable)
+  -> binary gains `injuries` command
+  -> tools/generate-skills/main.go regen picks it up via --help walk
+  -> plugin/skills/pp-espn/SKILL.md updated with new command
+  -> verify-skill unknown-command check passes
+```
+
+For a hand-written command (e.g. `dashboard`):
+
+```
+internal/cli/dashboard.go (hand-written, registers via init())
+  -> binary gains `dashboard` command
+  -> spec.yaml extra_commands: declares it
+  -> printing-press generate -> SKILL.md command reference includes it
+  -> tools/generate-skills/main.go regen picks it up
+  -> plugin/skills mirror updated
+  -> verify-skill unknown-command check passes
+```
 
 ## Implementation Units
 
-- [ ] Unit 1: ESPN spec.yaml extensions for injuries, transactions, leaders, plays
+- [x] Unit 1: cli-printing-press extra_commands: spec field + template support (shipped via mvanhorn/cli-printing-press#227, merged 2026-04-19)
 
-Goal: Add four new resources to `library/media-and-entertainment/espn/spec.yaml` so the generator produces real Cobra commands and MCP tools.
+Goal: Authors can declare hand-written commands in spec.yaml so they appear in the generated SKILL.md `## Command Reference`.
 
-Requirements: R1, R2, R6, R7
+Requirements: R2
 
 Dependencies: None
 
 Files:
-- Modify: `library/media-and-entertainment/espn/spec.yaml`
-- Regenerate: `library/media-and-entertainment/espn/internal/cli/promoted_injuries.go`, `promoted_transactions.go`, `promoted_leaders.go`, `promoted_plays.go` (generator output)
-- Regenerate: `library/media-and-entertainment/espn/internal/types/` entries for new response shapes
-- Modify: `library/media-and-entertainment/espn/internal/store/` if any new domain table is needed (likely yes for `leaders` and `plays`)
+- Modify: `internal/spec/spec.go` (add `ExtraCommands []ExtraCommand` to `APISpec`, define `ExtraCommand` struct with `Name`, `Description`, `Args` fields)
+- Modify: `internal/spec/spec_test.go` (round-trip parse test for the new field, including absent/empty/populated cases)
+- Modify: `internal/generator/templates/skill.md.tmpl` (extend `## Command Reference` block to iterate `.ExtraCommands` after `.Resources`, with a small subheading)
+- Modify: `internal/generator/skill_test.go` (assert rendered SKILL.md contains each extra_command's name and description)
+- Modify: `internal/generator/generator.go` if any field plumbing changes are required to pass extra_commands through to template data
 
 Approach:
-- Mirror existing resource shape (`news`, `summary`) for declarative shape.
-- Endpoints to register:
-  - `injuries`: `GET /{sport}/{league}/injuries`, params sport+league positional.
-  - `transactions`: `GET /sports/{sport}/leagues/{league}/transactions` against the sports.core base; will need a `base_url_override` field if the spec generator does not already support per-resource base swaps. If not, fall back to hand-written for transactions only.
-  - `leaders`: `GET /sports/{sport}/leagues/{league}/leaders` (sports.core) or the site.web equivalent, whichever has cleaner per-stat output. Pick during implementation.
-  - `plays`: `GET /sports/{sport}/leagues/{league}/events/{eventId}/competitions/{eventId}/plays`, eventId positional, optional `--limit` (default 200).
-- Run the existing generator (`cli-printing-press` Go binary) against the updated spec.
+- Mirror the YAML/JSON tags pattern used by `Resource` for the new `ExtraCommand` struct.
+- Validate that `Name` is a valid Go identifier-ish slug (lowercase + hyphens) at parse time. Empty `Name` is a parse error.
+- Template iteration uses `{{range .ExtraCommands}}` analogous to the existing `{{range $name, $resource := .Resources}}` block.
+- Output format keeps inline backticks for the binary+command snippet so verify-skill's parser picks them up.
 
 Patterns to follow:
-- `spec.yaml` `news:` and `summary:` blocks for resource shape.
-- `internal/store/news_store.go` for the upsert pattern when the new resource needs a domain table.
+- `Resource` struct in `internal/spec/spec.go` for the YAML tag style.
+- `## Command Reference` block in `internal/generator/templates/skill.md.tmpl` for the template iteration shape.
+- Existing skill_test.go tests for assertion patterns.
 
 Test scenarios:
-- Happy path: `espn-pp-cli injuries baseball mlb --agent` returns at least one injury record for an in-season league with valid `athlete`, `team`, `status` fields.
+- Happy path: spec.yaml with three extra_commands renders SKILL.md containing all three with correct binary prefix and description.
+- Edge case: spec.yaml with empty/absent extra_commands renders the SKILL.md exactly as before (backwards compatible).
+- Edge case: an extra_command with no `Args` renders as `binary name - description` with no trailing args placeholder.
+- Error path: spec.yaml with an extra_command missing `Name` produces a parse error referencing the offending entry.
+- Error path: spec.yaml with an extra_command whose Name contains invalid chars (uppercase, spaces) produces a parse error.
+- Integration: generator end-to-end (`printing-press generate` against a small fixture spec with extra_commands) produces a binary whose `--help` and SKILL.md agree on the command list.
+
+Verification:
+- `go test ./internal/spec/... ./internal/generator/...` passes.
+- A fixture spec with extra_commands generates a SKILL.md whose `## Command Reference` includes the new entries.
+- Round-trip: edit a real spec.yaml (use a copy, not ESPN), regenerate, observe the new commands in the rendered SKILL.md.
+
+- [ ] Unit 2: ESPN spec.yaml extensions for injuries, transactions, leaders, plays
+
+Goal: Add four spec-driven resources to ESPN. Each gets a generated promoted command and (where naturally row-shaped) a domain table.
+
+Requirements: R1, R2, R6, R7
+
+Dependencies: Unit 1 (regen needs the new generator)
+
+Files:
+- Modify: `library/media-and-entertainment/espn/spec.yaml`
+- Regenerate: `library/media-and-entertainment/espn/internal/cli/promoted_injuries.go`, `promoted_transactions.go`, `promoted_leaders.go`, `promoted_plays.go`
+- Regenerate: types in `library/media-and-entertainment/espn/internal/types/`
+- Modify or regenerate: `library/media-and-entertainment/espn/internal/store/injuries_store.go` (and similar for transactions, leaders, plays) if the store layer auto-generates from spec resources
+
+Approach:
+- Mirror existing resource shape (`news:` block is closest in shape).
+- `injuries`: GET on `site.web.api.espn.com/apis/site/v2/sports/{sport}/{league}/injuries`. Sport+league positional. No required flags.
+- `transactions`: GET on `sports.core.api.espn.com/v2/sports/{sport}/leagues/{league}/transactions`. Needs the `base_url_override` mechanism resolved in Unit 1's deferred question. Sport+league positional.
+- `leaders`: GET on `site.web.api.espn.com/apis/common/v3/sports/{sport}/{league}/leaders` (preferred) or the sports.core.api.espn.com equivalent. Pick the cleaner per-stat shape during implementation. Sport+league positional, optional `--category <name>`.
+- `plays`: GET on `sports.core.api.espn.com/v2/sports/{sport}/leagues/{league}/events/{eventId}/competitions/{eventId}/plays?limit=1000`. Event id positional, optional `--limit` (default 200).
+- After spec changes, run `printing-press generate` against ESPN. Verify the binary builds and the new commands appear in `--help`.
+
+Patterns to follow:
+- spec.yaml `news:` and `summary:` blocks for resource shape.
+- `internal/store/news_store.go` for the upsert pattern when the new resource gets a domain table.
+
+Test scenarios:
+- Happy path: `espn-pp-cli injuries baseball mlb --agent` returns at least one injury record with `athlete`, `team`, `status` fields.
 - Happy path: `espn-pp-cli leaders baseball mlb --agent` returns a list of athletes with stats for the current season.
 - Happy path: `espn-pp-cli plays basketball nba --event <live_event_id> --agent` returns plays for an in-progress game.
+- Happy path: `espn-pp-cli transactions baseball mlb --agent` returns recent trades/signings/waivers with `team`, `player`, `kind`, `date` fields.
 - Edge case: `espn-pp-cli injuries football nfl --agent` during the offseason returns an empty list, exit 0, not exit 3.
+- Edge case: `espn-pp-cli plays basketball nba --event <pre_game_id> --agent` returns empty plays array with exit 0.
 - Error path: `espn-pp-cli plays basketball nba --event 0 --agent` returns exit 3 with structured not-found error.
-- Integration: `espn-pp-cli sync --sport baseball --league mlb` populates the new `leaders` and `plays` tables in the local SQLite, verified by `sqlite3 ~/.local/share/espn-pp-cli/db.sqlite ".tables"`.
+- Error path: `espn-pp-cli leaders football nfl --category nonexistent --agent` returns exit 2 with usage error.
+- Integration: `espn-pp-cli sync --sport baseball --league mlb` populates the new `leaders`, `plays`, `injuries`, `transactions` tables; verify with `sqlite3 ~/.local/share/espn-pp-cli/db.sqlite ".tables"`.
 
 Verification:
 - New commands appear in `espn-pp-cli --help`.
 - Each command's `--help` includes at least one example.
 - `espn-pp-cli doctor` reports OK after running each command.
-- `dogfood-results.json` updates show new commands covered.
+- `dogfood-results.json` regenerated with new commands covered.
+- Full ESPN test suite passes.
 
-- [ ] Unit 2: ESPN hand-written commands - boxscore, odds, sos, h2h, compare, trending, dashboard
+- [ ] Unit 3: ESPN hand-written commands - boxscore, odds, sos, h2h, compare, trending, dashboard
 
 Goal: Add seven hand-written commands that compose multiple endpoints or read local state.
 
 Requirements: R1, R2, R6
 
-Dependencies: Unit 1 (only because dogfood verification runs after both)
+Dependencies: Unit 1 (so SKILL.md can declare these via extra_commands:)
 
 Files:
-- Create: `library/media-and-entertainment/espn/internal/cli/boxscore.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/odds.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/sos.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/h2h.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/compare.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/trending.go`
-- Create: `library/media-and-entertainment/espn/internal/cli/dashboard.go`
-- Modify: `library/media-and-entertainment/espn/internal/cli/teams_get.go` and `teams_list.go` to register hidden `team` alias of `teams`
-- Modify: `library/media-and-entertainment/espn/internal/config/` to add `[favorites]` table loader
-- Test: parallel `_test.go` files for each command using table-driven tests against recorded fixtures
+- Create: `library/media-and-entertainment/espn/internal/cli/boxscore.go` and `boxscore_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/odds.go` and `odds_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/sos.go` and `sos_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/h2h.go` and `h2h_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/compare.go` and `compare_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/trending.go` and `trending_test.go`
+- Create: `library/media-and-entertainment/espn/internal/cli/dashboard.go` and `dashboard_test.go`
+- Modify: `library/media-and-entertainment/espn/internal/config/` (or create) to add `[favorites]` table loader
+- Modify: existing config docs to mention the `[favorites]` schema
 
 Approach:
-- `boxscore <event_id>`: detect sport+league from a `scores` cache lookup if present, otherwise require `--sport` and `--league`. Fetch via existing `summary` client method, return only the `boxscore` subtree. In agent mode, return raw JSON; in human mode, render a leaders + line score table.
-- `odds <sport> <league>`: list current games with their `pickcenter` lines from each game's summary. Avoid one summary call per game by querying the scoreboard's `competitions[].odds` field which already carries the lines.
-- `sos <sport> <league>`: fetch standings, extract `strengthOfSchedule` and `remainingStrengthOfSchedule` fields per team. Sort by `strengthOfSchedule` descending in default human view.
-- `h2h <team1> <team2>`: resolve abbreviations via existing teams list, fetch each team's schedule, intersect by opponent and aggregate W-L plus average scores. Reuse `internal/cli/rivals.go` pattern (already does series records).
-- `compare <athlete1> <athlete2>`: search athletes via `site.web.api.espn.com/apis/common/v3/sports/{sport}/{league}/athletes?search=<name>`, fetch per-athlete season stats, render a side-by-side table. Require `--sport` and `--league`. In ambiguous matches, list candidates and exit 2.
-- `trending`: hit `https://site.api.espn.com/apis/site/v2/trending` (verified live endpoint as of session date), return ranked list of athletes and teams across leagues.
-- `dashboard`: read `[favorites]` from config, for each configured league fetch scores and standings for the favorited teams, render a single table grouped by league. No live polling; just one fetch.
-- `team` alias: `cobra.Command{Hidden: true, Aliases: []string{"team"}}` on the `teams` parent command, with a deprecated stderr note shown when invoked.
+- `boxscore <event_id>`: detect sport+league from a recent `scores` cache lookup if present; otherwise require `--sport`/`--league`. Fetch via existing `summary` client method, return only the `boxscore` subtree. Agent mode returns raw JSON; human mode renders leaders + line score table.
+- `odds <sport> <league>`: list current games with their `pickcenter` lines from each game's summary. Avoid one summary call per game by reading the scoreboard's `competitions[].odds` field which already carries the lines.
+- `sos <sport> <league>`: fetch standings, extract `strengthOfSchedule` and `remainingStrengthOfSchedule` per team. Sort by `strengthOfSchedule` descending in human view.
+- `h2h <team1> <team2>`: resolve abbreviations via teams list, fetch each team's schedule, intersect by opponent, aggregate W-L plus average scores. Reuse `internal/cli/rivals.go` pattern but scoped to one pair.
+- `compare <athlete1> <athlete2>`: search athletes via `site.web.api.espn.com/apis/common/v3/sports/{sport}/{league}/athletes?search=<name>`, fetch per-athlete season stats, render side-by-side table. Require `--sport`/`--league`. Ambiguous matches list candidates and exit 2.
+- `trending`: hit `https://site.api.espn.com/apis/site/v2/trending`, return ranked list across leagues with per-entry `entity_type`, `name`, `league`, `popularity`.
+- `dashboard`: read `[favorites]` from config; for each configured league fetch scores and standings for the favorited teams; render single table grouped by league. Use `cliutil.FanoutRun` for parallel per-league fetches.
+
+Execution note: Implement test-first for `dashboard` and `boxscore` because they have non-obvious sport+league inference and config-shape dependencies. Other commands can be pragmatic.
 
 Patterns to follow:
 - `today.go` for cross-league fetches.
-- `rivals.go` for head-to-head computations.
-- `streak.go` for derived-stat patterns reading from synced data.
+- `rivals.go` for h2h-style derivations.
+- `streak.go` for derivation from synced data.
 - `recap.go` for sport+league argument parsing.
+- `cliutil.FanoutRun` for `dashboard` (per-source error collection, bounded concurrency).
 
 Test scenarios:
-- Happy path (boxscore): `espn-pp-cli boxscore 401869192 --agent` returns a boxscore for a known live or recent NBA game without requiring `--sport`/`--league` if the game is in scores cache.
-- Happy path (boxscore explicit): with cache cleared, `boxscore 401869192 --sport basketball --league nba --agent` works.
+- Happy path (boxscore, hot cache): `espn-pp-cli boxscore 401869192 --agent` returns boxscore for a known live or recent NBA game without `--sport`/`--league`.
+- Happy path (boxscore, cold cache + flags): `boxscore 401869192 --sport basketball --league nba --agent` works after clearing the scores cache.
 - Edge case (boxscore): pre-game state returns boxscore subtree with empty player stats and exit 0.
+- Error path (boxscore): cold cache, no flags, returns exit 2 with hint to provide `--sport`/`--league`.
 - Happy path (odds): `espn-pp-cli odds basketball nba --agent` returns spreads, totals, and moneylines for tonight's slate.
+- Edge case (odds): no games scheduled returns empty list and exit 0.
 - Happy path (sos): `espn-pp-cli sos football nfl --agent` returns 32 entries sorted by SOS descending.
 - Happy path (h2h): `espn-pp-cli h2h chiefs eagles --agent` returns historical W-L and average scores.
-- Edge case (h2h): unknown team abbreviation returns exit 3 with structured error naming the invalid arg.
+- Error path (h2h): unknown team abbreviation returns exit 3 with structured error naming the invalid arg.
 - Happy path (compare): `espn-pp-cli compare Mahomes Allen --sport football --league nfl --agent` returns side-by-side stats.
 - Error path (compare): ambiguous name returns exit 2 with a list of candidate athlete IDs.
-- Happy path (trending): `espn-pp-cli trending --agent` returns at least 5 trending entries with `entity_type`, `name`, `league` fields.
+- Happy path (trending): `espn-pp-cli trending --agent` returns at least 5 entries with `entity_type`, `name`, `league`.
 - Happy path (dashboard): with a populated `[favorites]` block, `espn-pp-cli dashboard --agent` returns scores+standings for each favorited team.
 - Edge case (dashboard): empty `[favorites]` returns exit 0 with a hint about how to add favorites.
-- Integration (team alias): `espn-pp-cli team list football nfl` works and prints a stderr deprecation note pointing at `teams list`.
+- Edge case (dashboard): one league in `[favorites]` returns 5xx for one team - the result reports the partial failure but the other teams still come through (via `cliutil.FanoutRun` per-source error collection).
 
 Verification:
-- All seven commands appear in `espn-pp-cli --help` (except `team` which stays hidden).
-- Each new command has at least one `--help` example.
+- All seven commands appear in `espn-pp-cli --help`.
+- Each command's `--help` includes at least one example.
 - `espn-pp-cli doctor` continues to report OK.
+- Per-command `_test.go` covers the listed scenarios with table-driven tests against recorded fixtures.
 
-- [ ] Unit 3: ESPN SKILL.md update
+- [ ] Unit 4: ESPN spec.yaml extra_commands: + SKILL.md regeneration
 
-Goal: Make `library/media-and-entertainment/espn/SKILL.md` and `plugin/skills/pp-espn/SKILL.md` accurately describe the post-Unit-1+2 surface.
+Goal: Declare all seven hand-written commands in spec.yaml's new `extra_commands:` block, regenerate SKILL.md, regenerate plugin/skills mirror, bump plugin.json.
 
 Requirements: R1, R3, R5, R6
 
-Dependencies: Unit 1, Unit 2 (cannot document until commands exist)
+Dependencies: Unit 1 (generator support), Unit 3 (commands must exist before docs can claim them - verify-skill catches the inverse)
 
 Files:
-- Modify: `library/media-and-entertainment/espn/SKILL.md`
-- Modify: `plugin/skills/pp-espn/SKILL.md`
+- Modify: `library/media-and-entertainment/espn/spec.yaml` (add `extra_commands:` block listing all seven hand-written commands plus the four spec-driven ones from Unit 2 if they need promotion in the SKILL.md `## Command Reference`)
+- Regenerate: `library/media-and-entertainment/espn/SKILL.md` via printing-press
+- Modify: `library/media-and-entertainment/espn/SKILL.md` to restore the truthful descriptions and recipe blocks from PR #83 - do not lose hand-tuned content outside `## Command Reference`. Use `printing-press patch` if the regen would lose context.
+- Run: `tools/generate-skills/main.go` to regenerate `plugin/skills/pp-espn/SKILL.md`
+- Modify: `plugin/.claude-plugin/plugin.json` (bump `version` patch component)
 
 Approach:
-- Replace `## Command Reference` block with a list generated from `espn-pp-cli --help` output (manual once, automated by Unit 5 going forward).
-- Add `## Recipes` entries for `boxscore`, `dashboard`, `odds`, `compare`, `h2h`, `trending`, `today`, `streak`, `rivals`. Each recipe shows one realistic invocation plus one chained example.
-- Drop `athlete <sport> <league>` entry entirely. Add `--athletes` flag note under `teams get` if we want to expose roster fetching.
-- Replace all `team get` / `team list` references with `teams get` / `teams list`.
-- Add `--event` flag note under `summary` example (currently SKILL.md shows `summary <game_id>` which fails).
+- Add the `extra_commands:` block to spec.yaml in the order users will most likely look for them: discovery (`trending`, `dashboard`), game detail (`boxscore`), team analysis (`h2h`, `compare`), league analysis (`odds`, `sos`).
+- After regen, diff the SKILL.md against the PR #83 baseline and confirm all hand-tuned content (Unique Capabilities, Recipes, Auth Setup, Agent Mode, Exit Codes, Installation, Argument Parsing, Agent Workflow Features) survives.
+- If regen overwrites hand-tuned sections, switch to `printing-press patch` for the targeted edits and re-run only the `## Command Reference` regeneration.
+- Update Recipes section to use the now-real `boxscore`, `odds`, and `dashboard` examples from this work stream.
+- Run verify-skill against ESPN. Should report 0 errors.
 
 Patterns to follow:
-- Existing accurate sections of SKILL.md (auth setup, agent mode, exit codes) are fine and stay.
-- Examples should follow the `--agent`-by-default pattern already used elsewhere in the doc.
+- AGENTS.md SKILL.md sync workflow.
+- PR #83 commit style for the regen+bump combined commit.
 
 Test scenarios:
-- Happy path: every command in the updated `## Command Reference` resolves successfully when piped through `espn-pp-cli <cmd> --help`.
-- Happy path: every recipe example actually runs and returns exit 0 against a live ESPN API for an in-season league.
-- Edge case: SKILL.md no longer references `boxscore`, `leaders`, `plays`, etc. as missing - they all exist now.
+- Happy path: `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/espn/` exits 0.
+- Happy path: every command in the regenerated SKILL.md `## Command Reference` resolves under `espn-pp-cli <cmd> --help`.
+- Edge case: the regenerated SKILL.md preserves all hand-tuned non-Command-Reference sections from PR #83.
+- Integration: full plugin sweep via the verify-skills CI workflow passes for all 13 CLIs (no other CLI regresses).
 
 Verification:
-- Manual inspection: SKILL.md command reference matches `espn-pp-cli --help` line-for-line on top-level commands.
-- Both copies (`library/.../SKILL.md` and `plugin/skills/.../SKILL.md`) have identical content for the changed sections.
+- `library/media-and-entertainment/espn/SKILL.md` and `plugin/skills/pp-espn/SKILL.md` agree on the command list.
+- Both files reference all eleven new commands plus all existing commands.
+- `plugin/.claude-plugin/plugin.json` bumped one patch version.
+- Local verify-skill sweep across all 13 CLIs reports 0 errors.
 
-- [ ] Unit 4: Movie Goat audit and SKILL.md fix
+- [ ] Unit 5: skill-doctor / drift detection - DONE in PR #83
 
-Goal: Resolve the `tv get` vs `tv seasons get` collision question, document `tv airing-today`, `tv on-the-air`, `tv top-rated`, `genres tv` if real, and align SKILL.md.
+Goal: A check that prevents SKILL.md from documenting commands the binary does not implement.
 
-Requirements: R3, R4, R5
+Status: Shipped via PR #83 in a different form. Instead of a new top-level tool, the existing `.github/scripts/verify-skill/verify_skill.py` gained a fourth `unknown-command` check. CI workflow path filter now includes `.github/scripts/verify-skill/**`. Coverage matches the spirit of the original Unit 5 (no documented-but-missing commands can land silently).
 
-Dependencies: None (independent of ESPN units)
+Files (already shipped):
+- Modified: `.github/scripts/verify-skill/verify_skill.py` - new `check_unknown_commands` function plus `--only unknown-command` flag.
+- Modified: `.github/scripts/verify-skill/README.md` - documents the new check.
+- Modified: `.github/workflows/verify-skills.yml` - path filter expanded.
 
-Files:
-- Verify (read-only first pass): `library/media-and-entertainment/movie-goat/internal/cli/` - confirm `tv get`, `tv seasons get`, `genres tv` real signatures.
-- Modify (only if collision): `library/media-and-entertainment/movie-goat/internal/cli/tv_<x>.go` to disambiguate Cobra registration if `tv get` ambiguity exists.
-- Modify: `library/media-and-entertainment/movie-goat/SKILL.md`
-- Modify: `plugin/skills/pp-movie-goat/SKILL.md`
-
-Approach:
-- Run `movie-goat-pp-cli tv get --help`, `movie-goat-pp-cli tv seasons get --help`, `movie-goat-pp-cli genres tv --help`. Confirm intended behavior matches docs. The `tv` subcommand `Available Commands` listed two `get` entries during the audit - this needs verification and likely a Cobra registration fix.
-- Add the three undocumented TV subcommands to `## Command Reference`.
-- If `tv seasons get` does not exist as documented, either add it (small implementation, TMDb endpoint `/tv/{series_id}/season/{season_number}`) or rewrite the doc to match the real call site.
-- Verify `genres tv` resolves; if not, add it (TMDb has `/genre/tv/list`).
-
-Patterns to follow:
-- `internal/cli/tv_get.go` and any sibling tv_*.go for command registration shape.
-- `genres.go` for genre subcommand registration shape.
-
-Test scenarios:
-- Happy path: every `tv` subcommand documented in SKILL.md resolves under `--help`.
-- Happy path: `movie-goat-pp-cli tv seasons get 1399 1 --agent` returns season 1 of Game of Thrones with episodes.
-- Happy path: `movie-goat-pp-cli genres tv --agent` returns TMDb TV genre list.
-- Edge case: `movie-goat-pp-cli tv top-rated --agent --limit 5` returns 5 series.
-- Integration: documented and real surfaces match - no `--help` command in SKILL.md returns "unknown command".
-
-Verification:
-- `movie-goat-pp-cli --help` and SKILL.md `## Command Reference` agree on top-level commands.
-- All subcommand references in SKILL.md examples actually resolve.
-
-- [ ] Unit 5: skill-doctor drift check (recommended, can ship in a follow-up PR if scope creeps)
-
-Goal: A small Go tool that walks each `library/<area>/<cli>/SKILL.md`, extracts every `<binary> <command>` snippet from `## Command Reference` and `## Recipes`, runs `<binary> --help` for each, and fails if any documented command is not present.
-
-Requirements: R1, R3 (durably, going forward)
-
-Dependencies: Units 1-4 (so first run of skill-doctor passes against the freshly-aligned docs)
-
-Files:
-- Create: `tools/skill-doctor/main.go`
-- Create: `tools/skill-doctor/main_test.go`
-- Modify: `.github/workflows/ci.yaml` to run `go run ./tools/skill-doctor` against every CLI in `library/`
-- Modify: `Makefile` (root) to add `make skill-doctor` target
-
-Approach:
-- Walk `library/*/*/SKILL.md`, parse for fenced bash blocks and inline `binary command` patterns.
-- Resolve binary names from each SKILL.md's `metadata.openclaw.requires.bins` frontmatter.
-- For each unique `<binary> <command>` pair, exec `<binary> <command> --help` and capture exit code.
-- Exit 1 if any documented command exits with the Cobra `unknown command` error string or returns no `--help` output.
-- Print a per-CLI table of `documented | resolves | drift_kind`.
-
-Patterns to follow:
-- Existing tool shape under `tools/` (small standalone Go binary).
-- Existing CI step style in `.github/workflows/ci.yaml`.
-
-Test scenarios:
-- Happy path: against the post-Unit-3+4 SKILL.md, skill-doctor exits 0 for both ESPN and Movie Goat.
-- Failure path: introduce a fake `espn-pp-cli madeup-command` reference in a temp SKILL.md and confirm skill-doctor exits 1 with a clear message naming the offending command and SKILL.md file.
-- Edge case: SKILL.md with no `## Command Reference` section is reported as a warning, not a failure (some skills may legitimately have no command list).
-
-Verification:
-- CI run on the PR's own commit passes skill-doctor.
-- A local run reproduces the CI result.
+No further work in this unit.
 
 ## System-Wide Impact
 
-- Interaction graph: ESPN's MCP server auto-registers spec.yaml resources, so Unit 1 expands the MCP tool surface for free. Hand-written commands in Unit 2 stay CLI-only unless someone explicitly adds MCP wrappers.
-- Error propagation: new commands must use the same exit-code conventions documented in SKILL.md (0 success, 2 usage, 3 not found, 5 API, 7 rate limited). Unit 2 specs include explicit exit-code expectations per scenario.
-- State lifecycle risks: new domain tables in Unit 1 mean `sync` schema migrations. The store package likely uses `CREATE TABLE IF NOT EXISTS` already, but verify; if not, a one-time migration runner is needed before merge.
-- API surface parity: SKILL.md, README.md, and `--help` should agree. Unit 5's skill-doctor enforces SKILL.md vs `--help`. README.md should be spot-checked but is lower-leverage.
-- Integration coverage: dogfood-results.json gets regenerated; CI should include the new commands' example execution.
-- Unchanged invariants: existing exit codes, config path (`~/.config/espn-pp-cli/config.toml`), agent-mode flag set, cache layout, SQLite path.
+- Interaction graph: ESPN's MCP server auto-registers spec-driven resources, so Unit 2 expands MCP tool surface. Hand-written commands in Unit 3 stay CLI-only. Verify-skill check from PR #83 now gates SKILL.md drift across all 13 library CLIs.
+- Error propagation: New commands must use existing exit-code conventions (0 success, 2 usage, 3 not found, 5 API, 7 rate limited). Unit 3 test scenarios assert specific exit codes per failure case.
+- State lifecycle risks: New domain tables in Unit 2 mean `sync` schema migrations. Store package likely uses `CREATE TABLE IF NOT EXISTS`; verify in implementation. If not, a one-time migration runner is needed before merge.
+- API surface parity: SKILL.md ↔ `--help` ↔ README.md should agree. Unit 4's verify-skill run gates SKILL.md vs `--help`. README.md spot-checked but lower-leverage.
+- Integration coverage: dogfood-results.json regenerated; CI includes new commands' example execution.
+- Unchanged invariants: existing exit codes, config path (`~/.config/espn-pp-cli/config.toml`), agent-mode flag set, cache layout, SQLite path, MCP server registration mechanism.
 
 ## Risks and Dependencies
 
 | Risk | Mitigation |
 |------|------------|
-| ESPN endpoint stability for plays/leaders/transactions | Treat each new command as best-effort; on 5xx return exit 5 with the upstream URL in the error so users can debug. Don't aggressively retry. |
-| `boxscore` event-id-only call requires sport+league inference and may misroute in cold-cache scenarios | Default to friendly error suggesting `--sport`/`--league` flags when inference fails. |
-| Cobra collision in `tv get` may already be a real bug; fixing it changes behavior | Confirm via `--help` output during Unit 4 audit; if the collision is real, plan a one-line note in CHANGELOG and treat the rename as a fix not a feature. |
-| skill-doctor false positives on legitimate prose containing the binary name | Constrain extraction to fenced bash blocks and `## Command Reference` lists; ignore narrative prose. |
-| Movie Goat may have its own missing-command drift surfacing during Unit 4 audit beyond TV subcommands | Cap Unit 4 scope to documented-vs-real diff; defer any "should add this missing capability" findings to follow-up issues. |
-| Per-CLI PRs vs combined PR sequencing | Land Unit 1+2+3 as the ESPN PR, Unit 4 as the Movie Goat PR, Unit 5 as a third small PR. Lets each merge on its own evidence trail. |
+| ESPN endpoint stability for plays/leaders/transactions/injuries | Treat each new command as best-effort; on 5xx return exit 5 with the upstream URL in the error so users can debug. Don't aggressively retry. |
+| `boxscore` event-id-only call requires sport+league inference and may misroute on cold cache | Default to friendly error suggesting `--sport`/`--league` flags when inference fails. Test scenario covers this case explicitly. |
+| Generator extension breaks existing CLIs that have no extra_commands block | YAML parser must treat absent extra_commands as empty/no-op. Unit 1 explicitly tests the absent case. Run a regression: regenerate one existing CLI (yahoo-finance, kalshi) and confirm SKILL.md is byte-identical. |
+| `printing-press patch` versus full regen for ESPN's SKILL.md (Unit 4) | If full regen would lose hand-tuned content, fall back to patch. Decision deferred to implementation since it depends on actual regen behavior with the new extra_commands block. |
+| transactions endpoint requires base_url_override that may not exist in generator | Resolve in Unit 1 by reading Endpoint struct. If missing, add it to the generator scope (still Unit 1's PR). Hand-write transactions instead if the generator change is too risky. |
+| Three-PR sequencing requires release of cli-printing-press before printing-press-library can consume it | Manual: tag a cli-printing-press release after Unit 1 lands; bump printing-press-library's generator dependency in the Unit 2 PR. |
+| dashboard config schema is a new public surface; future schema evolution is a compatibility commitment | Document `[favorites]` schema explicitly in SKILL.md and the dashboard `--help`. Reserve unknown keys for forward compatibility. |
+| Movie Goat SKILL.md drift backlog (the original Unit 4) is now untracked | File a follow-up issue when this plan ships. Not blocking for the user-stated goal of making ESPN commands work. |
 
 ## Documentation and Operational Notes
 
 - Update CHANGELOG.md per CLI with a section listing new commands.
-- README.md per CLI: light update only if the README explicitly enumerates commands; otherwise leave alone.
-- No infra/deployment changes. No new env vars.
-- After merge, agents will start using the new ESPN commands automatically the next time the plugin cache refreshes - no agent-side migration needed.
+- Update ESPN README.md to list the new commands (light edit since README mostly defers to SKILL.md and `--help`).
+- No infra/deployment changes. No new env vars. No auth changes.
+- After merge, agents start using new commands automatically the next time the plugin cache refreshes - no agent-side migration.
+- cli-printing-press release notes for the Unit 1 PR should call out `extra_commands:` as a new spec field for hand-written command authors.
 
 ## Sources and References
 
+- Origin: this plan refreshed from prior version on 2026-04-19; PR #82 captured the original.
+- Generator code: `~/cli-printing-press/internal/spec/spec.go`, `~/cli-printing-press/internal/generator/templates/skill.md.tmpl`, `~/cli-printing-press/internal/generator/skill_test.go`
+- ESPN code: `library/media-and-entertainment/espn/spec.yaml`, `library/media-and-entertainment/espn/internal/cli/{today,recap,rivals,streak}.go`
+- Plugin tooling: `tools/generate-skills/main.go`, `plugin/.claude-plugin/plugin.json`, `.github/scripts/verify-skill/verify_skill.py`
 - ESPN unofficial API reference: https://github.com/pseudo-r/Public-ESPN-API
-- TMDb API docs: https://developer.themoviedb.org/reference/intro/getting-started
-- Local: `library/media-and-entertainment/espn/spec.yaml`
-- Local: `library/media-and-entertainment/espn/internal/cli/today.go`, `recap.go`, `rivals.go`, `streak.go`
-- Local: `library/media-and-entertainment/movie-goat/internal/cli/`
-- Cached SKILL.md (proof of drift): `/Users/mvanhorn/.claude/plugins/cache/printing-press-library/printing-press-library/1.1.10/skills/pp-espn/SKILL.md`
-- Prior plan: `docs/plans/2026-04-10-001-fix-cli-quality-bugs-plan.md`
-
-## Addendum (2026-04-19, mid-execution finding)
-
-While starting /ce:work I read `~/cli-printing-press/internal/generator/templates/skill.md.tmpl` and learned that SKILL.md is generated from spec.yaml. The template's `## Command Reference` block iterates `.Resources` only and has no awareness of hand-written commands (today, recap, rivals, streak, watch, scores, etc.). The currently-shipped pp-espn SKILL.md was hand-edited after generation, drifted both from the template's generator output and from the real CLI surface.
-
-This means:
-
-- The drift is partially the generator's fault: it cannot emit a Command Reference for hand-written commands, so authors hand-edit, and hand-edits silently invalidate on next generation or fall out of sync with new code.
-- The right durable fix is machine-level in `cli-printing-press`. The generator template needs either:
-  - An `extra_commands:` declaration in spec.yaml that names hand-written command files and their descriptions, OR
-  - A post-build introspection step that runs `<binary> --help` after generation and merges the discovered commands into the Command Reference, OR
-  - A pre-flight check (Unit 5's skill-doctor, but at the generator instead of CI) that fails generation if SKILL.md drifts from --help.
-- Per repo convention (`AGENTS.md`: "Default to machine changes"), Units 1-4 should not be implemented in printing-press-library until the generator side is decided. Otherwise we hand-edit SKILL.md again and the same drift returns the next time the CLI is regenerated.
-
-Revised execution path:
-
-1. Land this plan as a PR in printing-press-library.
-2. Open a companion plan in cli-printing-press for the generator-side fix (extra_commands declaration + skill-doctor at generation time).
-3. Implement the generator fix first.
-4. Then regenerate ESPN and Movie Goat with the new generator and add the missing commands (Units 1-2 here).
-5. SKILL.md becomes a regenerated artifact, not a hand-edited one (Unit 3 mostly disappears - it becomes "regenerate after Units 1-2").
-6. Unit 5 lives in cli-printing-press as part of generator quality gates, not as a printing-press-library CI tool.
-
-This is recorded as an addendum rather than a rewrite because the underlying problem and required commands are unchanged - only the where and order shift.
+- Trending endpoint sample: https://site.api.espn.com/apis/site/v2/trending (verified 2026-04-19)
+- Prior plans: `docs/plans/2026-04-10-001-fix-cli-quality-bugs-plan.md`
+- Shipped PRs in this work stream: #82 (plan), #83 (verify-skill + truth-up)
+- Shipped issues closed by #83: #84 (espn drift), #85 (cal-com), #86 (flightgoat)


### PR DESCRIPTION
## Summary

Refreshes `docs/plans/2026-04-19-002-feat-espn-movie-goat-missing-commands-plan.md` with what we learned in PR #83 (verify-skill unknown-command check) and reading the cli-printing-press generator architecture. Marks Unit 1 done now that mvanhorn/cli-printing-press#227 is merged.

## What changed in the plan

- Reframed around three sequenced PRs across two repos: cli-printing-press generator → ESPN spec-driven additions → ESPN hand-written commands.
- Movie Goat audit deferred to its own plan to keep this one ESPN-focused.
- Unit 5 (skill-doctor) recorded as DONE in different form (verify-skill `unknown-command` check from PR #83).
- Unit 1 checkbox flipped now that cli-printing-press#227 is merged.
- Concrete endpoint URLs added per command. Real file paths in cli-printing-press for the generator change. Test scenarios sharpened with named inputs and expected outcomes.

## Testing

Plan-only PR. No code changes.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: docs-only change.

---

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.56.1