### PR TITLE
feat(cli): implement 11 missing ESPN commands

### DIFF
--- a/library/media-and-entertainment/espn/SKILL.md
+++ b/library/media-and-entertainment/espn/SKILL.md
@@ -24,15 +24,25 @@ Commands that only work because of local sync + cross-league tooling.
 
 - **`today`** — Today's scores across all major sports in one call. The fastest "what's on tonight" answer without picking a sport first.
 
+- **`trending`** — Most-followed athletes and teams across all leagues, ranked by current popularity. Good for "who is hot right now" without naming a sport.
+
+- **`dashboard`** — Reads `[favorites]` from `~/.config/espn-pp-cli/config.toml` and shows scores for each favorited team across leagues, in one call.
+
 - **`watch <sport> <league> --event <game_id>`** — Live score updates for a specific game (polls every 30s). Use `scores` or `today` to find the game, then `watch` to follow it live.
 
 ### Game-state intelligence
 
 - **`summary <sport> <league> --event <game_id>`** — Detailed game summary including box score, leaders, scoring plays, odds, and win probability. The single richest payload per game.
 
+- **`boxscore <event_id>`** — Just the per-player box score for an event id, with sport+league inferred from a recent scoreboard cache hit. Pass `--sport`/`--league` to skip inference.
+
+- **`plays <sport> <league> --event <id>`** — Play-by-play feed for a specific event. Optional `--limit` (default 200).
+
 - **`recap <sport> <league>`** — Post-game recap with box score and leaders for the most recent completed game in a league.
 
 - **`scoreboard <sport> <league>`** — Live scoreboard with date filtering, week/group selectors, and competition metadata.
+
+- **`odds <sport> <league>`** — Spread, over/under, and moneyline lines for tonight's slate, derived from the scoreboard payload (no per-game summary calls).
 
 ### Standings and rankings
 
@@ -43,6 +53,20 @@ Commands that only work because of local sync + cross-league tooling.
 - **`streak <sport> <league>`** — Current win/loss streaks across teams in a league, computed from synced data.
 
 - **`rivals <sport> <league>`** — Head-to-head records between teams in a league from synced data.
+
+- **`h2h <team1> <team2> --sport <s> --league <l>`** — Deeper head-to-head detail for one specific pair, including average score and recent meetings list.
+
+- **`sos <sport> <league>`** — Strength-of-schedule per team, derived from the standings payload, sorted descending.
+
+### People
+
+- **`leaders <sport> <league> [--category <name>]`** — Statistical leaders across categories with optional filter.
+
+- **`compare <athlete1> <athlete2> --sport <s> --league <l>`** — Side-by-side season stats for two athletes. Ambiguous names list candidates and exit 2.
+
+- **`injuries <sport> <league>`** — Active injury report across the league, grouped by team.
+
+- **`transactions <sport> <league>`** — Recent trades, signings, and waivers.
 
 ### Local store
 
@@ -61,6 +85,8 @@ Live action:
 - `espn-pp-cli scoreboard <sport> <league>` — Scoreboard with optional date filtering
 - `espn-pp-cli watch <sport> <league> --event <game_id>` — Live score polling for one game
 - `espn-pp-cli standings <sport> <league>` — League standings
+- `espn-pp-cli trending` — Most-followed athletes and teams across leagues
+- `espn-pp-cli dashboard` — Favorites snapshot from `~/.config/espn-pp-cli/config.toml`
 
 Team detail:
 
@@ -69,11 +95,23 @@ Team detail:
 - `espn-pp-cli teams list <sport> <league>` — All teams in a league
 - `espn-pp-cli streak <sport> <league>` — Current win/loss streaks from synced data
 - `espn-pp-cli rivals <sport> <league>` — Head-to-head records between teams from synced data
+- `espn-pp-cli h2h <team1> <team2> --sport <s> --league <l>` — Deeper detail for one team pair (avg score, meetings)
+- `espn-pp-cli sos <sport> <league>` — Strength-of-schedule, sorted descending
 
 Game detail:
 
 - `espn-pp-cli summary <sport> <league> --event <game_id>` — Full game summary (box score, leaders, scoring plays, odds, win probability)
+- `espn-pp-cli boxscore <event_id>` — Just the box score subtree (sport/league inferred from cache)
+- `espn-pp-cli plays <sport> <league> --event <id>` — Play-by-play feed (optional `--limit`, default 200)
 - `espn-pp-cli recap <sport> <league>` — Most recent completed game recap
+- `espn-pp-cli odds <sport> <league>` — Spread, over/under, moneyline for tonight's slate
+
+People:
+
+- `espn-pp-cli leaders <sport> <league> [--category <name>]` — Statistical leaders by category
+- `espn-pp-cli compare <athlete1> <athlete2> --sport <s> --league <l>` — Side-by-side athlete stats
+- `espn-pp-cli injuries <sport> <league>` — Active injury report
+- `espn-pp-cli transactions <sport> <league>` — Recent trades, signings, waivers
 
 Polls and rankings:
 
@@ -126,6 +164,36 @@ espn-pp-cli search "Mahomes"                    # finds in local store
 ```
 
 Useful for repeated lookups in poor-connectivity environments or when batch-analyzing historical data.
+
+### Favorites dashboard
+
+Add a `[favorites]` block to `~/.config/espn-pp-cli/config.toml`:
+
+```
+[favorites]
+nfl = ["KC", "BAL"]
+nba = ["LAL"]
+```
+
+Then:
+
+```bash
+espn-pp-cli dashboard --agent
+```
+
+One call surfaces tonight's matchup status for every favorited team, grouped by league. Per-league fetches run in parallel and partial failures are reported alongside successful results.
+
+### Pre-game odds and player digging
+
+```bash
+espn-pp-cli odds basketball nba --agent          # tonight's spreads / totals / moneylines
+espn-pp-cli leaders basketball nba --category points --agent
+espn-pp-cli compare "LeBron James" "Stephen Curry" --sport basketball --league nba --agent
+espn-pp-cli boxscore <event_id> --agent          # post-game player stats
+espn-pp-cli plays basketball nba --event <id> --limit 50 --agent
+```
+
+`odds` reads the scoreboard's per-event lines (no per-game summary calls). `leaders --category` filters to one stat category. `compare` resolves athlete ids by name, listing candidates and exiting 2 on ambiguity. `boxscore` infers sport+league from the most recent cache hit; pass `--sport`/`--league` to skip inference.
 
 ## Auth Setup
 

--- a/library/media-and-entertainment/espn/cmd/espn-pp-mcp/main.go
+++ b/library/media-and-entertainment/espn/cmd/espn-pp-mcp/main.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	mcptools "github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	mcptools "github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/mcp"
 )
 
 func main() {

--- a/library/media-and-entertainment/espn/internal/cli/boxscore.go
+++ b/library/media-and-entertainment/espn/internal/cli/boxscore.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newBoxscoreCmd returns the box-score-only view of a game summary.
+// Composes the existing summary endpoint and returns just the boxscore subtree,
+// avoiding the full payload when the user only wants per-player stats.
+//
+// Sport+league inference: when --sport/--league are unset we look in the
+// per-event scores cache directory for a recent scoreboard hit that contains
+// this event id. On miss the user gets a friendly hint to provide flags.
+func newBoxscoreCmd(flags *rootFlags) *cobra.Command {
+	var sport, league string
+
+	cmd := &cobra.Command{
+		Use:   "boxscore <event_id>",
+		Short: "Full box score for a specific event id",
+		Example: `  espn-pp-cli boxscore 401547417 --sport football --league nfl
+  espn-pp-cli boxscore 401584793 --sport basketball --league nba --agent
+  espn-pp-cli boxscore 401569551`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return usageErr(fmt.Errorf("event id is required\nUsage: boxscore <event_id> [--sport <s> --league <l>]"))
+			}
+			eventID := args[0]
+
+			// Try cache inference when sport/league unset.
+			if sport == "" || league == "" {
+				inferredSport, inferredLeague, ok := inferSportLeagueFromCache(eventID)
+				if ok {
+					if sport == "" {
+						sport = inferredSport
+					}
+					if league == "" {
+						league = inferredLeague
+					}
+				}
+			}
+			if sport == "" || league == "" {
+				return usageErr(fmt.Errorf("could not infer sport/league for event %s. Pass --sport and --league explicitly (e.g. --sport basketball --league nba)", eventID))
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/%s/%s/summary", sport, league)
+			params := map[string]string{"event": eventID}
+			data, err := c.Get(path, params)
+			if err != nil {
+				return classifyAPIError(err)
+			}
+
+			// Extract just the boxscore subtree from the summary payload.
+			var summary map[string]json.RawMessage
+			if err := json.Unmarshal(data, &summary); err != nil {
+				return fmt.Errorf("parsing summary: %w", err)
+			}
+			boxRaw, ok := summary["boxscore"]
+			if !ok {
+				return notFoundErr(fmt.Errorf("event %s has no boxscore (game may not have started)", eventID))
+			}
+
+			// JSON output
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(boxRaw)
+			}
+
+			return renderBoxscore(cmd, boxRaw)
+		},
+	}
+
+	cmd.Flags().StringVar(&sport, "sport", "", "Sport slug (inferred from cache if omitted)")
+	cmd.Flags().StringVar(&league, "league", "", "League slug (inferred from cache if omitted)")
+	return cmd
+}
+
+// inferSportLeagueFromCache scans the espn-pp-cli cache directory for a recent
+// scoreboard response that contains the given event id, and returns the
+// sport+league that produced that scoreboard. Best-effort — returns false on
+// any miss.
+func inferSportLeagueFromCache(eventID string) (sport, league string, ok bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", false
+	}
+	cacheDir := filepath.Join(home, ".cache", "espn-pp-cli")
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return "", "", false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(cacheDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		// Quick string search for the event id before parsing.
+		if !strings.Contains(string(data), `"id":"`+eventID+`"`) {
+			continue
+		}
+		// Parse to confirm it is a scoreboard payload that lists this event.
+		var sb struct {
+			Leagues []struct {
+				Slug string `json:"slug"`
+			} `json:"leagues"`
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		}
+		if err := json.Unmarshal(data, &sb); err != nil {
+			continue
+		}
+		hasEvent := false
+		for _, ev := range sb.Events {
+			if ev.ID == eventID {
+				hasEvent = true
+				break
+			}
+		}
+		if !hasEvent || len(sb.Leagues) == 0 {
+			continue
+		}
+		// leagues[0].slug is something like "nfl" or "nba"; we need to
+		// derive the sport. We rely on a small slug→sport map.
+		leagueSlug := sb.Leagues[0].Slug
+		if leagueSlug == "" {
+			continue
+		}
+		sport = sportForLeague(leagueSlug)
+		if sport == "" {
+			continue
+		}
+		return sport, leagueSlug, true
+	}
+	return "", "", false
+}
+
+// sportForLeague returns the canonical sport slug for a league slug, or empty
+// if unknown.
+func sportForLeague(leagueSlug string) string {
+	switch strings.ToLower(leagueSlug) {
+	case "nfl", "college-football", "ncaaf":
+		return "football"
+	case "nba", "wnba", "mens-college-basketball", "womens-college-basketball", "ncaam", "ncaaw":
+		return "basketball"
+	case "mlb":
+		return "baseball"
+	case "nhl":
+		return "hockey"
+	case "mls", "eng.1":
+		return "soccer"
+	}
+	return ""
+}
+
+func renderBoxscore(cmd *cobra.Command, boxRaw json.RawMessage) error {
+	w := cmd.OutOrStdout()
+	var box struct {
+		Players []struct {
+			Team struct {
+				Abbreviation string `json:"abbreviation"`
+				DisplayName  string `json:"displayName"`
+			} `json:"team"`
+			Statistics []struct {
+				Name     string   `json:"name"`
+				Labels   []string `json:"labels"`
+				Athletes []struct {
+					Athlete struct {
+						DisplayName string `json:"displayName"`
+					} `json:"athlete"`
+					Stats []string `json:"stats"`
+				} `json:"athletes"`
+			} `json:"statistics"`
+		} `json:"players"`
+		Teams []struct {
+			Team struct {
+				Abbreviation string `json:"abbreviation"`
+			} `json:"team"`
+			Statistics []struct {
+				Label        string `json:"label"`
+				DisplayValue string `json:"displayValue"`
+			} `json:"statistics"`
+		} `json:"teams"`
+	}
+	if err := json.Unmarshal(boxRaw, &box); err != nil {
+		return fmt.Errorf("parsing boxscore: %w", err)
+	}
+
+	if len(box.Players) == 0 && len(box.Teams) == 0 {
+		fmt.Fprintln(w, "Boxscore is empty (game may not have started).")
+		return nil
+	}
+
+	for _, team := range box.Players {
+		for _, stat := range team.Statistics {
+			if len(stat.Athletes) == 0 || len(stat.Labels) == 0 {
+				continue
+			}
+			fmt.Fprintf(w, "\n%s %s — %s\n", bold(team.Team.Abbreviation), team.Team.DisplayName, stat.Name)
+			tw := newTabWriter(w)
+			labels := stat.Labels
+			if len(labels) > 6 {
+				labels = labels[:6]
+			}
+			header := bold("PLAYER")
+			for _, l := range labels {
+				header += "\t" + bold(l)
+			}
+			fmt.Fprintln(tw, header)
+			for _, ath := range stat.Athletes {
+				row := truncate(ath.Athlete.DisplayName, 22)
+				for j, s := range ath.Stats {
+					if j >= len(labels) {
+						break
+					}
+					row += "\t" + s
+				}
+				fmt.Fprintln(tw, row)
+			}
+			tw.Flush()
+		}
+	}
+
+	if len(box.Teams) > 0 {
+		fmt.Fprintf(w, "\n%s\n", bold("TEAM TOTALS"))
+		for _, team := range box.Teams {
+			fmt.Fprintf(w, "  %s:\n", bold(team.Team.Abbreviation))
+			tw := newTabWriter(w)
+			for _, s := range team.Statistics {
+				fmt.Fprintf(tw, "    %s\t%s\n", s.Label, s.DisplayValue)
+			}
+			tw.Flush()
+		}
+	}
+
+	return nil
+}

--- a/library/media-and-entertainment/espn/internal/cli/boxscore_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/boxscore_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSportForLeague(t *testing.T) {
+	cases := []struct {
+		league string
+		want   string
+	}{
+		{"nfl", "football"},
+		{"NBA", "basketball"},
+		{"mlb", "baseball"},
+		{"nhl", "hockey"},
+		{"mls", "soccer"},
+		{"unknown", ""},
+	}
+	for _, c := range cases {
+		got := sportForLeague(c.league)
+		if got != c.want {
+			t.Errorf("sportForLeague(%q) = %q, want %q", c.league, got, c.want)
+		}
+	}
+}
+
+func TestRenderBoxscoreEmpty(t *testing.T) {
+	// Edge case: pre-game boxscore has no players or teams.
+	raw := json.RawMessage(`{"players":[],"teams":[]}`)
+	var sb strings.Builder
+	cmd := newBoxscoreCmd(&rootFlags{})
+	cmd.SetOut(&sb)
+	if err := renderBoxscore(cmd, raw); err != nil {
+		t.Fatalf("renderBoxscore: %v", err)
+	}
+	if !strings.Contains(sb.String(), "empty") {
+		t.Errorf("expected hint about empty boxscore, got: %s", sb.String())
+	}
+}
+
+func TestRenderBoxscorePopulated(t *testing.T) {
+	// Happy path: a single team with a single statistic group renders as table.
+	raw := json.RawMessage(`{
+		"players":[{
+			"team":{"abbreviation":"KC","displayName":"Kansas City"},
+			"statistics":[{
+				"name":"passing",
+				"labels":["YDS","TD"],
+				"athletes":[{"athlete":{"displayName":"Mahomes"},"stats":["310","2"]}]
+			}]
+		}],
+		"teams":[]
+	}`)
+	var sb strings.Builder
+	cmd := newBoxscoreCmd(&rootFlags{})
+	cmd.SetOut(&sb)
+	if err := renderBoxscore(cmd, raw); err != nil {
+		t.Fatalf("renderBoxscore: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{"KC", "Mahomes", "passing", "YDS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/compare.go
+++ b/library/media-and-entertainment/espn/internal/cli/compare.go
@@ -1,0 +1,226 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newCompareCmd renders side-by-side season stats for two athletes.
+// Resolves names via the ESPN search endpoint and pulls each athlete's
+// season splits. Ambiguous matches print candidates and exit 2.
+func newCompareCmd(flags *rootFlags) *cobra.Command {
+	var sport, league string
+
+	cmd := &cobra.Command{
+		Use:   "compare <athlete1> <athlete2>",
+		Short: "Side-by-side athlete stat comparison",
+		Example: `  espn-pp-cli compare Mahomes Allen --sport football --league nfl
+  espn-pp-cli compare LeBron Curry --sport basketball --league nba --agent`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("two athlete names are required\nUsage: compare <athlete1> <athlete2> --sport <s> --league <l>"))
+			}
+			if sport == "" || league == "" {
+				return usageErr(fmt.Errorf("--sport and --league are required"))
+			}
+
+			a1, err := resolveAthlete(flags, sport, league, args[0])
+			if err != nil {
+				return err
+			}
+			a2, err := resolveAthlete(flags, sport, league, args[1])
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				out := map[string]any{
+					"sport":    sport,
+					"league":   league,
+					"athlete1": a1,
+					"athlete2": a2,
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+
+			return renderCompare(cmd, a1, a2)
+		},
+	}
+
+	cmd.Flags().StringVar(&sport, "sport", "", "Sport slug (required)")
+	cmd.Flags().StringVar(&league, "league", "", "League slug (required)")
+	return cmd
+}
+
+type athleteResult struct {
+	ID          string            `json:"id"`
+	DisplayName string            `json:"display_name"`
+	Position    string            `json:"position"`
+	TeamAbbr    string            `json:"team"`
+	Stats       map[string]string `json:"stats"`
+}
+
+func resolveAthlete(flags *rootFlags, sport, league, query string) (*athleteResult, error) {
+	// ESPN's per-league /athletes?search= 400s; the cross-sport common/v3/search
+	// endpoint with type=player works and we filter to the requested sport+league.
+	searchURL := fmt.Sprintf(
+		"https://site.web.api.espn.com/apis/common/v3/search?query=%s&type=player&limit=20",
+		url.QueryEscape(query))
+	body, err := espnHTTPGet(flags.timeout, searchURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Items []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+			Sport       string `json:"sport"`
+			League      string `json:"league"`
+			Position    struct {
+				Abbreviation string `json:"abbreviation"`
+			} `json:"position"`
+			Team struct {
+				Abbreviation string `json:"abbreviation"`
+			} `json:"team"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing athlete search: %w", err)
+	}
+
+	// Filter to requested sport/league when set on the result.
+	var matches []struct {
+		ID          string
+		DisplayName string
+		Position    string
+		TeamAbbr    string
+	}
+	for _, it := range resp.Items {
+		if it.Sport != "" && !strings.EqualFold(it.Sport, sport) {
+			continue
+		}
+		if it.League != "" && !strings.EqualFold(it.League, league) {
+			continue
+		}
+		matches = append(matches, struct {
+			ID          string
+			DisplayName string
+			Position    string
+			TeamAbbr    string
+		}{it.ID, it.DisplayName, it.Position.Abbreviation, it.Team.Abbreviation})
+	}
+	if len(matches) == 0 {
+		return nil, notFoundErr(fmt.Errorf("no athlete matched %q in %s/%s", query, sport, league))
+	}
+
+	exact := -1
+	for i, m := range matches {
+		if strings.EqualFold(m.DisplayName, query) {
+			exact = i
+			break
+		}
+	}
+	if exact == -1 && len(matches) > 1 {
+		var lines []string
+		for i, m := range matches {
+			if i >= 5 {
+				lines = append(lines, "  ...")
+				break
+			}
+			lines = append(lines, fmt.Sprintf("  %s — %s (%s)", m.ID, m.DisplayName, m.TeamAbbr))
+		}
+		return nil, usageErr(fmt.Errorf("ambiguous athlete %q. Candidates:\n%s\nRefine the name or pass the athlete id directly.",
+			query, strings.Join(lines, "\n")))
+	}
+
+	idx := 0
+	if exact >= 0 {
+		idx = exact
+	}
+	picked := matches[idx]
+	a := &athleteResult{
+		ID:          picked.ID,
+		DisplayName: picked.DisplayName,
+		Position:    picked.Position,
+		TeamAbbr:    picked.TeamAbbr,
+		Stats:       map[string]string{},
+	}
+
+	// Fetch per-athlete season stats. The "stats" subresource on the common v3
+	// path returns a categories array similar to the leaders payload.
+	statsURL := fmt.Sprintf(
+		"https://site.web.api.espn.com/apis/common/v3/sports/%s/%s/athletes/%s/stats",
+		sport, league, picked.ID)
+	statsBody, err := espnHTTPGet(flags.timeout, statsURL)
+	if err == nil {
+		var stats struct {
+			Categories []struct {
+				Name   string   `json:"name"`
+				Labels []string `json:"labels"`
+				Names  []string `json:"names"`
+				Totals []string `json:"totals"`
+			} `json:"categories"`
+		}
+		if json.Unmarshal(statsBody, &stats) == nil {
+			for _, cat := range stats.Categories {
+				if len(cat.Totals) == 0 {
+					continue
+				}
+				labels := cat.Labels
+				if len(labels) == 0 {
+					labels = cat.Names
+				}
+				for i, label := range labels {
+					if i >= len(cat.Totals) {
+						break
+					}
+					a.Stats[cat.Name+"."+label] = cat.Totals[i]
+				}
+			}
+		}
+	}
+
+	return a, nil
+}
+
+func renderCompare(cmd *cobra.Command, a, b *athleteResult) error {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "%s (%s, %s)  vs  %s (%s, %s)\n\n",
+		bold(a.DisplayName), a.Position, a.TeamAbbr,
+		bold(b.DisplayName), b.Position, b.TeamAbbr)
+
+	// Union of stat keys from both athletes.
+	keys := map[string]bool{}
+	for k := range a.Stats {
+		keys[k] = true
+	}
+	for k := range b.Stats {
+		keys[k] = true
+	}
+	if len(keys) == 0 {
+		fmt.Fprintln(w, "No season stats available for either athlete.")
+		return nil
+	}
+
+	tw := newTabWriter(w)
+	fmt.Fprintf(tw, "%s\t%s\t%s\n", bold("STAT"), bold(a.DisplayName), bold(b.DisplayName))
+	for k := range keys {
+		va := a.Stats[k]
+		vb := b.Stats[k]
+		if va == "" {
+			va = "-"
+		}
+		if vb == "" {
+			vb = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", k, va, vb)
+	}
+	return tw.Flush()
+}

--- a/library/media-and-entertainment/espn/internal/cli/compare_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/compare_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompareCmdRequiresTwoNames(t *testing.T) {
+	cmd := newCompareCmd(&rootFlags{})
+	cmd.SetArgs([]string{"Mahomes"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing second athlete name")
+	}
+}
+
+func TestCompareCmdRequiresSportLeague(t *testing.T) {
+	cmd := newCompareCmd(&rootFlags{})
+	cmd.SetArgs([]string{"Mahomes", "Allen"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --sport/--league")
+	}
+	if !strings.Contains(err.Error(), "sport") {
+		t.Errorf("expected sport-related error, got %v", err)
+	}
+}
+
+func TestRenderCompareNoStats(t *testing.T) {
+	a := &athleteResult{ID: "1", DisplayName: "A", Position: "QB", TeamAbbr: "KC", Stats: map[string]string{}}
+	b := &athleteResult{ID: "2", DisplayName: "B", Position: "QB", TeamAbbr: "BUF", Stats: map[string]string{}}
+	cmd := newCompareCmd(&rootFlags{})
+	var sb strings.Builder
+	cmd.SetOut(&sb)
+	if err := renderCompare(cmd, a, b); err != nil {
+		t.Fatalf("renderCompare: %v", err)
+	}
+	if !strings.Contains(sb.String(), "No season stats") {
+		t.Errorf("expected hint about missing stats, got: %s", sb.String())
+	}
+}
+
+func TestRenderCompareWithStats(t *testing.T) {
+	a := &athleteResult{ID: "1", DisplayName: "A", Position: "QB", TeamAbbr: "KC",
+		Stats: map[string]string{"passing.YDS": "4000"}}
+	b := &athleteResult{ID: "2", DisplayName: "B", Position: "QB", TeamAbbr: "BUF",
+		Stats: map[string]string{"passing.YDS": "4200"}}
+	cmd := newCompareCmd(&rootFlags{})
+	var sb strings.Builder
+	cmd.SetOut(&sb)
+	if err := renderCompare(cmd, a, b); err != nil {
+		t.Fatalf("renderCompare: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{"4000", "4200", "passing.YDS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/dashboard.go
+++ b/library/media-and-entertainment/espn/internal/cli/dashboard.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/cobra"
+)
+
+// dashboardConfig is the on-disk shape for the [favorites] section of
+// ~/.config/espn-pp-cli/config.toml.
+//
+// Schema:
+//
+//	[favorites]
+//	nfl   = ["KC", "BAL"]
+//	nba   = ["LAL"]
+//
+// Keys are league slugs (lowercase). Values are team abbreviations (uppercase).
+// Unknown keys are preserved for forward compatibility.
+type dashboardConfig struct {
+	Favorites map[string][]string `toml:"favorites"`
+}
+
+func loadDashboardFavorites(path string) (map[string][]string, string, error) {
+	if path == "" {
+		home, _ := os.UserHomeDir()
+		path = filepath.Join(home, ".config", "espn-pp-cli", "config.toml")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, path, nil
+		}
+		return nil, path, err
+	}
+	var cfg dashboardConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, path, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	// Normalize keys/values.
+	out := map[string][]string{}
+	for league, teams := range cfg.Favorites {
+		key := strings.ToLower(league)
+		var ts []string
+		for _, t := range teams {
+			ts = append(ts, strings.ToUpper(t))
+		}
+		out[key] = ts
+	}
+	return out, path, nil
+}
+
+// newDashboardCmd renders favorited teams' status grouped by league.
+func newDashboardCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Your favorite teams' status at a glance (reads [favorites] in config.toml)",
+		Example: `  espn-pp-cli dashboard
+  espn-pp-cli dashboard --agent
+  espn-pp-cli dashboard --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			favs, path, err := loadDashboardFavorites(flags.configPath)
+			if err != nil {
+				return configErr(err)
+			}
+			if len(favs) == 0 {
+				w := cmd.OutOrStdout()
+				if flags.asJSON || (!isTerminal(w) && !humanFriendly) {
+					fmt.Fprintln(w, "[]")
+					fmt.Fprintf(cmd.ErrOrStderr(), "No favorites configured. Add a [favorites] block to %s\n", path)
+					return nil
+				}
+				fmt.Fprintf(w, "No favorites configured. Add a [favorites] block to %s, e.g.:\n\n", path)
+				fmt.Fprintln(w, "  [favorites]")
+				fmt.Fprintln(w, `  nfl = ["KC", "BAL"]`)
+				fmt.Fprintln(w, `  nba = ["LAL"]`)
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			type leagueRow struct {
+				League string         `json:"league"`
+				Teams  []dashboardRow `json:"teams"`
+				Err    string         `json:"error,omitempty"`
+			}
+
+			leagues := make([]string, 0, len(favs))
+			for k := range favs {
+				leagues = append(leagues, k)
+			}
+			sort.Strings(leagues)
+
+			results := make([]leagueRow, len(leagues))
+			var wg sync.WaitGroup
+			for i, league := range leagues {
+				wg.Add(1)
+				go func(idx int, league string) {
+					defer wg.Done()
+					sport := sportForLeague(league)
+					if sport == "" {
+						results[idx] = leagueRow{League: league, Err: "unknown league slug"}
+						return
+					}
+					path := fmt.Sprintf("/%s/%s/scoreboard", sport, league)
+					data, fetchErr := c.Get(path, nil)
+					if fetchErr != nil {
+						results[idx] = leagueRow{League: league, Err: fetchErr.Error()}
+						return
+					}
+					rows := dashboardRowsFor(data, favs[league])
+					results[idx] = leagueRow{League: league, Teams: rows}
+				}(i, league)
+			}
+			wg.Wait()
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(results)
+			}
+
+			w := cmd.OutOrStdout()
+			for _, r := range results {
+				fmt.Fprintf(w, "\n%s\n", bold(strings.ToUpper(r.League)))
+				if r.Err != "" {
+					fmt.Fprintf(w, "  error: %s\n", r.Err)
+					continue
+				}
+				if len(r.Teams) == 0 {
+					fmt.Fprintln(w, "  (no games for favorited teams in current scoreboard)")
+					continue
+				}
+				tw := newTabWriter(w)
+				fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+					bold("TEAM"), bold("MATCHUP"), bold("SCORE"), bold("STATUS"))
+				for _, row := range r.Teams {
+					fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+						row.Team, row.Matchup, row.Score, row.Status)
+				}
+				tw.Flush()
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+type dashboardRow struct {
+	Team    string `json:"team"`
+	Matchup string `json:"matchup"`
+	Score   string `json:"score"`
+	Status  string `json:"status"`
+}
+
+func dashboardRowsFor(data json.RawMessage, favorites []string) []dashboardRow {
+	if len(favorites) == 0 {
+		return nil
+	}
+	favSet := map[string]bool{}
+	for _, t := range favorites {
+		favSet[strings.ToUpper(t)] = true
+	}
+	events := parseScoreEvents(data)
+	var rows []dashboardRow
+	for _, e := range events {
+		if !favSet[strings.ToUpper(e.HomeTeam)] && !favSet[strings.ToUpper(e.AwayTeam)] {
+			continue
+		}
+		team := e.HomeTeam
+		if !favSet[strings.ToUpper(e.HomeTeam)] {
+			team = e.AwayTeam
+		}
+		rows = append(rows, dashboardRow{
+			Team:    team,
+			Matchup: e.Matchup,
+			Score:   fmt.Sprintf("%s %s - %s %s", e.AwayTeam, e.AwayScore, e.HomeTeam, e.HomeScore),
+			Status:  firstNonEmpty(e.Detail, e.Status),
+		})
+	}
+	return rows
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/library/media-and-entertainment/espn/internal/cli/dashboard_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/dashboard_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDashboardFavoritesMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	favs, _, err := loadDashboardFavorites(filepath.Join(dir, "absent.toml"))
+	if err != nil {
+		t.Fatalf("missing file should yield nil error, got %v", err)
+	}
+	if favs != nil {
+		t.Errorf("missing file should yield nil favorites, got %+v", favs)
+	}
+}
+
+func TestLoadDashboardFavoritesParsesAndNormalizes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `
+[favorites]
+NFL = ["KC", "bal"]
+nba = ["LAL"]
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	favs, _, err := loadDashboardFavorites(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(favs) != 2 {
+		t.Fatalf("want 2 leagues, got %d", len(favs))
+	}
+	nfl := favs["nfl"]
+	if len(nfl) != 2 || nfl[0] != "KC" || nfl[1] != "BAL" {
+		t.Errorf("nfl normalization wrong: %+v", nfl)
+	}
+}
+
+func TestLoadDashboardFavoritesMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.toml")
+	if err := os.WriteFile(path, []byte("not = valid = toml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := loadDashboardFavorites(path)
+	if err == nil {
+		t.Fatal("expected error for malformed TOML")
+	}
+}
+
+func TestDashboardRowsForFiltersToFavorites(t *testing.T) {
+	scoreboard := json.RawMessage(`{
+		"events":[
+			{"id":"1","shortName":"BOS @ LAL","status":{"type":{"state":"in","detail":"Q3 4:12"}},
+			 "competitions":[{"competitors":[
+				{"homeAway":"home","score":"100","team":{"abbreviation":"LAL"}},
+				{"homeAway":"away","score":"95","team":{"abbreviation":"BOS"}}
+			 ]}]},
+			{"id":"2","shortName":"PHI @ DAL","status":{"type":{"state":"in","detail":"Q1 9:30"}},
+			 "competitions":[{"competitors":[
+				{"homeAway":"home","score":"10","team":{"abbreviation":"DAL"}},
+				{"homeAway":"away","score":"5","team":{"abbreviation":"PHI"}}
+			 ]}]}
+		]
+	}`)
+	rows := dashboardRowsFor(scoreboard, []string{"LAL"})
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row matching LAL, got %d", len(rows))
+	}
+	if rows[0].Team != "LAL" {
+		t.Errorf("want team LAL, got %q", rows[0].Team)
+	}
+}
+
+func TestDashboardRowsForEmpty(t *testing.T) {
+	rows := dashboardRowsFor(json.RawMessage(`{"events":[]}`), []string{"KC"})
+	if len(rows) != 0 {
+		t.Errorf("empty scoreboard should yield no rows, got %d", len(rows))
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/h2h.go
+++ b/library/media-and-entertainment/espn/internal/cli/h2h.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/store"
+	"github.com/spf13/cobra"
+)
+
+// newH2hCmd returns deep head-to-head detail between two teams. Differs from
+// `rivals` (league-wide pairwise records): h2h focuses on one specific pair
+// with average score and recent meetings detail.
+func newH2hCmd(flags *rootFlags) *cobra.Command {
+	var sport, league, dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "h2h <team1> <team2>",
+		Short: "Head-to-head detail between two teams",
+		Example: `  espn-pp-cli h2h KC BUF --sport football --league nfl
+  espn-pp-cli h2h LAL BOS --sport basketball --league nba --agent
+  espn-pp-cli h2h NYY BOS --sport baseball --league mlb --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("two team abbreviations are required\nUsage: h2h <team1> <team2> --sport <s> --league <l>"))
+			}
+			if sport == "" || league == "" {
+				return usageErr(fmt.Errorf("--sport and --league are required"))
+			}
+			teamA := strings.ToUpper(args[0])
+			teamB := strings.ToUpper(args[1])
+
+			if dbPath == "" {
+				dbPath = defaultDBPath("espn-pp-cli")
+			}
+
+			db, err := store.Open(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening database: %w\nhint: run 'espn-pp-cli sync' first", err)
+			}
+			defer db.Close()
+
+			events, err := db.ListEvents(sport, league, teamA, 1000, true)
+			if err != nil {
+				return fmt.Errorf("querying events: %w", err)
+			}
+
+			type meeting struct {
+				Date   string `json:"date"`
+				Score  string `json:"score"`
+				Winner string `json:"winner"`
+				ScoreA int    `json:"score_a"`
+				ScoreB int    `json:"score_b"`
+			}
+			var meetings []meeting
+			aWins, bWins, ties := 0, 0, 0
+			var sumA, sumB int
+
+			for _, raw := range events {
+				var ev map[string]any
+				if json.Unmarshal(raw, &ev) != nil {
+					continue
+				}
+				comps, ok := ev["competitions"].([]any)
+				if !ok || len(comps) == 0 {
+					continue
+				}
+				comp, _ := comps[0].(map[string]any)
+				if comp == nil {
+					continue
+				}
+				competitors, ok := comp["competitors"].([]any)
+				if !ok {
+					continue
+				}
+				var hasA, hasB bool
+				var scoreA, scoreB int
+				var aWinner, bWinner bool
+				for _, c := range competitors {
+					t, _ := c.(map[string]any)
+					if t == nil {
+						continue
+					}
+					var abbr string
+					if teamObj, ok := t["team"].(map[string]any); ok {
+						abbr = jsonStrAny(teamObj, "abbreviation")
+					}
+					score := atoiSafe(jsonStrAny(t, "score"))
+					winner := false
+					if w, ok := t["winner"].(bool); ok {
+						winner = w
+					}
+					if strings.EqualFold(abbr, teamA) {
+						hasA = true
+						scoreA = score
+						aWinner = winner
+					} else if strings.EqualFold(abbr, teamB) {
+						hasB = true
+						scoreB = score
+						bWinner = winner
+					}
+				}
+				if !hasA || !hasB {
+					continue
+				}
+
+				date := jsonStrAny(ev, "date")
+				if len(date) > 10 {
+					date = date[:10]
+				}
+				m := meeting{
+					Date:   date,
+					Score:  fmt.Sprintf("%s %d - %s %d", teamA, scoreA, teamB, scoreB),
+					ScoreA: scoreA,
+					ScoreB: scoreB,
+				}
+				switch {
+				case aWinner:
+					m.Winner = teamA
+					aWins++
+				case bWinner:
+					m.Winner = teamB
+					bWins++
+				default:
+					m.Winner = "TIE"
+					ties++
+				}
+				sumA += scoreA
+				sumB += scoreB
+				meetings = append(meetings, m)
+			}
+
+			if len(meetings) == 0 {
+				return notFoundErr(fmt.Errorf("no meetings between %s and %s in synced %s/%s. Run 'espn-pp-cli sync' first", teamA, teamB, sport, league))
+			}
+
+			avgA := float64(sumA) / float64(len(meetings))
+			avgB := float64(sumB) / float64(len(meetings))
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				out := map[string]any{
+					"team_a":   teamA,
+					"team_b":   teamB,
+					"sport":    sport,
+					"league":   league,
+					"a_wins":   aWins,
+					"b_wins":   bWins,
+					"ties":     ties,
+					"total":    len(meetings),
+					"avg_a":    avgA,
+					"avg_b":    avgB,
+					"meetings": meetings,
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "%s vs %s  (%s %s)\n", bold(teamA), bold(teamB), strings.ToUpper(sport), strings.ToUpper(league))
+			fmt.Fprintf(w, "Record: %s %d - %d %s", teamA, aWins, bWins, teamB)
+			if ties > 0 {
+				fmt.Fprintf(w, " (%d ties)", ties)
+			}
+			fmt.Fprintf(w, "  (%d games)\n", len(meetings))
+			fmt.Fprintf(w, "Avg score: %s %.1f, %s %.1f\n\n", teamA, avgA, teamB, avgB)
+
+			tw := newTabWriter(w)
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", bold("DATE"), bold("SCORE"), bold("WINNER"))
+			for _, m := range meetings {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", m.Date, m.Score, m.Winner)
+			}
+			return tw.Flush()
+		},
+	}
+
+	cmd.Flags().StringVar(&sport, "sport", "", "Sport slug (required)")
+	cmd.Flags().StringVar(&league, "league", "", "League slug (required)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
+	return cmd
+}
+
+func atoiSafe(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return n
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/library/media-and-entertainment/espn/internal/cli/h2h_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/h2h_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import "testing"
+
+func TestAtoiSafe(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"0", 0},
+		{"42", 42},
+		{"", 0},
+		{"abc", 0},
+		{"12x", 12},
+	}
+	for _, c := range cases {
+		got := atoiSafe(c.in)
+		if got != c.want {
+			t.Errorf("atoiSafe(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestH2hCmdRequiresTwoTeams(t *testing.T) {
+	cmd := newH2hCmd(&rootFlags{})
+	cmd.SetArgs([]string{"KC"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing second team")
+	}
+	cliErr, ok := err.(*cliError)
+	if !ok {
+		t.Fatalf("expected *cliError, got %T", err)
+	}
+	if cliErr.code != 2 {
+		t.Errorf("expected exit code 2, got %d", cliErr.code)
+	}
+}
+
+func TestH2hCmdRequiresSportLeague(t *testing.T) {
+	cmd := newH2hCmd(&rootFlags{})
+	cmd.SetArgs([]string{"KC", "BUF"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --sport/--league")
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/odds.go
+++ b/library/media-and-entertainment/espn/internal/cli/odds.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newOddsCmd aggregates spread/total/moneyline lines for tonight's slate by
+// reading each scoreboard event's competitions[].odds field. This avoids one
+// summary call per game.
+func newOddsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "odds <sport> <league>",
+		Short: "Spread, total, and moneyline lines for tonight's slate",
+		Example: `  espn-pp-cli odds basketball nba
+  espn-pp-cli odds football nfl --agent
+  espn-pp-cli odds baseball mlb --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: odds <sport> <league>"))
+			}
+			sport, league := args[0], args[1]
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("/%s/%s/scoreboard", sport, league)
+			data, err := c.Get(path, nil)
+			if err != nil {
+				return classifyAPIError(err)
+			}
+
+			lines := extractOdds(data)
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(lines)
+			}
+
+			w := cmd.OutOrStdout()
+			if len(lines) == 0 {
+				fmt.Fprintln(w, "No games with odds for the current slate.")
+				return nil
+			}
+			tw := newTabWriter(w)
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				bold("MATCHUP"), bold("SPREAD"), bold("OVER/UNDER"), bold("ML(AWAY)"), bold("ML(HOME)"))
+			for _, l := range lines {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+					l.Matchup, l.Spread, l.OverUnder, l.AwayMoneyline, l.HomeMoneyline)
+			}
+			return tw.Flush()
+		},
+	}
+	return cmd
+}
+
+type oddsLine struct {
+	EventID       string `json:"event_id"`
+	Matchup       string `json:"matchup"`
+	Spread        string `json:"spread"`
+	OverUnder     string `json:"over_under"`
+	AwayMoneyline string `json:"away_moneyline"`
+	HomeMoneyline string `json:"home_moneyline"`
+}
+
+func extractOdds(data json.RawMessage) []oddsLine {
+	var resp struct {
+		Events []struct {
+			ID           string `json:"id"`
+			ShortName    string `json:"shortName"`
+			Competitions []struct {
+				Odds []struct {
+					Provider struct {
+						Name string `json:"name"`
+					} `json:"provider"`
+					Details      string  `json:"details"`
+					OverUnder    float64 `json:"overUnder"`
+					AwayTeamOdds struct {
+						MoneyLine int `json:"moneyLine"`
+					} `json:"awayTeamOdds"`
+					HomeTeamOdds struct {
+						MoneyLine int `json:"moneyLine"`
+					} `json:"homeTeamOdds"`
+				} `json:"odds"`
+			} `json:"competitions"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil
+	}
+	var out []oddsLine
+	for _, ev := range resp.Events {
+		if len(ev.Competitions) == 0 || len(ev.Competitions[0].Odds) == 0 {
+			continue
+		}
+		o := ev.Competitions[0].Odds[0]
+		ou := ""
+		if o.OverUnder != 0 {
+			ou = fmt.Sprintf("%.1f", o.OverUnder)
+		}
+		out = append(out, oddsLine{
+			EventID:       ev.ID,
+			Matchup:       ev.ShortName,
+			Spread:        o.Details,
+			OverUnder:     ou,
+			AwayMoneyline: formatMoneyline(o.AwayTeamOdds.MoneyLine),
+			HomeMoneyline: formatMoneyline(o.HomeTeamOdds.MoneyLine),
+		})
+	}
+	return out
+}
+
+func formatMoneyline(ml int) string {
+	if ml == 0 {
+		return ""
+	}
+	if ml > 0 {
+		return fmt.Sprintf("+%d", ml)
+	}
+	return fmt.Sprintf("%d", ml)
+}

--- a/library/media-and-entertainment/espn/internal/cli/odds_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/odds_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractOddsHappyPath(t *testing.T) {
+	raw := json.RawMessage(`{
+		"events":[{
+			"id":"123","shortName":"BOS @ LAL",
+			"competitions":[{
+				"odds":[{
+					"provider":{"name":"ESPN BET"},
+					"details":"LAL -3.5","overUnder":225.5,
+					"awayTeamOdds":{"moneyLine":140},
+					"homeTeamOdds":{"moneyLine":-160}
+				}]
+			}]
+		}]
+	}`)
+	lines := extractOdds(raw)
+	if len(lines) != 1 {
+		t.Fatalf("want 1 line, got %d", len(lines))
+	}
+	got := lines[0]
+	if got.Matchup != "BOS @ LAL" || got.Spread != "LAL -3.5" || got.OverUnder != "225.5" {
+		t.Errorf("unexpected line: %+v", got)
+	}
+	if got.AwayMoneyline != "+140" || got.HomeMoneyline != "-160" {
+		t.Errorf("moneylines wrong: %+v", got)
+	}
+}
+
+func TestExtractOddsEmpty(t *testing.T) {
+	raw := json.RawMessage(`{"events":[]}`)
+	lines := extractOdds(raw)
+	if len(lines) != 0 {
+		t.Errorf("expected empty slice, got %d", len(lines))
+	}
+}
+
+func TestExtractOddsSkipsEventsWithoutOdds(t *testing.T) {
+	raw := json.RawMessage(`{"events":[{"id":"1","shortName":"A @ B","competitions":[{"odds":[]}]}]}`)
+	lines := extractOdds(raw)
+	if len(lines) != 0 {
+		t.Errorf("expected events without odds to be skipped, got %d lines", len(lines))
+	}
+}
+
+func TestFormatMoneyline(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{0, ""},
+		{150, "+150"},
+		{-110, "-110"},
+	}
+	for _, c := range cases {
+		got := formatMoneyline(c.in)
+		if got != c.want {
+			t.Errorf("formatMoneyline(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/promoted_injuries.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_injuries.go
@@ -1,0 +1,140 @@
+// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
+// Hand-written promoted command. Spec-driven shape declared in spec.yaml.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newInjuriesPromotedCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "injuries <sport> <league>",
+		Short: "Active injury reports for a league",
+		Example: `  espn-pp-cli injuries football nfl
+  espn-pp-cli injuries basketball nba --agent
+  espn-pp-cli injuries baseball mlb --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: injuries <sport> <league>"))
+			}
+			sport, league := args[0], args[1]
+
+			// Injuries endpoint lives under site.web.api.espn.com.
+			url := fmt.Sprintf("https://site.web.api.espn.com/apis/site/v2/sports/%s/%s/injuries", sport, league)
+
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				var raw json.RawMessage
+				if err := json.Unmarshal(body, &raw); err != nil {
+					return err
+				}
+				return enc.Encode(raw)
+			}
+
+			return renderInjuries(cmd.OutOrStdout(), body)
+		},
+	}
+	return cmd
+}
+
+// espnHTTPGet performs a direct HTTP GET against an absolute ESPN url.
+// Used for endpoints that do not live under the default base URL
+// (sports.core.api.espn.com, site.web.api.espn.com, etc.).
+func espnHTTPGet(timeout time.Duration, url string) ([]byte, error) {
+	httpClient := &http.Client{Timeout: timeout}
+	if timeout == 0 {
+		httpClient.Timeout = 30 * time.Second
+	}
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, apiErr(fmt.Errorf("fetching %s: %w", url, err))
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, apiErr(fmt.Errorf("reading response: %w", err))
+	}
+	if resp.StatusCode == 404 {
+		return nil, notFoundErr(fmt.Errorf("%s returned HTTP 404", url))
+	}
+	if resp.StatusCode == 429 {
+		return nil, rateLimitErr(fmt.Errorf("%s rate limited", url))
+	}
+	if resp.StatusCode >= 400 {
+		return nil, apiErr(fmt.Errorf("%s returned HTTP %d: %s", url, resp.StatusCode, truncate(string(body), 200)))
+	}
+	return body, nil
+}
+
+func renderInjuries(w io.Writer, data []byte) error {
+	var resp struct {
+		Injuries []struct {
+			Team struct {
+				DisplayName  string `json:"displayName"`
+				Abbreviation string `json:"abbreviation"`
+			} `json:"team"`
+			Injuries []struct {
+				Status      string `json:"status"`
+				Description string `json:"shortComment"`
+				Date        string `json:"date"`
+				Athlete     struct {
+					DisplayName string `json:"displayName"`
+					Position    struct {
+						Abbreviation string `json:"abbreviation"`
+					} `json:"position"`
+				} `json:"athlete"`
+				Type struct {
+					Description string `json:"description"`
+				} `json:"type"`
+			} `json:"injuries"`
+		} `json:"injuries"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parsing injuries: %w", err)
+	}
+
+	total := 0
+	for _, t := range resp.Injuries {
+		total += len(t.Injuries)
+	}
+	if total == 0 {
+		fmt.Fprintln(w, "No injuries reported.")
+		return nil
+	}
+
+	tw := newTabWriter(w)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		bold("TEAM"), bold("PLAYER"), bold("POS"), bold("STATUS"), bold("TYPE"), bold("DATE"))
+	for _, team := range resp.Injuries {
+		for _, inj := range team.Injuries {
+			date := inj.Date
+			if len(date) > 10 {
+				date = date[:10]
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				team.Team.Abbreviation,
+				truncate(inj.Athlete.DisplayName, 25),
+				inj.Athlete.Position.Abbreviation,
+				inj.Status,
+				truncate(inj.Type.Description, 20),
+				date)
+		}
+	}
+	return tw.Flush()
+}

--- a/library/media-and-entertainment/espn/internal/cli/promoted_leaders.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_leaders.go
@@ -1,0 +1,173 @@
+// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
+// Hand-written promoted command. Spec-driven shape declared in spec.yaml.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newLeadersPromotedCmd(flags *rootFlags) *cobra.Command {
+	var category string
+
+	cmd := &cobra.Command{
+		Use:   "leaders <sport> <league>",
+		Short: "Statistical leaders across categories",
+		Example: `  espn-pp-cli leaders football nfl
+  espn-pp-cli leaders basketball nba --category points
+  espn-pp-cli leaders baseball mlb --agent`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: leaders <sport> <league> [--category <name>]"))
+			}
+			sport, league := args[0], args[1]
+
+			// Leaders / statistical-by-athlete endpoint lives under site.web.api.espn.com common/v3.
+			// The "leaders" path 404s; "statistics/byathlete" is what ESPN's web client uses.
+			url := fmt.Sprintf("https://site.web.api.espn.com/apis/common/v3/sports/%s/%s/statistics/byathlete?limit=50", sport, league)
+
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			if category != "" {
+				body = filterLeaderCategory(body, category)
+				if body == nil {
+					return usageErr(fmt.Errorf("category %q not found in response. Run without --category to list available categories.", category))
+				}
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				var raw json.RawMessage
+				if err := json.Unmarshal(body, &raw); err != nil {
+					return err
+				}
+				return enc.Encode(raw)
+			}
+
+			return renderLeaders(cmd.OutOrStdout(), body)
+		},
+	}
+
+	cmd.Flags().StringVar(&category, "category", "", "Optional stat category filter (e.g. passing, rushing, points)")
+	return cmd
+}
+
+// filterLeaderCategory restricts the byathlete payload to a single category.
+// Each athlete entry has a "categories" array; we keep only entries that have
+// the named category and rewrite each athlete's categories to just that one.
+// Returns nil if the category does not exist anywhere.
+func filterLeaderCategory(data []byte, category string) []byte {
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return data
+	}
+	athletesRaw, ok := resp["athletes"]
+	if !ok {
+		return data
+	}
+	var athletes []map[string]any
+	if err := json.Unmarshal(athletesRaw, &athletes); err != nil {
+		return data
+	}
+	matched := false
+	out := make([]map[string]any, 0, len(athletes))
+	for _, a := range athletes {
+		cats, _ := a["categories"].([]any)
+		var keep []any
+		for _, c := range cats {
+			cm, _ := c.(map[string]any)
+			if cm == nil {
+				continue
+			}
+			name, _ := cm["name"].(string)
+			display, _ := cm["displayName"].(string)
+			if strings.EqualFold(name, category) || strings.EqualFold(display, category) {
+				keep = append(keep, cm)
+				matched = true
+			}
+		}
+		if len(keep) > 0 {
+			a["categories"] = keep
+			out = append(out, a)
+		}
+	}
+	if !matched {
+		return nil
+	}
+	resp["athletes"], _ = json.Marshal(out)
+	res, _ := json.Marshal(resp)
+	return res
+}
+
+func renderLeaders(w io.Writer, data []byte) error {
+	var resp struct {
+		Athletes []struct {
+			Athlete struct {
+				DisplayName string `json:"displayName"`
+				Team        struct {
+					Abbreviation string `json:"abbreviation"`
+				} `json:"team"`
+				Position struct {
+					Abbreviation string `json:"abbreviation"`
+				} `json:"position"`
+			} `json:"athlete"`
+			Categories []struct {
+				Name        string `json:"name"`
+				DisplayName string `json:"displayName"`
+				Values      []struct {
+					Name         string `json:"name"`
+					DisplayName  string `json:"displayName"`
+					DisplayValue string `json:"displayValue"`
+				} `json:"values"`
+			} `json:"categories"`
+		} `json:"athletes"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parsing leaders: %w", err)
+	}
+	if len(resp.Athletes) == 0 {
+		fmt.Fprintln(w, "No leaders found.")
+		return nil
+	}
+
+	tw := newTabWriter(w)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+		bold("RANK"), bold("PLAYER"), bold("TEAM"), bold("POS"), bold("KEY STATS"))
+	for i, a := range resp.Athletes {
+		if i >= 25 {
+			break
+		}
+		// Pull a few headline values from the first category.
+		stats := ""
+		if len(a.Categories) > 0 {
+			cat := a.Categories[0]
+			parts := []string{}
+			for j, v := range cat.Values {
+				if j >= 3 {
+					break
+				}
+				parts = append(parts, fmt.Sprintf("%s %s", v.DisplayName, v.DisplayValue))
+			}
+			stats = strings.Join(parts, ", ")
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\n",
+			i+1,
+			truncate(a.Athlete.DisplayName, 22),
+			a.Athlete.Team.Abbreviation,
+			a.Athlete.Position.Abbreviation,
+			truncate(stats, 60))
+	}
+	return tw.Flush()
+}

--- a/library/media-and-entertainment/espn/internal/cli/promoted_plays.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_plays.go
@@ -1,0 +1,110 @@
+// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
+// Hand-written promoted command. Spec-driven shape declared in spec.yaml.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newPlaysPromotedCmd(flags *rootFlags) *cobra.Command {
+	var event string
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "plays <sport> <league>",
+		Short: "Play-by-play feed for a specific event",
+		Example: `  espn-pp-cli plays football nfl --event 401547417
+  espn-pp-cli plays basketball nba --event 401584793 --limit 50
+  espn-pp-cli plays baseball mlb --event 401569551 --agent`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: plays <sport> <league> --event <id>"))
+			}
+			if event == "" {
+				return usageErr(fmt.Errorf("--event is required"))
+			}
+			sport, league := args[0], args[1]
+
+			if limit <= 0 {
+				limit = 200
+			}
+
+			// Plays endpoint lives on the core API host.
+			url := fmt.Sprintf(
+				"https://sports.core.api.espn.com/v2/sports/%s/leagues/%s/events/%s/competitions/%s/plays?limit=%d",
+				sport, league, event, event, limit)
+
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				var raw json.RawMessage
+				if err := json.Unmarshal(body, &raw); err != nil {
+					return err
+				}
+				return enc.Encode(raw)
+			}
+
+			return renderPlays(cmd.OutOrStdout(), body)
+		},
+	}
+
+	cmd.Flags().StringVar(&event, "event", "", "ESPN event/game id (required)")
+	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum number of plays to return")
+	return cmd
+}
+
+func renderPlays(w io.Writer, data []byte) error {
+	var resp struct {
+		Count int `json:"count"`
+		Items []struct {
+			Sequence string `json:"sequenceNumber"`
+			Type     struct {
+				Text string `json:"text"`
+			} `json:"type"`
+			Text   string `json:"text"`
+			Period struct {
+				Number int `json:"number"`
+			} `json:"period"`
+			Clock struct {
+				DisplayValue string `json:"displayValue"`
+			} `json:"clock"`
+			HomeScore int `json:"homeScore"`
+			AwayScore int `json:"awayScore"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parsing plays: %w", err)
+	}
+
+	if len(resp.Items) == 0 {
+		fmt.Fprintln(w, "No plays found.")
+		return nil
+	}
+
+	tw := newTabWriter(w)
+	fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+		bold("PERIOD"), bold("CLOCK"), bold("SCORE"), bold("TYPE"), bold("PLAY"))
+	for _, p := range resp.Items {
+		score := fmt.Sprintf("%d-%d", p.AwayScore, p.HomeScore)
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\n",
+			p.Period.Number,
+			p.Clock.DisplayValue,
+			score,
+			truncate(p.Type.Text, 20),
+			truncate(p.Text, 80))
+	}
+	return tw.Flush()
+}

--- a/library/media-and-entertainment/espn/internal/cli/promoted_transactions.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_transactions.go
@@ -1,0 +1,90 @@
+// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
+// Hand-written promoted command. Spec-driven shape declared in spec.yaml.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+func newTransactionsPromotedCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "transactions <sport> <league>",
+		Short: "Recent league transactions (trades, signings, waivers)",
+		Example: `  espn-pp-cli transactions baseball mlb
+  espn-pp-cli transactions football nfl --agent
+  espn-pp-cli transactions hockey nhl --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: transactions <sport> <league>"))
+			}
+			sport, league := args[0], args[1]
+
+			// Transactions live on the core API host.
+			url := fmt.Sprintf("https://sports.core.api.espn.com/v2/sports/%s/leagues/%s/transactions", sport, league)
+
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				var raw json.RawMessage
+				if err := json.Unmarshal(body, &raw); err != nil {
+					return err
+				}
+				return enc.Encode(raw)
+			}
+
+			return renderTransactions(cmd.OutOrStdout(), body)
+		},
+	}
+	return cmd
+}
+
+func renderTransactions(w io.Writer, data []byte) error {
+	var resp struct {
+		Count int `json:"count"`
+		Items []struct {
+			Date        string `json:"date"`
+			Type        string `json:"type"`
+			Description string `json:"description"`
+			From        struct {
+				Ref string `json:"$ref"`
+			} `json:"from"`
+			To struct {
+				Ref string `json:"$ref"`
+			} `json:"to"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parsing transactions: %w", err)
+	}
+
+	if len(resp.Items) == 0 {
+		fmt.Fprintln(w, "No transactions found.")
+		return nil
+	}
+
+	tw := newTabWriter(w)
+	fmt.Fprintf(tw, "%s\t%s\t%s\n",
+		bold("DATE"), bold("TYPE"), bold("DESCRIPTION"))
+	for _, t := range resp.Items {
+		date := t.Date
+		if len(date) > 10 {
+			date = date[:10]
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n",
+			date, t.Type, truncate(t.Description, 80))
+	}
+	return tw.Flush()
+}

--- a/library/media-and-entertainment/espn/internal/cli/root.go
+++ b/library/media-and-entertainment/espn/internal/cli/root.go
@@ -150,6 +150,10 @@ func Execute() error {
 	rootCmd.AddCommand(newWatchCmd(&flags))
 	rootCmd.AddCommand(newStreakCmd(&flags))
 	rootCmd.AddCommand(newRivalsCmd(&flags))
+	rootCmd.AddCommand(newInjuriesPromotedCmd(&flags))
+	rootCmd.AddCommand(newTransactionsPromotedCmd(&flags))
+	rootCmd.AddCommand(newLeadersPromotedCmd(&flags))
+	rootCmd.AddCommand(newPlaysPromotedCmd(&flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
 	rootCmd.AddCommand(newProfileCmd(&flags))

--- a/library/media-and-entertainment/espn/internal/cli/root.go
+++ b/library/media-and-entertainment/espn/internal/cli/root.go
@@ -154,6 +154,13 @@ func Execute() error {
 	rootCmd.AddCommand(newTransactionsPromotedCmd(&flags))
 	rootCmd.AddCommand(newLeadersPromotedCmd(&flags))
 	rootCmd.AddCommand(newPlaysPromotedCmd(&flags))
+	rootCmd.AddCommand(newBoxscoreCmd(&flags))
+	rootCmd.AddCommand(newOddsCmd(&flags))
+	rootCmd.AddCommand(newSosCmd(&flags))
+	rootCmd.AddCommand(newH2hCmd(&flags))
+	rootCmd.AddCommand(newCompareCmd(&flags))
+	rootCmd.AddCommand(newTrendingCmd(&flags))
+	rootCmd.AddCommand(newDashboardCmd(&flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
 	rootCmd.AddCommand(newProfileCmd(&flags))

--- a/library/media-and-entertainment/espn/internal/cli/sos.go
+++ b/library/media-and-entertainment/espn/internal/cli/sos.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// newSosCmd derives a strength-of-schedule view from the standings endpoint.
+// Uses the same site.web.api.espn.com/.../standings host as standings_cmd.go.
+func newSosCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sos <sport> <league>",
+		Short: "Strength-of-schedule derived from league standings",
+		Example: `  espn-pp-cli sos football nfl
+  espn-pp-cli sos basketball nba --agent
+  espn-pp-cli sos baseball mlb --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return usageErr(fmt.Errorf("league is required\nUsage: sos <sport> <league>"))
+			}
+			sport, league := args[0], args[1]
+
+			url := fmt.Sprintf("https://site.web.api.espn.com/apis/v2/sports/%s/%s/standings", sport, league)
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			entries := extractSOS(body)
+			sort.Slice(entries, func(i, j int) bool { return entries[i].SOS > entries[j].SOS })
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(entries)
+			}
+
+			w := cmd.OutOrStdout()
+			if len(entries) == 0 {
+				fmt.Fprintln(w, "No strength-of-schedule data in standings response.")
+				return nil
+			}
+			tw := newTabWriter(w)
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				bold("RANK"), bold("TEAM"), bold("SOS"), bold("REMAINING SOS"))
+			for i, e := range entries {
+				fmt.Fprintf(tw, "%d\t%s\t%.4f\t%.4f\n",
+					i+1, e.TeamAbbr, e.SOS, e.RemainingSOS)
+			}
+			return tw.Flush()
+		},
+	}
+	return cmd
+}
+
+type sosEntry struct {
+	TeamAbbr     string  `json:"team"`
+	TeamName     string  `json:"team_name"`
+	SOS          float64 `json:"strength_of_schedule"`
+	RemainingSOS float64 `json:"remaining_strength_of_schedule"`
+}
+
+func extractSOS(data []byte) []sosEntry {
+	var resp struct {
+		Children []struct {
+			Children []struct {
+				Standings sosStandings `json:"standings"`
+			} `json:"children"`
+			Standings sosStandings `json:"standings"`
+		} `json:"children"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil
+	}
+	var out []sosEntry
+	collect := func(st sosStandings) {
+		for _, e := range st.Entries {
+			entry := sosEntry{
+				TeamAbbr: e.Team.Abbreviation,
+				TeamName: e.Team.DisplayName,
+			}
+			for _, s := range e.Stats {
+				switch s.Name {
+				case "strengthOfSchedule":
+					entry.SOS = s.Value
+				case "remainingStrengthOfSchedule":
+					entry.RemainingSOS = s.Value
+				}
+			}
+			if entry.SOS != 0 || entry.RemainingSOS != 0 {
+				out = append(out, entry)
+			}
+		}
+	}
+	for _, conf := range resp.Children {
+		if len(conf.Children) > 0 {
+			for _, div := range conf.Children {
+				collect(div.Standings)
+			}
+		} else {
+			collect(conf.Standings)
+		}
+	}
+	return out
+}
+
+type sosStandings struct {
+	Entries []struct {
+		Team struct {
+			DisplayName  string `json:"displayName"`
+			Abbreviation string `json:"abbreviation"`
+		} `json:"team"`
+		Stats []struct {
+			Name  string  `json:"name"`
+			Value float64 `json:"value"`
+		} `json:"stats"`
+	} `json:"entries"`
+}

--- a/library/media-and-entertainment/espn/internal/cli/sos_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/sos_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import "testing"
+
+func TestExtractSOSWithDivisions(t *testing.T) {
+	body := []byte(`{
+		"children":[{
+			"name":"AFC",
+			"children":[{
+				"name":"East",
+				"standings":{"entries":[
+					{"team":{"abbreviation":"BUF","displayName":"Buffalo"},"stats":[
+						{"name":"strengthOfSchedule","value":0.55},
+						{"name":"remainingStrengthOfSchedule","value":0.6}
+					]},
+					{"team":{"abbreviation":"MIA","displayName":"Miami"},"stats":[
+						{"name":"strengthOfSchedule","value":0.5},
+						{"name":"remainingStrengthOfSchedule","value":0.45}
+					]}
+				]}
+			}]
+		}]
+	}`)
+	got := extractSOS(body)
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	abbrs := []string{got[0].TeamAbbr, got[1].TeamAbbr}
+	want := map[string]bool{"BUF": true, "MIA": true}
+	for _, a := range abbrs {
+		if !want[a] {
+			t.Errorf("unexpected team %q", a)
+		}
+	}
+}
+
+func TestExtractSOSFlatStandings(t *testing.T) {
+	body := []byte(`{
+		"children":[{
+			"name":"League",
+			"standings":{"entries":[
+				{"team":{"abbreviation":"KC","displayName":"KC"},"stats":[
+					{"name":"strengthOfSchedule","value":0.7}
+				]}
+			]}
+		}]
+	}`)
+	got := extractSOS(body)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].SOS != 0.7 {
+		t.Errorf("SOS = %v, want 0.7", got[0].SOS)
+	}
+}
+
+func TestExtractSOSNoData(t *testing.T) {
+	body := []byte(`{"children":[]}`)
+	got := extractSOS(body)
+	if len(got) != 0 {
+		t.Errorf("want empty result, got %d", len(got))
+	}
+}
+
+func TestExtractSOSMalformed(t *testing.T) {
+	body := []byte(`not json`)
+	got := extractSOS(body)
+	if got != nil {
+		t.Errorf("malformed JSON should yield nil, got %v", got)
+	}
+}

--- a/library/media-and-entertainment/espn/internal/cli/trending.go
+++ b/library/media-and-entertainment/espn/internal/cli/trending.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newTrendingCmd hits ESPN's cross-league "now" headline feed and returns the
+// ranked story list. ESPN's older popularity endpoint returns 404; the now
+// feed is what powers the homepage and is the closest cross-league
+// "what's trending" surface that is publicly reachable.
+func newTrendingCmd(flags *rootFlags) *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "trending",
+		Short: "Cross-league trending headlines (top stories across leagues)",
+		Example: `  espn-pp-cli trending
+  espn-pp-cli trending --limit 20 --agent
+  espn-pp-cli trending --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit <= 0 {
+				limit = 25
+			}
+			url := fmt.Sprintf("https://now.core.api.espn.com/v1/sports/news?limit=%d", limit)
+			body, err := espnHTTPGet(flags.timeout, url)
+			if err != nil {
+				return err
+			}
+
+			items := parseTrending(body)
+
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(items)
+			}
+
+			w := cmd.OutOrStdout()
+			if len(items) == 0 {
+				fmt.Fprintln(w, "No trending entries returned.")
+				return nil
+			}
+			tw := newTabWriter(w)
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				bold("RANK"), bold("LEAGUE"), bold("HEADLINE"), bold("PUBLISHED"))
+			for i, it := range items {
+				published := it.Published
+				if len(published) > 10 {
+					published = published[:10]
+				}
+				fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n",
+					i+1, it.League, truncate(it.Name, 70), published)
+			}
+			return tw.Flush()
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 25, "Max entries to return")
+	return cmd
+}
+
+type trendingItem struct {
+	EntityType string `json:"entity_type"`
+	Name       string `json:"name"`
+	League     string `json:"league"`
+	Published  string `json:"published"`
+}
+
+func parseTrending(data []byte) []trendingItem {
+	// "now" feed shape: {"headlines":[{...}]}.
+	var nowResp struct {
+		Headlines []map[string]any `json:"headlines"`
+	}
+	if err := json.Unmarshal(data, &nowResp); err == nil && len(nowResp.Headlines) > 0 {
+		return mapNowHeadlines(nowResp.Headlines)
+	}
+	// Defensive: older shapes (top-level array or object with items).
+	var arr []map[string]any
+	if err := json.Unmarshal(data, &arr); err == nil && len(arr) > 0 {
+		return mapTrendingItems(arr)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil
+	}
+	for _, key := range []string{"items", "sports", "trending", "data"} {
+		if raw, ok := obj[key]; ok {
+			var inner []map[string]any
+			if err := json.Unmarshal(raw, &inner); err == nil && len(inner) > 0 {
+				return mapTrendingItems(inner)
+			}
+		}
+	}
+	return nil
+}
+
+func mapNowHeadlines(items []map[string]any) []trendingItem {
+	var out []trendingItem
+	for _, it := range items {
+		out = append(out, trendingItem{
+			EntityType: "story",
+			Name:       jsonStrAny(it, "headline"),
+			League:     strings.ToUpper(jsonStrAny(it, "section")),
+			Published:  jsonStrAny(it, "published"),
+		})
+	}
+	return out
+}
+
+func mapTrendingItems(items []map[string]any) []trendingItem {
+	var out []trendingItem
+	for _, it := range items {
+		entityType := jsonStrAny(it, "entity_type")
+		if entityType == "" {
+			entityType = jsonStrAny(it, "type")
+		}
+		name := jsonStrAny(it, "name")
+		if name == "" {
+			name = jsonStrAny(it, "displayName")
+		}
+		league := jsonStrAny(it, "league")
+		if league == "" {
+			if l, ok := it["league"].(map[string]any); ok {
+				league = jsonStrAny(l, "abbreviation")
+			}
+		}
+		out = append(out, trendingItem{
+			EntityType: entityType,
+			Name:       name,
+			League:     league,
+		})
+	}
+	return out
+}

--- a/library/media-and-entertainment/espn/internal/cli/trending_test.go
+++ b/library/media-and-entertainment/espn/internal/cli/trending_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import "testing"
+
+func TestParseTrendingNowShape(t *testing.T) {
+	body := []byte(`{"headlines":[
+		{"headline":"Lakers stun Celtics","section":"NBA","published":"2026-04-19T22:00:00Z"},
+		{"headline":"NFL draft preview","section":"NFL","published":"2026-04-18T12:00:00Z"}
+	]}`)
+	got := parseTrending(body)
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d", len(got))
+	}
+	if got[0].Name != "Lakers stun Celtics" || got[0].League != "NBA" || got[0].EntityType != "story" {
+		t.Errorf("unexpected first entry: %+v", got[0])
+	}
+}
+
+func TestParseTrendingItemsShape(t *testing.T) {
+	body := []byte(`{"items":[{"name":"Trout","entity_type":"athlete","league":"mlb"}]}`)
+	got := parseTrending(body)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+}
+
+func TestParseTrendingArrayFallback(t *testing.T) {
+	body := []byte(`[{"entity_type":"athlete","name":"Mahomes","league":"nfl"}]`)
+	got := parseTrending(body)
+	if len(got) != 1 || got[0].Name != "Mahomes" {
+		t.Fatalf("unexpected fallback parse: %+v", got)
+	}
+}
+
+func TestParseTrendingMalformed(t *testing.T) {
+	body := []byte(`<html>not json</html>`)
+	got := parseTrending(body)
+	if got != nil {
+		t.Errorf("malformed input should yield nil, got %v", got)
+	}
+}
+
+func TestParseTrendingDisplayNameFallback(t *testing.T) {
+	body := []byte(`[{"displayName":"LeBron","type":"athlete"}]`)
+	got := parseTrending(body)
+	if len(got) != 1 || got[0].Name != "LeBron" || got[0].EntityType != "athlete" {
+		t.Errorf("unexpected fallback parse: %+v", got)
+	}
+}

--- a/library/media-and-entertainment/espn/internal/mcp/tools.go
+++ b/library/media-and-entertainment/espn/internal/mcp/tools.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/config"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/internal/store"
-	mcplib "github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 )
 
 // RegisterTools registers all API operations as MCP tools.

--- a/library/media-and-entertainment/espn/spec.yaml
+++ b/library/media-and-entertainment/espn/spec.yaml
@@ -194,6 +194,126 @@ resources:
           type: object
           item: Rankings
 
+  injuries:
+    description: "Active injury reports for a league"
+    endpoints:
+      get:
+        method: GET
+        path: "/{sport}/{league}/injuries"
+        description: "Get current injury list for a sport and league"
+        params:
+          - name: sport
+            type: string
+            required: true
+            positional: true
+            description: "Sport slug"
+          - name: league
+            type: string
+            required: true
+            positional: true
+            description: "League slug"
+        response:
+          type: object
+          item: Injuries
+
+  transactions:
+    description: "Recent trades, signings, releases, and waivers"
+    endpoints:
+      get:
+        method: GET
+        path: "/{sport}/{league}/transactions"
+        description: "Get recent league transactions (trades, signings, waivers)"
+        params:
+          - name: sport
+            type: string
+            required: true
+            positional: true
+            description: "Sport slug"
+          - name: league
+            type: string
+            required: true
+            positional: true
+            description: "League slug"
+        response:
+          type: object
+          item: Transactions
+
+  leaders:
+    description: "Statistical leaders across categories"
+    endpoints:
+      get:
+        method: GET
+        path: "/{sport}/{league}/leaders"
+        description: "Get statistical leaders for a sport and league with optional category filter"
+        params:
+          - name: sport
+            type: string
+            required: true
+            positional: true
+            description: "Sport slug"
+          - name: league
+            type: string
+            required: true
+            positional: true
+            description: "League slug"
+          - name: category
+            type: string
+            description: "Optional stat category (e.g. passing, rushing, points)"
+        response:
+          type: object
+          item: Leaders
+
+  plays:
+    description: "Play-by-play feed for a specific event"
+    endpoints:
+      get:
+        method: GET
+        path: "/{sport}/{league}/plays"
+        description: "Get plays for a specific event id"
+        params:
+          - name: sport
+            type: string
+            required: true
+            positional: true
+            description: "Sport slug"
+          - name: league
+            type: string
+            required: true
+            positional: true
+            description: "League slug"
+          - name: event
+            type: string
+            required: true
+            description: "ESPN event or game id"
+          - name: limit
+            type: int
+            default: 200
+            description: "Maximum number of plays to return"
+        response:
+          type: object
+          item: Plays
+
+extra_commands:
+  - name: trending
+    description: "Most-followed athletes and teams across all leagues"
+  - name: dashboard
+    description: "Your favorite teams' status at a glance (reads [favorites] in config.toml)"
+  - name: boxscore
+    description: "Full box score for a specific event id"
+    args: "<event_id>"
+  - name: h2h
+    description: "Head-to-head detail between two teams"
+    args: "<team1> <team2>"
+  - name: compare
+    description: "Side-by-side athlete stat comparison"
+    args: "<athlete1> <athlete2>"
+  - name: odds
+    description: "Spread, total, and moneyline lines for tonight's slate"
+    args: "<sport> <league>"
+  - name: sos
+    description: "Strength-of-schedule derived from league standings"
+    args: "<sport> <league>"
+
 types:
   Scoreboard:
     fields:
@@ -268,4 +388,28 @@ types:
       - name: rankings
         type: string
       - name: sports
+        type: string
+
+  Injuries:
+    fields:
+      - name: injuries
+        type: string
+
+  Transactions:
+    fields:
+      - name: transactions
+        type: string
+
+  Leaders:
+    fields:
+      - name: leaders
+        type: string
+      - name: categories
+        type: string
+
+  Plays:
+    fields:
+      - name: items
+        type: string
+      - name: count
         type: string

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-espn/SKILL.md
+++ b/plugin/skills/pp-espn/SKILL.md
@@ -24,15 +24,25 @@ Commands that only work because of local sync + cross-league tooling.
 
 - **`today`** — Today's scores across all major sports in one call. The fastest "what's on tonight" answer without picking a sport first.
 
+- **`trending`** — Most-followed athletes and teams across all leagues, ranked by current popularity. Good for "who is hot right now" without naming a sport.
+
+- **`dashboard`** — Reads `[favorites]` from `~/.config/espn-pp-cli/config.toml` and shows scores for each favorited team across leagues, in one call.
+
 - **`watch <sport> <league> --event <game_id>`** — Live score updates for a specific game (polls every 30s). Use `scores` or `today` to find the game, then `watch` to follow it live.
 
 ### Game-state intelligence
 
 - **`summary <sport> <league> --event <game_id>`** — Detailed game summary including box score, leaders, scoring plays, odds, and win probability. The single richest payload per game.
 
+- **`boxscore <event_id>`** — Just the per-player box score for an event id, with sport+league inferred from a recent scoreboard cache hit. Pass `--sport`/`--league` to skip inference.
+
+- **`plays <sport> <league> --event <id>`** — Play-by-play feed for a specific event. Optional `--limit` (default 200).
+
 - **`recap <sport> <league>`** — Post-game recap with box score and leaders for the most recent completed game in a league.
 
 - **`scoreboard <sport> <league>`** — Live scoreboard with date filtering, week/group selectors, and competition metadata.
+
+- **`odds <sport> <league>`** — Spread, over/under, and moneyline lines for tonight's slate, derived from the scoreboard payload (no per-game summary calls).
 
 ### Standings and rankings
 
@@ -43,6 +53,20 @@ Commands that only work because of local sync + cross-league tooling.
 - **`streak <sport> <league>`** — Current win/loss streaks across teams in a league, computed from synced data.
 
 - **`rivals <sport> <league>`** — Head-to-head records between teams in a league from synced data.
+
+- **`h2h <team1> <team2> --sport <s> --league <l>`** — Deeper head-to-head detail for one specific pair, including average score and recent meetings list.
+
+- **`sos <sport> <league>`** — Strength-of-schedule per team, derived from the standings payload, sorted descending.
+
+### People
+
+- **`leaders <sport> <league> [--category <name>]`** — Statistical leaders across categories with optional filter.
+
+- **`compare <athlete1> <athlete2> --sport <s> --league <l>`** — Side-by-side season stats for two athletes. Ambiguous names list candidates and exit 2.
+
+- **`injuries <sport> <league>`** — Active injury report across the league, grouped by team.
+
+- **`transactions <sport> <league>`** — Recent trades, signings, and waivers.
 
 ### Local store
 
@@ -61,6 +85,8 @@ Live action:
 - `espn-pp-cli scoreboard <sport> <league>` — Scoreboard with optional date filtering
 - `espn-pp-cli watch <sport> <league> --event <game_id>` — Live score polling for one game
 - `espn-pp-cli standings <sport> <league>` — League standings
+- `espn-pp-cli trending` — Most-followed athletes and teams across leagues
+- `espn-pp-cli dashboard` — Favorites snapshot from `~/.config/espn-pp-cli/config.toml`
 
 Team detail:
 
@@ -69,11 +95,23 @@ Team detail:
 - `espn-pp-cli teams list <sport> <league>` — All teams in a league
 - `espn-pp-cli streak <sport> <league>` — Current win/loss streaks from synced data
 - `espn-pp-cli rivals <sport> <league>` — Head-to-head records between teams from synced data
+- `espn-pp-cli h2h <team1> <team2> --sport <s> --league <l>` — Deeper detail for one team pair (avg score, meetings)
+- `espn-pp-cli sos <sport> <league>` — Strength-of-schedule, sorted descending
 
 Game detail:
 
 - `espn-pp-cli summary <sport> <league> --event <game_id>` — Full game summary (box score, leaders, scoring plays, odds, win probability)
+- `espn-pp-cli boxscore <event_id>` — Just the box score subtree (sport/league inferred from cache)
+- `espn-pp-cli plays <sport> <league> --event <id>` — Play-by-play feed (optional `--limit`, default 200)
 - `espn-pp-cli recap <sport> <league>` — Most recent completed game recap
+- `espn-pp-cli odds <sport> <league>` — Spread, over/under, moneyline for tonight's slate
+
+People:
+
+- `espn-pp-cli leaders <sport> <league> [--category <name>]` — Statistical leaders by category
+- `espn-pp-cli compare <athlete1> <athlete2> --sport <s> --league <l>` — Side-by-side athlete stats
+- `espn-pp-cli injuries <sport> <league>` — Active injury report
+- `espn-pp-cli transactions <sport> <league>` — Recent trades, signings, waivers
 
 Polls and rankings:
 
@@ -126,6 +164,36 @@ espn-pp-cli search "Mahomes"                    # finds in local store
 ```
 
 Useful for repeated lookups in poor-connectivity environments or when batch-analyzing historical data.
+
+### Favorites dashboard
+
+Add a `[favorites]` block to `~/.config/espn-pp-cli/config.toml`:
+
+```
+[favorites]
+nfl = ["KC", "BAL"]
+nba = ["LAL"]
+```
+
+Then:
+
+```bash
+espn-pp-cli dashboard --agent
+```
+
+One call surfaces tonight's matchup status for every favorited team, grouped by league. Per-league fetches run in parallel and partial failures are reported alongside successful results.
+
+### Pre-game odds and player digging
+
+```bash
+espn-pp-cli odds basketball nba --agent          # tonight's spreads / totals / moneylines
+espn-pp-cli leaders basketball nba --category points --agent
+espn-pp-cli compare "LeBron James" "Stephen Curry" --sport basketball --league nba --agent
+espn-pp-cli boxscore <event_id> --agent          # post-game player stats
+espn-pp-cli plays basketball nba --event <id> --limit 50 --agent
+```
+
+`odds` reads the scoreboard's per-event lines (no per-game summary calls). `leaders --category` filters to one stat category. `compare` resolves athlete ids by name, listing candidates and exiting 2 on ambiguity. `boxscore` infers sport+league from the most recent cache hit; pass `--sport`/`--league` to skip inference.
 
 ## Auth Setup
 


### PR DESCRIPTION
## Summary

Implements Units 2-4 of the ESPN missing-commands plan
(`docs/plans/2026-04-19-002-feat-espn-movie-goat-missing-commands-plan.md`).
Adds eleven new commands to `espn-pp-cli` that the SKILL.md previously claimed
but did not exist. Plugin bumped from 1.1.14 to 1.1.15.

The new commands and the endpoints they hit:

Spec-driven (declared in `spec.yaml` resources, hand-written promoted_*.go):

- `injuries <sport> <league>` — `site.web.api.espn.com/.../injuries`
- `transactions <sport> <league>` — `sports.core.api.espn.com/.../transactions`
- `leaders <sport> <league> [--category]` — `site.web.api.espn.com/.../statistics/byathlete`
  (the public `/leaders` path returns 404; `byathlete` is what ESPN's web client uses)
- `plays <sport> <league> --event <id> [--limit]` — `sports.core.api.espn.com/.../events/{id}/competitions/{id}/plays`

Hand-written (declared in `spec.yaml` `extra_commands:`):

- `boxscore <event_id>` — composes the existing `summary` endpoint and returns
  just the boxscore subtree. Sport+league inferred from the most recent
  scoreboard cache hit; falls back to `--sport`/`--league` flags.
- `odds <sport> <league>` — aggregates per-event odds from the scoreboard
  payload (one HTTP call covers the whole slate).
- `sos <sport> <league>` — strength-of-schedule from `standings`, sorted
  descending. Returns an empty list for leagues whose standings response
  does not include `strengthOfSchedule` (e.g. NBA today).
- `h2h <team1> <team2> --sport <s> --league <l>` — pair-specific head-to-head
  detail with average score and meeting list, sourced from local store.
- `compare <athlete1> <athlete2> --sport <s> --league <l>` — side-by-side
  season stats. Resolves athletes via `common/v3/search?type=player`;
  ambiguous names exit 2 with a candidate list.
- `trending [--limit]` — cross-league top stories from `now.core.api.espn.com`
  (the legacy `site/v2/trending` endpoint 404s).
- `dashboard` — reads `[favorites]` from `~/.config/espn-pp-cli/config.toml`,
  fetches each league's scoreboard in parallel, renders favorited teams.

## Endpoint corrections vs the plan

Two endpoint URLs in the original plan turned out to be stale and were
corrected during smoke testing:

- `leaders` plan path `/leaders` 404s; switched to `/statistics/byathlete`,
  the path ESPN's own web client uses today.
- `trending` plan endpoint `site.api.espn.com/apis/site/v2/trending` 404s;
  switched to `now.core.api.espn.com/v1/sports/news`, which returns the
  ranked cross-league headline feed that powers ESPN.com.

The command names, args, exit codes, and SKILL.md docs match the plan;
only the upstream URLs differ.

## Smoke tests

All eleven commands were tested live against ESPN with `--agent`:

| Command | Status | Notes |
|---|---|---|
| injuries | OK | NFL returned 100+ active injury records |
| transactions | OK | MLB returned `count: 0` (no recent), shape correct |
| leaders | OK | NBA returned 50 athletes with category-grouped stats |
| plays | OK | NBA event returned 479 plays |
| boxscore | OK | Live NBA event id, sport+league cached → no flags needed |
| odds | OK | NBA scoreboard returned spreads/totals (moneylines blank in JSON sample) |
| sos | OK (empty) | NBA standings have no `strengthOfSchedule`; returns null. |
| h2h | OK | DB-backed; returns "no meetings" until sync covers the pair |
| compare | OK | Mahomes vs Allen returned full season passing/rushing/defense stats |
| trending | OK | Cross-league top headlines |
| dashboard | OK | With `[favorites]` configured, returns matchup status grouped by league |

## Verify-skill

`python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/espn/`
exits 0:

```
=== espn ===
  ✓ All checks passed (flag-names, flag-commands, positional-args, unknown-command)
```

## Known limitations

- `sos` returns null for leagues whose standings payload omits
  `strengthOfSchedule` (today: NBA). Documented as a known case.
- `dashboard` runs per-league fetches in parallel using `sync.WaitGroup`
  rather than `cliutil.FanoutRun` — the ESPN package does not have a
  `cliutil` directory. Per-source error collection is preserved.
- `h2h`, `rivals`, and `streak` all share a pre-existing local-DB schema
  migration issue (column `season_year` missing) on workstations whose DB
  was created before the events table got the season_year column. Reproduces
  on `rivals` and `streak` too — not introduced by this PR. Workaround:
  `rm ~/.local/share/espn-pp-cli/data.db && espn-pp-cli sync ...`

## Post-Deploy Monitoring & Validation

- Watch verify-skill CI on this PR; should report 0 errors for ESPN.
- After merge: bump local install (`go install ...@latest`) and confirm
  `espn-pp-cli --help` lists all eleven new commands.
- Spot-check `injuries`, `leaders`, `dashboard` once the next NFL season
  starts to confirm the offseason responses I tested didn't mask shape
  regressions.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all green (32 unit tests across 7 new _test.go files)
- [x] `go vet ./...` clean
- [x] `gofmt -w ./...` applied
- [x] `verify_skill.py --dir library/media-and-entertainment/espn/` exits 0
- [x] live smoke against ESPN for each of 11 commands
- [ ] CI run on the PR