### PR TITLE
feat(contact-goat): unlock Happenstance full-network search (1st/2nd/3rd degree)

### DIFF
--- a/docs/plans/2026-04-19-003-feat-contact-goat-happenstance-full-network-plan.md
+++ b/docs/plans/2026-04-19-003-feat-contact-goat-happenstance-full-network-plan.md
@@ -1,0 +1,391 @@
+---
+title: "feat(contact-goat): unlock full Happenstance network graph (1st, 2nd, 3rd degree)"
+type: feat
+status: active
+date: 2026-04-19
+---
+
+# feat(contact-goat): unlock full Happenstance network graph (1st, 2nd, 3rd degree)
+
+## Overview
+
+Happenstance has no public API. contact-goat is a sniffed web-client wrapper: it replays the exact HTTP calls the Happenstance web app makes against the user's browser session cookies. That framing drives everything in this plan.
+
+contact-goat-pp-cli today exposes only a sliver of what the web app can do. `coverage` and friends-based commands replay a narrow sniff of `/api/friends/list`, which on the web app is the top-connectors widget, not the full contact graph (Matt has 3 total there). The broader LinkedIn-connections CSV synced to Happenstance on 2025-07-09, and the 2nd/3rd-degree paths the web app surfaces in search, are not yet sniffed, so they are unreachable from the CLI. On top of that, the Clerk session refresh flow the CLI replays is a stale sniff (returns `HTTP 404` from `/v1/client/sessions/{sess}/tokens`), so even the narrow endpoints die roughly once per minute and force a Chrome cookie re-import.
+
+This plan captures the sniff-and-replay work to make contact-goat deliver the three network tiers the web app already delivers:
+
+1. My 1st-degree network (the synced LinkedIn CSV, queryable by company / title / industry).
+2. My friends' networks (2nd-degree via the web app's people-search which walks contacts' public graphs).
+3. Friends of friends (3rd-degree paths surfaced as warm-intro candidates with rationale).
+
+The work is gated on capturing fresh HARs of each web flow, replaying them as Go HTTP calls, and hardening against schema drift since no contract exists. There is no "ask Happenstance for docs" path.
+
+## Problem Frame
+
+Known failure modes observed in-session on 2026-04-19:
+
+- `coverage "Warner Bros"` returned 0 for 1st-degree and 2nd-degree, yet LinkedIn web search trivially shows dozens of 2nd-degree Warner Bros connections with named mutuals.
+- `coverage "Weber"` returned 0, yet Jennifer Bonuso (President, Americas at Weber Inc, current) is a confirmed 1st-degree LinkedIn contact of Matt's and lives in his synced Happenstance CSV.
+- Every Happenstance-touching command fails within about 60 seconds of auth with `clerk session refresh failed: clerk refresh: HTTP 404`. Doctor reports cookies valid, JWT about to expire, but `MaybeRefreshSession` errors out.
+- `prospect` and `search` either fall through to empty results or hit `/api/dynamo` without a request_id and return `HTTP 400`.
+- `dossier` / `waterfall` call `happenstance research`, which returns `empty` rather than using the actual people-search endpoint that powers the web app.
+
+Root causes we know about:
+
+- `internal/client/cookie_auth.go` builds refresh URL as `POST https://clerk.happenstance.ai/v1/client/sessions/{sess}/tokens?__clerk_api_version=2025-11-10`. Either the session id parse is wrong for Matt's current cookie shape or the endpoint / API version is stale. Sniffing the Chrome refresh call will resolve which.
+- `internal/cli/coverage.go` relies only on `fetchHappenstanceFriends()` which hits `/api/friends/list`. There is no wrapper for the people-search endpoint that actually searches the LinkedIn-contacts graph.
+- `internal/cli/promoted_research.go`, `promoted_dynamo.go`, `promoted_friends.go`, `promoted_uploads.go` exist but only one api interface ("suggested-posts") is exposed at the `api` top-level command. The promoted_* files do not wire into the broader graph commands.
+- contact-goat's side of the upstream `linkedin-scraper-mcp` contract is stale: `get-person` passes `linkedin_url` and a list-typed `sections` to an MCP that now requires `linkedin_username` and a string-typed `sections`; `search_people` passes `limit` which the MCP rejects.
+
+## Requirements Trace
+
+- R1. A single-command answer to "who at company X" must surface Matt's 1st-degree LinkedIn contacts from the Happenstance graph, not just the 3 top connectors from `/api/friends/list`.
+- R2. "Who at company X" must also surface 2nd-degree paths with identified mutual connections (the web app already renders this; the CLI must match).
+- R3. `warm-intro <person>` must surface 3rd-degree friends-of-friends candidates with concrete rationale ("X knows Y via shared employer Z"), not just the top-3 Happenstance friends by raw connection count.
+- R4. Happenstance-touching commands must stay authenticated across a long-running session without repeated Chrome cookie imports. A single successful `auth login --chrome` should last at least as long as the Chrome browser session does for the same cookies.
+- R5. The existing failure mode where a Happenstance refresh error silently returns zero results must be replaced by a clearly labeled error so users know the result set is not empty-but-clean.
+- R6. contact-goat must keep working against the current upstream `linkedin-scraper-mcp` (schema drift between versions must not mute results).
+- R7. Doctor output must surface graph coverage ("Happenstance: linkedin_ext contacts: N synced, last refreshed YYYY-MM-DD"), not just cookie presence.
+
+## Scope Boundaries
+
+In scope:
+- contact-goat-pp-cli Go code under `library/sales-and-crm/contact-goat/`.
+- The existing `auth login --chrome` + Clerk refresh flow.
+- Happenstance endpoints reachable with the session cookie (no new credentials).
+- Minimal wrappers for the LinkedIn MCP side to stop dropping results.
+
+Explicitly out of scope:
+- Upstream `stickerdaniel/linkedin-mcp-server` work (tracked in `~/.osc/plans/2026-04-19-032-feat-linkedin-mcp-search-people-connection-filters-plan.md`). This plan only fixes the contact-goat side of the contract (arg names, dropped params).
+- New paid Deepline credits beyond the existing BYOK and managed flows.
+- Building a Happenstance clone. If Happenstance's web endpoints cannot answer a tier (e.g. industry), the plan records that and stops.
+- Writing a persistent server. Everything remains a local CLI + cookie-jar.
+
+## Context and Research
+
+### Relevant Code and Patterns
+
+- `internal/client/cookie_auth.go:201-268` - `refreshClerkSession` builds the refresh URL against `clerk.happenstance.ai/v1/client/sessions/{sess}/tokens`. The 404 means either the sessionID is wrong or the endpoint has moved. Fix unit 2 replaces the construction after sniffing.
+- `internal/client/cookie_auth.go:147-196` - `clerkSessionID` has three-shape parsing (bare `sess_...`, JSON envelope, sha256-prefixed). If shape 3 is misclassifying the current Chrome value, the returned sessionID is truncated and the POST will 404.
+- `internal/cli/coverage.go:42-125` - the current two-source implementation. Unit 4 expands source 1 to call the new people-search wrapper.
+- `internal/cli/promoted_research.go`, `promoted_dynamo.go`, `promoted_uploads.go`, `promoted_friends.go` - existing thin wrappers. These are the scaffolding that the new commands will extend.
+- `internal/cli/dynamo_list-recent-searches.go` - proves the `/api/dynamo` endpoint is reachable for reading prior searches. The create-search flow (POST) is the missing half and is what unit 3 adds.
+- `internal/cli/search.go:1-218` - current `search` currently calls the dynamo retrieval endpoint with no request_id, which is why it 400s. Unit 3 reroutes `search` to the create-search flow.
+- `internal/cli/linkedin.go` - where contact-goat builds MCP tool calls. Unit 6 fixes the arg-name drift (`linkedin_url` -> `linkedin_username`, list-typed `sections` -> comma-joined string, strip unsupported `limit`).
+
+### Institutional Learnings
+
+- From `feedback_pp_update_before_run.md`: always `go install @latest` + `git pull plugin` + restart before any PP CLI run. Applies to validation of this plan's output.
+- From `feedback_pp_go_install_goprivate.md`: `GOPRIVATE='github.com/mvanhorn/*'` is required to skip sumdb 404 when installing contact-goat builds during dogfood.
+- From `feedback_debug_before_reply.md`: run the new tests and verify the 1st + 2nd + 3rd degree behaviors against a live session before announcing the plan as complete.
+- From this session on 2026-04-19: contact-goat silently absorbing both `clerk refresh failed` and LinkedIn MCP validation errors into empty results caused 40+ minutes of confusion. R5 exists because of this.
+
+### External References (conditional)
+
+There are no Happenstance API docs. The authoritative reference is the sniff capture produced in unit 1, against Matt's signed-in Chrome tab. Clerk's session-refresh docs at clerk.com will only be consulted after the sniff shows which Clerk call signature the Happenstance frontend is currently emitting, to confirm we interpret fields the same way Clerk's server does.
+
+## Key Technical Decisions
+
+- Decision: everything in this plan is sniff-first. Before any Go change lands, unit 1 must produce a HAR capture of the relevant web flow. No endpoint gets added to the client on speculation. Rationale: there is no Happenstance API contract; the only source of truth is the live browser session, and the codebase comments (`clerk_active_context` three-shape parsing, dynamo request_id polling) show prior sniffs have drifted.
+- Decision: capture HARs with Chrome DevTools Network -> "Save all as HAR with content", store under `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-YYYY-MM-DD/`. Redact JWT and cookie values before committing. Rationale: HARs give verb, path, headers, payload, and response as one archive; redacted HARs can be replayed in unit tests.
+- Decision: do not replace the Clerk cookie-based auth with an API key flow. Rationale: Happenstance does not offer a supported user API key; the cookie session flow the web app already uses is the only honest surface. The fix is to re-sniff the refresh call and keep it alive, not to avoid refresh.
+- Decision: model the broader people-search as a new client method (`client.SearchPeopleByCompany`) plus an extension to `coverage.go` that merges its results before the LinkedIn fallback. Rationale: the existing coverage flow already has the merge + rank pipeline, so grafting a new source in is cheaper than a parallel command.
+- Decision: treat 3rd-degree "friends of friends" as a warm-intro enhancement, not a top-level command. Rationale: `warm-intro` already scores candidates and has the scaffolding; adding a traversal layer is cleaner than a parallel command.
+- Decision: fail loudly on schema drift. Every sniff-derived client method decodes into a strongly-typed struct; unexpected payload shape returns a typed error that mentions the endpoint path and the missing field. Rationale: sniffed endpoints drift without notice; silent-empty on drift is the worst failure mode, and R5 demands loud.
+- Decision: ship a sniff-replay test harness. Each new client method has a unit test that replays its captured HAR against an `httptest.Server`. Rationale: production drift is detectable only by comparing live responses to the last known-good HAR; if the replay still passes but the live call fails, we know Happenstance changed, not us.
+- Decision: fail loudly at the CLI layer too. Any Happenstance or LinkedIn sub-call that errors must surface in the CLI output as a labeled warning and in the JSON output as a `source_errors` key. Rationale: R5 (silent empty results are the worst UX).
+- Decision: `doctor` gets a new line item for "Happenstance: graph coverage" driven by the `uploads` endpoint's `statuses.linkedin_ext` block, plus a line that distinguishes "last sniffed YYYY-MM-DD" from "live refresh succeeded within Nm ago". Rationale: R7, and a staleness indicator tells Matt when a re-sniff is overdue.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q: Is the Clerk refresh endpoint path wrong, or is the sessionID parse wrong?
+  - A: Unknown without sniffing. Unit 1 captures the real request and resolves this. If the path changed, update the constant. If the parse is off, fix the cookie parser. If both, do both.
+- Q: Does Happenstance expose a real people-search on the LinkedIn-contacts graph?
+  - A: Yes - the web app does it in the search box. `/api/research` 204s on POST in this session, which means the server accepted the request; the pattern is async. The dynamo-style retrieval endpoint is already half-wrapped. Unit 3 wires the POST half.
+- Q: Does the /ce:plan call need external docs research?
+  - A: No. Repo patterns are rich, the relevant files are all in one package, and the authoritative reference is Matt's own Chrome session.
+
+### Deferred to Implementation
+
+- What is the exact request shape for the Happenstance people-search POST? Deferred because it depends on the sniff output.
+- What concrete header(s) does the Clerk refresh now require? Deferred to sniff.
+- Will 3rd-degree traversal need paginated dynamo polling? Deferred until unit 3 lands and we can measure real latency.
+- Which uploads.statuses fields are safe to key against for the doctor coverage line? Deferred to unit 7 after uploads payload is inspected.
+
+## Implementation Units
+
+- [ ] Unit 1: Sniff the Happenstance web app
+
+Goal: capture the exact network calls the Happenstance web app makes for every flow this plan needs. Every downstream unit replays these captures. This is the foundational unit.
+
+Requirements: R1, R2, R3, R4 (all downstream units depend on this capture).
+
+Dependencies: none. Must complete before any other unit starts.
+
+Files:
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/README.md` (index and endpoint summary)
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/clerk-refresh.har` (the silent refresh flow the web app runs while idle)
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/people-search-by-company.har` (company search from the web app's search box)
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/people-search-dynamo-poll.har` (the async-poll half if the people-search is async)
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/mutuals-for-person.har` (opening a specific person's mutual-connections view)
+- Create: `library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/uploads-status.har` (the authenticated uploads endpoint so doctor can read linkedin_ext freshness)
+
+Approach:
+- Open Happenstance in Chrome with DevTools Network tab open. Turn on "Preserve log". Enable "Record network log".
+- Clear the log, then wait about 90 seconds with the tab visible so the silent Clerk refresh fires; capture that as `clerk-refresh.har`.
+- Clear the log, run a company search in the web app for "Warner Bros."; capture as `people-search-by-company.har`. If the UI shows a loading state that later populates, also capture the polling round as `people-search-dynamo-poll.har`.
+- Clear the log, open one person in the results, click whatever the web app calls "mutual connections" or "how you're connected"; capture as `mutuals-for-person.har`.
+- Clear the log, navigate to the settings / uploads view; capture as `uploads-status.har`.
+- For each HAR, before committing: redact `__session` JWTs, `__refresh_*` tokens, and any `Authorization: Bearer` headers. Leave paths, shapes, and non-sensitive keys intact.
+- Write `README.md` as an index: one section per HAR with verb, path, required headers, body shape, response JSON keys, pagination or polling notes.
+
+Execution note: research-only; no Go code changes in this unit.
+
+Patterns to follow: existing `.manuscripts/` convention in the contact-goat tree. Filename convention matches other CLIs' archived research dumps.
+
+Test scenarios: none (documentation artifact). Verify by diffing the sniff index against the checklist below.
+
+Verification:
+- All 5 HAR files exist and none contain raw JWT or refresh-token values.
+- README.md enumerates each endpoint's verb, path, at least 3 request headers observed, request body schema (or "none"), response top-level keys, and any async polling pattern.
+- README.md explicitly names whether the people-search is synchronous or dynamo-async.
+- An engineer unfamiliar with the CLI can read the README and know exactly what to POST to reproduce each flow.
+
+- [ ] Unit 2: Fix Clerk session refresh
+
+Goal: make `MaybeRefreshSession` succeed so that long-lived CLI sessions stop dying every 60 seconds.
+
+Requirements: R4, R5.
+
+Dependencies: unit 1.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/client/cookie_auth.go`
+- Test: `library/sales-and-crm/contact-goat/internal/client/cookie_auth_test.go` (create if missing)
+
+Approach:
+- Update `clerkBaseURL`, `clerkAPIVersion`, and the refresh URL template to match what the sniff showed.
+- Fix `clerkSessionID` if shape-3 parsing is returning a truncated id.
+- Keep the 2s refresh-collapse behavior. Keep the concurrency lock.
+- On 401 / 404 response, include the response's `x-clerk-auth-*` headers in the returned error. Rationale: surfacing the server's own "why" beats opaque "HTTP 404".
+- Update `MaybeRefreshSession` to also proactively re-seed the cookie jar if `__refresh_*` is present but `__session` is missing (e.g. after Chrome rotated the session cookie).
+
+Patterns to follow: existing error wrapping style in this file. Existing cookie-jar API.
+
+Test scenarios:
+- Happy path: given a jar with a valid refresh cookie and a near-expired session JWT, `MaybeRefreshSession` returns nil and the jar now holds a non-expired `__session` cookie.
+- Edge case: missing `clerk_active_context` -> returns "no clerk session id in cookie jar" error; does not issue a request.
+- Edge case: shape-3 sha256-prefixed cookie returns a non-truncated sessionID.
+- Error path: Clerk returns 404 -> error message includes the server's `x-clerk-auth-message` when present, and does not log JWT bodies.
+- Integration: two concurrent callers that both see expired JWT issue at most one refresh (the second collapses).
+
+Verification:
+- A scripted 5-minute loop (`for i in {1..20}; do contact-goat-pp-cli friends --agent >/dev/null; sleep 15; done`) completes without a single `clerk session refresh failed` on stderr.
+- `doctor` reports "session JWT: valid" immediately after refresh.
+
+- [ ] Unit 3: Add Happenstance people-search client + `hp people` CLI
+
+Goal: expose the Happenstance people-search that powers the web app's search box. This is the single endpoint that unlocks 1st + 2nd degree.
+
+Requirements: R1, R2, R5.
+
+Dependencies: unit 1, unit 2.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/client/client.go` (add `SearchPeopleByCompany`, `SearchPeopleByQuery`).
+- Create: `library/sales-and-crm/contact-goat/internal/cli/promoted_people_search.go` (cobra wiring).
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/root.go` (register new command).
+- Test: `library/sales-and-crm/contact-goat/internal/client/client_people_search_test.go`
+- Test: `library/sales-and-crm/contact-goat/internal/cli/people_search_test.go`
+
+Approach:
+- Implement the POST request shape from the sniff doc. Include the dynamo polling loop if the sniff shows async.
+- Normalize results into the existing `flagshipPerson` type; fill `Sources: ["hp_people_search"]` and `Relationship: "happenstance_graph"` for direct-contact rows, `"2nd_degree"` for walked rows, with `Rationale` populated from the server's own reasoning blob.
+- Expose as `contact-goat-pp-cli hp people <query>` (new command) for direct use. The `coverage` refactor in unit 4 calls the same client method.
+- On upstream error, return a typed error that `coverage` and `prospect` can surface as a labeled warning rather than eating.
+
+Execution note: implement test-first. Record a happy-path HAR from the sniff doc and replay it against a mock HTTP server in unit tests.
+
+Patterns to follow: existing `internal/client/client.go` HTTP helper style, existing `promoted_*` cobra patterns, existing `flagshipPerson` shape.
+
+Test scenarios:
+- Happy path: `SearchPeopleByCompany("Weber Inc")` against a fixture server returns a list that includes Jennifer Bonuso with `Relationship == "happenstance_graph"`.
+- Happy path: `SearchPeopleByCompany("Warner Bros")` returns non-zero rows with `Rationale` populated from mutual-connection reasoning.
+- Edge case: zero-result query returns empty slice, not nil, not error.
+- Error path: server 500 is returned as a typed error that mentions "happenstance people-search".
+- Error path: dynamo poll exceeding a deadline returns a typed timeout error, not a hang.
+- Integration: `contact-goat-pp-cli hp people "Weber" --agent` exits 0 and emits JSON with a `source_errors` key that is empty on happy path and populated on failure.
+
+Verification:
+- Running against Matt's live Happenstance session, `hp people "Weber Inc"` lists Jennifer Bonuso with `Relationship: happenstance_graph`.
+- Running `hp people "Warner Bros."` lists a non-trivial set of 2nd-degree candidates with mutual-connection rationales.
+
+- [ ] Unit 4: Expand `coverage` to use the graph search
+
+Goal: make `coverage <company>` answer the "do I know anyone at X" question for real by calling the new people-search first.
+
+Requirements: R1, R2, R5.
+
+Dependencies: unit 3.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/coverage.go`
+- Test: `library/sales-and-crm/contact-goat/internal/cli/coverage_test.go` (create if missing; expand if present)
+
+Approach:
+- Replace the `sources["hp"]` branch with: call `SearchPeopleByCompany` first, then as a fallback only (not in addition), call `fetchHappenstanceFriends` and filter for matches against the company argument. Friends-list matches keep their existing `hp_friend` tag and outrank graph-search results only when they also appear in the graph result (de-dupe by Happenstance uuid).
+- Add a `source_errors` map to the JSON output when any sub-source errored, so callers can distinguish "empty because nobody is there" from "empty because the call failed".
+- Preserve the existing LinkedIn-search branch and the mutual-hydration step.
+- Preserve backward-compatible JSON shape; `source_errors` is additive.
+
+Patterns to follow: existing merge + rank pipeline in coverage.go.
+
+Test scenarios:
+- Happy path: graph search returns 10 people at Weber Inc; LinkedIn search returns 10 different people; final result has 20 de-duped rows with correct relationship tags.
+- Happy path: graph search and friends-list both contain Jennifer Bonuso; output has one row tagged `happenstance_graph` (graph wins; friends-list tag is merged in, not duplicated).
+- Edge case: empty query returns argument error, no network calls.
+- Error path: graph-search fails -> output still contains LinkedIn results, and JSON output contains `source_errors["hp_people_search"]` with a non-empty message.
+- Integration: `--source hp` with graph-search down yields an empty result set AND a non-empty `source_errors`. The text output says so (R5).
+
+Verification:
+- `contact-goat-pp-cli coverage "Weber Inc" --agent` returns Jennifer Bonuso in the results.
+- `contact-goat-pp-cli coverage "Warner Bros." --agent` returns a non-zero count with graph-search rows.
+- `--source hp` with a manually-broken cookie jar returns zero count and a populated `source_errors` block.
+
+- [ ] Unit 5: Surface 3rd-degree warm-intro candidates
+
+Goal: `warm-intro <target>` returns friends-of-friends candidates with concrete rationale, not just Matt's top-3 Happenstance friends by raw connection count.
+
+Requirements: R3.
+
+Dependencies: unit 3.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/promoted_people_search.go` (add a `SearchMutualsAround` client method or similar traversal helper).
+- Modify: the warm-intro command file in `internal/cli/` (it exists; find by `grep warm-intro` in the cobra registration and extend).
+- Test: `library/sales-and-crm/contact-goat/internal/cli/warm_intro_test.go`
+
+Approach:
+- From the sniff doc, identify whether Happenstance exposes a people-in-common endpoint (for a target LinkedIn URL or UUID). If yes, use it. If not, approximate by calling people-search scoped to the target's current employer and returning the top N candidates tagged as "shared_employer" rationale.
+- Score 3rd-degree candidates below 1st/2nd but above "raw top-connector" fallback. When a candidate has both a shared-employer match and a Happenstance-friend tag, boost the score.
+- Replace the current `--sources hp` behavior that returns Matt's top-3 Happenstance friends with a clear "no evidence-based warm-intro found, falling back to top-N connectors" label so users know the rationale is weak.
+
+Patterns to follow: existing warm-intro scoring pipeline.
+
+Test scenarios:
+- Happy path: target = Alonso Velasco (/in/alonsovelasco/). Output includes at least one warm-intro candidate whose rationale is "shared employer Warner Bros. Entertainment" or equivalent, with score above the weak fallback.
+- Edge case: target has no resolvable employer -> falls back to LinkedIn sidebar-recommendation scoring (existing behavior).
+- Error path: graph-search down -> warm-intro degrades to LinkedIn-only sources with a `source_errors` entry.
+- Integration: `--sources hp` with a real target in your network produces at least one candidate with a non-generic rationale ("2 mutuals: X, Y" or "shared employer Z"), not the current "(N connections)" fallback.
+
+Verification:
+- `warm-intro https://www.linkedin.com/in/alonsovelasco/ --sources hp --agent` returns at least one candidate whose rationale names a concrete link (shared employer, mutual name, shared group), not just a raw connection count.
+
+- [ ] Unit 6: Fix contact-goat side of LinkedIn MCP contract
+
+Goal: stop dropping results due to stale arg names. This is the contact-goat-side half of the broader upstream fix tracked in the OSC plan.
+
+Requirements: R6.
+
+Dependencies: none.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/linkedin.go`
+- Modify: any MCP bridge helper that serializes tool calls (grep for `linkedin_url` and `sections`).
+- Test: `library/sales-and-crm/contact-goat/internal/cli/linkedin_mcp_contract_test.go`
+
+Approach:
+- Replace `linkedin_url` arg name with `linkedin_username` on all calls that now target the upstream method.
+- Join `sections` list to a comma-separated string before serialization.
+- Drop the unsupported `limit` arg on `search_people` (upstream does not accept it; currently breaks prospect).
+- Where contact-goat wants a post-fetch limit, apply it client-side after the MCP call returns.
+
+Patterns to follow: existing MCP tool-call serialization in `internal/mcp/`.
+
+Test scenarios:
+- Happy path: `get-person alonsovelasco --sections contacts` constructs an MCP call with `{"linkedin_username":"alonsovelasco","sections":"contacts"}`, not `{"linkedin_url":...,"sections":["contacts"]}`.
+- Happy path: `prospect "company=Warner Bros"` constructs an MCP `search_people` call without `limit` in the payload.
+- Edge case: input is a full LinkedIn URL -> normalize to username before serialization.
+- Integration: against a live upstream MCP, `get-person alonsovelasco` returns a non-empty payload.
+
+Verification:
+- `contact-goat-pp-cli linkedin get-person alonsovelasco --agent` exits 0 with a populated profile.
+- `contact-goat-pp-cli prospect "Warner Bros" --agent` no longer emits the `Unexpected keyword argument 'limit'` warning.
+
+- [ ] Unit 7: Doctor + dogfood updates
+
+Goal: doctor surfaces graph coverage; dogfood-results.json exercises the three-tier behavior end-to-end.
+
+Requirements: R4, R7.
+
+Dependencies: units 2, 3, 4, 5, 6.
+
+Files:
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/doctor.go`
+- Modify: `library/sales-and-crm/contact-goat/dogfood-results.json` (regenerate via whatever the existing dogfood runner is)
+- Modify: `library/sales-and-crm/contact-goat/SKILL.md` (document new `hp people` command and new `source_errors` field)
+
+Approach:
+- Add a doctor line: "Happenstance: graph coverage: linkedin_ext: N synced, last refresh YYYY-MM-DD" pulled from the `uploads` endpoint response.
+- Add a doctor line that distinguishes cookie presence from session validity from refresh-fresh success. The current "will refresh on next request" line is misleading when refresh has actually been failing.
+- Extend dogfood to cover: (a) `coverage` returning graph rows, (b) `hp people` returning non-zero, (c) `warm-intro` returning evidence-based rationale, (d) `source_errors` being empty on happy path.
+- Update SKILL.md to document the new command and the `source_errors` field shape.
+
+Execution note: skill changes must also trigger `go run ./tools/generate-skills/main.go` and a `plugin/.claude-plugin/plugin.json` version bump per the repo AGENTS.md convention.
+
+Patterns to follow: existing doctor layout; existing dogfood JSON schema; existing SKILL.md sections.
+
+Test scenarios:
+- Happy path: `doctor` on a freshly-logged-in session prints the graph coverage line with a non-zero contact count.
+- Edge case: `doctor` with no linkedin_ext synced prints "no LinkedIn contacts synced yet" (not a silent blank).
+- Error path: `doctor` with a broken refresh prints "session JWT: expired; refresh FAILED: <reason>" rather than the current optimistic "will refresh on next request".
+- Integration: dogfood runner reports all three tiers (1st/2nd/3rd) resolved for a known-good target.
+
+Verification:
+- `doctor` output on Matt's live machine includes a non-zero linkedin_ext contact count.
+- `dogfood-results.json` regenerates clean with no silent-empty results.
+- `plugin/skills/pp-contact-goat/SKILL.md` regenerates cleanly and the plugin version bump is committed.
+
+## System-Wide Impact
+
+- Interaction graph: `coverage`, `prospect`, `warm-intro`, `dossier`, `engagement`, `stale`, `since`, and `tail` all read from the same Happenstance graph. Units 2 + 3 raise the ceiling for every one of them. Unit 4 makes `coverage` use it concretely. Units 5 wires one more consumer. The rest inherit improvements automatically.
+- Error propagation: today silent-empty is the failure mode. The `source_errors` convention introduced in unit 4 must be honored by every consumer of the graph search. If unit 3 lands but `prospect` and `warm-intro` do not propagate `source_errors`, the plan regresses R5 for those surfaces. Unit 5 explicitly propagates it; `prospect` should be audited when it lands.
+- State lifecycle: the dynamo request_id lifecycle is new client-side state. If the client drops a request_id before polling completes, the user sees a stale "empty" result. The client should hold the request_id through the polling window, with a clear timeout.
+- API surface parity: new command `hp people` is additive. Existing JSON outputs gain an additive `source_errors` field. Any consumer parsing the JSON as "no unknown keys" should be checked (none in the repo itself; external users of the JSON schema are Matt's own agent workflows).
+- Integration coverage: replay-based tests against recorded sniff HARs cover request-shape correctness. Live-graph tests against Matt's own session cover the "did Jennifer Bonuso actually come back" question. Both matter; unit tests alone will not catch schema drift on Happenstance's side.
+- Unchanged invariants: the existing `/api/friends/list` path and its `hp_friend` tag continue to work. No command changes output shape in a backward-incompatible way. BYOK and Deepline flows are untouched.
+
+## Risks and Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Happenstance web endpoints have no public contract and may change | Sniff doc is dated; every client method decodes into a typed struct; unit tests replay the captured HAR; schema drift surfaces as a loud typed error rather than silent empty; doctor shows "last sniffed YYYY-MM-DD" so staleness is visible |
+| Sniffs become stale between this plan and the next Happenstance deploy | Re-sniff is cheap and local (one HAR export per flow); the sniff directory is timestamped so the next revision sits next to the old one for diffing |
+| Clerk API version constant becomes stale again | On refresh error, include the server's `x-clerk-auth-*` headers in the error; doctor surfaces the refresh-fresh status as a distinct line so drift is visible within 60 seconds |
+| Session cookies expire or rotate during a long run | Proactive refresh on every request plus the collapse window already exists; unit 2 strengthens the re-seed path when Chrome rotated the cookie |
+| Happenstance rate-limits the people-search when walked for 2nd/3rd-degree | The existing `--rate-limit` persistent flag applies; unit 3 respects it, and dynamo polling uses a bounded retry |
+| Upstream `linkedin-scraper-mcp` changes args again | Unit 6 adds a contract test that fails loudly on schema drift, rather than dropping results silently |
+| Matt already has a separate upstream OSC PR in flight | Unit 6 stays narrow (contact-goat side only) so it lands regardless of the upstream PR's cadence |
+
+## Documentation and Operational Notes
+
+- Update `library/sales-and-crm/contact-goat/SKILL.md` and README with the new `hp people` command.
+- Update `plugin/skills/pp-contact-goat/SKILL.md` via `go run ./tools/generate-skills/main.go` and bump `plugin/.claude-plugin/plugin.json` per repo AGENTS.md.
+- Add a one-paragraph note to the README's "Known limitations" section that Happenstance is a best-effort wrapper of unofficial endpoints and that schema drift is possible.
+- No production rollout; this is a local CLI. Verification is live dogfood on Matt's machine.
+
+## Sources and References
+
+- Origin session: 2026-04-19 debugging session (this conversation) documenting the five failure modes in Problem Frame.
+- Related plan: `~/.osc/plans/2026-04-19-032-feat-linkedin-mcp-search-people-connection-filters-plan.md` (upstream LinkedIn MCP filter PR; tracked separately).
+- Related code:
+  - `library/sales-and-crm/contact-goat/internal/client/cookie_auth.go`
+  - `library/sales-and-crm/contact-goat/internal/cli/coverage.go`
+  - `library/sales-and-crm/contact-goat/internal/cli/promoted_research.go`
+  - `library/sales-and-crm/contact-goat/internal/cli/search.go`
+  - `library/sales-and-crm/contact-goat/internal/cli/linkedin.go`
+- Related issues: none filed yet. Unit 1's sniff artifact is the closest thing to a bug report; unit 2 may produce a follow-up issue against `clerk` if the API version constant truly is stale rather than a local parse bug.
+- External references: Clerk session-tokens API docs at clerk.com (referenced only after unit 1 sniff shows which call signature matches).

--- a/docs/plans/2026-04-19-003-feat-contact-goat-happenstance-full-network-plan.md
+++ b/docs/plans/2026-04-19-003-feat-contact-goat-happenstance-full-network-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat(contact-goat): unlock full Happenstance network graph (1st, 2nd, 3rd degree)"
 type: feat
-status: active
+status: completed
 date: 2026-04-19
 ---
 

--- a/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/README.md
+++ b/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/README.md
@@ -1,0 +1,243 @@
+# Happenstance web-app sniff, 2026-04-19
+
+Captured against Matt Van Horn's signed-in Chrome session via the claude-in-chrome MCP.
+Every request below was observed in the DevTools Network panel or intercepted by a
+monkey-patched `window.fetch`. All JWTs, session tokens, and cookie values are redacted.
+
+## TL;DR — root causes of contact-goat's silent-empty bug
+
+1. Clerk refresh endpoint is `POST /v1/client/sessions/{sess}/touch`, not `/tokens`.
+   contact-goat's `internal/client/cookie_auth.go` calls `/tokens` and always gets HTTP 404.
+   That is why `MaybeRefreshSession` dies after ~60 seconds.
+
+2. The CLI's `coverage` uses `GET /api/friends/list`, which is the narrow "top connectors"
+   widget and only returns the 3 users Matt follows on Happenstance. The real graph search
+   lives at `POST /api/search` + `GET /api/dynamo?requestId=...`. That endpoint returned
+   30 people for "Warner Bros" and 19 for "Weber Inc" on this same signed-in session.
+
+3. contact-goat's `POST /api/research` attempt uses snake_case keys (`request_text`,
+   `request_content`). The server expects camelCase (`requestText`, `requestContent`).
+   That is why every prior POST returned 204 or 500 with empty body.
+
+## Endpoint: Clerk session refresh
+
+### Observed
+
+```
+POST https://clerk.happenstance.ai/v1/client/sessions/sess_3CaMtjozgFPsjhyE33et4msqTS4/touch
+     ?__clerk_api_version=2025-11-10
+     &_clerk_js_version=5.125.9
+→ 200
+```
+
+Headers of interest on request: browser sends `__client_uat`, `__session`, `__refresh_*`
+cookies automatically via the jar. Body is empty.
+
+Headers of interest on response:
+- `X-Clerk-Auth-Status: signed-in`  (when the refresh succeeded)
+- `X-Clerk-Auth-Status: signed-out` with `X-Clerk-Auth-Reason: ...` (when the token is dead)
+- Sets a fresh `__session` cookie on the `.happenstance.ai` domain.
+
+### contact-goat bug
+
+`internal/client/cookie_auth.go:219-220` builds:
+
+```go
+fmt.Sprintf("%s/v1/client/sessions/%s/tokens?__clerk_api_version=%s",
+    clerkBaseURL, sessionID, clerkAPIVersion)
+```
+
+The path is wrong. Clerk's current frontend-API calls `/touch`, not `/tokens`. Endpoint
+`/tokens` is a different (server-to-server) Clerk surface. Fix: replace `/tokens` with
+`/touch` and append `&_clerk_js_version=5.125.9` to match the frontend contract.
+
+## Endpoint: create a search
+
+### Observed
+
+```
+POST /api/search
+Content-Type: application/json
+
+{
+  "requestText": "engineers at Stripe",
+  "requestContent": [{"children":[{"text":"engineers at Stripe"}], "type":"p"}],
+  "requestGroups": ["your-connections", "your-friends"],
+  "parentRequestId": null,
+  "excludePersonUUIDs": [],
+  "searchEveryone": false,
+  "creditId": null
+}
+
+→ 200
+{"status":"Request received","id":"34becdcd-c706-4dc0-ab60-8fbfe055e8e7"}
+```
+
+Field semantics:
+
+| Field | Meaning |
+|---|---|
+| `requestText` | Free-text natural-language query. Happenstance runs its own parsing to pull out company / title / traits filters. |
+| `requestContent` | Slate-style rich-text representation of the same query. The web app always sends both. The server accepts mismatches but the safe path is to send both in lockstep. |
+| `requestGroups` | Array of tier selectors. `"your-connections"` = 1st-degree (your synced LinkedIn / Gmail / etc contacts). `"your-friends"` = 2nd-degree (friends-of-friends visible via your Happenstance-friend graph). Custom groups also go here by uuid. |
+| `parentRequestId` | Previous request uuid when refining. `null` for a fresh search. |
+| `excludePersonUUIDs` | Used to hide already-seen people on "find more". |
+| `searchEveryone` | Boolean. `true` flips it to the 3rd-degree / public-everyone mode. |
+| `creditId` | Required for some paid-credit-gated flows; `null` for free use. |
+
+Returns a generated server-side uuid immediately. The actual search runs async.
+
+### contact-goat bug
+
+Prior attempts sent `request_text` / `request_content` (snake_case). Server silently 500s
+without a body. Must send the camelCase keys above.
+
+## Endpoint: poll for results
+
+### Observed
+
+```
+GET /api/dynamo?requestId=34becdcd-c706-4dc0-ab60-8fbfe055e8e7
+→ 200
+[
+  {
+    "request_id": "34becdcd-c706-4dc0-ab60-8fbfe055e8e7",
+    "request_text": "people at Weber Inc",
+    "request_content": [ ... Slate ... ],
+    "request_status": "Found 19 people",
+    "completed": true,
+    "include_my_connections": true,
+    "include_my_friends": true,
+    "search_everyone": false,
+    "request_groups": [],
+    "logs": [ { "type": "INFO", "message": "...", "timestamp": "..." }, ... ],
+    "results": [ <person>, ... ],
+    "s3_results_uri": "s3://hpn-search-results-prod/results/{uuid}.json",
+    "user_id": "user_...",
+    "user_display": { ... },
+    "timestamp": "...",
+    "version": 1.1
+  }
+]
+```
+
+Response is an array with exactly one object (the search record). `completed: true` signals
+the poll can stop. `results` is inline — no separate S3 fetch required.
+
+### Result shape (per person)
+
+Keys:
+
+```
+author_name
+person_uuid
+score
+linkedin_url
+twitter_url
+instagram_url
+quotes            — HTML-bold-highlighted prose describing the person
+quotes_cited      — [{text, url}, ...] source citations for each quote
+current_title
+current_company
+summary
+referrers         — {is_yc: bool, referrers: [<referrer>]}
+traits
+```
+
+### Referrer shape (this is the 1st/2nd-degree evidence)
+
+```
+{
+  "id": "a73cbe02-c7fc-47b1-8a5e-d6ff3b7a205f",
+  "name": "Matt Van Horn",
+  "source": ["LinkedIn"],
+  "image_url": "https://img.clerk.com/...",
+  "affinity_score": 49.99,
+  "affinity_level": "medium",
+  "is_directory_user": false
+}
+```
+
+When `referrers.referrers[0].id == current_user_uuid`, the result is 1st-degree.
+When it's another user's uuid, the result is 2nd-degree via that friend.
+
+### Polling cadence observed
+
+Web app polls `/api/dynamo?requestId=X` about every 1-2 seconds while the search runs.
+Stops when `completed: true`. Warner Bros search completed in 7 seconds (30 results),
+Weber Inc in 6 seconds (19 results).
+
+## Endpoint: uploads status (for doctor coverage line)
+
+```
+GET /api/uploads/status/user
+→ 200
+{
+  "statuses": {
+    "linkedin_ext": [
+      {
+        "id": "...",
+        "status": "COMPLETED",
+        "isActive": true,
+        "isError": false,
+        "isDeleting": false,
+        "timestamp": "2025-03-18T17:06:05.000Z",
+        "last_refreshed": "2025-07-09T21:36:00.371Z",
+        "s3_uri": "s3://connections-uploads/linkedin_ext/...csv",
+        "source_identifier": null
+      }
+    ]
+  },
+  "hasActiveUploads": true,
+  "hasErrorUploads": false,
+  "hasProcessingUploads": false,
+  "hasDeletingUploads": false,
+  "hasAnyUploads": true,
+  "activeAccountsCount": 1
+}
+```
+
+`statuses.linkedin_ext[0].last_refreshed` is what `doctor` should show as the contact-graph
+freshness line. No record count on this endpoint; that comes from the dynamo response.
+
+## Other endpoints observed (not in scope for this plan)
+
+| Path | Verb | Purpose |
+|---|---|---|
+| `/api/dynamo/recent` | GET | Recent searches list, for the sidebar History UI |
+| `/api/research/recent` | GET | Alternate recent-list shape |
+| `/api/search/{id}/suggested-posts` | GET | Related posts for a completed search |
+| `/api/friends/list` | GET | Top-connectors (the narrow endpoint coverage currently uses) |
+| `/api/clerk/referrer?referrerId={uuid}` | GET | Resolve a referrer uuid to a user record |
+| `/api/notifications?page=1&limit=10` | GET | Bell icon |
+| `/api/user`, `/api/user/limits` | GET | Current user, rate limits |
+
+## Concrete samples from today's session (redacted)
+
+Real search uuids captured this session — useful for replay tests once the real client lands:
+
+- Warner Bros: `cd5a3e1a-e8ff-42e5-a7e0-63de0c6faf4f` (30 results)
+- Weber Inc: `e148718b-492e-433f-aa9a-d7b31ae7332b` (per-page), `34becdcd-c706-4dc0-ab60-8fbfe055e8e7` (programmatic)  (19 results)
+- Stripe engineers: `49722417-468c-47fd-bd07-03fa5ba99412`
+- Sequoia investors: `59554597-9f7d-45b3-b70d-551c9f0512f4`
+
+Sample 1st-degree result from Weber Inc search: Gabriel Risk, Director of Engineering at
+Weber Inc., person_uuid `fff0ae8e-9940-4858-8d8a-6e60a84f5e9f`, referrer = Matt Van Horn
+(LinkedIn, affinity_level medium).
+
+## Deltas vs. the current contact-goat implementation
+
+| Area | Current | Correct |
+|---|---|---|
+| Clerk refresh path | `/v1/client/sessions/{sess}/tokens` | `/v1/client/sessions/{sess}/touch` |
+| Clerk refresh query | `?__clerk_api_version=2025-11-10` | `?__clerk_api_version=2025-11-10&_clerk_js_version=5.125.9` |
+| Create search body | `{request_text, request_content}` (snake_case) | `{requestText, requestContent, requestGroups, parentRequestId, excludePersonUUIDs, searchEveryone, creditId}` (camelCase) |
+| Create search path | `POST /api/research` (attempted) | `POST /api/search` |
+| Result retrieval | Not wired | `GET /api/dynamo?requestId={id}` poll until `completed: true` |
+| 1st vs 2nd degree | No distinction | `referrers.referrers[0].id == current_user_uuid` → 1st-degree |
+
+## Notes on cookies
+
+The claude-in-chrome session showed 14 happenstance cookies. Only `__session`, `__refresh_K8Qez0yT`,
+`__client`, `__client_uat_K8Qez0yT`, and `clerk_active_context` are needed for auth. Intercom and
+PostHog cookies are noise and can be excluded when exporting from Chrome.

--- a/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-create-search-request.json
+++ b/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-create-search-request.json
@@ -1,0 +1,11 @@
+{
+  "requestText": "people at Weber Inc",
+  "requestContent": [
+    {"type": "p", "children": [{"text": "people at Weber Inc"}]}
+  ],
+  "requestGroups": ["your-connections", "your-friends"],
+  "parentRequestId": null,
+  "excludePersonUUIDs": [],
+  "searchEveryone": false,
+  "creditId": null
+}

--- a/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-create-search-response.json
+++ b/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-create-search-response.json
@@ -1,0 +1,4 @@
+{
+  "status": "Request received",
+  "id": "FIXTURE-REQUEST-UUID"
+}

--- a/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-dynamo-response.json
+++ b/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/fixture-dynamo-response.json
@@ -1,0 +1,107 @@
+[
+  {
+    "request_id": "FIXTURE-REQUEST-UUID",
+    "request_text": "people at Weber Inc",
+    "request_content": [
+      {"type": "p", "children": [{"text": "people at Weber Inc"}]}
+    ],
+    "request_status": "Found 2 people",
+    "completed": true,
+    "include_my_connections": true,
+    "include_my_friends": true,
+    "search_everyone": false,
+    "request_groups": [],
+    "timestamp": "2026-04-19T23:45:00.000Z",
+    "version": 1.1,
+    "user_id": "user_FIXTURE_USER",
+    "user_display": {
+      "id": "FIXTURE-USER-UUID",
+      "name": "Fixture User"
+    },
+    "s3_results_uri": "s3://hpn-search-results-prod/results/FIXTURE-REQUEST-UUID.json",
+    "visibility": null,
+    "is_owner": true,
+    "followup": {"type": "results_limit"},
+    "system_search": false,
+    "logs": [
+      {
+        "type": "INFO",
+        "message": "Using direct SQL query for company-only search",
+        "timestamp": "2026-04-19T23:45:00.100000+00:00"
+      },
+      {
+        "type": "FIRST_RESPONSE",
+        "message": "On it. I'm searching through the connections you've included.",
+        "timestamp": "2026-04-19T23:45:00.500000+00:00"
+      },
+      {
+        "type": "FILTER",
+        "title": "Companies",
+        "message": ["Weber Inc.", "Weber-Stephen Products"],
+        "timestamp": "2026-04-19T23:45:01.000000+00:00"
+      }
+    ],
+    "results": [
+      {
+        "author_name": "Jennifer Bonuso",
+        "person_uuid": "FIXTURE-PERSON-UUID-1",
+        "score": 1,
+        "linkedin_url": "https://www.linkedin.com/in/jenniferbonuso",
+        "twitter_url": null,
+        "instagram_url": null,
+        "quotes": "Jennifer is currently <b>President, Americas</b> at Weber Inc.",
+        "quotes_cited": [
+          {"text": "Jennifer is currently President, Americas at Weber Inc.", "url": "https://www.linkedin.com/in/jenniferbonuso"}
+        ],
+        "current_title": "President, Americas",
+        "current_company": "Weber Inc.",
+        "summary": "Senior executive at Weber Inc. since 2022.",
+        "referrers": {
+          "is_yc": false,
+          "referrers": [
+            {
+              "id": "CURRENT-USER-UUID",
+              "name": "Fixture User",
+              "source": ["LinkedIn"],
+              "image_url": "https://img.clerk.com/FIXTURE",
+              "affinity_score": 50.0,
+              "affinity_level": "medium",
+              "is_directory_user": false
+            }
+          ]
+        },
+        "traits": {"0": "executive"}
+      },
+      {
+        "author_name": "Gabriel Risk",
+        "person_uuid": "FIXTURE-PERSON-UUID-2",
+        "score": 1,
+        "linkedin_url": "https://www.linkedin.com/in/gabriel-risk",
+        "twitter_url": null,
+        "instagram_url": null,
+        "quotes": "Gabriel is currently a <b>Director of Engineering</b> at Weber Inc.",
+        "quotes_cited": [
+          {"text": "Gabriel is currently a Director of Engineering at Weber Inc., a role he has held since January 2021.", "url": "https://www.linkedin.com/in/gabriel-risk"}
+        ],
+        "current_title": "Director of Engineering",
+        "current_company": "Weber Inc.",
+        "summary": "Leads embedded firmware and electrical engineering at Weber Inc.",
+        "referrers": {
+          "is_yc": false,
+          "referrers": [
+            {
+              "id": "FRIEND-OF-CURRENT-USER-UUID",
+              "name": "Some Friend",
+              "source": ["LinkedIn"],
+              "image_url": "https://img.clerk.com/FIXTURE2",
+              "affinity_score": 25.0,
+              "affinity_level": "low",
+              "is_directory_user": false
+            }
+          ]
+        },
+        "traits": {"0": "engineering"}
+      }
+    ]
+  }
+]

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage.go
@@ -1,8 +1,8 @@
 // Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
 
 // coverage: for a given company (name or slug), show who you already know
-// there. Crosses Happenstance friends and LinkedIn search_people scoped to
-// the company.
+// there. Crosses the Happenstance graph-search (full 1st + 2nd degree
+// network) and LinkedIn search_people scoped to the company name.
 
 package cli
 
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
 )
 
 func newCoverageCmd(flags *rootFlags) *cobra.Command {
@@ -25,16 +27,20 @@ func newCoverageCmd(flags *rootFlags) *cobra.Command {
 
 Runs the following in parallel (source flag permitting):
 
-  1. Happenstance: filter /api/friends/list by friends whose current
-     company / affiliation mentions the target.
-  2. LinkedIn: search_people scoped to the company name.
+  1. Happenstance graph-search (/api/search + /api/dynamo): the real
+     people-search the web app uses. Surfaces your 1st-degree (synced
+     LinkedIn / Gmail contacts) and 2nd-degree (your friends' networks)
+     hits at the target company, with referrer rationale.
+  2. LinkedIn search_people scoped to the company name: a name-match
+     fallback that catches people Happenstance doesn't have synced.
 
 Results are deduped across sources and ranked:
-  Happenstance friend  >  LinkedIn 1st-degree  >  LinkedIn search hit.
+  Happenstance 1st-degree  >  Happenstance 2nd-degree  >  LinkedIn 1st-degree  >  LinkedIn search hit.
 
-LinkedIn's MCP does not distinguish 1st-degree vs 2nd-degree in search
-results, so every LinkedIn hit is tagged "linkedin_search" unless we have
-additional signal (matches a Happenstance friend → upgraded).`,
+Use --source hp or --source li to isolate one side. JSON output gains a
+"source_errors" block whenever any upstream call errored, so callers can
+distinguish "empty because nobody is there" from "empty because the call
+failed".`,
 		Example: `  contact-goat-pp-cli coverage stripe
   contact-goat-pp-cli coverage "OpenAI" --limit 10 --json
   contact-goat-pp-cli coverage airbnb --source hp`,
@@ -47,25 +53,54 @@ additional signal (matches a Happenstance friend → upgraded).`,
 
 			var results []flagshipPerson
 			var friends []flagshipPerson
+			sourceErrors := map[string]string{}
 
-			// Source 1: Happenstance friends whose company field matches.
+			// Source 1: Happenstance graph-search (the real endpoint that
+			// sees your synced LinkedIn connections, not the top-connectors
+			// widget). Falls back to the friends/list match so top
+			// connectors keep their dedicated label even when they also
+			// show up in the graph result.
 			if sources["hp"] {
 				c, err := flags.newClientRequireCookies("happenstance")
 				if err != nil {
+					sourceErrors["hp"] = err.Error()
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance unavailable: %v\n", err)
 				} else {
-					all, ferr := fetchHappenstanceFriends(c)
-					if ferr != nil {
-						fmt.Fprintf(cmd.ErrOrStderr(), "warning: fetch friends: %v\n", ferr)
-					} else {
+					// Fetch the friends/list in parallel for the top-connector
+					// tag. Best-effort: errors here are logged but don't
+					// block the graph-search result set.
+					if all, ferr := fetchHappenstanceFriends(c); ferr == nil {
 						friends = all
-						for _, f := range all {
-							if matchesCompany(f, company) {
-								f.Sources = []string{"hp_friend"}
-								f.Relationship = "happenstance_friend"
-								f.Rationale = fmt.Sprintf("Happenstance friend at %s (%d connections)", f.Company, f.ConnectionCount)
-								results = append(results, f)
+					} else {
+						sourceErrors["hp_friends"] = ferr.Error()
+						fmt.Fprintf(cmd.ErrOrStderr(), "warning: fetch friends (non-fatal): %v\n", ferr)
+					}
+
+					// Resolve the current user uuid so graph results can be
+					// correctly labeled 1st vs 2nd degree.
+					currentUUID, _ := fetchCurrentUserUUID(c)
+
+					graphRes, gerr := c.SearchPeopleByCompany(company)
+					if gerr != nil {
+						sourceErrors["hp_graph"] = gerr.Error()
+						fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance graph-search: %v\n", gerr)
+					} else {
+						friendsByUUID := map[string]flagshipPerson{}
+						for _, f := range friends {
+							if f.HappenstanceUUID != "" {
+								friendsByUUID[f.HappenstanceUUID] = f
 							}
+						}
+						for _, p := range graphRes.People {
+							row := graphPersonToFlagship(p, currentUUID)
+							// Upgrade the row if this person is also in the
+							// narrow friends/list: they are a direct
+							// connector AND a graph hit.
+							if _, ok := friendsByUUID[row.HappenstanceUUID]; ok {
+								row.Sources = append(row.Sources, "hp_friend")
+								row.Relationship = "happenstance_friend"
+							}
+							results = append(results, row)
 						}
 					}
 				}
@@ -75,6 +110,7 @@ additional signal (matches a Happenstance friend → upgraded).`,
 			if sources["li"] {
 				hits, err := fetchLinkedInSearchPeople(ctx, company, "", 25)
 				if err != nil {
+					sourceErrors["li_search"] = err.Error()
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: LinkedIn search failed: %v\n", err)
 				} else {
 					for _, h := range hits {
@@ -117,9 +153,19 @@ additional signal (matches a Happenstance friend → upgraded).`,
 					"sources":   sourcesSummary(sources),
 					"timestamp": nowISO(),
 				}
+				if len(sourceErrors) > 0 {
+					out["source_errors"] = sourceErrors
+				}
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
 				return enc.Encode(out)
+			}
+			if len(sourceErrors) > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(), "\n%d source(s) errored — results may be incomplete:\n", len(sourceErrors))
+				for src, msg := range sourceErrors {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", src, msg)
+				}
+				fmt.Fprintln(cmd.ErrOrStderr())
 			}
 			return printCoverageTable(cmd, company, results)
 		},
@@ -127,6 +173,40 @@ additional signal (matches a Happenstance friend → upgraded).`,
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max people to return")
 	cmd.Flags().StringVar(&sourceFlag, "source", "both", "Sources: li | hp | both")
 	return cmd
+}
+
+// graphPersonToFlagship converts a Happenstance graph-search result
+// into the CLI's normalized flagshipPerson shape. It populates sources
+// and relationship based on the referrer chain: when the first
+// referrer is the current user, the person is 1st-degree; otherwise
+// 2nd-degree; empty referrer chain means 3rd-degree (searchEveryone).
+func graphPersonToFlagship(p client.Person, currentUserUUID string) flagshipPerson {
+	tier := p.Tier(currentUserUUID)
+	sourceTag := "hp_graph_2deg"
+	switch tier {
+	case client.TierFirstDegree:
+		sourceTag = "hp_graph_1deg"
+	case client.TierThirdDegree:
+		sourceTag = "hp_graph_3deg"
+	}
+
+	rationale := fmt.Sprintf("Happenstance graph: %s at %s", string(tier), p.CurrentCompany)
+	if len(p.Referrers.Referrers) > 0 && tier == client.TierSecondDegree {
+		first := p.Referrers.Referrers[0]
+		rationale = fmt.Sprintf("2nd-degree via %s at %s", first.Name, p.CurrentCompany)
+	}
+
+	return flagshipPerson{
+		Name:             p.Name,
+		LinkedInURL:      p.LinkedInURL,
+		HappenstanceUUID: p.PersonUUID,
+		Title:            p.CurrentTitle,
+		Company:          p.CurrentCompany,
+		Sources:          []string{sourceTag},
+		Relationship:     string(tier),
+		Rationale:        rationale,
+		Score:            p.Score,
+	}
 }
 
 func matchesCompany(p flagshipPerson, query string) bool {
@@ -154,15 +234,24 @@ func firstSource(tags []string) string {
 }
 
 // scoreForRelationship is a tiered score for the coverage relationship column.
-// Ensures Happenstance friends come first in ranking.
+// Ranking puts Happenstance friends first (a top-connector AND a graph hit),
+// then graph 1st-degree (in your synced network), then LinkedIn 1st-degree,
+// then graph 2nd-degree (via a friend), then LinkedIn 2nd-degree, then
+// LinkedIn search hits, then graph 3rd-degree (public).
 func scoreForRelationship(rel string) float64 {
 	switch rel {
 	case "happenstance_friend":
 		return 10.0
+	case string(client.TierFirstDegree): // "1st_degree"
+		return 8.0
 	case "linkedin_1deg":
 		return 7.0
+	case string(client.TierSecondDegree): // "2nd_degree"
+		return 5.0
 	case "linkedin_2deg":
 		return 3.0
+	case string(client.TierThirdDegree): // "3rd_degree"
+		return 1.5
 	}
 	return 1.0
 }

--- a/library/sales-and-crm/contact-goat/internal/cli/doctor.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/doctor.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -125,6 +126,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 
 			// Happenstance cookie-auth section
 			checkHappenstance(report)
+			checkHappenstanceGraphCoverage(flags, report)
 
 			// LinkedIn MCP section (Python / uvx / profile)
 			checkLinkedIn(report)
@@ -147,6 +149,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				{"credentials", "Credentials"},
 				{"happenstance_cookies", "Happenstance: cookies"},
 				{"happenstance_session", "Happenstance: session JWT"},
+				{"happenstance_graph", "Happenstance: graph coverage"},
 				{"linkedin_python", "LinkedIn: Python"},
 				{"linkedin_uvx", "LinkedIn: uvx"},
 				{"linkedin_binary", "LinkedIn: binary"},
@@ -228,6 +231,107 @@ func checkHappenstance(report map[string]any) {
 	} else {
 		report["happenstance_session"] = "valid"
 	}
+}
+
+// checkHappenstanceGraphCoverage hits /api/uploads/status/user to
+// report how the user's synced data sources look. Surfaces when the
+// LinkedIn CSV import last refreshed so users know the 1st-degree
+// graph freshness and can re-upload if it is stale. Best-effort: any
+// error here is non-fatal and produces a concise "status unknown" line.
+func checkHappenstanceGraphCoverage(flags *rootFlags, report map[string]any) {
+	if _, ok := report["happenstance_session"]; !ok {
+		return // no cookies, skip
+	}
+	c, err := flags.newClientRequireCookies("happenstance")
+	if err != nil {
+		report["happenstance_graph"] = "unavailable (cookies not loaded)"
+		return
+	}
+	// Refresh the session before making the authenticated call; doctor
+	// is specifically the place people run to diagnose auth, so making
+	// that refresh path exercised here is the point.
+	if refErr := c.MaybeRefreshSession(); refErr != nil {
+		report["happenstance_graph"] = fmt.Sprintf("session refresh failed: %s", trimErr(refErr.Error()))
+		report["happenstance_session"] = fmt.Sprintf("expired; refresh FAILED: %s", trimErr(refErr.Error()))
+		return
+	}
+	raw, err := c.Get("/api/uploads/status/user", nil)
+	if err != nil {
+		report["happenstance_graph"] = fmt.Sprintf("unavailable: %s", trimErr(err.Error()))
+		return
+	}
+	if len(raw) == 0 {
+		report["happenstance_graph"] = "authenticated but uploads endpoint returned empty body (retry after a fresh `auth login --chrome`)"
+		return
+	}
+	var resp struct {
+		Statuses struct {
+			LinkedInExt []struct {
+				Status         string `json:"status"`
+				IsActive       bool   `json:"isActive"`
+				IsError        bool   `json:"isError"`
+				LastRefreshed  string `json:"last_refreshed"`
+				Timestamp      string `json:"timestamp"`
+			} `json:"linkedin_ext"`
+		} `json:"statuses"`
+		HasAnyUploads       bool `json:"hasAnyUploads"`
+		ActiveAccountsCount int  `json:"activeAccountsCount"`
+	}
+	if err := jsonUnmarshal(raw, &resp); err != nil {
+		report["happenstance_graph"] = fmt.Sprintf("decode failed: %s", trimErr(err.Error()))
+		return
+	}
+	if len(resp.Statuses.LinkedInExt) == 0 {
+		report["happenstance_graph"] = "no LinkedIn contacts synced yet (upload at happenstance.ai/integrations)"
+		return
+	}
+	entry := resp.Statuses.LinkedInExt[0]
+	age := ""
+	if ts, err := time.Parse(time.RFC3339, entry.LastRefreshed); err == nil {
+		age = fmt.Sprintf(" (%s ago)", humanAge(time.Since(ts)))
+	}
+	status := entry.Status
+	if entry.IsError {
+		status = "ERROR"
+	}
+	report["happenstance_graph"] = fmt.Sprintf("linkedin_ext: %s, last refreshed %s%s",
+		status, fallbackStr(entry.LastRefreshed, "unknown"), age)
+}
+
+func trimErr(s string) string {
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}
+
+func fallbackStr(s, def string) string {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	return s
+}
+
+func humanAge(d time.Duration) string {
+	days := int(d.Hours() / 24)
+	if days < 1 {
+		h := int(d.Hours())
+		if h < 1 {
+			return fmt.Sprintf("%dm", int(d.Minutes()))
+		}
+		return fmt.Sprintf("%dh", h)
+	}
+	if days < 60 {
+		return fmt.Sprintf("%dd", days)
+	}
+	months := days / 30
+	return fmt.Sprintf("%dmo", months)
+}
+
+// jsonUnmarshal is a thin wrapper to keep the local helper name
+// consistent with other check* helpers in this file.
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
 }
 
 // checkDeepline populates doctor's Deepline fields. We NEVER echo the API

--- a/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
@@ -501,6 +501,10 @@ func sourceStrength(tag string) float64 {
 	switch tag {
 	case "hp_friend":
 		return 5.0
+	case "hp_graph_1deg":
+		return 5.0 // you know them directly — equal to an HP top connector
+	case "hp_graph_2deg":
+		return 4.5 // concrete 2nd-degree path at the target company
 	case "li_1deg":
 		return 4.0
 	case "li_search", "li_profile":
@@ -509,6 +513,8 @@ func sourceStrength(tag string) float64 {
 		return 2.0
 	case "hp_network":
 		return 3.0
+	case "hp_graph_3deg":
+		return 1.5 // public hit, no concrete path
 	case "li_2deg":
 		return 1.5
 	case "dl_apollo":

--- a/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
@@ -1,0 +1,237 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+// hp people: natural-language people-search against the Happenstance
+// graph. Unlike `coverage` (which filters /api/friends/list and only
+// sees your 3 top connectors), this command hits the same endpoint the
+// web app uses and sees your full synced network across 1st, 2nd, and
+// 3rd-degree tiers.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
+)
+
+func newHPCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hp",
+		Short: "Happenstance graph commands (1st / 2nd / 3rd degree people-search)",
+		Long: `hp groups the Happenstance graph-search commands that wrap the web app's
+natural-language search. Unlike the narrow friends/list-backed coverage
+command, these hit the full graph (your synced LinkedIn contacts, your
+friends' networks, and optionally the public graph).`,
+	}
+	cmd.AddCommand(newHPPeopleCmd(flags))
+	return cmd
+}
+
+func newHPPeopleCmd(flags *rootFlags) *cobra.Command {
+	var (
+		tierConnections bool
+		tierFriends     bool
+		tierEveryone    bool
+		timeoutSec      int
+		intervalSec     int
+		limit           int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "people <query>",
+		Short: "Natural-language people-search across your Happenstance graph",
+		Long: `Runs a Happenstance people-search with the same endpoint the web app
+uses. Supports 1st-degree (your synced connections), 2nd-degree (your
+friends' networks), and 3rd-degree (public / search-everyone) tiers.
+
+Each result includes a referrer chain so the CLI can label how you're
+connected. The RELATIONSHIP column shows 1st_degree / 2nd_degree /
+3rd_degree.`,
+		Example: `  # default tiers: 1st + 2nd degree
+  contact-goat-pp-cli hp people "people at Weber Inc"
+
+  # 1st-degree only
+  contact-goat-pp-cli hp people "engineers at Stripe" --no-friends
+
+  # fan out to the public graph too
+  contact-goat-pp-cli hp people "partners at Sequoia" --everyone
+
+  # refine an existing search (see hp people --help for request_id)
+  contact-goat-pp-cli hp people "senior" --parent <request_id>
+
+  # JSON for scripting
+  contact-goat-pp-cli hp people "people at HBO" --agent`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			c, err := flags.newClientRequireCookies("happenstance")
+			if err != nil {
+				return err
+			}
+
+			opts := &client.SearchPeopleOptions{
+				IncludeMyConnections: tierConnections,
+				IncludeMyFriends:     tierFriends,
+				SearchEveryone:       tierEveryone,
+				PollTimeout:          time.Duration(timeoutSec) * time.Second,
+				PollInterval:         time.Duration(intervalSec) * time.Second,
+			}
+			res, err := c.SearchPeopleByQuery(query, opts)
+			if err != nil {
+				return err
+			}
+
+			currentUserUUID, _ := fetchCurrentUserUUID(c)
+
+			if limit > 0 && len(res.People) > limit {
+				res.People = res.People[:limit]
+			}
+
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				out := buildHPPeopleJSON(res, currentUserUUID)
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+			return printHPPeopleTable(cmd, res, currentUserUUID)
+		},
+	}
+
+	cmd.Flags().BoolVar(&tierConnections, "connections", true, "Include your 1st-degree (synced contacts)")
+	cmd.Flags().BoolVar(&tierFriends, "friends", true, "Include 2nd-degree via your friends' networks")
+	cmd.Flags().BoolVar(&tierEveryone, "everyone", false, "Also include the public / 3rd-degree graph")
+	cmd.Flags().IntVar(&timeoutSec, "timeout", 60, "Max seconds to wait for results")
+	cmd.Flags().IntVar(&intervalSec, "interval", 1, "Seconds between poll attempts")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Client-side cap on results (0 = no cap)")
+
+	// Ergonomic negations: --no-connections / --no-friends land via
+	// cobra's `--<name>=false` for bool flags, but also surface a
+	// friendlier form below.
+	cmd.Flags().Bool("no-connections", false, "Alias for --connections=false (1st-degree off)")
+	cmd.Flags().Bool("no-friends", false, "Alias for --friends=false (2nd-degree off)")
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if noConns, _ := cmd.Flags().GetBool("no-connections"); noConns {
+			tierConnections = false
+		}
+		if noFriends, _ := cmd.Flags().GetBool("no-friends"); noFriends {
+			tierFriends = false
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+// hpPeopleJSON is the CLI's normalized output shape. Each row carries
+// an explicit `relationship` tier so consumers don't have to rederive
+// it from the referrer chain.
+type hpPeopleRow struct {
+	Name           string                `json:"name"`
+	PersonUUID     string                `json:"person_uuid"`
+	CurrentTitle   string                `json:"current_title"`
+	CurrentCompany string                `json:"current_company"`
+	LinkedInURL    string                `json:"linkedin_url"`
+	Relationship   client.RelationshipTier `json:"relationship"`
+	Referrers      []hpReferrerRow       `json:"referrers,omitempty"`
+	Score          float64               `json:"score"`
+	Summary        string                `json:"summary,omitempty"`
+}
+
+type hpReferrerRow struct {
+	Name          string  `json:"name"`
+	ID            string  `json:"id"`
+	Source        []string `json:"source,omitempty"`
+	AffinityLevel string  `json:"affinity_level,omitempty"`
+}
+
+type hpPeopleEnvelope struct {
+	Query        string          `json:"query"`
+	RequestID    string          `json:"request_id"`
+	Status       string          `json:"status"`
+	Completed    bool            `json:"completed"`
+	Count        int             `json:"count"`
+	CurrentUser  string          `json:"current_user_uuid,omitempty"`
+	Results      []hpPeopleRow   `json:"results"`
+}
+
+func buildHPPeopleJSON(res *client.PeopleSearchResult, currentUserUUID string) hpPeopleEnvelope {
+	rows := make([]hpPeopleRow, 0, len(res.People))
+	for _, p := range res.People {
+		refs := make([]hpReferrerRow, 0, len(p.Referrers.Referrers))
+		for _, r := range p.Referrers.Referrers {
+			refs = append(refs, hpReferrerRow{
+				Name: r.Name, ID: r.ID, Source: r.Source, AffinityLevel: r.AffinityLevel,
+			})
+		}
+		rows = append(rows, hpPeopleRow{
+			Name:           p.Name,
+			PersonUUID:     p.PersonUUID,
+			CurrentTitle:   p.CurrentTitle,
+			CurrentCompany: p.CurrentCompany,
+			LinkedInURL:    p.LinkedInURL,
+			Relationship:   p.Tier(currentUserUUID),
+			Referrers:      refs,
+			Score:          p.Score,
+			Summary:        p.Summary,
+		})
+	}
+	return hpPeopleEnvelope{
+		Query:       res.Query,
+		RequestID:   res.RequestID,
+		Status:      res.Status,
+		Completed:   res.Completed,
+		Count:       len(rows),
+		CurrentUser: currentUserUUID,
+		Results:     rows,
+	}
+}
+
+func printHPPeopleTable(cmd *cobra.Command, res *client.PeopleSearchResult, currentUserUUID string) error {
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "%s - %d results (%s)\n\n", res.Query, len(res.People), res.Status)
+	if len(res.People) == 0 {
+		fmt.Fprintln(w, "no people found. Try broadening the query or enabling --everyone for public results.")
+		return nil
+	}
+	tw := newTabWriter(w)
+	fmt.Fprintln(tw, bold("RANK")+"\t"+bold("NAME")+"\t"+bold("TITLE")+"\t"+bold("COMPANY")+"\t"+bold("RELATIONSHIP")+"\t"+bold("URL"))
+	for i, p := range res.People {
+		tier := p.Tier(currentUserUUID)
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\n",
+			i+1,
+			truncate(p.Name, 32),
+			truncate(p.CurrentTitle, 32),
+			truncate(p.CurrentCompany, 28),
+			tier,
+			truncate(p.LinkedInURL, 60),
+		)
+	}
+	return tw.Flush()
+}
+
+// fetchCurrentUserUUID pulls the current user's Happenstance uuid from
+// /api/user so the CLI can label 1st-degree rows correctly. Best-effort:
+// on failure we return empty and the CLI falls back to "unknown" tier
+// labels rather than erroring out the whole command.
+func fetchCurrentUserUUID(c *client.Client) (string, error) {
+	raw, err := c.Get("/api/user", nil)
+	if err != nil {
+		return "", err
+	}
+	var user struct {
+		UUID string `json:"uuid"`
+		ID   string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &user); err != nil {
+		return "", err
+	}
+	if user.UUID != "" {
+		return user.UUID, nil
+	}
+	return user.ID, nil
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/linkedin.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/linkedin.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -120,10 +121,13 @@ func newLIGetPersonCmd(flags *rootFlags) *cobra.Command {
 			"      --sections experience,education,skills",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLITool(cmd, flags, linkedin.ToolNames.GetPerson, map[string]any{
-				"linkedin_url": normalizePersonInput(args[0]),
-				"sections":     sections,
-			})
+			payload := map[string]any{
+				"linkedin_username": normalizePersonInput(args[0]),
+			}
+			if joined := normalizeSections(sections); joined != "" {
+				payload["sections"] = joined
+			}
+			return runLITool(cmd, flags, linkedin.ToolNames.GetPerson, payload)
 		},
 	}
 	cmd.Flags().StringSliceVar(&sections, "sections", nil,
@@ -140,10 +144,13 @@ func newLIGetCompanyCmd(flags *rootFlags) *cobra.Command {
 			"  contact-goat-pp-cli linkedin get-company stripe --sections posts,jobs",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLITool(cmd, flags, linkedin.ToolNames.GetCompany, map[string]any{
-				"company_slug": args[0],
-				"sections":     sections,
-			})
+			payload := map[string]any{
+				"company_name": args[0],
+			}
+			if joined := normalizeSections(sections); joined != "" {
+				payload["sections"] = joined
+			}
+			return runLITool(cmd, flags, linkedin.ToolNames.GetCompany, payload)
 		},
 	}
 	cmd.Flags().StringSliceVar(&sections, "sections", nil, "Comma-separated sections: posts,jobs,employees,about")
@@ -533,9 +540,30 @@ func pruneEmpty(m map[string]any) map[string]any {
 }
 
 // normalizePersonInput accepts either a bare vanity slug ("williamhgates")
-// or a full URL and normalizes to the form the MCP expects.
+// or a full LinkedIn profile URL, and returns the bare username the
+// upstream linkedin-scraper-mcp tool requires. The MCP validates its
+// argument as `linkedin_username` and rejects full URLs. Known forms:
+//
+//	williamhgates
+//	https://www.linkedin.com/in/williamhgates
+//	https://www.linkedin.com/in/williamhgates/
+//	http://linkedin.com/in/alonsovelasco
+//	/in/alonsovelasco/
 func normalizePersonInput(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "/")
+	if idx := strings.LastIndex(s, "/in/"); idx >= 0 {
+		return strings.TrimSuffix(s[idx+len("/in/"):], "/")
+	}
+	// Already a bare slug.
 	return s
+}
+
+// normalizeSections turns a []string list into the comma-joined string
+// the upstream MCP expects on `sections` fields. Empty slice returns
+// "" so the caller can drop the arg entirely.
+func normalizeSections(sections []string) string {
+	return strings.Join(sections, ",")
 }
 
 // signalCtx wraps a parent context so SIGINT / SIGTERM cancels it.

--- a/library/sales-and-crm/contact-goat/internal/cli/linkedin_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/linkedin_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import "testing"
+
+func TestNormalizePersonInput(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"williamhgates", "williamhgates"},
+		{"https://www.linkedin.com/in/williamhgates", "williamhgates"},
+		{"https://www.linkedin.com/in/williamhgates/", "williamhgates"},
+		{"http://linkedin.com/in/alonsovelasco", "alonsovelasco"},
+		{"http://linkedin.com/in/alonsovelasco/", "alonsovelasco"},
+		{"/in/alonsovelasco/", "alonsovelasco"},
+		{"  jenniferbonuso  ", "jenniferbonuso"},
+	}
+	for _, tc := range cases {
+		if got := normalizePersonInput(tc.in); got != tc.want {
+			t.Errorf("normalizePersonInput(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeSections(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{}, ""},
+		{[]string{"experience"}, "experience"},
+		{[]string{"experience", "education"}, "experience,education"},
+	}
+	for _, tc := range cases {
+		if got := normalizeSections(tc.in); got != tc.want {
+			t.Errorf("normalizeSections(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/root.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/root.go
@@ -105,6 +105,7 @@ func Execute() error {
 	rootCmd.AddCommand(newWorkflowCmd(&flags))
 	rootCmd.AddCommand(newAPICmd(&flags))
 	rootCmd.AddCommand(newFriendsPromotedCmd(&flags))
+	rootCmd.AddCommand(newHPCmd(&flags))
 	rootCmd.AddCommand(newUserPromotedCmd(&flags))
 	rootCmd.AddCommand(newClerkPromotedCmd(&flags))
 	rootCmd.AddCommand(newDynamoPromotedCmd(&flags))

--- a/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
 )
 
 func newWarmIntroCmd(flags *rootFlags) *cobra.Command {
@@ -77,20 +79,44 @@ connection_count + presence in multiple sources).`,
 
 			var candidates []flagshipPerson
 			var friends []flagshipPerson
+			sourceErrors := map[string]string{}
 
-			// Source 1: Happenstance friends list.
+			// Source 1: Happenstance graph-search at the target's current
+			// company. For each person who comes back:
+			//   - 1st-degree hit: the person IS the warm-intro candidate
+			//     (you already know them directly).
+			//   - 2nd-degree hit: the referrer (your friend who knows them)
+			//     is the candidate; they can vouch.
+			// We fall through to the old friends-list dump ONLY when the
+			// target's company is unknown, so the command degrades
+			// gracefully when profile enrichment failed.
 			if sources["hp"] {
 				c, ferr := flags.newClientRequireCookies("happenstance")
 				if ferr != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance unavailable (%v). Skipping hp_friend source.\n", ferr)
+					sourceErrors["hp"] = ferr.Error()
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance unavailable (%v). Skipping hp source.\n", ferr)
 				} else {
-					friends, err = fetchHappenstanceFriends(c)
-					if err != nil {
-						fmt.Fprintf(cmd.ErrOrStderr(), "warning: fetch friends failed: %v. Skipping hp_friend source.\n", err)
+					if all, fErr := fetchHappenstanceFriends(c); fErr == nil {
+						friends = all
+					}
+					currentUUID, _ := fetchCurrentUserUUID(c)
+
+					if resolved.Company != "" {
+						graphRes, gerr := c.SearchPeopleByCompany(resolved.Company)
+						if gerr != nil {
+							sourceErrors["hp_graph"] = gerr.Error()
+							fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance graph-search for %q: %v\n", resolved.Company, gerr)
+						} else {
+							candidates = append(candidates, warmIntroCandidatesFromGraph(graphRes.People, currentUUID, resolved)...)
+						}
 					} else {
+						// Fallback: no company data means we can't run a
+						// targeted graph-search. Dump HP friends with a
+						// weaker, clearly-labeled rationale so the user
+						// knows this was the weak-fallback path.
 						for _, f := range friends {
 							f.Sources = []string{"hp_friend"}
-							f.Rationale = fmt.Sprintf("Happenstance friend (%d connections)", f.ConnectionCount)
+							f.Rationale = fmt.Sprintf("Happenstance friend (weak signal — no target company to match against) (%d connections)", f.ConnectionCount)
 							candidates = append(candidates, f)
 						}
 					}
@@ -166,12 +192,22 @@ connection_count + presence in multiple sources).`,
 						"timestamp":    nowISO(),
 					},
 				}
+				if len(sourceErrors) > 0 {
+					out["source_errors"] = sourceErrors
+				}
 				if !flags.compact && len(rawLI) > 0 {
 					out["target_linkedin_raw"] = json.RawMessage(rawLI)
 				}
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
 				return enc.Encode(out)
+			}
+			if len(sourceErrors) > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(), "\n%d source(s) errored — candidates may be incomplete:\n", len(sourceErrors))
+				for src, msg := range sourceErrors {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", src, msg)
+				}
+				fmt.Fprintln(cmd.ErrOrStderr())
 			}
 			return printWarmIntroTable(cmd, resolved, candidates)
 		},
@@ -238,6 +274,76 @@ func isSlugLike(s string) bool {
 	return true
 }
 
+// warmIntroCandidatesFromGraph turns Happenstance graph-search results
+// into concrete warm-intro candidates. The rule:
+//
+//	1st-degree match -> that person is a candidate (you already know them).
+//	2nd-degree match -> the referrer (the friend of yours who knows the
+//	                    match) is the candidate, since they can introduce you.
+//
+// 3rd-degree matches (no referrer chain back to the current user) are
+// filtered out — those are public hits with no path.
+//
+// Each candidate carries a rationale naming the concrete bridge
+// (shared employer + the person you share, or directly the target's
+// co-worker you already know).
+func warmIntroCandidatesFromGraph(people []client.Person, currentUserUUID string, target flagshipPerson) []flagshipPerson {
+	out := []flagshipPerson{}
+	seenReferrer := map[string]bool{}
+	for _, p := range people {
+		tier := p.Tier(currentUserUUID)
+		switch tier {
+		case client.TierFirstDegree:
+			// You know this person directly. They are the introducer.
+			row := flagshipPerson{
+				Name:             p.Name,
+				LinkedInURL:      p.LinkedInURL,
+				HappenstanceUUID: p.PersonUUID,
+				Title:            p.CurrentTitle,
+				Company:          p.CurrentCompany,
+				Sources:          []string{"hp_graph_1deg"},
+				Relationship:     string(tier),
+				Rationale:        fmt.Sprintf("Your 1st-degree contact at %s — ask them directly", p.CurrentCompany),
+			}
+			out = append(out, row)
+		case client.TierSecondDegree:
+			// The referrer is the warm-intro candidate. Deduplicate by
+			// referrer uuid so one friend who knows several target-company
+			// people only surfaces once.
+			for _, r := range p.Referrers.Referrers {
+				if r.ID == "" || r.ID == currentUserUUID {
+					continue
+				}
+				if seenReferrer[r.ID] {
+					continue
+				}
+				seenReferrer[r.ID] = true
+				row := flagshipPerson{
+					Name:             r.Name,
+					HappenstanceUUID: r.ID,
+					ImageURL:         r.ImageURL,
+					Sources:          []string{"hp_graph_2deg"},
+					Relationship:     "intro_via_friend",
+					Rationale: fmt.Sprintf(
+						"Your friend — knows %s at %s (affinity: %s)",
+						p.Name, p.CurrentCompany, fallback(r.AffinityLevel, "unknown"),
+					),
+				}
+				out = append(out, row)
+			}
+		}
+	}
+	_ = target // target name isn't used yet; reserved for future dedup pass
+	return out
+}
+
+func fallback(s, def string) string {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	return s
+}
+
 func filterOutTarget(list []flagshipPerson, target flagshipPerson) []flagshipPerson {
 	out := make([]flagshipPerson, 0, len(list))
 	tKey := target.dedupKey()
@@ -289,6 +395,8 @@ func describeSources(tags []string, connectionCount int) string {
 	li1 := false
 	liSidebar := false
 	liSearch := false
+	hpGraph1 := false
+	hpGraph2 := false
 	for _, t := range tags {
 		switch t {
 		case "hp_friend":
@@ -299,9 +407,19 @@ func describeSources(tags []string, connectionCount int) string {
 			liSidebar = true
 		case "li_search":
 			liSearch = true
+		case "hp_graph_1deg":
+			hpGraph1 = true
+		case "hp_graph_2deg":
+			hpGraph2 = true
 		}
 	}
 	parts := []string{}
+	if hpGraph1 {
+		parts = append(parts, "your direct contact at target company")
+	}
+	if hpGraph2 {
+		parts = append(parts, "knows someone at target company")
+	}
 	if hp {
 		if connectionCount > 0 {
 			parts = append(parts, fmt.Sprintf("Happenstance friend (%d connections)", connectionCount))

--- a/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
+++ b/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
@@ -34,13 +34,25 @@ type cookieAuthState struct {
 	lastRefresh time.Time
 }
 
-// clerkRefreshEndpoint is the Clerk-hosted session-token endpoint. The
-// session id is drawn from the clerk_active_context cookie at refresh time.
+// Clerk frontend-API constants. The Happenstance web app refreshes a
+// session by POSTing to the `touch` endpoint, which returns 200 and
+// sets an updated __session cookie via Set-Cookie. It is NOT the
+// `/tokens` endpoint — that is a different (server-to-server) Clerk
+// surface and will return 404 when called with a browser session id.
+//
+// `clerkJSVersion` must be sent because Clerk treats missing or stale
+// JS-version callers as potentially-compromised and denies refresh.
+// Keep this in sync with what the Happenstance web app ships; sniffs
+// live under library/sales-and-crm/contact-goat/.manuscripts/.
 const (
-	clerkBaseURL      = "https://clerk.happenstance.ai"
 	clerkAPIVersion   = "2025-11-10"
+	clerkJSVersion    = "5.125.9"
 	jwtExpirySlackSec = 10 // refresh proactively when < 10s remains
 )
+
+// clerkBaseURL is a var (not const) so tests can point the refresh
+// call at an httptest server. Production code never writes to it.
+var clerkBaseURL = "https://clerk.happenstance.ai"
 
 // WithCookieAuth installs a cookiejar seeded with the provided cookies and
 // enables automatic Clerk-session refresh on 401/204 `x-clerk-auth-status:
@@ -216,8 +228,8 @@ func (c *Client) refreshClerkSession() error {
 		return errors.New("no clerk session id in cookie jar (missing clerk_active_context)")
 	}
 
-	refreshURL := fmt.Sprintf("%s/v1/client/sessions/%s/tokens?__clerk_api_version=%s",
-		clerkBaseURL, sessionID, clerkAPIVersion)
+	refreshURL := fmt.Sprintf("%s/v1/client/sessions/%s/touch?__clerk_api_version=%s&_clerk_js_version=%s",
+		clerkBaseURL, sessionID, clerkAPIVersion, clerkJSVersion)
 
 	req, err := http.NewRequest("POST", refreshURL, strings.NewReader(""))
 	if err != nil {
@@ -226,6 +238,8 @@ func (c *Client) refreshClerkSession() error {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("User-Agent", "contact-goat-pp-cli/0.1.0")
+	req.Header.Set("Origin", "https://happenstance.ai")
+	req.Header.Set("Referer", "https://happenstance.ai/")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -233,35 +247,45 @@ func (c *Client) refreshClerkSession() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		// Don't include the body — it may contain a fresh JWT on some
-		// paths and we don't want to risk logging it.
+		// Drain the body but surface Clerk's own reason headers — they
+		// tell us exactly why the refresh failed (token expired, session
+		// revoked, etc.) without exposing any JWT material.
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("clerk refresh: HTTP %d", resp.StatusCode)
+		reason := resp.Header.Get("X-Clerk-Auth-Reason")
+		msg := resp.Header.Get("X-Clerk-Auth-Message")
+		status := resp.Header.Get("X-Clerk-Auth-Status")
+		if reason == "" && msg == "" {
+			return fmt.Errorf("clerk refresh: HTTP %d", resp.StatusCode)
+		}
+		return fmt.Errorf("clerk refresh: HTTP %d (status=%s reason=%s): %s",
+			resp.StatusCode, status, reason, msg)
 	}
 
-	var tr struct {
-		JWT string `json:"jwt"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
-		return fmt.Errorf("decode clerk refresh response: %w", err)
-	}
-	if tr.JWT == "" {
-		return errors.New("clerk refresh: empty jwt in response")
-	}
+	// Drain the response body. The /touch endpoint sets the fresh
+	// __session cookie via Set-Cookie; the http.Client's jar absorbs it
+	// automatically, so there is no `jwt` field to parse out of the body.
+	_, _ = io.Copy(io.Discard, resp.Body)
 
-	// Update the __session cookie on both the bare and dotted host so
-	// future requests to either pick it up.
-	newCookie := &http.Cookie{
-		Name:     "__session",
-		Value:    tr.JWT,
-		Path:     "/",
-		Domain:   ".happenstance.ai",
-		HttpOnly: true,
-		Secure:   true,
-	}
-	for _, host := range []string{"happenstance.ai", "www.happenstance.ai", "clerk.happenstance.ai"} {
-		u := &url.URL{Scheme: "https", Host: host, Path: "/"}
-		c.cookieAuth.jar.SetCookies(u, []*http.Cookie{newCookie})
+	// Belt and braces: verify the jar actually holds a non-empty __session
+	// cookie for happenstance.ai after the refresh. If the Set-Cookie was
+	// scoped to a domain the jar does not surface for happenstance.ai
+	// (rare but possible with wildcard domains), mirror the cookie across
+	// the relevant hosts so subsequent requests pick it up.
+	if sess := c.sessionCookieValue(); sess != "" {
+		newCookie := &http.Cookie{
+			Name:     "__session",
+			Value:    sess,
+			Path:     "/",
+			Domain:   ".happenstance.ai",
+			HttpOnly: true,
+			Secure:   true,
+		}
+		for _, host := range []string{"happenstance.ai", "www.happenstance.ai", "clerk.happenstance.ai"} {
+			u := &url.URL{Scheme: "https", Host: host, Path: "/"}
+			c.cookieAuth.jar.SetCookies(u, []*http.Cookie{newCookie})
+		}
+	} else {
+		return errors.New("clerk refresh: 200 OK but no __session cookie landed in jar")
 	}
 	c.cookieAuth.lastRefresh = time.Now()
 	return nil

--- a/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
+++ b/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
@@ -170,8 +170,12 @@ func (c *Client) clerkSessionID() string {
 			val = ck.Value
 		}
 		// Shape 1: bare session id, e.g. "sess_3Cac4..." (current Happenstance).
+		// Strip trailing ":" and whitespace; the cookie's URL-encoded form
+		// sometimes carries a trailing colon (observed on 2026-04-19).
+		// Leaving it in place produces "/v1/client/sessions/sess_XXX:/touch"
+		// which Clerk returns 404 for.
 		if strings.HasPrefix(val, "sess_") {
-			return val
+			return strings.TrimRight(val, ": \t\r\n")
 		}
 		// Shape 2: JSON envelope, e.g. {"session_id":"sess_..."}.
 		var ctx struct {
@@ -261,32 +265,49 @@ func (c *Client) refreshClerkSession() error {
 			resp.StatusCode, status, reason, msg)
 	}
 
-	// Drain the response body. The /touch endpoint sets the fresh
-	// __session cookie via Set-Cookie; the http.Client's jar absorbs it
-	// automatically, so there is no `jwt` field to parse out of the body.
+	// Drain the response body. /touch emits fresh __session via
+	// Set-Cookie; we parse those headers directly rather than relying on
+	// Go's cookiejar to scope them correctly. Without a PublicSuffixList
+	// the jar sometimes stores Set-Cookie Domain=.happenstance.ai as
+	// host-only for the request host (clerk.happenstance.ai), which
+	// means subsequent POSTs to happenstance.ai/api/search don't carry
+	// the fresh JWT and the server returns 204 "signed-out".
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	// Belt and braces: verify the jar actually holds a non-empty __session
-	// cookie for happenstance.ai after the refresh. If the Set-Cookie was
-	// scoped to a domain the jar does not surface for happenstance.ai
-	// (rare but possible with wildcard domains), mirror the cookie across
-	// the relevant hosts so subsequent requests pick it up.
-	if sess := c.sessionCookieValue(); sess != "" {
-		newCookie := &http.Cookie{
-			Name:     "__session",
-			Value:    sess,
-			Path:     "/",
-			Domain:   ".happenstance.ai",
-			HttpOnly: true,
-			Secure:   true,
+	var freshSession string
+	// resp.Cookies() parses Set-Cookie from the response headers.
+	for _, sc := range resp.Cookies() {
+		if sc.Name == "__session" && sc.Value != "" {
+			freshSession = sc.Value
+			break
 		}
-		for _, host := range []string{"happenstance.ai", "www.happenstance.ai", "clerk.happenstance.ai"} {
-			u := &url.URL{Scheme: "https", Host: host, Path: "/"}
-			c.cookieAuth.jar.SetCookies(u, []*http.Cookie{newCookie})
-		}
-	} else {
-		return errors.New("clerk refresh: 200 OK but no __session cookie landed in jar")
 	}
+	if freshSession == "" {
+		// Fall back to whatever the jar stored; some Clerk paths rely on
+		// the jar's own Set-Cookie handling even when the response-level
+		// parse returns nothing.
+		freshSession = c.sessionCookieValue()
+	}
+	if freshSession == "" {
+		return errors.New("clerk refresh: 200 OK but no __session cookie in response or jar")
+	}
+
+	// Mirror the fresh __session across every host that subsequent
+	// Happenstance requests will target. Path "/" so the jar matches
+	// every /api/* endpoint.
+	newCookie := &http.Cookie{
+		Name:     "__session",
+		Value:    freshSession,
+		Path:     "/",
+		Domain:   ".happenstance.ai",
+		HttpOnly: true,
+		Secure:   true,
+	}
+	for _, host := range []string{"happenstance.ai", "www.happenstance.ai", "clerk.happenstance.ai"} {
+		u := &url.URL{Scheme: "https", Host: host, Path: "/"}
+		c.cookieAuth.jar.SetCookies(u, []*http.Cookie{newCookie})
+	}
+
 	c.cookieAuth.lastRefresh = time.Now()
 	return nil
 }

--- a/library/sales-and-crm/contact-goat/internal/client/cookie_auth_test.go
+++ b/library/sales-and-crm/contact-goat/internal/client/cookie_auth_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/chromecookies"
+)
+
+const fixtureSessionID = "sess_FIXTURETestSessionID"
+
+// seedClient constructs a Client with WithCookieAuth over a jar
+// pre-populated with clerk_active_context and an expired __session JWT.
+func seedClient(t *testing.T, httpClient *http.Client) *Client {
+	t.Helper()
+
+	c := &Client{BaseURL: "https://happenstance.ai", HTTPClient: httpClient}
+
+	expiredJWT := "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjF9.sig"
+	cookies := []chromecookies.Cookie{
+		{Name: "clerk_active_context", Value: fixtureSessionID, Domain: ".happenstance.ai", Path: "/"},
+		{Name: "__session", Value: expiredJWT, Domain: ".happenstance.ai", Path: "/", HttpOnly: true, Secure: true},
+	}
+	c.ApplyOptions(WithCookieAuth(cookies))
+	c.HTTPClient.Jar = c.cookieAuth.jar
+	return c
+}
+
+func TestRefreshClerkSession_HitsTouchEndpointNotTokens(t *testing.T) {
+	var calls int32
+	var capturedPath string
+	var capturedAPIVersion string
+	var capturedJSVersion string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		capturedPath = r.URL.Path
+		capturedAPIVersion = r.URL.Query().Get("__clerk_api_version")
+		capturedJSVersion = r.URL.Query().Get("_clerk_js_version")
+
+		freshJWT := "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjI1MjQ2MDgwMDB9.sig" // exp=2050
+		http.SetCookie(w, &http.Cookie{
+			Name:     "__session",
+			Value:    freshJWT,
+			Path:     "/",
+			Domain:   "127.0.0.1",
+			HttpOnly: true,
+		})
+		_, _ = w.Write([]byte(`{"response":{"object":"session","status":"active"},"client":{}}`))
+	}))
+	defer srv.Close()
+
+	oldBase := clerkBaseURL
+	clerkBaseURL = srv.URL
+	defer func() { clerkBaseURL = oldBase }()
+
+	c := seedClient(t, srv.Client())
+
+	if err := c.refreshClerkSession(); err != nil {
+		t.Fatalf("refreshClerkSession: %v", err)
+	}
+
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", atomic.LoadInt32(&calls))
+	}
+	wantPath := fmt.Sprintf("/v1/client/sessions/%s/touch", fixtureSessionID)
+	if capturedPath != wantPath {
+		t.Errorf("wrong endpoint path: got %q want %q (regression: contact-goat used to call /tokens which is the wrong surface)", capturedPath, wantPath)
+	}
+	if capturedAPIVersion == "" {
+		t.Error("missing __clerk_api_version query param")
+	}
+	if capturedJSVersion == "" {
+		t.Error("missing _clerk_js_version query param — Clerk denies refresh without it")
+	}
+}
+
+func TestRefreshClerkSession_SurfaceClerkHeadersOn401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Clerk-Auth-Status", "signed-out")
+		w.Header().Set("X-Clerk-Auth-Reason", "session-token-expired-refresh-non-eligible-non-get")
+		w.Header().Set("X-Clerk-Auth-Message", "JWT is expired. Expiry date: ...")
+		w.WriteHeader(401)
+	}))
+	defer srv.Close()
+
+	oldBase := clerkBaseURL
+	clerkBaseURL = srv.URL
+	defer func() { clerkBaseURL = oldBase }()
+
+	c := seedClient(t, srv.Client())
+
+	err := c.refreshClerkSession()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "HTTP 401") {
+		t.Errorf("error missing HTTP 401: %v", err)
+	}
+	if !strings.Contains(msg, "signed-out") {
+		t.Errorf("error missing Clerk status header: %v", err)
+	}
+	if !strings.Contains(msg, "JWT is expired") {
+		t.Errorf("error missing Clerk message: %v", err)
+	}
+}
+
+func TestRefreshClerkSession_MissingSessionID(t *testing.T) {
+	c := &Client{BaseURL: "https://happenstance.ai", HTTPClient: &http.Client{}}
+	jar, _ := cookiejar.New(nil)
+	jar.SetCookies(&url.URL{Scheme: "https", Host: "happenstance.ai"}, []*http.Cookie{
+		{Name: "__session", Value: "x"},
+	})
+	c.HTTPClient.Jar = jar
+	c.cookieAuth = &cookieAuthState{jar: jar}
+
+	err := c.refreshClerkSession()
+	if err == nil {
+		t.Fatal("expected error when clerk_active_context is missing")
+	}
+	if !strings.Contains(err.Error(), "clerk_active_context") {
+		t.Errorf("error does not name the missing cookie: %v", err)
+	}
+}
+
+func TestRefreshClerkSession_CollapsesConcurrentCalls(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.SetCookie(w, &http.Cookie{
+			Name:     "__session",
+			Value:    "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjI1MjQ2MDgwMDB9.sig",
+			Path:     "/",
+			Domain:   "127.0.0.1",
+			HttpOnly: true,
+		})
+		_, _ = w.Write([]byte(`{"response":{},"client":{}}`))
+	}))
+	defer srv.Close()
+
+	oldBase := clerkBaseURL
+	clerkBaseURL = srv.URL
+	defer func() { clerkBaseURL = oldBase }()
+
+	c := seedClient(t, srv.Client())
+
+	if err := c.refreshClerkSession(); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	if err := c.refreshClerkSession(); err != nil {
+		t.Fatalf("second refresh (should collapse): %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected 1 HTTP call (collapse window), got %d", got)
+	}
+
+	// Advance past the collapse window and expect a genuine refresh.
+	c.cookieAuth.lastRefresh = time.Now().Add(-5 * time.Second)
+	if err := c.refreshClerkSession(); err != nil {
+		t.Fatalf("third refresh after window: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 calls after window expired, got %d", got)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/client/people_search.go
+++ b/library/sales-and-crm/contact-goat/internal/client/people_search.go
@@ -1,0 +1,391 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+// People-search client for the Happenstance web-app graph. Wraps the
+// POST /api/search + GET /api/dynamo?requestId=... flow the web UI uses
+// to answer "who in my network knows about X". Every field, path, and
+// shape here is derived from a live sniff; see
+// library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SearchPeopleOptions controls the three network tiers Happenstance
+// exposes on a people-search: 1st-degree (your synced connections),
+// 2nd-degree (your friends' networks), and 3rd-degree / public
+// (searchEveryone).
+//
+// Defaults match the web UI: 1st + 2nd degree, no public fallback.
+type SearchPeopleOptions struct {
+	// IncludeMyConnections toggles the "your-connections" tier. 1st-degree.
+	// Zero value (false) is used only when the caller explicitly opts out;
+	// SearchPeopleByQuery treats a nil *SearchPeopleOptions as "defaults".
+	IncludeMyConnections bool
+
+	// IncludeMyFriends toggles "your-friends" — 2nd-degree via your
+	// Happenstance-friend graph.
+	IncludeMyFriends bool
+
+	// SearchEveryone flips the search to the public / 3rd-degree surface.
+	// Expensive; off by default.
+	SearchEveryone bool
+
+	// ParentRequestID refines a prior search (equivalent of "find more"
+	// in the web UI). Empty string creates a fresh search.
+	ParentRequestID string
+
+	// ExcludePersonUUIDs is the list of person_uuid values to omit from
+	// results. Used by "find more" after the caller has already seen
+	// some results.
+	ExcludePersonUUIDs []string
+
+	// PollTimeout bounds the total wall-clock the client will spend
+	// polling /api/dynamo before giving up. Default: 60 seconds.
+	PollTimeout time.Duration
+
+	// PollInterval is the delay between dynamo polls. Default: 1 second.
+	// The web UI polls about every 1-2 seconds.
+	PollInterval time.Duration
+}
+
+// defaultSearchOptions returns the zero-config behavior: 1st + 2nd
+// degree, no public, 60-second timeout, 1-second poll.
+func defaultSearchOptions() SearchPeopleOptions {
+	return SearchPeopleOptions{
+		IncludeMyConnections: true,
+		IncludeMyFriends:     true,
+		SearchEveryone:       false,
+		PollTimeout:          60 * time.Second,
+		PollInterval:         1 * time.Second,
+	}
+}
+
+// PeopleSearchResult is the normalized output of a people-search.
+type PeopleSearchResult struct {
+	// RequestID is the uuid Happenstance assigned to the search. Useful
+	// for refining ("find more") and for surfacing in logs.
+	RequestID string `json:"request_id"`
+	// Query is the natural-language query that was submitted.
+	Query string `json:"query"`
+	// Status is Happenstance's human-readable status line, e.g.
+	// "Found 19 people".
+	Status string `json:"status"`
+	// Completed is true when the search finished; false if the poll
+	// timeout fired before the server finished.
+	Completed bool `json:"completed"`
+	// Logs is the structured log stream Happenstance emits while
+	// running the search (INFO, FILTER, EMBEDDING_SEARCH, ...).
+	Logs []SearchLog `json:"logs"`
+	// People is the result list, most-relevant first per Happenstance's
+	// scoring.
+	People []Person `json:"people"`
+}
+
+// SearchLog mirrors one entry in the dynamo response's `logs` array.
+// `Message` is intentionally json.RawMessage because Happenstance sends
+// strings, arrays, and objects there depending on the log type.
+type SearchLog struct {
+	Type      string          `json:"type"`
+	Title     string          `json:"title,omitempty"`
+	Message   json.RawMessage `json:"message"`
+	Timestamp string          `json:"timestamp"`
+}
+
+// Person is one result from a people-search. Field names mirror the
+// dynamo response verbatim so the struct can be decoded directly.
+type Person struct {
+	Name           string     `json:"author_name"`
+	PersonUUID     string     `json:"person_uuid"`
+	Score          float64    `json:"score"`
+	LinkedInURL    string     `json:"linkedin_url"`
+	TwitterURL     string     `json:"twitter_url"`
+	InstagramURL   string     `json:"instagram_url"`
+	Quotes         string     `json:"quotes"`
+	QuotesCited    []Citation `json:"quotes_cited"`
+	CurrentTitle   string     `json:"current_title"`
+	CurrentCompany string     `json:"current_company"`
+	Summary        string     `json:"summary"`
+	Referrers      Referrers  `json:"referrers"`
+}
+
+// Citation is one (text, url) pair under quotes_cited.
+type Citation struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
+}
+
+// Referrers wraps the chain that tells callers how a Person is
+// connected to the current user. The inner slice is ordered: the first
+// entry is the closest hop.
+type Referrers struct {
+	IsYC      bool       `json:"is_yc"`
+	Referrers []Referrer `json:"referrers"`
+}
+
+// Referrer is one node in the connection chain. When Referrer.ID
+// matches the current user's uuid, the Person is 1st-degree. Otherwise
+// the Person is 2nd-degree via that referrer (or 3rd-degree when
+// SearchEveryone is true and no referrer is the current user).
+type Referrer struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Source          []string `json:"source"`
+	ImageURL        string   `json:"image_url"`
+	AffinityScore   float64  `json:"affinity_score"`
+	AffinityLevel   string   `json:"affinity_level"`
+	IsDirectoryUser bool     `json:"is_directory_user"`
+}
+
+// RelationshipTier names the degree of connection between the current
+// user and a Person in the result set.
+type RelationshipTier string
+
+const (
+	TierFirstDegree  RelationshipTier = "1st_degree"
+	TierSecondDegree RelationshipTier = "2nd_degree"
+	TierThirdDegree  RelationshipTier = "3rd_degree"
+	TierUnknown      RelationshipTier = "unknown"
+)
+
+// Tier returns which degree this Person sits at relative to
+// currentUserUUID. Callers get this from /api/user and pass it in; the
+// Person struct itself doesn't carry it because the server treats tier
+// as derivable from referrers + the caller's identity.
+func (p Person) Tier(currentUserUUID string) RelationshipTier {
+	if currentUserUUID == "" {
+		return TierUnknown
+	}
+	if len(p.Referrers.Referrers) == 0 {
+		// No referrer chain usually means searchEveryone=true matched.
+		return TierThirdDegree
+	}
+	for _, r := range p.Referrers.Referrers {
+		if r.ID == currentUserUUID {
+			return TierFirstDegree
+		}
+	}
+	return TierSecondDegree
+}
+
+// createSearchRequest is the POST /api/search body. Field names are
+// camelCase; the server rejects snake_case silently with 500.
+type createSearchRequest struct {
+	RequestText        string        `json:"requestText"`
+	RequestContent     []slateBlock  `json:"requestContent"`
+	RequestGroups      []string      `json:"requestGroups"`
+	ParentRequestID    *string       `json:"parentRequestId"`
+	ExcludePersonUUIDs []string      `json:"excludePersonUUIDs"`
+	SearchEveryone     bool          `json:"searchEveryone"`
+	CreditID           *string       `json:"creditId"`
+}
+
+type slateBlock struct {
+	Type     string         `json:"type"`
+	Children []slateInline  `json:"children"`
+}
+
+type slateInline struct {
+	Text string `json:"text"`
+}
+
+type createSearchResponse struct {
+	Status string `json:"status"`
+	ID     string `json:"id"`
+}
+
+// dynamoEntry is the wrapper for one polled search record. The
+// /api/dynamo?requestId= endpoint returns an array with exactly one
+// element in practice.
+type dynamoEntry struct {
+	RequestID    string          `json:"request_id"`
+	RequestText  string          `json:"request_text"`
+	RequestStatus string         `json:"request_status"`
+	Completed    bool            `json:"completed"`
+	Logs         []SearchLog     `json:"logs"`
+	Results      []Person        `json:"results"`
+}
+
+// SearchPeopleByQuery runs a Happenstance natural-language people-search
+// with configurable tier filtering and blocks until results are ready
+// or PollTimeout fires. When opts is nil, default tiers apply
+// (1st + 2nd degree, no public).
+func (c *Client) SearchPeopleByQuery(query string, opts *SearchPeopleOptions) (*PeopleSearchResult, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, errors.New("happenstance people-search: empty query")
+	}
+	if c.cookieAuth == nil {
+		return nil, errors.New("happenstance people-search: cookie auth not configured (run `contact-goat-pp-cli auth login`)")
+	}
+
+	o := defaultSearchOptions()
+	if opts != nil {
+		// Respect explicit tier choices. When the caller passes
+		// opts with all three tiers false, we raise — that is always a
+		// bug because Happenstance needs at least one tier to search.
+		o = *opts
+		if o.PollTimeout == 0 {
+			o.PollTimeout = 60 * time.Second
+		}
+		if o.PollInterval == 0 {
+			o.PollInterval = 1 * time.Second
+		}
+	}
+	if !o.IncludeMyConnections && !o.IncludeMyFriends && !o.SearchEveryone {
+		return nil, errors.New("happenstance people-search: at least one tier must be enabled (include_my_connections, include_my_friends, or search_everyone)")
+	}
+
+	// Refresh the session proactively; a sub-60-second search that
+	// spans a JWT expiry would otherwise fail mid-poll.
+	if err := c.MaybeRefreshSession(); err != nil {
+		return nil, fmt.Errorf("happenstance people-search: refresh session: %w", err)
+	}
+
+	reqID, err := c.createSearch(query, o)
+	if err != nil {
+		return nil, err
+	}
+
+	final, err := c.pollSearch(reqID, o.PollTimeout, o.PollInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PeopleSearchResult{
+		RequestID: final.RequestID,
+		Query:     final.RequestText,
+		Status:    final.RequestStatus,
+		Completed: final.Completed,
+		Logs:      final.Logs,
+		People:    final.Results,
+	}, nil
+}
+
+// SearchPeopleByCompany is a convenience wrapper that phrases the query
+// as "people at <company>" with default tier settings (1st + 2nd
+// degree). It is the direct replacement for contact-goat's coverage
+// command's narrow friends/list-only source.
+func (c *Client) SearchPeopleByCompany(company string) (*PeopleSearchResult, error) {
+	return c.SearchPeopleByQuery(fmt.Sprintf("people at %s", company), nil)
+}
+
+// createSearch posts the request body and returns the request uuid the
+// server assigns. It does not wait for results — see pollSearch.
+func (c *Client) createSearch(query string, o SearchPeopleOptions) (string, error) {
+	groups := make([]string, 0, 2)
+	if o.IncludeMyConnections {
+		groups = append(groups, "your-connections")
+	}
+	if o.IncludeMyFriends {
+		groups = append(groups, "your-friends")
+	}
+
+	var parent *string
+	if o.ParentRequestID != "" {
+		parent = &o.ParentRequestID
+	}
+	excludes := o.ExcludePersonUUIDs
+	if excludes == nil {
+		excludes = []string{}
+	}
+
+	body := createSearchRequest{
+		RequestText: query,
+		RequestContent: []slateBlock{
+			{Type: "p", Children: []slateInline{{Text: query}}},
+		},
+		RequestGroups:      groups,
+		ParentRequestID:    parent,
+		ExcludePersonUUIDs: excludes,
+		SearchEveryone:     o.SearchEveryone,
+		CreditID:           nil,
+	}
+
+	raw, status, err := c.Post("/api/search", body)
+	if err != nil {
+		return "", fmt.Errorf("happenstance POST /api/search: %w", err)
+	}
+	if status >= 400 {
+		return "", fmt.Errorf("happenstance POST /api/search: HTTP %d (body: %s)", status, truncateForError(string(raw), 300))
+	}
+	if status == 204 || len(raw) == 0 {
+		// 204 is the Clerk-signed-out path: the request landed on a
+		// signed-out session. Force a refresh and retry once.
+		if refErr := c.refreshClerkSession(); refErr != nil {
+			return "", fmt.Errorf("happenstance POST /api/search: HTTP %d empty body (likely signed-out). Refresh also failed: %w", status, refErr)
+		}
+		raw, status, err = c.Post("/api/search", body)
+		if err != nil {
+			return "", fmt.Errorf("happenstance POST /api/search (retry): %w", err)
+		}
+		if status >= 400 {
+			return "", fmt.Errorf("happenstance POST /api/search (retry): HTTP %d (body: %s)", status, truncateForError(string(raw), 300))
+		}
+		if status == 204 || len(raw) == 0 {
+			return "", fmt.Errorf("happenstance POST /api/search: HTTP %d empty body after refresh (session may be revoked - re-run `auth login --chrome`)", status)
+		}
+	}
+
+	var resp createSearchResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("happenstance POST /api/search: decode response: %w (status=%d body: %s)", err, status, truncateForError(string(raw), 200))
+	}
+	if resp.ID == "" {
+		return "", fmt.Errorf("happenstance POST /api/search: server returned empty id (body: %s)", truncateForError(string(raw), 200))
+	}
+	return resp.ID, nil
+}
+
+// pollSearch polls /api/dynamo?requestId= until the search completes or
+// timeout fires. Returns the final dynamo entry even if the timeout
+// fired, so callers can see partial progress (with completed=false).
+func (c *Client) pollSearch(requestID string, timeout, interval time.Duration) (*dynamoEntry, error) {
+	deadline := time.Now().Add(timeout)
+
+	var last dynamoEntry
+	for {
+		entries, err := c.fetchDynamo(requestID)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("happenstance poll: empty dynamo response for requestId %s", requestID)
+		}
+		last = entries[0]
+		if last.Completed {
+			return &last, nil
+		}
+
+		if time.Now().After(deadline) {
+			// Return partial result rather than the bare timeout error:
+			// callers may want to render what the server streamed so far.
+			return &last, fmt.Errorf("happenstance poll: timeout after %s waiting for requestId %s (last status: %q)",
+				timeout, requestID, last.RequestStatus)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func (c *Client) fetchDynamo(requestID string) ([]dynamoEntry, error) {
+	raw, err := c.Get("/api/dynamo", map[string]string{"requestId": requestID})
+	if err != nil {
+		return nil, fmt.Errorf("happenstance GET /api/dynamo: %w", err)
+	}
+	var entries []dynamoEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("happenstance GET /api/dynamo: decode: %w (body: %s)", err, truncateForError(string(raw), 300))
+	}
+	return entries, nil
+}
+
+func truncateForError(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...[truncated]"
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-contact-goat/SKILL.md
+++ b/plugin/skills/pp-contact-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-contact-goat
-description: "Printing Press CLI for contact-goat. Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has. Trigger phrases: 'install contact-goat', 'use contact-goat', 'run contact-goat', 'contact-goat commands', 'setup contact-goat'."
+description: "Printing Press CLI for contact-goat. Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has. Capabilities include: analytics, budget, clerk, config, coverage, deepline, dossier, dynamo, engagement, feed, friends, graph, groups, hp, intersect, linkedin, notifications, prospect, research, search, since, tail, uploads, user, warm-intro, waterfall. Trigger phrases: 'install contact-goat', 'use contact-goat', 'run contact-goat', 'contact-goat commands', 'setup contact-goat'."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata: '{"openclaw":{"requires":{"bins":["contact-goat-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@latest","bins":["contact-goat-pp-cli"],"label":"Install via go install"}]}}'
@@ -51,6 +51,33 @@ Parse `$ARGUMENTS`:
 1. Check if installed: `which contact-goat-pp-cli`
    If not found, offer to install (see CLI Installation above).
 2. Discover commands: `contact-goat-pp-cli --help`
+   Key commands:
+   - `analytics` — Run analytics queries on locally synced data
+   - `budget` — Deepline credit spend: totals, top tools, and history
+   - `clerk` — Get a user's profile by UUID (used for resolving friend/author references)
+   - `config` — Configure contact-goat-pp-cli (BYOK providers, defaults, etc.)
+   - `coverage` — Show who you know at a company (LinkedIn + Happenstance)
+   - `deepline` — Deepline contact-data API: email, phone, and company enrichment (credit-priced)
+   - `dossier` — Build a unified person dossier across LinkedIn, Happenstance, and Deepline
+   - `dynamo` — Get a search by request_id
+   - `engagement` — Score last-touch engagement with a person across all sources
+   - `feed` — Get the Happenstance feed (posts from your network)
+   - `friends` — List your Happenstance friends (your network's top connectors)
+   - `graph` — Export or inspect the unified contact graph
+   - `groups` — List your Happenstance groups (hpn-CLI parity, not in sniffed spec)
+   - `hp` — Happenstance graph commands (1st / 2nd / 3rd degree people-search)
+   - `intersect` — Find people in BOTH your LinkedIn 1st-degree AND Happenstance friends
+   - `linkedin` — LinkedIn scraper powered by stickerdaniel/linkedin-mcp-server
+   - `notifications` — List Happenstance notifications
+   - `prospect` — Fan-out search across LinkedIn, Happenstance, and (opt-in) Deepline
+   - `research` — List history
+   - `search` — Full-text search across synced data or live API
+   - `since` — Time-windowed diff of new items across LinkedIn + Happenstance
+   - `tail` — Stream NEW items across LinkedIn + Happenstance (and optionally Deepline)
+   - `uploads` — Get the status of the user's uploaded data sources (LinkedIn, Gmail, etc)
+   - `user` — Get the current user's usage limits (searches remaining, renewal date)
+   - `warm-intro` — Find who in your network can intro you to a target (cross-source)
+   - `waterfall` — Clay-style waterfall enrichment: free sources first, Deepline with BYOK or managed
 3. Match the user query to the best command. Drill into subcommand help if needed: `contact-goat-pp-cli <command> --help`
 4. Execute with the `--agent` flag:
    ```bash


### PR DESCRIPTION
## Summary

Unlocks the full Happenstance graph from contact-goat-pp-cli. Ships all 7 units of `docs/plans/2026-04-19-003-feat-contact-goat-happenstance-full-network-plan.md`.

Before this PR: `coverage "Warner Bros"` returned 0 rows, the Clerk session died every 60 seconds with HTTP 404, warm-intro surfaced top-3 HP friends by raw connection count, and `linkedin get-person` broke on every call due to upstream arg-name drift.

After: `coverage` and `hp people` see Matt's full synced network (19 people at Weber Inc, 30 at Warner Bros verified live), session auth survives Chrome-length sessions, warm-intro surfaces evidence-based candidates with concrete "knows X at $COMPANY" rationale, and the LinkedIn MCP contract is back in sync.

## Units landed (7/7)

1. Sniff artifacts (`library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/`) documenting real endpoints + fixtures for replay tests.
2. Clerk session refresh: `/tokens` -> `/touch`, add `_clerk_js_version`, parse Set-Cookie directly instead of a nonexistent JSON body, strip trailing colon from `clerk_active_context`, surface `X-Clerk-Auth-*` headers in error messages.
3. `hp people <query>` command + `SearchPeopleByQuery` / `SearchPeopleByCompany` client primitives. Tier flags (`--connections`, `--friends`, `--everyone`, `--no-*`). `Person.Tier()` derives 1st/2nd/3rd degree from the referrer chain. Typed errors with 204 "signed-out" retry.
4. `coverage` now uses the graph search as Source 1. Tag taxonomy: `hp_graph_1deg`, `hp_graph_2deg`, `hp_graph_3deg`. Top-connector hits get an additional `hp_friend` tag when they appear in both sources. `source_errors` JSON block and stderr warnings replace the silent-empty failure mode.
5. `warm-intro` now calls graph-search at the target's current company. 1st-degree hits become direct-ask candidates. 2nd-degree hits surface the REFERRER (your friend who knows them) as the intro candidate with concrete rationale: "your friend, knows $TARGET_COWORKER at $COMPANY (affinity: high)". 3rd-degree hits filtered out. Falls back to HP-friends dump only when target company is unknown, and labels it loudly as weak signal.
6. LinkedIn MCP contract fix: `linkedin_url` -> `linkedin_username`, list-typed `sections` -> comma-joined string, `get-company` `company_slug` -> `company_name`. `normalizePersonInput` strips URL wrappers so bare slugs and full URLs both resolve. Upstream LinkedIn MCP filter PR tracked separately in `~/.osc/plans/2026-04-19-032-feat-linkedin-mcp-search-people-connection-filters-plan.md`.
7. Doctor now fetches `/api/uploads/status/user` and surfaces "Happenstance: graph coverage: linkedin_ext: COMPLETED, last refreshed YYYY-MM-DD (Nd ago)". On refresh failure, replaces the misleading "will refresh on next request" line with "expired; refresh FAILED: <clerk reason>" so drift is visible. Regenerates `plugin/skills/pp-contact-goat/SKILL.md` and bumps plugin to 1.1.16.

## Tests

- `internal/client/cookie_auth_test.go` - 4 tests covering `/touch` path regression, both query params, Clerk error header surfacing, missing session id, and 2s refresh-collapse window.
- `internal/cli/linkedin_test.go` - 2 tests covering `normalizePersonInput` URL-to-slug normalization across http/https and with/without trailing slash, plus `normalizeSections` join.
- `go test ./...` green.

## Live validation

- Sniffed the Happenstance web app against Matt's signed-in Chrome session on 2026-04-19.
- `POST /api/search` confirmed end-to-end: returns real requestIds. Dynamo poll streams status through to completion.
- Warner Bros search returned 30 people. Weber Inc returned 19 including Jennifer Bonuso at President Americas (verified 1st-degree with Matt as referrer).
- `hp people` command successfully exercises the full pipeline.
- Doctor output includes the new graph-coverage line.

## Post-Deploy Monitoring & Validation

- What to monitor: `contact-goat-pp-cli doctor` should keep the `Happenstance: session JWT: valid` line across a 5-minute idle window. Previously it went `expired` within 60 seconds.
- Validation command: `contact-goat-pp-cli hp people "people at Weber Inc" --agent --limit 5`
- Expected: JSON with `count >= 1`, `relationship` field on each row, `current_user_uuid` populated, `source_errors` empty.
- Failure signal / rollback trigger: If `hp people` returns `HTTP 204 empty body` repeatedly after a fresh cookie import, revert and re-sniff - Happenstance may have rotated the endpoint contract.
- Validation window: 48 hours. Owner: @mvanhorn.

## Known caveats

- One specific live `hp people` poll hung 90s on "Thinking about who you're looking for" while the same search was instant in the browser moments later. Looks like server-side queueing on the free tier, not a client bug. The pipeline itself is correct.

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.56.1