### PR TITLE
fix(contact-goat): parse fresh JWT from Clerk /touch body (fixes post-#91 204 loop)

### DIFF
--- a/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
+++ b/library/sales-and-crm/contact-goat/internal/client/cookie_auth.go
@@ -265,31 +265,55 @@ func (c *Client) refreshClerkSession() error {
 			resp.StatusCode, status, reason, msg)
 	}
 
-	// Drain the response body. /touch emits fresh __session via
-	// Set-Cookie; we parse those headers directly rather than relying on
-	// Go's cookiejar to scope them correctly. Without a PublicSuffixList
-	// the jar sometimes stores Set-Cookie Domain=.happenstance.ai as
-	// host-only for the request host (clerk.happenstance.ai), which
-	// means subsequent POSTs to happenstance.ai/api/search don't carry
-	// the fresh JWT and the server returns 204 "signed-out".
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// /touch returns the fresh JWT in the JSON body at
+	// response.last_active_token.jwt. It does NOT set a Set-Cookie:
+	// __session header — only __client_uat. The response.body shape
+	// captured on 2026-04-19:
+	//   { "response": { "last_active_token": { "jwt": "eyJ..." }, ... } }
+	// Also present under response.client.sessions[0].last_active_token
+	// for clients with multiple sessions; the outer one is the active
+	// session and is what we want.
+	bodyBytes, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("clerk refresh: read body: %w", readErr)
+	}
 
 	var freshSession string
-	// resp.Cookies() parses Set-Cookie from the response headers.
-	for _, sc := range resp.Cookies() {
-		if sc.Name == "__session" && sc.Value != "" {
-			freshSession = sc.Value
-			break
+	if len(bodyBytes) > 0 {
+		var parsed struct {
+			Response struct {
+				LastActiveToken struct {
+					JWT string `json:"jwt"`
+				} `json:"last_active_token"`
+			} `json:"response"`
+		}
+		if err := json.Unmarshal(bodyBytes, &parsed); err == nil {
+			freshSession = parsed.Response.LastActiveToken.JWT
 		}
 	}
+
+	// Fallback 1: Set-Cookie header (kept for forward compatibility in
+	// case Clerk starts emitting __session via cookie again).
 	if freshSession == "" {
-		// Fall back to whatever the jar stored; some Clerk paths rely on
-		// the jar's own Set-Cookie handling even when the response-level
-		// parse returns nothing.
+		for _, sc := range resp.Cookies() {
+			if sc.Name == "__session" && sc.Value != "" {
+				freshSession = sc.Value
+				break
+			}
+		}
+	}
+	// Fallback 2: the jar (in case Clerk's cookie scoping lands on
+	// happenstance.ai directly without the PublicSuffixList quirk).
+	if freshSession == "" {
 		freshSession = c.sessionCookieValue()
 	}
 	if freshSession == "" {
-		return errors.New("clerk refresh: 200 OK but no __session cookie in response or jar")
+		return errors.New("clerk refresh: 200 OK but no fresh JWT in response body or cookies")
+	}
+	// Guard: if we fell through to the jar, the value may be the same
+	// expired JWT we started with. Detect and surface that clearly.
+	if IsJWTExpired(freshSession) {
+		return errors.New("clerk refresh: 200 OK but returned JWT is already expired (session likely revoked — re-run `auth login --chrome`)")
 	}
 
 	// Mirror the fresh __session across every host that subsequent

--- a/library/sales-and-crm/contact-goat/internal/client/cookie_auth_test.go
+++ b/library/sales-and-crm/contact-goat/internal/client/cookie_auth_test.go
@@ -115,6 +115,65 @@ func TestRefreshClerkSession_SurfaceClerkHeadersOn401(t *testing.T) {
 	}
 }
 
+// TestRefreshClerkSession_ReadsJWTFromResponseBody guards against the
+// regression we hit on 2026-04-20: Clerk's /touch returns the fresh
+// JWT in response.last_active_token.jwt, NOT via Set-Cookie: __session.
+// Only __client_uat comes back as a Set-Cookie. If the refresher only
+// looks at Set-Cookie it keeps the expired __session in the jar and
+// every subsequent Happenstance request gets a 204 signed-out.
+func TestRefreshClerkSession_ReadsJWTFromResponseBody(t *testing.T) {
+	freshJWT := "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjI1MjQ2MDgwMDB9.sig" // exp=2050
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mirror the real Clerk shape: only __client_uat via Set-Cookie.
+		http.SetCookie(w, &http.Cookie{Name: "__client_uat", Value: "1776619443", Path: "/"})
+		fmt.Fprintf(w, `{"response":{"object":"session","status":"active","last_active_token":{"object":"token","jwt":"%s"}},"client":{}}`, freshJWT)
+	}))
+	defer srv.Close()
+
+	oldBase := clerkBaseURL
+	clerkBaseURL = srv.URL
+	defer func() { clerkBaseURL = oldBase }()
+
+	c := seedClient(t, srv.Client())
+
+	if err := c.refreshClerkSession(); err != nil {
+		t.Fatalf("refreshClerkSession: %v", err)
+	}
+
+	// The fresh JWT must be written into the jar under .happenstance.ai
+	// so subsequent POSTs to /api/search carry it.
+	got := c.sessionCookieValue()
+	if got != freshJWT {
+		t.Errorf("jar's __session not updated from response body:\n  got  %q\n  want %q", got, freshJWT)
+	}
+}
+
+// TestRefreshClerkSession_ErrorsWhenBodyJWTExpired guards the guard:
+// a /touch response that (somehow) returns an already-expired JWT must
+// surface a clear error rather than silently keeping it, since every
+// subsequent request would fail with a cryptic 204.
+func TestRefreshClerkSession_ErrorsWhenBodyJWTExpired(t *testing.T) {
+	expiredJWT := "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjF9.sig" // exp=1970
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"response":{"last_active_token":{"jwt":"%s"}},"client":{}}`, expiredJWT)
+	}))
+	defer srv.Close()
+
+	oldBase := clerkBaseURL
+	clerkBaseURL = srv.URL
+	defer func() { clerkBaseURL = oldBase }()
+
+	c := seedClient(t, srv.Client())
+
+	err := c.refreshClerkSession()
+	if err == nil {
+		t.Fatal("expected error when refresh returns an expired JWT, got nil")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("error does not mention expiry: %v", err)
+	}
+}
+
 func TestRefreshClerkSession_MissingSessionID(t *testing.T) {
 	c := &Client{BaseURL: "https://happenstance.ai", HTTPClient: &http.Client{}}
 	jar, _ := cookiejar.New(nil)


### PR DESCRIPTION
## Summary

- Clerk's `/touch` returns the fresh session JWT in the JSON response body at `response.last_active_token.jwt`, not via `Set-Cookie: __session`. PR #91 assumed the opposite, so `refreshClerkSession` silently kept the expired JWT in the jar.
- Every Happenstance request since #91 hit `POST /api/search` → 204 "signed-out" → retry with same expired JWT → cryptic ``session may be revoked - re-run `auth login --chrome` `` error, even with fresh Chrome cookies.
- Fix: read and JSON-parse the `/touch` body; fall back to `Set-Cookie` + jar for forward compatibility; guard the fallback so an already-expired JWT is surfaced as a clear error instead of silently retained.

## Evidence

Before this PR, on tip of `main` (be86607):

```
$ contact-goat-pp-cli hp people "people who work at Disney"
Error: happenstance POST /api/search: HTTP 204 empty body after refresh
(session may be revoked - re-run `auth login --chrome`)
```

Direct curl to `/touch` on the same cookies shows only `__client_uat` in `Set-Cookie` and the fresh JWT inside `response.last_active_token.jwt` — confirming the PR #91 assumption was incorrect.

After this PR, same command, same cookies:

```json
{
  "request_id": "...",
  "query": "people who work at Disney",
  "completed": true,
  "people": [
    { "name": "Evan Schneider", "relationship": "1st_degree",
      "current_title": "Staff Product Manager", "current_company": "Ghost",
      "summary": "Former PM at Disney (ABC, FXNOW, National Geographic TV apps)" },
    { "name": "Jack Mackey Jr.", "relationship": "2nd_degree",
      "current_title": "Wine Educator", "referrers": [{"name":"Garry Tan"}] },
    ...
  ]
}
```

## Tests

- `TestRefreshClerkSession_ReadsJWTFromResponseBody` (new): mirrors the real Clerk shape (only `__client_uat` as `Set-Cookie`, JWT in body) and asserts the jar is updated.
- `TestRefreshClerkSession_ErrorsWhenBodyJWTExpired` (new): covers the fallback guard.
- Existing `TestRefreshClerkSession_HitsTouchEndpointNotTokens`, `_SurfaceClerkHeadersOn401`, `_MissingSessionID`, `_CollapsesConcurrentCalls` all still pass (Set-Cookie fallback is preserved).

## Test plan

- [x] `go test ./library/sales-and-crm/contact-goat/internal/client/...` — all 6 TestRefreshClerkSession tests pass
- [x] `go build ./...` clean
- [x] End-to-end: `hp people` and `coverage --source hp` return real Happenstance results with no 204 loops

## Notes

- Does not modify SKILL.md or touch `plugin/skills/*`, so the manual `plugin.json` version bump in AGENTS.md does not apply.
- The sniff doc (`.manuscripts/happenstance-sniff-2026-04-19/README.md`) says `/touch` "Sets a fresh `__session` cookie on the `.happenstance.ai` domain" — that is incorrect per the live response captured today. Worth updating in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)