### PR TITLE
docs(contact-goat): correct /touch sniff + stop doctor lying about auth

### DIFF
--- a/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/README.md
+++ b/library/sales-and-crm/contact-goat/.manuscripts/happenstance-sniff-2026-04-19/README.md
@@ -36,7 +36,28 @@ cookies automatically via the jar. Body is empty.
 Headers of interest on response:
 - `X-Clerk-Auth-Status: signed-in`  (when the refresh succeeded)
 - `X-Clerk-Auth-Status: signed-out` with `X-Clerk-Auth-Reason: ...` (when the token is dead)
-- Sets a fresh `__session` cookie on the `.happenstance.ai` domain.
+- `Set-Cookie: __client_uat=...; Domain=happenstance.ai` (NOT `__session`)
+
+**The fresh JWT is in the JSON response body, not in Set-Cookie.** A live
+2026-04-20 capture on a signed-in session returned:
+
+```json
+{
+  "response": {
+    "object": "session",
+    "status": "active",
+    "last_active_token": { "object": "token", "jwt": "eyJ..." },
+    ...
+  },
+  "client": { "sessions": [{ "last_active_token": { "jwt": "eyJ..." }, ... }] }
+}
+```
+
+Consumers must parse the body and extract `response.last_active_token.jwt`,
+then write it into the cookie jar as `__session`. Relying on `resp.Cookies()`
+to pick up a Set-Cookie that Clerk never emits silently keeps the expired
+JWT in the jar and every subsequent Happenstance request returns 204
+"signed-out". (This was the original post-#91 regression; fixed in #92.)
 
 ### contact-goat bug
 

--- a/library/sales-and-crm/contact-goat/internal/cli/doctor.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/doctor.go
@@ -261,7 +261,12 @@ func checkHappenstanceGraphCoverage(flags *rootFlags, report map[string]any) {
 		return
 	}
 	if len(raw) == 0 {
-		report["happenstance_graph"] = "authenticated but uploads endpoint returned empty body (retry after a fresh `auth login --chrome`)"
+		// Empty body on an authenticated endpoint is Clerk's
+		// signed-out signal. It means the refresh above returned 200
+		// but didn't actually hand us a fresh JWT — usually because
+		// the source cookies are stale. Say so plainly; the previous
+		// phrasing ("authenticated but …") was misleading.
+		report["happenstance_graph"] = "signed-out (empty body on authenticated endpoint — session is dead, re-run `auth login --chrome` against a signed-in browser)"
 		return
 	}
 	var resp struct {


### PR DESCRIPTION
Two small follow-ups to #92 (the /touch JWT-in-body fix) so future contributors don't re-introduce the same regression.

## 1. Sniff doc corrected

`.manuscripts/happenstance-sniff-2026-04-19/README.md` previously claimed:

> Sets a fresh \`__session\` cookie on the \`.happenstance.ai\` domain.

That was the exact wrong premise that led #91 to wire the refresher around \`resp.Cookies()\`. A live 2026-04-20 capture shows \`/touch\` only sets \`__client_uat\` via \`Set-Cookie\`; the fresh JWT lives in the JSON body at \`response.last_active_token.jwt\`. The sniff README now reflects reality and calls out the #91→#92 regression so the next agent reading the manuscripts doesn't repeat it.

## 2. Doctor stops saying "authenticated" when the session is dead

When \`/api/uploads/status/user\` returns an empty body, \`doctor\` used to print:

> authenticated but uploads endpoint returned empty body (retry after a fresh \`auth login --chrome\`)

That was misleading — an empty body from an authenticated endpoint on this stack is Clerk's signed-out signal, not a partial-auth state. Doctor now says:

> signed-out (empty body on authenticated endpoint — session is dead, re-run \`auth login --chrome\` against a signed-in browser)

so users diagnose the real failure mode immediately.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean (\`internal/cli\` + \`internal/client\` both pass, including the two regression tests added in #92)
- [x] No user-facing CLI behavior change on the happy path — only the failure message on \`doctor\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)