### PR TITLE
fix(pp): uniform @main fallback for all 22 CLIs' install docs

### DIFF
--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -8,7 +8,15 @@ across LinkedIn, Happenstance, and Deepline from one SQLite-backed CLI.
 ### Go
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/contact-goat/cmd/contact-goat-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@latest
+```
+
+If `@latest` installs a stale build (the Go module proxy cache can lag
+the repo by hours after a fresh merge), install from main directly:
+
+```bash
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@main
 ```
 
 ### Binary

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-agent-capture/SKILL.md
+++ b/plugin/skills/pp-agent-capture/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture/cmd/agent-capture@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture/cmd/agent-capture@main
+   ```
 3. Verify: `agent-capture --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 

--- a/plugin/skills/pp-archive-is/SKILL.md
+++ b/plugin/skills/pp-archive-is/SKILL.md
@@ -158,6 +158,10 @@ Notable flags:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-cli@main
 archive-is-pp-cli doctor
 ```
 
@@ -165,6 +169,10 @@ archive-is-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-mcp@main
 claude mcp add archive-is-pp-mcp -- archive-is-pp-mcp
 ```
 

--- a/plugin/skills/pp-cal-com/SKILL.md
+++ b/plugin/skills/pp-cal-com/SKILL.md
@@ -207,6 +207,10 @@ Paginated commands also emit NDJSON progress events on stderr by default, so `--
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-cli@main
 cal-com-pp-cli auth set-token YOUR_CAL_COM_TOKEN
 cal-com-pp-cli doctor
 ```
@@ -215,6 +219,10 @@ cal-com-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-mcp@main
 claude mcp add -e CAL_COM_TOKEN=<token> cal-com-pp-mcp -- cal-com-pp-mcp
 ```
 

--- a/plugin/skills/pp-contact-goat/SKILL.md
+++ b/plugin/skills/pp-contact-goat/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@main
+   ```
 3. Verify: `contact-goat-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — log in via browser:
@@ -38,6 +44,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-dominos/SKILL.md
+++ b/plugin/skills/pp-dominos/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-pp-cli@main
+   ```
 3. Verify: `dominos-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — log in via browser:
@@ -38,6 +44,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/commerce/dominos-pp-cli/cmd/dominos-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-dub/SKILL.md
+++ b/plugin/skills/pp-dub/SKILL.md
@@ -199,6 +199,10 @@ Flag glossary:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-cli@main
 dub-pp-cli auth set-token YOUR_DUB_API_KEY
 dub-pp-cli doctor
 ```
@@ -207,6 +211,10 @@ dub-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-mcp@main
 claude mcp add -e DUB_API_KEY=<key> dub-pp-mcp -- dub-pp-mcp
 ```
 

--- a/plugin/skills/pp-espn/SKILL.md
+++ b/plugin/skills/pp-espn/SKILL.md
@@ -222,6 +222,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-cli@main
 espn-pp-cli doctor
 ```
 
@@ -229,6 +233,10 @@ espn-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-mcp@main
 claude mcp add espn-pp-mcp -- espn-pp-mcp
 ```
 

--- a/plugin/skills/pp-flightgoat/SKILL.md
+++ b/plugin/skills/pp-flightgoat/SKILL.md
@@ -169,6 +169,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/travel/flightgoat/cmd/flightgoat-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/travel/flightgoat/cmd/flightgoat-pp-cli@main
 flightgoat-pp-cli doctor
 ```
 

--- a/plugin/skills/pp-hackernews/SKILL.md
+++ b/plugin/skills/pp-hackernews/SKILL.md
@@ -160,6 +160,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli@main
 hackernews-pp-cli doctor  # verifies API reachability
 ```
 
@@ -169,6 +173,10 @@ hackernews-pp-cli doctor  # verifies API reachability
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-mcp@main
 claude mcp add hackernews-pp-mcp -- hackernews-pp-mcp
 ```
 

--- a/plugin/skills/pp-hubspot/SKILL.md
+++ b/plugin/skills/pp-hubspot/SKILL.md
@@ -162,6 +162,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-cli@main
 hubspot-pp-cli auth set-token YOUR_HUBSPOT_ACCESS_TOKEN
 hubspot-pp-cli doctor
 ```
@@ -170,6 +174,10 @@ hubspot-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot/cmd/hubspot-pp-mcp@main
 claude mcp add -e HUBSPOT_ACCESS_TOKEN=<token> hubspot-pp-mcp -- hubspot-pp-mcp
 ```
 

--- a/plugin/skills/pp-instacart/SKILL.md
+++ b/plugin/skills/pp-instacart/SKILL.md
@@ -209,6 +209,10 @@ Error surfaces worth translating for the user:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@main
 instacart-pp-cli --version
 ```
 

--- a/plugin/skills/pp-kalshi/SKILL.md
+++ b/plugin/skills/pp-kalshi/SKILL.md
@@ -178,6 +178,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-mcp@main
 claude mcp add -e KALSHI_API_KEY=<key> -e KALSHI_PRIVATE_KEY_PATH=<path> kalshi-pp-mcp -- kalshi-pp-mcp
 claude mcp list
 ```

--- a/plugin/skills/pp-linear/SKILL.md
+++ b/plugin/skills/pp-linear/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@main
+   ```
 3. Verify: `linear-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — set the API key and register it with the CLI:
@@ -39,6 +45,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-movie-goat/SKILL.md
+++ b/plugin/skills/pp-movie-goat/SKILL.md
@@ -275,6 +275,10 @@ Given `$ARGUMENTS`:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@main
 movie-goat-pp-cli --version
 ```
 
@@ -282,6 +286,10 @@ movie-goat-pp-cli --version
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-mcp@main
 claude mcp add movie-goat movie-goat-pp-mcp -e TMDB_API_KEY=<your-key>
 ```
 

--- a/plugin/skills/pp-pagliacci-pizza/SKILL.md
+++ b/plugin/skills/pp-pagliacci-pizza/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/food-and-dining/pagliacci-pizza/cmd/pagliacci-pizza-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/food-and-dining/pagliacci-pizza/cmd/pagliacci-pizza-pp-cli@main
+   ```
 3. Verify: `pagliacci-pizza-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — log in via browser:
@@ -40,6 +46,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/food-and-dining/pagliacci-pizza/cmd/pagliacci-pizza-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/food-and-dining/pagliacci-pizza/cmd/pagliacci-pizza-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-postman-explore/SKILL.md
+++ b/plugin/skills/pp-postman-explore/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@main
+   ```
 3. Verify: `postman-explore-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
@@ -33,6 +39,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-recipe-goat/SKILL.md
+++ b/plugin/skills/pp-recipe-goat/SKILL.md
@@ -196,6 +196,10 @@ Parse `$ARGUMENTS`:
 2. Install:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat-pp-cli/cmd/recipe-goat-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat-pp-cli/cmd/recipe-goat-pp-cli@main
    ```
 3. Verify: `recipe-goat-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -205,6 +209,10 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat-pp-cli/cmd/recipe-goat-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat-pp-cli/cmd/recipe-goat-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-slack/SKILL.md
+++ b/plugin/skills/pp-slack/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@main
+   ```
 3. Verify: `slack-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — set the API key and register it with the CLI:
@@ -39,6 +45,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-steam-web/SKILL.md
+++ b/plugin/skills/pp-steam-web/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@main
+   ```
 3. Verify: `steam-web-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — set the API key and register it with the CLI:
@@ -39,6 +45,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-trigger-dev/SKILL.md
+++ b/plugin/skills/pp-trigger-dev/SKILL.md
@@ -25,6 +25,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@main
+   ```
 3. Verify: `trigger-dev-pp-cli --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 5. Auth setup — set the API key and register it with the CLI:
@@ -39,6 +45,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-mcp@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-mcp@main
    ```
 2. Register with Claude Code:
    ```bash

--- a/plugin/skills/pp-weather-goat/SKILL.md
+++ b/plugin/skills/pp-weather-goat/SKILL.md
@@ -151,6 +151,10 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-cli@main
 weather-goat-pp-cli config set-location "Your City, ST"
 weather-goat-pp-cli doctor
 ```
@@ -159,6 +163,10 @@ weather-goat-pp-cli doctor
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-mcp@main
 claude mcp add weather-goat-pp-mcp -- weather-goat-pp-mcp
 ```
 

--- a/plugin/skills/pp-yahoo-finance/SKILL.md
+++ b/plugin/skills/pp-yahoo-finance/SKILL.md
@@ -244,6 +244,10 @@ Given `$ARGUMENTS`:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-cli@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-cli@main
 yahoo-finance-pp-cli --version
 ```
 
@@ -251,6 +255,10 @@ yahoo-finance-pp-cli --version
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-mcp@latest
+
+# If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+  go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-mcp@main
 claude mcp add yahoo-finance yahoo-finance-pp-mcp
 ```
 

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -268,10 +270,47 @@ func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		return false, fmt.Errorf("mkdir %s: %w", skillDir, err)
 	}
-	if err := os.WriteFile(skillFile, data, 0644); err != nil {
+	augmented := injectStaleBuildFallback(data)
+	if err := os.WriteFile(skillFile, augmented, 0644); err != nil {
 		return false, fmt.Errorf("write %s: %w", skillFile, err)
 	}
 	return true, nil
+}
+
+// injectStaleBuildFallback adds a short "if @latest is stale, install
+// from @main" code block right after every `go install ...@latest` line
+// that targets a printing-press-library cmd. Upstream (hand-authored)
+// SKILL.md files bypass the template, so they need this augmentation at
+// copy time to match what template-generated skills already ship.
+//
+// Idempotent: if the file already contains `@main` (either from a
+// prior run of this generator or hand-added guidance), we make no
+// changes and return the original bytes unchanged.
+func injectStaleBuildFallback(data []byte) []byte {
+	if bytes.Contains(data, []byte("@main")) {
+		return data
+	}
+	// Pattern: a line ending in `cmd/<binary>@latest` that is NOT inside
+	// the metadata JSON (metadata is always on line 6 of the frontmatter
+	// and uses a different quoting shape — we filter by the leading whitespace
+	// plus the `go install` prefix, which metadata does not have).
+	goInstallRE := regexp.MustCompile(
+		`(?m)^(\s*)(go install github\.com/mvanhorn/printing-press-library/library/[^\s@]+@latest)\s*$`)
+	fallbackBlock := func(indent, installCmd string) string {
+		mainCmd := strings.Replace(installCmd, "@latest", "@main", 1)
+		return fmt.Sprintf(
+			"%s%s\n%s\n%s# If `@latest` installs a stale build (Go module proxy cache lag), install from main:\n%sGOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \\\n%s  %s",
+			indent, installCmd, indent, indent, indent, indent, mainCmd)
+	}
+	return goInstallRE.ReplaceAllFunc(data, func(match []byte) []byte {
+		sub := goInstallRE.FindSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		indent := string(sub[1])
+		installCmd := string(sub[2])
+		return []byte(fallbackBlock(indent, installCmd))
+	})
 }
 
 // resolveCLIBinary resolves the CLI binary name using layered precedence:

--- a/tools/generate-skills/main_test.go
+++ b/tools/generate-skills/main_test.go
@@ -106,6 +106,53 @@ func TestCopyUpstreamSkill_OverwritesExisting(t *testing.T) {
 	}
 }
 
+// TestInjectStaleBuildFallback covers the copy-time augmentation that
+// teaches upstream (hand-authored) SKILL.md files the same @main
+// fallback the generator template already emits. See the 2026-04-19
+// stale-@latest bug for context.
+func TestInjectStaleBuildFallback(t *testing.T) {
+	t.Run("injects after go install @latest line in a code block", func(t *testing.T) {
+		in := []byte("## CLI Installation\n\n```bash\ngo install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-cli@latest\nyahoo-finance-pp-cli --version\n```\n")
+		got := string(injectStaleBuildFallback(in))
+		if !strings.Contains(got, "@main") {
+			t.Errorf("expected @main fallback injected, got:\n%s", got)
+		}
+		if !strings.Contains(got, "GOPRIVATE='github.com/mvanhorn/*'") {
+			t.Errorf("expected GOPRIVATE guidance injected, got:\n%s", got)
+		}
+		if !strings.Contains(got, "yahoo-finance-pp-cli@main") {
+			t.Errorf("expected binary-specific @main line, got:\n%s", got)
+		}
+	})
+
+	t.Run("is idempotent when @main already present", func(t *testing.T) {
+		in := []byte("go install github.com/mvanhorn/printing-press-library/library/x/cmd/x-pp-cli@latest\n\n# fallback: go install ...@main\n")
+		got := injectStaleBuildFallback(in)
+		if string(got) != string(in) {
+			t.Errorf("expected idempotent no-op when @main already present\nwant: %q\ngot:  %q", in, got)
+		}
+	})
+
+	t.Run("no go install lines means no injection", func(t *testing.T) {
+		in := []byte("# Title\n\nNarrative content with no install commands.\n")
+		got := injectStaleBuildFallback(in)
+		if string(got) != string(in) {
+			t.Errorf("expected no-op when no @latest install line present")
+		}
+	})
+
+	t.Run("skips metadata-JSON @latest since it is not a plain install line", func(t *testing.T) {
+		// The frontmatter metadata line is long and uses JSON quoting.
+		// Our regex requires a line starting with optional whitespace
+		// then `go install` — metadata lines do NOT satisfy this.
+		in := []byte("metadata: '{\"openclaw\":{\"install\":[{\"command\":\"go install github.com/mvanhorn/printing-press-library/library/x/cmd/x-pp-cli@latest\"}]}}'\n")
+		got := injectStaleBuildFallback(in)
+		if string(got) != string(in) {
+			t.Errorf("expected metadata @latest to be left alone (it is not a user-runnable line)")
+		}
+	})
+}
+
 func TestCopyUpstreamSkill_EmptyFallsThrough(t *testing.T) {
 	tmp := t.TempDir()
 	entryPath := filepath.Join(tmp, "library", "commerce", "blank")

--- a/tools/generate-skills/skill-template.md
+++ b/tools/generate-skills/skill-template.md
@@ -27,6 +27,12 @@ Parse `$ARGUMENTS`:
    ```bash
    go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.CLIBinary}}@latest
    ```
+
+   If `@latest` installs a stale build (the Go module proxy cache can lag the repo by hours after a fresh merge), install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.CLIBinary}}@main
+   ```
 3. Verify: `{{.CLIBinary}} --version`
 4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 {{- if eq .AuthType "api_key"}}
@@ -58,6 +64,12 @@ Parse `$ARGUMENTS`:
 1. Install the MCP server:
    ```bash
    go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.MCPBinary}}@latest
+   ```
+
+   If `@latest` installs a stale build, install from main directly:
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/{{.InstallPath}}/cmd/{{.MCPBinary}}@main
    ```
 2. Register with Claude Code:
    ```bash


### PR DESCRIPTION
Follow-up to PR #94 addressing R5 from docs/plans/2026-04-19-003-fix-contact-goat-usability-and-install-freshness-plan.md. After a fresh merge to main, `go install ...@latest` reliably serves a stale build for hours because `proxy.golang.org`'s `@latest` pointer lags repo HEAD. Today one user installed `@latest` right after a merge and silently got a build 8 days older than HEAD.

## What lands in every PP CLI

Right below every `go install ...@latest` line in every generated SKILL.md (and the contact-goat README), users now see:

\`\`\`
If \`@latest\` installs a stale build (Go module proxy cache lag), install from main:

GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \\
  go install github.com/mvanhorn/printing-press-library/.../<binary>@main
\`\`\`

No behavior change — purely additive documentation.

## Why two mechanisms

PP has two skill sources:

| Source | Count | Mechanism |
|---|---|---|
| Template-synthesized | 9 | \`tools/generate-skills/skill-template.md\` |
| Upstream (hand-authored) | 13 | \`library/<cat>/<cli>/SKILL.md\` copied verbatim |

Template change alone would have reached only 9/22 CLIs. Commit 2 teaches the generator's \`copyUpstreamSkill\` to inject the fallback at copy time, so hand-authored SKILL.md files stay clean while the shipped plugin output is uniform.

## Commits

1. \`docs(generate-skills): add stale-@latest escape hatch to install template\` — template-only change, affects the 9 template-synthesized skills.
2. \`feat(generate-skills): inject @main fallback into upstream SKILL.md on copy\` — generator helper \`injectStaleBuildFallback\` runs on every upstream copy, idempotent if the file already contains \`@main\`, skips metadata-JSON lines.
3. \`chore(plugin): regenerate pp-* skills + bump to 1.1.17\` — mechanical regen; AGENTS.md requires manual version bump for SKILL content changes.
4. \`docs(contact-goat): fix broken install path + add @main fallback to README\` — also fixes a pre-existing broken path (\`library/contact-goat/\` that does not exist; should be \`library/sales-and-crm/contact-goat/\`).

## Tests

New tests in \`tools/generate-skills/main_test.go\`:

- \`TestInjectStaleBuildFallback\` covers positive inject, idempotency, no-op when no install line present, and explicit skip for the frontmatter metadata-JSON \`@latest\`.
- Existing \`TestCopyUpstreamSkill_Present\` and \`_OverwritesExisting\` still pass because their fixtures don't contain \`@latest\`, so the new inject is a no-op on them.

\`\`\`
$ (cd tools/generate-skills && go test ./...)
ok   generate-skills   0.920s
\`\`\`

## Test plan

- [x] Generator tests green
- [x] 22 of 22 generated SKILL.md files contain \`@main\` after regen (was 0 of 22 before these commits)
- [x] Running the generator a second time produces no diff (idempotent)
- [x] Frontmatter \`metadata.openclaw.install\` JSON blocks unchanged (injection is line-anchored, doesn't touch them)
- [x] \`plugin.json\` version bumped exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)