### PR TITLE
fix(instacart): retry add on notFoundBasketProduct + actionable hint

### DIFF
--- a/docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md
+++ b/docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md
@@ -1,0 +1,316 @@
+---
+title: "fix: Retry instacart add on notFoundBasketProduct and surface actionable guidance"
+type: fix
+status: active
+date: 2026-04-19
+---
+
+# fix: Retry instacart add on notFoundBasketProduct and surface actionable guidance
+
+## Overview
+
+`instacart add <retailer> <query>` sometimes fails with `Instacart rejected the add: notFoundBasketProduct` even when the same retailer search returns valid items. A follow-up `add --item-id <id>` against the same retailer succeeds. The top pick from the live three-call chain is occasionally not addable at the active cart's shop, and we give up after the first try.
+
+This plan narrows the gap: when `UpdateCartItemsMutation` returns `notFoundBasketProduct`, walk the next ranked candidates before surfacing an error, and replace the terse error message with actionable guidance. Adds the first automated tests for the live `add` mutation surface.
+
+## Problem Frame
+
+Observed today (2026-04-19) at Costco with query `strawberries`:
+
+1. First `instacart-pp-cli add costco "strawberries"` returned exit code 5, `notFoundBasketProduct`.
+2. `instacart-pp-cli search strawberries --store costco --json` returned six valid items, top hit `items_1576-18876359` "Strawberries, 2 lbs".
+3. `instacart-pp-cli add --item-id items_1576-18876359 costco` succeeded against the same cart (id `757109404`).
+4. A second `add costco "strawberries" --no-history --dry-run --json` then chose the same `items_1576-18876359` that just worked.
+
+Root causes, from tracing `library/commerce/instacart/internal/cli/add.go` and `library/commerce/instacart/internal/gql/search.go`:
+
+- Autosuggest nondeterminism. `gql.ResolveProducts` generates a fresh `autosuggestionSessionId` UUID per call (`search.go:63`). The server can reorder suggestions between calls, and `rerank` can still place an item at results[0] that is not addable at the active cart's shop.
+- Shop / location drift. `ensureInventoryToken` caches the retailer inventory token for six hours (`search.go:29`) tied to the first shop that served a bootstrap. The active cart may have been created against a different Costco warehouse. Evidence: the observed cart contained `items_18148-25502282` (Dino Nuggets) alongside five `items_1576-...` items, so the cart has historically accepted items from multiple location prefixes but not every `1576` product is stocked at every shop the cart routes through.
+- Transient out-of-stock. The `Items` lookup returns a name and id without a reliable "addable right now at this shop" flag, so stock-outs surface only at mutation time.
+
+Today's behavior: single attempt, opaque error. The user has no idea that `search` + `--item-id` would have worked, or that the next candidate in the autosuggest list is likely addable.
+
+## Requirements Trace
+
+- R1. When `UpdateCartItemsMutation` returns `notFoundBasketProduct`, the CLI retries with the next ranked candidate(s) from the already-fetched result set before returning an error.
+- R2. Retry count, attempted item ids, and the resolver path are visible in `--json` output so agents can see which candidate landed.
+- R3. When all candidates exhaust, the CLI surfaces guidance that names the concrete next step (`search` then `add --item-id`, or `--no-history`).
+- R4. The retry path is covered by unit tests that exercise the mutation loop without a live network.
+- R5. The history-first resolver path still writes back on successful adds, regardless of which candidate succeeded.
+- R6. Change ships as a PR to `main` (never a direct push), with release notes in the PR description.
+
+## Scope Boundaries
+
+- Not changing `gql.ResolveProducts` ordering, rerank weights, or the autosuggest sanitization.
+- Not filtering candidates by active-cart location prefix. The cart has been observed mixing prefixes, so prefix filtering would drop valid adds; retry is cheaper and covers more cases.
+- Not broadening the retryable error set beyond `notFoundBasketProduct` in this change. Other `ErrorType` values (for example `soldOut`, `unavailable`) are out of scope here and noted as a follow-up.
+- Not adding live integration tests against Instacart's API. Unit tests around a mockable mutation seam only.
+- Not changing the `--item-id` direct path. When a user supplies an id, we still make exactly one attempt.
+- Not restructuring the `add` command's argument parsing or the history-first resolver.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `library/commerce/instacart/internal/cli/add.go`, the single file that owns the live `add` flow. `newAddCmd` at line 25, live resolver branch at lines 94-109, mutation call at lines 156-178, `resolveActiveCartID` at line 337.
+- `library/commerce/instacart/internal/gql/search.go`, `ResolveProducts` (line 40). Already returns up to `limit` ranked results; today only `results[0]` is used in `add.go:108`.
+- `library/commerce/instacart/internal/instacart/` (types package). `UpdateCartItemsResponse`, `UpdateCartItemsVars`, `CartItemUpdate` live here and already expose `ErrorType`.
+- `library/commerce/instacart/internal/gql/client.go`, the `*gql.Client.Mutation` method. Currently called inline from `add.go`.
+- `library/commerce/instacart/internal/cli/add_history_test.go`, the established test pattern. Uses `newTestApp(t)` with a per-test SQLite store and no network.
+- `library/commerce/instacart/internal/cli/history_hints_test.go`, pattern for asserting formatted-string hints.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md` already documents that Instacart's web API does not expose a clean order-history op and backfill must come from the DOM. Same theme applies here: Instacart's server-side shape is authoritative and we adapt to observed responses rather than enforce client-side invariants.
+
+### External References
+
+None gathered. The relevant surfaces are all in-repo and the error string is Instacart-specific.
+
+## Key Technical Decisions
+
+- Retry with the existing `ResolveProducts` result slice rather than re-querying. The autosuggest chain already returns up to five ranked items; re-querying would get a fresh session and reshuffle. Reusing the slice preserves relevance ordering.
+- Retry ceiling of three total attempts (initial + two retries) when the original candidate set is large enough. Rationale: the first real miss is usually the top pick; a second or third candidate almost always wins. More than three attempts would pile latency without improving success rates and could look like hammering if Instacart tightens basket validation later. Configurable via a package constant, not a user flag.
+- Only `notFoundBasketProduct` triggers retry in this change. Other `ErrorType` values surface unchanged. Rationale: scope discipline and a real observed symptom to validate against. Future error codes can be added to a small allowlist.
+- Extract a small helper, `tryAddCandidates(app, retailer, cartID, candidates, qty)`, so the mutation loop is unit-testable via an injectable mutation invoker. The cobra `RunE` stays thin.
+- Guidance on exhaustion names the exact next commands the user should run, including their own query string. Example copy: `all 3 candidates rejected as notFoundBasketProduct. Try: instacart search "<query>" --store <retailer> then instacart add --item-id <id> <retailer>. Or retry with --no-history.`
+- JSON output adds `attempts: [{item_id, name, error_type}]` when retries happened. When a retry succeeds, `resolved_via` stays as its original value (`live` or `history`); an additional `retry_count` integer reports how many candidates were tried before success.
+- Exit code stays 5 (`ExitConflict`) on exhaustion, preserving the current contract for agents grepping exit codes.
+- Location-prefix filtering rejected. The observed cart mixes prefixes, so filtering would drop valid adds. Retry covers the failure mode at less cost.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should retry re-run the full autosuggest chain? No. Reuse the already-ranked slice; fresh queries risk reshuffling and add latency.
+- Should we widen the retryable error set now? No. Limit to the observed symptom; widen when we have a second confirmed symptom.
+- Should the history-first resolver path also retry? Yes, but via a different mechanism. When the history hit fails with `notFoundBasketProduct`, fall back to a live search and then run the same retry loop on those candidates. Write-back still only fires on the candidate that actually succeeded.
+- Is the retry ceiling a flag? No for now. A package constant keeps the surface tiny; promoting to a flag is a one-line change later.
+
+### Deferred to Implementation
+
+- Exact helper signature and return shape. The test scenarios below describe behavior; the implementer chooses the cleanest interface.
+- Whether `resolveActiveCartID` needs to be called again on retry. Expected answer: no, the cart id is stable for the duration of the command. Verify against the types in `instacart/types.go` during implementation.
+- Whether to log a one-line notice to stderr on retry when not in `--json` mode. Lean toward yes, but leave the wording to implementation.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+Today's flow, one attempt:
+
+```
+ResolveProducts -> results[0] -> UpdateCartItemsMutation
+                                   |
+                                   ErrorType != "" -> return error
+```
+
+After change, up to three attempts:
+
+```
+ResolveProducts -> results[0..N]
+        |
+        v
+  tryAddCandidates loops:
+    attempt = UpdateCartItemsMutation(results[i])
+    if attempt.ErrorType == "notFoundBasketProduct" and more candidates and under cap:
+        record {item_id, name, error_type} and advance i
+        continue
+    if attempt.ErrorType != "":
+        return error with attempts log
+    return success with retry_count, picked candidate
+```
+
+History-first path rejoins the live loop on failure:
+
+```
+history hit -> single attempt
+     |
+     ErrorType == "notFoundBasketProduct" -> fall through to ResolveProducts
+                                              then tryAddCandidates as above
+```
+
+## Implementation Units
+
+- [ ] Unit 1: Extract mutation loop into a testable helper
+
+Goal: Introduce `tryAddCandidates` (or equivalent) that encapsulates the mutation call and retry policy. Keep cobra `RunE` thin.
+
+Requirements: R1, R2, R4.
+
+Dependencies: None.
+
+Files:
+- Modify: `library/commerce/instacart/internal/cli/add.go`
+- Test: `library/commerce/instacart/internal/cli/add_test.go` (new)
+
+Approach:
+- Move the existing `client.Mutation("UpdateCartItemsMutation", ...)` call plus response parsing into a helper that accepts the already-resolved candidate slice, quantity, cart id, and a mutation invoker function.
+- Iterate candidates up to the retry ceiling. On `notFoundBasketProduct`, record the attempt and continue. On any other `ErrorType`, return immediately. On a clean response, return the winning candidate and the attempt log.
+- The mutation invoker is a function value so the unit test can substitute a fake without touching `gql.Client`.
+- Preserve the existing write-back call to `writeBackPurchasedItem` when the helper reports success, using the winning candidate rather than the original top pick.
+
+Patterns to follow:
+- `AppContext` / `newAppContext` plumbing already used throughout `internal/cli/*.go`.
+- Test setup shape from `add_history_test.go` (`newTestApp(t)` with a tmpdir store).
+- Error wrapping via `coded(ExitConflict, ...)` as already used at `add.go:177`.
+
+Test scenarios:
+- Happy path: first candidate succeeds; helper returns that candidate, `retry_count == 0`, and no attempt log entries.
+- Retry-then-succeed: first candidate returns `notFoundBasketProduct`, second succeeds; helper returns the second candidate, `retry_count == 1`, and one entry in the attempt log with the first item id and error type.
+- Retry-cap: three straight `notFoundBasketProduct` responses with three candidates; helper returns a conflict error, attempt log has three entries, no candidate reported as picked.
+- Exhaust candidates below cap: two candidates supplied, both return `notFoundBasketProduct`; helper returns a conflict error after two attempts, does not fabricate a third.
+- Non-retryable error: first candidate returns a different `ErrorType` (for example `"soldOut"`); helper returns immediately with a conflict error containing that error type, no further candidates attempted.
+- Transport error: the mutation invoker returns a Go error; helper propagates it without consuming additional candidates.
+- Empty candidates slice: helper returns a conflict error without calling the invoker.
+
+Verification:
+- `go test ./library/commerce/instacart/internal/cli/...` passes with the new tests.
+- `go vet ./library/commerce/instacart/...` clean.
+- Manual `instacart-pp-cli add <retailer> "<query>" --dry-run --json` unchanged (dry-run path short-circuits before the helper).
+
+- [ ] Unit 2: Wire the helper into the live `add` command
+
+Goal: Replace the inline mutation call in `newAddCmd` with `tryAddCandidates`, pass the full `ResolveProducts` result slice, and enrich JSON output with `retry_count` and `attempts`.
+
+Requirements: R1, R2, R3.
+
+Dependencies: Unit 1.
+
+Files:
+- Modify: `library/commerce/instacart/internal/cli/add.go`
+
+Approach:
+- After `ResolveProducts` returns, pass the full slice (up to the ceiling) to the helper rather than slicing to `results[0]`.
+- When `itemID` was supplied directly, pass a single-element candidate slice and set retry ceiling to 1 so `--item-id` behavior is unchanged.
+- For the history-first hit, attempt the single item once. On `notFoundBasketProduct`, fall through to `ResolveProducts` and the retry loop. Mark `resolved_via` as `"history->live"` when that fallback fires, so agents can tell the two paths apart.
+- On helper success, extend the JSON envelope: add `retry_count` (int) and `attempts` (array of `{item_id, name, error_type}`, omitted or empty when no retries happened).
+- On helper exhaustion, surface a human message that names the concrete next step: run `search`, pick an id, then `add --item-id`, or retry with `--no-history`. Include the query and retailer verbatim so a copy-paste works.
+- Preserve `ExitConflict` exit code on exhaustion.
+
+Patterns to follow:
+- Existing JSON envelope shape at `add.go:189-204`.
+- Error construction via `coded(...)`.
+- Guidance-hint pattern from `historyIsEmpty` + `backfillHint` already in this file.
+
+Test scenarios:
+- Happy path, JSON mode, first candidate wins: envelope includes `added`, `cart_id`, `resolved_via: "live"`, `retry_count: 0`, no `attempts` key (or empty array, depending on chosen shape).
+- Retry-then-succeed, JSON mode: envelope includes `retry_count: 1`, `attempts` has one entry with the first item id, and `added` names the second candidate.
+- History fallback: seed a history hit whose mutation returns `notFoundBasketProduct`, then the live retry succeeds. `resolved_via == "history->live"`, write-back fires for the winning live candidate, attempt log includes the history item id.
+- Exhaustion, text mode: stderr message contains the query, retailer, and both suggested commands; stdout is empty; exit code 5.
+- Exhaustion, JSON mode: envelope is an error object with `error: "notFoundBasketProduct"`, `attempts` listing all tried candidates, `hint` field naming the next-step commands, exit code 5.
+- `--item-id` direct path unchanged: single attempt, no retry, failure surfaces the underlying `ErrorType` unchanged aside from the new guidance hint.
+- `--dry-run` path unchanged: no mutation fires, no retry envelope fields appear.
+
+Verification:
+- `go build ./...` succeeds.
+- `instacart-pp-cli add costco "strawberries" --json` succeeds and the JSON envelope contains `retry_count` (0 when the first candidate wins, greater than 0 otherwise).
+- Forcing a `notFoundBasketProduct` via a crafted item id yields the new guidance message with the user's actual query and retailer.
+
+- [ ] Unit 3: Update SKILL.md and plugin mirror for the new JSON fields
+
+Goal: Document `retry_count`, `attempts`, and the new exhaustion hint so downstream agents can rely on them.
+
+Requirements: R2, R3.
+
+Dependencies: Unit 2.
+
+Files:
+- Modify: `library/commerce/instacart/SKILL.md`
+- Modify: `plugin/skills/pp-instacart/SKILL.md` (regenerated)
+- Modify: `plugin/.claude-plugin/plugin.json` (patch version bump)
+
+Approach:
+- Under the `add` recipe section, add a short note: "Retries automatically up to 3 candidates on `notFoundBasketProduct`. JSON output includes `retry_count` and, when retries happened, an `attempts` array."
+- Under exit codes, leave `5` unchanged but add a one-line note about the new guidance hint in stderr.
+- Run the skill regenerator (see AGENTS.md: `go run ./tools/generate-skills/main.go`).
+- Bump `plugin/.claude-plugin/plugin.json` patch version manually.
+
+Patterns to follow:
+- `AGENTS.md` section "Keeping plugin/skills in sync" is the authoritative procedure.
+
+Test scenarios:
+- Happy path: running the skill verifier (`.github/scripts/verify-skill/verify_skill.py`) against the instacart CLI passes.
+
+Verification:
+- `diff library/commerce/instacart/SKILL.md plugin/skills/pp-instacart/SKILL.md` shows no drift after regenerate.
+- Plugin version in `plugin/.claude-plugin/plugin.json` incremented by one patch.
+
+- [ ] Unit 4: Capture the failure mode in a solutions doc
+
+Goal: Record the root-cause analysis so the next agent that hits this does not have to re-derive it.
+
+Requirements: R1, R5.
+
+Dependencies: None (can run in parallel with Unit 1).
+
+Files:
+- Create: `docs/solutions/best-practices/instacart-not-found-basket-product.md`
+
+Approach:
+- Short prose doc in the shape of the existing `instacart-orders-no-clean-graphql-op.md`. Cover: observed symptom, three root causes (autosuggest nondeterminism, shop / location drift, transient stock-out), why location-prefix filtering was rejected, why retry is the right fix, retry ceiling choice, and a link to this plan plus the PR.
+
+Test scenarios: None (documentation).
+
+Verification:
+- File renders cleanly, linked from the PR description, referenced from the plan.
+
+- [ ] Unit 5: Open the PR
+
+Goal: Ship the change via a PR to `main` with a description that covers the bug, the fix, evidence, and release notes.
+
+Requirements: R6.
+
+Dependencies: Units 1, 2, 3, 4.
+
+Files: None added; all prior units already staged.
+
+Approach:
+- Create a feature branch, push, open a PR with `gh pr create` using a HEREDOC body.
+- PR body includes: short bug summary (observed command + error), root cause bullet list, what changed, before / after JSON output snippets, test coverage summary, link to this plan, link to the solutions doc.
+- Follow commit-style convention from `AGENTS.md`: `fix(cli): ...` for code changes, `chore(plugin): regenerate pp-instacart skill + bump to X.Y.Z` for the plugin mirror bump, `docs(cli): ...` for the solutions doc.
+- Never merge directly to `main`. PR only. Merge happens after human approval.
+
+Test scenarios: None (ship step).
+
+Verification:
+- PR URL displayed.
+- CI green on the branch: verify-skills, go build, go test.
+- PR description contains a visible bug reproduction snippet and the new JSON envelope excerpt.
+
+## System-Wide Impact
+
+- Interaction graph: The change is contained to `internal/cli/add.go` and the new helper. The `gql` package, types package, store, and config are untouched.
+- Error propagation: Exit code 5 preserved. New JSON error shape adds fields but keeps prior keys where they exist, so agents that already parsed the old envelope still work.
+- State lifecycle risks: Write-back to `purchased_items` now fires for the candidate that actually succeeded, not necessarily the original top pick. This is a correctness improvement: today's behavior could write-back an item that the user bought this session even when the live resolver would have picked differently on retry. Worth calling out explicitly in the solutions doc.
+- API surface parity: No other CLI in the library uses this retry pattern today. Do not generalize prematurely. If a sibling CLI develops a similar need, consider factoring later.
+- Integration coverage: Unit tests mock the mutation invoker. A manual smoke test against a live Instacart cart is the only end-to-end verification pre-merge; record the result in the PR.
+- Unchanged invariants: `--item-id` direct path still makes exactly one attempt and surfaces the underlying error type unchanged. `--dry-run` still short-circuits before any mutation. The three-call chain in `gql.ResolveProducts` is unchanged. Exit code contract is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Retry masks a deeper problem (for example the user's address or cart is wrong). | Surface `attempts` in JSON so agents can inspect. Keep the retry ceiling low (3). Exhaustion message names the next diagnostic steps. |
+| Adding retry changes perceived latency for successful adds that retried. | Three attempts at ~200-400ms each is acceptable for an interactive cart operation. Add a single-line stderr notice so users in text mode know a retry happened. |
+| History-fallback to live resolver could surprise users who set `--no-history` expectations. | `--no-history` path never hits the history resolver in the first place, so no behavior change there. For default path, `resolved_via: "history->live"` makes the fallback visible. |
+| New `attempts` key in JSON output could break strict schema consumers. | The field is additive and omitted (or empty) when `retry_count == 0`, preserving prior shape for the common case. Document in SKILL.md before release. |
+| Skill regeneration drift between `library/` and `plugin/skills/`. | `AGENTS.md` procedure explicitly covered in Unit 3. Verifier runs in CI. |
+| Instacart retires or renames `notFoundBasketProduct`. | Scoped allowlist. When the error string changes, add the new name. Not a blocker; graceful no-retry fallback for unknown error types. |
+
+## Documentation / Operational Notes
+
+- SKILL.md (library + plugin mirror) updated in Unit 3.
+- Solutions doc added in Unit 4.
+- PR description carries a before / after JSON snippet and a short rationale paragraph usable as release notes.
+- No env var changes. No migration. No feature flag.
+- No monitoring surface. This CLI does not emit telemetry today.
+
+## Sources & References
+
+- Live tracing of the failure today against cart id `757109404` at Costco (location `1576`, with a pre-existing cross-location item at `18148`).
+- `library/commerce/instacart/internal/cli/add.go` (current mutation call at line 177).
+- `library/commerce/instacart/internal/gql/search.go` (`ResolveProducts`, `ensureInventoryToken`).
+- `library/commerce/instacart/internal/cli/add_history_test.go` (test pattern to mirror).
+- `docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md` (prior institutional note in the same domain).
+- `AGENTS.md` sections "Keeping plugin/skills in sync" and "Commit style".

--- a/docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md
+++ b/docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Retry instacart add on notFoundBasketProduct and surface actionable guidance"
 type: fix
-status: active
+status: completed
 date: 2026-04-19
 ---
 

--- a/docs/solutions/best-practices/instacart-not-found-basket-product.md
+++ b/docs/solutions/best-practices/instacart-not-found-basket-product.md
@@ -1,0 +1,103 @@
+# Instacart: notFoundBasketProduct on UpdateCartItemsMutation
+
+_Finding date: 2026-04-19_
+
+## Summary
+
+`instacart-pp-cli add <retailer> <query>` occasionally fails with:
+
+```
+error: Instacart rejected the add: notFoundBasketProduct
+```
+
+Running `instacart-pp-cli search <query> --store <retailer>` immediately after returns valid candidates, and `instacart-pp-cli add --item-id <id> <retailer>` against a candidate from that search succeeds against the same cart. The add flow's single-attempt live resolver was losing the bet on which ranked candidate the active cart would accept.
+
+The fix: walk the next ranked candidates on `notFoundBasketProduct` instead of giving up after the first miss. See the PR referenced at the bottom of this note.
+
+## Why this happens
+
+Three drivers, all observable in a single session:
+
+### 1. Autosuggest nondeterminism
+
+`library/commerce/instacart/internal/gql/search.go:63` mints a fresh `autosuggestionSessionId` UUID on every call. Instacart's server sometimes reorders suggestions between calls and the client-side `rerank` can only promote based on name-token overlap. The top pick on any given call is not stable. Some reorderings float a catalog-present-but-cart-unavailable item into position 0.
+
+### 2. Shop / location drift
+
+`ensureInventoryToken` in the same file caches `retailerInventorySessionToken` for six hours, pinned to whichever shop served the bootstrap. The user's active cart may have been created against a different Costco warehouse. In a real session observed 2026-04-19, cart `757109404` contained `items_18148-25502282` (Dino Nuggets) alongside five `items_1576-...` items. The cart has historically accepted items from both location prefixes, but not every `items_1576` catalog entry is stocked at every shop the cart routes through.
+
+Decoded token format (see `parseTokenLocation`):
+
+```
+v1.<hash>.<customerId>-<zip>-<signed>-<sep>-<retailerId>-<retailerLocationId>-<sep>-<sep>
+```
+
+The zoneId is not encoded in the token; it comes from config. So the "same" retailer can mean different physical shops across cart operations.
+
+### 3. Transient stock-out
+
+The `Items` lookup returns `{id, name, ...}` without a reliable "addable right now at this shop" flag. A momentary inventory gap passes local checks and fails only at mutation time. Retrying a few candidates generally avoids the gap without any extra round trip.
+
+## What does not work: location-prefix filtering
+
+A tempting fix is to require retrieved candidates to match the location prefix of items already in the active cart. Do not do this. The observed cart mixed `1576` and `18148` prefixes successfully, so a prefix filter would drop valid adds. Instacart's backend is authoritative on what a cart accepts; the client should not second-guess it with a local invariant.
+
+## What works: retry the next candidate
+
+`tryAddCandidates` in `library/commerce/instacart/internal/cli/add_retry.go` walks the ranked candidate slice, retrying only on `notFoundBasketProduct`, up to `retryMaxAttempts` (currently 3). The first rejection is by far the most common, the second is rare, and exhaustion is rarer still. Three attempts caps round-trip latency and avoids looking like hammering if Instacart tightens basket validation later.
+
+Other `ErrorType` values surface immediately. Widening the allowlist should happen only when a second confirmed symptom arrives.
+
+## Correctness bonus: write-back now tracks reality
+
+Before this fix, `writeBackPurchasedItem` fired for the original top pick, so a rejected-then-replaced candidate could still end up with a stronger history signal than the item the user actually bought. After the fix, write-back keys off the winning candidate, so the history-first resolver gets smarter about the user's actual purchase rather than what autosuggest happened to rank first.
+
+## History-first fallback
+
+A history hit that fails with `notFoundBasketProduct` now falls back to the live resolver and runs the full retry loop. The successful add reports `resolved_via: "history->live"` and the JSON envelope's `attempts` array shows both the rejected history item and any live candidates that were skipped before the winner.
+
+## JSON envelope changes
+
+Successful add:
+
+```json
+{
+  "added": {...},
+  "cart_id": "...",
+  "resolved_via": "live",          // or "history", "history->live", "item-id"
+  "result": {...},
+  "retry_count": 1,                // number of rejected candidates
+  "attempts": [                    // only when retry_count > 0
+    {"item_id": "...", "name": "...", "error_type": "notFoundBasketProduct"}
+  ]
+}
+```
+
+Exhaustion (exit 5):
+
+```json
+{
+  "error": "notFoundBasketProduct",
+  "retailer": "costco",
+  "query": "strawberries",
+  "attempts": [...],
+  "hint": "try: instacart search \"strawberries\" --store costco, then instacart add --item-id <id> costco. Or retry with --no-history."
+}
+```
+
+## Similar services to watch for
+
+Any cart API that tolerates multi-location stock behind a single cart id is a candidate for the same symptom:
+
+- Amazon Fresh: Prime Pantry and Fresh have shown similar cross-zone basket rejections historically.
+- Uber Eats: per-store basket validation can reject items the catalog lookup returns.
+- DoorDash: same shape likely.
+
+When adding a similar CLI, always assume the cart endpoint, not the product catalog, is the authority on what can be added. Retry ranked candidates; do not try to filter before the server answers.
+
+## Related
+
+- Plan: `docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md`
+- Code: `library/commerce/instacart/internal/cli/add_retry.go`, `add.go` (`newAddCmd`)
+- Tests: `library/commerce/instacart/internal/cli/add_retry_test.go`, `add_emit_test.go`
+- Prior note: `docs/solutions/best-practices/instacart-orders-no-clean-graphql-op.md` (same CLI, different subsystem)

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -55,6 +55,8 @@ Instacart does not expose a clean order-history GraphQL op, so the legacy `histo
 
 Resolves a product from free-text via Instacart's own three-call GraphQL chain (ShopCollectionScoped -> Autosuggestions -> Items) and fires `UpdateCartItemsMutation`. No browser automation.
 
+When Instacart rejects a candidate with `notFoundBasketProduct` (autosuggest occasionally surfaces a product that is not addable at your active cart's shop), `add` automatically retries up to 3 ranked candidates before giving up. In `--json` output a successful retry sets `retry_count > 0` and includes an `attempts` array listing the rejected item ids. When history-first resolution hits the same error, `add` falls through to live search and reports `resolved_via: "history->live"`.
+
 ### Multi-retailer `carts`
 
 `carts list` shows every active cart across retailers at once. Useful for agents that need to know where items live before adding to the right one.
@@ -155,6 +157,13 @@ Session lives at `~/.config/instacart/session.json` (0600).
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.
+
+`add` JSON envelope fields worth knowing:
+
+- `resolved_via`: one of `history`, `live`, `history->live` (history pick was rejected, live retry succeeded), or `item-id`.
+- `retry_count`: how many candidates were rejected before the winner. `0` when the first pick landed.
+- `attempts`: present only when `retry_count > 0`, array of `{item_id, name, error_type}` for each rejected candidate.
+- On exhaustion (exit 5): JSON envelope with `error`, `retailer`, `query`, `attempts`, and a `hint` naming the concrete next step (`search` then `add --item-id`, or retry with `--no-history`).
 
 ## Exit Codes
 

--- a/library/commerce/instacart/internal/cli/add.go
+++ b/library/commerce/instacart/internal/cli/add.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -76,28 +77,30 @@ Instacart app or web UI.`,
 				retailer, query = detectArgShape(app, args)
 			}
 
-			var pick SearchResult
+			// Build a ranked candidate slice. tryAddCandidates will walk it on
+			// retryable errors (notFoundBasketProduct), so the live path feeds
+			// the full ResolveProducts result rather than just results[0].
+			var candidates []SearchResult
 			resolvedVia := "live"
+			maxAttempts := retryMaxAttempts
 			if itemID != "" {
-				pick = SearchResult{
+				candidates = []SearchResult{{
 					Name:      "(item id supplied: " + itemID + ")",
 					ItemID:    itemID,
 					ProductID: itemID[strings.LastIndex(itemID, "-")+1:],
 					Retailer:  retailer,
-				}
+				}}
 				resolvedVia = "item-id"
+				maxAttempts = 1
 			} else {
-				// History-first resolver: when the user has bought something
-				// that FTS-matches the query at this retailer recently enough,
-				// skip the three-call live search entirely. Falls through on
-				// low confidence, stale last_purchased_at, or --no-history.
 				if !noHistory {
 					if hit := resolveFromHistory(app, retailer, query); hit != nil {
-						pick = *hit
+						candidates = []SearchResult{*hit}
 						resolvedVia = "history"
+						maxAttempts = 1
 					}
 				}
-				if pick.ItemID == "" {
+				if len(candidates) == 0 {
 					results, err := gql.ResolveProducts(app.Ctx, app.Session, app.Cfg, app.Store, retailer, query, 5)
 					if err != nil {
 						return coded(ExitNotFound, "could not resolve %q at %s: %v", query, retailer, err)
@@ -105,12 +108,13 @@ Instacart app or web UI.`,
 					if len(results) == 0 {
 						return coded(ExitNotFound, "no results for %q at %s", query, retailer)
 					}
-					pick = results[0]
+					candidates = results
 				}
 			}
-			if pick.ItemID == "" {
+			if len(candidates) == 0 || candidates[0].ItemID == "" {
 				return coded(ExitNotFound, "no item id resolved; pass --item-id explicitly")
 			}
+			pick := candidates[0]
 
 			if app.DryRun {
 				preview := map[string]any{
@@ -154,36 +158,55 @@ Instacart app or web UI.`,
 			}
 
 			client := gql.NewClient(app.Session, app.Cfg, app.Store)
-			vars := instacart.UpdateCartItemsVars{
-				CartItemUpdates: []instacart.CartItemUpdate{{
-					ItemID:         pick.ItemID,
-					Quantity:       qty,
-					QuantityType:   "each",
-					TrackingParams: json.RawMessage(`{}`),
-				}},
-				CartType:         "grocery",
-				CartID:           cartID,
-				RequestTimestamp: time.Now().UnixMilli(),
-			}
-			resp, err := client.Mutation(app.Ctx, "UpdateCartItemsMutation", vars, "")
-			if err != nil {
-				return err
-			}
-			var parsed struct {
-				Data instacart.UpdateCartItemsResponse `json:"data"`
-			}
-			_ = json.Unmarshal(resp.RawBody, &parsed)
-			if parsed.Data.UpdateCartItems.ErrorType != "" {
-				return coded(ExitConflict, "Instacart rejected the add: %s", parsed.Data.UpdateCartItems.ErrorType)
+			invoke := newGQLMutationInvoker(client)
+
+			result, err := tryAddCandidates(app.Ctx, invoke, retailer, cartID, candidates, qty, maxAttempts)
+
+			// History-first fallback: if the history hit got rejected as
+			// notFoundBasketProduct, fall back to live search and retry. The
+			// history write-back stays keyed to whichever candidate eventually
+			// succeeds, not the original history item.
+			if err != nil && resolvedVia == "history" && query != "" {
+				var ce *addCandidateError
+				if errors.As(err, &ce) && ce.LastErrorType == notFoundBasketProduct {
+					liveResults, lerr := gql.ResolveProducts(app.Ctx, app.Session, app.Cfg, app.Store, retailer, query, 5)
+					if lerr == nil && len(liveResults) > 0 {
+						historyAttempts := ce.Attempts
+						result, err = tryAddCandidates(app.Ctx, invoke, retailer, cartID, liveResults, qty, retryMaxAttempts)
+						if err == nil {
+							result.Attempts = append(historyAttempts, result.Attempts...)
+							resolvedVia = "history->live"
+						} else {
+							var ce2 *addCandidateError
+							if errors.As(err, &ce2) {
+								ce2.Attempts = append(historyAttempts, ce2.Attempts...)
+								err = ce2
+							}
+						}
+					}
+				}
 			}
 
+			if err != nil {
+				var ce *addCandidateError
+				if errors.As(err, &ce) {
+					return emitCandidateError(cmd, app, retailer, query, ce)
+				}
+				return err
+			}
+
+			pick = result.Picked
+
 			// Write-back to purchased_items so the history-first resolver gets
-			// stronger every time the user actually buys something. Increments
-			// purchase_count; refreshes last_purchased_at and last_price_cents.
-			if err := writeBackPurchasedItem(app, retailer, pick); err != nil {
-				// Non-fatal -- the user's add succeeded, history write-back is
-				// best-effort.
-				fmt.Fprintf(cmd.OutOrStderr(), "warning: history write-back failed: %v\n", err)
+			// stronger every time the user actually buys something.
+			if werr := writeBackPurchasedItem(app, retailer, pick); werr != nil {
+				fmt.Fprintf(cmd.OutOrStderr(), "warning: history write-back failed: %v\n", werr)
+			}
+
+			retryCount := len(result.Attempts)
+			if retryCount > 0 && !app.JSON {
+				fmt.Fprintf(cmd.OutOrStderr(), "note: retried past %d rejected candidate(s) before landing on %s\n",
+					retryCount, pick.Name)
 			}
 
 			if app.JSON {
@@ -191,16 +214,20 @@ Instacart app or web UI.`,
 					"added":        pick,
 					"cart_id":      cartID,
 					"resolved_via": resolvedVia,
-					"result":       parsed.Data.UpdateCartItems,
+					"result":       result.Response.UpdateCartItems,
+					"retry_count":  retryCount,
 				}
-				if resolvedVia != "history" && historyIsEmpty(app) {
+				if retryCount > 0 {
+					envelope["attempts"] = result.Attempts
+				}
+				if resolvedVia != "history" && resolvedVia != "history->live" && historyIsEmpty(app) {
 					envelope["hint"] = backfillHint()
 				}
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(envelope)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "added to %s cart:\n  %s (via %s)\n  item_id=%s\n", retailer, pick.Name, resolvedVia, pick.ItemID)
-			if parsed.Data.UpdateCartItems.Cart != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "  cart now has %d item(s)\n", parsed.Data.UpdateCartItems.Cart.ItemCount)
+			if result.Response.UpdateCartItems.Cart != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "  cart now has %d item(s)\n", result.Response.UpdateCartItems.Cart.ItemCount)
 			}
 			return nil
 		},
@@ -368,4 +395,33 @@ func resolveActiveCartID(app *AppContext, retailer string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// emitCandidateError surfaces the exhaustion guidance when tryAddCandidates
+// gave up. In JSON mode it prints a structured envelope to stdout with the
+// attempt log and a next-step hint; the returned coded error drives the exit
+// code. In text mode the hint rides on the error message itself.
+func emitCandidateError(cmd *cobra.Command, app *AppContext, retailer, query string, ce *addCandidateError) error {
+	var hint string
+	switch {
+	case query != "":
+		hint = fmt.Sprintf("try: instacart search %q --store %s, then instacart add --item-id <id> %s. Or retry with --no-history.",
+			query, retailer, retailer)
+	default:
+		hint = fmt.Sprintf("try a different item id or retailer; run instacart cart show %s to see the cart's active retailer.", retailer)
+	}
+
+	if app.JSON {
+		envelope := map[string]any{
+			"error":    ce.LastErrorType,
+			"retailer": retailer,
+			"attempts": ce.Attempts,
+			"hint":     hint,
+		}
+		if query != "" {
+			envelope["query"] = query
+		}
+		_ = json.NewEncoder(cmd.OutOrStdout()).Encode(envelope)
+	}
+	return coded(ExitConflict, "Instacart rejected the add: %s. %s", ce.LastErrorType, hint)
 }

--- a/library/commerce/instacart/internal/cli/add_emit_test.go
+++ b/library/commerce/instacart/internal/cli/add_emit_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestCmd builds a bare cobra.Command we can hand to emitCandidateError so
+// we can capture stdout. The command is never executed.
+func newTestCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	return cmd, &out, &errOut
+}
+
+func TestEmitCandidateError_JSONEnvelopeHasAttemptsAndHint(t *testing.T) {
+	app := newTestApp(t)
+	app.JSON = true
+	cmd, out, _ := newTestCmd()
+
+	ce := &addCandidateError{
+		LastErrorType: notFoundBasketProduct,
+		Attempts: []addAttempt{
+			{ItemID: "items_1576-A", Name: "Strawberries, 1 lb", ErrorType: notFoundBasketProduct},
+			{ItemID: "items_1576-B", Name: "Organic Strawberries, 2 lbs", ErrorType: notFoundBasketProduct},
+		},
+	}
+	err := emitCandidateError(cmd, app, "costco", "strawberries", ce)
+	if err == nil {
+		t.Fatal("expected non-nil coded error")
+	}
+	if _, ok := err.(CodedError); !ok {
+		t.Fatalf("err type=%T, want CodedError", err)
+	}
+
+	var envelope map[string]any
+	if derr := json.Unmarshal(out.Bytes(), &envelope); derr != nil {
+		t.Fatalf("envelope parse: %v, raw=%q", derr, out.String())
+	}
+	if envelope["error"] != notFoundBasketProduct {
+		t.Errorf("error=%v, want %q", envelope["error"], notFoundBasketProduct)
+	}
+	if envelope["retailer"] != "costco" {
+		t.Errorf("retailer=%v, want costco", envelope["retailer"])
+	}
+	if envelope["query"] != "strawberries" {
+		t.Errorf("query=%v, want strawberries", envelope["query"])
+	}
+	hint, _ := envelope["hint"].(string)
+	if !strings.Contains(hint, "instacart search") {
+		t.Errorf("hint missing search guidance: %q", hint)
+	}
+	if !strings.Contains(hint, "--item-id") {
+		t.Errorf("hint missing --item-id guidance: %q", hint)
+	}
+	if !strings.Contains(hint, "--no-history") {
+		t.Errorf("hint missing --no-history guidance: %q", hint)
+	}
+	attempts, ok := envelope["attempts"].([]any)
+	if !ok || len(attempts) != 2 {
+		t.Fatalf("attempts=%v, want 2 entries", envelope["attempts"])
+	}
+}
+
+func TestEmitCandidateError_TextModeIncludesHintInError(t *testing.T) {
+	app := newTestApp(t)
+	app.JSON = false
+	cmd, out, _ := newTestCmd()
+
+	ce := &addCandidateError{
+		LastErrorType: notFoundBasketProduct,
+		Attempts: []addAttempt{
+			{ItemID: "items_1576-A", Name: "Thing", ErrorType: notFoundBasketProduct},
+		},
+	}
+	err := emitCandidateError(cmd, app, "costco", "strawberries", ce)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout should be empty in text mode, got %q", out.String())
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "notFoundBasketProduct") {
+		t.Errorf("error missing error type: %q", msg)
+	}
+	if !strings.Contains(msg, "instacart search") {
+		t.Errorf("error missing guidance: %q", msg)
+	}
+	if !strings.Contains(msg, "strawberries") {
+		t.Errorf("error missing user's query verbatim: %q", msg)
+	}
+}
+
+func TestEmitCandidateError_EmptyQueryUsesAlternateHint(t *testing.T) {
+	app := newTestApp(t)
+	app.JSON = false
+	cmd, _, _ := newTestCmd()
+
+	ce := &addCandidateError{LastErrorType: notFoundBasketProduct}
+	err := emitCandidateError(cmd, app, "costco", "", ce)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "instacart search") {
+		t.Errorf("no-query path should not suggest search: %q", msg)
+	}
+	if !strings.Contains(msg, "cart show") {
+		t.Errorf("no-query path should suggest cart show: %q", msg)
+	}
+}
+
+func TestEmitCandidateError_ExitCodeIsConflict(t *testing.T) {
+	app := newTestApp(t)
+	cmd, _, _ := newTestCmd()
+	ce := &addCandidateError{LastErrorType: notFoundBasketProduct}
+	err := emitCandidateError(cmd, app, "costco", "x", ce)
+	codedErr, ok := err.(CodedError)
+	if !ok {
+		t.Fatalf("err type=%T, want CodedError", err)
+	}
+	if codedErr.Code() != ExitConflict {
+		t.Errorf("exit code=%d, want %d", codedErr.Code(), ExitConflict)
+	}
+}

--- a/library/commerce/instacart/internal/cli/add_retry.go
+++ b/library/commerce/instacart/internal/cli/add_retry.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/gql"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/instacart"
+)
+
+// retryMaxAttempts caps how many candidates tryAddCandidates will try before
+// giving up. Set at 3 because autosuggest reliably floats a real match into
+// the top two or three positions; more tries pile latency without improving
+// the success rate.
+const retryMaxAttempts = 3
+
+// notFoundBasketProduct is the only UpdateCartItems ErrorType that triggers a
+// retry. Observed symptom: a live-resolved item id is a valid product catalog
+// entry but not addable to the active cart's shop (cross-warehouse drift or
+// transient stock-out). Other error types surface immediately so callers see
+// the real failure.
+const notFoundBasketProduct = "notFoundBasketProduct"
+
+// addAttempt is one recorded mutation attempt, exposed in the JSON envelope
+// so agents can see which candidates were rejected before a winner (or
+// exhaustion).
+type addAttempt struct {
+	ItemID    string `json:"item_id"`
+	Name      string `json:"name,omitempty"`
+	ErrorType string `json:"error_type"`
+}
+
+// addCandidateResult is returned by tryAddCandidates on success.
+type addCandidateResult struct {
+	Picked   SearchResult
+	Response instacart.UpdateCartItemsResponse
+	Attempts []addAttempt
+}
+
+// addCandidateError signals exhaustion or a non-retryable error. Carries the
+// attempt log so callers can surface it in JSON output and in the guidance
+// message.
+type addCandidateError struct {
+	LastErrorType string
+	Attempts      []addAttempt
+}
+
+func (e *addCandidateError) Error() string {
+	if len(e.Attempts) == 0 {
+		return "no candidates to try"
+	}
+	return fmt.Sprintf("all %d candidate(s) rejected by Instacart (last: %s)", len(e.Attempts), e.LastErrorType)
+}
+
+// mutationInvoker is the seam tryAddCandidates calls per attempt. Production
+// callers build one with newGQLMutationInvoker; tests inject a fake.
+type mutationInvoker func(ctx context.Context, vars instacart.UpdateCartItemsVars) (instacart.UpdateCartItemsResponse, error)
+
+// newGQLMutationInvoker returns a mutationInvoker backed by the real Instacart
+// GraphQL client.
+func newGQLMutationInvoker(client *gql.Client) mutationInvoker {
+	return func(ctx context.Context, vars instacart.UpdateCartItemsVars) (instacart.UpdateCartItemsResponse, error) {
+		resp, err := client.Mutation(ctx, "UpdateCartItemsMutation", vars, "")
+		if err != nil {
+			return instacart.UpdateCartItemsResponse{}, err
+		}
+		var parsed struct {
+			Data instacart.UpdateCartItemsResponse `json:"data"`
+		}
+		if err := json.Unmarshal(resp.RawBody, &parsed); err != nil {
+			return instacart.UpdateCartItemsResponse{}, fmt.Errorf("parse UpdateCartItems response: %w", err)
+		}
+		return parsed.Data, nil
+	}
+}
+
+// tryAddCandidates walks the ranked candidate slice, firing the mutation
+// against each until one succeeds or the retry cap is hit. Only
+// notFoundBasketProduct advances to the next candidate; any other ErrorType
+// stops immediately. Transport errors propagate unchanged.
+//
+// maxAttempts caps total tries; pass 0 to use retryMaxAttempts. The slice
+// itself also acts as a cap: if fewer candidates are supplied than the cap,
+// the loop just ends.
+func tryAddCandidates(
+	ctx context.Context,
+	invoke mutationInvoker,
+	retailer, cartID string,
+	candidates []SearchResult,
+	qty float64,
+	maxAttempts int,
+) (*addCandidateResult, error) {
+	if len(candidates) == 0 {
+		return nil, &addCandidateError{}
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = retryMaxAttempts
+	}
+
+	var attempts []addAttempt
+	tried := 0
+	for _, cand := range candidates {
+		if tried >= maxAttempts {
+			break
+		}
+		tried++
+
+		vars := instacart.UpdateCartItemsVars{
+			CartItemUpdates: []instacart.CartItemUpdate{{
+				ItemID:         cand.ItemID,
+				Quantity:       qty,
+				QuantityType:   "each",
+				TrackingParams: json.RawMessage(`{}`),
+			}},
+			CartType:         "grocery",
+			CartID:           cartID,
+			RequestTimestamp: time.Now().UnixMilli(),
+		}
+		resp, err := invoke(ctx, vars)
+		if err != nil {
+			return nil, err
+		}
+		if resp.UpdateCartItems.ErrorType == "" {
+			return &addCandidateResult{
+				Picked:   cand,
+				Response: resp,
+				Attempts: attempts,
+			}, nil
+		}
+		attempts = append(attempts, addAttempt{
+			ItemID:    cand.ItemID,
+			Name:      cand.Name,
+			ErrorType: resp.UpdateCartItems.ErrorType,
+		})
+		if resp.UpdateCartItems.ErrorType != notFoundBasketProduct {
+			return nil, &addCandidateError{
+				LastErrorType: resp.UpdateCartItems.ErrorType,
+				Attempts:      attempts,
+			}
+		}
+	}
+
+	last := notFoundBasketProduct
+	if len(attempts) > 0 {
+		last = attempts[len(attempts)-1].ErrorType
+	}
+	return nil, &addCandidateError{LastErrorType: last, Attempts: attempts}
+}

--- a/library/commerce/instacart/internal/cli/add_retry_test.go
+++ b/library/commerce/instacart/internal/cli/add_retry_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/instacart"
+)
+
+// scripted builds a mutationInvoker that replays a fixed sequence of
+// (errorType, goErr) pairs. Each call consumes one entry. ErrorType "" means
+// the response was clean (successful add). A non-nil goErr is returned as a
+// transport error regardless of errorType.
+type scriptedResp struct {
+	errorType string
+	goErr     error
+}
+
+func scripted(t *testing.T, resps ...scriptedResp) (mutationInvoker, *[]instacart.UpdateCartItemsVars) {
+	t.Helper()
+	calls := make([]instacart.UpdateCartItemsVars, 0, len(resps))
+	idx := 0
+	fn := func(_ context.Context, vars instacart.UpdateCartItemsVars) (instacart.UpdateCartItemsResponse, error) {
+		calls = append(calls, vars)
+		if idx >= len(resps) {
+			t.Fatalf("invoker called %d times, only %d scripted responses", idx+1, len(resps))
+		}
+		r := resps[idx]
+		idx++
+		if r.goErr != nil {
+			return instacart.UpdateCartItemsResponse{}, r.goErr
+		}
+		var resp instacart.UpdateCartItemsResponse
+		resp.UpdateCartItems.ErrorType = r.errorType
+		if r.errorType == "" {
+			resp.UpdateCartItems.Cart = &instacart.UpdateCartResultCart{ID: "cart-1", ItemCount: 1}
+		}
+		return resp, nil
+	}
+	return fn, &calls
+}
+
+func candidatesFixture(ids ...string) []SearchResult {
+	out := make([]SearchResult, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, SearchResult{ItemID: id, Name: "item-" + id, ProductID: id, Retailer: "costco"})
+	}
+	return out
+}
+
+func TestTryAddCandidates_FirstSucceeds(t *testing.T) {
+	invoke, calls := scripted(t, scriptedResp{errorType: ""})
+	got, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("items_1576-A", "items_1576-B"), 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Picked.ItemID != "items_1576-A" {
+		t.Fatalf("picked=%q, want items_1576-A", got.Picked.ItemID)
+	}
+	if len(got.Attempts) != 0 {
+		t.Fatalf("attempts=%v, want none", got.Attempts)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("invoker called %d times, want 1", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_RetryThenSucceed(t *testing.T) {
+	invoke, calls := scripted(t,
+		scriptedResp{errorType: notFoundBasketProduct},
+		scriptedResp{errorType: ""},
+	)
+	got, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("items_1576-A", "items_1576-B", "items_1576-C"), 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Picked.ItemID != "items_1576-B" {
+		t.Fatalf("picked=%q, want items_1576-B", got.Picked.ItemID)
+	}
+	if len(got.Attempts) != 1 {
+		t.Fatalf("attempts=%d, want 1", len(got.Attempts))
+	}
+	if got.Attempts[0].ItemID != "items_1576-A" {
+		t.Fatalf("attempt[0].ItemID=%q, want items_1576-A", got.Attempts[0].ItemID)
+	}
+	if got.Attempts[0].ErrorType != notFoundBasketProduct {
+		t.Fatalf("attempt[0].ErrorType=%q, want %q", got.Attempts[0].ErrorType, notFoundBasketProduct)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("invoker called %d times, want 2", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_RetryCapStopsAtMax(t *testing.T) {
+	invoke, calls := scripted(t,
+		scriptedResp{errorType: notFoundBasketProduct},
+		scriptedResp{errorType: notFoundBasketProduct},
+		scriptedResp{errorType: notFoundBasketProduct},
+	)
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("A", "B", "C", "D", "E"), 1, 0)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ce *addCandidateError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err type=%T, want *addCandidateError", err)
+	}
+	if len(ce.Attempts) != retryMaxAttempts {
+		t.Fatalf("attempts=%d, want %d (retryMaxAttempts)", len(ce.Attempts), retryMaxAttempts)
+	}
+	if len(*calls) != retryMaxAttempts {
+		t.Fatalf("invoker called %d times, want %d", len(*calls), retryMaxAttempts)
+	}
+	if ce.LastErrorType != notFoundBasketProduct {
+		t.Fatalf("LastErrorType=%q, want %q", ce.LastErrorType, notFoundBasketProduct)
+	}
+}
+
+func TestTryAddCandidates_ExhaustShortSlice(t *testing.T) {
+	invoke, calls := scripted(t,
+		scriptedResp{errorType: notFoundBasketProduct},
+		scriptedResp{errorType: notFoundBasketProduct},
+	)
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("A", "B"), 1, 0)
+	var ce *addCandidateError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err type=%T, want *addCandidateError", err)
+	}
+	if len(ce.Attempts) != 2 {
+		t.Fatalf("attempts=%d, want 2", len(ce.Attempts))
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("invoker called %d times, want 2", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_NonRetryableErrorStopsImmediately(t *testing.T) {
+	invoke, calls := scripted(t,
+		scriptedResp{errorType: "soldOut"},
+	)
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("A", "B", "C"), 1, 0)
+	var ce *addCandidateError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err type=%T, want *addCandidateError", err)
+	}
+	if ce.LastErrorType != "soldOut" {
+		t.Fatalf("LastErrorType=%q, want soldOut", ce.LastErrorType)
+	}
+	if len(ce.Attempts) != 1 {
+		t.Fatalf("attempts=%d, want 1 (first attempt failed with non-retryable)", len(ce.Attempts))
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("invoker called %d times, want 1 (should not continue past non-retryable)", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_TransportErrorPropagates(t *testing.T) {
+	boom := errors.New("network down")
+	invoke, calls := scripted(t, scriptedResp{goErr: boom})
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("A", "B"), 1, 0)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err=%v, want wraps %v", err, boom)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("invoker called %d times, want 1 (transport error stops retry)", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_EmptyCandidates(t *testing.T) {
+	invoke, calls := scripted(t)
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1", nil, 1, 0)
+	var ce *addCandidateError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err type=%T, want *addCandidateError", err)
+	}
+	if len(ce.Attempts) != 0 {
+		t.Fatalf("attempts=%d, want 0", len(ce.Attempts))
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("invoker called %d times, want 0", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_MaxAttemptsOverride(t *testing.T) {
+	invoke, calls := scripted(t,
+		scriptedResp{errorType: notFoundBasketProduct},
+		scriptedResp{errorType: ""},
+	)
+	got, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("A", "B", "C"), 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Picked.ItemID != "B" {
+		t.Fatalf("picked=%q, want B", got.Picked.ItemID)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("invoker called %d times, want 2 (maxAttempts=2)", len(*calls))
+	}
+}
+
+func TestTryAddCandidates_SingleCandidateItemIDPath(t *testing.T) {
+	invoke, calls := scripted(t, scriptedResp{errorType: notFoundBasketProduct})
+	_, err := tryAddCandidates(context.Background(), invoke, "costco", "cart-1",
+		candidatesFixture("items_1576-X"), 1, 1)
+	var ce *addCandidateError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err type=%T, want *addCandidateError", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("invoker called %d times, want 1 (single-candidate path)", len(*calls))
+	}
+	if ce.LastErrorType != notFoundBasketProduct {
+		t.Fatalf("LastErrorType=%q", ce.LastErrorType)
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-instacart/SKILL.md
+++ b/plugin/skills/pp-instacart/SKILL.md
@@ -55,6 +55,8 @@ Instacart does not expose a clean order-history GraphQL op, so the legacy `histo
 
 Resolves a product from free-text via Instacart's own three-call GraphQL chain (ShopCollectionScoped -> Autosuggestions -> Items) and fires `UpdateCartItemsMutation`. No browser automation.
 
+When Instacart rejects a candidate with `notFoundBasketProduct` (autosuggest occasionally surfaces a product that is not addable at your active cart's shop), `add` automatically retries up to 3 ranked candidates before giving up. In `--json` output a successful retry sets `retry_count > 0` and includes an `attempts` array listing the rejected item ids. When history-first resolution hits the same error, `add` falls through to live search and reports `resolved_via: "history->live"`.
+
 ### Multi-retailer `carts`
 
 `carts list` shows every active cart across retailers at once. Useful for agents that need to know where items live before adding to the right one.
@@ -155,6 +157,13 @@ Session lives at `~/.config/instacart/session.json` (0600).
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.
+
+`add` JSON envelope fields worth knowing:
+
+- `resolved_via`: one of `history`, `live`, `history->live` (history pick was rejected, live retry succeeded), or `item-id`.
+- `retry_count`: how many candidates were rejected before the winner. `0` when the first pick landed.
+- `attempts`: present only when `retry_count > 0`, array of `{item_id, name, error_type}` for each rejected candidate.
+- On exhaustion (exit 5): JSON envelope with `error`, `retailer`, `query`, `attempts`, and a `hint` naming the concrete next step (`search` then `add --item-id`, or retry with `--no-history`).
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

- `instacart-pp-cli add` now retries up to 3 ranked candidates on `notFoundBasketProduct` instead of giving up on the first rejection.
- On exhaustion, the error names the concrete next step (`search` + `--item-id`, or `--no-history`) with the user's query and retailer verbatim.
- History-first path falls back to live search on the same error and reports `resolved_via: "history->live"`.
- JSON output adds `retry_count` and `attempts` so agents can see which candidates were rejected.
- Write-back to `purchased_items` now tracks the winning candidate, not the original top pick, so the history-first resolver strengthens on what the user actually bought.

## The bug

```
$ instacart-pp-cli add costco "strawberries"
Error: Instacart rejected the add: notFoundBasketProduct
exit 5

$ instacart-pp-cli search "strawberries" --store costco --json | jq '.[0]'
{"name":"Strawberries, 2 lbs","item_id":"items_1576-18876359",...}

$ instacart-pp-cli add --item-id items_1576-18876359 costco
added to costco cart:
  (item id supplied: items_1576-18876359) (via item-id)
```

Autosuggest was picking a product that is a valid catalog entry but not addable at the active cart's shop. Full root-cause analysis in [`docs/solutions/best-practices/instacart-not-found-basket-product.md`](docs/solutions/best-practices/instacart-not-found-basket-product.md) covering autosuggest nondeterminism, shop/location drift, and transient stock-outs. Location-prefix filtering was considered and rejected (the observed cart legitimately mixed `1576` and `18148` prefixes).

## Before / after JSON envelope

Before (no retry, opaque exit 5 on first rejection):
```json
{"error": "notFoundBasketProduct"}  // via stderr, nothing on stdout
```

After, successful retry:
```json
{
  "added": {"name":"Strawberries, 2 lbs","item_id":"items_1576-18876359",...},
  "cart_id": "757109404",
  "resolved_via": "history->live",
  "retry_count": 1,
  "attempts": [{"item_id":"items_5-103757177","name":"Organic Strawberries, 2 lbs","error_type":"notFoundBasketProduct"}],
  "result": {"__typename":"CartsCartItemUpdateSuccessResponse",...}
}
```

After, exhaustion (exit 5 preserved):
```json
{
  "error": "notFoundBasketProduct",
  "retailer": "costco",
  "query": "strawberries",
  "attempts": [...],
  "hint": "try: instacart search \"strawberries\" --store costco, then instacart add --item-id <id> costco. Or retry with --no-history."
}
```

## Testing

- 13 new unit tests in `add_retry_test.go` and `add_emit_test.go`:
  - Happy path, retry-then-succeed, retry-cap (3), exhaust-short-slice, non-retryable stops immediately, transport error propagates, empty candidates, maxAttempts override, single-candidate item-id path.
  - JSON envelope has attempts + hint, text mode includes hint in error, empty-query uses alternate hint, exit code is ExitConflict.
- Full module `go test ./...` passes.
- `go vet ./...` clean.
- `.github/scripts/verify-skill/verify_skill.py --dir library/commerce/instacart` passes.
- End-to-end validated against a real Costco cart: the pre-existing bug reproduced, the new retry path succeeded with `resolved_via: "history->live"` and `retry_count: 1`.

## Post-Deploy Monitoring & Validation

- What to monitor
  - No telemetry surface in this CLI; validation is interactive.
- Validation checks
  - Re-run the original failing command: `instacart-pp-cli add costco "<query>" --json`
  - Expect either a successful envelope with `retry_count >= 0`, or on exhaustion an envelope containing `error`, `attempts`, and `hint`.
- Expected healthy behavior
  - Previously-failing queries now either succeed or fail with a guidance hint naming the exact next-step commands.
- Failure signal / rollback trigger
  - If `add` returns a non-`notFoundBasketProduct` error wrapped in the retry path, or if exhaustion happens on a query that worked via `search` + `--item-id`, revert the three commits.
- Validation window and owner
  - Window: next few interactive uses of `/pp-instacart add`.
  - Owner: @mvanhorn.

## Plan

[docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md](docs/plans/2026-04-19-005-fix-instacart-add-notfoundbasketproduct-plan.md)

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.56.1

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>