### PR TITLE
fix(contact-goat): preserve Happenstance bearer mutuals + affinity on every bearer-path command

### DIFF
--- a/library/sales-and-crm/contact-goat/docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md
+++ b/library/sales-and-crm/contact-goat/docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md
@@ -1,0 +1,357 @@
+---
+title: "fix: Preserve Happenstance bearer API mutuals + affinity on all bearer-path commands"
+type: fix
+status: active
+date: 2026-04-19
+---
+
+# fix: Preserve Happenstance bearer API mutuals + affinity on all bearer-path commands
+
+## Overview
+
+The Happenstance bearer API (`POST /v1/search` + `GET /v1/search/{id}`) returns a top-level `mutuals[]` array naming the user's 1st-degree bridges, plus per-result `mutuals[].index + affinity_score` pointing into that array. contact-goat currently unmarshals none of it. Every bearer result surfaces as a bare `{name, title, company}` with a generic "Happenstance bearer" rationale and a score derived only from `weighted_traits_score`. Users cannot tell which friend bridges to which person, nor how strong the signal actually is.
+
+This plan captures that data in the API types, carries it through the normalizer, and renders it on every bearer-surface command.
+
+## Problem Frame
+
+The contact-goat CLI is positioned as a warm-intro tool. On the bearer path it fails at that positioning: the API gives us a graph (bridges + affinity), we throw the graph away and print a list of names. A real-session trace on 2026-04-19 (Tesla coverage query) returned 25 hits with no bridge info via the CLI; the same query against the raw bearer API returned full `mutuals` + `affinity_score` data. The disconnect is a pure client-side bug, not an API limitation.
+
+This is discovered in the Tesla session documented in the conversation that produced this plan: LinkedIn's cookie path surfaces mutuals well ("Charly Mwangi + 3 others"), Happenstance's cookie path surfaces referrer rationale, but the bearer fallback silently drops the equivalent metadata.
+
+## Requirements Trace
+
+- R1. Every bearer-surface command response MUST include, for each result, an enumerated list of bridges with name, UUID, and affinity_score.
+- R2. The rationale string MUST name the top bridge and affinity score (e.g., `via Jeff Clavier (affinity 104.4)`) instead of the generic `Happenstance bearer`.
+- R3. Results MUST be sortable / rankable by max affinity across bridges, with stable fallback to `weighted_traits_score` on zero-affinity hits.
+- R4. Zero-affinity hits MUST be distinguishable from strong-affinity hits in both JSON and human-friendly output (tag + sort position).
+- R5. Existing cookie-path behavior MUST NOT regress. Only the bearer-path projection changes.
+- R6. Commands affected: `coverage`, `hp people`, `prospect`, `warm-intro`, `api hpn search`.
+
+## Scope Boundaries
+
+- Not changing the cookie-surface output shape or rationale text.
+- Not redesigning warm-intro's scoring algorithm. That belongs in a separate plan; here we only ensure warm-intro sees affinity data when it exists.
+- Not adding new bearer endpoints or pagination controls. `has_more` / `next_page` remain as they are.
+- Not modeling every bearer field (e.g., `traits[].evidence` prose, `socials.twitter_url`). Only bridge metadata and the minimum socials needed to render a result cleanly (linkedin_url).
+- Not changing `flagshipPerson.MutualCount` semantics. A new field holds bridge detail.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/happenstance/api/types.go` lines 62-83: `SearchEnvelope` + `SearchResult` structs. Neither captures `mutuals` today.
+- `internal/happenstance/api/search.go` lines 87-107: `POST /v1/search` + `PollSearch` pipeline. Unmarshaling uses the types above; no request shape change needed.
+- `internal/happenstance/api/normalize.go` lines 50-57: `ToClientPerson` maps SearchResult to `client.Person`. Currently drops anything not in the 4-field struct.
+- `internal/cli/source_selection.go` lines 361-423 (`ExecuteWithSourceFallback`), 453-491 (`BearerSearchAdapter`): bearer fallback + result normalization plumbing. Adapter calls `ToClientPerson` on each result (line 482).
+- `internal/cli/flagship_helpers.go` lines 32-47: `flagshipPerson` struct used by coverage/prospect/warm-intro. Has `MutualCount` (cookie path only) and `Raw` escape hatch but no bridge-detail field.
+- `internal/cli/coverage.go` lines 275-290: bearer-row mapping block. The site of the visible bug.
+- `internal/cli/prospect.go` lines 128-148: same bug pattern.
+- `internal/cli/hp_people.go`: `buildHPPeopleJSON` projection, same bug pattern.
+- `internal/cli/warm_intro.go`: bearer row projection, same bug pattern.
+- `internal/cli/api_hpn_search.go` lines 290-300: emits a thin `hpnSearchResult` (no bridge fields).
+
+### Institutional Learnings
+
+- None found in `docs/solutions/` for this CLI (directory does not exist yet for contact-goat).
+
+### External References
+
+- Happenstance bearer API response shape verified empirically 2026-04-19 against production: `https://api.happenstance.ai/v1/search` + `GET /v1/search/{id}`. Response includes top-level `mutuals[]`, per-result `mutuals[].index + affinity_score`, `traits[]`, and `socials{linkedin_url, twitter_url, instagram_url, happenstance_url}`.
+- No public Happenstance OpenAPI at time of writing; shape is treated as empirical.
+
+## Key Technical Decisions
+
+- **Field placement, API layer:** Add `Mutuals []SearchMutual` at the envelope level and `Mutuals []ResultMutual` + `Socials *SearchSocials` + `Traits []SearchTrait` at the result level. Rationale: the envelope-level list is the source of truth for names; per-result entries only carry `index + affinity_score` and must dereference against it. Colocating both in types.go matches the API shape exactly and keeps the struct grep-able.
+
+- **Field placement, canonical person:** Add `Bridges []client.Bridge` to `client.Person`. Each Bridge holds `Name, HappenstanceUUID, AffinityScore`. Rationale: canonical Person is what every renderer consumes; putting bridges here means a single change propagates across coverage/prospect/warm-intro/hp-people/api-hpn-search.
+
+- **Self-bridge handling:** The API's top-level mutuals include the user themselves (e.g., `"Matt Van Horn"` at index 3). Results with `mutuals[].index` pointing at the self-entry represent 1st-degree contacts in the user's own synced graph. Tag these as `self_graph` in Bridge; do not present "via Matt Van Horn" as a bridge string. Rationale: the CLI already knows who the current user is (`currentUUID` is plumbed through coverage.go). Filtering self-bridges at the normalizer keeps renderers simple.
+
+- **Rationale string format:** `via <top bridge name> (affinity X.X)` when at least one non-zero affinity bridge exists; `in your synced graph` when only self-bridge hits; `Happenstance bearer (weak signal)` when all bridge affinities are zero. Rationale: matches how the user would describe the relationship aloud and is greppable.
+
+- **Sorting:** Sort bearer-path results by `max(affinity_score)` desc, with `weighted_traits_score` as secondary key. Zero-affinity entries sink below any positive-affinity entry regardless of traits score. Rationale: a score-1.0 Tesla employee with zero graph connection is less useful than a score-0.5 ex-Tesla founder via your strongest bridge.
+
+- **Backwards compat:** `flagshipPerson.MutualCount` stays. New `Bridges []BridgeRef` is additive. JSON consumers that ignore unknown fields are unaffected. Rationale: CLI is user-owned, no external consumers of JSON output that we know of, but additive change is still cheaper than migration.
+
+- **SKILL.md + plugin regen:** Per `printing-press-library/AGENTS.md`, changes under `library/**/internal/cli/**` require running `go run ./tools/generate-skills/main.go` and bumping `plugin/.claude-plugin/plugin.json` patch version. Rationale: repo convention, CI depends on it.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Should we change warm-intro's ranking to use affinity?** Resolved: no, this plan only ensures warm-intro has affinity available in `client.Person`. Ranking redesign is out of scope.
+- **Q: Should we surface `traits[].evidence` prose?** Resolved: no for this plan. `traits` is captured in the API types so it is available to future renderers, but no command prints it in this plan. Keeps the change bounded.
+- **Q: Filter out self-bridge entries, or present them as "in your contacts"?** Resolved: present as `in your synced graph` tag and do not list the user by name. The existing `currentUUID` plumbing already lets the normalizer identify the self-entry.
+
+### Deferred to Implementation
+
+- Exact Go type names for new structs (SearchMutual vs BridgeEntry etc.) - pick during implementation, prefer names that already appear elsewhere in the codebase.
+- Whether to inline-define Bridge in `client` package or make it a sub-package - decide by looking at how client.Person is currently organized.
+- Whether the human-friendly renderer should show all bridges or just the top 1 - decide once the JSON path is working and the human render can be tested.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+Data flow:
+
+```
+POST /v1/search (bearer)
+       |
+       v
+GET /v1/search/{id}              <- poll until COMPLETED
+       |
+       v
+SearchEnvelope {
+  Mutuals: [                      <- NEW: top-level bridge list
+    {index:0, id, name},          <- friends
+    {index:3, id, name}           <- self-entry (identified by currentUUID)
+  ],
+  Results: [
+    { Name, CurrentTitle, CurrentCompany,
+      WeightedTraitsScore,
+      Mutuals: [{index, affinity_score}],   <- NEW
+      Socials: {linkedin_url, ...},          <- NEW
+      Traits:  [{index, score, evidence}]    <- NEW (captured, not rendered)
+    }
+  ]
+}
+       |
+       v  ToClientPerson(result, envelopeMutuals, currentUUID)
+       |
+       v
+client.Person {
+  Name, Title, Company, Score,
+  Bridges: [                      <- NEW, dereferenced + filtered
+    {Name:"Jeff Clavier", UUID, AffinityScore:104.38, Kind:"friend"},
+  ]
+  Socials: {LinkedInURL}
+}
+       |
+       v  per-command projection (coverage/prospect/warm-intro/hp-people/api-hpn-search)
+       |
+       v
+Output row {
+  Rationale: "via Jeff Clavier (affinity 104.4)",
+  Bridges:   [...],
+  Score:     max(Bridges.AffinityScore) || WeightedTraitsScore
+}
+```
+
+Rationale-string decision table:
+
+| Bridges present | Max affinity | Rationale string |
+|---|---|---|
+| 1+ friend bridge | > 0 | `via <top bridge name> (affinity X.X)` |
+| 1+ friend bridge | = 0 | `Happenstance bearer (weak signal, no graph affinity)` |
+| Only self-bridge | n/a | `in your synced graph` |
+| No bridges at all | n/a | `Happenstance bearer (no graph match)` |
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend Happenstance bearer API types to capture mutuals, socials, traits**
+
+**Goal:** `SearchEnvelope` and `SearchResult` unmarshal the full bearer response shape including bridges, affinity, socials, and traits. No behavior change yet; just the structs.
+
+**Requirements:** R1
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `internal/happenstance/api/types.go`
+- Test: `internal/happenstance/api/search_test.go`
+
+**Approach:**
+- Add `SearchMutual` type (envelope-level): `Index int`, `Id string`, `Name string`, `HappenstanceURL string`.
+- Add `ResultMutual` type (result-level): `Index int`, `AffinityScore float64`.
+- Add `SearchSocials` type: `LinkedInURL`, `TwitterURL`, `InstagramURL`, `HappenstanceURL` (all omitempty).
+- Add `SearchTrait` type: `Index int`, `Score float64`, `Evidence string`.
+- Extend `SearchEnvelope` with `Mutuals []SearchMutual`.
+- Extend `SearchResult` with `Mutuals []ResultMutual`, `Socials *SearchSocials`, `Traits []SearchTrait`, `Summary string`, `Id string`.
+- Keep all new fields `omitempty` so existing cookie-path fixtures remain valid.
+
+**Patterns to follow:**
+- Existing struct definitions at `internal/happenstance/api/types.go` lines 62-83.
+- Tag convention: `json:"snake_case_field,omitempty"`.
+
+**Test scenarios:**
+- Happy path: Unmarshal a fixture JSON matching the verified 2026-04-19 Tesla response (top-level `mutuals` with 4 entries, result rows with per-result `mutuals` + `affinity_score` + `socials.linkedin_url`); assert all fields populate.
+- Edge case: Unmarshal a response with an empty `mutuals: []` array at both levels; assert no panic and empty slice.
+- Edge case: Unmarshal a response where `mutuals` field is absent entirely (older API or cookie path); assert nil slice, no error.
+- Edge case: Unmarshal a result row where `mutuals[].affinity_score` is a very small float (e.g., `4.77e-39` per observed response) and a very large float (`245.23`); assert both round-trip without precision loss.
+
+**Verification:**
+- Test fixture unmarshal round-trips every new field.
+- `go vet ./...` and `go build ./...` clean.
+- No existing test fails.
+
+- [ ] **Unit 2: Extend canonical Person with Bridges + Socials; update normalizer**
+
+**Goal:** `client.Person` carries bridge info and linkedin_url. `api.ToClientPerson` dereferences the envelope-level `Mutuals` against each result's `Mutuals[].index`, filters out the self-entry (matched by `currentUUID`), and emits `client.Bridge` entries.
+
+**Requirements:** R1, R3, R5
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `internal/client/person.go` (or wherever `client.Person` is defined - locate during implementation)
+- Modify: `internal/happenstance/api/normalize.go`
+- Modify: `internal/happenstance/api/search.go` (if `ToClientPerson` signature needs envelope mutuals + currentUUID passed in)
+- Modify: `internal/cli/source_selection.go` (BearerSearchAdapter calls `ToClientPerson`; update call site at line 482)
+- Test: `internal/happenstance/api/normalize_test.go`
+
+**Approach:**
+- Define `client.Bridge { Name string; HappenstanceUUID string; AffinityScore float64; Kind string }`. Kind is `"friend"` or `"self_graph"`.
+- Add `Bridges []Bridge` and `LinkedInURL string` fields on `client.Person`.
+- `ToClientPerson` now takes the envelope `Mutuals` slice and `currentUUID` as extra args. Build an index map (`index -> SearchMutual`) once per envelope; for each result, resolve its `Mutuals[].index` to bridge entries; skip / retag any bridge whose `Id` equals `currentUUID`.
+- Propagate the extra args through BearerSearchAdapter without changing exported return shape.
+
+**Patterns to follow:**
+- Existing ToClientPerson mapping at `internal/happenstance/api/normalize.go` lines 50-57.
+- `currentUUID` is already plumbed through `coverage.go`; reuse the same source (Happenstance auth layer or session context).
+
+**Test scenarios:**
+- Happy path: Envelope with 3 friend mutuals + 1 self-mutual; result row with two bridges (one friend at affinity 104, one self at affinity 0). Assert `Bridges` contains only the friend bridge with `Kind:"friend"`, and a `self_graph` marker attached separately (field TBD during impl).
+- Edge case: Result with empty `Mutuals: []`; assert `Bridges` is empty and no panic.
+- Edge case: Result with a single bridge whose `index` points to an entry NOT in the envelope (malformed API response); assert the bridge is dropped silently and a debug log line is emitted.
+- Edge case: Envelope with `currentUUID` not matching any top-level mutual; assert no panic, all bridges treated as `friend`.
+- Integration scenario: Call BearerSearchAdapter with a captured fixture via a stubbed HTTP transport; assert the returned `[]client.Person` have Bridges populated end-to-end.
+
+**Verification:**
+- Normalizer tests pass.
+- `client.Person` JSON marshal produces `bridges` and `linkedin_url` fields when populated, omits them when empty.
+
+- [ ] **Unit 3: Update flagshipPerson + coverage bearer-path rendering**
+
+**Goal:** Coverage command surfaces bridges, affinity-aware rationale, and affinity-based sort for bearer rows. `flagshipPerson` gains a `Bridges` field.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `internal/cli/flagship_helpers.go` (lines 32-47 struct def; plus dedup/merge logic if any touches Bridges)
+- Modify: `internal/cli/coverage.go` (lines 275-290 bearer mapping block; plus final sort)
+- Test: `internal/cli/flagship_helpers_test.go`
+- Create: `internal/cli/coverage_test.go`
+
+**Approach:**
+- Add `Bridges []BridgeRef` to `flagshipPerson` where `BridgeRef = {Name, HappenstanceUUID, AffinityScore, Kind}`.
+- In coverage.go bearer block: populate `row.Bridges` from `p.Bridges`; compute `maxAff := max(p.Bridges[i].AffinityScore)`; set `row.Rationale` per the rationale decision table; set `row.Score = maxAff` when > 0, else fall back to the existing `p.Score` (WeightedTraitsScore).
+- After the bearer block and before cross-source dedup, sort bearer-tagged rows by `Score` desc, zero-affinity rows last.
+- Ensure cross-source dedup (cookie row + bearer row for same person) merges Bridges from the bearer row into the kept row.
+
+**Patterns to follow:**
+- Existing `graphPersonToFlagship` helper in coverage.go.
+- Existing dedup/merge logic in `flagship_helpers.go` (whatever merges duplicate rows across sources).
+
+**Test scenarios:**
+- Happy path: 3 bearer results with affinities [104, 50, 0]; assert output rationale strings `via Jeff Clavier (affinity 104.4)`, `via Garry Tan (affinity 50.0)`, `Happenstance bearer (weak signal, no graph affinity)` and sort order [104, 50, 0].
+- Happy path: 1 bearer result whose only bridge is self; assert rationale `in your synced graph` and sort-wise treated as weak.
+- Edge case: Result with zero bridges at all; assert rationale `Happenstance bearer (no graph match)`, sort position after all bridged rows.
+- Error path: `ExecuteWithSourceFallback` returns no results (all upstream failed); assert `count:0` JSON with `source_errors` still propagated.
+- Integration scenario: Run coverage for a company where cookie path returns 1 row and bearer path returns 3 rows (including 1 duplicate of the cookie row); assert dedup keeps the cookie row but merges bearer Bridges onto it.
+
+**Verification:**
+- `contact-goat-pp-cli coverage Tesla --agent` against a recorded fixture reproduces the expected JSON with Bridges + affinity-aware rationale.
+- Zero-affinity hits sort last.
+- Existing cookie-path coverage test (if any) still passes.
+
+- [ ] **Unit 4: Apply the same bearer-path fix to prospect, hp-people, warm-intro, api-hpn-search**
+
+**Goal:** Bearer-surface projection is consistent across every command that calls BearerSearchAdapter or the bearer path directly. No remaining code path emits `Rationale: "Happenstance bearer"` without bridge detail.
+
+**Requirements:** R2, R6
+
+**Dependencies:** Unit 3 (the rationale decision table + `flagshipPerson.Bridges` shape must be locked in first).
+
+**Files:**
+- Modify: `internal/cli/prospect.go` (lines 128-148)
+- Modify: `internal/cli/hp_people.go` (buildHPPeopleJSON)
+- Modify: `internal/cli/warm_intro.go` (bearer row projection site)
+- Modify: `internal/cli/api_hpn_search.go` (lines 290-300; extend `hpnSearchResult` with Bridges)
+- Test: `internal/cli/prospect_test.go` (if exists; else create)
+- Test: `internal/cli/warm_intro_test.go` (if exists; else create)
+- Test: `internal/cli/api_hpn_search_test.go` (if exists; else create)
+
+**Approach:**
+- Each file gets the same change: read `p.Bridges`, compute rationale via a shared helper in `flagship_helpers.go` called e.g. `bearerRationale(bridges, selfUUID) string`, set output rationale + score identically.
+- Extract the rationale formatter into one helper so the decision table has a single source of truth.
+- `api_hpn_search.go`'s `hpnSearchResult` is a thinner struct (no flagshipPerson); extend it with `Bridges []BridgeRef` and `Rationale string`.
+
+**Patterns to follow:**
+- The bearer-row mapping pattern established in Unit 3.
+- Shared helper placement convention: generic flagship helpers live in `flagship_helpers.go`.
+
+**Test scenarios:**
+- Happy path (prospect): Fan-out search with a bearer hit at affinity 50; assert same rationale format as coverage.
+- Happy path (warm-intro): Target person with one bearer bridge at affinity 104; assert the candidate output includes the bridge + affinity (warm-intro's own ranking stays unchanged).
+- Happy path (hp people): Same as coverage assertions.
+- Happy path (api hpn search): hpnSearchResult JSON now includes `bridges` and `rationale` fields.
+- Edge case: Each command still handles an empty results array without panicking.
+
+**Verification:**
+- No command in `internal/cli/` references the literal `"Happenstance bearer"` string for rationale anymore - grep confirms the only reference is in the shared helper.
+- `go test ./...` passes.
+
+- [ ] **Unit 5: Regenerate plugin/skills mirror + bump plugin version**
+
+**Goal:** Repo convention (per `printing-press-library/AGENTS.md`) that any change under `library/**/internal/cli/**` must commit the regenerated `plugin/skills/pp-contact-goat/SKILL.md` plus a semver-patch bump on `plugin/.claude-plugin/plugin.json`.
+
+**Requirements:** R5 (repo-convention compliance; CI dependency)
+
+**Dependencies:** Units 1-4 merged (regen runs against final source).
+
+**Files:**
+- Modify: `plugin/.claude-plugin/plugin.json` (version field)
+- Modify: `plugin/skills/pp-contact-goat/SKILL.md` (auto-generated)
+
+**Approach:**
+- Run `go run ./tools/generate-skills/main.go` from repo root.
+- Bump `plugin/.claude-plugin/plugin.json` patch version by 1.
+- Commit alongside the feature commit per AGENTS.md commit-style guidance: `chore(plugin): regenerate pp-contact-goat skill + bump to X.Y.Z`.
+
+**Patterns to follow:**
+- `printing-press-library/AGENTS.md` "Keeping plugin/skills in sync" section.
+
+**Test scenarios:**
+- Not applicable; this is a regen step.
+
+**Verification:**
+- `git diff plugin/skills/pp-contact-goat/SKILL.md` shows only changes that reflect the new flags/behavior (if SKILL.md documents bearer-path behavior) or is empty (if SKILL.md does not mention bearer details).
+- CI `verify-skills.yml` passes locally via `python .github/scripts/verify-skill/verify_skill.py library/sales-and-crm/contact-goat`.
+
+## System-Wide Impact
+
+- **Interaction graph:** Every command consuming bearer results flows through `BearerSearchAdapter -> ToClientPerson`. Changes in Unit 2 propagate automatically; per-command projections (Units 3-4) catch the remaining surface.
+- **Error propagation:** Bearer API 429s and malformed responses are already handled in `ExecuteWithSourceFallback`. New code paths must not swallow errors - e.g., a malformed `mutuals[].index` should log at debug and drop the entry, not fail the request.
+- **State lifecycle risks:** None. No persistent state; each request is stateless.
+- **API surface parity:** All 5 bearer-path commands must match on rationale format. Single shared helper enforces this.
+- **Integration coverage:** Need one end-to-end test per command that exercises the bearer path (stubbed HTTP) and asserts bridge + rationale appear in output. Unit-level tests on the normalizer and flagship helper are insufficient alone.
+- **Unchanged invariants:** Cookie-path output unchanged. JSON consumers that ignore unknown fields unaffected. `flagshipPerson.MutualCount` semantics unchanged. Existing `Rationale` field is a string (still a string, just a richer value). `Score` field is a float (still a float, new semantics documented in code).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Cookie-path projections accidentally get "bearer rationale" formatting | Apply new rationale logic only inside the `if out.UsedSource == SourceAPI` branches; unit tests per command verify cookie path unchanged. |
+| `currentUUID` plumbing isn't available in all bearer call sites | Pre-flight audit during Unit 2: grep every `ToClientPerson` call and confirm currentUUID source. If missing, pass `""` and skip self-filtering; add a TODO + test expecting self-bridge tagged as `friend` in that fallback. |
+| Malformed bearer response (index out of range) crashes the normalizer | Unit 2 tests cover this; defensive index check in the dereference loop. |
+| Score field now mixes affinity and traits-score magnitudes (affinity can be 0-300+, traits is 0-1) | Document clearly in `flagshipPerson` struct doc comment. Downstream consumers already treat Score as relative, not absolute. Cross-source ranking in coverage.go lines ~ranked section still uses source-strength tiers, not raw Score comparisons. |
+| SKILL.md regen drift between library copy and plugin copy | Unit 5 is explicit step; CI verify-skills catches residual drift. |
+| Plan deploys before affinity scores are validated to mean what we think they mean | Affinity observed in live 2026-04-19 Tesla response: friend-bridge hits showed 104, 71, 62, 55, 48, 24 etc.; self-bridge hits showed 0 or near-zero. Behavior matches "higher = stronger graph signal." Accepting this empirical interpretation without API docs. |
+
+## Documentation / Operational Notes
+
+- Update `library/sales-and-crm/contact-goat/README.md` Coverage section to describe bridge + affinity output (one paragraph).
+- Update `library/sales-and-crm/contact-goat/SKILL.md` if it documents bearer-path behavior; per AGENTS.md the verifier checks flags, not field names, so this is discretionary.
+- No migration needed. No feature flag. Change is additive for JSON consumers.
+- Dogfood: rerun the Tesla coverage query that surfaced this bug and confirm Ira Ehrenpreis rationale reads `via Jeff Clavier (affinity 104.4)`.
+
+## Sources & References
+
+- Live bearer API response capture: 2026-04-19, `/v1/search` id `4d0f3992-2587-47c2-a743-1a4365d6c8f2`, query `"people at Tesla"`.
+- Repo source: `/Users/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat`
+- Upstream repo: https://github.com/mvanhorn/printing-press-library (via AGENTS.md reference)
+- Related convention doc: `/Users/mvanhorn/printing-press-library/AGENTS.md` (SKILL.md + plugin sync section)

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
@@ -56,10 +56,13 @@ type hpnSearchEnvelope struct {
 // .results[].name keep working whether the result came from a /v1/search
 // row or from a normalizer shim.
 type hpnSearchResult struct {
-	Name           string  `json:"name"`
-	CurrentTitle   string  `json:"current_title,omitempty"`
-	CurrentCompany string  `json:"current_company,omitempty"`
-	Score          float64 `json:"score,omitempty"`
+	Name           string      `json:"name"`
+	CurrentTitle   string      `json:"current_title,omitempty"`
+	CurrentCompany string      `json:"current_company,omitempty"`
+	LinkedInURL    string      `json:"linkedin_url,omitempty"`
+	Score          float64     `json:"score,omitempty"`
+	Bridges        []bridgeRef `json:"bridges,omitempty"`
+	Rationale      string      `json:"rationale,omitempty"`
 }
 
 // newAPIHpnSearchCmd builds `api hpn search`. The parent command takes a
@@ -290,13 +293,26 @@ func runHpnSearch(ctx context.Context, c *api.Client, text string, opts *api.Sea
 func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchEnvelope, query string) error {
 	results := make([]hpnSearchResult, 0, len(env.Results))
 	for _, r := range env.Results {
-		p := api.ToClientPerson(r)
-		results = append(results, hpnSearchResult{
+		// `api hpn search` is a raw developer surface — the caller did
+		// not pass a currentUUID so we cannot retag the self-entry.
+		// Pass "" so every bridge shows up as a friend bridge (harmless;
+		// the raw endpoint JSON is meant to be grepped by humans).
+		p := api.ToClientPersonWithBridges(r, env.Mutuals, "")
+		row := hpnSearchResult{
 			Name:           p.Name,
 			CurrentTitle:   p.CurrentTitle,
 			CurrentCompany: p.CurrentCompany,
+			LinkedInURL:    p.LinkedInURL,
 			Score:          p.Score,
-		})
+		}
+		if len(p.Bridges) > 0 {
+			row.Bridges = bridgesToFlagship(p.Bridges)
+			row.Rationale = bearerRationale(p.Bridges)
+			if score := bearerScore(p.Bridges, p.Score); score > row.Score {
+				row.Score = score
+			}
+		}
+		results = append(results, row)
 	}
 	out := hpnSearchEnvelope{
 		SearchID:  env.Id,

--- a/library/sales-and-crm/contact-goat/internal/cli/bearer_rationale_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/bearer_rationale_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
+)
+
+// TestBearerRationale_DecisionTable pins down the exact rationale strings
+// every bearer-surface command should emit, keyed off the shape of the
+// bridge slice. Fixing these strings here keeps coverage, prospect,
+// hp-people, warm-intro, and api-hpn-search in lockstep — if a renderer
+// drifts, this test catches it before a user sees a rationale mismatch.
+func TestBearerRationale_DecisionTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		bridges  []client.Bridge
+		want     string
+	}{
+		{
+			name:    "friend bridge with positive affinity",
+			bridges: []client.Bridge{{Name: "Jeff Clavier", Kind: client.BridgeKindFriend, AffinityScore: 104.38}},
+			want:    "via Jeff Clavier (affinity 104.4)",
+		},
+		{
+			name: "multiple friend bridges picks highest affinity",
+			bridges: []client.Bridge{
+				{Name: "Weak", Kind: client.BridgeKindFriend, AffinityScore: 3.0},
+				{Name: "Strong", Kind: client.BridgeKindFriend, AffinityScore: 50.0},
+				{Name: "Mid", Kind: client.BridgeKindFriend, AffinityScore: 10.0},
+			},
+			want: "via Strong (affinity 50.0)",
+		},
+		{
+			name:    "friend bridge with zero affinity is weak-signal",
+			bridges: []client.Bridge{{Name: "Garry Tan", Kind: client.BridgeKindFriend, AffinityScore: 0}},
+			want:    "Happenstance bearer (weak signal, no graph affinity)",
+		},
+		{
+			name:    "only self-graph bridge renders as synced graph",
+			bridges: []client.Bridge{{Name: "Matt", Kind: client.BridgeKindSelfGraph, AffinityScore: 0}},
+			want:    "in your synced graph",
+		},
+		{
+			name: "friend bridge with real affinity wins over self-graph",
+			bridges: []client.Bridge{
+				{Name: "Matt", Kind: client.BridgeKindSelfGraph, AffinityScore: 5},
+				{Name: "Jeff", Kind: client.BridgeKindFriend, AffinityScore: 10},
+			},
+			want: "via Jeff (affinity 10.0)",
+		},
+		{
+			name:    "no bridges at all",
+			bridges: nil,
+			want:    "Happenstance bearer (no graph match)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bearerRationale(tc.bridges)
+			if got != tc.want {
+				t.Errorf("bearerRationale(%+v) = %q, want %q", tc.bridges, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBearerScore_AffinityWinsWhenPositive verifies the score-selection
+// policy: max friend-bridge affinity trumps traits score when positive,
+// otherwise traits score is the fallback.
+func TestBearerScore_AffinityWinsWhenPositive(t *testing.T) {
+	cases := []struct {
+		name    string
+		bridges []client.Bridge
+		traits  float64
+		want    float64
+	}{
+		{"positive affinity beats traits", []client.Bridge{{Kind: client.BridgeKindFriend, AffinityScore: 50}}, 0.9, 50},
+		{"zero affinity falls back to traits", []client.Bridge{{Kind: client.BridgeKindFriend, AffinityScore: 0}}, 0.75, 0.75},
+		{"no friend bridges falls back to traits", []client.Bridge{{Kind: client.BridgeKindSelfGraph, AffinityScore: 100}}, 0.42, 0.42},
+		{"no bridges at all falls back to traits", nil, 0.33, 0.33},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bearerScore(tc.bridges, tc.traits)
+			if got != tc.want {
+				t.Errorf("bearerScore = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBridgesToFlagship_RoundTrip verifies the canonical->render
+// projection preserves every field and returns nil (not an empty slice)
+// when the input is empty so JSON output omits the field.
+func TestBridgesToFlagship_RoundTrip(t *testing.T) {
+	in := []client.Bridge{
+		{Name: "Jeff", HappenstanceUUID: "u1", AffinityScore: 104.4, Kind: client.BridgeKindFriend},
+		{Name: "Self", HappenstanceUUID: "u2", AffinityScore: 0, Kind: client.BridgeKindSelfGraph},
+	}
+	got := bridgesToFlagship(in)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Name != "Jeff" || got[0].Kind != "friend" || got[0].AffinityScore != 104.4 || got[0].HappenstanceUUID != "u1" {
+		t.Errorf("[0] = %+v", got[0])
+	}
+	if got[1].Kind != "self_graph" {
+		t.Errorf("[1].Kind = %q, want self_graph", got[1].Kind)
+	}
+	if bridgesToFlagship(nil) != nil {
+		t.Errorf("empty input should return nil, not empty slice")
+	}
+}
+
+// TestMergePeople_BridgesCarriedAcrossDedup covers the integration case
+// where a cookie-path row and a bearer-path row dedupe to the same
+// Person (matched by LinkedIn URL). The bearer row's bridges are
+// additive graph context and must survive the merge onto the cookie
+// row. Without this the user sees a "1st-degree" cookie tag but loses
+// the affinity-weighted bridge detail the bearer API gave us.
+func TestMergePeople_BridgesCarriedAcrossDedup(t *testing.T) {
+	cookieRow := flagshipPerson{
+		Name:        "Ira Ehrenpreis",
+		LinkedInURL: "https://www.linkedin.com/in/iraehrenpreis",
+		Sources:     []string{"hp_graph_2deg"},
+	}
+	bearerRow := flagshipPerson{
+		Name:        "Ira Ehrenpreis",
+		LinkedInURL: "https://linkedin.com/in/iraehrenpreis/",
+		Sources:     []string{"hp_api"},
+		Bridges: []bridgeRef{
+			{Name: "Jeff Clavier", AffinityScore: 104.4, Kind: "friend"},
+		},
+	}
+	merged := mergePeople([]flagshipPerson{cookieRow, bearerRow})
+	if len(merged) != 1 {
+		t.Fatalf("merged rows = %d, want 1 (should dedupe by canonical LinkedIn URL)", len(merged))
+	}
+	row := merged[0]
+	if len(row.Bridges) != 1 || row.Bridges[0].Name != "Jeff Clavier" {
+		t.Errorf("merged bridges = %+v, want one Jeff Clavier entry", row.Bridges)
+	}
+	// Cookie source should appear first (kept as primary); the bearer
+	// source is appended but the merge retains both for provenance.
+	if len(row.Sources) != 2 {
+		t.Errorf("merged sources = %v, want both cookie + api tags", row.Sources)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/config"
-	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/happenstance/api"
 )
 
 func newCoverageCmd(flags *rootFlags) *cobra.Command {
@@ -128,7 +128,15 @@ failed".`,
 				} else if containsSource(p.Sources, "li_1deg") {
 					p.Relationship = "linkedin_1deg"
 				}
-				p.Score = scoreForRelationship(p.Relationship) + sourceStrength(firstSource(p.Sources)) + connectionBonus(p.ConnectionCount)
+				// Bridge affinity from the bearer API is additive on top of
+				// the tier+source composite so a 2nd-degree-via-strong-bridge
+				// row can outrank a 2nd-degree-via-weak-bridge row without
+				// disturbing the coarse tier ordering. See bridgeAffinityBonus
+				// in flagship_helpers.go for the scaling rationale.
+				p.Score = scoreForRelationship(p.Relationship) +
+					sourceStrength(firstSource(p.Sources)) +
+					connectionBonus(p.ConnectionCount) +
+					bridgeAffinityBonus(p.Bridges)
 			}
 			results = mergePeople(results)
 			rankPeople(results)
@@ -252,7 +260,7 @@ func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company strin
 	var bearerRun BearerRunner
 	if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
 		bearerRun = func() (*client.PeopleSearchResult, error) {
-			return BearerSearchAdapter(cmd.Context(), bc, "people at "+company, nil)
+			return BearerSearchAdapter(cmd.Context(), bc, "people at "+company, currentUUID, nil)
 		}
 	}
 
@@ -268,25 +276,44 @@ func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company strin
 
 	// Project /api/dynamo Person rows (cookie) or normalized bearer rows
 	// into flagshipPerson. The graphPersonToFlagship path uses the
-	// referrer chain to label tier; the bearer surface has no referrer
-	// data so labels collapse to "happenstance" with rationale that
-	// names the source.
+	// referrer chain to label tier; the bearer path uses envelope-level
+	// mutuals (dereferenced into p.Bridges by the normalizer) to pick a
+	// rationale string, score, and bridge list that callers can act on.
 	graph := make([]flagshipPerson, 0, len(out.Result.People))
 	for _, p := range out.Result.People {
 		row := graphPersonToFlagship(p, currentUUID)
 		if out.UsedSource == SourceAPI {
-			// Bearer rows have no referrer chain; keep the score from
-			// WeightedTraitsScore (already mapped by the normalizer)
-			// and tag them so the renderer can show "source: api".
 			row.Sources = []string{"hp_api"}
-			if out.FellBackFromCookie {
-				row.Rationale = fmt.Sprintf("Happenstance bearer (%s)", api.DefaultBaseURL)
+			row.Rationale = bearerRationale(p.Bridges)
+			row.Score = bearerScore(p.Bridges, p.Score)
+			row.Bridges = bridgesToFlagship(p.Bridges)
+			// Relationship is a coarse tier label used by downstream
+			// ranking. Promote self-graph to "hp_graph_1deg" parity (the
+			// person is literally in the user's own synced contacts);
+			// friend-bridged rows fall under the API tag so the renderer
+			// still shows "source: api" and so mixed cookie+API result
+			// sets sort by actual affinity rather than by tag strength.
+			if hasSelfGraphBridge(p.Bridges) {
+				row.Relationship = string(client.TierFirstDegree)
 			} else {
-				row.Rationale = "Happenstance bearer surface"
+				row.Relationship = "happenstance_api"
 			}
-			row.Relationship = "happenstance_api"
 		}
 		graph = append(graph, row)
+	}
+
+	// Sort the bearer slice by affinity-aware score so zero-affinity
+	// hits sink below any row with real graph signal. Cookie-only rows
+	// keep the default relative order chosen upstream.
+	if out.UsedSource == SourceAPI {
+		sort.SliceStable(graph, func(i, j int) bool {
+			si := graph[i].Score
+			sj := graph[j].Score
+			if si != sj {
+				return si > sj
+			}
+			return strings.ToLower(graph[i].Name) < strings.ToLower(graph[j].Name)
+		})
 	}
 	return graph, errs
 }

--- a/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"sort"
@@ -30,20 +31,145 @@ import (
 // struct with typed fields — downstream output is --json by default, and the
 // set of fields varies by feature.
 type flagshipPerson struct {
-	Name             string   `json:"name"`
-	LinkedInURL      string   `json:"linkedin_url,omitempty"`
-	HappenstanceUUID string   `json:"happenstance_uuid,omitempty"`
-	Title            string   `json:"title,omitempty"`
-	Company          string   `json:"company,omitempty"`
-	Location         string   `json:"location,omitempty"`
-	ImageURL         string   `json:"image_url,omitempty"`
-	ConnectionCount  int      `json:"connection_count,omitempty"`
-	Sources          []string `json:"sources,omitempty"`
-	Rationale        string   `json:"rationale,omitempty"`
-	Relationship     string   `json:"relationship,omitempty"`
-	MutualCount      int      `json:"mutual_count,omitempty"`
-	Score            float64  `json:"score,omitempty"`
-	Raw              any      `json:"raw,omitempty"`
+	Name             string         `json:"name"`
+	LinkedInURL      string         `json:"linkedin_url,omitempty"`
+	HappenstanceUUID string         `json:"happenstance_uuid,omitempty"`
+	Title            string         `json:"title,omitempty"`
+	Company          string         `json:"company,omitempty"`
+	Location         string         `json:"location,omitempty"`
+	ImageURL         string         `json:"image_url,omitempty"`
+	ConnectionCount  int            `json:"connection_count,omitempty"`
+	Sources          []string       `json:"sources,omitempty"`
+	Rationale        string         `json:"rationale,omitempty"`
+	Relationship     string         `json:"relationship,omitempty"`
+	MutualCount      int            `json:"mutual_count,omitempty"`
+	Bridges          []bridgeRef    `json:"bridges,omitempty"`
+	Score            float64        `json:"score,omitempty"`
+	Raw              any            `json:"raw,omitempty"`
+}
+
+// bridgeRef is flagshipPerson's render-time projection of a client.Bridge.
+// Kept separate from the client type so the JSON output schema is stable
+// even if the canonical Bridge struct gains internal fields. Zero
+// AffinityScore is a valid weak-signal marker; renderers must treat it as
+// "bridge exists but mention-only" rather than filtering it out.
+type bridgeRef struct {
+	Name             string  `json:"name,omitempty"`
+	HappenstanceUUID string  `json:"happenstance_uuid,omitempty"`
+	AffinityScore    float64 `json:"affinity_score"`
+	Kind             string  `json:"kind,omitempty"`
+}
+
+// bridgesToFlagship projects a slice of canonical client.Bridge entries
+// onto the flagshipPerson render shape. Returns nil when the input is
+// empty so JSON output omits the field.
+func bridgesToFlagship(in []client.Bridge) []bridgeRef {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]bridgeRef, 0, len(in))
+	for _, b := range in {
+		out = append(out, bridgeRef{
+			Name:             b.Name,
+			HappenstanceUUID: b.HappenstanceUUID,
+			AffinityScore:    b.AffinityScore,
+			Kind:             b.Kind,
+		})
+	}
+	return out
+}
+
+// topFriendBridge returns the highest-affinity friend bridge from the
+// slice, or (zero, false) if none exist. Self-graph bridges are
+// ignored so "via <your own contacts>" never leaks into renderer prose.
+func topFriendBridge(bridges []client.Bridge) (client.Bridge, bool) {
+	var top client.Bridge
+	found := false
+	for _, b := range bridges {
+		if b.Kind == client.BridgeKindSelfGraph {
+			continue
+		}
+		if !found || b.AffinityScore > top.AffinityScore {
+			top = b
+			found = true
+		}
+	}
+	return top, found
+}
+
+// hasSelfGraphBridge reports whether the slice contains at least one
+// self-graph bridge (meaning the person sits in the user's own synced
+// LinkedIn/Gmail contacts bucket on the bearer surface).
+func hasSelfGraphBridge(bridges []client.Bridge) bool {
+	for _, b := range bridges {
+		if b.Kind == client.BridgeKindSelfGraph {
+			return true
+		}
+	}
+	return false
+}
+
+// bearerRationale formats a human-readable rationale string for a
+// bearer-surface person based on the graph signal the API returned.
+// The decision table:
+//
+//   - One+ friend bridge with affinity > 0 -> "via <top name> (affinity X.X)"
+//   - One+ friend bridge with all affinities 0 -> weak-signal string
+//   - Only self-graph bridges -> "in your synced graph"
+//   - No bridges at all -> "Happenstance bearer (no graph match)"
+//
+// Exported (lowercase, package-scoped) so every bearer-path command in
+// this package formats consistently. If two commands disagree, fix them
+// here, not inline at the call site.
+func bearerRationale(bridges []client.Bridge) string {
+	top, ok := topFriendBridge(bridges)
+	if ok {
+		if top.AffinityScore > 0 {
+			return fmt.Sprintf("via %s (affinity %.1f)", top.Name, top.AffinityScore)
+		}
+		return "Happenstance bearer (weak signal, no graph affinity)"
+	}
+	if hasSelfGraphBridge(bridges) {
+		return "in your synced graph"
+	}
+	return "Happenstance bearer (no graph match)"
+}
+
+// bridgeAffinityBonus converts a slice of bridges into an additive
+// ranking bonus, scaled so coarse tier ordering from scoreForRelationship
+// stays intact for typical affinities but strong graph signal (observed
+// up to ~300) can still push a 2nd-degree row past a 1st-degree row
+// with a weak source. Scale: log1p(max_friend_affinity). A typical
+// non-zero friend bridge sits in the 10-100 range, yielding a bonus of
+// 2.4-4.6 — enough to distinguish adjacent bearer rows, not enough to
+// leap tiers. Zero or self-graph-only inputs return 0.
+func bridgeAffinityBonus(bridges []bridgeRef) float64 {
+	var top float64
+	for _, b := range bridges {
+		if b.Kind == client.BridgeKindSelfGraph {
+			continue
+		}
+		if b.AffinityScore > top {
+			top = b.AffinityScore
+		}
+	}
+	if top <= 0 {
+		return 0
+	}
+	return math.Log1p(top)
+}
+
+// bearerScore picks the score a bearer-surface row should sort by.
+// Priority: max friend-bridge affinity (if > 0) > traits score > 0. The
+// traits fallback keeps bearer rows with no graph signal comparable to
+// each other via the API's WeightedTraitsScore, which is what the old
+// bearer projection relied on exclusively.
+func bearerScore(bridges []client.Bridge, traitsScore float64) float64 {
+	top, ok := topFriendBridge(bridges)
+	if ok && top.AffinityScore > 0 {
+		return top.AffinityScore
+	}
+	return traitsScore
 }
 
 // personLookupKey returns the best available unique key (linkedin URL, else
@@ -106,6 +232,15 @@ func mergePeople(in []flagshipPerson) []flagshipPerson {
 			}
 			if p.ConnectionCount > existing.ConnectionCount {
 				existing.ConnectionCount = p.ConnectionCount
+			}
+			// Bridges are a bearer-surface signal. When a cookie-path row
+			// and a bearer-path row dedupe to the same person, the cookie
+			// row wins on most fields but the bearer bridges are still
+			// useful context — no overlap with the cookie Referrers
+			// chain, which lives in the untyped Raw field today. Merge
+			// them on so downstream renderers see both.
+			if len(p.Bridges) > 0 && len(existing.Bridges) == 0 {
+				existing.Bridges = p.Bridges
 			}
 			continue
 		}

--- a/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
@@ -92,6 +92,15 @@ connected. The RELATIONSHIP column shows 1st_degree / 2nd_degree /
 			}
 			LogDeferredHint(cmd.ErrOrStderr(), deferredErr)
 
+			// Resolve currentUserUUID up-front so the bearer adapter can
+			// retag the self-entry in its envelope mutuals. Without this
+			// the bearer path cannot distinguish "in your synced graph"
+			// from "via one of your friends".
+			currentUserUUID := ""
+			if cookieAvailable {
+				currentUserUUID, _ = fetchCurrentUserUUID(cookieClient)
+			}
+
 			cookieRun := CookieRunner(nil)
 			if cookieAvailable {
 				opts := &client.SearchPeopleOptions{
@@ -108,7 +117,7 @@ connected. The RELATIONSHIP column shows 1st_degree / 2nd_degree /
 			var bearerRun BearerRunner
 			if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
 				bearerRun = func() (*client.PeopleSearchResult, error) {
-					return BearerSearchAdapter(cmd.Context(), bc, query, &api.SearchOptions{
+					return BearerSearchAdapter(cmd.Context(), bc, query, currentUserUUID, &api.SearchOptions{
 						IncludeMyConnections:      tierConnections,
 						IncludeFriendsConnections: tierFriends,
 					})
@@ -120,11 +129,6 @@ connected. The RELATIONSHIP column shows 1st_degree / 2nd_degree /
 				return err
 			}
 			res := out.Result
-
-			currentUserUUID := ""
-			if cookieAvailable {
-				currentUserUUID, _ = fetchCurrentUserUUID(cookieClient)
-			}
 
 			if limit > 0 && len(res.People) > limit {
 				res.People = res.People[:limit]
@@ -177,6 +181,8 @@ type hpPeopleRow struct {
 	LinkedInURL    string                `json:"linkedin_url"`
 	Relationship   client.RelationshipTier `json:"relationship"`
 	Referrers      []hpReferrerRow       `json:"referrers,omitempty"`
+	Bridges        []bridgeRef           `json:"bridges,omitempty"`
+	Rationale      string                `json:"rationale,omitempty"`
 	Score          float64               `json:"score"`
 	Summary        string                `json:"summary,omitempty"`
 }
@@ -207,7 +213,7 @@ func buildHPPeopleJSON(res *client.PeopleSearchResult, currentUserUUID string) h
 				Name: r.Name, ID: r.ID, Source: r.Source, AffinityLevel: r.AffinityLevel,
 			})
 		}
-		rows = append(rows, hpPeopleRow{
+		row := hpPeopleRow{
 			Name:           p.Name,
 			PersonUUID:     p.PersonUUID,
 			CurrentTitle:   p.CurrentTitle,
@@ -217,7 +223,20 @@ func buildHPPeopleJSON(res *client.PeopleSearchResult, currentUserUUID string) h
 			Referrers:      refs,
 			Score:          p.Score,
 			Summary:        p.Summary,
-		})
+		}
+		// When bearer-surface bridges are present (cookie path leaves
+		// this nil), surface them alongside the referrer chain and
+		// build an affinity-aware rationale string. Bridges and
+		// Referrers are parallel: Referrers is the cookie-rich chain,
+		// Bridges is the bearer-thin chain. Renderers see both.
+		if len(p.Bridges) > 0 {
+			row.Bridges = bridgesToFlagship(p.Bridges)
+			row.Rationale = bearerRationale(p.Bridges)
+			if score := bearerScore(p.Bridges, p.Score); score > row.Score {
+				row.Score = score
+			}
+		}
+		rows = append(rows, row)
 	}
 	return hpPeopleEnvelope{
 		Query:       res.Query,

--- a/library/sales-and-crm/contact-goat/internal/cli/prospect.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/prospect.go
@@ -127,17 +127,23 @@ Results are deduped across sources and ranked by one of:
 					}
 				} else if chosen == SourceAPI {
 					if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
-						bres, brerr := BearerSearchAdapter(cmd.Context(), bc, keywords, &api.SearchOptions{IncludeMyConnections: true, IncludeFriendsConnections: true})
+						currentUUID := ""
+						if cookieAvailable {
+							currentUUID, _ = fetchCurrentUserUUID(cookieClient)
+						}
+						bres, brerr := BearerSearchAdapter(cmd.Context(), bc, keywords, currentUUID, &api.SearchOptions{IncludeMyConnections: true, IncludeFriendsConnections: true})
 						if brerr != nil {
 							fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance bearer search: %v\n", brerr)
 						} else if bres != nil {
 							for _, p := range bres.People {
 								row := flagshipPerson{
-									Name:    p.Name,
-									Title:   p.CurrentTitle,
-									Company: p.CurrentCompany,
-									Sources: []string{"hp_api"},
-									Rationale: "Happenstance bearer surface match",
+									Name:      p.Name,
+									Title:     p.CurrentTitle,
+									Company:   p.CurrentCompany,
+									Sources:   []string{"hp_api"},
+									Rationale: bearerRationale(p.Bridges),
+									Score:     bearerScore(p.Bridges, p.Score),
+									Bridges:   bridgesToFlagship(p.Bridges),
 								}
 								results = append(results, row)
 							}

--- a/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
@@ -441,6 +441,13 @@ func LogDeferredHint(errOut io.Writer, err error) {
 // project the results into a client.PeopleSearchResult so the
 // downstream rendering code does not branch on source.
 //
+// currentUUID is the current user's Happenstance UUID (fetched by the
+// caller from its cookie client). It is used to retag the self-entry
+// in the envelope's mutuals list so renderers can distinguish
+// 1st-degree-via-friend hits from self-graph hits. Pass "" when the
+// caller cannot resolve it (then every bridge is treated as a friend
+// bridge, which is harmless but less precise).
+//
 // The PollSearch loop honors ctx for cancellation; default poll
 // timeout / interval mirror the cookie surface (180s / 1s).
 //
@@ -450,7 +457,7 @@ func LogDeferredHint(errOut io.Writer, err error) {
 // surface". This matches the cookie surface's "Completed=false on
 // timeout" convention, where the call site is responsible for
 // interpreting partial state.
-func BearerSearchAdapter(ctx context.Context, c *api.Client, query string, opts *api.SearchOptions) (*client.PeopleSearchResult, error) {
+func BearerSearchAdapter(ctx context.Context, c *api.Client, query string, currentUUID string, opts *api.SearchOptions) (*client.PeopleSearchResult, error) {
 	if c == nil {
 		return nil, fmt.Errorf("bearer search: nil client")
 	}
@@ -479,7 +486,7 @@ func BearerSearchAdapter(ctx context.Context, c *api.Client, query string, opts 
 	}
 	people := make([]client.Person, 0, len(final.Results))
 	for _, r := range final.Results {
-		people = append(people, api.ToClientPerson(r))
+		people = append(people, api.ToClientPersonWithBridges(r, final.Mutuals, currentUUID))
 	}
 	return &client.PeopleSearchResult{
 		RequestID: final.Id,

--- a/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
@@ -95,10 +95,11 @@ connection_count + presence in multiple sources).`,
 			// Routed via SelectSource: cookie-first (free quota), bearer
 			// fallback when cookie is unavailable, exhausted, or 429s
 			// mid-flight. --source api forces bearer; --source hp forces
-			// cookie. The bearer surface has no friends/list and no
-			// referrer chain, so the warm-intro 2nd-degree synthesis is
-			// degraded when bearer is selected (we tag rows as hp_api and
-			// fall back to "Happenstance bearer match" rationale).
+			// cookie. The bearer surface has no friends/list, but its
+			// envelope-level mutuals (dereferenced by the normalizer into
+			// p.Bridges) let warm-intro rationalize via named 1st-degree
+			// connections with real affinity scores. See bearerRationale
+			// in flagship_helpers.go for the output format.
 			if sources["hp"] || sources[SourceFlagAPI] {
 				cfg, cfgErr := config.Load(flags.configPath)
 				if cfgErr != nil {
@@ -147,7 +148,7 @@ connection_count + presence in multiple sources).`,
 						var bearerRun BearerRunner
 						if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
 							bearerRun = func() (*client.PeopleSearchResult, error) {
-								return BearerSearchAdapter(cmd.Context(), bc, "people at "+resolved.Company, nil)
+								return BearerSearchAdapter(cmd.Context(), bc, "people at "+resolved.Company, currentUUID, nil)
 							}
 						}
 						out, runErr := ExecuteWithSourceFallback(cmd.Context(), chosen, cookieRun, bearerRun, cmd.ErrOrStderr())
@@ -158,17 +159,22 @@ connection_count + presence in multiple sources).`,
 							if out.UsedSource == SourceCookie {
 								candidates = append(candidates, warmIntroCandidatesFromGraph(out.Result.People, currentUUID, resolved)...)
 							} else {
-								// Bearer surface: thin schema, no referrer
-								// chain. Project each row as a candidate with
-								// the bearer source tag so renderers show it
-								// as a paid-surface match.
+								// Bearer surface: envelope-level mutuals have
+								// already been dereferenced into p.Bridges by
+								// the normalizer. Project each row with the
+								// shared bearer rationale + affinity-aware
+								// score so warm-intro ranking (composite score
+								// later in this function) can see real graph
+								// signal instead of flat WeightedTraitsScore.
 								for _, p := range out.Result.People {
 									candidates = append(candidates, flagshipPerson{
-										Name:    p.Name,
-										Title:   p.CurrentTitle,
-										Company: p.CurrentCompany,
-										Sources: []string{"hp_api"},
-										Rationale: fmt.Sprintf("Happenstance bearer match at %s", p.CurrentCompany),
+										Name:      p.Name,
+										Title:     p.CurrentTitle,
+										Company:   p.CurrentCompany,
+										Sources:   []string{"hp_api"},
+										Rationale: bearerRationale(p.Bridges),
+										Score:     bearerScore(p.Bridges, p.Score),
+										Bridges:   bridgesToFlagship(p.Bridges),
 									})
 								}
 							}

--- a/library/sales-and-crm/contact-goat/internal/client/people_search.go
+++ b/library/sales-and-crm/contact-goat/internal/client/people_search.go
@@ -106,6 +106,16 @@ type SearchLog struct {
 
 // Person is one result from a people-search. Field names mirror the
 // dynamo response verbatim so the struct can be decoded directly.
+//
+// Bridges is an optional, source-agnostic list of named 1st-degree
+// connections that link the current user to this Person, with a raw
+// affinity score per bridge. The cookie surface populates equivalent
+// data into Referrers (a richer, ordered chain with image URLs and
+// affinity levels). The bearer surface populates Bridges from the
+// SearchEnvelope's top-level mutuals list, dereferenced at normalize
+// time. Renderers should treat the two as parallel signals: Referrers
+// is primary on cookie results, Bridges is primary on bearer-only
+// results. Empty on sources that cannot produce bridge data.
 type Person struct {
 	Name           string     `json:"author_name"`
 	PersonUUID     string     `json:"person_uuid"`
@@ -119,7 +129,29 @@ type Person struct {
 	CurrentCompany string     `json:"current_company"`
 	Summary        string     `json:"summary"`
 	Referrers      Referrers  `json:"referrers"`
+	Bridges        []Bridge   `json:"bridges,omitempty"`
 }
+
+// Bridge names a 1st-degree connection that the bearer API surfaced as
+// linking the current user to a Person, with the raw affinity score the
+// API returned. Kind distinguishes a real 1st-degree friend from the
+// self-graph entry (the user's own synced contacts bucket, which appears
+// in the bearer API's top-level mutuals list alongside friends). A
+// zero AffinityScore is valid and means "bridge exists but carries no
+// graph weight" — treat as weak-signal, not absent.
+type Bridge struct {
+	Name             string  `json:"name,omitempty"`
+	HappenstanceUUID string  `json:"happenstance_uuid,omitempty"`
+	AffinityScore    float64 `json:"affinity_score"`
+	Kind             string  `json:"kind,omitempty"`
+}
+
+// Bridge kind constants. Kept alongside Bridge because they belong to
+// its contract, not the normalizer.
+const (
+	BridgeKindFriend    = "friend"
+	BridgeKindSelfGraph = "self_graph"
+)
 
 // Citation is one (text, url) pair under quotes_cited.
 type Citation struct {

--- a/library/sales-and-crm/contact-goat/internal/happenstance/api/normalize.go
+++ b/library/sales-and-crm/contact-goat/internal/happenstance/api/normalize.go
@@ -35,25 +35,82 @@ package api
 import "github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
 
 // ToClientPerson projects a /v1/search SearchResult row into the canonical
-// client.Person. Only the four fields the public-API search endpoint
-// returns are populated:
+// client.Person. Only the fields the public-API search endpoint returns
+// are populated:
 //
 //   - Name          <- SearchResult.Name
 //   - CurrentTitle  <- SearchResult.CurrentTitle
 //   - CurrentCompany<- SearchResult.CurrentCompany
 //   - Score         <- SearchResult.WeightedTraitsScore
+//   - LinkedInURL   <- SearchResult.Socials.LinkedInURL (when present)
+//   - TwitterURL    <- SearchResult.Socials.TwitterURL  (when present)
+//   - InstagramURL  <- SearchResult.Socials.InstagramURL (when present)
+//   - Summary       <- SearchResult.Summary
 //
-// Every other client.Person field stays at its Go zero value (empty
-// string for strings, nil for slices). Downstream renderers must tolerate
-// those zero values; see the package-doc comment above for the
-// invariant.
+// Bridges are not populated here — call ToClientPersonWithBridges when
+// the envelope-level mutuals list is available and the caller knows the
+// current user's UUID. Keeping ToClientPerson bridge-free preserves the
+// simpler back-compat signature for call sites that never surface
+// bridges (e.g. /v1/research or test code that hand-builds SearchResult
+// values).
+//
+// Every other client.Person field stays at its Go zero value. Downstream
+// renderers must tolerate those zero values; see the package-doc comment
+// above for the invariant.
 func ToClientPerson(api SearchResult) client.Person {
-	return client.Person{
+	p := client.Person{
 		Name:           api.Name,
 		CurrentTitle:   api.CurrentTitle,
 		CurrentCompany: api.CurrentCompany,
+		Summary:        api.Summary,
 		Score:          api.WeightedTraitsScore,
 	}
+	if api.Socials != nil {
+		p.LinkedInURL = api.Socials.LinkedInURL
+		p.TwitterURL = api.Socials.TwitterURL
+		p.InstagramURL = api.Socials.InstagramURL
+	}
+	return p
+}
+
+// ToClientPersonWithBridges projects a SearchResult into client.Person
+// and additionally hydrates client.Person.Bridges by dereferencing the
+// result's Mutuals[].Index against the envelope-level bridge list. The
+// current user's own self-entry in the envelope's mutuals (identified
+// by matching Id against currentUUID) is retagged as BridgeKindSelfGraph
+// so renderers can distinguish "you know them through a friend" from
+// "they are in your own synced contacts". Pass an empty currentUUID to
+// disable self-retagging — every bridge will then be BridgeKindFriend.
+//
+// Malformed indexes (out of range) are dropped silently. A result with
+// no mutuals returns a Person with Bridges nil, not an empty slice, so
+// JSON consumers see the field omitted entirely.
+func ToClientPersonWithBridges(r SearchResult, envelopeMutuals []SearchMutual, currentUUID string) client.Person {
+	p := ToClientPerson(r)
+	if len(r.Mutuals) == 0 || len(envelopeMutuals) == 0 {
+		return p
+	}
+	bridges := make([]client.Bridge, 0, len(r.Mutuals))
+	for _, m := range r.Mutuals {
+		if m.Index < 0 || m.Index >= len(envelopeMutuals) {
+			continue
+		}
+		src := envelopeMutuals[m.Index]
+		kind := client.BridgeKindFriend
+		if currentUUID != "" && src.Id == currentUUID {
+			kind = client.BridgeKindSelfGraph
+		}
+		bridges = append(bridges, client.Bridge{
+			Name:             src.Name,
+			HappenstanceUUID: src.Id,
+			AffinityScore:    m.AffinityScore,
+			Kind:             kind,
+		})
+	}
+	if len(bridges) > 0 {
+		p.Bridges = bridges
+	}
+	return p
 }
 
 // ToClientPersonFromResearch projects a /v1/research ResearchProfile into

--- a/library/sales-and-crm/contact-goat/internal/happenstance/api/normalize_test.go
+++ b/library/sales-and-crm/contact-goat/internal/happenstance/api/normalize_test.go
@@ -216,3 +216,138 @@ func TestToClientPerson_JSONSnapshotMatchesCookieShape(t *testing.T) {
 			cookieJSON, bearerJSON)
 	}
 }
+
+// TestToClientPerson_PopulatesSocials verifies that Socials.LinkedInURL
+// (and its siblings) hydrate onto client.Person so renderers have
+// something to link to on bearer-only rows.
+func TestToClientPerson_PopulatesSocials(t *testing.T) {
+	in := SearchResult{
+		Name: "Ira Ehrenpreis",
+		Socials: &SearchSocials{
+			LinkedInURL:  "https://www.linkedin.com/in/iraehrenpreis",
+			TwitterURL:   "https://twitter.com/iraehrenpreis",
+			InstagramURL: "",
+		},
+	}
+	got := ToClientPerson(in)
+	if got.LinkedInURL != "https://www.linkedin.com/in/iraehrenpreis" {
+		t.Errorf("LinkedInURL = %q", got.LinkedInURL)
+	}
+	if got.TwitterURL != "https://twitter.com/iraehrenpreis" {
+		t.Errorf("TwitterURL = %q", got.TwitterURL)
+	}
+	if got.InstagramURL != "" {
+		t.Errorf("InstagramURL = %q, want empty", got.InstagramURL)
+	}
+}
+
+// TestToClientPersonWithBridges_HappyPath covers the canonical case:
+// a result with two bridges (one friend, one self-graph) dereferences
+// against an envelope containing four top-level mutuals. The friend
+// bridge keeps its kind; the self-entry (matched by currentUUID) is
+// retagged as self_graph.
+func TestToClientPersonWithBridges_HappyPath(t *testing.T) {
+	envelope := []SearchMutual{
+		{Index: 0, Id: "friend-1", Name: "Jeff Clavier"},
+		{Index: 1, Id: "friend-2", Name: "Garry Tan"},
+		{Index: 2, Id: "friend-3", Name: "Alex Teichman"},
+		{Index: 3, Id: "user-self", Name: "Matt Van Horn"},
+	}
+	in := SearchResult{
+		Name: "Ira Ehrenpreis",
+		Mutuals: []ResultMutual{
+			{Index: 0, AffinityScore: 104.4},
+			{Index: 3, AffinityScore: 0},
+		},
+	}
+	got := ToClientPersonWithBridges(in, envelope, "user-self")
+	if len(got.Bridges) != 2 {
+		t.Fatalf("bridges = %d, want 2", len(got.Bridges))
+	}
+	if got.Bridges[0].Name != "Jeff Clavier" || got.Bridges[0].Kind != client.BridgeKindFriend {
+		t.Errorf("bridge[0] = %+v", got.Bridges[0])
+	}
+	if got.Bridges[0].AffinityScore != 104.4 {
+		t.Errorf("bridge[0] affinity = %v, want 104.4", got.Bridges[0].AffinityScore)
+	}
+	if got.Bridges[1].Name != "Matt Van Horn" || got.Bridges[1].Kind != client.BridgeKindSelfGraph {
+		t.Errorf("bridge[1] (self) = %+v", got.Bridges[1])
+	}
+}
+
+// TestToClientPersonWithBridges_EmptyInputs covers the two no-op paths:
+// a result with no mutuals, and an envelope with no mutuals. Both must
+// return a Person with Bridges nil (not an empty slice) so JSON output
+// omits the field.
+func TestToClientPersonWithBridges_EmptyInputs(t *testing.T) {
+	envelope := []SearchMutual{{Index: 0, Id: "friend-1", Name: "Jeff"}}
+	cases := []struct {
+		name     string
+		result   SearchResult
+		envelope []SearchMutual
+	}{
+		{"no result mutuals", SearchResult{Name: "X"}, envelope},
+		{"no envelope mutuals", SearchResult{Name: "X", Mutuals: []ResultMutual{{Index: 0}}}, nil},
+		{"both empty", SearchResult{Name: "X"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ToClientPersonWithBridges(tc.result, tc.envelope, "")
+			if got.Bridges != nil {
+				t.Errorf("Bridges = %+v, want nil", got.Bridges)
+			}
+		})
+	}
+}
+
+// TestToClientPersonWithBridges_OutOfRangeIndex covers malformed API
+// responses where a result's Mutual[].Index does not point at a real
+// envelope entry. The dereference must drop silently; no panic, no
+// placeholder bridge inserted.
+func TestToClientPersonWithBridges_OutOfRangeIndex(t *testing.T) {
+	envelope := []SearchMutual{
+		{Index: 0, Id: "friend-1", Name: "Jeff"},
+	}
+	in := SearchResult{
+		Name: "Broken",
+		Mutuals: []ResultMutual{
+			{Index: -1, AffinityScore: 10},
+			{Index: 5, AffinityScore: 20},
+			{Index: 0, AffinityScore: 50},
+		},
+	}
+	got := ToClientPersonWithBridges(in, envelope, "")
+	if len(got.Bridges) != 1 {
+		t.Fatalf("bridges = %d, want 1 (the two malformed indexes should be dropped)", len(got.Bridges))
+	}
+	if got.Bridges[0].Name != "Jeff" || got.Bridges[0].AffinityScore != 50 {
+		t.Errorf("surviving bridge = %+v", got.Bridges[0])
+	}
+}
+
+// TestToClientPersonWithBridges_EmptyCurrentUUID covers the fallback
+// where the caller cannot resolve the current user's UUID. Every bridge
+// must be tagged as friend (no retagging to self_graph), including any
+// bridge that is actually the user's own self-entry. This is the
+// less-precise-but-safe behavior documented on the function.
+func TestToClientPersonWithBridges_EmptyCurrentUUID(t *testing.T) {
+	envelope := []SearchMutual{
+		{Index: 0, Id: "friend-1", Name: "Jeff"},
+		{Index: 1, Id: "user-self", Name: "Matt"},
+	}
+	in := SearchResult{
+		Mutuals: []ResultMutual{
+			{Index: 0, AffinityScore: 10},
+			{Index: 1, AffinityScore: 0},
+		},
+	}
+	got := ToClientPersonWithBridges(in, envelope, "")
+	if len(got.Bridges) != 2 {
+		t.Fatalf("bridges = %d, want 2", len(got.Bridges))
+	}
+	for i, b := range got.Bridges {
+		if b.Kind != client.BridgeKindFriend {
+			t.Errorf("bridge[%d] kind = %q, want friend (no currentUUID, no retag)", i, b.Kind)
+		}
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/happenstance/api/search_test.go
+++ b/library/sales-and-crm/contact-goat/internal/happenstance/api/search_test.go
@@ -364,6 +364,135 @@ func TestGroupRoundTripIntoSearchTextAsAtMention(t *testing.T) {
 	}
 }
 
+// TestSearchEnvelope_UnmarshalsBridgesAndAffinity verifies that the full
+// bearer-API response shape — top-level mutuals plus per-result mutuals,
+// socials, and traits — round-trips through encoding/json without losing
+// bridge detail. Fixture mirrors the live 2026-04-19 Tesla response.
+func TestSearchEnvelope_UnmarshalsBridgesAndAffinity(t *testing.T) {
+	raw := `{
+	  "id":"srch_tesla",
+	  "status":"COMPLETED",
+	  "text":"people at Tesla",
+	  "mutuals":[
+	    {"index":0,"id":"friend-1","name":"Jeff Clavier","happenstance_url":"https://happenstance.ai/u/friend-1"},
+	    {"index":1,"id":"friend-2","name":"Garry Tan"},
+	    {"index":2,"id":"friend-3","name":"Alex Teichman"},
+	    {"index":3,"id":"user-self","name":"Matt Van Horn"}
+	  ],
+	  "results":[
+	    {
+	      "id":"p-ira",
+	      "name":"Ira Ehrenpreis",
+	      "current_title":"Board of Directors",
+	      "current_company":"Tesla Motors",
+	      "summary":"Board of Directors at Tesla Motors since 2007.",
+	      "weighted_traits_score":1.0,
+	      "mutuals":[{"index":0,"affinity_score":104.38174315088183}],
+	      "socials":{"linkedin_url":"https://www.linkedin.com/in/iraehrenpreis"},
+	      "traits":[{"index":0,"score":1.0,"evidence":"Board seat since 2007."}]
+	    },
+	    {
+	      "name":"Nathan Ng",
+	      "current_title":"Manager, Senior Staff Mechanical Engineer",
+	      "current_company":"Tesla",
+	      "weighted_traits_score":1.0,
+	      "mutuals":[{"index":3,"affinity_score":0}]
+	    }
+	  ],
+	  "has_more":true
+	}`
+	var env SearchEnvelope
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Mutuals) != 4 {
+		t.Fatalf("envelope mutuals = %d, want 4", len(env.Mutuals))
+	}
+	if env.Mutuals[0].Name != "Jeff Clavier" || env.Mutuals[0].Id != "friend-1" {
+		t.Errorf("mutual[0] = %+v", env.Mutuals[0])
+	}
+	if env.Mutuals[3].Name != "Matt Van Horn" {
+		t.Errorf("self-entry = %+v, want name 'Matt Van Horn'", env.Mutuals[3])
+	}
+	if len(env.Results) != 2 {
+		t.Fatalf("results = %d, want 2", len(env.Results))
+	}
+
+	ira := env.Results[0]
+	if ira.Id != "p-ira" || ira.Summary == "" {
+		t.Errorf("ira scalar fields = %+v", ira)
+	}
+	if len(ira.Mutuals) != 1 || ira.Mutuals[0].Index != 0 || ira.Mutuals[0].AffinityScore != 104.38174315088183 {
+		t.Errorf("ira bridges = %+v", ira.Mutuals)
+	}
+	if ira.Socials == nil || ira.Socials.LinkedInURL != "https://www.linkedin.com/in/iraehrenpreis" {
+		t.Errorf("ira socials = %+v", ira.Socials)
+	}
+	if len(ira.Traits) != 1 || ira.Traits[0].Evidence == "" {
+		t.Errorf("ira traits = %+v", ira.Traits)
+	}
+
+	nathan := env.Results[1]
+	if len(nathan.Mutuals) != 1 || nathan.Mutuals[0].Index != 3 || nathan.Mutuals[0].AffinityScore != 0 {
+		t.Errorf("nathan bridges = %+v", nathan.Mutuals)
+	}
+	if nathan.Socials != nil {
+		t.Errorf("nathan socials should be nil (omitted in fixture); got %+v", nathan.Socials)
+	}
+}
+
+// TestSearchEnvelope_EmptyMutuals covers cookie-surface responses and
+// edge-case bearer responses where mutuals slices are explicitly empty
+// or entirely absent. Both should produce a valid, nil/empty-slice
+// envelope with no panic.
+func TestSearchEnvelope_EmptyMutuals(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty arrays", `{"id":"s","status":"COMPLETED","mutuals":[],"results":[{"name":"X","mutuals":[]}]}`},
+		{"absent fields", `{"id":"s","status":"COMPLETED","results":[{"name":"X"}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var env SearchEnvelope
+			if err := json.Unmarshal([]byte(tc.raw), &env); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(env.Mutuals) != 0 {
+				t.Errorf("envelope mutuals = %d, want 0", len(env.Mutuals))
+			}
+			if len(env.Results) != 1 {
+				t.Fatalf("results = %d, want 1", len(env.Results))
+			}
+			if len(env.Results[0].Mutuals) != 0 {
+				t.Errorf("result mutuals = %d, want 0", len(env.Results[0].Mutuals))
+			}
+		})
+	}
+}
+
+// TestSearchEnvelope_ExtremeFloatAffinity guards against precision loss on
+// the AffinityScore field. Observed values span seven orders of magnitude
+// (4.77e-39 on zero-weight synthetic bridges, 245 on the strongest observed
+// real bridge). Both must round-trip.
+func TestSearchEnvelope_ExtremeFloatAffinity(t *testing.T) {
+	raw := `{"id":"s","status":"COMPLETED","results":[
+	  {"name":"Tiny","mutuals":[{"index":1,"affinity_score":4.772363296454658e-39}]},
+	  {"name":"Huge","mutuals":[{"index":2,"affinity_score":245.23555284520657}]}
+	]}`
+	var env SearchEnvelope
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := env.Results[0].Mutuals[0].AffinityScore; got != 4.772363296454658e-39 {
+		t.Errorf("tiny affinity = %g, want 4.77e-39", got)
+	}
+	if got := env.Results[1].Mutuals[0].AffinityScore; got != 245.23555284520657 {
+		t.Errorf("huge affinity = %g, want 245.235...", got)
+	}
+}
+
 func TestFormatGroupMention(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/library/sales-and-crm/contact-goat/internal/happenstance/api/types.go
+++ b/library/sales-and-crm/contact-goat/internal/happenstance/api/types.go
@@ -62,24 +62,83 @@ func (e *RateLimitError) Error() string {
 // SearchEnvelope is the response from POST /v1/search. The asynchronous
 // search is identified by Id; callers poll GET /v1/search/{id} for the
 // full result list. URL is the human-facing happenstance.ai page.
+//
+// Mutuals is the top-level bridge list — the named 1st-degree connections
+// (your Happenstance friends plus your own synced-graph self-entry) that
+// every per-result bridge indexes into. Populated on bearer-surface
+// responses when the request sets include_friends_connections or
+// include_my_connections. Empty for cookie-surface responses.
 type SearchEnvelope struct {
-	Id      string         `json:"id"`
-	URL     string         `json:"url,omitempty"`
-	Status  string         `json:"status,omitempty"`
-	Text    string         `json:"text,omitempty"`
-	Results []SearchResult `json:"results,omitempty"`
-	HasMore bool           `json:"has_more,omitempty"`
-	NextPage string        `json:"next_page,omitempty"`
+	Id       string          `json:"id"`
+	URL      string          `json:"url,omitempty"`
+	Status   string          `json:"status,omitempty"`
+	Text     string          `json:"text,omitempty"`
+	Mutuals  []SearchMutual  `json:"mutuals,omitempty"`
+	Results  []SearchResult  `json:"results,omitempty"`
+	HasMore  bool            `json:"has_more,omitempty"`
+	NextPage string          `json:"next_page,omitempty"`
+}
+
+// SearchMutual is one row of SearchEnvelope.Mutuals. Each entry names a
+// bridge person (a 1st-degree connection of the caller, or the caller
+// themselves) with a stable Index that ResultMutual rows dereference. The
+// caller identifies its own self-entry by matching Id against the current
+// user's Happenstance UUID.
+type SearchMutual struct {
+	Index           int    `json:"index"`
+	Id              string `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	HappenstanceURL string `json:"happenstance_url,omitempty"`
 }
 
 // SearchResult is one row of GET /v1/search/{id}.results. Field names match
-// the OpenAPI shape verbatim. The normalizer in normalize.go (unit 3) maps
-// these into the canonical client.Person consumed by every renderer.
+// the OpenAPI shape verbatim. The normalizer in normalize.go maps these
+// into the canonical client.Person consumed by every renderer.
+//
+// Mutuals carries the per-result bridge list: each entry's Index points
+// into the envelope's top-level Mutuals slice, and AffinityScore signals
+// how strong the graph connection is (observed range 0 to ~300+, with 0
+// meaning "mentioned but weak" and higher meaning stronger). The
+// normalizer dereferences these into client.Bridge entries.
 type SearchResult struct {
-	Name                 string  `json:"name"`
-	CurrentTitle         string  `json:"current_title,omitempty"`
-	CurrentCompany       string  `json:"current_company,omitempty"`
-	WeightedTraitsScore  float64 `json:"weighted_traits_score,omitempty"`
+	Id                  string         `json:"id,omitempty"`
+	Name                string         `json:"name"`
+	CurrentTitle        string         `json:"current_title,omitempty"`
+	CurrentCompany      string         `json:"current_company,omitempty"`
+	Summary             string         `json:"summary,omitempty"`
+	WeightedTraitsScore float64        `json:"weighted_traits_score,omitempty"`
+	Mutuals             []ResultMutual `json:"mutuals,omitempty"`
+	Socials             *SearchSocials `json:"socials,omitempty"`
+	Traits              []SearchTrait  `json:"traits,omitempty"`
+}
+
+// ResultMutual is one row of SearchResult.Mutuals. Index points into the
+// envelope-level Mutuals slice; AffinityScore is the bearer API's raw
+// signal strength (higher = stronger). Zero is a valid value meaning the
+// bridge exists but carries no graph weight — treat as "mention only".
+type ResultMutual struct {
+	Index         int     `json:"index"`
+	AffinityScore float64 `json:"affinity_score"`
+}
+
+// SearchSocials is the socials subobject on a SearchResult. Every field is
+// optional and omitempty because the API omits fields it cannot populate.
+type SearchSocials struct {
+	LinkedInURL     string `json:"linkedin_url,omitempty"`
+	TwitterURL      string `json:"twitter_url,omitempty"`
+	InstagramURL    string `json:"instagram_url,omitempty"`
+	HappenstanceURL string `json:"happenstance_url,omitempty"`
+}
+
+// SearchTrait is one row of SearchResult.Traits. Index points into a
+// request-level traits list (not modeled here; requests are currently
+// built without explicit traits on the client side). Score ranges 0-1
+// per the bearer API; Evidence is free-form prose. Captured so future
+// renderers can surface why a result matched without a round-trip.
+type SearchTrait struct {
+	Index    int     `json:"index"`
+	Score    float64 `json:"score,omitempty"`
+	Evidence string  `json:"evidence,omitempty"`
 }
 
 // FindMoreEnvelope is the response from POST /v1/search/{id}/find-more.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"


### PR DESCRIPTION
## Summary

The Happenstance bearer API returns a graph: a top-level \`mutuals[]\` list of the user's 1st-degree bridges, plus per-result \`mutuals[].index + affinity_score\` pointing into it. contact-goat was unmarshalling none of it. Every bearer row surfaced as a bare name/title/company with generic \"Happenstance bearer\" rationale, making coverage/prospect/warm-intro/hp-people output look like a random contact list.

This preserves the graph data end-to-end across 5 bearer-surface commands.

**Before:**
\`\`\`json
{ \"name\": \"Ira Ehrenpreis\", \"rationale\": \"Happenstance bearer\", \"score\": 1.5 }
\`\`\`

**After:**
\`\`\`json
{
  \"name\": \"Ira Ehrenpreis\",
  \"rationale\": \"via Jeff Clavier (affinity 104.4)\",
  \"relationship\": \"happenstance_api\",
  \"bridges\": [{\"name\": \"Jeff Clavier\", \"affinity_score\": 104.38, \"kind\": \"friend\"}],
  \"score\": 6.16
}
\`\`\`

## Changes

- \`internal/happenstance/api/types.go\`: \`SearchEnvelope.Mutuals\`, \`SearchResult.Mutuals / Socials / Traits / Summary / Id\`
- \`internal/happenstance/api/normalize.go\`: \`ToClientPersonWithBridges\` dereferences per-result mutuals against the envelope list, retags the self-entry as \`BridgeKindSelfGraph\`, silently drops out-of-range indexes
- \`internal/client/people_search.go\`: new \`Bridges []client.Bridge\` + \`LinkedInURL\` on \`client.Person\`
- \`internal/cli/flagship_helpers.go\`: shared \`bearerRationale()\` decision table (via <top> / weak signal / in your synced graph / no graph match), \`bearerScore()\` max-affinity-with-traits-fallback, \`bridgeAffinityBonus()\` log-scaled ranking bump so bearer rows sort by real graph signal
- \`coverage / prospect / warm-intro / hp-people / api-hpn-search\`: all wired to the shared helper; no remaining literal bearer rationale strings outside it
- \`docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md\`: the \`ce:plan\` output this work was built from

## Testing

- New: 3 unmarshal tests for the extended envelope shape (\`search_test.go\`)
- New: 4 normalizer tests for bridge dereference + self-retagging + malformed index handling (\`normalize_test.go\`)
- New: \`bearer_rationale_test.go\` with decision-table coverage for \`bearerRationale\`, \`bearerScore\`, \`bridgesToFlagship\`, and a merge-dedup integration test that verifies bearer bridges carry onto a cookie row when they dedupe to the same person
- All existing cookie-path tests still pass (no regression on \`SourceFallback\` / \`SourceSelection\` / \`ExecuteWithSourceFallback\`)
- Dogfooded live against the Tesla bearer response (matches the example above)

\`\`\`
go test ./...
ok   internal/cli             3.371s
ok   internal/client          (cached)
ok   internal/config          (cached)
ok   internal/happenstance/api (cached)
ok   internal/mcp             (cached)
\`\`\`

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: nothing expected. Bearer fallback code path hasn't changed, just the output shape.
  - Metrics/Dashboards: n/a (CLI tool, no server-side metrics).
- **Validation checks (queries/commands)**
  - \`HAPPENSTANCE_API_KEY=... contact-goat-pp-cli coverage <company> --agent --source hp\` — output JSON should include \`bridges[]\` and non-generic \`rationale\` on every result
  - \`grep -R '\"Happenstance bearer\"' library/sales-and-crm/contact-goat/internal/cli/\` — should only hit \`bearer_rationale_test.go\` and the decision-table doc comment in \`flagship_helpers.go\`
- **Expected healthy behavior**
  - Bearer rows rank by bridge affinity (strongest first); zero-affinity rows sink below rows with positive affinity
  - Self-graph rows tagged \`relationship: \"1st_degree\"\` and prose \"in your synced graph\"
- **Failure signal(s) / rollback trigger**
  - If bearer rows regress to empty \`bridges\` or generic rationale after upgrade, revert by reverting the merge commit
- **Validation window & owner**
  - Window: next few bearer coverage/prospect/warm-intro runs
  - Owner: @mvanhorn (CLI tool, no shared infra)

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)