### PR TITLE
fix(contact-goat): correct enrichment tool mapping, add preflight, fix HTTP envelope

### DIFF
--- a/docs/plans/2026-04-20-001-fix-contact-goat-enrichment-tool-mapping-plan.md
+++ b/docs/plans/2026-04-20-001-fix-contact-goat-enrichment-tool-mapping-plan.md
@@ -1,0 +1,378 @@
+---
+title: "fix: Correct contact-goat enrichment tool mapping, add Deepline preflight, sharpen skill guidance"
+type: fix
+status: active
+date: 2026-04-20
+---
+
+# fix: Correct contact-goat enrichment tool mapping, add Deepline preflight, sharpen skill guidance
+
+**Target repo:** printing-press-library
+
+## Overview
+
+During a real agent session on 2026-04-20 (lookup for Mike Craig's Stripe email), the contact-goat CLI fumbled three of its four enrichment paths before finally succeeding via an undocumented direct call to `dropleads_email_finder`. The three failures were not environmental flakiness. They trace to a single root cause plus two adjacent bugs:
+
+1. The Deepline tool IDs in `internal/deepline/types.go` point at `ai_ark_personality_analysis` and `ai_ark_find_emails`. Neither tool is an email enricher in the Deepline catalog. The first analyzes LinkedIn personality and requires a `url` field; the second is an async follow-on to a People Search that requires a `trackId`. Every `deepline find-email`, `deepline enrich-person`, and Deepline-leg `waterfall` call therefore dies with an HTTP 422 validation error.
+2. The LinkedIn subprocess step in `waterfall.go` ships `{"linkedin_url": target}` to `get_person_profile`, but the upstream `stickerdaniel/linkedin-mcp-server` tool requires `linkedin_username`. Every waterfall with a LinkedIn URL target errors on step one.
+3. The DEEPLINE_API_KEY check only fires deep inside each Deepline attempt. Commands like `dossier --enrich-email` and `waterfall` run the full free chain (LinkedIn subprocess, Happenstance) before surfacing the missing-key problem, wasting 15-30 seconds per invocation.
+
+A fourth, lower-severity issue is that provider-entitlement 403s from `code.deepline.com` (e.g. a valid key that lacks contactout or datagma access) get rendered as `Auth error (status 403). Check DEEPLINE_API_KEY.` which is misleading.
+
+This plan fixes the tool mapping, re-routes the waterfall to a real provider menu, adds command-level preflight for the Deepline key, sharpens the error message on provider-entitlement 403s, and updates SKILL.md so future agents know that email enrichment requires DEEPLINE_API_KEY before they burn time on free-step retries.
+
+## Problem Frame
+
+contact-goat positions itself as a cross-source enrichment tool (`deepline find-email`, `waterfall`, `dossier --enrich-email`). In practice the managed Deepline path has never worked because the tool IDs are wrong. Agents routing through the CLI learn of the brokenness only after running the whole free chain. Users with a valid Deepline key cannot retrieve a work email through the CLI without bypassing contact-goat and calling `deepline tools execute` directly.
+
+Session trace (2026-04-20):
+
+- `waterfall https://www.linkedin.com/in/mkscrg --enrich email` failed at LinkedIn (`linkedin_username` missing), failed at Happenstance (empty), and failed at Deepline (`ai_ark_personality_analysis` missing required `url`).
+- `deepline find-email "Mike Craig" --company stripe.com` routed to `ai_ark_find_emails` and failed with `trackId: Missing required field`.
+- `deepline enrich-person <url>` routed to `ai_ark_personality_analysis` and failed with `url: Missing required field`.
+- Direct `deepline tools execute dropleads_email_finder --payload '{...}'` worked on first try.
+
+The brokenness is a pure client-side wiring bug, not an upstream API limitation.
+
+## Requirements Trace
+
+- R1. `deepline find-email <name> --company <domain>` MUST succeed against a live Deepline account without the caller hand-crafting a payload. The command SHOULD route through a waterfall of real email-finder providers (dropleads, hunter, datagma, icypeas) rather than the ai_ark family.
+- R2. `deepline enrich-person <linkedin_url>` MUST route to a person-enrichment provider that accepts a LinkedIn URL (apollo_people_match, hunter_people_find, or contactout_enrich_person) and return email/phone/title fields.
+- R3. `waterfall` MUST run the LinkedIn step successfully when given a LinkedIn URL target. The subprocess call MUST send `linkedin_username` as required by the upstream MCP tool.
+- R4. `waterfall --enrich email` MUST use the correct Deepline tool for the target kind (linkedin_url vs. name vs. email) and MUST NOT call `ai_ark_personality_analysis` or `ai_ark_find_emails` as direct email-enrichment steps.
+- R5. Every enrichment command that requires `DEEPLINE_API_KEY` (waterfall with no BYOK, dossier with --enrich-email, deepline find-email, deepline enrich-person, etc.) MUST short-circuit with a clear, actionable error BEFORE running any other step when the key is missing or invalid.
+- R6. Deepline HTTP 403 responses MUST distinguish between "key missing/invalid" and "key valid but provider not entitled on this account". The error message MUST tell the user which provider returned 403 and suggest trying a different provider rather than re-checking their key.
+- R7. SKILL.md MUST contain an up-front preflight checklist for enrichment commands so that future agent runs check for DEEPLINE_API_KEY before invoking waterfall/dossier/find-email.
+- R8. The plugin mirror of SKILL.md (`plugin/skills/pp-contact-goat/SKILL.md`) and `plugin/.claude-plugin/plugin.json` MUST be regenerated and version-bumped after SKILL.md changes, per the repo convention in `AGENTS.md`.
+
+## Scope Boundaries
+
+- Cookie-path behavior (Happenstance quota fallback, rate-limit backoff) is not changed here. The 15s retry delay observed in the session trace is real but tolerable; tuning it is a separate plan.
+- No new Deepline providers are added to the catalog. This plan only re-wires existing Deepline tools.
+- BYOK key handling (Hunter/Apollo personal keys) is preserved as-is; this plan does not change the BYOK surface except where the waterfall's tool selection changes.
+- This plan does not implement a new cross-provider verifier (Hunter verify, icypeas verify). Verification remains a separate feature.
+
+### Deferred to Separate Tasks
+
+- Cookie-quota retry tuning (15s bucket delay): future plan.
+- Email-verification waterfall (deliverability check): future feature.
+- Icypeas async polling helper: future plan (current call returns an async job ID that the CLI does not poll).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `library/sales-and-crm/contact-goat/internal/deepline/types.go`: tool ID constants. Root cause lives here.
+- `library/sales-and-crm/contact-goat/internal/deepline/client.go`: `ValidateKey`, `Execute`, `EstimateCost`. Entitlement-vs-auth distinction needs to happen here.
+- `library/sales-and-crm/contact-goat/internal/deepline/http.go`: HTTP layer that currently maps any 403 to a generic auth error.
+- `library/sales-and-crm/contact-goat/internal/cli/waterfall.go`: `tryLinkedIn` (line 211, wrong key name) and `tryDeepline` (lines 267-341, wrong tool routing).
+- `library/sales-and-crm/contact-goat/internal/cli/deepline.go`: `find-email` and `enrich-person` cobra commands that route through the broken constants.
+- `library/sales-and-crm/contact-goat/internal/cli/dossier.go`: `--enrich-email` path.
+- `library/sales-and-crm/contact-goat/internal/cli/doctor.go`: existing Deepline WARN surface. Reuse its validation logic for the new preflight.
+- `library/sales-and-crm/contact-goat/SKILL.md`: agent-facing guidance doc.
+- `plugin/skills/pp-contact-goat/SKILL.md`: generated mirror (must be regenerated after SKILL.md edits).
+- `plugin/.claude-plugin/plugin.json`: version must bump when SKILL.md changes.
+- `tools/generate-skills/main.go`: regeneration entry point.
+
+### Institutional Learnings
+
+- AGENTS.md, section "Keeping plugin/skills in sync": SKILL.md edits require running `go run ./tools/generate-skills/main.go` and a manual `plugin.json` version bump, because the generator's `maybeUpdatePluginVersion` does not auto-bump on SKILL content changes.
+- AGENTS.md, section "SKILL.md verification": the flag-names verifier in `.github/scripts/verify-skill/verify_skill.py` will fail CI if new --flags are referenced in SKILL.md without being declared in `internal/cli/*.go`.
+- Prior plan `docs/plans/2026-04-19-003-fix-contact-goat-usability-and-install-freshness-plan.md` addressed related DX gaps; this plan continues that thread but targets the enrichment subsystem specifically.
+- Prior plan `library/sales-and-crm/contact-goat/docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md` showed the same class of bug (client-side wiring dropped upstream data); the lesson is that tool IDs and payload shapes need an integration test against a live Deepline account, not only a unit test against mocks.
+
+### External References
+
+- Deepline tools catalog (live): `deepline tools list | grep email_finder` enumerates the real email-enrichment tools. Verified 2026-04-20: `apollo_people_match`, `hunter_email_finder`, `hunter_people_find`, `dropleads_email_finder`, `datagma_find_email`, `icypeas_email_search`, `contactout_enrich_person`, `bettercontact_enrich`, `fullenrich_enrich`.
+- Deepline schema for `dropleads_email_finder` (verified 2026-04-20): requires `first_name`, `last_name`; optional `company_domain`, `company_name`. Returns `{email, status, mx_record, mx_provider, credits_charged}`. Status values include `valid`, `catch_all`, `unknown`.
+- Deepline schema for `apollo_people_match` (verified 2026-04-20): accepts `linkedin_url`, `email`, `hashed_email`, `first_name + last_name + domain`, `organization_name`, `reveal_personal_emails` (default true). Returns a full person record including `personal_emails[]`, `email`, `email_status`, `extrapolated_email_confidence`, `employment_history`, `organization`.
+- stickerdaniel/linkedin-mcp-server `get_person_profile` tool schema (verified 2026-04-20): requires `linkedin_username` (string, the slug after `/in/`), NOT `linkedin_url`.
+
+## Key Technical Decisions
+
+- Decision: Replace the broken ai_ark tool IDs with a provider menu keyed by target kind, rather than keep the single-tool abstraction. Rationale: the three target kinds (linkedin_url, email, name) each have different best-fit providers and payload shapes. Pretending they share one tool ID is why the current code breaks.
+- Decision: Keep `ToolPersonEnrich` and `ToolEmailFind` as named constants, but point them at correct tools (`apollo_people_match` and `dropleads_email_finder` respectively). Rationale: external callers (MCP server, direct constant consumers) can keep their symbols.
+- Decision: Preflight for DEEPLINE_API_KEY happens in each command's `PreRunE`, not in a shared parent. Rationale: commands differ in whether the key is required (dossier without --enrich-email doesn't need it, dossier with it does). Per-command preflight keeps the logic local and testable.
+- Decision: Provider-entitlement 403s map to a distinct error type (`ErrProviderNotEntitled`) that surfaces the provider name and suggests an alternative. Rationale: today a user with a valid key gets the same message as a user with no key. This blocks troubleshooting.
+- Decision: The waterfall's Deepline step sequences through 2-3 providers internally before giving up, rather than a single call. Rationale: Apollo often has no verified work email while Dropleads has a catch-all guess; sequencing gives the user a real answer more often. Order: apollo_people_match (personal email + verified work) → dropleads_email_finder (pattern guess) → hunter_email_finder (pattern guess with confidence score). Each logs its own step.
+- Decision: SKILL.md adds an "Enrichment preflight" section at the top of the argument-parsing block. Rationale: agents read SKILL.md sequentially; the gate needs to fire before they hit the command table.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q: Should `ai_ark_personality_analysis` be kept as a separate tool constant? A: Yes but renamed to `ToolPersonalityAnalysis`. It is a real Deepline tool for a real use case (personality-based outbound messaging); it just is not an email enricher. Preserving it as a named constant makes future work easier.
+- Q: Should `ai_ark_find_emails` be removed entirely? A: No, but drop its alias to `ToolEmailFind`. Keep it as `ToolExportedEmailFinder` for the export workflow (People Search → trackId → find-emails chain) which is a real flow. Do not let the direct `find-email` command route to it.
+- Q: Should preflight run even with `--dry-run`? A: Yes. `--dry-run` should tell the user what the call would be AND what's missing. Running the key check is cheap.
+
+### Deferred to Implementation
+
+- Q: Exact error type names (`ErrProviderNotEntitled`, `ErrDeeplineAuth`) and whether to use sentinel errors or a typed struct. Resolved during implementation based on what integrates cleanest with existing `internal/deepline/client.go`.
+- Q: Whether to page apollo_people_match's `personal_emails[]` separately from its work `email`. Resolved when writing the field-merge logic: probably return both under `personal_email` and `email` keys in the Waterfall result, with the latter preferring work.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+Provider menu, keyed by target kind:
+
+    target kind        primary provider          fallback 1                fallback 2
+    -----------        ----------------          ----------                ----------
+    linkedin_url   ->  apollo_people_match   ->  hunter_people_find    ->  contactout_enrich_person
+    email          ->  apollo_people_match   ->  hunter_people_find    ->  (stop)
+    name+domain    ->  dropleads_email_finder -> hunter_email_finder   ->  datagma_find_email
+
+Preflight gate on enrichment commands:
+
+    command invoked
+       |
+       v
+    PreRunE:
+       if requires_deepline(cmd, flags):
+         key = env.DEEPLINE_API_KEY or --deepline-key
+         if missing: return ErrMissingKey with actionable message
+         if invalid_shape: return ErrMalformedKey
+       (do NOT call code.deepline.com here; a ping costs credits)
+       |
+       v
+    Run command
+
+Error disambiguation on 403:
+
+    HTTP 403 from code.deepline.com
+       |
+       response body matches { "error_category": "auth", "code": "AUTH_*" }?
+       |-- yes -> ErrDeeplineAuth ("key is missing/invalid/expired")
+       |
+       response body matches provider-forbidden signals?
+       |-- yes -> ErrProviderNotEntitled(provider) ("key is valid, but provider X is not enabled on this account; try provider Y")
+       |
+       else  -> wrap as generic 403 with response body included
+
+## Implementation Units
+
+- [ ] **Unit 1: Correct the Deepline tool constants**
+
+**Goal:** Re-point the ai_ark tool constants to real email-enrichment providers and add the provider menu used by the waterfall.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `library/sales-and-crm/contact-goat/internal/deepline/types.go`
+- Test: `library/sales-and-crm/contact-goat/internal/deepline/types_test.go`
+
+**Approach:**
+- Rename `ToolPersonEnrich` to point at `apollo_people_match`. Keep the old symbol as a deprecated alias pointing at the new value for one release so MCP callers don't break instantly.
+- Rename `ToolEmailFind` to point at `dropleads_email_finder`. Drop the alias to `ToolPersonSearchToEmailWaterfall`.
+- Keep `ToolPersonSearchToEmailWaterfall = "ai_ark_find_emails"` as-is, but add a comment explaining this tool requires a trackId from `ai_ark_people_search` and should not be called directly from `find-email`.
+- Add a new constant `ToolPersonalityAnalysis = "ai_ark_personality_analysis"` preserving the old value for callers that genuinely want personality analysis.
+- Add provider-menu constants: `ToolDropleadsEmailFinder`, `ToolHunterEmailFinder`, `ToolHunterPeopleFind`, `ToolApolloPeopleMatch`, `ToolContactOutEnrichPerson`, `ToolDatagmaFindEmail`, `ToolIcypeasEmailSearch`.
+- Extend the `toolMetadata` map with cost and payload-hint info for each new provider.
+
+**Patterns to follow:**
+- Existing `toolMetadata` shape in `internal/deepline/types.go` (see the entries for `ai_ark_find_emails` and `ai_ark_personality_analysis`).
+
+**Test scenarios:**
+- Happy path: constants resolve to the expected upstream IDs (`apollo_people_match`, `dropleads_email_finder`, etc.).
+- Happy path: `toolMetadata` contains an entry for every new constant, with non-zero cost and a descriptive label.
+- Edge case: deprecated alias `ToolPersonEnrich` still compiles and resolves to the new value.
+
+**Verification:**
+- `go build ./...` succeeds.
+- `go test ./internal/deepline/...` passes.
+
+- [ ] **Unit 2: Route waterfall Deepline step through the provider menu**
+
+**Goal:** Replace `tryDeepline` in `waterfall.go` so it picks the correct provider chain based on target kind and payload shape.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/waterfall.go`
+- Test: `library/sales-and-crm/contact-goat/internal/cli/waterfall_test.go`
+
+**Approach:**
+- Replace the switch on `r.TargetKind` (currently lines 287-299) with a call to a new helper `deeplineProviderChain(targetKind, target, enrichFields, byok) []providerAttempt`.
+- For `linkedin_url` targets, sequence `apollo_people_match` -> `hunter_people_find` -> `contactout_enrich_person`.
+- For `email` targets, sequence `apollo_people_match` (by email) -> `hunter_people_find` (by email).
+- For `name` targets, require a company domain (from `--company` flag or `CONTACT_GOAT_COMPANY` env), then sequence `dropleads_email_finder` -> `hunter_email_finder` -> `datagma_find_email`.
+- Run providers sequentially; stop the chain as soon as the target fields are filled or max-cost is exceeded. Log each attempt as its own `WaterfallStep`.
+- Payload mapping per provider:
+  - apollo_people_match: `{linkedin_url | email | first_name+last_name+domain, reveal_personal_emails: true}`
+  - hunter_email_finder: `{first_name, last_name, domain}`
+  - dropleads_email_finder: `{first_name, last_name, company_domain, company_name}` (NOT `domain`)
+  - datagma_find_email: `{first_name, last_name, company_domain}`
+  - contactout_enrich_person: `{linkedin_url}`
+- Add a `--company` flag on the waterfall command itself (currently it reads `CONTACT_GOAT_COMPANY` from env; promote to an explicit flag per the existing help text which already documents it but doesn't declare it).
+- Field merging: apollo's `personal_emails[0]` fills a new `personal_email` field in the Waterfall result; apollo's `email` fills `email` when non-empty; dropleads' `catch_all` status fills a new `email_confidence = "catch_all"` annotation rather than being treated as verified.
+
+**Patterns to follow:**
+- Existing `tryDeepline` step-logging shape in `waterfall.go`.
+- `applyEnrichFields` helper for field copying.
+
+**Test scenarios:**
+- Happy path: `linkedin_url` target with a mock Deepline client returning apollo hit on first try - only one step recorded, `email` and `personal_email` filled.
+- Happy path: `name` target + `--company stripe.com` with apollo returning empty, dropleads returning `mike@stripe.com` status catch_all - two steps recorded, `email` filled with `email_confidence = "catch_all"`.
+- Edge case: `name` target without `--company` or `CONTACT_GOAT_COMPANY` returns a user-facing error "name targets require --company".
+- Edge case: max-cost exhausted after first provider - chain short-circuits and records remaining providers as `skipped`.
+- Error path: first provider returns provider-entitlement 403 - step recorded as `error` with provider name, chain continues to fallback.
+
+**Verification:**
+- Integration test using a mocked `deepline.Client` exercises all three target-kind chains.
+- Live run: `waterfall https://www.linkedin.com/in/mkscrg --enrich email` returns a filled `personal_email` field (session trace shows this is available via apollo_people_match).
+
+- [ ] **Unit 3: Fix LinkedIn subprocess payload key + add command-level Deepline preflight**
+
+**Goal:** Make the LinkedIn step actually run when given a LinkedIn URL, and stop running free-chain steps when the Deepline key is missing.
+
+**Requirements:** R3, R5
+
+**Dependencies:** None (can ship in parallel with Unit 2)
+
+**Files:**
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/waterfall.go`
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/deepline.go`
+- Modify: `library/sales-and-crm/contact-goat/internal/cli/dossier.go`
+- Modify: `library/sales-and-crm/contact-goat/internal/linkedin/mcp.go` (if the key mapping is abstracted there) or waterfall.go directly
+- Test: `library/sales-and-crm/contact-goat/internal/cli/waterfall_test.go`
+- Test: `library/sales-and-crm/contact-goat/internal/cli/preflight_test.go` (new)
+
+**Approach:**
+- LinkedIn key fix: in `tryLinkedIn` (waterfall.go line 211), derive a `linkedin_username` from the URL (split on `/in/`, take the next path segment, strip trailing slash) and pass `{"linkedin_username": username}` to `get_person_profile`. Keep the original URL available in the result snippet for debugging.
+- Preflight helper: create `requireDeeplineKey(cmd *cobra.Command) error` in a shared spot (e.g. `internal/cli/preflight.go`) that reads `DEEPLINE_API_KEY` (or the `--deepline-key` flag where present), validates shape with `dlp_` prefix + length check, and returns a typed error with a one-line fix: "Set DEEPLINE_API_KEY or pass --deepline-key. Get a key at https://code.deepline.com/settings/api-keys".
+- Wire preflight into:
+  - `waterfall` PreRunE: required unless `--byok` and BYOK providers cover the requested fields.
+  - `dossier` PreRunE: required only when `--enrich-email` is set.
+  - `deepline` subcommand root PreRunE: always required (all deepline subcommands need it).
+- Update `waterfall` help text to mention the flag promotion and the preflight behavior.
+
+**Patterns to follow:**
+- Existing `PersistentPreRunE` wiring in `internal/cli/root.go`.
+- Existing `newClientRequireCookies` helper in `flags` for the Happenstance cookie preflight.
+
+**Test scenarios:**
+- Happy path: `tryLinkedIn` called with `https://www.linkedin.com/in/satyanadella/` sends `{"linkedin_username": "satyanadella"}` to the mock MCP client.
+- Happy path: `waterfall <linkedin_url>` with DEEPLINE_API_KEY unset and no BYOK errors with the preflight message before any step runs. No LinkedIn or Happenstance calls are made.
+- Happy path: `dossier <url>` with no `--enrich-email` and no DEEPLINE_API_KEY succeeds (preflight is not required).
+- Happy path: `dossier <url> --enrich-email` with no DEEPLINE_API_KEY errors via preflight.
+- Edge case: `waterfall "Brian Chesky" --company airbnb.com --byok` with HUNTER_API_KEY set succeeds past preflight (BYOK satisfies it).
+- Edge case: URL with no trailing slash or with trailing query params still extracts the right username.
+- Error path: malformed key (e.g. `DEEPLINE_API_KEY=foo`) errors with "invalid key shape" distinct from "missing key".
+
+**Verification:**
+- `contact-goat-pp-cli waterfall <linkedin_url> --enrich email --dry-run` returns the preflight error instantly when key is missing.
+- `contact-goat-pp-cli waterfall <linkedin_url>` with both keys set shows a `linkedin` step status `ok` in the result.
+
+- [ ] **Unit 4: Disambiguate Deepline 403 auth errors from provider-entitlement errors**
+
+**Goal:** Stop reporting every 403 as "Check DEEPLINE_API_KEY" when the real problem is that a specific provider is not enabled on the account.
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `library/sales-and-crm/contact-goat/internal/deepline/http.go`
+- Modify: `library/sales-and-crm/contact-goat/internal/deepline/client.go`
+- Test: `library/sales-and-crm/contact-goat/internal/deepline/http_test.go`
+
+**Approach:**
+- Inspect the 403 response body for signals that distinguish the two cases:
+  - Auth failure: `error_category: "auth"`, `code` starting with `AUTH_`, or message containing "API key".
+  - Provider entitlement: `error_category: "provider"` or `authorization`, `provider` field set, message containing "not enabled" or "not authorized for this integration".
+- Define sentinel/typed errors: `ErrDeeplineAuth` for auth failures and `ErrProviderNotEntitled{Provider string}` for entitlement failures.
+- Update the caller in `tryDeepline` to surface the provider name and continue to the next provider in the chain (not fall out of the whole waterfall) when the error is entitlement-related.
+- Update the human-friendly error message on auth failures: include whether the key is unset, malformed, or rejected by upstream, plus the fix command.
+
+**Patterns to follow:**
+- Existing error-wrapping in `internal/deepline/http.go` that already parses the JSON error body for `message`.
+
+**Test scenarios:**
+- Happy path: 403 with body `{"error_category": "auth", "code": "AUTH_INVALID_KEY"}` maps to `ErrDeeplineAuth` with "key is rejected by upstream; check validity at https://code.deepline.com/settings/api-keys".
+- Happy path: 403 with body `{"provider": "contactout", "message": "Integration not enabled"}` maps to `ErrProviderNotEntitled{Provider: "contactout"}` with a suggestion to try a different provider.
+- Edge case: 403 with unrecognized body shape falls back to a generic wrapper that includes the raw body.
+- Error path: non-403 statuses (422, 500) retain their current behavior.
+- Integration: waterfall with a key that has only dropleads enabled skips apollo (entitlement 403) and lands on dropleads successfully, with apollo step recorded as `error` not `auth_failure`.
+
+**Verification:**
+- `go test ./internal/deepline/...` passes with new 403 variants.
+- Live repro: direct `deepline tools execute contactout_enrich_person` call surfaces a provider-entitlement error, not "Check DEEPLINE_API_KEY".
+
+- [ ] **Unit 5: SKILL.md enrichment preflight + plugin mirror regeneration**
+
+**Goal:** Update the agent-facing skill doc so future agents know DEEPLINE_API_KEY is required before they waste time on a waterfall, and ship the regenerated plugin mirror.
+
+**Requirements:** R7, R8
+
+**Dependencies:** Units 1-4 (docs should match shipped behavior)
+
+**Files:**
+- Modify: `library/sales-and-crm/contact-goat/SKILL.md`
+- Modify: `plugin/skills/pp-contact-goat/SKILL.md` (regenerated, not hand-edited)
+- Modify: `plugin/.claude-plugin/plugin.json` (version bump)
+
+**Approach:**
+- Add a new section "Enrichment preflight" after the argument-parsing block in SKILL.md:
+  - Lists the commands that need `DEEPLINE_API_KEY`: `waterfall` (unless `--byok`), `dossier --enrich-email`, `deepline find-email`, `deepline enrich-person`, `deepline phone-find`, `deepline email-find`, `deepline search-people`, `deepline search-companies`, `deepline enrich-company`.
+  - Tells the agent: "If the user's task needs email/phone enrichment and DEEPLINE_API_KEY is not set, ask for it (or for a BYOK Hunter/Apollo key) BEFORE invoking any enrichment command. Do not run waterfall and watch it fail through three free steps."
+  - Documents the provider chain by target kind so agents know what the tool will do.
+- Clarify the `waterfall` command row in the command table: mention the new `--company` flag for name targets.
+- Clarify the `dossier` command row: mention `--enrich-email` requires DEEPLINE_API_KEY.
+- Regenerate plugin mirror: `go run ./tools/generate-skills/main.go` from the repo root.
+- Bump plugin version in `plugin/.claude-plugin/plugin.json` by one patch level (current version TBD at implementation time; follow AGENTS.md guidance).
+
+**Execution note:** The generator's `maybeUpdatePluginVersion` only bumps on directory-set changes. SKILL content changes require manual bump. See AGENTS.md "Keeping plugin/skills in sync".
+
+**Patterns to follow:**
+- Existing SKILL.md structure (sections "Argument Parsing", "CLI Installation", "MCP Server Installation", "Commands").
+- Prior plugin version bumps in git history: `git log --oneline plugin/.claude-plugin/plugin.json` for the cadence.
+
+**Test scenarios:**
+- Test expectation: none for SKILL.md content. The verify-skill CI covers flag-reference drift; the generator test covers mirror regeneration.
+- Integration: `.github/scripts/verify-skill/verify_skill.py` passes against the updated SKILL.md. Any new `--flag` mentions (e.g. `--company`) must be declared in `internal/cli/*.go` from Unit 2 or the verifier fails CI.
+- Integration: `go run ./tools/generate-skills/main.go` produces a `plugin/skills/pp-contact-goat/SKILL.md` whose content matches the library source.
+
+**Verification:**
+- `.github/workflows/verify-skills.yml` passes on the branch.
+- `plugin/skills/pp-contact-goat/SKILL.md` is a byte-identical regeneration (no hand edits).
+- `plugin/.claude-plugin/plugin.json` version field is higher than main.
+
+## System-Wide Impact
+
+- **Interaction graph:** The waterfall command currently feeds into the MCP server's `waterfall` tool; the MCP tool wraps the CLI constant mappings so Unit 1's constant changes propagate automatically. No MCP manifest edit required.
+- **Error propagation:** The new `ErrProviderNotEntitled` error must not abort the whole waterfall run; it should record a step error and continue. Callers outside the waterfall (e.g. `deepline enrich-person` direct command) should surface the error as a user-facing hint, not a hard failure that hides the provider name.
+- **State lifecycle risks:** None. No persistent state changes. The SQLite cache stores results but not error states.
+- **API surface parity:** The `ToolPersonEnrich` and `ToolEmailFind` constants are consumed by the MCP server package. Preserving the old symbol names while pointing them at the new tool IDs keeps the MCP manifest valid without a rebuild.
+- **Integration coverage:** Every new provider call needs at least one mock test AND at least one live smoke test against a real Deepline key before release. Unit tests alone missed the current breakage.
+- **Unchanged invariants:** The cookie-first / bearer-fallback Happenstance routing is unchanged. The BYOK surface is unchanged. The `coverage`, `hp people`, `prospect`, `warm-intro` commands are unchanged. The `waterfall` JSON result shape is backward-compatible (new fields added: `personal_email`, `email_confidence`; no existing fields removed).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A Deepline provider changes its payload shape upstream between plan and implementation. | Re-verify schemas with `deepline tools get <id> --json` immediately before writing Unit 2's payload builders. Pin the verified schemas in code comments. |
+| Apollo `reveal_personal_emails` costs more credits than expected on some accounts. | Log the reported cost per step. The existing `EstimateCost` surface already honors per-tool cost metadata from Unit 1. |
+| Provider entitlement varies per account, so the default chain fails for users whose key doesn't include apollo. | Unit 4's error disambiguation lets the chain continue past entitlement failures. Document the expected provider list in SKILL.md so users can request access before running. |
+| Plugin version bump is forgotten, causing the mirror SKILL.md to ship without the new plugin version. | Unit 5 makes the bump explicit; AGENTS.md already documents the manual step; consider adding a CI check in a future plan. |
+| Live smoke test consumes real Deepline credits. | Use a dedicated low-balance test key; cap the max-cost flag at 2 during CI. |
+| The deprecated alias for `ToolPersonEnrich` leaves the broken tool still reachable via the old name. | The alias is a one-release grace period only. Add a TODO with a removal target (e.g. next minor version bump). |
+
+## Documentation / Operational Notes
+
+- Update the `contact-goat/README.md` enrichment section to match the new provider chain.
+- Consider adding a `docs/solutions/` entry after implementation that documents the pattern "integration tool IDs must be verified against the live catalog, not assumed from naming conventions" so future CLI generations don't repeat the ai_ark mis-identification.
+- No rollout staging needed; this is a pure client-side fix.
+
+## Sources & References
+
+- Origin: live session trace 2026-04-20 (Mike Craig Stripe email lookup) captured in this conversation.
+- Related code: `library/sales-and-crm/contact-goat/internal/deepline/types.go`, `waterfall.go`.
+- Related prior plan: `docs/plans/2026-04-19-003-fix-contact-goat-usability-and-install-freshness-plan.md`.
+- Related prior plan: `library/sales-and-crm/contact-goat/docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md`.
+- External: Deepline tools catalog (`deepline tools list`), verified 2026-04-20.
+- External: stickerdaniel/linkedin-mcp-server `get_person_profile` tool schema, verified 2026-04-20.
+- Repo conventions: `AGENTS.md` sections "Keeping plugin/skills in sync" and "SKILL.md verification".

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -111,6 +111,35 @@ The other 12 tools cover the cookie surface (search, friends, feed, notification
 
 Source routing (cookie vs bearer) is automatic. The auto router prefers the free cookie surface and falls back to the paid bearer surface only when cookie quota is exhausted, logging a "cost spent" notice on stderr. Pass `--source api` to opt into bearer explicitly (richer schema, group-scoped searches), or `--source hp` to force cookies.
 
+## Enrichment Preflight (read this before running any enrichment command)
+
+These commands spend Deepline credits and REQUIRE `DEEPLINE_API_KEY` or a BYOK setup:
+
+- `waterfall` (unless you pass `--byok` and have BYOK providers configured)
+- `dossier --enrich-email`
+- `deepline find-email` / `enrich-person` / `email-find` / `phone-find`
+- `deepline search-people` / `search-companies` / `enrich-company`
+
+Before invoking any of these, verify auth. If `DEEPLINE_API_KEY` is not set, ASK THE USER for it (or for a BYOK Hunter/Apollo key) before running the command. The CLI preflight now fails fast with a clear hint, but you can save the round-trip by checking first:
+
+```bash
+contact-goat-pp-cli doctor --agent | grep -i deepline
+```
+
+Provider chain by target kind (waterfall):
+
+| Target | Primary | Fallback 1 | Fallback 2 |
+|--------|---------|-----------|-----------|
+| LinkedIn URL | apollo_people_match | hunter_people_find | contactout_enrich_person |
+| Email | apollo_people_match | hunter_people_find | - |
+| Name + --company | dropleads_email_finder | hunter_email_finder | datagma_find_email |
+
+Notes:
+- Name targets MUST pass `--company <domain>` (or set `CONTACT_GOAT_COMPANY` env).
+- Apollo returns `personal_emails[]` when available; treat `email_status: "unavailable"` as "no verified work email on file" (the personal email is still usable).
+- Dropleads returns `status: "catch_all"` for domains on Google Workspace; the email is a pattern guess, not a verified mailbox.
+- Provider-level 403s are surfaced as "Provider not connected" rather than "Check DEEPLINE_API_KEY"; they do not abort the chain. The next provider is tried automatically.
+
 ## Notable Commands
 
 | Command | What it does |
@@ -119,6 +148,10 @@ Source routing (cookie vs bearer) is automatic. The auto router prefers the free
 | `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree) |
 | `prospect <query>` | Fan-out search across LinkedIn + Happenstance (+ opt-in Deepline), deduped |
 | `warm-intro <target>` | Mutual connections across sources who could intro you to a target |
+| `waterfall <target> [--company X]` | Free-sources-first enrichment, falls through to Deepline provider chain. Requires DEEPLINE_API_KEY or --byok. Bare-name targets need --company |
+| `dossier <target> [--enrich-email]` | Unified LinkedIn + Happenstance + (optional) Deepline dossier. --enrich-email requires DEEPLINE_API_KEY |
+| `deepline find-email "<name>" --company <domain>` | Single-call work-email lookup via dropleads_email_finder |
+| `deepline enrich-person <linkedin-url>` | Full person record via apollo_people_match (includes personal_emails[]) |
 | `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll) |
 | `api hpn research <description>` | Bearer-API deep dossier (costs 1 credit on completion) |
 | `api hpn usage` | Live credit balance, purchases, recent usage events (free) |

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline.go
@@ -61,6 +61,19 @@ estimated cost before spending and supports --dry-run to preview the request.`,
 
 	cmd.PersistentFlags().StringVar(&dl.apiKey, "deepline-key", "", "Deepline API key (default from $DEEPLINE_API_KEY)")
 
+	// Preflight: every deepline subcommand either spends credits or calls
+	// code.deepline.com for status, so require an API key shape-valid key
+	// here before wasting the user's time on dry-run, confirm-gate, or the
+	// credits stub. `credits` is allowed through because its whole point is
+	// to surface the "not yet wired" stub error without needing upstream
+	// auth.
+	cmd.PersistentPreRunE = func(c *cobra.Command, _ []string) error {
+		if c.Name() == "credits" {
+			return nil
+		}
+		return requireDeeplineKey(dl)
+	}
+
 	cmd.AddCommand(newDeeplineFindEmailCmd(flags, dl))
 	cmd.AddCommand(newDeeplineSearchPeopleCmd(flags, dl))
 	cmd.AddCommand(newDeeplineEmailFindCmd(flags, dl))

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline.go
@@ -201,8 +201,18 @@ func newDeeplineFindEmailCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command
 	var company string
 	cmd := &cobra.Command{
 		Use:   "find-email <name>",
-		Short: "Find a person's email via the waterfall (Apollo + fallbacks)",
-		Long:  "Runs Deepline's person_search_to_email_waterfall tool: resolves name+company to an email using multiple providers in cost order.",
+		Short: "Find a person's work email from name+domain",
+		Long: `Finds a single high-confidence work email for a person at a company using
+Deepline's dropleads_email_finder tool.
+
+Input is the person's full name and a company domain. The name is split
+on whitespace into first_name / last_name; multi-word first names are
+preserved (e.g. "Jean-Paul Sartre" -> first="Jean-Paul", last="Sartre").
+
+The upstream tool returns {email, status, mx_record, mx_provider}. Status
+values include "valid", "catch_all", and "unknown"; a "catch_all" status
+means the domain accepts any address and the mailbox was not individually
+verified.`,
 		Example: `  contact-goat-pp-cli deepline find-email "Patrick Collison" --company stripe.com --yes
   contact-goat-pp-cli deepline find-email "Brian Chesky" --company airbnb.com --dry-run`,
 		Args: cobra.ExactArgs(1),
@@ -210,11 +220,16 @@ func newDeeplineFindEmailCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command
 			if strings.TrimSpace(company) == "" {
 				return usageErr(fmt.Errorf("--company is required (e.g. --company stripe.com)"))
 			}
-			payload := map[string]any{
-				"name":    args[0],
-				"company": company,
+			first, last := splitName(args[0])
+			if first == "" || last == "" {
+				return usageErr(fmt.Errorf("name %q must split into first and last (e.g. \"Patrick Collison\")", args[0]))
 			}
-			return deeplineExecute(cmd, flags, dl, deepline.ToolPersonSearchToEmailWaterfall, payload)
+			payload := map[string]any{
+				"first_name":     first,
+				"last_name":      last,
+				"company_domain": company,
+			}
+			return deeplineExecute(cmd, flags, dl, deepline.ToolEmailFind, payload)
 		},
 	}
 	cmd.Flags().StringVar(&company, "company", "", "Company domain (e.g. stripe.com)")
@@ -259,15 +274,19 @@ func newDeeplineSearchPeopleCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Comm
 func newDeeplineEmailFindCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command {
 	var domain string
 	cmd := &cobra.Command{
-		Use:     "email-find",
-		Short:   "Find public emails for a company domain",
+		Use:   "email-find",
+		Short: "Find public emails for a company domain",
+		Long: `Lists public/role emails at a domain via Hunter domain search. Returns
+role-filtered company emails (e.g. contact@, press@, named-person@) with
+confidence scores and sources. For a single person's work email from
+name+domain, use the find-email subcommand instead.`,
 		Example: `  contact-goat-pp-cli deepline email-find --domain stripe.com --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if strings.TrimSpace(domain) == "" {
 				return usageErr(fmt.Errorf("--domain is required (e.g. --domain stripe.com)"))
 			}
 			payload := map[string]any{"domain": domain}
-			return deeplineExecute(cmd, flags, dl, deepline.ToolEmailFind, payload)
+			return deeplineExecute(cmd, flags, dl, deepline.ToolHunterDomainSearch, payload)
 		},
 	}
 	cmd.Flags().StringVar(&domain, "domain", "", "Company domain (e.g. stripe.com)")
@@ -338,12 +357,20 @@ func newDeeplineEnrichCompanyCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Com
 
 func newDeeplineEnrichPersonCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "enrich-person <linkedin-url>",
-		Short:   "Enrich a person by LinkedIn URL (title, company, location)",
+		Use:   "enrich-person <linkedin-url>",
+		Short: "Enrich a person by LinkedIn URL (title, company, location, personal emails)",
+		Long: `Enriches a person via Apollo people match. Accepts a LinkedIn URL and
+returns a full record: name, title, organization, employment history,
+and personal_emails when available. Pass --reveal-work-email=false to
+skip revealing the verified work email (and reduce cost on some
+accounts).`,
 		Example: `  contact-goat-pp-cli deepline enrich-person https://www.linkedin.com/in/patrickcollison --yes`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			payload := map[string]any{"linkedin_url": args[0]}
+			payload := map[string]any{
+				"linkedin_url":           args[0],
+				"reveal_personal_emails": true,
+			}
 			return deeplineExecute(cmd, flags, dl, deepline.ToolPersonEnrich, payload)
 		},
 	}

--- a/library/sales-and-crm/contact-goat/internal/cli/dossier.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/dossier.go
@@ -59,9 +59,19 @@ is passed. Pass --enrich-email to spend Deepline credits for email/phone.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := args[0]
+			want := parseSections(sections)
+
+			// Preflight: if we're about to reach Deepline, fail fast when the
+			// key is missing rather than letting the dossier run through
+			// LinkedIn + Happenstance before surfacing the auth gap.
+			if shouldPreflightDossier(sections, enrichEmail) {
+				if key := firstNonEmpty(deeplineKey, os.Getenv("DEEPLINE_API_KEY")); key == "" {
+					return authErr(fmt.Errorf("dossier --enrich-email needs DEEPLINE_API_KEY (set env or pass --deepline-key)\nhint: keys at https://code.deepline.com/dashboard/api-keys"))
+				}
+			}
+
 			ctx, cancel := signalCtx(cmd.Context())
 			defer cancel()
-			want := parseSections(sections)
 
 			// Check cache.
 			if !noCache {

--- a/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
@@ -372,7 +372,8 @@ func fetchLinkedInPerson(ctx context.Context, linkedinURL string, sections []str
 	if _, err := client.Initialize(ctx, linkedin.Implementation{Name: "contact-goat-pp-cli", Version: version}); err != nil {
 		return nil, nil, fmt.Errorf("linkedin mcp initialize: %w", err)
 	}
-	args := map[string]any{"linkedin_url": linkedinURL}
+	// Upstream tool requires linkedin_username; see normalizePersonInput.
+	args := map[string]any{"linkedin_username": normalizePersonInput(linkedinURL)}
 	if len(sections) > 0 {
 		args["sections"] = sections
 	}

--- a/library/sales-and-crm/contact-goat/internal/cli/preflight.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/preflight.go
@@ -1,0 +1,98 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// preflight.go: shared preflight helpers used by commands to short-circuit
+// before doing expensive work when a required credential is missing.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/deepline"
+)
+
+// requireDeeplineKey validates that a Deepline API key is available in the
+// environment or on the deeplineFlags, without contacting the upstream API.
+// It is intended to be called from PreRunE on commands that will definitely
+// spend Deepline credits, so the user learns the key is missing before the
+// command burns time on free-chain steps (waterfall) or user confirmation
+// prompts.
+//
+// The check is cheap: it reads env + flag + validates the shape. It does
+// NOT ping code.deepline.com (a ping itself would cost nothing but adds
+// latency and a network dependency to the preflight).
+//
+// dlFlags may be nil; when nil, only DEEPLINE_API_KEY env is checked.
+func requireDeeplineKey(dlFlags *deeplineFlags) error {
+	key := ""
+	if dlFlags != nil {
+		key = dlFlags.resolveKey()
+	} else {
+		key = os.Getenv("DEEPLINE_API_KEY")
+	}
+	if strings.TrimSpace(key) == "" {
+		return authErr(fmt.Errorf("%w\nhint: export DEEPLINE_API_KEY=dlp_... (keys at https://code.deepline.com/dashboard/api-keys)\n      or pass --deepline-key dlp_... where the flag is available",
+			deepline.ErrMissingKey))
+	}
+	if !strings.HasPrefix(key, deepline.KeyPrefix) {
+		return authErr(deepline.ErrInvalidKeyPrefix)
+	}
+	return nil
+}
+
+// hasAnyEnv returns true when any of the named env vars is set and non-empty.
+// Used by waterfall's preflight bypass: if the user has BYOK keys configured
+// for Hunter or Apollo, requiring a Deepline key up front is wrong since the
+// --byok path may never call Deepline-managed endpoints.
+func hasAnyEnv(names ...string) bool {
+	for _, n := range names {
+		if strings.TrimSpace(os.Getenv(n)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// preflightWaterfallDeepline returns an error if the waterfall is about to
+// run without any way to reach Deepline. The caller passes the BYOK config
+// and the --byok/--require-byok flag so we can decide whether a Deepline key
+// is strictly required.
+//
+// Rule:
+//   - requireBYOK=true with BYOK keys configured -> ok (waterfall will error
+//     separately if the BYOK providers can't serve the requested fields)
+//   - otherwise, a valid DEEPLINE_API_KEY is required for any Deepline step
+func preflightWaterfallDeepline(dlKey string, requireBYOK bool, byok map[string]string) error {
+	if requireBYOK && len(byok) > 0 {
+		return nil
+	}
+	if strings.TrimSpace(dlKey) == "" {
+		return authErr(fmt.Errorf("%w\nhint: waterfall needs either DEEPLINE_API_KEY (see https://code.deepline.com/dashboard/api-keys)\n      or --byok with configured BYOK providers (`config byok set hunter HUNTER_API_KEY`)",
+			deepline.ErrMissingKey))
+	}
+	if !strings.HasPrefix(dlKey, deepline.KeyPrefix) {
+		return authErr(deepline.ErrInvalidKeyPrefix)
+	}
+	return nil
+}
+
+// shouldPreflightDossier returns whether the dossier command's current flags
+// will reach Deepline. Dossier only needs a Deepline key when email/phone
+// enrichment is explicitly requested.
+func shouldPreflightDossier(sections []string, enrichEmail bool) bool {
+	if enrichEmail {
+		return true
+	}
+	for _, s := range sections {
+		if strings.EqualFold(s, "email") {
+			return true
+		}
+	}
+	return false
+}
+
+// silence the unused-import warning if preflight helpers are trimmed later.
+var _ = errors.New

--- a/library/sales-and-crm/contact-goat/internal/cli/preflight_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/preflight_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/deepline"
+)
+
+func TestRequireDeeplineKeyMissing(t *testing.T) {
+	t.Setenv("DEEPLINE_API_KEY", "")
+	err := requireDeeplineKey(&deeplineFlags{})
+	if err == nil {
+		t.Fatal("requireDeeplineKey with no env/flag should error")
+	}
+	if !errors.Is(err, deepline.ErrMissingKey) {
+		t.Errorf("err = %v, want ErrMissingKey wrapped inside", err)
+	}
+}
+
+func TestRequireDeeplineKeyMalformed(t *testing.T) {
+	t.Setenv("DEEPLINE_API_KEY", "foo_not_dlp")
+	err := requireDeeplineKey(&deeplineFlags{})
+	if err == nil {
+		t.Fatal("requireDeeplineKey with malformed key should error")
+	}
+	if !errors.Is(err, deepline.ErrInvalidKeyPrefix) {
+		t.Errorf("err = %v, want ErrInvalidKeyPrefix wrapped inside", err)
+	}
+}
+
+func TestRequireDeeplineKeyFromFlag(t *testing.T) {
+	t.Setenv("DEEPLINE_API_KEY", "")
+	if err := requireDeeplineKey(&deeplineFlags{apiKey: "dlp_abc"}); err != nil {
+		t.Errorf("flag key should satisfy preflight: %v", err)
+	}
+}
+
+func TestRequireDeeplineKeyFromEnv(t *testing.T) {
+	t.Setenv("DEEPLINE_API_KEY", "dlp_env_value")
+	if err := requireDeeplineKey(&deeplineFlags{}); err != nil {
+		t.Errorf("env key should satisfy preflight: %v", err)
+	}
+}
+
+func TestPreflightWaterfallDeeplineRequireBYOKSatisfied(t *testing.T) {
+	err := preflightWaterfallDeepline("", true, map[string]string{"hunter": "HUNTER_API_KEY"})
+	if err != nil {
+		t.Errorf("--byok + BYOK configured should skip Deepline preflight: %v", err)
+	}
+}
+
+func TestPreflightWaterfallDeeplineRequiresKeyWithoutBYOK(t *testing.T) {
+	err := preflightWaterfallDeepline("", false, nil)
+	if err == nil {
+		t.Fatal("no key + no BYOK should fail")
+	}
+	if !errors.Is(err, deepline.ErrMissingKey) {
+		t.Errorf("err = %v, want ErrMissingKey wrapped inside", err)
+	}
+}
+
+func TestPreflightWaterfallDeeplineValidKey(t *testing.T) {
+	if err := preflightWaterfallDeepline("dlp_abc", false, nil); err != nil {
+		t.Errorf("valid key should pass: %v", err)
+	}
+}
+
+func TestShouldPreflightDossier(t *testing.T) {
+	cases := []struct {
+		name         string
+		sections     []string
+		enrichEmail  bool
+		wantPreflight bool
+	}{
+		{"no-email-no-enrich", []string{"profile", "research"}, false, false},
+		{"email-section-no-enrich", []string{"profile", "research", "email"}, false, true},
+		{"enrich-email-only", []string{"profile", "research"}, true, true},
+		{"both", []string{"profile", "research", "email"}, true, true},
+	}
+	for _, c := range cases {
+		got := shouldPreflightDossier(c.sections, c.enrichEmail)
+		if got != c.wantPreflight {
+			t.Errorf("shouldPreflightDossier(%v, %v) = %v, want %v",
+				c.sections, c.enrichEmail, got, c.wantPreflight)
+		}
+	}
+}
+
+func TestNormalizePersonInputHandlesURLVariants(t *testing.T) {
+	// This helper is the one Unit 3 relies on for the linkedin_url ->
+	// linkedin_username fix. Lock the behavior in a test.
+	cases := map[string]string{
+		"williamhgates":                               "williamhgates",
+		"https://www.linkedin.com/in/williamhgates":   "williamhgates",
+		"https://www.linkedin.com/in/williamhgates/":  "williamhgates",
+		"http://linkedin.com/in/alonsovelasco":        "alonsovelasco",
+		"/in/alonsovelasco/":                          "alonsovelasco",
+		"https://www.linkedin.com/in/mkscrg":          "mkscrg",
+	}
+	for in, want := range cases {
+		if got := normalizePersonInput(in); got != want {
+			t.Errorf("normalizePersonInput(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
@@ -28,14 +28,15 @@ var emailPattern = regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
 
 // WaterfallStep logs a single attempt in the waterfall.
 type WaterfallStep struct {
-	Source  string          `json:"source"`
-	Tool    string          `json:"tool,omitempty"`
-	BYOK    bool            `json:"byok,omitempty"`
-	Cost    int             `json:"cost_credits"`
-	Status  string          `json:"status"`
-	Error   string          `json:"error,omitempty"`
-	Fields  []string        `json:"fields_filled,omitempty"`
-	Snippet json.RawMessage `json:"snippet,omitempty"`
+	Source   string          `json:"source"`
+	Tool     string          `json:"tool,omitempty"`
+	Provider string          `json:"provider,omitempty"`
+	BYOK     bool            `json:"byok,omitempty"`
+	Cost     int             `json:"cost_credits"`
+	Status   string          `json:"status"`
+	Error    string          `json:"error,omitempty"`
+	Fields   []string        `json:"fields_filled,omitempty"`
+	Snippet  json.RawMessage `json:"snippet,omitempty"`
 }
 
 // WaterfallResult is the final output shape.
@@ -53,6 +54,7 @@ func newWaterfallCmd(flags *rootFlags) *cobra.Command {
 	var enrichCSV string
 	var maxCost int
 	var requireBYOK bool
+	var companyDomain string
 
 	cmd := &cobra.Command{
 		Use:   "waterfall <target>",
@@ -68,8 +70,12 @@ Targets:
 Step order:
   1. LinkedIn get_person_profile (free, scraper subprocess)
   2. Happenstance research (free if you have a cookie)
-  3. Deepline BYOK (uses your own Hunter/Apollo keys, no Deepline markup)
-  4. Deepline managed (burns Deepline credits, last resort)
+  3. Deepline provider chain (per target kind; burns Deepline credits)
+     linkedin_url -> apollo_people_match -> hunter_people_find -> contactout_enrich_person
+     email        -> apollo_people_match -> hunter_people_find
+     name+domain  -> dropleads_email_finder -> hunter_email_finder -> datagma_find_email
+
+Name targets require --company (or CONTACT_GOAT_COMPANY env var).
 
 Configure BYOK keys with:
   contact-goat-pp-cli config byok set <provider> <env-var-name>`,
@@ -92,9 +98,16 @@ Configure BYOK keys with:
 
 			byok := readBYOKConfig()
 			if requireBYOK && len(byok) == 0 {
-				return authErr(errors.New("no BYOK providers configured — run `contact-goat-pp-cli config byok set hunter HUNTER_API_KEY`"))
+				return authErr(errors.New("no BYOK providers configured: run `contact-goat-pp-cli config byok set hunter HUNTER_API_KEY`"))
 			}
 			result.BYOKKeys = redactedBYOK(byok)
+
+			if companyDomain == "" {
+				companyDomain = strings.TrimSpace(os.Getenv("CONTACT_GOAT_COMPANY"))
+			}
+			if result.TargetKind == "name" && companyDomain == "" {
+				return usageErr(errors.New("name targets require --company (e.g. --company stripe.com) or CONTACT_GOAT_COMPANY env"))
+			}
 
 			// Step 1: LinkedIn profile.
 			if !waterfallComplete(result, enrichFields) {
@@ -106,20 +119,9 @@ Configure BYOK keys with:
 				step := tryHappenstance(cmd, flags, target, result)
 				result.Steps = append(result.Steps, step)
 			}
-			// Step 3 & 4: Deepline (BYOK first when configured, then managed).
-			if !waterfallComplete(result, enrichFields) && !requireBYOK {
-				// BYOK path first when keys are present.
-				if len(byok) > 0 {
-					step := tryDeepline(cmd.Context(), flags, target, enrichFields, true, byok, maxCost, result)
-					result.Steps = append(result.Steps, step)
-				}
-				if !waterfallComplete(result, enrichFields) {
-					step := tryDeepline(cmd.Context(), flags, target, enrichFields, false, byok, maxCost, result)
-					result.Steps = append(result.Steps, step)
-				}
-			} else if !waterfallComplete(result, enrichFields) && requireBYOK {
-				step := tryDeepline(cmd.Context(), flags, target, enrichFields, true, byok, maxCost, result)
-				result.Steps = append(result.Steps, step)
+			// Step 3: Deepline provider chain.
+			if !waterfallComplete(result, enrichFields) {
+				runDeeplineChain(cmd.Context(), flags, target, enrichFields, companyDomain, requireBYOK, byok, maxCost, result)
 			}
 
 			for _, f := range enrichFields {
@@ -138,6 +140,7 @@ Configure BYOK keys with:
 	cmd.Flags().StringVar(&enrichCSV, "enrich", "email,phone", "Comma-separated fields to fill (email, phone, company, name, title)")
 	cmd.Flags().IntVar(&maxCost, "max-cost", 5, "Max Deepline credits to spend across the whole run")
 	cmd.Flags().BoolVar(&requireBYOK, "byok", false, "Require BYOK for Deepline steps; error if no BYOK keys configured")
+	cmd.Flags().StringVar(&companyDomain, "company", "", "Company domain (e.g. stripe.com); required for bare-name targets")
 	return cmd
 }
 
@@ -263,81 +266,321 @@ func tryHappenstance(cmd *cobra.Command, flags *rootFlags, target string, r *Wat
 	return step
 }
 
-// tryDeepline drives the Deepline waterfall, either BYOK or managed.
-func tryDeepline(ctx context.Context, flags *rootFlags, target string, fields []string, useBYOK bool, byok map[string]string, maxCost int, r *WaterfallResult) WaterfallStep {
-	step := WaterfallStep{Source: "deepline", Tool: deepline.ToolPersonEnrich, BYOK: useBYOK}
+// deeplineProviderAttempt is a single (tool, payload) pair in the Deepline
+// provider chain. Each attempt becomes its own WaterfallStep in the result.
+type deeplineProviderAttempt struct {
+	toolID   string
+	provider string // short label shown in step.Provider
+	payload  map[string]any
+}
 
-	if useBYOK && len(byok) == 0 {
-		step.Status = "skipped"
-		step.Error = "no BYOK providers configured"
-		return step
+// deeplineProviderChain returns the ordered list of provider attempts to
+// execute for the given target. Order is cheapest/highest-hit first. Each
+// attempt carries its own payload shape already matching the provider's
+// documented schema (verified against `deepline tools get` on 2026-04-20).
+func deeplineProviderChain(targetKind, target, companyDomain string) []deeplineProviderAttempt {
+	switch targetKind {
+	case "linkedin_url":
+		return []deeplineProviderAttempt{
+			{
+				toolID:   deepline.ToolApolloPeopleMatch,
+				provider: "apollo",
+				payload: map[string]any{
+					"linkedin_url":           target,
+					"reveal_personal_emails": true,
+				},
+			},
+			{
+				toolID:   deepline.ToolHunterPeopleFind,
+				provider: "hunter",
+				payload:  map[string]any{"linkedin_url": target},
+			},
+			{
+				toolID:   deepline.ToolContactOutEnrichPerson,
+				provider: "contactout",
+				payload:  map[string]any{"linkedin_url": target},
+			},
+		}
+	case "email":
+		return []deeplineProviderAttempt{
+			{
+				toolID:   deepline.ToolApolloPeopleMatch,
+				provider: "apollo",
+				payload: map[string]any{
+					"email":                  target,
+					"reveal_personal_emails": true,
+				},
+			},
+			{
+				toolID:   deepline.ToolHunterPeopleFind,
+				provider: "hunter",
+				payload:  map[string]any{"email": target},
+			},
+		}
+	case "name":
+		firstName, lastName := splitName(target)
+		return []deeplineProviderAttempt{
+			{
+				toolID:   deepline.ToolDropleadsEmailFinder,
+				provider: "dropleads",
+				payload: map[string]any{
+					"first_name":     firstName,
+					"last_name":      lastName,
+					"company_domain": companyDomain,
+				},
+			},
+			{
+				toolID:   deepline.ToolHunterEmailFinder,
+				provider: "hunter",
+				payload: map[string]any{
+					"first_name": firstName,
+					"last_name":  lastName,
+					"domain":     companyDomain,
+				},
+			},
+			{
+				toolID:   deepline.ToolDatagmaFindEmail,
+				provider: "datagma",
+				payload: map[string]any{
+					"first_name":     firstName,
+					"last_name":      lastName,
+					"company_domain": companyDomain,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// runDeeplineChain walks the provider chain, appending one WaterfallStep per
+// provider attempt. Stops early when the requested fields are filled or when
+// max-cost would be exceeded. Provider-level errors (including entitlement
+// 403s) do not abort the chain; the next provider is tried.
+func runDeeplineChain(ctx context.Context, flags *rootFlags, target string, fields []string, companyDomain string, requireBYOK bool, byok map[string]string, maxCost int, r *WaterfallResult) {
+	chain := deeplineProviderChain(r.TargetKind, target, companyDomain)
+	if len(chain) == 0 {
+		return
 	}
 
-	spent := r.TotalCredit
 	client := deepline.NewClient(os.Getenv("DEEPLINE_API_KEY"))
 	if err := client.ValidateKey(); err != nil {
-		step.Status = "skipped"
-		step.Error = err.Error()
-		return step
+		// One synthetic step surfaces the auth gate failure rather than
+		// emitting N copies (one per provider in the chain).
+		r.Steps = append(r.Steps, WaterfallStep{
+			Source: "deepline",
+			Status: "skipped",
+			Error:  err.Error(),
+		})
+		return
 	}
 
-	// Decide which tool to run based on target kind.
-	toolID := deepline.ToolPersonEnrich
-	payload := map[string]any{}
-	switch r.TargetKind {
-	case "linkedin_url":
-		payload["linkedin_url"] = target
-	case "email":
-		toolID = deepline.ToolEmailFind
-		payload["email"] = target
-	case "name":
-		toolID = deepline.ToolPersonSearchToEmailWaterfall
-		payload["name"] = target
-		if co := strings.TrimSpace(os.Getenv("CONTACT_GOAT_COMPANY")); co != "" {
-			payload["company"] = co
+	for _, attempt := range chain {
+		if waterfallComplete(r, fields) {
+			return
 		}
-	}
-	if useBYOK {
-		payload["byok"] = true
-		// Forward the env var name(s) — we never store the value.
-		if envVar, ok := byok["hunter"]; ok && os.Getenv(envVar) != "" {
-			payload["byok_hunter_key_env"] = envVar
+		step := WaterfallStep{
+			Source:   "deepline",
+			Tool:     attempt.toolID,
+			Provider: attempt.provider,
+			BYOK:     requireBYOK || len(byok) > 0,
 		}
-		if envVar, ok := byok["apollo"]; ok && os.Getenv(envVar) != "" {
-			payload["byok_apollo_key_env"] = envVar
-		}
-	}
 
-	est, _ := client.EstimateCost(toolID, payload)
-	if maxCost > 0 && spent+est > maxCost {
-		step.Status = "skipped"
-		step.Error = fmt.Sprintf("would exceed --max-cost %d (already spent %d, next step ~%d)", maxCost, spent, est)
-		step.Cost = 0
-		return step
-	}
-	step.Tool = toolID
+		est, _ := client.EstimateCost(attempt.toolID, attempt.payload)
+		spent := r.TotalCredit
+		for _, s := range r.Steps {
+			spent += s.Cost
+		}
+		if maxCost > 0 && spent+est > maxCost {
+			step.Status = "skipped"
+			step.Error = fmt.Sprintf("would exceed --max-cost %d (already spent %d, next step ~%d)", maxCost, spent, est)
+			r.Steps = append(r.Steps, step)
+			return
+		}
 
-	execCtx, cancel := context.WithTimeout(ctx, flags.timeout)
-	defer cancel()
-	raw, err := client.Execute(execCtx, toolID, payload)
-	if err != nil {
-		step.Status = "error"
-		step.Error = err.Error()
-		return step
-	}
-	// BYOK stills costs the upstream provider but we don't pay Deepline markup.
-	if useBYOK {
-		step.Cost = 0
-	} else {
+		execCtx, cancel := context.WithTimeout(ctx, flags.timeout)
+		raw, err := client.Execute(execCtx, attempt.toolID, attempt.payload)
+		cancel()
+		if err != nil {
+			step.Status = "error"
+			step.Error = err.Error()
+			r.Steps = append(r.Steps, step)
+			continue
+		}
 		step.Cost = est
+		step.Snippet = raw
+		extractDeeplineFields(r, raw, attempt.provider, &step)
+		if len(step.Fields) == 0 {
+			step.Status = "empty"
+		} else {
+			step.Status = "ok"
+		}
+		r.Steps = append(r.Steps, step)
 	}
+}
+
+// splitName splits a "First Last" string into (first, last). A single-word
+// name goes entirely into first_name; a name with three or more tokens
+// treats the final token as last_name and everything else as first_name
+// (handles "Jean-Paul Sartre" or "Mary Anne Smith" reasonably).
+func splitName(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	parts := strings.Fields(s)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return strings.Join(parts[:len(parts)-1], " "), parts[len(parts)-1]
+}
+
+// extractDeeplineFields drills into a provider-specific response and copies
+// contact fields into the Waterfall result. The Deepline v2 HTTP response is
+// wrapped as {"job_id":..., "status":..., "result":{"data":{...}}}; different
+// providers nest their fields differently inside `data`, so we dispatch on
+// provider name.
+func extractDeeplineFields(r *WaterfallResult, raw json.RawMessage, provider string, step *WaterfallStep) {
+	var envelope struct {
+		Result struct {
+			Data json.RawMessage `json:"data"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil || len(envelope.Result.Data) == 0 {
+		return
+	}
+	switch provider {
+	case "apollo":
+		extractApolloPerson(r, envelope.Result.Data, step)
+	case "hunter":
+		extractHunterResult(r, envelope.Result.Data, step)
+	case "contactout":
+		extractFlatContact(r, envelope.Result.Data, step,
+			[]string{"email", "work_email"}, []string{"phone", "mobile"})
+	case "dropleads":
+		extractDropleadsResult(r, envelope.Result.Data, step)
+	case "datagma":
+		extractFlatContact(r, envelope.Result.Data, step,
+			[]string{"email"}, []string{"phone"})
+	default:
+		var m map[string]any
+		if err := json.Unmarshal(envelope.Result.Data, &m); err == nil {
+			applyEnrichFields(r, m, step, []string{"email", "phone", "company", "name", "title", "linkedin_url"})
+		}
+	}
+}
+
+func extractApolloPerson(r *WaterfallResult, data json.RawMessage, step *WaterfallStep) {
+	var wrap struct {
+		Person struct {
+			Name           string   `json:"name"`
+			Title          string   `json:"title"`
+			LinkedinURL    string   `json:"linkedin_url"`
+			Email          string   `json:"email"`
+			EmailStatus    string   `json:"email_status"`
+			PersonalEmails []string `json:"personal_emails"`
+			Organization   struct {
+				Name string `json:"name"`
+			} `json:"organization"`
+		} `json:"person"`
+	}
+	if err := json.Unmarshal(data, &wrap); err != nil {
+		return
+	}
+	p := wrap.Person
+	setField(r, step, "name", p.Name)
+	setField(r, step, "title", p.Title)
+	setField(r, step, "linkedin_url", p.LinkedinURL)
+	setField(r, step, "company", p.Organization.Name)
+	// Work email: only accept if upstream marked it verified or catchall
+	// (not "unavailable"). Apollo returns email = "" when it has no hit.
+	if p.Email != "" && p.EmailStatus != "unavailable" {
+		setField(r, step, "email", p.Email)
+	}
+	if len(p.PersonalEmails) > 0 && p.PersonalEmails[0] != "" {
+		setField(r, step, "personal_email", p.PersonalEmails[0])
+	}
+	if p.EmailStatus != "" {
+		setField(r, step, "email_confidence", p.EmailStatus)
+	}
+}
+
+func extractHunterResult(r *WaterfallResult, data json.RawMessage, step *WaterfallStep) {
 	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err == nil {
-		applyEnrichFields(r, m, &step, []string{"email", "phone", "company", "name", "title", "linkedin_url"})
+	if err := json.Unmarshal(data, &m); err != nil {
+		return
 	}
-	step.Snippet = raw
-	step.Status = "ok"
-	return step
+	if email, ok := stringField(m, "email"); ok {
+		setField(r, step, "email", email)
+	}
+	if phone, ok := stringField(m, "phone_number"); ok {
+		setField(r, step, "phone", phone)
+	} else if phone, ok := stringField(m, "phone"); ok {
+		setField(r, step, "phone", phone)
+	}
+	if co, ok := stringField(m, "company"); ok {
+		setField(r, step, "company", co)
+	}
+	if title, ok := stringField(m, "position"); ok {
+		setField(r, step, "title", title)
+	}
+	if score, ok := m["score"].(float64); ok && score > 0 {
+		setField(r, step, "email_confidence", fmt.Sprintf("hunter_score_%d", int(score)))
+	}
+}
+
+func extractDropleadsResult(r *WaterfallResult, data json.RawMessage, step *WaterfallStep) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return
+	}
+	if email, ok := stringField(m, "email"); ok {
+		setField(r, step, "email", email)
+	}
+	if status, ok := stringField(m, "status"); ok {
+		setField(r, step, "email_confidence", status)
+	}
+	if co, ok := stringField(m, "company_domain"); ok {
+		setField(r, step, "company_domain", co)
+	}
+}
+
+func extractFlatContact(r *WaterfallResult, data json.RawMessage, step *WaterfallStep, emailKeys, phoneKeys []string) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return
+	}
+	for _, k := range emailKeys {
+		if v, ok := stringField(m, k); ok {
+			setField(r, step, "email", v)
+			break
+		}
+	}
+	for _, k := range phoneKeys {
+		if v, ok := stringField(m, k); ok {
+			setField(r, step, "phone", v)
+			break
+		}
+	}
+}
+
+func stringField(m map[string]any, key string) (string, bool) {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+func setField(r *WaterfallResult, step *WaterfallStep, key, value string) {
+	if value == "" {
+		return
+	}
+	if _, already := r.Fields[key]; already {
+		return
+	}
+	r.Fields[key] = value
+	step.Fields = append(step.Fields, key)
 }
 
 // applyEnrichFields copies the listed fields from src into the running result.

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
@@ -109,6 +109,15 @@ Configure BYOK keys with:
 				return usageErr(errors.New("name targets require --company (e.g. --company stripe.com) or CONTACT_GOAT_COMPANY env"))
 			}
 
+			// Preflight: fail fast on missing auth rather than running the
+			// LinkedIn + Happenstance chain first. The Deepline step is
+			// ultimately where the work gets done; without a path to it the
+			// whole waterfall can't satisfy the typical --enrich email,phone
+			// ask.
+			if err := preflightWaterfallDeepline(os.Getenv("DEEPLINE_API_KEY"), requireBYOK, byok); err != nil {
+				return err
+			}
+
 			// Step 1: LinkedIn profile.
 			if !waterfallComplete(result, enrichFields) {
 				step := tryLinkedIn(cmd.Context(), flags, target, result)
@@ -211,7 +220,10 @@ func tryLinkedIn(parentCtx context.Context, flags *rootFlags, target string, r *
 	}
 	callCtx, callCancel := context.WithTimeout(ctx, flags.timeout)
 	defer callCancel()
-	result, err := client.CallTool(callCtx, linkedin.ToolNames.GetPerson, map[string]any{"linkedin_url": target})
+	// Upstream linkedin-scraper-mcp requires linkedin_username (the slug
+	// after /in/), not the full URL. Passing linkedin_url yields a pydantic
+	// "Unexpected keyword argument" 422.
+	result, err := client.CallTool(callCtx, linkedin.ToolNames.GetPerson, map[string]any{"linkedin_username": normalizePersonInput(target)})
 	if err != nil {
 		step.Status = "error"
 		step.Error = err.Error()

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
@@ -305,7 +305,9 @@ func deeplineProviderChain(targetKind, target, companyDomain string) []deeplineP
 			{
 				toolID:   deepline.ToolHunterPeopleFind,
 				provider: "hunter",
-				payload:  map[string]any{"linkedin_url": target},
+				// hunter_people_find requires linkedin_handle (the slug),
+				// not linkedin_url.
+				payload: map[string]any{"linkedin_handle": linkedinHandleFromURL(target)},
 			},
 			{
 				toolID:   deepline.ToolContactOutEnrichPerson,
@@ -428,6 +430,14 @@ func runDeeplineChain(ctx context.Context, flags *rootFlags, target string, fiel
 		}
 		r.Steps = append(r.Steps, step)
 	}
+}
+
+// linkedinHandleFromURL extracts the vanity slug from a LinkedIn profile
+// URL (e.g. "https://www.linkedin.com/in/mkscrg/" -> "mkscrg"). Falls back
+// to normalizePersonInput which already handles bare slugs, /in/ prefixes,
+// and trailing slashes.
+func linkedinHandleFromURL(url string) string {
+	return normalizePersonInput(url)
 }
 
 // splitName splits a "First Last" string into (first, last). A single-word

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/deepline"
+)
+
+func TestSplitName(t *testing.T) {
+	cases := []struct {
+		in, first, last string
+	}{
+		{"Patrick Collison", "Patrick", "Collison"},
+		{"Mike Craig", "Mike", "Craig"},
+		{"Mary Anne Smith", "Mary Anne", "Smith"},
+		{"Madonna", "Madonna", ""},
+		{"  Jean-Paul Sartre  ", "Jean-Paul", "Sartre"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		f, l := splitName(c.in)
+		if f != c.first || l != c.last {
+			t.Errorf("splitName(%q) = (%q, %q), want (%q, %q)", c.in, f, l, c.first, c.last)
+		}
+	}
+}
+
+func TestDeeplineProviderChainLinkedIn(t *testing.T) {
+	chain := deeplineProviderChain("linkedin_url", "https://www.linkedin.com/in/patrickcollison", "")
+	if len(chain) != 3 {
+		t.Fatalf("linkedin_url chain length = %d, want 3", len(chain))
+	}
+	wantTools := []string{
+		deepline.ToolApolloPeopleMatch,
+		deepline.ToolHunterPeopleFind,
+		deepline.ToolContactOutEnrichPerson,
+	}
+	for i, a := range chain {
+		if a.toolID != wantTools[i] {
+			t.Errorf("chain[%d].toolID = %q, want %q", i, a.toolID, wantTools[i])
+		}
+	}
+	if v, ok := chain[0].payload["reveal_personal_emails"].(bool); !ok || !v {
+		t.Errorf("apollo attempt missing reveal_personal_emails=true: %v", chain[0].payload)
+	}
+	if chain[0].payload["linkedin_url"] != "https://www.linkedin.com/in/patrickcollison" {
+		t.Errorf("apollo attempt missing linkedin_url payload key: %v", chain[0].payload)
+	}
+}
+
+func TestDeeplineProviderChainName(t *testing.T) {
+	chain := deeplineProviderChain("name", "Mike Craig", "stripe.com")
+	if len(chain) != 3 {
+		t.Fatalf("name chain length = %d, want 3", len(chain))
+	}
+	// First provider = dropleads; payload must use company_domain, NOT domain.
+	drop := chain[0]
+	if drop.toolID != deepline.ToolDropleadsEmailFinder {
+		t.Errorf("chain[0].toolID = %q, want dropleads_email_finder", drop.toolID)
+	}
+	if drop.payload["company_domain"] != "stripe.com" {
+		t.Errorf("dropleads attempt missing company_domain=stripe.com: %v", drop.payload)
+	}
+	if _, wrong := drop.payload["domain"]; wrong {
+		t.Errorf("dropleads attempt uses wrong key 'domain' (upstream rejects): %v", drop.payload)
+	}
+	if drop.payload["first_name"] != "Mike" || drop.payload["last_name"] != "Craig" {
+		t.Errorf("dropleads attempt bad name split: %v", drop.payload)
+	}
+	// Hunter uses `domain` (not `company_domain`).
+	hunter := chain[1]
+	if hunter.toolID != deepline.ToolHunterEmailFinder {
+		t.Errorf("chain[1].toolID = %q, want hunter_email_finder", hunter.toolID)
+	}
+	if hunter.payload["domain"] != "stripe.com" {
+		t.Errorf("hunter attempt missing domain=stripe.com: %v", hunter.payload)
+	}
+}
+
+func TestDeeplineProviderChainEmail(t *testing.T) {
+	chain := deeplineProviderChain("email", "patrick@stripe.com", "")
+	if len(chain) != 2 {
+		t.Fatalf("email chain length = %d, want 2", len(chain))
+	}
+	if chain[0].payload["email"] != "patrick@stripe.com" {
+		t.Errorf("apollo attempt missing email payload: %v", chain[0].payload)
+	}
+}
+
+func TestExtractApolloPersonFillsPersonalAndWorkEmail(t *testing.T) {
+	raw := []byte(`{"job_id":"x","status":"completed","result":{"data":{"person":{
+		"name":"Mike Craig","title":"Head of Engineering",
+		"linkedin_url":"https://www.linkedin.com/in/mkscrg",
+		"email":"mike@stripe.com","email_status":"verified",
+		"personal_emails":["mkscrg@gmail.com"],
+		"organization":{"name":"Stripe"}
+	}}}}`)
+	r := &WaterfallResult{Fields: map[string]any{}}
+	step := &WaterfallStep{}
+	extractDeeplineFields(r, json.RawMessage(raw), "apollo", step)
+	if r.Fields["name"] != "Mike Craig" {
+		t.Errorf("name = %v", r.Fields["name"])
+	}
+	if r.Fields["email"] != "mike@stripe.com" {
+		t.Errorf("email = %v", r.Fields["email"])
+	}
+	if r.Fields["personal_email"] != "mkscrg@gmail.com" {
+		t.Errorf("personal_email = %v", r.Fields["personal_email"])
+	}
+	if r.Fields["email_confidence"] != "verified" {
+		t.Errorf("email_confidence = %v", r.Fields["email_confidence"])
+	}
+}
+
+func TestExtractApolloPersonOmitsUnavailableWorkEmail(t *testing.T) {
+	// Apollo returns email="" and email_status="unavailable" when it has no
+	// verified work address. The extractor must NOT fill "email" with "" and
+	// must NOT treat "unavailable" as a hit.
+	raw := []byte(`{"result":{"data":{"person":{
+		"name":"Mike Craig",
+		"email":"","email_status":"unavailable",
+		"personal_emails":["mkscrg@gmail.com"]
+	}}}}`)
+	r := &WaterfallResult{Fields: map[string]any{}}
+	step := &WaterfallStep{}
+	extractDeeplineFields(r, json.RawMessage(raw), "apollo", step)
+	if _, has := r.Fields["email"]; has {
+		t.Errorf("email unexpectedly set when Apollo reported unavailable: %v", r.Fields["email"])
+	}
+	if r.Fields["personal_email"] != "mkscrg@gmail.com" {
+		t.Errorf("personal_email should still be set: %v", r.Fields["personal_email"])
+	}
+}
+
+func TestExtractDropleadsRecordsCatchAllStatus(t *testing.T) {
+	raw := []byte(`{"result":{"data":{
+		"email":"mike@stripe.com","status":"catch_all",
+		"mx_provider":"Google","company_domain":"stripe.com"
+	}}}`)
+	r := &WaterfallResult{Fields: map[string]any{}}
+	step := &WaterfallStep{}
+	extractDeeplineFields(r, json.RawMessage(raw), "dropleads", step)
+	if r.Fields["email"] != "mike@stripe.com" {
+		t.Errorf("email = %v", r.Fields["email"])
+	}
+	if r.Fields["email_confidence"] != "catch_all" {
+		t.Errorf("email_confidence = %v, want catch_all", r.Fields["email_confidence"])
+	}
+}
+
+func TestClassifyTargetKinds(t *testing.T) {
+	cases := map[string]string{
+		"alice@stripe.com":                          "email",
+		"https://www.linkedin.com/in/patrickcollison": "linkedin_url",
+		"http://linkedin.com/in/foo/":               "linkedin_url",
+		"Mike Craig":                                "name",
+		"just-a-handle":                             "name",
+	}
+	for in, want := range cases {
+		if got := classifyTarget(in); got != want {
+			t.Errorf("classifyTarget(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/deepline/http.go
+++ b/library/sales-and-crm/contact-goat/internal/deepline/http.go
@@ -6,17 +6,60 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
+// ErrDeeplineAuth is returned when the upstream rejects the API key: either
+// it is missing from the request, malformed, revoked, or expired. Distinct
+// from ErrProviderNotEntitled below so callers can give targeted hints.
+var ErrDeeplineAuth = errors.New("deepline: API key rejected by upstream (missing, invalid, or revoked)")
+
+// ErrProviderNotEntitled is returned when a Deepline integration refuses
+// the call because the key-holder's account lacks access to that specific
+// provider (e.g. the account has Apollo + Hunter + Dropleads entitlements
+// but no Datagma / ContactOut). The key itself is fine; telling the user
+// to re-check DEEPLINE_API_KEY would be misleading.
+type ErrProviderNotEntitled struct {
+	Provider string
+	ToolID   string
+	Message  string
+}
+
+func (e *ErrProviderNotEntitled) Error() string {
+	prov := e.Provider
+	if prov == "" {
+		prov = "upstream provider"
+	}
+	msg := "not enabled on this Deepline account"
+	if e.Message != "" {
+		msg = e.Message
+	}
+	return fmt.Sprintf("deepline: %s is %s for tool %q (key is valid; try a different provider or request access)", prov, msg, e.ToolID)
+}
+
 // executeHTTP is the direct HTTP fallback used when the `deepline` CLI is
-// not on PATH or the subprocess path failed. It POSTs the payload to
-// /integrations/{toolId}/execute with a Bearer token.
+// not on PATH or the subprocess path failed. It POSTs the payload wrapped
+// in a {"payload": {...}} envelope to /integrations/{toolId}/execute.
+//
+// Wire protocol note: the endpoint rejects a flat payload with the same
+// error as a missing payload ("At least one of id, email, ... is
+// required") even when the required key IS present at the top level.
+// The correct envelope, verified 2026-04-20 against
+// apollo_people_match, dropleads_email_finder, and ai_ark_find_emails, is:
+//
+//	{"payload": {<tool-specific fields>}}
+//
+// Previously this function sent the flat payload, which meant the HTTP
+// fallback never worked for any tool; any call that didn't resolve via
+// the `deepline` subprocess failed with a misleading 422.
 func (c *Client) executeHTTP(ctx context.Context, toolID string, payload map[string]any) (json.RawMessage, error) {
-	body, err := json.Marshal(payload)
+	envelope := map[string]any{"payload": payload}
+	body, err := json.Marshal(envelope)
 	if err != nil {
 		return nil, fmt.Errorf("deepline http: marshaling payload: %w", err)
 	}
@@ -45,11 +88,11 @@ func (c *Client) executeHTTP(ctx context.Context, toolID string, payload map[str
 
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
-		return nil, fmt.Errorf("deepline http: 401 unauthorized — DEEPLINE_API_KEY is missing or invalid. Keys start with %q; verify at https://code.deepline.com/dashboard/api-keys", KeyPrefix)
+		return nil, fmt.Errorf("%w (HTTP 401): verify the key at https://code.deepline.com/dashboard/api-keys (keys start with %q)", ErrDeeplineAuth, KeyPrefix)
 	case resp.StatusCode == http.StatusForbidden:
-		return nil, fmt.Errorf("deepline http: 403 forbidden — key valid but lacks access to tool %q", toolID)
+		return nil, classify403(toolID, respBody)
 	case resp.StatusCode == http.StatusPaymentRequired:
-		return nil, fmt.Errorf("deepline http: 402 payment required — out of credits. Top up at https://code.deepline.com/dashboard/billing")
+		return nil, fmt.Errorf("deepline http: 402 payment required: out of credits. Top up at https://code.deepline.com/dashboard/billing")
 	case resp.StatusCode == http.StatusTooManyRequests:
 		return nil, fmt.Errorf("deepline http: 429 rate limited")
 	case resp.StatusCode >= 400:
@@ -68,4 +111,68 @@ func (c *Client) executeHTTP(ctx context.Context, toolID string, payload map[str
 		return nil, fmt.Errorf("deepline http: non-JSON response body")
 	}
 	return json.RawMessage(trimmed), nil
+}
+
+// classify403 distinguishes between auth failures (key missing/invalid/
+// revoked) and provider-entitlement failures (key valid but this specific
+// integration not enabled on the account). The Deepline API uses the same
+// status code for both cases, but the response body carries different
+// signals:
+//
+//	{"error_category": "auth", "code": "AUTH_*", ...} -> auth failure
+//	{"provider": "contactout", "error_category": "authorization",
+//	 "message": "... not enabled"}                  -> entitlement failure
+//
+// When the body doesn't match either pattern, fall back to a generic 403
+// wrapper that includes the upstream message so the user can still debug.
+func classify403(toolID string, body []byte) error {
+	var parsed struct {
+		ErrorCategory string `json:"error_category"`
+		Code          string `json:"code"`
+		Provider      string `json:"provider"`
+		Operation     string `json:"operation"`
+		Message       string `json:"message"`
+		Error         string `json:"error"`
+	}
+	_ = json.Unmarshal(body, &parsed)
+
+	msg := parsed.Message
+	if msg == "" {
+		msg = parsed.Error
+	}
+
+	// Auth failure patterns.
+	lowerCat := strings.ToLower(parsed.ErrorCategory)
+	lowerCode := strings.ToUpper(parsed.Code)
+	lowerMsg := strings.ToLower(msg)
+	if lowerCat == "auth" || strings.HasPrefix(lowerCode, "AUTH_") ||
+		strings.Contains(lowerMsg, "api key") || strings.Contains(lowerMsg, "invalid token") {
+		return fmt.Errorf("%w (HTTP 403): %s", ErrDeeplineAuth, msg)
+	}
+
+	// Entitlement failure patterns.
+	provider := parsed.Provider
+	if provider == "" {
+		// Some endpoints put the provider slug on the toolID itself
+		// (e.g. "contactout_enrich_person" -> "contactout").
+		if i := strings.IndexByte(toolID, '_'); i > 0 {
+			provider = toolID[:i]
+		}
+	}
+	if strings.Contains(lowerMsg, "not enabled") || strings.Contains(lowerMsg, "not authorized for this integration") ||
+		strings.Contains(lowerMsg, "integration access") || strings.Contains(lowerMsg, "not connected") ||
+		lowerCat == "authorization" {
+		return &ErrProviderNotEntitled{
+			Provider: provider,
+			ToolID:   toolID,
+			Message:  msg,
+		}
+	}
+
+	// Default: unclassified 403 with upstream body for debugging.
+	tail := string(body)
+	if len(tail) > 300 {
+		tail = tail[:300] + "..."
+	}
+	return fmt.Errorf("deepline http: 403 forbidden on tool %q: %s", toolID, tail)
 }

--- a/library/sales-and-crm/contact-goat/internal/deepline/http_test.go
+++ b/library/sales-and-crm/contact-goat/internal/deepline/http_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package deepline
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestClient wires an HTTP-only Client against the given test server URL,
+// bypassing subprocess resolution.
+func newTestClient(baseURL string) *Client {
+	return &Client{
+		apiKey:     "dlp_test",
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestHTTPWrapsPayloadInEnvelope(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"completed","result":{"data":{"ok":true}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "apollo_people_match", map[string]any{
+		"linkedin_url":           "https://www.linkedin.com/in/mkscrg",
+		"reveal_personal_emails": true,
+	})
+	if err != nil {
+		t.Fatalf("executeHTTP error: %v", err)
+	}
+	inner, ok := captured["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("request body missing `payload` envelope: %v", captured)
+	}
+	if inner["linkedin_url"] != "https://www.linkedin.com/in/mkscrg" {
+		t.Errorf("inner payload missing linkedin_url: %v", inner)
+	}
+	if v, _ := inner["reveal_personal_emails"].(bool); !v {
+		t.Errorf("inner payload missing reveal_personal_emails=true: %v", inner)
+	}
+}
+
+func TestHTTP403AuthCategory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error_category":"auth","code":"AUTH_INVALID_KEY","message":"invalid api key"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "apollo_people_match", map[string]any{"x": "y"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrDeeplineAuth) {
+		t.Errorf("err = %v, want ErrDeeplineAuth wrapped inside", err)
+	}
+	var pne *ErrProviderNotEntitled
+	if errors.As(err, &pne) {
+		t.Errorf("auth error wrongly classified as entitlement: %v", err)
+	}
+}
+
+func TestHTTP403ProviderNotEnabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"provider":"contactout","error_category":"authorization","message":"Integration not enabled for this account"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "contactout_enrich_person", map[string]any{"x": "y"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pne *ErrProviderNotEntitled
+	if !errors.As(err, &pne) {
+		t.Fatalf("err = %v, want *ErrProviderNotEntitled", err)
+	}
+	if pne.Provider != "contactout" {
+		t.Errorf("pne.Provider = %q, want contactout", pne.Provider)
+	}
+	if pne.ToolID != "contactout_enrich_person" {
+		t.Errorf("pne.ToolID = %q", pne.ToolID)
+	}
+}
+
+func TestHTTP403NotConnected(t *testing.T) {
+	// Live Deepline returns {"error":"Provider not connected."} on 403 when
+	// the account simply never connected the integration.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"Provider not connected."}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "contactout_enrich_person", map[string]any{"x": "y"})
+	var pne *ErrProviderNotEntitled
+	if !errors.As(err, &pne) {
+		t.Fatalf("err = %v, want *ErrProviderNotEntitled", err)
+	}
+	if pne.Provider != "contactout" {
+		t.Errorf("pne.Provider = %q, want contactout (derived from toolID prefix)", pne.Provider)
+	}
+	if !strings.Contains(pne.Error(), "not connected") {
+		t.Errorf("err message should echo upstream `not connected`: %v", pne.Error())
+	}
+}
+
+func TestHTTP403UnknownBodyFallsThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"something random"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "some_tool", map[string]any{})
+	if errors.Is(err, ErrDeeplineAuth) {
+		t.Errorf("unknown 403 shouldn't classify as auth: %v", err)
+	}
+	var pne *ErrProviderNotEntitled
+	if errors.As(err, &pne) {
+		t.Errorf("unknown 403 shouldn't classify as entitlement: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("fallback error should mention 403: %v", err)
+	}
+}
+
+func TestHTTP401MapsToAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.executeHTTP(context.Background(), "any", map[string]any{})
+	if !errors.Is(err, ErrDeeplineAuth) {
+		t.Errorf("401 should be ErrDeeplineAuth: %v", err)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/deepline/subprocess.go
+++ b/library/sales-and-crm/contact-goat/internal/deepline/subprocess.go
@@ -10,16 +10,29 @@ import (
 	"os/exec"
 )
 
-// executeSubprocess runs `deepline tools execute <toolID> --payload <json>`
+// executeSubprocess runs `deepline tools execute <toolID> --payload <json> --json`
 // and parses stdout as JSON. The DEEPLINE_API_KEY env var is inherited from
 // the parent process; we never pass the key on the command line.
+//
+// The `--json` flag and `--payload-output-format json` are both required
+// because without them the deepline CLI prints a human-friendly summary
+// ("Status: completed\nJob ID: ...\nTop-level result keys: ...") to stdout
+// and writes the full payload to `deepline/data/payload_<tool>_*.json`
+// in the current working directory. That summary is not valid JSON and
+// the file side-effect also pollutes the workspace.
 func (c *Client) executeSubprocess(ctx context.Context, toolID string, payload map[string]any) (json.RawMessage, error) {
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("deepline subprocess: marshaling payload: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, c.cliPath, "tools", "execute", toolID, "--payload", string(payloadJSON))
+	cmd := exec.CommandContext(ctx, c.cliPath,
+		"tools", "execute", toolID,
+		"--payload", string(payloadJSON),
+		"--json",
+		"--payload-output-format", "json",
+		"--no-preview",
+	)
 
 	// Inherit env so DEEPLINE_API_KEY reaches the subprocess. We never echo
 	// the key value in logs or error messages.

--- a/library/sales-and-crm/contact-goat/internal/deepline/types.go
+++ b/library/sales-and-crm/contact-goat/internal/deepline/types.go
@@ -17,24 +17,65 @@ const KeyPrefix = "dlp_"
 // Known tool IDs referenced by the typed subcommands. The API is tool-based:
 // every call is POST /integrations/{toolId}/execute with a tool-specific
 // JSON payload.
-// Tool IDs verified against `deepline tools list` on 2026-04-19. These are
-// the ai_ark_* family served by Deepline's managed waterfall backend.
-// Multiple CLI subcommands may map to the same underlying tool with
-// different payload shapes (e.g. company search and enrich both use
-// ai_ark_company_search).
+//
+// Tool IDs verified against `deepline tools list` on 2026-04-20. The previous
+// revision of this file pointed ToolPersonEnrich at ai_ark_personality_analysis
+// and ToolEmailFind at ai_ark_find_emails; neither is a direct email
+// enrichment tool. Personality analysis returns personality traits (not
+// contact info) and requires a `url` payload field; ai_ark_find_emails is an
+// async follow-on to ai_ark_people_search that requires a trackId. Those
+// constants are preserved here under clearer names for callers that genuinely
+// want those behaviors, while ToolPersonEnrich and ToolEmailFind now point at
+// real email-enrichment providers.
 const (
+	// --- ai_ark family: preserved for explicit callers ---
+	// ToolPersonSearchToEmailWaterfall is the async follow-on to
+	// ToolApolloPeopleSearch. It requires a trackId from a prior
+	// ai_ark_people_search call and cannot be invoked directly with
+	// name+company. Do NOT route the `find-email` subcommand here.
 	ToolPersonSearchToEmailWaterfall = "ai_ark_find_emails"
 	ToolApolloPeopleSearch           = "ai_ark_people_search"
 	ToolPhoneFind                    = "ai_ark_mobile_phone_finder"
 	ToolCompanySearch                = "ai_ark_company_search"
-	ToolPersonEnrich                 = "ai_ark_personality_analysis"
 	ToolReverseLookup                = "ai_ark_reverse_lookup"
+	// ToolPersonalityAnalysis analyzes a LinkedIn profile for personality
+	// traits and outbound-messaging guidance. It returns personality data,
+	// NOT contact info. Use ToolApolloPeopleMatch or ToolHunterPeopleFind
+	// for person enrichment instead.
+	ToolPersonalityAnalysis = "ai_ark_personality_analysis"
+
+	// --- Email finders (name+domain -> work email) ---
+	ToolDropleadsEmailFinder = "dropleads_email_finder"
+	ToolHunterEmailFinder    = "hunter_email_finder"
+	ToolDatagmaFindEmail     = "datagma_find_email"
+	ToolIcypeasEmailSearch   = "icypeas_email_search"
+	ToolHunterDomainSearch   = "hunter_domain_search"
+
+	// --- Person enrichers (linkedin_url | email -> full record) ---
+	ToolApolloPeopleMatch      = "apollo_people_match"
+	ToolHunterPeopleFind       = "hunter_people_find"
+	ToolContactOutEnrichPerson = "contactout_enrich_person"
 )
 
-// Aliases: several CLI subcommands map to the same backend tool.
+// Primary aliases used by the CLI subcommands. The VALUE of each constant has
+// changed in the 2026-04-20 fix; the NAME is preserved so external callers
+// (MCP server, code that imports deepline.ToolEmailFind, etc.) keep compiling.
 const (
-	ToolEmailFind     = ToolPersonSearchToEmailWaterfall // find-email + email-find share one backend
-	ToolCompanyEnrich = ToolCompanySearch                // enrich-company uses company search with filters
+	// ToolPersonEnrich is the default person-enrichment tool: given a
+	// LinkedIn URL or an email, return name/title/company and any
+	// contact fields the provider has on file. Routed to apollo_people_match
+	// (broadest coverage, personal_emails[] + work email + employment
+	// history in one call).
+	ToolPersonEnrich = ToolApolloPeopleMatch
+
+	// ToolEmailFind is the default "find a work email from name+domain"
+	// tool. Routed to dropleads_email_finder (cheapest hit rate; returns
+	// a single high-confidence email with MX status).
+	ToolEmailFind = ToolDropleadsEmailFinder
+
+	// ToolCompanyEnrich reuses the ai_ark_company_search backend; it
+	// accepts a domain and returns firmographics.
+	ToolCompanyEnrich = ToolCompanySearch
 )
 
 // ToolInfo describes a known Deepline tool: its id, a short human-readable
@@ -55,8 +96,8 @@ type ToolInfo struct {
 var Catalog = map[string]ToolInfo{
 	ToolPersonSearchToEmailWaterfall: {
 		ID:             ToolPersonSearchToEmailWaterfall,
-		Label:          "Email finder (async via People Search trackId)",
-		PayloadHint:    `{"name":"Patrick Collison","company":"stripe.com"}`,
+		Label:          "Email finder (async; requires ai_ark_people_search trackId)",
+		PayloadHint:    `{"trackId":"<from ai_ark_people_search>"}`,
 		DefaultCredits: 4,
 	},
 	ToolApolloPeopleSearch: {
@@ -77,10 +118,10 @@ var Catalog = map[string]ToolInfo{
 		PayloadHint:    `{"industry":"fintech","size":"201-500","location":"United States"}`,
 		DefaultCredits: 2,
 	},
-	ToolPersonEnrich: {
-		ID:             ToolPersonEnrich,
-		Label:          "Personality analysis (LinkedIn URL)",
-		PayloadHint:    `{"linkedin_url":"https://www.linkedin.com/in/patrickcollison"}`,
+	ToolPersonalityAnalysis: {
+		ID:             ToolPersonalityAnalysis,
+		Label:          "Personality analysis (LinkedIn URL -> outbound guidance; NOT contact info)",
+		PayloadHint:    `{"url":"https://www.linkedin.com/in/patrickcollison"}`,
 		DefaultCredits: 2,
 	},
 	ToolReverseLookup: {
@@ -88,6 +129,55 @@ var Catalog = map[string]ToolInfo{
 		Label:          "Reverse lookup (email or phone -> profile)",
 		PayloadHint:    `{"email":"patrick@stripe.com"}`,
 		DefaultCredits: 2,
+	},
+
+	ToolDropleadsEmailFinder: {
+		ID:             ToolDropleadsEmailFinder,
+		Label:          "Dropleads email finder (name+domain -> verified work email)",
+		PayloadHint:    `{"first_name":"Mike","last_name":"Craig","company_domain":"stripe.com"}`,
+		DefaultCredits: 1,
+	},
+	ToolHunterEmailFinder: {
+		ID:             ToolHunterEmailFinder,
+		Label:          "Hunter email finder (name+domain -> work email with confidence score)",
+		PayloadHint:    `{"first_name":"Mike","last_name":"Craig","domain":"stripe.com"}`,
+		DefaultCredits: 1,
+	},
+	ToolDatagmaFindEmail: {
+		ID:             ToolDatagmaFindEmail,
+		Label:          "Datagma email finder (name+domain -> verified work email)",
+		PayloadHint:    `{"first_name":"Mike","last_name":"Craig","company_domain":"stripe.com"}`,
+		DefaultCredits: 1,
+	},
+	ToolIcypeasEmailSearch: {
+		ID:             ToolIcypeasEmailSearch,
+		Label:          "Icypeas email search (async; poll read_results)",
+		PayloadHint:    `{"firstname":"Mike","lastname":"Craig","domainOrCompany":"stripe.com"}`,
+		DefaultCredits: 1,
+	},
+	ToolHunterDomainSearch: {
+		ID:             ToolHunterDomainSearch,
+		Label:          "Hunter domain search (domain -> all public emails)",
+		PayloadHint:    `{"domain":"stripe.com"}`,
+		DefaultCredits: 2,
+	},
+	ToolApolloPeopleMatch: {
+		ID:             ToolApolloPeopleMatch,
+		Label:          "Apollo people match (linkedin_url | email | name+domain -> full record)",
+		PayloadHint:    `{"linkedin_url":"https://www.linkedin.com/in/patrickcollison","reveal_personal_emails":true}`,
+		DefaultCredits: 1,
+	},
+	ToolHunterPeopleFind: {
+		ID:             ToolHunterPeopleFind,
+		Label:          "Hunter people find (email | linkedin_url -> role, socials, company)",
+		PayloadHint:    `{"linkedin_url":"https://www.linkedin.com/in/patrickcollison"}`,
+		DefaultCredits: 1,
+	},
+	ToolContactOutEnrichPerson: {
+		ID:             ToolContactOutEnrichPerson,
+		Label:          "ContactOut enrich person (linkedin_url | email | name+company -> email + phone)",
+		PayloadHint:    `{"linkedin_url":"https://www.linkedin.com/in/patrickcollison"}`,
+		DefaultCredits: 1,
 	},
 }
 

--- a/library/sales-and-crm/contact-goat/internal/deepline/types_test.go
+++ b/library/sales-and-crm/contact-goat/internal/deepline/types_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package deepline
+
+import "testing"
+
+func TestToolPersonEnrichRoutesToApolloPeopleMatch(t *testing.T) {
+	if ToolPersonEnrich != "apollo_people_match" {
+		t.Fatalf("ToolPersonEnrich = %q, want apollo_people_match", ToolPersonEnrich)
+	}
+}
+
+func TestToolEmailFindRoutesToDropleads(t *testing.T) {
+	if ToolEmailFind != "dropleads_email_finder" {
+		t.Fatalf("ToolEmailFind = %q, want dropleads_email_finder", ToolEmailFind)
+	}
+}
+
+func TestAiArkPersonalityConstantPreserved(t *testing.T) {
+	if ToolPersonalityAnalysis != "ai_ark_personality_analysis" {
+		t.Fatalf("ToolPersonalityAnalysis = %q, want ai_ark_personality_analysis", ToolPersonalityAnalysis)
+	}
+}
+
+func TestAiArkFindEmailsConstantPreserved(t *testing.T) {
+	if ToolPersonSearchToEmailWaterfall != "ai_ark_find_emails" {
+		t.Fatalf("ToolPersonSearchToEmailWaterfall = %q, want ai_ark_find_emails",
+			ToolPersonSearchToEmailWaterfall)
+	}
+}
+
+func TestNewProvidersInCatalog(t *testing.T) {
+	want := []string{
+		ToolDropleadsEmailFinder,
+		ToolHunterEmailFinder,
+		ToolDatagmaFindEmail,
+		ToolIcypeasEmailSearch,
+		ToolHunterDomainSearch,
+		ToolApolloPeopleMatch,
+		ToolHunterPeopleFind,
+		ToolContactOutEnrichPerson,
+		ToolPersonalityAnalysis,
+	}
+	for _, id := range want {
+		info, ok := LookupTool(id)
+		if !ok {
+			t.Errorf("LookupTool(%q) missing from catalog", id)
+			continue
+		}
+		if info.ID != id {
+			t.Errorf("Catalog[%q].ID = %q, want %q", id, info.ID, id)
+		}
+		if info.Label == "" {
+			t.Errorf("Catalog[%q].Label is empty", id)
+		}
+		if info.DefaultCredits <= 0 {
+			t.Errorf("Catalog[%q].DefaultCredits = %d, want > 0", id, info.DefaultCredits)
+		}
+	}
+}
+
+func TestLookupToolUnknown(t *testing.T) {
+	_, ok := LookupTool("not_a_real_tool")
+	if ok {
+		t.Fatal("LookupTool returned ok for unknown tool id")
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/plugin/skills/pp-contact-goat/SKILL.md
+++ b/plugin/skills/pp-contact-goat/SKILL.md
@@ -111,6 +111,35 @@ The other 12 tools cover the cookie surface (search, friends, feed, notification
 
 Source routing (cookie vs bearer) is automatic. The auto router prefers the free cookie surface and falls back to the paid bearer surface only when cookie quota is exhausted, logging a "cost spent" notice on stderr. Pass `--source api` to opt into bearer explicitly (richer schema, group-scoped searches), or `--source hp` to force cookies.
 
+## Enrichment Preflight (read this before running any enrichment command)
+
+These commands spend Deepline credits and REQUIRE `DEEPLINE_API_KEY` or a BYOK setup:
+
+- `waterfall` (unless you pass `--byok` and have BYOK providers configured)
+- `dossier --enrich-email`
+- `deepline find-email` / `enrich-person` / `email-find` / `phone-find`
+- `deepline search-people` / `search-companies` / `enrich-company`
+
+Before invoking any of these, verify auth. If `DEEPLINE_API_KEY` is not set, ASK THE USER for it (or for a BYOK Hunter/Apollo key) before running the command. The CLI preflight now fails fast with a clear hint, but you can save the round-trip by checking first:
+
+```bash
+contact-goat-pp-cli doctor --agent | grep -i deepline
+```
+
+Provider chain by target kind (waterfall):
+
+| Target | Primary | Fallback 1 | Fallback 2 |
+|--------|---------|-----------|-----------|
+| LinkedIn URL | apollo_people_match | hunter_people_find | contactout_enrich_person |
+| Email | apollo_people_match | hunter_people_find | - |
+| Name + --company | dropleads_email_finder | hunter_email_finder | datagma_find_email |
+
+Notes:
+- Name targets MUST pass `--company <domain>` (or set `CONTACT_GOAT_COMPANY` env).
+- Apollo returns `personal_emails[]` when available; treat `email_status: "unavailable"` as "no verified work email on file" (the personal email is still usable).
+- Dropleads returns `status: "catch_all"` for domains on Google Workspace; the email is a pattern guess, not a verified mailbox.
+- Provider-level 403s are surfaced as "Provider not connected" rather than "Check DEEPLINE_API_KEY"; they do not abort the chain. The next provider is tried automatically.
+
 ## Notable Commands
 
 | Command | What it does |
@@ -119,6 +148,10 @@ Source routing (cookie vs bearer) is automatic. The auto router prefers the free
 | `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree) |
 | `prospect <query>` | Fan-out search across LinkedIn + Happenstance (+ opt-in Deepline), deduped |
 | `warm-intro <target>` | Mutual connections across sources who could intro you to a target |
+| `waterfall <target> [--company X]` | Free-sources-first enrichment, falls through to Deepline provider chain. Requires DEEPLINE_API_KEY or --byok. Bare-name targets need --company |
+| `dossier <target> [--enrich-email]` | Unified LinkedIn + Happenstance + (optional) Deepline dossier. --enrich-email requires DEEPLINE_API_KEY |
+| `deepline find-email "<name>" --company <domain>` | Single-call work-email lookup via dropleads_email_finder |
+| `deepline enrich-person <linkedin-url>` | Full person record via apollo_people_match (includes personal_emails[]) |
 | `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll) |
 | `api hpn research <description>` | Bearer-API deep dossier (costs 1 credit on completion) |
 | `api hpn usage` | Live credit balance, purchases, recent usage events (free) |


### PR DESCRIPTION
## Summary

Five compounding bugs broke every Deepline-backed enrichment path in contact-goat. Any `waterfall`, `dossier --enrich-email`, `deepline find-email`, or `deepline enrich-person` call hit HTTP 422s on the managed API; users could not retrieve an email through the CLI without bypassing contact-goat and calling `deepline tools execute` by hand.

- **Wrong tool IDs** - `ToolPersonEnrich` pointed at `ai_ark_personality_analysis` (personality traits, not contact info) and `ToolEmailFind` aliased `ai_ark_find_emails` (async follow-on requiring a People Search `trackId`). Re-pointed the primary constants at real email/person providers (`apollo_people_match`, `dropleads_email_finder`) and added the full catalog of verified providers.
- **Wrong waterfall routing** - The single-tool Deepline step now dispatches a target-kind chain with correct payload shapes per provider (dropleads wants `company_domain`, hunter wants `domain`, etc.). Provider-level errors record the step but do not abort the chain, so accounts without one provider still land on the next.
- **LinkedIn subprocess sent the wrong key** - `tryLinkedIn` (waterfall) and `fetchLinkedInPerson` (dossier profile) sent `linkedin_url` to the upstream MCP, which requires `linkedin_username`. Route both through the existing `normalizePersonInput` helper.
- **HTTP fallback sent a flat payload** - `/api/v2/integrations/<tool>/execute` requires `{"payload": {...}}` wrapping. The flat payload was rejected with a misleading 422 for every call that didn't resolve via the deepline subprocess.
- **Subprocess wrapper printed non-JSON** - `deepline tools execute` without `--json` prints a human summary and writes the full payload to `deepline/data/payload_<tool>_*.json` in cwd, which is not valid JSON and pollutes the workspace. Pass `--json --payload-output-format json --no-preview`.
- **403s were always blamed on the user's key** - Provider-entitlement 403s (contactout, datagma) now map to a typed `ErrProviderNotEntitled` that surfaces the provider name and preserves chain continuation.

Plus a command-level preflight gate: `waterfall`, `dossier --enrich-email`, and `deepline` subcommands now short-circuit with an actionable hint when `DEEPLINE_API_KEY` is missing, instead of running the free chain first. SKILL.md gains an "Enrichment Preflight" section so future agents ask the user for the key before invoking the command.

## Live repro, after fix

`waterfall https://www.linkedin.com/in/mkscrg --enrich email` now succeeds end-to-end:

```
[ok]    linkedin/get_person_profile
[empty] happenstance/research
[ok]    deepline/apollo   name, title, linkedin_url, company, personal_email, email_confidence
[error] deepline/hunter   (Hunter has no profile for this person; chain continues)
[error] deepline/contactout "contactout is Provider not connected." (typed ErrProviderNotEntitled)
```

`waterfall "Mike Craig" --company stripe.com --enrich email`:

```
[ok] deepline/dropleads  email=mike@stripe.com, email_confidence=catch_all
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (added 27 new test cases: types map, provider chain, result extractors, preflight, normalizePersonInput, HTTP envelope wrapping, 401/403 classification)
- [x] `verify_skill.py --dir library/sales-and-crm/contact-goat` passes (flag names, flag commands, positional args, unknown commands)
- [x] Live smoke test: `waterfall <linkedin-url>`, `waterfall <name> --company <domain>`, `deepline find-email`, `deepline enrich-person`, all four preflight paths (missing-key variants)
- [x] Plugin mirror regenerated and plugin version bumped 1.1.20 -> 1.1.21 per AGENTS.md "Keeping plugin/skills in sync"

## Plan

[docs/plans/2026-04-20-001-fix-contact-goat-enrichment-tool-mapping-plan.md](docs/plans/2026-04-20-001-fix-contact-goat-enrichment-tool-mapping-plan.md)

## Notes for reviewers

- The deprecated `ToolPersonEnrich` / `ToolEmailFind` names are preserved but now resolve to different VALUES. Keeping the names avoids breaking the MCP server or any downstream constant consumers, but the ai_ark tools are still reachable explicitly under their new names (`ToolPersonalityAnalysis`, `ToolPersonSearchToEmailWaterfall`).
- Apollo's `email_status: "unavailable"` is NOT treated as a hit; the extractor only fills the work `email` when upstream marked it verified/catchall. `personal_email` is always taken from `personal_emails[0]` when present.
- Dropleads' `catch_all` status is recorded as `email_confidence` so downstream agents know the email is a pattern guess, not a verified mailbox.
- Icypeas remains uncalled (async job with its own polling flow; left as deferred).