### PR TITLE
fix(plugin): declare commands path so /pp-* surfaces in slash autocomplete

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"
@@ -8,5 +8,6 @@
   "repository": "https://github.com/mvanhorn/printing-press-library",
   "license": "MIT",
   "keywords": ["cli", "mcp", "api", "printing-press"],
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "commands": "./commands/"
 }


### PR DESCRIPTION
## Summary

Typing `/pp` in Claude Code still returns no pp-* matches after 1.1.22, even though 23 `plugin/commands/*.md` shims ship. Root cause: the plugin manifest declares `skills` explicitly but not `commands`. Claude Code's explicit-declaration mode does not auto-discover sibling directories.

Add `"commands": "./commands/"` alongside the existing `skills` key. Verified by comparing to vercel (claude-plugins-official) which ships both declarations and has working slash commands.

Why compound-engineering works without either key: that's the conventional-discovery path, which activates only when neither `skills` nor `commands` is declared. Our plugin opted into explicit skills declaration, so commands needs its own explicit key.

## Test plan

- [x] `plugin.json` now carries both `skills: ./skills/` and `commands: ./commands/`.
- [x] Version bumped 1.1.22 -> 1.1.23.
- [ ] After merge + `/plugin` update + `/reload-plugins`, typing `/pp` in Claude Code surfaces the pp-* entries.

The verification of the last item requires the user to re-run `/plugin` and check autocomplete after the marketplace pulls this version.