### PR TITLE
chore(skills): regenerate pp-* skill mirrors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/skills/pp-agent-capture/SKILL.md
+++ b/skills/pp-agent-capture/SKILL.md
@@ -95,6 +95,29 @@ Parse `$ARGUMENTS`:
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+<cli>-pp-cli <command> --agent --select id,name
+<cli>-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-archive-is/SKILL.md
+++ b/skills/pp-archive-is/SKILL.md
@@ -144,6 +144,22 @@ Notable flags:
 - `--backend archive-is,wayback` — backend preference and fallback order
 - `--format text|html` — `get`/`tldr` output format
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+archive-is-pp-cli <command> --agent --select id,name
+archive-is-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-cal-com/SKILL.md
+++ b/skills/pp-cal-com/SKILL.md
@@ -189,6 +189,22 @@ Useful root flags (all persistent):
 
 Paginated commands also emit NDJSON progress events on stderr by default, so `--agent | jq` pipelines only see the final JSON on stdout.
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+cal-com-pp-cli <command> --agent --select id,name
+cal-com-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-contact-goat/SKILL.md
+++ b/skills/pp-contact-goat/SKILL.md
@@ -159,6 +159,34 @@ Notes:
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+contact-goat-pp-cli <command> --agent --select id,name
+contact-goat-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-dominos/SKILL.md
+++ b/skills/pp-dominos/SKILL.md
@@ -100,6 +100,34 @@ claude mcp add dominos-mcp -- dominos-mcp
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+dominos-pp-cli <command> --agent --select id,name
+dominos-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-dub/SKILL.md
+++ b/skills/pp-dub/SKILL.md
@@ -181,6 +181,22 @@ Flag glossary:
 - `--interval <duration>` — analytics time window (7d, 30d, etc.)
 - `--group-by <field>` — analytics aggregation dimension
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+dub-pp-cli <command> --agent --select id,name
+dub-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-espn/SKILL.md
+++ b/skills/pp-espn/SKILL.md
@@ -138,12 +138,12 @@ League values: `nfl`, `nba`, `mlb`, `nhl`, `ncaaf`, `ncaam`, `ncaaw`, `mls`, `en
 ### Morning sports scan
 
 ```bash
-espn-pp-cli today --agent                       # cross-league: what's on
-espn-pp-cli scores football nfl --agent         # one league drilldown
-espn-pp-cli standings football nfl --agent      # context for the scores
+espn-pp-cli today --agent --select events.shortName,events.status
+espn-pp-cli scores football nfl --agent --select events.shortName,events.competitions.competitors.team.displayName,events.status.type.detail
+espn-pp-cli standings football nfl --agent
 ```
 
-One `today` call covers cross-league activity, one `scores` for the league you care about, one `standings` for context. Covers a morning briefing.
+One `today` call covers cross-league activity, one `scores` for the league you care about, one `standings` for context. The nested `--select` paths cut a scoreboard payload from tens of KB down to the fields that actually matter — essential for keeping agent context small.
 
 ### Pre-game research from synced data
 
@@ -207,6 +207,22 @@ Optional config:
 ## Agent Mode
 
 Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes`. Use `--select` for field cherry-picking, `--dry-run` to preview requests, `--no-cache` to bypass GET cache.
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+espn-pp-cli <command> --agent --select id,name
+espn-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
 
 ## Exit Codes
 

--- a/skills/pp-flightgoat/SKILL.md
+++ b/skills/pp-flightgoat/SKILL.md
@@ -152,6 +152,22 @@ Add `--agent` to any command. Expands to `--json --compact --no-input --no-color
 - `--min-hours N` — minimum duration (for `longhaul`)
 - `--country <CC>` — country filter (for `explore`)
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+flightgoat-pp-cli <command> --agent --select id,name
+flightgoat-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-hackernews/SKILL.md
+++ b/skills/pp-hackernews/SKILL.md
@@ -144,6 +144,22 @@ Optional config:
 
 Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes` — structured, pipe-friendly, no prompts. Use `--select <fields>` to cherry-pick fields for compact agent context, `--dry-run` to preview the API request, `--no-cache` to bypass the 5-minute GET cache.
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+hackernews-pp-cli <command> --agent --select id,name
+hackernews-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-hubspot/SKILL.md
+++ b/skills/pp-hubspot/SKILL.md
@@ -144,6 +144,22 @@ Grant the private app the scopes you need (typically: `crm.objects.contacts.*`, 
 
 Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes`. Useful flags: `--select`, `--dry-run`, `--rate-limit N` (HubSpot is aggressive on rate limits; throttle for bulk ops), `--query <expr>` for search commands.
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+hubspot-pp-cli <command> --agent --select id,name
+hubspot-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-instacart/SKILL.md
+++ b/skills/pp-instacart/SKILL.md
@@ -165,6 +165,22 @@ The CLI is agent-native by default. Pass `--json` on any command for machine-rea
 - `attempts`: present only when `retry_count > 0`, array of `{item_id, name, error_type}` for each rejected candidate.
 - On exhaustion (exit 5): JSON envelope with `error`, `retailer`, `query`, `attempts`, and a `hint` naming the concrete next step (`search` then `add --item-id`, or retry with `--no-history`).
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+instacart-pp-cli <command> --agent --select id,name
+instacart-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-kalshi/SKILL.md
+++ b/skills/pp-kalshi/SKILL.md
@@ -154,6 +154,22 @@ Alternatives: `KALSHI_PRIVATE_KEY` (inline PEM), `KALSHI_BASE_URL` (override), `
 
 Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes` — structured output, no prompts. Also supports `--select <fields>` for cherry-picking, `--dry-run` to preview requests, and `--no-cache` to bypass the 5-minute GET cache.
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+kalshi-pp-cli <command> --agent --select id,name
+kalshi-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-linear/SKILL.md
+++ b/skills/pp-linear/SKILL.md
@@ -126,6 +126,34 @@ linear-pp-cli issues list --team ESP --state started --json
 
 `--assignee` accepts `me`, a user UUID, a display name, or an email. `--team` and `--project` accept either a key (e.g. `ESP`) or a UUID.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+linear-pp-cli <command> --agent --select id,name
+linear-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-movie-goat/SKILL.md
+++ b/skills/pp-movie-goat/SKILL.md
@@ -250,6 +250,22 @@ Useful companion flags:
 - `--rate-limit <n>`
 - `--data-source auto|live|local`
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+movie-goat-pp-cli <command> --agent --select id,name
+movie-goat-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-pagliacci-pizza/SKILL.md
+++ b/skills/pp-pagliacci-pizza/SKILL.md
@@ -88,6 +88,29 @@ Parse `$ARGUMENTS`:
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+pagliacci-pizza-pp-cli <command> --agent --select id,name
+pagliacci-pizza-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-postman-explore/SKILL.md
+++ b/skills/pp-postman-explore/SKILL.md
@@ -70,6 +70,34 @@ Parse `$ARGUMENTS`:
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+postman-explore-pp-cli <command> --agent --select id,name
+postman-explore-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-recipe-goat/SKILL.md
+++ b/skills/pp-recipe-goat/SKILL.md
@@ -170,6 +170,22 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 - **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
 - **Non-interactive** — never prompts, every input is a flag
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+recipe-goat-pp-cli <command> --agent --select id,name
+recipe-goat-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-slack/SKILL.md
+++ b/skills/pp-slack/SKILL.md
@@ -111,6 +111,34 @@ Source routing (local vs live) is controlled by `--data-source`: `auto` (default
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+slack-pp-cli <command> --agent --select id,name
+slack-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-steam-web/SKILL.md
+++ b/skills/pp-steam-web/SKILL.md
@@ -98,6 +98,34 @@ claude mcp add -e STEAM_WEB_API_KEY=... steam-web-pp-mcp -- steam-web-pp-mcp
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+steam-web-pp-cli <command> --agent --select id,name
+steam-web-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-trigger-dev/SKILL.md
+++ b/skills/pp-trigger-dev/SKILL.md
@@ -97,6 +97,34 @@ claude mcp add -e TRIGGER_SECRET_KEY=tr_... trigger-dev-pp-mcp -- trigger-dev-pp
 
 Run any command with `--help` for full flag documentation.
 
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields, with dotted-path support (see below)
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Non-interactive** — never prompts, every input is a flag
+
+
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+trigger-dev-pp-cli <command> --agent --select id,name
+trigger-dev-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-weather-goat/SKILL.md
+++ b/skills/pp-weather-goat/SKILL.md
@@ -137,6 +137,17 @@ Optional config:
 
 Add `--agent` to any command. Expands to `--json --compact --no-input --no-color --yes`. Use `--days N` for forecast range on relevant commands, `--no-cache` to bypass the 15-minute GET cache.
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+weather-goat-pp-cli <command> --agent --select id,name
+weather-goat-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/skills/pp-yahoo-finance/SKILL.md
+++ b/skills/pp-yahoo-finance/SKILL.md
@@ -219,6 +219,22 @@ Useful companion flags:
 - `--data-source auto|live|local`
 - `--rate-limit <n>`
 
+### Filtering output
+
+`--select` accepts dotted paths to descend into nested responses; arrays traverse element-wise:
+
+```bash
+yahoo-finance-pp-cli <command> --agent --select id,name
+yahoo-finance-pp-cli <command> --agent --select items.id,items.owner.name
+```
+
+Use this to narrow huge payloads to the fields you actually need — critical for deeply nested API responses.
+
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
 ## Exit Codes
 
 | Code | Meaning |


### PR DESCRIPTION
## Problem

`skills/pp-*` is generated plugin output that mirrors the upstream `library/**/SKILL.md` files. The checked-in mirrors had drifted from the library skills, so people installing the plugin could receive older agent guidance than the guidance maintained beside each CLI.

That matters because these skills are the user-facing entrypoints for the plugin. In this drift, the focused skills were missing newer operational guidance such as agent-mode behavior, output filtering with `--select`, stale `@latest` install fallback text, and response-envelope notes for some tools. The repo's own `AGENTS.md` says these mirrors should be regenerated alongside library skill changes, and that plugin content changes need a patch version bump.

## What changed

- Re-ran `go run ./tools/generate-skills/main.go` so all 22 focused `skills/pp-*` mirrors match their upstream library `SKILL.md` sources.
- Committed only the generated mirror output plus the plugin manifest version bump.
- Bumped `.claude-plugin/plugin.json` from `1.2.0` to `1.2.1` for the plugin content update.

## Scope

This is intentionally a generated-output maintenance PR. It does not change any library CLI source, generator behavior, registry metadata, or workflow automation.

The automation gap that made this easy to miss is handled separately in #108, so this PR stays reviewable as the mirror refresh itself.

## Verification

- `cd tools/generate-skills && go test ./...`
- Ran `.github/scripts/verify-skill/verify_skill.py` against all 22 CLI directories with `SKILL.md` files.
- The verifier completed with 0 blocking failures. HubSpot still reports 2 likely false positives for `associations companies` examples, which matches the verifier's documented false-positive pattern.
