### PR TITLE
feat(cli): opt hackernews into auto-refresh cache

### DIFF
--- a/library/media-and-entertainment/hackernews/spec.yaml
+++ b/library/media-and-entertainment/hackernews/spec.yaml
@@ -263,3 +263,17 @@ types:
         type: string
       - name: story_text
         type: string
+
+# Opt in to auto-refresh (discrawl-inspired, cli-printing-press #232/#233).
+# HN item data is immutable once posted so a 24h global staleness window is
+# generous. Story pointers — top/new/best/ask/show/job — move continuously, so
+# those refresh every 30 minutes so agents see today's front page rather than
+# yesterday's snapshot. Activation requires regenerating (or `printing-press
+# patch`-ing) this CLI with a PP binary at >= 0.55.0 that understands the
+# cache block.
+cache:
+  enabled: true
+  stale_after: 24h
+  refresh_timeout: 20s
+  resources:
+    stories: 30m


### PR DESCRIPTION
## Summary

First library adopter of the auto-refresh capability shipped in [cli-printing-press #232](https://github.com/mvanhorn/cli-printing-press/pull/232) and [#233](https://github.com/mvanhorn/cli-printing-press/pull/233). Adds a `cache:` block to hackernews's spec.yaml declaring the CLI opts in.

## Chosen thresholds

- **Global stale_after: 24h** — HN items are immutable once posted; a day-old view of an item is fine.
- **Per-resource: stories @ 30m** — the top/new/best/ask/show/job pointers move continuously so agents need today's front page, not yesterday's snapshot.
- **refresh_timeout: 20s** — HN is fast; a tight budget keeps repeated agent calls cheap.

## Activation path

This PR is the declarative opt-in only. Activation runs when hackernews is regenerated (or `printing-press patch`-ed) with a PP binary at >= 0.55.0 that understands the new block. Per this repo's AGENTS.md, patch is preferred over full regenerate to preserve hand-written commands (my.go, ask_enhanced.go, hiring_stats.go, pulse.go, since.go).

## Evidence from dry-run

Built the generator from cli-printing-press main, generated a throwaway hackernews-pp-cli from this updated spec, and confirmed:

- `internal/cliutil/freshness.go` + `freshness_test.go` emitted (auto-refresh decision helper)
- `internal/cli/auto_refresh.go` emitted (PersistentPreRunE hook)
- `doctor --json` now includes a populated `cache` block (status: unknown pre-sync, with a hydration hint)
- All quality gates pass: `go mod tidy`, `go vet`, `go build`, `--help`, `version`, `doctor`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required for this PR alone — it's a declarative opt-in. Validation runs when the CLI is actually regenerated:

- `sqlite3 ~/.local/share/hackernews-pp-cli/data.db "pragma user_version"` returns `1` after the first run of a regenerated binary.
- `hackernews-pp-cli doctor --json` includes a `cache` block with `schema_version: 1` and `stale_after: 24h`.
- After `hackernews-pp-cli sync`, `doctor --json` flips `cache.status` to `fresh`.
- `HACKERNEWS_NO_AUTO_REFRESH=1 hackernews-pp-cli stories top` makes zero extra HTTP calls beyond the base command.
- Failure signal: auto-refresh blocks a command beyond 20s. Mitigation: set `HACKERNEWS_NO_AUTO_REFRESH=1` while investigating, or widen the per-resource override.
- Validation window: 48 hours after activation. Owner: mvanhorn.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)