### PR TITLE
docs(cli): rewrite scrape-creators README + add SKILL.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "printing-press-library",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Discover, install, and use CLI tools and MCP servers for hundreds of APIs",
   "author": {
     "name": "mvanhorn"

--- a/library/developer-tools/scrape-creators/README.md
+++ b/library/developer-tools/scrape-creators/README.md
@@ -1,15 +1,21 @@
 # Scrape Creators CLI
 
-The easiest way to scrape public social media data at scale. Extract profiles, posts, videos, comments, and more from TikTok, Instagram, YouTube, Twitter, LinkedIn, Facebook, Reddit, and 27+ platforms.
+Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.
 
-Learn more at [Scrape Creators](https://scrapecreators.com).
+Powered by the [Scrape Creators](https://scrapecreators.com) API. Read-only — this CLI fetches data, it does not post.
 
 ## Install
 
 ### Go
 
-```
+```bash
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest
+```
+
+The MCP server installs from the same repo:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-mcp@latest
 ```
 
 ### Binary
@@ -18,333 +24,344 @@ Download from [Releases](https://github.com/mvanhorn/printing-press-library/rele
 
 ## Quick Start
 
-### 1. Install
-
-See [Install](#install) above.
-
-### 2. Set Up Credentials
-
-Get your API key from your API provider's developer portal. The key typically looks like a long alphanumeric string.
-
 ```bash
-export SCRAPE_CREATORS_API_KEY_AUTH="<paste-your-key>"
-```
+# 1. Get an API key at https://app.scrapecreators.com and export it
+export SCRAPE_CREATORS_API_KEY_AUTH="<your-key>"
 
-You can also persist this in your config file at `~/.config/scrape-creators-pp-cli/config.toml`.
-
-### 3. Verify Setup
-
-```bash
+# 2. Verify your setup
 scrape-creators-pp-cli doctor
+
+# 3. Check your credit balance and burn rate
+scrape-creators-pp-cli account budget
+
+# 4. Try a real scrape
+scrape-creators-pp-cli tiktok profile --handle @charlidamelio
 ```
 
-This checks your configuration and credentials.
+The CLI normalizes handles (strips leading `@`) and hashtags (strips `#`) automatically, so `@charlidamelio` and `charlidamelio` both work.
 
-### 4. Try Your First Command
+## Key Features
 
-```bash
-scrape-creators-pp-cli account list
-```
+Commands that go beyond what the raw API returns, built on top of the local SQLite sync:
 
-## Unique Features
+- **`account budget`** — Show credit balance and project days remaining at your current burn rate.
+- **`search trends`** — Search a hashtag and snapshot result count + top videos for growth tracking.
+- **`tiktok spikes`** — Find videos that outperformed a creator's average engagement rate.
+- **`tiktok transcripts`** — Fetch and search across all of a creator's video transcripts.
+- **`tiktok compare`** — Compare multiple TikTok creators on followers, engagement, and posting cadence.
+- **`tiktok cadence`** — Show a creator's posting frequency by day of week and hour of day.
+- **`tiktok track`** — Record daily follower snapshots and chart a creator's growth trajectory.
+- **`tiktok analyze`** — Rank a creator's videos by engagement rate (not raw likes).
+- **`workflow archive`** — Sync every platform's available data locally for offline search and analysis.
 
-These capabilities aren't available in any other tool for this API.
+## Interactive Wizard
 
-- **`videos spikes`** — Find videos that performed significantly above a creator's average — the ones that actually went viral.
-- **`transcripts search`** — Search across all a creator's video transcripts for any keyword or phrase — like grep for TikTok.
-- **`profile compare`** — Compare two or more creators side-by-side on follower count, engagement rate, posting cadence, and content volume.
-- **`videos cadence`** — See when a creator posts — by day of week and hour — so you can benchmark their publishing strategy.
-- **`profile track`** — Record daily follower snapshots for any creator and chart their growth trajectory over time.
-- **`account budget`** — Track how quickly you're spending API credits and project how many days until you hit your limit.
-- **`search trends`** — Track whether a hashtag is growing or shrinking by comparing video counts across snapshot intervals.
-- **`videos analyze`** — Rank all of a creator's synced videos by engagement rate (not raw likes) to surface their true best performers.
-
-## Usage
-
-<!-- HELP_OUTPUT -->
+Running `scrape-creators-pp-cli` with no arguments on a TTY walks you through platform → action → required params, then executes the resolved command. Bypass with `--no-input`, `--agent`, `--yes`, or by piping stdin.
 
 ## Commands
 
-### account
-
-Manage account
-
-- **`scrape-creators-pp-cli account list`** - Get credit balance
-- **`scrape-creators-pp-cli account list-getapiusage`** - Get request history
-- **`scrape-creators-pp-cli account list-getdailyusagecount`** - Get daily usage
-- **`scrape-creators-pp-cli account list-getmostusedroutes`** - Get most used routes
-
-### amazon
-
-Manage amazon
-
-- **`scrape-creators-pp-cli amazon list`** - Amazon Shop page
-
-### bluesky
-
-Get Bluesky posts and profile info
-
-- **`scrape-creators-pp-cli bluesky list`** - Fetches a single Bluesky post by URL, returning the post's record text, author info, embed content, replyCount, repostCount, likeCount, and quoteCount. Also includes a replies array with threaded reply posts.
-- **`scrape-creators-pp-cli bluesky list-profile`** - Retrieves a Bluesky user's public profile including handle, displayName, avatar, description, followersCount, followsCount, postsCount, createdAt, and verification status. The associated field shows counts for lists, feed generators, and starter packs.
-- **`scrape-creators-pp-cli bluesky list-user`** - Fetches a paginated feed of posts from a Bluesky user, returning each post's uri, record text, author info, embed content, replyCount, repostCount, likeCount, quoteCount, and indexedAt. Supports pagination via cursor. Use user_id (the 'did') instead of handle for faster response times.
-
-### detect-age-gender
-
-Manage detect age gender
-
-- **`scrape-creators-pp-cli detect-age-gender list`** - Get Age and Gender
-
-### facebook
-
-Get public Facebook profiles and posts
-
-- **`scrape-creators-pp-cli facebook list`** - Ad Details
-- **`scrape-creators-pp-cli facebook list-adlibrary`** - Company Ads
-- **`scrape-creators-pp-cli facebook list-adlibrary-2`** - Searches the Meta Ad Library by keyword and returns matching ads. Each result includes ad_archive_id, page_name, is_active, publisher_platform, and a snapshot with body text, images, videos, and cta_text. Results cap around 1,500 via GET due to cursor size limits; switch to POST method with body params for larger result sets.
-- **`scrape-creators-pp-cli facebook list-adlibrary-3`** - Search for Companies
-- **`scrape-creators-pp-cli facebook list-group`** - Facebook Group Posts
-- **`scrape-creators-pp-cli facebook list-post`** - Retrieves a single public Facebook post or reel by URL. Returns post_id, like_count, comment_count, share_count, view_count, description, creation_time, and author details. For video posts, includes video sd_url, hd_url, thumbnail, and length_in_second. Optionally fetches comments and transcript via get_comments and get_transcript parameters.
-- **`scrape-creators-pp-cli facebook list-post-2`** - Fetches comments from a Facebook post or reel with cursor-based pagination. Each comment includes id, text, created_at, reply_count, reaction_count, and author details with name and profile_picture. Passing a feedback_id instead of a url significantly speeds up the request.
-- **`scrape-creators-pp-cli facebook list-post-3`** - Extracts the transcript text from a Facebook video post or reel. Returns the transcript as a single text string with line breaks. Only works on videos under 2 minutes in length.
-- **`scrape-creators-pp-cli facebook list-profile`** - Retrieves public Facebook page details including category, address, email, phone, website, services, priceRange, rating, likeCount, and followerCount. Also returns adLibrary status with the page's ad activity and pageId. Optionally includes businessHours when get_business_hours is set to true.
-- **`scrape-creators-pp-cli facebook list-profile-2`** - Profile Photos
-- **`scrape-creators-pp-cli facebook list-profile-3`** - Profile Posts
-- **`scrape-creators-pp-cli facebook list-profile-4`** - Profile Reels
-
-### google
-
-Scrape Google search results
-
-- **`scrape-creators-pp-cli google list`** - Ad Details
-- **`scrape-creators-pp-cli google list-adlibrary`** - Advertiser Search
-- **`scrape-creators-pp-cli google list-company`** - Company Ads
-- **`scrape-creators-pp-cli google list-search`** - Performs a Google search and returns organic results with url, title, and description for each result. Supports an optional region parameter (2-letter country code) to get localized results from a specific country.
-
-### instagram
-
-Gets Instagram profiles, posts, and reels
-
-- **`scrape-creators-pp-cli instagram list`** - Basic Profile
-- **`scrape-creators-pp-cli instagram list-media`** - Generates an AI-powered speech-to-text transcription for an Instagram video post or reel. The video must be under 2 minutes long. Returns a transcripts array with each item's shortcode and transcribed text; carousel posts produce one transcript per video slide. Expect 10-30 second response times, and null when no speech is detected.
-- **`scrape-creators-pp-cli instagram list-post`** - Post/Reel Info
-- **`scrape-creators-pp-cli instagram list-post-2`** - Retrieves comments on a public Instagram post or reel. Each comment includes the comment text, creation timestamp, and commenter details such as username, user ID, verification status, and profile picture URL. Supports cursor-based pagination to load additional comment pages.
-- **`scrape-creators-pp-cli instagram list-profile`** - Retrieves comprehensive public Instagram profile information including biography, bio links, follower and following counts, verification status, and profile picture URLs. Also returns recent timeline posts with engagement metrics such as likes, comments, and video view counts, plus a list of related profiles. Useful for account overview, audience analysis, or discovering similar creators.
-- **`scrape-creators-pp-cli instagram list-reels`** - Search Reels
-- **`scrape-creators-pp-cli instagram list-song`** - Reels using Song (Deprecated)
-- **`scrape-creators-pp-cli instagram list-user`** - Embed HTML
-- **`scrape-creators-pp-cli instagram list-user-2`** - Highlights Details
-- **`scrape-creators-pp-cli instagram list-user-3`** - Story Highlights
-- **`scrape-creators-pp-cli instagram list-user-4`** - Returns a paginated list of a user's public Instagram reels (short-form videos). Each reel includes its shortcode, play count, like count, comment count, video versions with download URLs, thumbnail image, and owner info. Note that reel captions are not returned by this endpoint. Play counts are Instagram-only views and exclude cross-posted Facebook views. Supports cursor-based pagination via max_id; providing a user_id instead of a handle yields faster responses.
-- **`scrape-creators-pp-cli instagram list-user-5`** - Returns a paginated feed of a user's public Instagram posts, including photos, videos, and carousels. Each item includes media type, shortcode, caption text, like count, comment count, play count, video URLs, image URLs, and tagged users. Play counts reflect Instagram-only views and exclude cross-posted Facebook views. Supports cursor-based pagination via next_max_id for scrolling through the full timeline.
-
-### kick
-
-Scrape Kick clips
-
-- **`scrape-creators-pp-cli kick list`** - Fetches detailed data for a Kick clip by URL, including video, metadata, and channel info. Returns clip id, title, clip_url, thumbnail_url, video_url, view_count, likes_count, duration, privacy status, and is_mature flag. Also includes category details (name, slug), creator info (username), and channel info (username, profile_picture).
-
-### komi
-
-Scrape Komi pages
-
-- **`scrape-creators-pp-cli komi list`** - Komi page
-
-### linkbio
-
-Scrape Linkbio (lnk.bio) pages
-
-- **`scrape-creators-pp-cli linkbio list`** - Linkbio page
-
-### linkedin
-
-Scrape LinkedIn
-
-- **`scrape-creators-pp-cli linkedin list`** - Ad Details
-- **`scrape-creators-pp-cli linkedin list-ads`** - Search Ads
-- **`scrape-creators-pp-cli linkedin list-company`** - Company Page
-- **`scrape-creators-pp-cli linkedin list-company-2`** - Company Posts
-- **`scrape-creators-pp-cli linkedin list-post`** - Fetches a single LinkedIn post or article, returning the title, headline, full description text, author info with follower count, publication date, like count (reactions), comment count, and individual comments. Also includes related articles from the same author in moreArticles.
-- **`scrape-creators-pp-cli linkedin list-profile`** - Person's Profile
-
-### linkme
-
-Get Linkme profile info
-
-- **`scrape-creators-pp-cli linkme list`** - Retrieves a Linkme profile by URL, including identity, social links, and contact details. Returns profile with id, firstName, username, bio, profileVisitCount, profileImage, verifiedAccount, and isAmbassador flag. Also includes infoLinks (email addresses) and webLinks, an array of categorized social platform links (Spotify, Instagram, YouTube, Twitter, Facebook, and more) each with linkValue and faceValue.
-
-### linktree
-
-Scrape Linktree pages
-
-- **`scrape-creators-pp-cli linktree list`** - Linktree page
-
-### pillar
-
-Scrape Pillar pages
-
-- **`scrape-creators-pp-cli pillar list`** - Pillar page
-
-### pinterest
-
-Scrape Pinterest pins
-
-- **`scrape-creators-pp-cli pinterest list`** - Fetches a paginated list of pins from a Pinterest board by URL, returning each pin's id, description, title, images, board info, pin_join annotations, and aggregated_pin_data. Supports pagination via cursor and a trim option for lighter responses.
-- **`scrape-creators-pp-cli pinterest list-pin`** - Fetches detailed information about a single Pinterest pin by URL, returning title, description, link, dominantColor, originPinner, pinner, images at multiple resolutions (imageSpec_236x through imageSpec_orig), and pinJoin with visual annotations. Supports a trim option for lighter responses.
-- **`scrape-creators-pp-cli pinterest list-search`** - Searches Pinterest for pins matching a query, returning results with id, url, title, description, images, link, domain, board info, and pinner details. Supports pagination via cursor and a trim option for lighter responses.
-- **`scrape-creators-pp-cli pinterest list-user`** - User Boards
-
-### reddit
-
-Scrape Reddit posts and comments
-
-- **`scrape-creators-pp-cli reddit list`** - Get Ad
-- **`scrape-creators-pp-cli reddit list-ads`** - Search Ads
-- **`scrape-creators-pp-cli reddit list-post`** - Post Comments
-- **`scrape-creators-pp-cli reddit list-search`** - Searches across all of Reddit for posts matching a query. Each post includes title, author, selftext, subreddit, score, ups, upvote_ratio, num_comments, created_utc, url, permalink, and is_video. Supports sort (relevance, new, top, comment_count), timeframe filtering, pagination via the after token, and a trim parameter for lighter responses.
-- **`scrape-creators-pp-cli reddit list-subreddit`** - Subreddit Posts
-- **`scrape-creators-pp-cli reddit list-subreddit-2`** - Subreddit Details
-- **`scrape-creators-pp-cli reddit list-subreddit-3`** - Subreddit Search
-
-### snapchat
-
-Scrape Snapchat user profiles and thier stories
-
-- **`scrape-creators-pp-cli snapchat list`** - User Profile
-
-### threads
-
-Get Threads posts
-
-- **`scrape-creators-pp-cli threads list`** - Fetches a single Threads post by URL, returning the post's caption, like_count, view_counts, reshare_count, direct_reply_count, image_versions2, and taken_at. Also includes comments and related_posts arrays. Supports a trim option for lighter responses.
-- **`scrape-creators-pp-cli threads list-profile`** - Retrieves a Threads user's public profile including username, full_name, biography, profile_pic_url, follower_count, is_verified, bio_links, and hd_profile_pic_versions. Also indicates whether the account is a threads-only user via is_threads_only_user.
-- **`scrape-creators-pp-cli threads list-search`** - Search by Keyword
-- **`scrape-creators-pp-cli threads list-search-2`** - Search Users
-- **`scrape-creators-pp-cli threads list-user`** - Fetches the most recent posts from a Threads user, returning id, caption text, code, like_count, reshare_count, direct_reply_count, repost_count, image_versions2, video_versions, and taken_at. Only the last 20-30 posts are publicly visible. Supports a trim option for lighter responses.
-
-### tiktok
-
-Scrape TikTok profiles, videos, and more
-
-- **`scrape-creators-pp-cli tiktok list`** - Get popular creators
-- **`scrape-creators-pp-cli tiktok list-gettrendingfeed`** - Trending Feed
-- **`scrape-creators-pp-cli tiktok list-hashtags`** - Get popular hashtags
-- **`scrape-creators-pp-cli tiktok list-product`** - Product Details
-- **`scrape-creators-pp-cli tiktok list-profile`** - Fetches public profile data for a TikTok user by their handle — useful for looking up a creator's identity, bio, and account stats. Returns a `user` object (display name, avatar URLs, bio/signature, verification status, bio link) and a `stats` object (followerCount, followingCount, heartCount/total likes, videoCount). This only returns profile metadata, not the user's actual videos or followers list.
-- **`scrape-creators-pp-cli tiktok list-profile-2`** - Profile Videos
-- **`scrape-creators-pp-cli tiktok list-search`** - Search by Hashtag
-- **`scrape-creators-pp-cli tiktok list-search-2`** - Search by Keyword
-- **`scrape-creators-pp-cli tiktok list-search-3`** - Top Search
-- **`scrape-creators-pp-cli tiktok list-search-4`** - Search Users
-- **`scrape-creators-pp-cli tiktok list-shop`** - Product Reviews
-- **`scrape-creators-pp-cli tiktok list-shop-2`** - Shop Products
-- **`scrape-creators-pp-cli tiktok list-shop-3`** - Shop Search
-- **`scrape-creators-pp-cli tiktok list-song`** - Get Song Details
-- **`scrape-creators-pp-cli tiktok list-song-2`** - TikToks using Song
-- **`scrape-creators-pp-cli tiktok list-songs`** - Get popular songs
-- **`scrape-creators-pp-cli tiktok list-user`** - User's Audience Demographics
-- **`scrape-creators-pp-cli tiktok list-user-2`** - Retrieves the follower list of a TikTok account by handle or user_id — useful for seeing who follows a creator or getting subscriber data. Returns `followers`, an array of user objects each with `nickname`, `unique_id`, `uid`, `follower_count`, `following_count`, and avatar URLs; also returns `total` follower count. Paginate with `min_time` from the previous response.
-- **`scrape-creators-pp-cli tiktok list-user-3`** - Retrieves the following list — accounts that a TikTok user follows — by their handle. Returns `followings`, an array of user objects each with `nickname`, `unique_id`, `uid`, `follower_count`, `following_count`, `signature`, and avatar URLs; also returns `total` count. Paginate with `min_time` from the previous response.
-- **`scrape-creators-pp-cli tiktok list-user-4`** - TikTok Live
-- **`scrape-creators-pp-cli tiktok list-user-5`** - User Showcase
-- **`scrape-creators-pp-cli tiktok list-video`** - Comment Replies
-- **`scrape-creators-pp-cli tiktok list-video-2`** - Fetches comments on a TikTok video by URL — useful for reading audience reactions, replies, and engagement. Returns `comments`, an array where each comment includes `text`, `digg_count` (likes), `reply_comment_total`, `create_time`, and a `user` object with the commenter's nickname and unique_id; also returns `total` comment count. Paginate with `cursor` from the previous response.
-- **`scrape-creators-pp-cli tiktok list-video-3`** - Extracts the transcript, captions, or subtitles from a TikTok video by URL. Returns `id`, `url`, and `transcript` as a WEBVTT-formatted string with timestamped text segments. Video must be under 2 minutes; costs an additional 10 credits when `use_ai_as_fallback=true`.
-- **`scrape-creators-pp-cli tiktok list-video-4`** - Video Info
-- **`scrape-creators-pp-cli tiktok list-videos`** - Get popular videos
-
-### truthsocial
-
-Manage truthsocial
-
-- **`scrape-creators-pp-cli truthsocial list`** - Fetches a single Truth Social post by URL, returning text, id, created_at, url, content, account details, media_attachments, card link previews, replies_count, reblogs_count, and favourites_count. Only posts from prominent public figures (e.g., Trump, Vance) are accessible without authentication.
-- **`scrape-creators-pp-cli truthsocial list-profile`** - Retrieves a Truth Social user's public profile including display_name, username, avatar, header, followers_count, following_count, statuses_count, verified status, website, and created_at. Only prominent public figures (e.g., Trump, Vance) are accessible without authentication; most other accounts will not work.
-- **`scrape-creators-pp-cli truthsocial list-user`** - User Posts
-
-### twitch
-
-Scrape Twitch clips
-
-- **`scrape-creators-pp-cli twitch list`** - Fetches detailed data for a Twitch clip by URL, including metadata and direct video URLs. Returns clip id, slug, url, embedURL, title, viewCount, language, durationSeconds, game info, broadcaster details with follower count, thumbnailURL, and videoQualities at multiple resolutions with a signed videoURL for playback. Also includes additional clips from the same broadcaster.
-- **`scrape-creators-pp-cli twitch list-profile`** - Retrieves a Twitch user's public profile by handle, including identity, social links, and content. Returns id, handle, displayName, description, followers count, and linked social accounts (instagram, x, tiktok). Also includes allVideos with game info, duration, and view counts, featuredClips with clip metadata and thumbnails, and similarStreamers.
-
-### twitter
-
-Get Twitter profiles, tweets, followers and more
-
-- **`scrape-creators-pp-cli twitter list`** - Retrieves details about a Twitter/X Community by URL. Returns the community name, description, rest_id, join_policy, created_at, member_count, rules, and creator_results with the creator's profile. Also includes members_facepile_results with avatar images of recent members.
-- **`scrape-creators-pp-cli twitter list-community`** - Community Tweets
-- **`scrape-creators-pp-cli twitter list-profile`** - Retrieves a Twitter user's profile by handle, including account metadata and statistics. Returns name, screen_name, description, followers_count, friends_count, statuses_count, favourites_count, location, profile_image_url_https, and is_blue_verified. Also includes verification_info, tipjar_settings, highlights_info, and creator_subscriptions_count.
-- **`scrape-creators-pp-cli twitter list-tweet`** - Tweet Details
-- **`scrape-creators-pp-cli twitter list-tweet-2`** - Extracts the transcript from a Twitter video tweet using AI-powered transcription. The video must be under 2 minutes long. Returns a success flag and the full transcript text. This endpoint is slower than others due to the AI processing step.
-- **`scrape-creators-pp-cli twitter list-usertweets`** - User Tweets
-
-### youtube
-
-Scrape YouTube channels, videos, and more
-
-- **`scrape-creators-pp-cli youtube list`** - Channel Details
-- **`scrape-creators-pp-cli youtube list-channel`** - Channel Shorts
-- **`scrape-creators-pp-cli youtube list-channelvideos`** - Channel Videos
-- **`scrape-creators-pp-cli youtube list-communitypost`** - Community Post Details
-- **`scrape-creators-pp-cli youtube list-playlist`** - Retrieves all videos in a YouTube playlist, including the playlist title, owner info, total video count, and each video's title, URL, thumbnail, duration, and channel. Accepts the playlist ID found in the 'list' URL parameter.
-- **`scrape-creators-pp-cli youtube list-search`** - Searches YouTube by keyword query and returns matching videos, channels, playlists, shorts, shelves, and live streams. Each video result includes title, URL, thumbnail, view count (views), publish date, duration, channel info, and badges. Supports filtering by upload date, sorting by relevance or popularity, and paginating with continuationToken.
-- **`scrape-creators-pp-cli youtube list-search-2`** - Search by Hashtag
-- **`scrape-creators-pp-cli youtube list-shorts`** - Trending Shorts
-- **`scrape-creators-pp-cli youtube list-video`** - Video/Short Details
-- **`scrape-creators-pp-cli youtube list-video-2`** - Comment Replies
-- **`scrape-creators-pp-cli youtube list-video-3`** - Fetches comments and replies from a YouTube video, including each comment's text content, author details, like count, reply count, and publish date. Supports ordering by top or newest, and paginating with continuationToken. Limited to approximately 1,000 top comments or 7,000 newest comments.
-- **`scrape-creators-pp-cli youtube list-video-4`** - Retrieves the captions, subtitles, or transcript of a YouTube video or short. Returns both a timestamped transcript array with start/end times and a plain-text version in transcript_only_text. Supports specifying a language code. Note: the video must be under 2 minutes for transcript extraction to work.
-
+The command surface is organized as `<platform> <action>`. Running any platform by itself prints help. A hidden alias layer keeps older OpenAPI-style names (`list-post-2`, `list-user-5`, etc.) working for existing scripts.
+
+### TikTok
+
+```
+scrape-creators-pp-cli tiktok <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Public profile: identity, bio, followers, follower/following/like/video counts |
+| `profile-videos` | Recent videos for a profile |
+| `user-audience` | Audience demographics |
+| `user-followers` | Follower list (paginated) |
+| `user-following` | Accounts the user follows (paginated) |
+| `user-live` | Live status |
+| `user-showcase` | User showcase products |
+| `video` | Full video metadata |
+| `video-comments` | Comments on a video |
+| `video-comment-replies` | Replies to a specific comment |
+| `video-transcript` | Transcript / captions (video must be < 2 min) |
+| `search-hashtag` / `search-keyword` / `search-top` / `search-users` | Search surfaces |
+| `songs-popular` / `song` / `song-videos` | Song discovery + songs-to-videos |
+| `creators-popular` / `videos-popular` / `hashtags-popular` | Popular feeds |
+| `trending-feed` | For-You-style trending feed |
+| `shop-products` / `shop-search` / `product` | Shop browsing + product details |
+| `analyze` / `compare` / `cadence` / `spikes` / `track` / `transcripts` | Local-analytics commands (see Key Features) |
+
+### Instagram
+
+```
+scrape-creators-pp-cli instagram <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Public profile details, bio links, follower/following, recent posts, related profiles |
+| `basic-profile` | Lightweight profile metadata |
+| `post` | Single post or reel info |
+| `post-comments` | Comments on a post or reel |
+| `media-transcript` | AI-powered transcription for a reel (< 2 min) |
+| `reels-search` | Search reels |
+| `song-reels` | Reels using a specific song (deprecated upstream) |
+| `user-posts` | Paginated feed of a user's posts |
+| `user-embed` | Embed HTML for a user |
+| `user-highlights` / `user-highlight-detail` | Story highlights |
+
+### YouTube
+
+```
+scrape-creators-pp-cli youtube <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `channel` | Channel details |
+| `channel-videos` / `channel-shorts` | Videos or shorts from a channel |
+| `community-post` | Community post details |
+| `playlist` | All videos in a playlist |
+| `video` | Video or short metadata |
+| `video-comment-replies` | Comment replies |
+| `video-transcript` | Timestamped transcript + plain text (video must be < 2 min) |
+| `search` / `search-hashtag` | Search surfaces |
+| `shorts-trending` | Trending shorts |
+
+### Twitter / X
+
+```
+scrape-creators-pp-cli twitter <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Profile metadata and statistics |
+| `user-tweets` | Recent tweets from a user |
+| `tweet` | Single tweet details (includes AI transcript for video tweets < 2 min) |
+| `community` | Community details |
+| `community-tweets` | Tweets from a community |
+
+### LinkedIn
+
+```
+scrape-creators-pp-cli linkedin <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Person's profile |
+| `company` | Company page |
+| `company-posts` | Posts from a company page |
+| `post` | Single post / article with reactions, comments, related articles |
+| `ad` | Ad details (Search Ads via `scrape-creators-pp-cli linkedin` with a keyword) |
+
+### Facebook
+
+```
+scrape-creators-pp-cli facebook <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Public page details (category, contact, hours, ad library status) |
+| `profile-posts` / `profile-photos` / `profile-reels` | Page content |
+| `post` | Single public post or reel (optionally with comments + transcript) |
+| `post-comments` | Comments on a post (feedback_id path is faster than url) |
+| `post-transcript` | Video post transcript (< 2 min) |
+| `group-posts` | Posts from a public Facebook group |
+| `adlibrary-ad` / `adlibrary-company-ads` / `adlibrary-search-companies` | Meta Ad Library (searching via keyword caps around 1,500 results) |
+
+### Reddit
+
+```
+scrape-creators-pp-cli reddit <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `subreddit-details` | Subreddit metadata |
+| `subreddit-search` | Search posts within a subreddit |
+| `search` | Full-site post search with sort, timeframe, and pagination |
+| `post-comments` | Comments on a post |
+| `ad` / `ads-search` | Reddit ad lookup / search |
+
+### Threads
+
+```
+scrape-creators-pp-cli threads <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Public profile (username, bio, followers, bio links) |
+| `post` | Single post with comments + related posts |
+| `search` / `search-users` | Keyword and user search |
+
+### Pinterest
+
+```
+scrape-creators-pp-cli pinterest <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `pin` | Single pin (multiple resolutions, annotations) |
+| `search` | Pin search |
+| `user-boards` | A user's boards |
+
+### Bluesky
+
+```
+scrape-creators-pp-cli bluesky <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `post` | Single post with replies |
+| `user-posts` | Paginated post feed for a user (use `did` not handle for speed) |
+
+### Truth Social
+
+```
+scrape-creators-pp-cli truthsocial <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `profile` | Profile (prominent public figures only) |
+| `user-posts` | Recent posts |
+
+Running `scrape-creators-pp-cli truthsocial` with a URL fetches a single post.
+
+### Twitch / Kick
+
+```
+scrape-creators-pp-cli twitch profile --handle <name>
+scrape-creators-pp-cli twitch --url <clip-url>   # clip details
+scrape-creators-pp-cli kick   --url <clip-url>   # clip details
+```
+
+### Google
+
+```
+scrape-creators-pp-cli google <action>
+```
+
+| Action | What it does |
+|--------|--------------|
+| `search` | Organic Google search results |
+| `ad` | Ad details |
+| `company-ads` | Advertiser company ads (the `google` shortcut is "Advertiser Search") |
+
+### Single-endpoint platforms
+
+These platforms expose one endpoint each — run the top-level command directly.
+
+| Platform | Command | Returns |
+|----------|---------|---------|
+| Snapchat | `snapchat --handle <name>` | User profile + stories |
+| Amazon Shop | `amazon --url <url>` | Amazon shop page |
+| Linkbio | `linkbio --url <url>` | Linkbio (lnk.bio) page |
+| Linktree | `linktree --url <url>` | Linktree page |
+| Linkme | `linkme --url <url>` | Linkme profile + social links |
+| Komi | `komi --url <url>` | Komi page |
+| Pillar | `pillar --url <url>` | Pillar page |
+| Detect age/gender | `detect-age-gender --url <image-url>` | Age and gender estimate |
+
+### Account + infrastructure
+
+| Command | What it does |
+|---------|--------------|
+| `account` (alias of `account list`) | Credit balance |
+| `account api-usage` | Request history |
+| `account daily-usage` | Daily usage |
+| `account most-used-routes` | Most-used endpoints |
+| `account budget` | Credit balance + projected days remaining (see Key Features) |
+| `auth set-token` / `auth status` / `auth logout` | Token management |
+| `doctor` | Environment / auth / connectivity health check |
+| `version` | Print version |
+
+### Data layer — sync, search, export, analytics
+
+The CLI ships a local SQLite layer so you can pull data once and iterate fast.
+
+| Command | What it does |
+|---------|--------------|
+| `sync` | Pull API data into local SQLite with resumable pagination |
+| `tail` | Stream live changes by polling the API (NDJSON to stdout) |
+| `search <query>` | FTS5 full-text search over synced data (falls back to API when available) |
+| `search trends <hashtag>` | Snapshot hashtag result count + top videos for trend tracking |
+| `analytics` | Count / group-by / top-N over synced data |
+| `export` | Export to JSONL or JSON |
+| `import` | Import a JSONL file via API upsert |
+| `api` | Browse every raw API endpoint by interface name (power-user escape hatch) |
+| `workflow archive` | One-shot sync of every supported resource |
+| `workflow status` | Local archive sync state |
 
 ## Output Formats
 
 ```bash
-# Human-readable table (default in terminal, JSON when piped)
-scrape-creators-pp-cli account list
+# Human-readable table (default on a TTY) / JSON when piped
+scrape-creators-pp-cli account budget
 
-# JSON for scripting and agents
-scrape-creators-pp-cli account list --json
+# JSON always
+scrape-creators-pp-cli account budget --json
 
-# Filter to specific fields
-scrape-creators-pp-cli account list --json --select id,name,status
+# Keep only specific fields (dotted paths traverse arrays)
+scrape-creators-pp-cli tiktok profile --handle charlidamelio --json --select user.nickname,stats.followerCount
 
-# Dry run — show the request without sending
-scrape-creators-pp-cli account list --dry-run
+# CSV / tab-separated / one-value-per-line
+scrape-creators-pp-cli tiktok videos-popular --csv
+scrape-creators-pp-cli tiktok videos-popular --plain
+scrape-creators-pp-cli tiktok videos-popular --quiet
 
-# Agent mode — JSON + compact + no prompts in one flag
-scrape-creators-pp-cli account list --agent
+# Dry run — print the HTTP request without sending
+scrape-creators-pp-cli tiktok profile --handle charlidamelio --dry-run
+
+# Agent preset — JSON + compact + no prompts + no color + yes
+scrape-creators-pp-cli tiktok profile --handle charlidamelio --agent
 ```
+
+Responses use a `{"meta": {...}, "results": <data>}` envelope. Parse `.results` for payload, `.meta.source` for `live` vs `local`. The `N results (live)` footer prints to stderr only when stdout is a TTY.
 
 ## Agent Usage
 
-This CLI is designed for AI agent consumption:
+Designed for AI-agent consumption:
 
-- **Non-interactive** - never prompts, every input is a flag
-- **Pipeable** - `--json` output to stdout, errors to stderr
-- **Filterable** - `--select id,name` returns only fields you need
-- **Previewable** - `--dry-run` shows the request without sending
-- **Retryable** - creates return "already exists" on retry, deletes return "already deleted"
-- **Confirmable** - `--yes` for explicit confirmation of destructive actions
-- **Piped input** - `echo '{"key":"value"}' | scrape-creators-pp-cli <resource> create --stdin`
-- **Cacheable** - GET responses cached for 5 minutes, bypass with `--no-cache`
-- **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
-- **Progress events** - paginated commands emit NDJSON events to stderr in default mode
+- **Non-interactive** — `--no-input` disables every prompt; `--agent` implies it.
+- **Pipeable** — JSON on stdout, errors on stderr, NDJSON progress events to stderr for paginated ops.
+- **Filterable** — `--select field1,field2` (dotted paths supported, arrays traverse element-wise).
+- **Previewable** — `--dry-run` shows the HTTP request without sending.
+- **Cacheable** — GET responses cached 5 min, bypass with `--no-cache`.
+- **Rate-limitable** — `--rate-limit <rps>` caps requests per second.
+- **Data-source switch** — `--data-source live|local|auto` chooses between API, local SQLite, or automatic fallback.
 
-Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
+Exit codes: `0` success · `2` usage error · `3` not found · `4` auth error · `5` API error · `7` rate limited · `10` config error.
 
-## Use as MCP Server
+## MCP Server
 
-This CLI ships a companion MCP server for use with Claude Desktop, Cursor, and other MCP-compatible tools.
+This CLI ships a companion MCP server (`scrape-creators-pp-mcp`) for Claude Code, Claude Desktop, Cursor, and Codex.
 
-### Claude Code
+### One-liner install
 
 ```bash
-claude mcp add scrape-creators scrape-creators-pp-mcp -e SCRAPE_CREATORS_API_KEY_AUTH=<your-key>
+# Claude Code (writes ~/.claude.json)
+scrape-creators-pp-cli agent add claude-code
+
+# Claude Desktop (writes ~/Library/Application Support/Claude/claude_desktop_config.json)
+scrape-creators-pp-cli agent add claude-desktop
+
+# Cursor (writes ~/.cursor/mcp.json)
+scrape-creators-pp-cli agent add cursor
+
+# Codex (writes ~/.codex/config.toml)
+scrape-creators-pp-cli agent add codex
+
+# Add --hosted to wire the hosted endpoint at https://api.scrapecreators.com/mcp instead of the local binary
+# Add --force to overwrite an existing scrape-creators entry (a diff is printed by default)
 ```
 
-### Claude Desktop
+All writes are `chmod 0600`. Existing entries are refused without `--force`.
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+### Manual config (Claude Desktop)
 
 ```json
 {
@@ -359,28 +376,42 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 }
 ```
 
-## Cookbook
-
-Common workflows and recipes:
+### Claude Code via `claude mcp add`
 
 ```bash
-# List resources as JSON for scripting
-scrape-creators-pp-cli account list --json
+claude mcp add scrape-creators scrape-creators-pp-mcp -e SCRAPE_CREATORS_API_KEY_AUTH=<your-key>
+```
 
-# Filter to specific fields
-scrape-creators-pp-cli account list --json --select id,name,status
+## Cookbook
 
-# Dry run to preview the request
-scrape-creators-pp-cli account list --dry-run
+```bash
+# Find a creator's best-performing videos (2× their own engagement-rate average)
+scrape-creators-pp-cli tiktok spikes --handle charlidamelio --threshold 2 --json
 
-# Sync data locally for offline search
-scrape-creators-pp-cli sync
+# Record a daily growth snapshot (run on a schedule) and show history
+scrape-creators-pp-cli tiktok track --handle charlidamelio
+scrape-creators-pp-cli tiktok track --handle charlidamelio --history
 
-# Search synced data
-scrape-creators-pp-cli search "query"
+# Archive everything locally, then search offline
+scrape-creators-pp-cli workflow archive
+scrape-creators-pp-cli search "viral marketing"
 
-# Export for backup
-scrape-creators-pp-cli export --format jsonl > backup.jsonl
+# Budget watch — alert when credits dip below 1000
+scrape-creators-pp-cli account budget --agent
+
+# Compare three creators side-by-side (repeat --handle once per creator)
+scrape-creators-pp-cli tiktok compare \
+  --handle charlidamelio --handle khaby.lame --handle addisonre --json
+
+# Hashtag trend snapshot (re-run over time to detect growth)
+scrape-creators-pp-cli search trends --hashtag fyp --json
+
+# Search across all of a creator's transcripts
+scrape-creators-pp-cli tiktok transcripts --handle charlidamelio --search "morning routine"
+
+# Sync a subset of resources then export for external analysis
+scrape-creators-pp-cli sync --resources tiktok_videos --since 30d
+scrape-creators-pp-cli export tiktok_videos --format jsonl --output tiktok.jsonl
 ```
 
 ## Health Check
@@ -389,36 +420,43 @@ scrape-creators-pp-cli export --format jsonl > backup.jsonl
 scrape-creators-pp-cli doctor
 ```
 
-<!-- DOCTOR_OUTPUT -->
+Reports config path, auth status, base URL, CLI version, and a live connectivity probe.
 
 ## Configuration
 
 Config file: `~/.config/scrape-creators-pp-cli/config.toml`
 
-Environment variables:
-- `SCRAPE_CREATORS_API_KEY_AUTH`
+Required environment variable:
+
+- `SCRAPE_CREATORS_API_KEY_AUTH` — your API key from <https://app.scrapecreators.com>
+
+Optional:
+
+- `SCRAPE_CREATORS_BASE_URL` — override API base (defaults to `https://api.scrapecreators.com`)
 
 ## Troubleshooting
 
-**Authentication errors (exit code 4)**
-- Run `scrape-creators-pp-cli doctor` to check credentials
-- Verify the environment variable is set: `echo $SCRAPE_CREATORS_API_KEY_AUTH`
+**Auth error (exit 4)**
+- `scrape-creators-pp-cli doctor` to see what's set
+- `echo $SCRAPE_CREATORS_API_KEY_AUTH` to verify the variable is exported
 
-**Not found errors (exit code 3)**
-- Check the resource ID is correct
-- Run the `list` command to see available items
+**Not found (exit 3)**
+- Check the handle / URL is correct and the account is public
+- Some platforms (Truth Social, older Snapchat profiles) only expose prominent public accounts
 
-**Rate limit errors (exit code 7)**
+**Rate limited (exit 7)**
 - The CLI auto-retries with exponential backoff
-- If persistent, wait a few minutes and try again
+- Lower concurrency with `--rate-limit 2` (2 requests per second)
+
+**Transcript returns nothing**
+- Video must be under ~2 minutes for AI transcription endpoints (Facebook, Instagram, TikTok, Twitter, Threads)
 
 ---
 
 ## Sources & Inspiration
 
-This CLI was built by studying these projects and resources:
+- [**@scrapecreators/cli**](https://www.npmjs.com/package/@scrapecreators/cli) — official JS CLI (command naming mirrors v1)
+- [**n8n-nodes-scrape-creators**](https://github.com/adrianhorning08/n8n-nodes-scrape-creators) — n8n integration
+- [**scrape-creators-examples**](https://github.com/adrianhorning08/scrape-creators-examples) — JS examples
 
-- [**n8n-nodes-scrape-creators**](https://github.com/adrianhorning08/n8n-nodes-scrape-creators) — JavaScript
-- [**scrape-creators-examples**](https://github.com/adrianhorning08/scrape-creators-examples) — JavaScript
-
-Generated by [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press)
+Generated by [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press).

--- a/library/developer-tools/scrape-creators/SKILL.md
+++ b/library/developer-tools/scrape-creators/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: pp-scrape-creators
+description: "Scrape Creators CLI — scrape public social-media data across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio platforms. Use when the user wants to fetch a profile, posts, comments, videos, ads, or transcripts from a social platform; compare creators; find spike/viral videos; track follower growth; analyze posting cadence; snapshot hashtag trends; inspect API credit budget; or sync a platform's data locally for offline search and analytics."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["scrape-creators-pp-cli"],"env":["SCRAPE_CREATORS_API_KEY_AUTH"]},"primaryEnv":"SCRAPE_CREATORS_API_KEY_AUTH","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest","bins":["scrape-creators-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Scrape Creators - Printing Press CLI
+
+Scrape public social-media data from the terminal — profiles, posts, comments, videos, ads, and transcripts across 30+ platforms. Read-only wrapper around the [Scrape Creators](https://scrapecreators.com) API. Ships a local SQLite sync and analytics commands (`spikes`, `compare`, `cadence`, `track`, `analyze`, `transcripts`, `search trends`, `account budget`) that compound over time.
+
+## When to Use This CLI
+
+Reach for this when the user wants to:
+
+- Look up a public profile or post on any supported platform (`<platform> profile`, `<platform> post`, `<platform> user-posts`)
+- Fetch comments, transcripts, or ad details (`<platform> post-comments`, `<platform> video-transcript`, `facebook adlibrary-search-companies`)
+- Find a creator's best-performing videos by engagement rate (`tiktok spikes`, `tiktok analyze`)
+- Compare creators side-by-side or track one over time (`tiktok compare`, `tiktok track`)
+- Understand *when* a creator posts (`tiktok cadence`)
+- Search across all of a creator's video transcripts (`tiktok transcripts`)
+- Snapshot a hashtag's momentum (`search trends`)
+- Audit API credit spend and forecast days remaining (`account budget`)
+- Pull a platform's data into local SQLite for offline work (`sync`, `workflow archive`)
+- Full-text-search synced data (`search`)
+
+Skip this CLI when the user wants to *post* content (it's read-only) or authenticate as a specific social-media user (it only sees public data).
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `scrape-creators-pp-cli --help`
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (map to the best command and run it)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.22+).
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest
+   ```
+
+   If `@latest` installs a stale build (Go module proxy cache lag):
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@main
+   ```
+3. Verify: `scrape-creators-pp-cli --version`.
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup:
+   ```bash
+   export SCRAPE_CREATORS_API_KEY_AUTH="<your-key>"
+   ```
+   Get a key at <https://app.scrapecreators.com>.
+6. Verify: `scrape-creators-pp-cli doctor` reports config, auth, and connectivity status.
+
+## MCP Server Installation
+
+The CLI ships an MCP server (`scrape-creators-pp-mcp`) and a one-liner installer that wires it into any supported agent's config:
+
+```bash
+# Preferred — lets the CLI write the correct config format for each agent
+scrape-creators-pp-cli agent add claude-code
+scrape-creators-pp-cli agent add claude-desktop
+scrape-creators-pp-cli agent add cursor
+scrape-creators-pp-cli agent add codex
+
+# Use --hosted to point at https://api.scrapecreators.com/mcp instead of the local binary
+scrape-creators-pp-cli agent add claude-code --hosted
+
+# Use --force to overwrite an existing scrape-creators entry (diff is printed by default)
+scrape-creators-pp-cli agent add cursor --force
+```
+
+All writes land at mode `0600`. Alternatively, install the MCP binary manually:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-mcp@latest
+claude mcp add scrape-creators scrape-creators-pp-mcp -e SCRAPE_CREATORS_API_KEY_AUTH=<your-key>
+```
+
+## Direct Use
+
+1. Check installed: `which scrape-creators-pp-cli`. If missing, offer CLI installation.
+2. Ensure `SCRAPE_CREATORS_API_KEY_AUTH` is exported (or saved to the config file) before any call that hits the API.
+3. Discover commands: `scrape-creators-pp-cli --help`; drill in with `scrape-creators-pp-cli <platform> --help`.
+4. Execute with `--agent` for structured output:
+   ```bash
+   scrape-creators-pp-cli <platform> <action> [args] --agent
+   ```
+5. For repeat analytics, run `scrape-creators-pp-cli sync --resources <type>` first so later commands read from local SQLite.
+
+Handle / hashtag normalization: the CLI strips leading `@` from handles and `#` from hashtags automatically. Both `@charlidamelio` and `charlidamelio` work.
+
+## Notable Commands
+
+### Platform scrapers
+
+| Platform | Top-level command | Example leaf actions |
+|----------|-------------------|----------------------|
+| TikTok | `tiktok` | `profile`, `video`, `video-comments`, `video-transcript`, `search-keyword`, `trending-feed` |
+| Instagram | `instagram` | `profile`, `post`, `post-comments`, `user-posts`, `media-transcript` |
+| YouTube | `youtube` | `channel`, `playlist`, `video`, `video-transcript`, `search` |
+| Twitter / X | `twitter` | `profile`, `user-tweets`, `tweet`, `community` |
+| LinkedIn | `linkedin` | `profile`, `company`, `company-posts`, `post`, `ad` |
+| Facebook | `facebook` | `profile`, `post`, `post-comments`, `group-posts`, `adlibrary-search-companies` |
+| Reddit | `reddit` | `subreddit-details`, `subreddit-search`, `search`, `post-comments` |
+| Threads | `threads` | `profile`, `post`, `search` |
+| Pinterest | `pinterest` | `pin`, `search`, `user-boards` |
+| Bluesky | `bluesky` | `post`, `user-posts` |
+| Truth Social | `truthsocial` | `profile`, `user-posts` |
+| Twitch | `twitch` | `profile` (clip via bare `twitch --url`) |
+| Kick | `kick` | clip via bare `kick --url` |
+| Snapchat | `snapchat` | `snapchat --handle <name>` |
+| Google | `google` | `search`, `ad`, `company-ads` |
+| Link-in-bio | `linkbio`, `linktree`, `linkme`, `komi`, `pillar`, `amazon` | `<platform> --url <page-url>` |
+| Age/gender detection | `detect-age-gender` | `--url <image-url>` |
+
+### Analytics commands (TikTok, built on top of the scraped data)
+
+| Command | What it does |
+|---------|--------------|
+| `tiktok spikes` | Videos that outperformed the creator's own engagement-rate average (threshold multiplier via `--threshold`) |
+| `tiktok analyze` | Rank a creator's videos by engagement rate (likes+comments+shares / views) |
+| `tiktok compare` | Compare multiple creators — repeat `--handle` once per creator |
+| `tiktok cadence` | Posting frequency by day of week and hour of day |
+| `tiktok track` | Daily follower snapshot; pass `--history` to chart growth |
+| `tiktok transcripts` | Fetch all transcripts for a creator; `--search <term>` to grep across them |
+
+### Cross-platform and data-layer commands
+
+| Command | What it does |
+|---------|--------------|
+| `search <query>` | FTS5 full-text search over synced data (falls back to API when available) |
+| `search trends` | Snapshot a hashtag's result count + top videos (`--hashtag <tag>`) |
+| `account budget` | Credit balance + projected days remaining at current burn rate |
+| `account api-usage` / `daily-usage` / `most-used-routes` | Usage history views |
+| `sync` | Pull API data into local SQLite (`--resources <list>`, `--since <dur>`, `--full`) |
+| `tail` | Stream live changes by polling the API (NDJSON to stdout) |
+| `analytics` | Count / group-by / top-N over synced data |
+| `export` | Export synced data to JSONL or JSON (`--format`, `--output`) |
+| `import` | Push a JSONL file into the API via upsert |
+| `workflow archive` | One-shot sync of every supported resource; `--full` forces re-archive |
+| `workflow status` | Local archive sync state |
+| `api` | Browse every raw API endpoint by interface name (power-user escape hatch) |
+| `agent add` | Wire the MCP server into `claude-code`, `claude-desktop`, `cursor`, or `codex` |
+| `doctor` | Config / auth / connectivity health check |
+
+Run any command with `--help` for full flag documentation.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr; paginated commands emit NDJSON progress to stderr
+- **Filterable** — `--select` keeps a subset of fields, dotted paths descend into nested responses
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Rate-limitable** — `--rate-limit <rps>` caps requests per second (helpful when walking a large follower list)
+- **Data-source switch** — `--data-source live|local|auto` chooses API, local SQLite, or auto fallback
+- **Non-interactive** — never prompts; `--no-input` disables every prompt and `--agent` implies it
+
+### Filtering output
+
+`--select` accepts dotted paths; arrays traverse element-wise:
+
+```bash
+scrape-creators-pp-cli tiktok profile --handle charlidamelio --agent --select user.nickname,stats.followerCount
+scrape-creators-pp-cli tiktok videos-popular --agent --select items.id,items.stats.playCount
+```
+
+Use this to narrow huge payloads to the fields you actually need.
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found (profile, post, video, …) |
+| 4 | Authentication required (`SCRAPE_CREATORS_API_KEY_AUTH` missing or invalid) |
+| 5 | API error (Scrape Creators upstream) |
+| 7 | Rate limited |
+| 10 | Config error |

--- a/skills/pp-scrape-creators/SKILL.md
+++ b/skills/pp-scrape-creators/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: pp-scrape-creators
+description: "Scrape Creators CLI — scrape public social-media data across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio platforms. Use when the user wants to fetch a profile, posts, comments, videos, ads, or transcripts from a social platform; compare creators; find spike/viral videos; track follower growth; analyze posting cadence; snapshot hashtag trends; inspect API credit budget; or sync a platform's data locally for offline search and analytics."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["scrape-creators-pp-cli"],"env":["SCRAPE_CREATORS_API_KEY_AUTH"]},"primaryEnv":"SCRAPE_CREATORS_API_KEY_AUTH","install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest","bins":["scrape-creators-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Scrape Creators - Printing Press CLI
+
+Scrape public social-media data from the terminal — profiles, posts, comments, videos, ads, and transcripts across 30+ platforms. Read-only wrapper around the [Scrape Creators](https://scrapecreators.com) API. Ships a local SQLite sync and analytics commands (`spikes`, `compare`, `cadence`, `track`, `analyze`, `transcripts`, `search trends`, `account budget`) that compound over time.
+
+## When to Use This CLI
+
+Reach for this when the user wants to:
+
+- Look up a public profile or post on any supported platform (`<platform> profile`, `<platform> post`, `<platform> user-posts`)
+- Fetch comments, transcripts, or ad details (`<platform> post-comments`, `<platform> video-transcript`, `facebook adlibrary-search-companies`)
+- Find a creator's best-performing videos by engagement rate (`tiktok spikes`, `tiktok analyze`)
+- Compare creators side-by-side or track one over time (`tiktok compare`, `tiktok track`)
+- Understand *when* a creator posts (`tiktok cadence`)
+- Search across all of a creator's video transcripts (`tiktok transcripts`)
+- Snapshot a hashtag's momentum (`search trends`)
+- Audit API credit spend and forecast days remaining (`account budget`)
+- Pull a platform's data into local SQLite for offline work (`sync`, `workflow archive`)
+- Full-text-search synced data (`search`)
+
+Skip this CLI when the user wants to *post* content (it's read-only) or authenticate as a specific social-media user (it only sees public data).
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `scrape-creators-pp-cli --help`
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (map to the best command and run it)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.22+).
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest
+   ```
+
+   If `@latest` installs a stale build (Go module proxy cache lag):
+   ```bash
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@main
+   ```
+3. Verify: `scrape-creators-pp-cli --version`.
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+5. Auth setup:
+   ```bash
+   export SCRAPE_CREATORS_API_KEY_AUTH="<your-key>"
+   ```
+   Get a key at <https://app.scrapecreators.com>.
+6. Verify: `scrape-creators-pp-cli doctor` reports config, auth, and connectivity status.
+
+## MCP Server Installation
+
+The CLI ships an MCP server (`scrape-creators-pp-mcp`) and a one-liner installer that wires it into any supported agent's config:
+
+```bash
+# Preferred — lets the CLI write the correct config format for each agent
+scrape-creators-pp-cli agent add claude-code
+scrape-creators-pp-cli agent add claude-desktop
+scrape-creators-pp-cli agent add cursor
+scrape-creators-pp-cli agent add codex
+
+# Use --hosted to point at https://api.scrapecreators.com/mcp instead of the local binary
+scrape-creators-pp-cli agent add claude-code --hosted
+
+# Use --force to overwrite an existing scrape-creators entry (diff is printed by default)
+scrape-creators-pp-cli agent add cursor --force
+```
+
+All writes land at mode `0600`. Alternatively, install the MCP binary manually:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-mcp@latest
+claude mcp add scrape-creators scrape-creators-pp-mcp -e SCRAPE_CREATORS_API_KEY_AUTH=<your-key>
+```
+
+## Direct Use
+
+1. Check installed: `which scrape-creators-pp-cli`. If missing, offer CLI installation.
+2. Ensure `SCRAPE_CREATORS_API_KEY_AUTH` is exported (or saved to the config file) before any call that hits the API.
+3. Discover commands: `scrape-creators-pp-cli --help`; drill in with `scrape-creators-pp-cli <platform> --help`.
+4. Execute with `--agent` for structured output:
+   ```bash
+   scrape-creators-pp-cli <platform> <action> [args] --agent
+   ```
+5. For repeat analytics, run `scrape-creators-pp-cli sync --resources <type>` first so later commands read from local SQLite.
+
+Handle / hashtag normalization: the CLI strips leading `@` from handles and `#` from hashtags automatically. Both `@charlidamelio` and `charlidamelio` work.
+
+## Notable Commands
+
+### Platform scrapers
+
+| Platform | Top-level command | Example leaf actions |
+|----------|-------------------|----------------------|
+| TikTok | `tiktok` | `profile`, `video`, `video-comments`, `video-transcript`, `search-keyword`, `trending-feed` |
+| Instagram | `instagram` | `profile`, `post`, `post-comments`, `user-posts`, `media-transcript` |
+| YouTube | `youtube` | `channel`, `playlist`, `video`, `video-transcript`, `search` |
+| Twitter / X | `twitter` | `profile`, `user-tweets`, `tweet`, `community` |
+| LinkedIn | `linkedin` | `profile`, `company`, `company-posts`, `post`, `ad` |
+| Facebook | `facebook` | `profile`, `post`, `post-comments`, `group-posts`, `adlibrary-search-companies` |
+| Reddit | `reddit` | `subreddit-details`, `subreddit-search`, `search`, `post-comments` |
+| Threads | `threads` | `profile`, `post`, `search` |
+| Pinterest | `pinterest` | `pin`, `search`, `user-boards` |
+| Bluesky | `bluesky` | `post`, `user-posts` |
+| Truth Social | `truthsocial` | `profile`, `user-posts` |
+| Twitch | `twitch` | `profile` (clip via bare `twitch --url`) |
+| Kick | `kick` | clip via bare `kick --url` |
+| Snapchat | `snapchat` | `snapchat --handle <name>` |
+| Google | `google` | `search`, `ad`, `company-ads` |
+| Link-in-bio | `linkbio`, `linktree`, `linkme`, `komi`, `pillar`, `amazon` | `<platform> --url <page-url>` |
+| Age/gender detection | `detect-age-gender` | `--url <image-url>` |
+
+### Analytics commands (TikTok, built on top of the scraped data)
+
+| Command | What it does |
+|---------|--------------|
+| `tiktok spikes` | Videos that outperformed the creator's own engagement-rate average (threshold multiplier via `--threshold`) |
+| `tiktok analyze` | Rank a creator's videos by engagement rate (likes+comments+shares / views) |
+| `tiktok compare` | Compare multiple creators — repeat `--handle` once per creator |
+| `tiktok cadence` | Posting frequency by day of week and hour of day |
+| `tiktok track` | Daily follower snapshot; pass `--history` to chart growth |
+| `tiktok transcripts` | Fetch all transcripts for a creator; `--search <term>` to grep across them |
+
+### Cross-platform and data-layer commands
+
+| Command | What it does |
+|---------|--------------|
+| `search <query>` | FTS5 full-text search over synced data (falls back to API when available) |
+| `search trends` | Snapshot a hashtag's result count + top videos (`--hashtag <tag>`) |
+| `account budget` | Credit balance + projected days remaining at current burn rate |
+| `account api-usage` / `daily-usage` / `most-used-routes` | Usage history views |
+| `sync` | Pull API data into local SQLite (`--resources <list>`, `--since <dur>`, `--full`) |
+| `tail` | Stream live changes by polling the API (NDJSON to stdout) |
+| `analytics` | Count / group-by / top-N over synced data |
+| `export` | Export synced data to JSONL or JSON (`--format`, `--output`) |
+| `import` | Push a JSONL file into the API via upsert |
+| `workflow archive` | One-shot sync of every supported resource; `--full` forces re-archive |
+| `workflow status` | Local archive sync state |
+| `api` | Browse every raw API endpoint by interface name (power-user escape hatch) |
+| `agent add` | Wire the MCP server into `claude-code`, `claude-desktop`, `cursor`, or `codex` |
+| `doctor` | Config / auth / connectivity health check |
+
+Run any command with `--help` for full flag documentation.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr; paginated commands emit NDJSON progress to stderr
+- **Filterable** — `--select` keeps a subset of fields, dotted paths descend into nested responses
+- **Previewable** — `--dry-run` shows the request without sending
+- **Cacheable** — GET responses cached for 5 minutes, bypass with `--no-cache`
+- **Rate-limitable** — `--rate-limit <rps>` caps requests per second (helpful when walking a large follower list)
+- **Data-source switch** — `--data-source live|local|auto` chooses API, local SQLite, or auto fallback
+- **Non-interactive** — never prompts; `--no-input` disables every prompt and `--agent` implies it
+
+### Filtering output
+
+`--select` accepts dotted paths; arrays traverse element-wise:
+
+```bash
+scrape-creators-pp-cli tiktok profile --handle charlidamelio --agent --select user.nickname,stats.followerCount
+scrape-creators-pp-cli tiktok videos-popular --agent --select items.id,items.stats.playCount
+```
+
+Use this to narrow huge payloads to the fields you actually need.
+
+### Response envelope
+
+Data-layer commands wrap output in `{"meta": {...}, "results": <data>}`. Parse `.results` for data and `.meta.source` to know whether it's `live` or local. The `N results (live)` summary is printed to stderr only when stdout is a TTY; piped/agent consumers see pure JSON on stdout.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found (profile, post, video, …) |
+| 4 | Authentication required (`SCRAPE_CREATORS_API_KEY_AUTH` missing or invalid) |
+| 5 | API error (Scrape Creators upstream) |
+| 7 | Rate limited |
+| 10 | Config error |


### PR DESCRIPTION
## Summary

Stacks on top of #113 / #115 to close two long-standing doc issues: the README was built against the pre-rename OpenAPI-style command names (`list-post-2`, `list-user-5`, `list-adlibrary-3`, …) and was never regenerated after #115 flipped the primary surface to `<platform> <action>` pairs, and there was no SKILL.md — so agents could not invoke the CLI via `/pp-scrape-creators`.

## What changed

### README.md
- Replaced every command listing with the real command tree from the shipped binary (`scrape-creators-pp-cli --help` output post-#115).
- Rewrote the Key Features / Commands sections so the TikTok-specific analytics (`spikes`, `compare`, `cadence`, `track`, `analyze`, `transcripts`), `search trends`, `account budget`, and `workflow archive` are documented under their actual command paths.
- Dropped the read-only-API-inappropriate Agent Usage bullets (create/delete/confirmable destructive actions).
- Replaced generic "Manage X" placeholder descriptions with accurate summaries derived from each platform's child commands.
- Documented the #115 additions that had no user-facing docs: interactive wizard, `agent add <target>` for MCP installation, and `@`/`#` input normalization.
- Fixed cookbook examples to use real flags (`--handle` stringArray on `tiktok compare`, `--resources` on `sync`, positional `<resource>` on `export`, `--hashtag` on `search trends`).
- Removed the unrendered `<!-- HELP_OUTPUT -->` / `<!-- DOCTOR_OUTPUT -->` placeholders and the "thier stories" typo.

### SKILL.md (new at `library/developer-tools/scrape-creators/SKILL.md`)
- Modeled on `library/developer-tools/trigger-dev/SKILL.md`: frontmatter with `openclaw` install metadata, When to Use, Argument Parsing, CLI Install, MCP Install, Direct Use, Notable Commands, Agent Mode, Exit Codes.
- Highlights `scrape-creators-pp-cli agent add claude-code|claude-desktop|cursor|codex` as the preferred MCP install path (since #115 shipped it).
- Every `--flag` and positional referenced is verified against the Go source — `.github/scripts/verify-skill/verify_skill.py` passes all four checks (`flag-names`, `flag-commands`, `positional-args`, `unknown-command`).

### Plumbing
- Ran `go run ./tools/generate-skills/main.go`; `skills/pp-scrape-creators/SKILL.md` mirrors the library copy byte-for-byte.
- `.claude-plugin/plugin.json` auto-bumped to `1.2.2` by the generator (a new CLI joined the skills directory set).

## Test plan
- [x] `go build ./...` in `library/developer-tools/scrape-creators/`
- [x] `go vet ./...` clean
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/developer-tools/scrape-creators` → all checks passed
- [x] `diff library/.../SKILL.md skills/pp-scrape-creators/SKILL.md` → identical (generator mirror is in sync)
- [x] `./scrape-creators-pp-cli --help` output spot-checked against the new Commands section

🤖 Generated with [Claude Code](https://claude.com/claude-code)