### PR TITLE
docs(cli): rewrite README for launch (Apr 28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Printing Press Library
 
-Printing Press Library is the published catalog for the [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press): agent-friendly CLIs, MCP servers, and plugin skills generated from real APIs and shipped as installable tools.
+Nothing is more valuable than time and money. In a world of AI agents, that's speed and token spend. A well-designed CLI is muscle memory for an agent: no hunting through docs, no wrong turns, no wasted tokens. The [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press) prints those CLIs. This repo is the catalog of CLIs already printed and ready to install.
 
-This repository currently includes 21 CLIs, 19 MCP servers, one mega-skill (`/ppl`), and 21 focused `pp-*` skills.
+24 CLIs across 17 categories. 17 ship a full MCP server. Browse them all at [printingpress.dev](https://printingpress.dev).
 
-## Start Here
+Three to try first:
 
-This repo is its own Claude Code plugin marketplace. Add the marketplace, then install the plugin:
+- ESPN (sniffed, no official API). _"Tonight's NBA playoff games with live score, series state, each team's leading scorer's stat line, and any injury or lineup news from the last 24 hours."_ One call.
+- flight-goat (Kayak nonstop search plus sniffed Google Flights). _"Non-stop flights over 8 hours from Seattle for 4 people, Dec 24 to Jan 1, cheapest first."_ Two sources, one query.
+- linear-pp-cli (50ms against a local SQLite mirror). _"Every blocked issue whose blocker has been stuck for a week."_ Compound queries the Linear API can't answer.
+
+## Start here
+
+This repo is itself a Claude Code plugin marketplace. Add it, install the plugin, and you have every CLI in the catalog one slash-command away.
 
 ```text
 /plugin marketplace add mvanhorn/printing-press-library
@@ -19,19 +25,18 @@ After install, the main router skill is:
 /ppl
 ```
 
-That naming split is intentional:
-
-- The repository and plugin are named `printing-press-library`
-- The mega-skill you actually use is `/ppl`
-
-If you also want to generate new tools from API specs, install the source project too:
+Want to print new CLIs from API specs? Install the Printing Press itself too:
 
 ```text
 /plugin marketplace add mvanhorn/cli-printing-press
 /plugin install cli-printing-press@cli-printing-press
 ```
 
-## Quick Examples
+## Two ways in
+
+The repository and plugin are named `printing-press-library`. The mega-skill you actually use is `/ppl`. That naming split is intentional.
+
+Use `/ppl` when you want discovery, routing, or installation. Examples:
 
 ```text
 /ppl
@@ -40,62 +45,50 @@ If you also want to generate new tools from API specs, install the source projec
 /ppl install espn mcp
 /ppl espn lakers score
 /ppl linear my open issues
+```
+
+Use a focused `/pp-<name>` skill when you already know the tool you want. Examples:
+
+```text
 /pp-espn lakers score
+/pp-flightgoat sea to lax dec 24 to jan 1 nonstop
 /pp-weather-goat phoenix forecast
 ```
 
-Use `/ppl` when you want discovery, routing, or installation. Use a focused `pp-*` skill when you already know the tool you want.
-
-## What This Repo Ships
-
-- [`skills/ppl/SKILL.md`](skills/ppl/SKILL.md): the mega-skill that browses the catalog, installs CLIs and MCP servers, and routes user requests to the right tool
-- [`skills/`](skills/): one focused skill per published tool, such as `pp-espn`, `pp-linear`, and `pp-weather-goat`
-- [`library/`](library/): the actual Go modules for each CLI and MCP server
-- [`registry.json`](registry.json): the machine-readable source of truth for the published catalog
-- [`.claude-plugin/`](.claude-plugin/): the marketplace and plugin manifests — the whole repo is the plugin
-
-The top-level README is the human guide. `registry.json` is the authoritative index.
+`/ppl` is the catalog plus the librarian. Each `/pp-<name>` is a single shelf you reach directly when you don't need help finding it.
 
 ## Catalog
 
-Current published tools, grouped by how people usually reach for them. Each row links to the tool source and its focused plugin skill.
+Tools grouped by category, sourced from [`registry.json`](registry.json). Each row links to the tool source and its focused plugin skill.
 
-| Name | Skill | Auth | MCP | What it does |
-|------|-------|------|-----|--------------|
-| [`agent-capture`](library/developer-tools/agent-capture/) | [`/pp-agent-capture`](skills/pp-agent-capture/SKILL.md) | local only | no | Record, screenshot, and convert macOS windows and screens for agent evidence. |
-| [`archive-is`](library/media-and-entertainment/archive-is/) | [`/pp-archive-is`](skills/pp-archive-is/SKILL.md) | none | full | Find and create Archive.today snapshots for URLs. |
-| [`cal-com`](library/productivity/cal-com/) | [`/pp-cal-com`](skills/pp-cal-com/SKILL.md) | API key | full | Manage bookings, schedules, event types, and availability. |
-| [`dominos-pp-cli`](library/commerce/dominos-pp-cli/) | [`/pp-dominos`](skills/pp-dominos/SKILL.md) | browser login | full | Order Domino's, browse menus, and track deliveries. |
-| [`dub`](library/marketing/dub/) | [`/pp-dub`](skills/pp-dub/SKILL.md) | API key | full | Create short links, track analytics, and manage domains. |
-| [`espn`](library/media-and-entertainment/espn/) | [`/pp-espn`](skills/pp-espn/SKILL.md) | none | full | Live scores, standings, schedules, and sports news. |
-| [`flightgoat`](library/travel/flightgoat/) | [`/pp-flightgoat`](skills/pp-flightgoat/SKILL.md) | API key optional | full | Search flights, explore routes, and track flights. |
-| [`hackernews`](library/media-and-entertainment/hackernews/) | [`/pp-hackernews`](skills/pp-hackernews/SKILL.md) | none | full | Browse stories, comments, jobs, and topic slices from Hacker News. |
-| [`hubspot-pp-cli`](library/sales-and-crm/hubspot/) | [`/pp-hubspot`](skills/pp-hubspot/SKILL.md) | API key | full | Work with contacts, companies, deals, tickets, and pipelines. |
-| [`instacart`](library/commerce/instacart/) | [`/pp-instacart`](skills/pp-instacart/SKILL.md) | browser session | no | Search products, manage carts, and shop Instacart from the terminal. |
-| [`kalshi`](library/payments/kalshi/) | [`/pp-kalshi`](skills/pp-kalshi/SKILL.md) | API key | full | Trade markets, inspect portfolios, and analyze odds. |
-| [`linear`](library/project-management/linear/) | [`/pp-linear`](skills/pp-linear/SKILL.md) | API key | full | Manage issues, cycles, teams, and projects with local sync. |
-| [`movie-goat`](library/media-and-entertainment/movie-goat/) | [`/pp-movie-goat`](skills/pp-movie-goat/SKILL.md) | bearer token | full | Compare movie ratings, streaming availability, and recommendations. |
-| [`pagliacci-pizza`](library/food-and-dining/pagliacci-pizza/) | [`/pp-pagliacci-pizza`](skills/pp-pagliacci-pizza/SKILL.md) | browser login | partial | Order Pagliacci and browse public menu and store data without login. |
-| [`postman-explore`](library/developer-tools/postman-explore/) | [`/pp-postman-explore`](skills/pp-postman-explore/SKILL.md) | none | full | Search and browse the Postman API Network. |
-| [`recipe-goat`](library/food-and-dining/recipe-goat/) | [`/pp-recipe-goat`](skills/pp-recipe-goat/SKILL.md) | API key | full | Find recipes across trusted sites and pull nutrition context. |
-| [`slack`](library/productivity/slack/) | [`/pp-slack`](skills/pp-slack/SKILL.md) | API key | full | Send messages, search conversations, and monitor channels. |
-| [`steam-web`](library/media-and-entertainment/steam-web/) | [`/pp-steam-web`](skills/pp-steam-web/SKILL.md) | API key | full | Look up Steam players, games, achievements, and stats. |
-| [`trigger-dev`](library/developer-tools/trigger-dev/) | [`/pp-trigger-dev`](skills/pp-trigger-dev/SKILL.md) | API key | full | Monitor runs, trigger tasks, and inspect schedules and failures. |
-| [`weather-goat`](library/other/weather-goat/) | [`/pp-weather-goat`](skills/pp-weather-goat/SKILL.md) | none | full | Forecasts, alerts, air quality, and activity verdicts. |
-| [`yahoo-finance`](library/commerce/yahoo-finance/) | [`/pp-yahoo-finance`](skills/pp-yahoo-finance/SKILL.md) | none | full | Quotes, charts, fundamentals, options, and watchlists. |
+| Name | Skill | Auth | MCP | Slash install | What it does |
+|------|-------|------|-----|---------------|--------------|
+| [`agent-capture`](library/developer-tools/agent-capture/) | [`/pp-agent-capture`](skills/pp-agent-capture/SKILL.md) | local only | no | `/ppl install agent-capture cli` | Record, screenshot, and convert macOS windows and screens for agent evidence. |
+| [`archive-is`](library/media-and-entertainment/archive-is/) | [`/pp-archive-is`](skills/pp-archive-is/SKILL.md) | none | full | `/ppl install archive-is cli` | Find and create Archive.today snapshots for URLs. |
+| [`cal-com`](library/productivity/cal-com/) | [`/pp-cal-com`](skills/pp-cal-com/SKILL.md) | API key | full | `/ppl install cal-com cli` | Manage bookings, schedules, event types, and availability. |
+| [`contact-goat`](library/sales-and-crm/contact-goat/) | [`/pp-contact-goat`](skills/pp-contact-goat/SKILL.md) | mixed | full | `/ppl install contact-goat cli` | Cross-source warm-intro graph across LinkedIn, Happenstance, and Deepline with a unified local store. |
+| [`dominos-pp-cli`](library/commerce/dominos-pp-cli/) | [`/pp-dominos`](skills/pp-dominos/SKILL.md) | browser login | full | `/ppl install dominos cli` | Order Domino's, browse menus, and track deliveries. |
+| [`dub`](library/marketing/dub/) | [`/pp-dub`](skills/pp-dub/SKILL.md) | API key | full | `/ppl install dub cli` | Create short links, track analytics, and manage domains. |
+| [`espn`](library/media-and-entertainment/espn/) | [`/pp-espn`](skills/pp-espn/SKILL.md) | none | full | `/ppl install espn cli` | Live scores, standings, schedules, and sports news. |
+| [`flightgoat`](library/travel/flightgoat/) | [`/pp-flightgoat`](skills/pp-flightgoat/SKILL.md) | API key optional | full | `/ppl install flightgoat cli` | Search flights, explore routes, and track flights. |
+| [`hackernews`](library/media-and-entertainment/hackernews/) | [`/pp-hackernews`](skills/pp-hackernews/SKILL.md) | none | full | `/ppl install hackernews cli` | Browse stories, comments, jobs, and topic slices from Hacker News. |
+| [`hubspot-pp-cli`](library/sales-and-crm/hubspot/) | [`/pp-hubspot`](skills/pp-hubspot/SKILL.md) | API key | full | `/ppl install hubspot cli` | Work with contacts, companies, deals, tickets, and pipelines. |
+| [`instacart`](library/commerce/instacart/) | [`/pp-instacart`](skills/pp-instacart/SKILL.md) | browser session | no | `/ppl install instacart cli` | Search products, manage carts, and shop Instacart from the terminal. |
+| [`kalshi`](library/payments/kalshi/) | [`/pp-kalshi`](skills/pp-kalshi/SKILL.md) | API key | full | `/ppl install kalshi cli` | Trade markets, inspect portfolios, and analyze odds. |
+| [`linear`](library/project-management/linear/) | [`/pp-linear`](skills/pp-linear/SKILL.md) | API key | full | `/ppl install linear cli` | Manage issues, cycles, teams, and projects with local sync. |
+| [`movie-goat`](library/media-and-entertainment/movie-goat/) | [`/pp-movie-goat`](skills/pp-movie-goat/SKILL.md) | bearer token | full | `/ppl install movie-goat cli` | Compare movie ratings, streaming availability, and recommendations. |
+| [`pagliacci-pizza`](library/food-and-dining/pagliacci-pizza/) | [`/pp-pagliacci-pizza`](skills/pp-pagliacci-pizza/SKILL.md) | browser login | partial | `/ppl install pagliacci-pizza cli` | Order Pagliacci and browse public menu and store data without login. |
+| [`pokeapi`](library/media-and-entertainment/pokeapi/) | [`/pp-pokeapi`](skills/pp-pokeapi/SKILL.md) | none | full | `/ppl install pokeapi cli` | PokeAPI as an agent-ready knowledge graph plus matchup and team-coverage workflows. |
+| [`postman-explore`](library/developer-tools/postman-explore/) | [`/pp-postman-explore`](skills/pp-postman-explore/SKILL.md) | none | full | `/ppl install postman-explore cli` | Search and browse the Postman API Network. |
+| [`producthunt`](library/marketing/producthunt/) | [`/pp-producthunt`](skills/pp-producthunt/SKILL.md) | none | full | `/ppl install producthunt cli` | Token-free Product Hunt CLI with local sync and views the website doesn't expose. |
+| [`recipe-goat`](library/food-and-dining/recipe-goat/) | [`/pp-recipe-goat`](skills/pp-recipe-goat/SKILL.md) | API key | full | `/ppl install recipe-goat cli` | Find recipes across 37 trusted sites with trust-aware ranking and local cookbook. |
+| [`slack`](library/productivity/slack/) | [`/pp-slack`](skills/pp-slack/SKILL.md) | API key | full | `/ppl install slack cli` | Send messages, search conversations, and monitor channels. |
+| [`steam-web`](library/media-and-entertainment/steam-web/) | [`/pp-steam-web`](skills/pp-steam-web/SKILL.md) | API key | full | `/ppl install steam-web cli` | Look up Steam players, games, achievements, and stats. |
+| [`trigger-dev`](library/developer-tools/trigger-dev/) | [`/pp-trigger-dev`](skills/pp-trigger-dev/SKILL.md) | API key | full | `/ppl install trigger-dev cli` | Monitor runs, trigger tasks, and inspect schedules and failures. |
+| [`weather-goat`](library/other/weather-goat/) | [`/pp-weather-goat`](skills/pp-weather-goat/SKILL.md) | none | full | `/ppl install weather-goat cli` | Forecasts, alerts, air quality, and activity verdicts. |
+| [`yahoo-finance`](library/commerce/yahoo-finance/) | [`/pp-yahoo-finance`](skills/pp-yahoo-finance/SKILL.md) | none | full | `/ppl install yahoo-finance cli` | Quotes, charts, fundamentals, options, and watchlists. |
 
-## Installation Paths
-
-### Recommended: let `/ppl` handle it
-
-```text
-/ppl install <name> cli
-/ppl install <name> mcp
-```
-
-That keeps users off of repo-path trivia and lets the skill read from [`registry.json`](registry.json).
-
-### Direct CLI install
+## Direct install
 
 You need [Go 1.23+](https://go.dev/dl/).
 
@@ -103,34 +96,24 @@ You need [Go 1.23+](https://go.dev/dl/).
 go install github.com/mvanhorn/printing-press-library/<path>/cmd/<binary>@latest
 ```
 
-Examples:
+A few worked examples:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-cli@latest
 go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
-go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/travel/flightgoat/cmd/flightgoat-pp-cli@latest
 ```
 
-### Direct MCP install
-
-```bash
-go install github.com/mvanhorn/printing-press-library/<path>/cmd/<mcp-binary>@latest
-claude mcp add <mcp-binary> -- <mcp-binary>
-```
-
-Examples:
+For the MCP server companion:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-mcp@latest
 claude mcp add espn-pp-mcp -- espn-pp-mcp
-
-go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-mcp@latest
-claude mcp add weather-goat-pp-mcp -- weather-goat-pp-mcp
 ```
 
-If a tool needs credentials, the focused skill and the tool README document the required environment variables.
+If a CLI needs credentials, the focused skill and the per-CLI README document the required environment variables.
 
-## Repo Structure
+## Repo structure
 
 ```text
 library/
@@ -153,26 +136,26 @@ skills/
   ppl/
     SKILL.md
   pp-*/
-    SKILL.md
+    SKILL.md                 # generated mirror of library/<.>/SKILL.md
 
 registry.json
 ```
 
-Each published tool is self-contained: source code, a local README, provenance metadata, and manuscripts from the printing run.
+Each published tool is self-contained: source code, a local README, a `.printing-press.json` provenance manifest, and the manuscripts from the printing run. `skills/pp-*` is a generated mirror of each library `SKILL.md`, produced by `tools/generate-skills/main.go`.
 
-## What "Endorsed" Means
+## What endorsed means
 
 Every published tool in this repo has passed:
 
-1. Generation from an API spec or captured interface through the CLI Printing Press
-2. Validation checks such as build, vet, help, and version
+1. Generation from an API spec or captured interface through the [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press)
+2. Validation checks: build, vet, help, version, plus the structural dogfood and runtime verify gates
 3. Provenance capture through `.printing-press.json` and `.manuscripts/`
 
 Some tools are refined after generation. The generated artifacts remain in the tool directory so the provenance stays inspectable.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). For deeper architecture, see [AGENTS.md](AGENTS.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Pivot the README from a thin catalog page to a story-then-catalog page that opens with the same hero as cli-printing-press
- Three live one-liner demos (ESPN sniffed, flight-goat Kayak+Google, Linear local SQLite mirror) match the cli-printing-press hero so the two repos feel like one product
- New 'Two ways in' section explains the `/ppl` (mega-skill router) vs `/pp-<name>` (focused per-CLI skill) split
- Catalog table refreshed from registry.json: 24 rows (adds contact-goat, pokeapi, producthunt that were missing in the old table), new 'Slash install' column, MCP column accurate
- Cross-link to cli-printing-press and printingpress.dev throughout
- Scrub emdashes, endashes, bold from prose

Companion change: refreshes cli-printing-press README with the same shared hero (separate PR in mvanhorn/cli-printing-press#306).

## Test plan

- [ ] Catalog table renders 24 rows on github.com (matches `jq '.entries|length' registry.json`)
- [ ] Every per-CLI link in the table lands on a real `library/<category>/<slug>/` directory
- [ ] Plugin install commands paste cleanly into a fresh Claude Code session and `/ppl` becomes available
- [ ] Cross-link to cli-printing-press and printingpress.dev resolve
- [ ] No new emdashes/endashes/bold introduced (verified locally)