### PR TITLE
fix(mcp): substitute path placeholders in 49 MCP tool registrations

### DIFF
--- a/library/developer-tools/company-goat/internal/mcp/tools.go
+++ b/library/developer-tools/company-goat/internal/mcp/tools.go
@@ -26,7 +26,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription("Fetch all SEC submissions for a given CIK (Central Index Key). Used as the seed call when resolving a company's... Returns object."),
 			mcplib.WithString("cik", mcplib.Required(), mcplib.Description("10-digit zero-padded SEC Central Index Key (e.g., 0001318605 for Tesla)")),
 		),
-		makeAPIHandler("GET", "/submissions/CIK{cik}.json", []string{}),
+		makeAPIHandler("GET", "/submissions/CIK{cik}.json", []string{"cik"}),
 	)
 	// Sync tool — populates local database for offline search and sql queries
 	s.AddTool(

--- a/library/food-and-dining/pagliacci-pizza/internal/mcp/tools.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/mcp/tools.go
@@ -58,7 +58,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("account_confirm_email",
 			mcplib.WithDescription("Confirm a new account by clicking the email-confirmation link's token"),
 		),
-		makeAPIHandler("GET", "/ConfirmEmail/{token}", []string{}),
+		makeAPIHandler("GET", "/ConfirmEmail/{token}", []string{"token"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("account_create_token",
@@ -106,19 +106,19 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("address_delete",
 			mcplib.WithDescription("Delete a saved address Destructive operation."),
 		),
-		makeAPIHandler("DELETE", "/AddressName/{id}", []string{}),
+		makeAPIHandler("DELETE", "/AddressName/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("address_get",
 			mcplib.WithDescription("Get a saved address by ID"),
 		),
-		makeAPIHandler("GET", "/AddressName/{id}", []string{}),
+		makeAPIHandler("GET", "/AddressName/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("address_get_info",
 			mcplib.WithDescription("Get address info by saved ID"),
 		),
-		makeAPIHandler("GET", "/AddressInfo/{id}", []string{}),
+		makeAPIHandler("GET", "/AddressInfo/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("address_list",
@@ -136,7 +136,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("cart_get_quote_building",
 			mcplib.WithDescription("Get the current cart/quote-building state by building ID"),
 		),
-		makeAPIHandler("GET", "/QuoteBuilding/{buildingId}", []string{}),
+		makeAPIHandler("GET", "/QuoteBuilding/{buildingId}", []string{"buildingId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("cart_price_order",
@@ -154,19 +154,19 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("cart_update_quote_building",
 			mcplib.WithDescription("Update cart contents (add/remove/modify items)"),
 		),
-		makeAPIHandler("POST", "/QuoteBuilding/{buildingId}", []string{}),
+		makeAPIHandler("POST", "/QuoteBuilding/{buildingId}", []string{"buildingId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("credit_delete",
 			mcplib.WithDescription("Remove an account credit entry Destructive operation."),
 		),
-		makeAPIHandler("DELETE", "/StoredCredit/{id}", []string{}),
+		makeAPIHandler("DELETE", "/StoredCredit/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("credit_get",
 			mcplib.WithDescription("Get a single credit entry"),
 		),
-		makeAPIHandler("GET", "/StoredCredit/{id}", []string{}),
+		makeAPIHandler("GET", "/StoredCredit/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("credit_list",
@@ -178,7 +178,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("customer_access_devices_delete",
 			mcplib.WithDescription("Revoke a device's access to the account Destructive operation."),
 		),
-		makeAPIHandler("DELETE", "/AccessDevice/{deviceId}", []string{}),
+		makeAPIHandler("DELETE", "/AccessDevice/{deviceId}", []string{"deviceId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("customer_access_devices_list",
@@ -190,7 +190,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("customer_get",
 			mcplib.WithDescription("Get customer profile by ID"),
 		),
-		makeAPIHandler("GET", "/Customer/{customerId}", []string{}),
+		makeAPIHandler("GET", "/Customer/{customerId}", []string{"customerId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("customer_migrate_answer",
@@ -208,7 +208,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("customer_feedback_get",
 			mcplib.WithDescription("Get a feedback submission by ID"),
 		),
-		makeAPIHandler("GET", "/Feedback/{id}", []string{}),
+		makeAPIHandler("GET", "/Feedback/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("customer_feedback_submit",
@@ -220,19 +220,19 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("gifts_check",
 			mcplib.WithDescription("Check the balance of a gift card by ID and PIN (no auth required to check)"),
 		),
-		makeAPIHandler("GET", "/CheckGift/{id}/{pin}", []string{}),
+		makeAPIHandler("GET", "/CheckGift/{id}/{pin}", []string{"id", "pin"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("gifts_delete",
 			mcplib.WithDescription("Remove a stored gift card from the account Destructive operation."),
 		),
-		makeAPIHandler("DELETE", "/StoredGift/{id}", []string{}),
+		makeAPIHandler("DELETE", "/StoredGift/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("gifts_get",
 			mcplib.WithDescription("Get a single stored gift card by ID"),
 		),
-		makeAPIHandler("GET", "/StoredGift/{id}", []string{}),
+		makeAPIHandler("GET", "/StoredGift/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("gifts_list",
@@ -250,13 +250,13 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("gifts_value",
 			mcplib.WithDescription("Get current value/balance of a saved gift card"),
 		),
-		makeAPIHandler("GET", "/GiftValue/{id}", []string{}),
+		makeAPIHandler("GET", "/GiftValue/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("menu_cache",
 			mcplib.WithDescription("Get the full menu (categories, products, prices, descriptions, images) for a store"),
 		),
-		makeAPIHandler("GET", "/MenuCache/{storeId}", []string{}),
+		makeAPIHandler("GET", "/MenuCache/{storeId}", []string{"storeId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("menu_product_price",
@@ -274,25 +274,25 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("menu_top",
 			mcplib.WithDescription("Get featured top-of-menu items for a store"),
 		),
-		makeAPIHandler("GET", "/MenuTop/{storeId}", []string{}),
+		makeAPIHandler("GET", "/MenuTop/{storeId}", []string{"storeId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("orders_clone",
 			mcplib.WithDescription("Get order data shaped for re-ordering (transforms a past order into a new cart)"),
 		),
-		makeAPIHandler("GET", "/OrderClone/{orderId}", []string{}),
+		makeAPIHandler("GET", "/OrderClone/{orderId}", []string{"orderId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("orders_get",
 			mcplib.WithDescription("Get the full detail of a single past order (items, prices, store, time)"),
 		),
-		makeAPIHandler("GET", "/OrderListItem/{orderId}", []string{}),
+		makeAPIHandler("GET", "/OrderListItem/{orderId}", []string{"orderId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("orders_list",
 			mcplib.WithDescription("List the authenticated user's order history (paginated)"),
 		),
-		makeAPIHandler("GET", "/OrderList/{page}/{pageSize}", []string{}),
+		makeAPIHandler("GET", "/OrderList/{page}/{pageSize}", []string{"page", "pageSize"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("orders_list_gift_cards",
@@ -310,7 +310,7 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("orders_suggestion",
 			mcplib.WithDescription("Get personalized order suggestions for a customer"),
 		),
-		makeAPIHandler("GET", "/OrderSuggestion/{customerId}", []string{}),
+		makeAPIHandler("GET", "/OrderSuggestion/{customerId}", []string{"customerId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("rewards_card",
@@ -322,13 +322,13 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("rewards_coupon_lookup",
 			mcplib.WithDescription("Look up a coupon by its serial number (validate before applying)"),
 		),
-		makeAPIHandler("GET", "/CouponSerial/{serial}", []string{}),
+		makeAPIHandler("GET", "/CouponSerial/{serial}", []string{"serial"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("rewards_history",
 			mcplib.WithDescription("Get reward earning/redemption history (most recent N entries)"),
 		),
-		makeAPIHandler("GET", "/RewardHistory/{customerId}/{count}", []string{}),
+		makeAPIHandler("GET", "/RewardHistory/{customerId}/{count}", []string{"customerId", "count"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("rewards_stored_coupons",
@@ -340,37 +340,37 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool("scheduling_slot_list",
 			mcplib.WithDescription("List available time-window slots for a store and service type"),
 		),
-		makeAPIHandler("GET", "/TimeWindows/{storeId}/{serviceType}", []string{}),
+		makeAPIHandler("GET", "/TimeWindows/{storeId}/{serviceType}", []string{"storeId", "serviceType"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("scheduling_slot_list_for_date",
 			mcplib.WithDescription("List allowed slot times for a specific delivery/pickup date (YYYYMMDD)"),
 		),
-		makeAPIHandler("GET", "/TimeWindows/{storeId}/{serviceType}/{date}", []string{}),
+		makeAPIHandler("GET", "/TimeWindows/{storeId}/{serviceType}/{date}", []string{"storeId", "serviceType", "date"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("scheduling_window_days",
 			mcplib.WithDescription("List available delivery or pickup days for a store. serviceType is DEL (delivery) or PICK (pickup)"),
 		),
-		makeAPIHandler("GET", "/TimeWindowDays/{storeId}/{serviceType}", []string{}),
+		makeAPIHandler("GET", "/TimeWindowDays/{storeId}/{serviceType}", []string{"storeId", "serviceType"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("store_compute_quote",
 			mcplib.WithDescription("Compute a quote for a specific store with cart contents (returns Delivery, Drone, Pickup wait values)"),
 		),
-		makeAPIHandler("POST", "/QuoteStore/{storeId}", []string{}),
+		makeAPIHandler("POST", "/QuoteStore/{storeId}", []string{"storeId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("store_get",
 			mcplib.WithDescription("Get a single store by its numeric ID"),
 		),
-		makeAPIHandler("GET", "/Store/{storeId}", []string{}),
+		makeAPIHandler("GET", "/Store/{storeId}", []string{"storeId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("store_get_quote",
 			mcplib.WithDescription("Get quote-store metadata (delivery fee, drone status, pickup wait time) for a single store"),
 		),
-		makeAPIHandler("GET", "/QuoteStore/{storeId}", []string{}),
+		makeAPIHandler("GET", "/QuoteStore/{storeId}", []string{"storeId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("store_list",

--- a/library/media-and-entertainment/movie-goat/internal/mcp/tools.go
+++ b/library/media-and-entertainment/movie-goat/internal/mcp/tools.go
@@ -194,7 +194,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("timeWindow", mcplib.Required(), mcplib.Description("Time window: day or week")),
 			mcplib.WithString("page", mcplib.Description("Page number")),
 		),
-		makeAPIHandler("GET", "/trending/all/{timeWindow}", []string{}),
+		makeAPIHandler("GET", "/trending/all/{timeWindow}", []string{"timeWindow"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("trending_movies",
@@ -202,14 +202,14 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("timeWindow", mcplib.Required(), mcplib.Description("Time window: day or week")),
 			mcplib.WithString("page", mcplib.Description("Page number")),
 		),
-		makeAPIHandler("GET", "/trending/movie/{timeWindow}", []string{}),
+		makeAPIHandler("GET", "/trending/movie/{timeWindow}", []string{"timeWindow"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("trending_people",
 			mcplib.WithDescription("Get trending people Returns array of Person."),
 			mcplib.WithString("timeWindow", mcplib.Required(), mcplib.Description("Time window: day or week")),
 		),
-		makeAPIHandler("GET", "/trending/person/{timeWindow}", []string{}),
+		makeAPIHandler("GET", "/trending/person/{timeWindow}", []string{"timeWindow"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("trending_tv",
@@ -217,7 +217,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("timeWindow", mcplib.Required(), mcplib.Description("Time window: day or week")),
 			mcplib.WithString("page", mcplib.Description("Page number")),
 		),
-		makeAPIHandler("GET", "/trending/tv/{timeWindow}", []string{}),
+		makeAPIHandler("GET", "/trending/tv/{timeWindow}", []string{"timeWindow"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("tv_airing-today",

--- a/library/productivity/cal-com/internal/mcp/tools.go
+++ b/library/productivity/cal-com/internal/mcp/tools.go
@@ -306,7 +306,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription("Check a calendar connection Returns CalendarsResponse."),
 			mcplib.WithString("calendar", mcplib.Description("Calendar")),
 		),
-		makeAPIHandler("GET", "/v2/calendars/{calendar}/check", []string{}),
+		makeAPIHandler("GET", "/v2/calendars/{calendar}/check", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_connect_calendars-redirect",
@@ -315,21 +315,21 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("isDryRun", mcplib.Required(), mcplib.Description("Is dry run")),
 			mcplib.WithString("redir", mcplib.Description("Redirect URL after successful calendar authorization.")),
 		),
-		makeAPIHandler("GET", "/v2/calendars/{calendar}/connect", []string{}),
+		makeAPIHandler("GET", "/v2/calendars/{calendar}/connect", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_credentials_calendars-sync",
 			mcplib.WithDescription("Save Apple calendar credentials"),
 			mcplib.WithString("calendar", mcplib.Description("Calendar")),
 		),
-		makeAPIHandler("POST", "/v2/calendars/{calendar}/credentials", []string{}),
+		makeAPIHandler("POST", "/v2/calendars/{calendar}/credentials", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_disconnect_calendars-delete-calendar-credentials",
 			mcplib.WithDescription("Disconnect a calendar Returns DeletedCalendarCredentialsOutputResponseDto."),
 			mcplib.WithString("calendar", mcplib.Description("Calendar")),
 		),
-		makeAPIHandler("POST", "/v2/calendars/{calendar}/disconnect", []string{}),
+		makeAPIHandler("POST", "/v2/calendars/{calendar}/disconnect", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_event_cal-unified-calendars-get-calendar-details",
@@ -352,7 +352,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription("Create a calendar event Returns GetUnifiedCalendarEventOutput."),
 			mcplib.WithString("calendar", mcplib.Description("Calendar")),
 		),
-		makeAPIHandler("POST", "/v2/calendars/{calendar}/events", []string{}),
+		makeAPIHandler("POST", "/v2/calendars/{calendar}/events", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_events_cal-unified-calendars-delete-calendar",
@@ -379,7 +379,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("timeZone", mcplib.Description("IANA time zone for the request (e.g. America/New_York)")),
 			mcplib.WithString("calendarId", mcplib.Description("Calendar ID. Use 'primary' for the user's primary calendar, or the external ID of a connected calendar.")),
 		),
-		makeAPIHandler("GET", "/v2/calendars/{calendar}/events", []string{}),
+		makeAPIHandler("GET", "/v2/calendars/{calendar}/events", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_events_cal-unified-calendars-update-calendar",
@@ -397,7 +397,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("to", mcplib.Required(), mcplib.Description("End of the date range (ISO 8601 date or date-time)")),
 			mcplib.WithString("timeZone", mcplib.Description("IANA time zone (e.g. America/New_York)")),
 		),
-		makeAPIHandler("GET", "/v2/calendars/{calendar}/freebusy", []string{}),
+		makeAPIHandler("GET", "/v2/calendars/{calendar}/freebusy", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("calendars_save_calendars",
@@ -406,7 +406,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("code", mcplib.Required(), mcplib.Description("Code")),
 			mcplib.WithString("calendar", mcplib.Description("Calendar")),
 		),
-		makeAPIHandler("GET", "/v2/calendars/{calendar}/save", []string{}),
+		makeAPIHandler("GET", "/v2/calendars/{calendar}/save", []string{"calendar"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("conferencing_get-default",
@@ -425,21 +425,21 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription("Connect your conferencing application Returns ConferencingAppOutputResponseDto."),
 			mcplib.WithString("app", mcplib.Description("Conferencing application type")),
 		),
-		makeAPIHandler("POST", "/v2/conferencing/{app}/connect", []string{}),
+		makeAPIHandler("POST", "/v2/conferencing/{app}/connect", []string{"app"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("conferencing_default_conferencing",
 			mcplib.WithDescription("Set your default conferencing application Returns SetDefaultConferencingAppOutputResponseDto."),
 			mcplib.WithString("app", mcplib.Description("Conferencing application type")),
 		),
-		makeAPIHandler("POST", "/v2/conferencing/{app}/default", []string{}),
+		makeAPIHandler("POST", "/v2/conferencing/{app}/default", []string{"app"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("conferencing_disconnect_conferencing",
 			mcplib.WithDescription("Disconnect your conferencing application Returns DisconnectConferencingAppOutputResponseDto. Destructive."),
 			mcplib.WithString("app", mcplib.Description("Conferencing application type")),
 		),
-		makeAPIHandler("DELETE", "/v2/conferencing/{app}/disconnect", []string{}),
+		makeAPIHandler("DELETE", "/v2/conferencing/{app}/disconnect", []string{"app"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("conferencing_oauth_conferencing-redirect",
@@ -448,7 +448,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("returnTo", mcplib.Required(), mcplib.Description("Return to")),
 			mcplib.WithString("onErrorReturnTo", mcplib.Required(), mcplib.Description("On error return to")),
 		),
-		makeAPIHandler("GET", "/v2/conferencing/{app}/oauth/auth-url", []string{}),
+		makeAPIHandler("GET", "/v2/conferencing/{app}/oauth/auth-url", []string{"app"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("conferencing_oauth_conferencing-save",
@@ -457,7 +457,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("app", mcplib.Description("Conferencing application type")),
 			mcplib.WithString("code", mcplib.Required(), mcplib.Description("Code")),
 		),
-		makeAPIHandler("GET", "/v2/conferencing/{app}/oauth/callback", []string{}),
+		makeAPIHandler("GET", "/v2/conferencing/{app}/oauth/callback", []string{"app"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("destination-calendars_update",

--- a/library/travel/flightgoat/internal/mcp/tools.go
+++ b/library/travel/flightgoat/internal/mcp/tools.go
@@ -325,7 +325,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("max_pages", mcplib.Description("Maximum number of pages to fetch. This is an upper limit and not a guarantee of how many pages will be returned.")),
 			mcplib.WithString("cursor", mcplib.Description("Opaque value used to get the next batch of data from a paged collection.")),
 		),
-		makeAPIHandler("GET", "/disruption_counts/{entity_type}", []string{}),
+		makeAPIHandler("GET", "/disruption_counts/{entity_type}", []string{"entity_type"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("flights_get",
@@ -592,7 +592,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("max_pages", mcplib.Description("Maximum number of pages to fetch. This is an upper limit and not a guarantee of how many pages will be returned.")),
 			mcplib.WithString("cursor", mcplib.Description("Opaque value used to get the next batch of data from a paged collection.")),
 		),
-		makeAPIHandler("GET", "/schedules/{date_start}/{date_end}", []string{}),
+		makeAPIHandler("GET", "/schedules/{date_start}/{date_end}", []string{"date_start", "date_end"}),
 	)
 	// Sync tool
 	s.AddTool(


### PR DESCRIPTION
## Summary

49 MCP tool registrations across 5 published CLIs were sending the literal string `{cik}` (or `{id}`, `{date}`, etc.) to upstream APIs instead of substituting the parameter value. Agents calling these tools through MCP got 404s, error responses, or unparseable bodies depending on how each upstream handled the bogus path. This PR replaces every empty `[]string{}` positionalParams with the placeholder names extracted from the URL template.

| CLI | Sites fixed |
|---|---|
| food-and-dining/pagliacci-pizza | 29 |
| productivity/cal-com | 13 |
| media-and-entertainment/movie-goat | 4 |
| travel/flightgoat | 2 |
| developer-tools/company-goat | 1 |
| **Total** | **49** |

## Root cause

Generator-side bug in cli-printing-press: when a spec author declared a path-template parameter as `location: query` (or omitted location), the MCP template emitted `[]string{}` as positionalParams instead of including the path placeholder. The runtime handler's substitution loop then never ran, so `{name}` reached the API verbatim.

```go
// Before (broken)
makeAPIHandler("GET", "/submissions/CIK{cik}.json", []string{}),

// After (fixed)
makeAPIHandler("GET", "/submissions/CIK{cik}.json", []string{"cik"}),
```

The generator fix landed in cli-printing-press [#355](https://github.com/mvanhorn/cli-printing-press/pull/355) (parser promotion of declared placeholders) and cli-printing-press [#358](https://github.com/mvanhorn/cli-printing-press/pull/358) (manifest emission, broader MCPB story). This PR applies the equivalent fix to already-published CLIs without a full regenerate, preserving each CLI's hand-written customizations.

## Codemod scope

Mechanical: for every `makeAPIHandler(METHOD, PATH-with-{placeholders}, []string{})` line, extract the placeholder names from the path and insert them into the slice. Touches only `internal/mcp/tools.go` in each affected CLI. No other generator-emitted code modified.

After codemod: zero remaining empty-slice + path-placeholder mismatches across the entire `library/` tree.

## Validation

Per-CLI build verification: each of the 5 CLIs runs `go build ./...` clean.

End-to-end validation precedent: `company-goat-pp-mcp`, hand-patched with the same fix on the spike branch (`spike/mcpb-company-goat`) and tested in Claude Desktop, returned real Tesla SEC submissions data. Both halves of the substitution path verified — parser-side promotion and template-emission inclusion.

## Out of scope (separate PR)

The companion **MCPB-enable codemod** — adding `manifest.json` (so the bundle is installable in Claude Desktop), updating `cmd/<api>-pp-mcp/main.go` for the friendly server identity, refactoring `handleContext` for the new capability boundary, and appending novel-feature MCP tools — follows in a separate PR per the agreed hybrid-2-PR sequencing. That codemod is bigger and warrants its own focused review; this PR is the urgent bug-fix track.

Plan doc lives in cli-printing-press at `docs/plans/2026-04-28-feat-mcpb-novel-feature-tools-plan.md`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)