### PR TITLE
feat(cli): contact-goat — auto-discover Deepline key from sibling CLI

### DIFF
--- a/cli-skills/pp-contact-goat/SKILL.md
+++ b/cli-skills/pp-contact-goat/SKILL.md
@@ -120,11 +120,20 @@ These commands spend Deepline credits and REQUIRE `DEEPLINE_API_KEY` or a BYOK s
 - `deepline find-email` / `enrich-person` / `email-find` / `phone-find`
 - `deepline search-people` / `search-companies` / `enrich-company`
 
-Before invoking any of these, verify auth. If `DEEPLINE_API_KEY` is not set, ASK THE USER for it (or for a BYOK Hunter/Apollo key) before running the command. The CLI preflight now fails fast with a clear hint, but you can save the round-trip by checking first:
+Before invoking any of these, verify auth by running doctor first:
 
 ```bash
 contact-goat-pp-cli doctor --agent | grep -i deepline
 ```
+
+`deepline_env` shows the resolution source:
+
+- `set (env)` — `DEEPLINE_API_KEY` exported in the current shell
+- `set (flag)` — `--deepline-key` passed on the command line
+- `set (file:~/.local/deepline/<host>/.env)` — auto-discovered from the official Deepline CLI's persisted key (the user authenticated with `deepline auth register` or `deepline auth status`; no shell export needed)
+- `not set` — none of the above. Ask the user for a key, or for a BYOK Hunter/Apollo key
+
+The auto-discovery path means a user who has the Deepline CLI installed and authenticated does NOT need to re-export the key into their shell — contact-goat reads `~/.local/deepline/code-deepline-com/.env` directly (mode 0600, owned by the user). Don't ask the user to re-export when `set (file:...)` is reported. If `deepline_discovery_skipped` is also reported, those are candidate files the resolver rejected for a security reason (wrong mode, missing prefix); surface them so the user can fix the underlying issue.
 
 Provider chain by target kind (waterfall):
 

--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -83,6 +83,16 @@ and `budget`. Get a key from [code.deepline.com](https://code.deepline.com):
 export DEEPLINE_API_KEY="dlp_..."
 ```
 
+If you have the official [Deepline CLI](https://code.deepline.com) installed
+and authenticated (`deepline auth register` or `deepline auth status`),
+contact-goat auto-discovers the saved key from
+`~/.local/deepline/<host>/.env` — you do **not** need to re-export it into
+your shell. The resolver checks `--deepline-key` first, then
+`DEEPLINE_API_KEY` env, then the sibling-CLI file (mode 0600 or 0400
+required, value must start with `dlp_`, no symlinks outside `$HOME`).
+`contact-goat-pp-cli doctor` reports the resolution source as
+`set (env)` / `set (flag)` / `set (file:~/.local/...)` / `not set`.
+
 Every Deepline-touching command surfaces estimated credit cost before
 execution and requires `--yes` to spend.
 
@@ -298,7 +308,8 @@ Sample output:
   OK LinkedIn: uvx: ok
   OK LinkedIn: binary: will launch via `uvx linkedin-scraper-mcp@latest`
   WARN LinkedIn: profile: not logged in — run `uvx linkedin-scraper-mcp@latest --login`
-  WARN Deepline: DEEPLINE_API_KEY: not set
+  OK Deepline: DEEPLINE_API_KEY: set (file:~/.local/deepline/code-deepline-com/.env)
+  OK Deepline: prefix: ok (dlp_)
   OK Deepline: CLI on PATH: /Users/you/.local/bin/deepline
   config_path: ~/.config/contact-goat-pp-cli/config.toml
   base_url: https://happenstance.ai

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -120,11 +120,20 @@ These commands spend Deepline credits and REQUIRE `DEEPLINE_API_KEY` or a BYOK s
 - `deepline find-email` / `enrich-person` / `email-find` / `phone-find`
 - `deepline search-people` / `search-companies` / `enrich-company`
 
-Before invoking any of these, verify auth. If `DEEPLINE_API_KEY` is not set, ASK THE USER for it (or for a BYOK Hunter/Apollo key) before running the command. The CLI preflight now fails fast with a clear hint, but you can save the round-trip by checking first:
+Before invoking any of these, verify auth by running doctor first:
 
 ```bash
 contact-goat-pp-cli doctor --agent | grep -i deepline
 ```
+
+`deepline_env` shows the resolution source:
+
+- `set (env)` — `DEEPLINE_API_KEY` exported in the current shell
+- `set (flag)` — `--deepline-key` passed on the command line
+- `set (file:~/.local/deepline/<host>/.env)` — auto-discovered from the official Deepline CLI's persisted key (the user authenticated with `deepline auth register` or `deepline auth status`; no shell export needed)
+- `not set` — none of the above. Ask the user for a key, or for a BYOK Hunter/Apollo key
+
+The auto-discovery path means a user who has the Deepline CLI installed and authenticated does NOT need to re-export the key into their shell — contact-goat reads `~/.local/deepline/code-deepline-com/.env` directly (mode 0600, owned by the user). Don't ask the user to re-export when `set (file:...)` is reported. If `deepline_discovery_skipped` is also reported, those are candidate files the resolver rejected for a security reason (wrong mode, missing prefix); surface them so the user can fix the underlying issue.
 
 Provider chain by target kind (waterfall):
 

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline.go
@@ -90,10 +90,8 @@ estimated cost before spending and supports --dry-run to preview the request.`,
 // resolveDeeplineKey returns the API key to use (flag wins, env fallback).
 // The value is never logged anywhere.
 func (dl *deeplineFlags) resolveKey() string {
-	if dl.apiKey != "" {
-		return dl.apiKey
-	}
-	return os.Getenv("DEEPLINE_API_KEY")
+	key, _ := resolveDeeplineKey(dl.apiKey)
+	return key
 }
 
 // deeplineExecute is the shared "estimate cost, maybe dry-run, confirm,
@@ -120,7 +118,7 @@ func deeplineExecute(cmd *cobra.Command, flags *rootFlags, dl *deeplineFlags, to
 	if err := client.ValidateKey(); err != nil {
 		logDeeplineSafely(toolID, payloadHash, cost, "auth-error")
 		if errors.Is(err, deepline.ErrMissingKey) {
-			return authErr(fmt.Errorf("%w\nhint: export DEEPLINE_API_KEY=dlp_...\n      or pass --deepline-key dlp_...", err))
+			return authErr(fmt.Errorf("%w\nhint: export DEEPLINE_API_KEY=dlp_...\n      or pass --deepline-key dlp_...\n      or run 'deepline auth status --reveal' if you've already authenticated with the Deepline CLI", err))
 		}
 		return authErr(err)
 	}

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver.go
@@ -1,0 +1,296 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// resolveDeeplineKey centralizes Deepline API key resolution across every
+// paid path in the CLI (waterfall, dossier, prospect, deepline subcommands,
+// doctor). The resolver checks three sources in priority order:
+//
+//   1. flag      — value passed on the command line via --deepline-key
+//   2. env       — DEEPLINE_API_KEY in the process environment
+//   3. file:<P>  — the Deepline CLI's persisted key at $HOME/.local/deepline/<host>/.env
+//
+// The file source closes the UX gap reported on 2026-04-28: a user with the
+// official Deepline CLI installed and authenticated has the key on disk at
+// mode 600, but contact-goat used to fail with "API key required" because it
+// only checked env + flag. The user already trusts the file (their own home
+// dir, mode 600 by default); reading it is a sibling-tool integration, not a
+// new trust boundary.
+//
+// Security guards on file discovery:
+//
+//   - File must be under $HOME (no path traversal escape, no symlinks pointing
+//     outside $HOME).
+//   - File must have mode 0600 or 0400 — group/world readability disqualifies.
+//   - Value must start with "dlp_" (the Deepline key prefix) — otherwise we
+//     skip the file rather than emit a malformed key.
+//   - Empty values are skipped, not returned with an empty source.
+//
+// The resolver never logs or echoes the key value. Callers that want to
+// surface the discovery state (e.g., doctor) use the returned source string,
+// which is safe — it names the bucket and (for files) the path, never the
+// secret.
+
+package cli
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// deeplineKeyPrefix is the canonical Deepline API key prefix. Mirrors
+// internal/deepline.KeyPrefix; duplicated here to avoid an import cycle from
+// internal/cli into internal/deepline (which imports internal/cli for nothing
+// today, but the resolver is dependency-free on purpose).
+const deeplineKeyPrefix = "dlp_"
+
+// deeplineHomeFunc is the home-directory accessor used by resolveDeeplineKey.
+// Tests override this via a setter so they can sandbox file discovery to a
+// t.TempDir() without touching the real $HOME.
+var deeplineHomeFunc = os.UserHomeDir
+
+// preferredDeeplineHostSlug is the host-slug subdirectory the resolver
+// prefers when multiple sibling-CLI key files exist. The Deepline CLI today
+// writes to ~/.local/deepline/code-deepline-com/.env; we prefer that path
+// when both it and another slug are present, then fall back to the first
+// lexically-sorted slug whose key parses successfully.
+const preferredDeeplineHostSlug = "code-deepline-com"
+
+// resolveDeeplineKey returns the Deepline API key and a label for where it
+// came from. The label values are "flag", "env", "file:<absolute-path>", or
+// the empty string when nothing resolved.
+//
+// Precedence: a non-empty flagValue wins over env, env wins over file. Any
+// value found at a higher-priority source short-circuits the chain — we do
+// not validate flag/env shape here (callers that validate the prefix run
+// after the resolver returns).
+func resolveDeeplineKey(flagValue string) (key, source string) {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v, "flag"
+	}
+	if v := strings.TrimSpace(os.Getenv("DEEPLINE_API_KEY")); v != "" {
+		return v, "env"
+	}
+	if v, path := discoverDeeplineKeyFromSiblingCLI(); v != "" {
+		return v, "file:" + path
+	}
+	return "", ""
+}
+
+// resolveDeeplineKeyWithSkips returns the same primary result as
+// resolveDeeplineKey, plus a list of human-readable reasons describing any
+// candidate sibling-CLI files that were rejected during file discovery.
+// The doctor command surfaces these so users can fix a permissions or
+// prefix-shape issue without having to re-discover what the resolver did.
+//
+// Skip reasons are file-shaped strings ("<path>: <reason>") suitable for
+// display. They never include the key value.
+func resolveDeeplineKeyWithSkips(flagValue string) (key, source string, skips []string) {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v, "flag", nil
+	}
+	if v := strings.TrimSpace(os.Getenv("DEEPLINE_API_KEY")); v != "" {
+		return v, "env", nil
+	}
+	v, path, fileSkips := discoverDeeplineKeyFromSiblingCLIWithSkips()
+	if v != "" {
+		return v, "file:" + path, fileSkips
+	}
+	return "", "", fileSkips
+}
+
+// discoverDeeplineKeyFromSiblingCLI walks $HOME/.local/deepline/*/.env and
+// returns the first acceptable key with its absolute path. It prefers the
+// canonical host slug ("code-deepline-com") before falling back to lexical
+// order across all matching directories.
+func discoverDeeplineKeyFromSiblingCLI() (key, path string) {
+	v, p, _ := discoverDeeplineKeyFromSiblingCLIWithSkips()
+	return v, p
+}
+
+// discoverDeeplineKeyFromSiblingCLIWithSkips is the same walk but also
+// returns rejection reasons for candidate files that were found but failed
+// one of the security guards (mode wrong, symlink escape, prefix wrong,
+// empty value). The doctor command displays these so the user can correct
+// a permissions issue without having to re-discover the resolver's logic.
+func discoverDeeplineKeyFromSiblingCLIWithSkips() (key, path string, skips []string) {
+	home, err := deeplineHomeFunc()
+	if err != nil || home == "" {
+		return "", "", nil
+	}
+
+	root := filepath.Join(home, ".local", "deepline")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		// Most users won't have the Deepline CLI installed. ENOENT here is
+		// the common, silent path — not a skip.
+		return "", "", nil
+	}
+
+	// Build the candidate list: every immediate subdirectory's .env file.
+	// Sort lexically so the fallback "first match" is deterministic when
+	// the preferred slug is absent.
+	var candidates []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidates = append(candidates, e.Name())
+	}
+	sort.Strings(candidates)
+
+	// Reorder so the preferred host slug is tried first when present.
+	if preferredIdx := indexOfSlug(candidates, preferredDeeplineHostSlug); preferredIdx > 0 {
+		candidates = append([]string{preferredDeeplineHostSlug}, removeSlugAt(candidates, preferredIdx)...)
+	}
+
+	for _, slug := range candidates {
+		envPath := filepath.Join(root, slug, ".env")
+		v, reason := readDeeplineEnvFile(envPath, home)
+		if v != "" {
+			return v, envPath, skips
+		}
+		if reason != "" {
+			skips = append(skips, envPath+": "+reason)
+		}
+	}
+	return "", "", skips
+}
+
+// readDeeplineEnvFile parses a sibling-CLI .env file and returns either a
+// validated key or a skip reason describing why the file was rejected. An
+// empty key with an empty reason means the file simply did not contain a
+// DEEPLINE_API_KEY entry — that's not a security skip, just a non-match.
+//
+// Guards (in order):
+//
+//   - Lstat — symlink whose target leaves $HOME is rejected.
+//   - Mode  — group or world readability is rejected.
+//   - Parse — non-quoted KEY=VALUE per line, comments and blanks ignored.
+//   - Prefix — value must start with "dlp_".
+//   - Empty — DEEPLINE_API_KEY="" falls through (no error, no key).
+func readDeeplineEnvFile(envPath, home string) (key, skipReason string) {
+	info, err := os.Lstat(envPath)
+	if err != nil {
+		// File doesn't exist — silent miss, not a skip.
+		return "", ""
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		target, terr := filepath.EvalSymlinks(envPath)
+		if terr != nil {
+			return "", "skipped: broken symlink"
+		}
+		// Refuse symlinks whose resolved target lies outside $HOME. A symlink
+		// from inside $HOME to /etc/passwd or to a shared scratch dir is
+		// exactly the trust-boundary escape this guard exists to refuse.
+		absHome, herr := filepath.Abs(home)
+		if herr != nil {
+			return "", "skipped: cannot resolve home directory"
+		}
+		absTarget, terr := filepath.Abs(target)
+		if terr != nil {
+			return "", "skipped: cannot resolve symlink target"
+		}
+		if !strings.HasPrefix(absTarget+string(filepath.Separator), absHome+string(filepath.Separator)) &&
+			absTarget != absHome {
+			return "", "skipped: symlink escapes home directory"
+		}
+		// Re-stat through the symlink so the mode check uses the real file.
+		info, err = os.Stat(envPath)
+		if err != nil {
+			return "", "skipped: cannot stat symlink target"
+		}
+	}
+
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		return "", "skipped: mode " + modeOctal(mode) + " (must be 0600 or 0400)"
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		return "", "skipped: read failed (" + err.Error() + ")"
+	}
+
+	rawValue, found := parseDotenvDeeplineKey(string(data))
+	if !found {
+		return "", ""
+	}
+	if rawValue == "" {
+		return "", "skipped: empty value"
+	}
+	if !strings.HasPrefix(rawValue, deeplineKeyPrefix) {
+		return "", "skipped: value missing dlp_ prefix"
+	}
+	return rawValue, ""
+}
+
+// parseDotenvDeeplineKey is a tiny dotenv parser: KEY=VALUE per line, blank
+// lines and comments ignored, surrounding double or single quotes stripped.
+// Returns the value of the first DEEPLINE_API_KEY assignment encountered,
+// and a bool indicating whether the key appeared at all (so callers can
+// distinguish "not in file" from "in file but empty").
+func parseDotenvDeeplineKey(data string) (value string, found bool) {
+	for _, rawLine := range strings.Split(data, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip an optional leading "export " so files written with the
+		// shell-export form parse the same way.
+		line = strings.TrimPrefix(line, "export ")
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if key != "DEEPLINE_API_KEY" {
+			continue
+		}
+		val := strings.TrimSpace(line[eq+1:])
+		// Strip a single matching pair of surrounding quotes — the dotenv
+		// convention. Both single and double quotes accepted.
+		if len(val) >= 2 {
+			if (val[0] == '"' && val[len(val)-1] == '"') ||
+				(val[0] == '\'' && val[len(val)-1] == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+		return val, true
+	}
+	return "", false
+}
+
+// modeOctal renders a Unix mode as the conventional octal string ("0644")
+// for use in skip-reason messages.
+func modeOctal(m fs.FileMode) string {
+	return "0" + octal3(uint32(m.Perm()))
+}
+
+// octal3 formats a 9-bit Unix mode as a 3-digit octal string. Hand-rolled
+// to avoid importing fmt for one call in a hot path that runs on every
+// doctor invocation.
+func octal3(n uint32) string {
+	digits := []byte{'0', '0', '0'}
+	digits[0] = byte('0' + ((n >> 6) & 0o7))
+	digits[1] = byte('0' + ((n >> 3) & 0o7))
+	digits[2] = byte('0' + (n & 0o7))
+	return string(digits)
+}
+
+func indexOfSlug(s []string, target string) int {
+	for i, v := range s {
+		if v == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func removeSlugAt(s []string, i int) []string {
+	out := make([]string, 0, len(s)-1)
+	out = append(out, s[:i]...)
+	out = append(out, s[i+1:]...)
+	return out
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withFakeHome redirects the resolver's home accessor to dir for the duration
+// of the test, restoring the previous accessor (and unsetting DEEPLINE_API_KEY)
+// on cleanup. Tests use this to sandbox file discovery in t.TempDir() so the
+// real $HOME is never touched.
+func withFakeHome(t *testing.T, dir string) {
+	t.Helper()
+	prev := deeplineHomeFunc
+	deeplineHomeFunc = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { deeplineHomeFunc = prev })
+	t.Setenv("DEEPLINE_API_KEY", "")
+}
+
+// writeKeyFile writes a sibling-CLI .env file under fakeHome at the given
+// host slug with mode 0600. The intermediate directories are created with
+// permissive-but-test-only perms (0700) since the resolver only checks the
+// .env file's mode, not its parents.
+func writeKeyFile(t *testing.T, fakeHome, slug, body string, mode os.FileMode) string {
+	t.Helper()
+	dir := filepath.Join(fakeHome, ".local", "deepline", slug)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte(body), mode); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return envPath
+}
+
+func TestResolveDeeplineKey_FlagWins(t *testing.T) {
+	withFakeHome(t, t.TempDir())
+	t.Setenv("DEEPLINE_API_KEY", "dlp_ENV")
+	key, source := resolveDeeplineKey("dlp_FLAG")
+	if key != "dlp_FLAG" || source != "flag" {
+		t.Fatalf("got (%q,%q); want (dlp_FLAG, flag)", key, source)
+	}
+}
+
+func TestResolveDeeplineKey_EnvWins(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_FILE\n", 0o600)
+	t.Setenv("DEEPLINE_API_KEY", "dlp_ENV")
+	key, source := resolveDeeplineKey("")
+	if key != "dlp_ENV" || source != "env" {
+		t.Fatalf("got (%q,%q); want (dlp_ENV, env)", key, source)
+	}
+}
+
+func TestResolveDeeplineKey_FileFallback(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	envPath := writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_FILE\n", 0o600)
+	key, source := resolveDeeplineKey("")
+	if key != "dlp_FILE" {
+		t.Fatalf("key=%q; want dlp_FILE", key)
+	}
+	if source != "file:"+envPath {
+		t.Fatalf("source=%q; want file:%s", source, envPath)
+	}
+}
+
+func TestResolveDeeplineKey_PreferredHostSlugWinsOverOthers(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	// Write the non-preferred slug first (alphabetically earlier), then the
+	// preferred one. The resolver must still pick code-deepline-com.
+	writeKeyFile(t, fakeHome, "alpha-deepline", "DEEPLINE_API_KEY=dlp_OTHER\n", 0o600)
+	preferredPath := writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_PREFERRED\n", 0o600)
+	key, source := resolveDeeplineKey("")
+	if key != "dlp_PREFERRED" {
+		t.Fatalf("key=%q; want dlp_PREFERRED (preferred slug should win)", key)
+	}
+	if source != "file:"+preferredPath {
+		t.Fatalf("source=%q; want file:%s", source, preferredPath)
+	}
+}
+
+func TestResolveDeeplineKey_LexicalFallbackWhenNoPreferredSlug(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	// Two non-preferred slugs. Lexical order picks "alpha" before "beta".
+	alphaPath := writeKeyFile(t, fakeHome, "alpha-deepline", "DEEPLINE_API_KEY=dlp_ALPHA\n", 0o600)
+	writeKeyFile(t, fakeHome, "beta-deepline", "DEEPLINE_API_KEY=dlp_BETA\n", 0o600)
+	key, source := resolveDeeplineKey("")
+	if key != "dlp_ALPHA" {
+		t.Fatalf("key=%q; want dlp_ALPHA (lexical first wins absent preferred slug)", key)
+	}
+	if source != "file:"+alphaPath {
+		t.Fatalf("source=%q; want file:%s", source, alphaPath)
+	}
+}
+
+func TestResolveDeeplineKey_EmptyValueIsSkipped(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=\n", 0o600)
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty", key, source)
+	}
+	if len(skips) == 0 || !strings.Contains(skips[0], "empty value") {
+		t.Fatalf("expected 'empty value' skip reason; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_DoubleQuotedValue(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", `DEEPLINE_API_KEY="dlp_QUOTED"`+"\n", 0o600)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_QUOTED" {
+		t.Fatalf("key=%q; want dlp_QUOTED (quotes should strip)", key)
+	}
+}
+
+func TestResolveDeeplineKey_SingleQuotedValue(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", `DEEPLINE_API_KEY='dlp_SINGLE'`+"\n", 0o600)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_SINGLE" {
+		t.Fatalf("key=%q; want dlp_SINGLE", key)
+	}
+}
+
+func TestResolveDeeplineKey_CommentsAndBlanksIgnored(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	body := "# Deepline auth status\n\n# saved 2026-04-28\nDEEPLINE_API_KEY=dlp_AFTER_COMMENTS\n"
+	writeKeyFile(t, fakeHome, "code-deepline-com", body, 0o600)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_AFTER_COMMENTS" {
+		t.Fatalf("key=%q; want dlp_AFTER_COMMENTS", key)
+	}
+}
+
+func TestResolveDeeplineKey_ExportPrefixHandled(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "export DEEPLINE_API_KEY=dlp_EXPORTED\n", 0o600)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_EXPORTED" {
+		t.Fatalf("key=%q; want dlp_EXPORTED", key)
+	}
+}
+
+func TestResolveDeeplineKey_GroupReadableFileSkipped(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_LOOSE\n", 0o644)
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty (mode 0644 should skip)", key, source)
+	}
+	if len(skips) == 0 || !strings.Contains(skips[0], "mode 0644") {
+		t.Fatalf("expected 'mode 0644' skip reason; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_Mode0400Accepted(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_READONLY\n", 0o400)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_READONLY" {
+		t.Fatalf("key=%q; want dlp_READONLY (mode 0400 should be accepted)", key)
+	}
+}
+
+func TestResolveDeeplineKey_SymlinkOutsideHomeRejected(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	// Build a real key file outside the fake home.
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "stolen.env")
+	if err := os.WriteFile(outsideFile, []byte("DEEPLINE_API_KEY=dlp_ESCAPED\n"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	// Create a symlink from inside the fake home that points at it.
+	dir := filepath.Join(fakeHome, ".local", "deepline", "code-deepline-com")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	link := filepath.Join(dir, ".env")
+	if err := os.Symlink(outsideFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty (symlink escape should skip)", key, source)
+	}
+	if len(skips) == 0 || !strings.Contains(skips[0], "symlink escapes home directory") {
+		t.Fatalf("expected escape skip reason; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_NoFlagNoEnvNoFile(t *testing.T) {
+	withFakeHome(t, t.TempDir())
+	key, source := resolveDeeplineKey("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty empty", key, source)
+	}
+}
+
+func TestResolveDeeplineKey_BadPrefixSkipped(t *testing.T) {
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dpl_VERCEL_PREFIX\n", 0o600)
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty (bad prefix should skip)", key, source)
+	}
+	if len(skips) == 0 || !strings.Contains(skips[0], "missing dlp_ prefix") {
+		t.Fatalf("expected prefix skip reason; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_FileNotInDirectorySilent(t *testing.T) {
+	// $HOME exists but no ~/.local/deepline directory at all — the common
+	// case for users without the sibling CLI installed. Should be a clean
+	// empty return with NO skip reasons (not a security skip, just absent).
+	withFakeHome(t, t.TempDir())
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty", key, source)
+	}
+	if len(skips) != 0 {
+		t.Fatalf("expected no skip reasons when sibling CLI absent; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_FlagDoesNotTriggerFileScan(t *testing.T) {
+	// When the flag is provided, the resolver must short-circuit and never
+	// touch the filesystem. We assert this by setting deeplineHomeFunc to a
+	// function that fails the test if called.
+	fakeHome := t.TempDir()
+	called := false
+	prev := deeplineHomeFunc
+	deeplineHomeFunc = func() (string, error) {
+		called = true
+		return fakeHome, nil
+	}
+	t.Cleanup(func() { deeplineHomeFunc = prev })
+	t.Setenv("DEEPLINE_API_KEY", "")
+	key, source := resolveDeeplineKey("dlp_FLAG")
+	if key != "dlp_FLAG" || source != "flag" {
+		t.Fatalf("got (%q,%q); want (dlp_FLAG, flag)", key, source)
+	}
+	if called {
+		t.Fatal("resolver touched the filesystem when flag was set")
+	}
+}
+
+func TestModeOctalFormatting(t *testing.T) {
+	// Spot-check the small helper so a regex-based skip-reason assertion
+	// elsewhere can rely on the exact rendering.
+	cases := []struct {
+		mode os.FileMode
+		want string
+	}{
+		{0o600, "0600"},
+		{0o644, "0644"},
+		{0o400, "0400"},
+		{0o777, "0777"},
+		{0o000, "0000"},
+	}
+	for _, c := range cases {
+		got := modeOctal(c.mode)
+		if got != c.want {
+			t.Errorf("modeOctal(%o)=%q; want %q", c.mode, got, c.want)
+		}
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/doctor.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/doctor.go
@@ -508,15 +508,17 @@ func keyTail(key string) string {
 }
 
 // checkDeepline populates doctor's Deepline fields. We NEVER echo the API
-// key value: only "set"/"not set", the prefix validity, and whether the
-// official CLI is on PATH (informational, not required).
+// key value: only the source it came from ("flag" / "env" / "file:<path>" /
+// "not found"), the prefix validity, and whether the official CLI is on
+// PATH. The source attribution is what makes auto-discovery visible without
+// trading off any secret-handling guarantees.
 func checkDeepline(report map[string]any) {
-	key := os.Getenv("DEEPLINE_API_KEY")
+	key, source, skips := resolveDeeplineKeyWithSkips("")
 	if key == "" {
 		report["deepline_env"] = "not set"
-		report["deepline_hint"] = "export DEEPLINE_API_KEY=dlp_... (Deepline CLI falls back to HTTP when the `deepline` binary isn't on PATH)"
+		report["deepline_hint"] = "export DEEPLINE_API_KEY=dlp_..., pass --deepline-key dlp_..., or run 'deepline auth status --reveal' if you've already authenticated with the Deepline CLI"
 	} else {
-		report["deepline_env"] = "set"
+		report["deepline_env"] = "set (" + source + ")"
 		if strings.HasPrefix(key, "dlp_") {
 			report["deepline_prefix"] = "ok (dlp_)"
 		} else if strings.HasPrefix(key, "dpl_") {
@@ -526,8 +528,18 @@ func checkDeepline(report map[string]any) {
 		}
 	}
 
+	// Surface any sibling-CLI candidate files that were rejected during
+	// discovery. This lets the user fix a mode-too-loose or wrong-prefix
+	// problem without re-deriving the resolver's logic. Skips are paths +
+	// reasons; never key values.
+	if len(skips) > 0 {
+		report["deepline_discovery_skipped"] = skips
+	}
+
 	// Informational: is the official CLI on PATH? Not required — we have
-	// an HTTP fallback.
+	// an HTTP fallback. When auto-discovery is in play (source starts with
+	// "file:"), this also explains where the key came from at the file
+	// system level for users tracing the trust chain.
 	if path, err := exec.LookPath("deepline"); err == nil {
 		report["deepline_cli"] = fmt.Sprintf("found: %s", path)
 	} else {

--- a/library/sales-and-crm/contact-goat/internal/cli/dossier.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/dossier.go
@@ -65,8 +65,8 @@ is passed. Pass --enrich-email to spend Deepline credits for email/phone.`,
 			// key is missing rather than letting the dossier run through
 			// LinkedIn + Happenstance before surfacing the auth gap.
 			if shouldPreflightDossier(sections, enrichEmail) {
-				if key := firstNonEmpty(deeplineKey, os.Getenv("DEEPLINE_API_KEY")); key == "" {
-					return authErr(fmt.Errorf("dossier --enrich-email needs DEEPLINE_API_KEY (set env or pass --deepline-key)\nhint: keys at https://code.deepline.com/dashboard/api-keys"))
+				if key, _ := resolveDeeplineKey(deeplineKey); key == "" {
+					return authErr(fmt.Errorf("dossier --enrich-email needs DEEPLINE_API_KEY (set env or pass --deepline-key)\nhint: keys at https://code.deepline.com/dashboard/api-keys\n      or run 'deepline auth status --reveal' if you've already authenticated with the Deepline CLI"))
 				}
 			}
 
@@ -126,10 +126,7 @@ is passed. Pass --enrich-email to spend Deepline credits for email/phone.`,
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					key := deeplineKey
-					if key == "" {
-						key = os.Getenv("DEEPLINE_API_KEY")
-					}
+					key, _ := resolveDeeplineKey(deeplineKey)
 					if key == "" {
 						dlErr = errors.New("no Deepline API key")
 						return

--- a/library/sales-and-crm/contact-goat/internal/cli/preflight.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/preflight.go
@@ -27,14 +27,13 @@ import (
 //
 // dlFlags may be nil; when nil, only DEEPLINE_API_KEY env is checked.
 func requireDeeplineKey(dlFlags *deeplineFlags) error {
-	key := ""
+	flagValue := ""
 	if dlFlags != nil {
-		key = dlFlags.resolveKey()
-	} else {
-		key = os.Getenv("DEEPLINE_API_KEY")
+		flagValue = dlFlags.apiKey
 	}
+	key, _ := resolveDeeplineKey(flagValue)
 	if strings.TrimSpace(key) == "" {
-		return authErr(fmt.Errorf("%w\nhint: export DEEPLINE_API_KEY=dlp_... (keys at https://code.deepline.com/dashboard/api-keys)\n      or pass --deepline-key dlp_... where the flag is available",
+		return authErr(fmt.Errorf("%w\nhint: export DEEPLINE_API_KEY=dlp_... (keys at https://code.deepline.com/dashboard/api-keys)\n      or pass --deepline-key dlp_... where the flag is available\n      or run 'deepline auth status --reveal' if you've already authenticated with the Deepline CLI",
 			deepline.ErrMissingKey))
 	}
 	if !strings.HasPrefix(key, deepline.KeyPrefix) {
@@ -70,7 +69,7 @@ func preflightWaterfallDeepline(dlKey string, requireBYOK bool, byok map[string]
 		return nil
 	}
 	if strings.TrimSpace(dlKey) == "" {
-		return authErr(fmt.Errorf("%w\nhint: waterfall needs either DEEPLINE_API_KEY (see https://code.deepline.com/dashboard/api-keys)\n      or --byok with configured BYOK providers (`config byok set hunter HUNTER_API_KEY`)",
+		return authErr(fmt.Errorf("%w\nhint: waterfall needs either DEEPLINE_API_KEY (see https://code.deepline.com/dashboard/api-keys)\n      or --byok with configured BYOK providers (`config byok set hunter HUNTER_API_KEY`)\n      or run 'deepline auth status --reveal' if you've already authenticated with the Deepline CLI",
 			deepline.ErrMissingKey))
 	}
 	if !strings.HasPrefix(dlKey, deepline.KeyPrefix) {

--- a/library/sales-and-crm/contact-goat/internal/cli/prospect.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/prospect.go
@@ -8,7 +8,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -160,10 +159,7 @@ Results are deduped across sources and ranked by one of:
 				if budget <= 0 {
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: --deepline set but --budget=%d; Deepline skipped\n", budget)
 				} else {
-					key := deeplineKey
-					if key == "" {
-						key = os.Getenv("DEEPLINE_API_KEY")
-					}
+					key, _ := resolveDeeplineKey(deeplineKey)
 					if key == "" {
 						fmt.Fprintln(cmd.ErrOrStderr(), "warning: no Deepline API key (set DEEPLINE_API_KEY or pass --deepline-key); Deepline skipped")
 					} else if !flags.yes {

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
@@ -114,7 +114,8 @@ Configure BYOK keys with:
 			// ultimately where the work gets done; without a path to it the
 			// whole waterfall can't satisfy the typical --enrich email,phone
 			// ask.
-			if err := preflightWaterfallDeepline(os.Getenv("DEEPLINE_API_KEY"), requireBYOK, byok); err != nil {
+			dlKey, _ := resolveDeeplineKey("")
+			if err := preflightWaterfallDeepline(dlKey, requireBYOK, byok); err != nil {
 				return err
 			}
 
@@ -376,7 +377,8 @@ func runDeeplineChain(ctx context.Context, flags *rootFlags, target string, fiel
 		return
 	}
 
-	client := deepline.NewClient(os.Getenv("DEEPLINE_API_KEY"))
+	dlKey, _ := resolveDeeplineKey("")
+	client := deepline.NewClient(dlKey)
 	if err := client.ValidateKey(); err != nil {
 		// One synthetic step surfaces the auth gate failure rather than
 		// emitting N copies (one per provider in the chain).


### PR DESCRIPTION
## Summary

Closes the UX gap where contact-goat reported "API key required" even when the user had the official Deepline CLI installed and authenticated. The key was on disk at `~/.local/deepline/<host>/.env` (mode 0600); contact-goat just wasn't looking.

A single resolver now checks three sources in priority order:
1. `--deepline-key` flag
2. `DEEPLINE_API_KEY` env
3. `~/.local/deepline/<host>/.env` (auto-discovered, with security guards)

All six existing call sites (waterfall ×2, dossier ×2, prospect, deepline subcommands, preflight, doctor) route through the resolver — explicit signals always win over file discovery. Doctor surfaces the resolution source as `set (env)` / `set (flag)` / `set (file:~/.local/...)` / `not set` and lists any candidate files rejected on security grounds.

## Changes

- **`internal/cli/deepline_key_resolver.go`** (new) — resolveDeeplineKey + resolveDeeplineKeyWithSkips with sandboxed home accessor. Refuses files outside `$HOME`, broken/escaping symlinks, group/world-readable modes (0644+), missing `dlp_` prefix, and empty values.
- **`internal/cli/deepline_key_resolver_test.go`** (new) — 17 scenarios covering flag/env/file precedence, preferred host slug (`code-deepline-com`), lexical fallback, quoted/exported/empty/comment values, mode 0400 accepted, mode 0644 rejected, symlink-out-of-home rejected, bad-prefix rejected.
- **`internal/cli/{deepline,preflight,prospect,dossier,waterfall,doctor}.go`** — every `os.Getenv("DEEPLINE_API_KEY")` call site replaced with the resolver. No callers stayed on the raw env path.
- **`internal/cli/doctor.go`** — `checkDeepline` now reports `deepline_env` with source attribution + optional `deepline_discovery_skipped` array (paths + reasons; never values).
- **Error hints** — every missing-key path now mentions `deepline auth status --reveal` alongside the existing export and `--deepline-key` options.
- **`SKILL.md`** + **`README.md`** — document the auto-discovery path; agents read doctor's source attribution before asking the user to re-export.
- **`cli-skills/pp-contact-goat/SKILL.md`** — regenerated mirror per AGENTS.md "Keeping cli-skills/ in sync".

## Test plan

- [x] `go test ./internal/cli/ -run TestResolveDeeplineKey` — 17 pass
- [x] `go test ./...` — 239 pass across 13 packages
- [x] `go vet ./...` — clean
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/sales-and-crm/contact-goat/` — all checks pass (flag-names, flag-commands, positional-args, unknown-command)
- [x] No release-owned files modified (`plugin.json`, `marketplace.json`, `CHANGELOG.md` untouched)

## Plan

`docs/plans/2026-04-28-001-feat-contact-goat-deepline-key-discovery-plan.md` — 6 implementation units (U1 resolver + tests, U2 wire 6 call sites, U3 doctor source attribution, U4 error hints, U5 docs, U6 cli-skills regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)