### PR TITLE
fix(cli): contact-goat — accept Deepline CLI's actual file mode (0644)

### DIFF
--- a/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver.go
@@ -19,7 +19,13 @@
 //
 //   - File must be under $HOME (no path traversal escape, no symlinks pointing
 //     outside $HOME).
-//   - File must have mode 0600 or 0400 — group/world readability disqualifies.
+//   - File must NOT be group- or world-writable. The threat model is: a
+//     non-owner process substituting a malicious key while we read it. Any
+//     write bit outside the owner triple disqualifies the file. Read-only
+//     looseness (e.g., mode 0644 — what the official Deepline CLI actually
+//     writes) is accepted; "anyone can read but only owner can write" is the
+//     upstream sibling tool's choice and refusing it would defeat the whole
+//     auto-discovery feature.
 //   - Value must start with "dlp_" (the Deepline key prefix) — otherwise we
 //     skip the file rather than emit a malformed key.
 //   - Empty values are skipped, not returned with an empty source.
@@ -166,7 +172,8 @@ func discoverDeeplineKeyFromSiblingCLIWithSkips() (key, path string, skips []str
 // Guards (in order):
 //
 //   - Lstat — symlink whose target leaves $HOME is rejected.
-//   - Mode  — group or world readability is rejected.
+//   - Mode  — group or world WRITE access is rejected. Read access is
+//             accepted because the upstream sibling CLI writes mode 0644.
 //   - Parse — non-quoted KEY=VALUE per line, comments and blanks ignored.
 //   - Prefix — value must start with "dlp_".
 //   - Empty — DEEPLINE_API_KEY="" falls through (no error, no key).
@@ -204,8 +211,14 @@ func readDeeplineEnvFile(envPath, home string) (key, skipReason string) {
 	}
 
 	mode := info.Mode().Perm()
-	if mode&0o077 != 0 {
-		return "", "skipped: mode " + modeOctal(mode) + " (must be 0600 or 0400)"
+	// Reject only group/world WRITE bits. World/group READ is acceptable —
+	// the official Deepline CLI writes the .env file at mode 0644, and
+	// rejecting that would defeat auto-discovery. The trust property is
+	// "no other principal can substitute the key"; read access by other
+	// users on a single-user workstation isn't a credential-substitution
+	// vector.
+	if mode&0o022 != 0 {
+		return "", "skipped: mode " + modeOctal(mode) + " is group- or world-writable (chmod g-w,o-w to fix)"
 	}
 
 	data, err := os.ReadFile(envPath)

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline_key_resolver_test.go
@@ -22,9 +22,10 @@ func withFakeHome(t *testing.T, dir string) {
 }
 
 // writeKeyFile writes a sibling-CLI .env file under fakeHome at the given
-// host slug with mode 0600. The intermediate directories are created with
-// permissive-but-test-only perms (0700) since the resolver only checks the
-// .env file's mode, not its parents.
+// host slug with mode `mode`. We chmod after WriteFile because the OS umask
+// would otherwise strip group/world bits from the requested perms — without
+// this, asking for 0664 silently yields 0644 on a default-umask macOS box,
+// which would mask the very test cases that exist to catch loose modes.
 func writeKeyFile(t *testing.T, fakeHome, slug, body string, mode os.FileMode) string {
 	t.Helper()
 	dir := filepath.Join(fakeHome, ".local", "deepline", slug)
@@ -34,6 +35,9 @@ func writeKeyFile(t *testing.T, fakeHome, slug, body string, mode os.FileMode) s
 	envPath := filepath.Join(dir, ".env")
 	if err := os.WriteFile(envPath, []byte(body), mode); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(envPath, mode); err != nil {
+		t.Fatalf("chmod: %v", err)
 	}
 	return envPath
 }
@@ -156,16 +160,46 @@ func TestResolveDeeplineKey_ExportPrefixHandled(t *testing.T) {
 	}
 }
 
-func TestResolveDeeplineKey_GroupReadableFileSkipped(t *testing.T) {
+func TestResolveDeeplineKey_Mode0644Accepted(t *testing.T) {
+	// The official Deepline CLI writes the .env file at mode 0644. Auto-
+	// discovery must accept that mode — rejecting it would defeat the
+	// feature. The security boundary is group/world WRITE, not READ. (See
+	// TestResolveDeeplineKey_GroupWritableRejected for the negative case.)
 	fakeHome := t.TempDir()
 	withFakeHome(t, fakeHome)
-	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_LOOSE\n", 0o644)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_UPSTREAM_DEFAULT\n", 0o644)
+	key, _ := resolveDeeplineKey("")
+	if key != "dlp_UPSTREAM_DEFAULT" {
+		t.Fatalf("key=%q; want dlp_UPSTREAM_DEFAULT (mode 0644 must be accepted — Deepline CLI writes this mode)", key)
+	}
+}
+
+func TestResolveDeeplineKey_GroupWritableRejected(t *testing.T) {
+	// Group-writable means a non-owner principal could substitute the key
+	// before we read it. Refuse.
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_TAMPERABLE\n", 0o664)
 	key, source, skips := resolveDeeplineKeyWithSkips("")
 	if key != "" || source != "" {
-		t.Fatalf("got (%q,%q); want empty (mode 0644 should skip)", key, source)
+		t.Fatalf("got (%q,%q); want empty (group-writable mode 0664 must skip)", key, source)
 	}
-	if len(skips) == 0 || !strings.Contains(skips[0], "mode 0644") {
-		t.Fatalf("expected 'mode 0644' skip reason; got %v", skips)
+	if len(skips) == 0 || !strings.Contains(skips[0], "0664") {
+		t.Fatalf("expected mode 0664 in skip reason; got %v", skips)
+	}
+}
+
+func TestResolveDeeplineKey_WorldWritableRejected(t *testing.T) {
+	// World-writable is the canonical credential-substitution risk.
+	fakeHome := t.TempDir()
+	withFakeHome(t, fakeHome)
+	writeKeyFile(t, fakeHome, "code-deepline-com", "DEEPLINE_API_KEY=dlp_TAMPERABLE\n", 0o666)
+	key, source, skips := resolveDeeplineKeyWithSkips("")
+	if key != "" || source != "" {
+		t.Fatalf("got (%q,%q); want empty (world-writable mode 0666 must skip)", key, source)
+	}
+	if len(skips) == 0 || !strings.Contains(skips[0], "0666") {
+		t.Fatalf("expected mode 0666 in skip reason; got %v", skips)
 	}
 }
 

--- a/library/sales-and-crm/contact-goat/internal/cli/preflight_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/preflight_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestRequireDeeplineKeyMissing(t *testing.T) {
-	t.Setenv("DEEPLINE_API_KEY", "")
+	// Sandbox $HOME so the resolver's file-discovery step can't find the
+	// real ~/.local/deepline/<host>/.env on the dev machine. Without this,
+	// "no env/flag" doesn't actually mean "no key" — auto-discovery would
+	// pick up the user's real key and the assertion would flip.
+	withFakeHome(t, t.TempDir())
 	err := requireDeeplineKey(&deeplineFlags{})
 	if err == nil {
 		t.Fatal("requireDeeplineKey with no env/flag should error")
@@ -21,6 +25,7 @@ func TestRequireDeeplineKeyMissing(t *testing.T) {
 }
 
 func TestRequireDeeplineKeyMalformed(t *testing.T) {
+	withFakeHome(t, t.TempDir())
 	t.Setenv("DEEPLINE_API_KEY", "foo_not_dlp")
 	err := requireDeeplineKey(&deeplineFlags{})
 	if err == nil {
@@ -32,7 +37,7 @@ func TestRequireDeeplineKeyMalformed(t *testing.T) {
 }
 
 func TestRequireDeeplineKeyFromFlag(t *testing.T) {
-	t.Setenv("DEEPLINE_API_KEY", "")
+	withFakeHome(t, t.TempDir())
 	if err := requireDeeplineKey(&deeplineFlags{apiKey: "dlp_abc"}); err != nil {
 		t.Errorf("flag key should satisfy preflight: %v", err)
 	}


### PR DESCRIPTION
## Summary

The auto-discovery mode check from #150 was wrong about the security boundary. It required mode 0600/0400 on the sibling-CLI key file, but the official Deepline CLI writes `~/.local/deepline/<host>/.env` at mode 0644 — so the strict check rejected exactly the file the feature was meant to find.

End-to-end verification on a real machine after #150 merged:

```
$ unset DEEPLINE_API_KEY
$ contact-goat-pp-cli doctor --agent --json | jq .deepline_env
"not set"     # bug — key file exists, mode 0644, valid dlp_ prefix
```

After this fix:

```
$ contact-goat-pp-cli doctor --agent --json | jq .deepline_env
"set (file:/Users/.../code-deepline-com/.env)"
```

## Security re-analysis

The mode guard exists to block "another principal substitutes a malicious key file before we read it." The relevant boundary is therefore **write access by non-owners**, not read access. Mode 0644 means owner-write + everyone-read; an attacker can read the key (bad on a multi-user box but not a credential-substitution vector) but cannot replace it.

New rule: reject only group/world WRITE bits (`mode & 0o022`). Read access is accepted because the upstream sibling tool sets the file that way.

## Changes

- **`internal/cli/deepline_key_resolver.go`** — mask changed from `0o077` (any group/world bit) to `0o022` (group/world write bits only). Doc comments updated to explain the trust model.
- **`internal/cli/deepline_key_resolver_test.go`** — replaced `TestResolveDeeplineKey_GroupReadableFileSkipped` (0644 rejected) with three new tests: `Mode0644Accepted` (positive), `GroupWritableRejected` (0664), `WorldWritableRejected` (0666). The `writeKeyFile` helper now chmods explicitly after WriteFile so umask doesn't silently strip the bits the negative tests exist to catch.
- **`internal/cli/preflight_test.go`** — `TestRequireDeeplineKeyMissing`, `Malformed`, and `FromFlag` now sandbox `$HOME` via the `withFakeHome` helper so the resolver's file-discovery step cannot pick up the dev's real key during "missing key" assertions. Same bug shape as the production one.

## Test plan

- [x] `go test ./...` — 241 pass across 13 packages
- [x] `go vet ./...` — clean
- [x] Live verification: with `DEEPLINE_API_KEY` unset and the file at `~/.local/deepline/code-deepline-com/.env` (mode 0644), `doctor` reports `set (file:...)` and `waterfall --dry-run` passes preflight
- [x] No release-owned files modified

## Origin

Bug observed during the post-merge verification of #150. Worth landing immediately because #150 shipped a feature that doesn't work for the canonical use case (default Deepline CLI install) without this follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)