### PR TITLE
chore: remove leftover per-CLI smithery.yaml files

### DIFF
--- a/docs/plans/2026-04-19-001-feat-ppl-brew-of-clis-and-distribution-plan.md
+++ b/docs/plans/2026-04-19-001-feat-ppl-brew-of-clis-and-distribution-plan.md
@@ -617,7 +617,7 @@ Tap model: `~/.pp/taps/mvanhorn-printing-press-library/` is a git clone. `ppl ta
 - Happy path (per CLI): tag `<cli>/v<x>` -> GH Release + tap PR + NPM publish + registry PR -> `brew install`, `npx`, and `ppl install` all succeed for that CLI.
 - Edge case: a CLI whose binary name differs from its registry name (dominos-pp-cli) -> workflow picks the correct archive, formula file is `dominos-pp-cli.rb`, NPM package is `@printing-press/dominos-pp-cli`.
 - Edge case: a CLI with both `<cli>-pp-cli` and `<cli>-pp-mcp` binaries -> brew formula installs both into `bin/`, NPM ships both binaries in the platform package.
-- Error path: a CLI fails goreleaser build (e.g. broken smithery.yaml) -> other CLIs in the same wave are unaffected; that CLI blocks until fixed; release log records the failure.
+- Error path: a CLI fails goreleaser build (e.g. broken go.mod or compile error) -> other CLIs in the same wave are unaffected; that CLI blocks until fixed; release log records the failure.
 - Integration: `/ppl install espn cli` on a machine with `ppl` on PATH -> skill delegates to `ppl install espn`, prints the same outcome as before.
 - Integration: `/ppl install espn cli` on a machine without `ppl` -> skill falls back to `go install` path and still works.
 

--- a/library/commerce/yahoo-finance/smithery.yaml
+++ b/library/commerce/yahoo-finance/smithery.yaml
@@ -1,4 +1,0 @@
-name: yahoo-finance-pp-mcp
-description: yahoo-finance API
-startCommand:
-    command: go run ./cmd/yahoo-finance-pp-mcp

--- a/library/developer-tools/company-goat/smithery.yaml
+++ b/library/developer-tools/company-goat/smithery.yaml
@@ -1,4 +1,0 @@
-name: company-goat-pp-mcp
-description: company API
-startCommand:
-    command: go run ./cmd/company-goat-pp-mcp

--- a/library/food-and-dining/allrecipes/smithery.yaml
+++ b/library/food-and-dining/allrecipes/smithery.yaml
@@ -1,4 +1,0 @@
-name: allrecipes-pp-mcp
-description: allrecipes API
-startCommand:
-    command: go run ./cmd/allrecipes-pp-mcp

--- a/library/food-and-dining/food52/smithery.yaml
+++ b/library/food-and-dining/food52/smithery.yaml
@@ -1,4 +1,0 @@
-name: food52-pp-mcp
-description: food52 API
-startCommand:
-    command: go run ./cmd/food52-pp-mcp

--- a/library/food-and-dining/recipe-goat/smithery.yaml
+++ b/library/food-and-dining/recipe-goat/smithery.yaml
@@ -1,8 +1,0 @@
-name: recipe-goat-pp-mcp
-description: recipe-goat API
-startCommand:
-    command: go run ./cmd/recipe-goat-pp-mcp
-env:
-    USDA_FDC_API_KEY:
-        description: recipe-goat API credential
-        required: true

--- a/library/marketing/dub/smithery.yaml
+++ b/library/marketing/dub/smithery.yaml
@@ -1,8 +1,0 @@
-name: dub-pp-mcp
-description: dub API
-startCommand:
-    command: go run ./cmd/dub-pp-mcp
-env:
-    DUB_TOKEN:
-        description: dub API credential
-        required: true

--- a/library/marketing/producthunt/smithery.yaml
+++ b/library/marketing/producthunt/smithery.yaml
@@ -1,4 +1,0 @@
-name: producthunt-pp-mcp
-description: producthunt API
-startCommand:
-    command: go run ./cmd/producthunt-pp-mcp

--- a/library/media-and-entertainment/espn/smithery.yaml
+++ b/library/media-and-entertainment/espn/smithery.yaml
@@ -1,4 +1,0 @@
-name: espn-pp-mcp
-description: espn API
-startCommand:
-    command: go run ./cmd/espn-pp-mcp

--- a/library/media-and-entertainment/hackernews/smithery.yaml
+++ b/library/media-and-entertainment/hackernews/smithery.yaml
@@ -1,4 +1,0 @@
-name: hackernews-pp-mcp
-description: hackernews API
-startCommand:
-    command: go run ./cmd/hackernews-pp-mcp

--- a/library/media-and-entertainment/movie-goat/smithery.yaml
+++ b/library/media-and-entertainment/movie-goat/smithery.yaml
@@ -1,8 +1,0 @@
-name: movie-goat-pp-mcp
-description: movie-goat-pp-cli API
-startCommand:
-    command: go run ./cmd/movie-goat-pp-mcp
-env:
-    TMDB_API_KEY:
-        description: movie-goat-pp-cli API credential
-        required: true

--- a/library/other/weather-goat/smithery.yaml
+++ b/library/other/weather-goat/smithery.yaml
@@ -1,4 +1,0 @@
-name: weather-goat-pp-mcp
-description: weather-goat API
-startCommand:
-    command: go run ./cmd/weather-goat-pp-mcp

--- a/library/payments/kalshi/smithery.yaml
+++ b/library/payments/kalshi/smithery.yaml
@@ -1,8 +1,0 @@
-name: kalshi-trade-manual-pp-mcp
-description: kalshi-trade-manual API
-startCommand:
-    command: go run ./cmd/kalshi-trade-manual-pp-mcp
-env:
-    KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY:
-        description: kalshi-trade-manual API credential
-        required: true

--- a/library/productivity/cal-com/smithery.yaml
+++ b/library/productivity/cal-com/smithery.yaml
@@ -1,8 +1,0 @@
-name: cal-com-pp-mcp
-description: cal-com API
-startCommand:
-    command: go run ./cmd/cal-com-pp-mcp
-env:
-    CAL_COM_TOKEN:
-        description: cal-com API credential
-        required: true

--- a/library/sales-and-crm/contact-goat/smithery.yaml
+++ b/library/sales-and-crm/contact-goat/smithery.yaml
@@ -1,8 +1,0 @@
-name: contact-goat-pp-mcp
-description: contact-goat-pp-cli API
-startCommand:
-    command: go run ./cmd/contact-goat-pp-mcp
-env:
-    HAPPENSTANCE_WEB_APP_COOKIE_AUTH:
-        description: contact-goat-pp-cli API credential
-        required: true


### PR DESCRIPTION
## Summary

14 stale per-CLI \`smithery.yaml\` files in the library, plus one plan doc reference.

Smithery (smithery.ai) was an early MCP marketplace experiment we never adopted. The top-level \`smithery.yaml\` was removed from cli-printing-press in mvanhorn/cli-printing-press#363 (megamcp removal), but the per-CLI files were left behind. They:

- Use \`go run ./cmd/<api>-pp-mcp\` as \`startCommand\` — points at a source-build flow that requires Smithery's hosting, which we don't ship to
- Have stub descriptions (e.g. "dub API") that don't match the registry's curated descriptions
- Aren't emitted by the current cli-printing-press generator (verified — zero smithery references in the generator codebase), so deleting them doesn't risk recreation on next regen

## Current MCP distribution channels

None of these involve Smithery:
1. MCPB bundles for Claude Desktop drag-drop install
2. \`/pp-<api>\` agent skills (cross-client install via the \`printing-press-library\` plugin marketplace)
3. \`go install ...@latest\` for power users wiring per-CLI MCP servers into any client

## Diff

- 14 \`smithery.yaml\` files deleted
- 1 plan doc edit (replaced "broken smithery.yaml" example in goreleaser error path with "broken go.mod or compile error")
- Net -80 lines

## Verification

- \`grep -r smithery library/\` returns nothing after the deletion
- \`grep -r smithery\` across the rest of the repo returns only references in completed plan docs (historical record, intentionally untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)