### PR TITLE
fix(cli): scrape-creators cursor/page/min-time pagination flags as strings

### DIFF
--- a/docs/plans/2026-04-30-001-fix-cli-float-pagination-encoding-plan.md
+++ b/docs/plans/2026-04-30-001-fix-cli-float-pagination-encoding-plan.md
@@ -1,0 +1,312 @@
+---
+title: "fix: Stop emitting Float64Var for cursor/page/timestamp pagination flags in generated CLIs"
+type: fix
+status: active
+date: 2026-04-30
+---
+
+# fix: Stop emitting Float64Var for cursor/page/timestamp pagination flags in generated CLIs
+
+## Overview
+
+Generated Printing Press CLIs declare cursor, page, and timestamp pagination flags as `Float64Var`. Go's default float formatter renders any value at or above ~10^6 in scientific notation (`1.740168616e+09`), and the upstream APIs reject those strings as invalid integer cursors. The bug stays hidden during page 1 and during local testing with small cursors (which round-trip as `30`, `60`, …), then breaks on every paginating call where the server returns a real Unix-second or Unix-millisecond cursor.
+
+This plan fixes the root cause in `cli-printing-press` (the generator) and re-emits the affected CLI in `printing-press-library`, with the scrape-creators CLI as the demonstration target. A secondary `client.go.tmpl` change cleans up a misleading dry-run formatter that prints `?` before every query parameter.
+
+This is a two-repo change. The generator PR is the durable fix; the library PR is the regenerated artifact.
+
+---
+
+## Problem Frame
+
+Observed during a TikTok follow-graph pull on 2026-04-30:
+
+1. `scrape-creators-pp-cli tiktok user-following --handle mattvanhorn24 --min-time 1740168616` returns
+   `HTTP 500: "Request failed with status code 400"`.
+2. `--dry-run` shows the param encoded as `min_time=1.740168616e+09`.
+3. The same URL with `min_time=1740168616` returns 200 from the upstream API.
+4. The flag is declared `cmd.Flags().Float64Var(&flagMinTime, "min-time", 0.0, ...)` in `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go:87`. Go's `fmt.Sprintf("%v", float64)` switches to scientific notation around magnitude 10^6.
+
+The bug is invisible until pagination crosses the scientific-notation boundary, which it always does for Unix-second timestamps and reliably does for Unix-millisecond cursors. Dry-run testing with small literals (`--cursor 30`) hides the bug entirely.
+
+The same flag-type mismatch affects 19 generated declarations across the scrape-creators CLI and 257 non-rate-limit `Float64Var` declarations across 171 generated files in `library/`. All will be remediated when the generator is fixed and the affected CLIs are regenerated; this plan ships the scrape-creators slice and leaves a follow-up unit for the rest of the library.
+
+A secondary cosmetic bug in the same area: the dry-run printer in the generated `internal/client/client.go` emits `?key=value` for every parameter, producing output that looks like `?handle=x ?min_time=...`. The actual HTTP request assembles correctly with `&`, but the printed preview misleads anyone debugging a paginated failure into suspecting URL malformation.
+
+---
+
+## Requirements Trace
+
+- R1. Generated CLIs must encode integer-valued query parameters (cursor, page, min_time, max_time, offset) as integers, never as scientific-notation floats.
+- R2. The fix must hold for every generated CLI in `printing-press-library`, not just scrape-creators — i.e., the change must live in the generator, not as a hand patch.
+- R3. Dry-run output must show a syntactically faithful preview of the URL: one `?` separator before the first parameter and `&` between subsequent parameters.
+- R4. The scrape-creators CLI must paginate `tiktok user-following`, `tiktok user-followers`, and at least one cursor-based endpoint end-to-end against the live API after regeneration.
+- R5. Generator behavior is regression-tested: a generator-level test fails if the OpenAPI `number`/`float` parameter type ever maps back to `Float64Var` for the param-name classes covered here.
+- R6. No breaking change to existing scripts that pass integer literals (`--min-time 1740168616`) — string-typed cobra flags accept any token.
+
+---
+
+## Scope Boundaries
+
+- Local-side `--rate-limit float` flags stay `Float64Var`. They are throttle ratios, not query parameters, and never feed into URL encoding.
+- `tiktok spikes --threshold float` stays `Float64Var`. It is a real engagement-rate multiplier, not a pagination cursor.
+- Upstream proxy error mapping (the 400→500 wrapping that surfaces "Request failed with status code 400") is owned by Scrape Creators; this plan does not attempt to change it.
+
+### Deferred to Follow-Up Work
+
+- Regeneration of the other 170 generated CLIs in `library/` carrying the same flag-type bug: a separate plan and PR after the scrape-creators slice merges. The fix is identical (regenerate); each CLI just needs its own smoke check. Tracked in a follow-up plan, not this one.
+- Replacing every existing `--cursor`/`--page`/`--min-time`/`--max-time`/`--offset` numeric default that scripts may currently pass as `0` — string default `""` is functionally equivalent because the generated client only includes the param when non-empty, but a downstream caller relying on Go's float zero-value semantics would need to switch to comparing against `""`.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Generator (`cli-printing-press`):**
+- `internal/generator/generator.go:2201` — `cobraFlagFunc(t string)` switch that maps `"float" → "Float64Var"`. This is the root mapping to change.
+- `internal/generator/generator.go:2086` — `isIDParam(name string)` — existing precedent for name-based type override (IDs that look numeric get `StringVar` regardless of declared spec type). This is the pattern to mirror for cursor/timestamp params.
+- `internal/generator/generator.go:2227` — `cobraFlagFuncForParam(name, t string)` — the per-param wrapper that already gates ID overrides; cursor/timestamp override belongs here.
+- `internal/generator/templates/client.go.tmpl:530-540` — dry-run printer that hardcodes `?` for each param. Needs first-iteration vs subsequent-iteration distinction.
+- `internal/generator/templates/command_endpoint.go.tmpl:530`, `internal/generator/templates/command_promoted.go.tmpl:225` — call sites that invoke `cobraFlagFuncForParam` for endpoint params.
+- `internal/generator/generator_test.go` — existing generator test file; new test cases extend this rather than create a new one.
+
+**Library (`printing-press-library`):**
+- `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go:87` — canonical example of the buggy declaration (`user-following --min-time`).
+- `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-2.go:89` — sibling case (`user-followers --min-time`).
+- 17 additional declarations across 18 files in `library/developer-tools/scrape-creators/internal/cli/` (cursor + page variants).
+- `library/developer-tools/scrape-creators/internal/client/client.go:341-348` — generated dry-run printer that exhibits the cosmetic bug.
+- The "DO NOT EDIT" header on every file: hand-patching the library is explicitly forbidden by the existing generator contract.
+
+### Institutional Learnings
+
+- `docs/solutions/` was scanned for existing learnings on Float64 / pagination / cobra flag typing — none found. This is the first documented occurrence of the class.
+- Existing convention from `isIDParam`: name-based overrides are how the generator handles "spec says number but runtime needs string" mismatches. Add a parallel `isCursorParam` rather than blanket-converting all floats.
+
+### External References
+
+- Go `strconv.FormatFloat` documentation: with `'g'` verb (which `fmt.Sprintf("%v", float64)` uses), values with magnitude ≥ 10^6 switch to scientific notation. This is the deterministic boundary that makes the bug appear at exactly the values pagination needs to handle.
+- Cobra `StringVar` accepts any token, integer literals included — the migration from `Float64Var` to `StringVar` is non-breaking for callers passing `--cursor 1740168616`.
+
+---
+
+## Key Technical Decisions
+
+- **Override at the generator, not the spec**: The OpenAPI specs on file declare cursor/timestamp params as `number` because that is what the upstream APIs document. Rewriting every spec would mean fighting the source of truth on every regeneration. Override in the generator's name-based classifier instead, mirroring how `isIDParam` already handles a parallel mismatch.
+- **Use `StringVar`, not `Int64Var`**: Some endpoints return cursors as opaque base64 tokens (`next_page_token: "eyJtYXhfY3Vyc29yI..."`), some return numeric strings, some return integers. `StringVar` handles all three uniformly and matches the pattern already used by `tiktok profile-videos --max-cursor string` (which works correctly today).
+- **Name-based classifier**: Add `isCursorParam(name)` covering `cursor`, `min_time`, `max_time`, `min_cursor`, `max_cursor`, `next_cursor`, `page`, `page_token`, `next_page_token`, `offset`. Keep the list narrow and obvious; do not blanket-convert every numeric param.
+- **Default value adjustment**: When the override flips a param from `Float64Var` to `StringVar`, the generated default changes from `0.0` to `""`. The downstream `if flagMinTime != 0.0` guard becomes `if flagMinTime != ""`, which is the correct way to detect "user didn't pass a value." The template already uses `defaultValForParam` and `cobraFlagFuncForParam` together, so they will agree if both consult the same classifier.
+- **Dry-run printer**: Range over `params` in deterministic order so subsequent fixes (e.g., snapshot tests) are stable. The current map iteration is non-deterministic; the new printer should sort keys before printing.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- _Should the fix live in the generator or the library?_ Generator. The library files carry "DO NOT EDIT" headers and a hand patch will be wiped on the next regeneration. User confirmed via planning question.
+- _StringVar or Int64Var for cursor types?_ StringVar — handles opaque tokens uniformly and matches the existing `tiktok profile-videos --max-cursor` precedent.
+- _Does this break callers?_ No. Cobra string flags accept integer literals. Scripts passing `--min-time 1740168616` continue to work.
+
+### Deferred to Implementation
+
+- Whether the per-CLI regen produces any unrelated diff drift (e.g., reformatted comments, version bumps in client.go) that should be split into its own commit. Decide while reviewing the regen output.
+- Whether the dry-run printer's deterministic key ordering should be alphabetical or insertion-preserving. Either is acceptable; pick whichever the existing template style favors when implementing.
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Add `isCursorParam` classifier and route through `cobraFlagFuncForParam`**
+
+**Goal:** Introduce a name-based override that returns `StringVar` for cursor, page, and timestamp pagination params regardless of the spec's declared `number`/`float` type, mirroring the existing `isIDParam` pattern.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/generator/generator.go` (in `cli-printing-press`)
+- Test: `internal/generator/generator_test.go` (in `cli-printing-press`)
+
+**Approach:**
+- Add `isCursorParam(name string) bool` next to `isIDParam`. Match suffix/exact comparisons against the documented set: `cursor`, `min_cursor`, `max_cursor`, `next_cursor`, `page`, `page_token`, `next_page_token`, `min_time`, `max_time`, `offset`.
+- Extend `cobraFlagFuncForParam(name, t string)` so a hit on `isCursorParam` returns `"StringVar"` regardless of `t`.
+- Extend `goTypeForParam(name, t string)` so the same names return `"string"`. The flag function and the field type must agree, otherwise the generated code won't compile.
+- Mirror the change anywhere `defaultValForParam` decides default values, so the StringVar's default becomes `""` instead of `0.0`.
+
+**Patterns to follow:**
+- `isIDParam` and its routing through `cobraFlagFuncForParam` and `goTypeForParam` — same shape, different name list.
+
+**Test scenarios:**
+- Happy path: `cobraFlagFuncForParam("cursor", "number")` returns `"StringVar"`.
+- Happy path: `cobraFlagFuncForParam("min_time", "integer")` returns `"StringVar"`.
+- Happy path: `cobraFlagFuncForParam("page", "number")` returns `"StringVar"`.
+- Edge case: `cobraFlagFuncForParam("page_size", "integer")` returns `"IntVar"` — `page_size` is not a cursor; only the documented names override.
+- Edge case: `cobraFlagFuncForParam("threshold", "number")` returns `"Float64Var"` — non-cursor floats still map to float.
+- Edge case: `goTypeForParam("min_time", "number")` returns `"string"` — the field type matches the flag function.
+- Regression: `cobraFlagFuncForParam("user_id", "integer")` still returns `"StringVar"` via `isIDParam` — the new classifier does not stomp the existing one.
+
+**Verification:**
+- New generator tests pass.
+- Re-running the generator for any CLI with cursor/page/min_time params emits `StringVar` with default `""` and `string` field types in the resulting Go file.
+
+---
+
+- [ ] U2. **Fix dry-run query-string formatter in `client.go.tmpl`**
+
+**Goal:** Print one `?` before the first query parameter and `&` between subsequent ones, so the dry-run preview is a faithful representation of the actual URL.
+
+**Requirements:** R3
+
+**Dependencies:** None (independent of U1; either can land first)
+
+**Files:**
+- Modify: `internal/generator/templates/client.go.tmpl` (in `cli-printing-press`)
+
+**Approach:**
+- Sort `params` keys before printing so output is deterministic.
+- Track whether any param has been printed; emit `?` for the first, `&` for subsequent.
+- Apply the same pattern to the auth-as-query-param sub-block (the `{{if and .Auth .Auth.In (eq .Auth.In "query")}}` branch in the template) so the auth line correctly uses `&` when other params preceded it.
+
+**Patterns to follow:**
+- Existing `path + "?" + strings.Join(parts, "&")` pattern at template line 87 — same idea, applied to the printer.
+
+**Test scenarios:**
+- Snapshot: dry-run of a single-param request prints exactly one `  ?key=value` line.
+- Snapshot: dry-run of a two-param request prints `  ?<first>=...` then `  &<second>=...` in deterministic order.
+- Snapshot: dry-run of a request with query-position auth prints `&<auth_param>=...` when other params preceded it.
+- Edge case: dry-run of a zero-param request prints no `?`/`&` line at all.
+
+**Verification:**
+- Snapshot test in the generator's template-render tests asserts the new output shape.
+- Regenerating any CLI and running `--dry-run` with two flags shows `?...` then `&...`.
+
+---
+
+- [ ] U3. **Regenerate scrape-creators CLI in `printing-press-library` and verify pagination end-to-end**
+
+**Goal:** Apply U1 and U2 to the live scrape-creators CLI by running the generator, commit the regenerated diff, and prove pagination works against the live API.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify (regenerated): `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go`, `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-2.go`, and the other 17 cli files identified in the float-flag inventory below.
+- Modify (regenerated): `library/developer-tools/scrape-creators/internal/client/client.go`
+- Test: `library/developer-tools/scrape-creators/internal/cli/tiktok_pagination_test.go` (new) — integration smoke test using the live API or a recorded fixture.
+
+**Approach:**
+- Run the same regeneration command the user already uses for scrape-creators (the generator's standard entry point against the existing `.printing-press.json`).
+- Commit the regenerated files in one commit so the diff is reviewable as "regen output of U1+U2."
+- Spot-check the diff: every formerly-`Float64Var` cursor/page/timestamp flag should now be `StringVar`, every formerly-`float64` field should now be `string`, every default `0.0` should be `""`, and `client.go` dry-run should use `&`.
+
+**Patterns to follow:**
+- Existing regen workflow used in prior plans under `library/developer-tools/`.
+
+**Test scenarios:**
+- Integration: `tiktok user-following --handle mattvanhorn24` paginates past page 1 with a real `min_time` cursor and returns ≥ 2 distinct pages with `has_more=false` on the last page.
+- Integration: `tiktok user-followers --handle mattvanhorn24 --min-time <large>` returns 200, not 500.
+- Integration: `tiktok video-comments --url <known-url> --cursor <real>` paginates past page 1.
+- Edge case: `--min-time 0` (zero) is not sent as a query param (string-empty guard works).
+- Edge case: `--min-time 30` (small int as string) round-trips correctly.
+- Snapshot: `--dry-run` output shows `?` then `&`, not `?` then `?`.
+- Regression: `tiktok profile-videos --max-cursor <ms-timestamp>` (already string-typed, already works) is not affected by the regeneration.
+
+**Verification:**
+- The full follow-graph fetch reproduced from the original bug report (paginating to ≥ 13 pages and recovering ≥ 260 entries) works through the CLI rather than requiring the direct-API workaround.
+- `go build ./...` and `go vet ./...` clean for the regenerated package.
+
+---
+
+- [ ] U4. **Open paired PRs and link them**
+
+**Goal:** Ship the fix as two reviewable PRs that reference each other, so a reviewer sees the generator change first and the library regen as the consequence.
+
+**Requirements:** R2
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- New PR 1 against `cli-printing-press` containing U1 and U2.
+- New PR 2 against `printing-press-library` containing U3.
+
+**Approach:**
+- PR 1 title: `fix: stop emitting Float64Var for cursor/page/timestamp pagination flags` against `cli-printing-press`. Body links to this plan and includes the encoding-boundary repro.
+- PR 2 title: `fix: regenerate scrape-creators CLI for cursor/page string-flag fix` against `printing-press-library`. Body links PR 1 and notes that the change is purely the regen output, no hand edits.
+- In PR 2, paste the before/after dry-run output for one cursor flag and the integration test result so reviewers can see the bug and the fix without running it themselves.
+- Note in PR 2 that 170 other generated CLIs in `library/` carry the same flag-type bug and a follow-up regen PR will batch them.
+
+**Test expectation:** none — this unit is PR mechanics, not behavioral.
+
+**Verification:**
+- Both PRs link to each other in their descriptions.
+- PR 1 is mergeable on its own; PR 2 is mergeable once PR 1 is merged and the generator binary is rebuilt.
+
+---
+
+## Affected scrape-creators files (regenerated by U3)
+
+This list is the inventory U3 should produce as a regenerated diff. If the regen output diverges from this list (more files affected, fewer, or different), investigate before committing.
+
+| File | Flag | Param name |
+|------|------|------------|
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go` | `--min-time` | user-following |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-2.go` | `--min-time` | user-followers |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-search.go` | `--cursor` | search-keyword |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-2.go` | `--cursor` | search-hashtag |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-3.go` | `--cursor` | search-top |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-4.go` | `--cursor` | search-users |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-song-2.go` | `--cursor` | song-videos |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-video.go` | `--cursor` | video-comment-replies |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-video-2.go` | `--cursor` | video-comments |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-videos.go` | `--page` | videos-popular |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-songs.go` | `--page` | songs-popular |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-hashtags.go` | `--page` | hashtags-popular |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list.go` | `--page` | creators-popular |
+| `library/developer-tools/scrape-creators/internal/cli/tiktok_list-shop-3.go` | `--page` | shop-search |
+| `library/developer-tools/scrape-creators/internal/cli/google_list-search.go` | `--page` | google search |
+| `library/developer-tools/scrape-creators/internal/cli/instagram_list-reels.go` | `--page` | instagram reels-search |
+| `library/developer-tools/scrape-creators/internal/cli/linkedin_list-company-2.go` | `--page` | linkedin company-posts |
+| `library/developer-tools/scrape-creators/internal/cli/promoted_tiktok.go` | `--page` | tiktok-related promoted call |
+| `library/developer-tools/scrape-creators/internal/client/client.go` | n/a | dry-run printer |
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The generator change ripples to every CLI in `library/` on regeneration. This plan only regenerates scrape-creators; other CLIs continue to carry the bug until their own regen.
+- **Error propagation:** The fix removes a silent client-side encoding error. Upstream proxy errors (the 400→500 wrap) are unchanged; users will now see the real upstream errors when they happen, not the fake-server errors caused by malformed cursors.
+- **State lifecycle risks:** None. The change is purely flag-typing and printer formatting; no persistent state.
+- **API surface parity:** Cobra string flags accept integer literals, so callers passing `--min-time 1740168616` see no change in invocation. Callers reading the flag's Go type inside the same binary do not exist (these are CLI-only flags).
+- **Unchanged invariants:** `--rate-limit float`, `--threshold float`, and any non-cursor numeric param continue to use float. The HTTP request-assembly path in `client.go` is unchanged; only the dry-run *printer* format changes.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Regenerating scrape-creators surfaces unrelated diff drift (comments, copyright years, formatting changes from a generator that's moved on since the last regen) | U3 commits the regen as a single commit; review-time check separates intentional change from drift; if drift is significant, split into "unrelated regen drift" and "U1/U2 effect" commits before opening the PR |
+| `isCursorParam`'s name list misses an endpoint that uses an unconventional cursor param name | The list is narrow on purpose; any escape gets caught in U3's integration spot-checks. If found, add to the list and re-test |
+| Some downstream code depends on the float zero-value to detect "not set" | Searched the generated codebase; the only consumer is the `if flag != 0.0` guard inside the same generated file, which becomes `if flag != ""` automatically when the type changes. No external consumer reads these flag values directly |
+| Default-value template (`defaultValForParam`) and flag-function template (`cobraFlagFuncForParam`) disagree about a cursor param, producing code that doesn't compile | U1 mandates that both consult the same classifier; the generator's existing test suite + a clean `go build` after regen catches any disagreement immediately |
+| Other 170 affected CLIs ship before they're regenerated, leaving them visibly broken on cursor pagination | They are no more broken than they are today; the follow-up plan handles them. Note explicitly in PR 2's description so users know the scope |
+
+---
+
+## Documentation / Operational Notes
+
+- The fix is invisible to end users who only use page 1 of any endpoint. Most TikTok scraping flows involve pagination, so most real users will benefit.
+- After PR 1 lands and the user updates their local `cli-printing-press` install, any future `pp install` of an existing or new CLI will pick up the fix automatically. The library PR 2 unblocks the scrape-creators CLI immediately for users who don't regenerate locally.
+- A short note in `cli-printing-press` `CHANGELOG.md` (if present) under "fixed" is sufficient. No public API change.
+
+---
+
+## Sources & References
+
+- Original bug observation and CLI debugging session: 2026-04-30 conversation with the user, paginating `tiktok user-following` for `@mattvanhorn24`.
+- Encoding-boundary probe results (small ints render literally, ≥ 10^6 flips to scientific notation): documented in the conversation under "Probe: float-encoding boundary."
+- Live-API confirmation that the URL difference between `min_time=1.740168616e+09` and `min_time=1740168616` is the entire problem: documented in the same probe.
+- Existing generator pattern that this change mirrors: `isIDParam` and its use sites in `internal/generator/generator.go`.

--- a/library/developer-tools/scrape-creators/internal/cli/cursor_flag_types_test.go
+++ b/library/developer-tools/scrape-creators/internal/cli/cursor_flag_types_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 adrian-horning. Licensed under Apache-2.0. See LICENSE.
+// Regression coverage for the cursor/page/min_time pagination encoding fix.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestCursorFlagsAreStringTyped ensures pagination flag declarations across the
+// generated cli package use StringVar rather than Float64Var. Float64Var causes
+// values >= ~10^6 to render in scientific notation (e.g. 1.740168616e+09), which
+// upstream APIs reject as invalid integer cursors.
+func TestCursorFlagsAreStringTyped(t *testing.T) {
+	cursorFlagPattern := regexp.MustCompile(`Flags\(\)\.Float64Var\([^,]+,\s*"(cursor|min-time|max-time|page|offset)"`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read internal/cli: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if m := cursorFlagPattern.FindString(string(body)); m != "" {
+			t.Errorf("%s: cursor pagination flag still typed as Float64Var: %s", name, m)
+		}
+	}
+}

--- a/library/developer-tools/scrape-creators/internal/cli/google_list-search.go
+++ b/library/developer-tools/scrape-creators/internal/cli/google_list-search.go
@@ -15,7 +15,7 @@ func newGoogleListSearchCmd(flags *rootFlags) *cobra.Command {
 	var flagQuery string
 	var flagRegion string
 	var flagDatePosted string
-	var flagPage float64
+	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "search",
@@ -43,7 +43,7 @@ func newGoogleListSearchCmd(flags *rootFlags) *cobra.Command {
 			if flagDatePosted != "" {
 				params["date_posted"] = fmt.Sprintf("%v", flagDatePosted)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			data, prov, err := resolveRead(c, flags, "google", false, path, params)
@@ -90,7 +90,7 @@ func newGoogleListSearchCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagQuery, "query", "", "Search query")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "2 letter country code, ie US, UK, CA, etc This will show results from that country")
 	cmd.Flags().StringVar(&flagDatePosted, "date-posted", "", "Date posted")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number to retrieve")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number to retrieve")
 
 	return cmd
 }

--- a/library/developer-tools/scrape-creators/internal/cli/instagram_list-reels.go
+++ b/library/developer-tools/scrape-creators/internal/cli/instagram_list-reels.go
@@ -14,7 +14,7 @@ import (
 func newInstagramListReelsCmd(flags *rootFlags) *cobra.Command {
 	var flagQuery string
 	var flagDatePosted string
-	var flagPage float64
+	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "reels-search",
@@ -39,7 +39,7 @@ func newInstagramListReelsCmd(flags *rootFlags) *cobra.Command {
 			if flagDatePosted != "" {
 				params["date_posted"] = fmt.Sprintf("%v", flagDatePosted)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			data, prov, err := resolveRead(c, flags, "instagram", false, path, params)
@@ -85,7 +85,7 @@ func newInstagramListReelsCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&flagQuery, "query", "", "The keyword to search for")
 	cmd.Flags().StringVar(&flagDatePosted, "date-posted", "", "Date posted")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "The page number to return.")
+	cmd.Flags().StringVar(&flagPage, "page", "", "The page number to return.")
 
 	return cmd
 }

--- a/library/developer-tools/scrape-creators/internal/cli/linkedin_list-company-2.go
+++ b/library/developer-tools/scrape-creators/internal/cli/linkedin_list-company-2.go
@@ -13,7 +13,7 @@ import (
 
 func newLinkedinListCompany2Cmd(flags *rootFlags) *cobra.Command {
 	var flagUrl string
-	var flagPage float64
+	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "company-posts",
@@ -35,7 +35,7 @@ func newLinkedinListCompany2Cmd(flags *rootFlags) *cobra.Command {
 			if flagUrl != "" {
 				params["url"] = fmt.Sprintf("%v", flagUrl)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			data, prov, err := resolveRead(c, flags, "linkedin", false, path, params)
@@ -80,7 +80,7 @@ func newLinkedinListCompany2Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagUrl, "url", "", "The URL of the LinkedIn company page to get")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "The page number to get")
+	cmd.Flags().StringVar(&flagPage, "page", "", "The page number to get")
 
 	return cmd
 }

--- a/library/developer-tools/scrape-creators/internal/cli/promoted_tiktok.go
+++ b/library/developer-tools/scrape-creators/internal/cli/promoted_tiktok.go
@@ -15,7 +15,7 @@ func newTiktokPromotedCmd(flags *rootFlags) *cobra.Command {
 	var flagUrl string
 	var flagProductId string
 	var flagRegion string
-	var flagPage float64
+	var flagPage string
 
 	cmd := &cobra.Command{
 		Use:         "tiktok",
@@ -40,7 +40,7 @@ func newTiktokPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flagRegion != "" {
 				params["region"] = fmt.Sprintf("%v", flagRegion)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			data, prov, err := resolveRead(c, flags, "tiktok", false, path, params)
@@ -97,7 +97,7 @@ func newTiktokPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagUrl, "url", "", "The URL of the product (required if product_id is not provided)")
 	cmd.Flags().StringVar(&flagProductId, "product-id", "", "The ID of the product (required if url is not provided)")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "The region of the product. This is *very* important.")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "The page number of the reviews")
+	cmd.Flags().StringVar(&flagPage, "page", "", "The page number of the reviews")
 
 	// Wire sibling endpoints and sub-resources as subcommands
 	cmd.AddCommand(newTiktokListCmd(flags))

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-hashtags.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-hashtags.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListHashtagsCmd(flags *rootFlags) *cobra.Command {
 	var flagPeriod string
-	var flagPage float64
+	var flagPage string
 	var flagCountryCode string
 	var flagNewOnBoard bool
 	var flagIndustry string
@@ -35,7 +35,7 @@ func newTiktokListHashtagsCmd(flags *rootFlags) *cobra.Command {
 			if flagPeriod != "" {
 				params["period"] = fmt.Sprintf("%v", flagPeriod)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			if flagCountryCode != "" {
@@ -89,7 +89,7 @@ func newTiktokListHashtagsCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagPeriod, "period", "", "Time period in days (7, 30, or 120)")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number")
 	cmd.Flags().StringVar(&flagCountryCode, "country-code", "", "Country code to get popular hashtags from")
 	cmd.Flags().BoolVar(&flagNewOnBoard, "new-on-board", false, "Show only newly trending hashtags")
 	cmd.Flags().StringVar(&flagIndustry, "industry", "", "Industry to get popular hashtags from.")

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-2.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-2.go
@@ -16,7 +16,7 @@ func newTiktokListSearch2Cmd(flags *rootFlags) *cobra.Command {
 	var flagDatePosted string
 	var flagSortBy string
 	var flagRegion string
-	var flagCursor float64
+	var flagCursor string
 	var flagTrim bool
 	var flagAll bool
 
@@ -88,7 +88,7 @@ func newTiktokListSearch2Cmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagDatePosted, "date-posted", "", "Time Frame")
 	cmd.Flags().StringVar(&flagSortBy, "sort-by", "", "Sort by")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "Note, this doesn't filter the tiktoks only in a specfic region, it puts the proxy there. Use it in case you want to...")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more videos. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more videos. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-3.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-3.go
@@ -16,7 +16,7 @@ func newTiktokListSearch3Cmd(flags *rootFlags) *cobra.Command {
 	var flagPublishTime string
 	var flagSortBy string
 	var flagRegion string
-	var flagCursor float64
+	var flagCursor string
 	var flagAll bool
 
 	cmd := &cobra.Command{
@@ -86,7 +86,7 @@ func newTiktokListSearch3Cmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagPublishTime, "publish-time", "", "Time Frame TikTok was posted")
 	cmd.Flags().StringVar(&flagSortBy, "sort-by", "", "Sort by")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "Note, this doesn't filter the tiktoks only in a specfic region, it puts the proxy there. Use it in case you want to...")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more videos. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more videos. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-4.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search-4.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListSearch4Cmd(flags *rootFlags) *cobra.Command {
 	var flagQuery string
-	var flagCursor float64
+	var flagCursor string
 	var flagTrim bool
 	var flagAll bool
 
@@ -79,7 +79,7 @@ func newTiktokListSearch4Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagQuery, "query", "", "Search query for users")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more users. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more users. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-search.go
@@ -14,7 +14,7 @@ import (
 func newTiktokListSearchCmd(flags *rootFlags) *cobra.Command {
 	var flagHashtag string
 	var flagRegion string
-	var flagCursor float64
+	var flagCursor string
 	var flagTrim bool
 	var flagAll bool
 
@@ -82,7 +82,7 @@ func newTiktokListSearchCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&flagHashtag, "hashtag", "", "Hashtag to search for (without #)")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "Region the proxy will be set to. Note: this isn't going to grab you all tiktoks from this region, you're just...")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more videos. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more videos. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-shop-3.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-shop-3.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListShop3Cmd(flags *rootFlags) *cobra.Command {
 	var flagQuery string
-	var flagPage float64
+	var flagPage string
 	var flagRegion string
 
 	cmd := &cobra.Command{
@@ -36,7 +36,7 @@ func newTiktokListShop3Cmd(flags *rootFlags) *cobra.Command {
 			if flagQuery != "" {
 				params["query"] = fmt.Sprintf("%v", flagQuery)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			if flagRegion != "" {
@@ -84,7 +84,7 @@ func newTiktokListShop3Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagQuery, "query", "", "Term you want to search for")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number to retrieve")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number to retrieve")
 	cmd.Flags().StringVar(&flagRegion, "region", "", "Region to search shop products in.")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-song-2.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-song-2.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListSong2Cmd(flags *rootFlags) *cobra.Command {
 	var flagClipId string
-	var flagCursor float64
+	var flagCursor string
 	var flagAll bool
 
 	cmd := &cobra.Command{
@@ -74,7 +74,7 @@ func newTiktokListSong2Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagClipId, "clip-id", "", "This is clipId. Can be found on a url like so: https://www.tiktok.com/music/That%27s-Who-I-Praise-7370375686554782506...")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "The cursor to get the next page of results.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "The cursor to get the next page of results.")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-songs.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-songs.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newTiktokListSongsCmd(flags *rootFlags) *cobra.Command {
-	var flagPage float64
+	var flagPage string
 	var flagTimePeriod string
 	var flagRankType string
 	var flagNewOnBoard bool
@@ -33,7 +33,7 @@ func newTiktokListSongsCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/v1/tiktok/songs/popular"
 			params := map[string]string{}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			if flagTimePeriod != "" {
@@ -92,7 +92,7 @@ func newTiktokListSongsCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		},
 	}
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number")
 	cmd.Flags().StringVar(&flagTimePeriod, "time-period", "", "Time period to get popular songs from")
 	cmd.Flags().StringVar(&flagRankType, "rank-type", "", "Get popular or surging songs")
 	cmd.Flags().BoolVar(&flagNewOnBoard, "new-on-board", false, "New to top 100")

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-2.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-2.go
@@ -14,7 +14,7 @@ import (
 func newTiktokListUser2Cmd(flags *rootFlags) *cobra.Command {
 	var flagHandle string
 	var flagUserId string
-	var flagMinTime float64
+	var flagMinTime string
 	var flagTrim bool
 
 	cmd := &cobra.Command{
@@ -37,7 +37,7 @@ func newTiktokListUser2Cmd(flags *rootFlags) *cobra.Command {
 			if flagUserId != "" {
 				params["user_id"] = fmt.Sprintf("%v", flagUserId)
 			}
-			if flagMinTime != 0.0 {
+			if flagMinTime != "" {
 				params["min_time"] = fmt.Sprintf("%v", flagMinTime)
 			}
 			if flagTrim != false {
@@ -86,7 +86,7 @@ func newTiktokListUser2Cmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&flagHandle, "handle", "", "TikTok handle")
 	cmd.Flags().StringVar(&flagUserId, "user-id", "", "User id. Use this for faster response times.")
-	cmd.Flags().Float64Var(&flagMinTime, "min-time", 0.0, "Used to paginate. Get 'min_time' from previous response.")
+	cmd.Flags().StringVar(&flagMinTime, "min-time", "", "Used to paginate. Get 'min_time' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-user-3.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListUser3Cmd(flags *rootFlags) *cobra.Command {
 	var flagHandle string
-	var flagMinTime float64
+	var flagMinTime string
 	var flagTrim bool
 
 	cmd := &cobra.Command{
@@ -36,7 +36,7 @@ func newTiktokListUser3Cmd(flags *rootFlags) *cobra.Command {
 			if flagHandle != "" {
 				params["handle"] = NormalizeHandle(fmt.Sprintf("%v", flagHandle))
 			}
-			if flagMinTime != 0.0 {
+			if flagMinTime != "" {
 				params["min_time"] = fmt.Sprintf("%v", flagMinTime)
 			}
 			if flagTrim != false {
@@ -84,7 +84,7 @@ func newTiktokListUser3Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagHandle, "handle", "", "TikTok handle")
-	cmd.Flags().Float64Var(&flagMinTime, "min-time", 0.0, "Used to paginate. Get 'min_time' from previous response.")
+	cmd.Flags().StringVar(&flagMinTime, "min-time", "", "Used to paginate. Get 'min_time' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-video-2.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-video-2.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListVideo2Cmd(flags *rootFlags) *cobra.Command {
 	var flagUrl string
-	var flagCursor float64
+	var flagCursor string
 	var flagTrim bool
 	var flagAll bool
 
@@ -79,7 +79,7 @@ func newTiktokListVideo2Cmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagUrl, "url", "", "TikTok video URL")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more comments. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more comments. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagTrim, "trim", false, "Set to true to get a trimmed response")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-video.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-video.go
@@ -14,7 +14,7 @@ import (
 func newTiktokListVideoCmd(flags *rootFlags) *cobra.Command {
 	var flagCommentId string
 	var flagUrl string
-	var flagCursor float64
+	var flagCursor string
 	var flagAll bool
 
 	cmd := &cobra.Command{
@@ -83,7 +83,7 @@ func newTiktokListVideoCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&flagCommentId, "comment-id", "", "TikTok comment ID. This is the cid from the comments endpoint.")
 	cmd.Flags().StringVar(&flagUrl, "url", "", "TikTok video URL. This is the url from the comments endpoint.")
-	cmd.Flags().Float64Var(&flagCursor, "cursor", 0.0, "Cursor to get more replies. Get 'cursor' from previous response.")
+	cmd.Flags().StringVar(&flagCursor, "cursor", "", "Cursor to get more replies. Get 'cursor' from previous response.")
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")
 
 	return cmd

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list-videos.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list-videos.go
@@ -13,7 +13,7 @@ import (
 
 func newTiktokListVideosCmd(flags *rootFlags) *cobra.Command {
 	var flagPeriod string
-	var flagPage float64
+	var flagPage string
 	var flagOrderBy string
 	var flagCountryCode string
 
@@ -34,7 +34,7 @@ func newTiktokListVideosCmd(flags *rootFlags) *cobra.Command {
 			if flagPeriod != "" {
 				params["period"] = fmt.Sprintf("%v", flagPeriod)
 			}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			if flagOrderBy != "" {
@@ -85,7 +85,7 @@ func newTiktokListVideosCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagPeriod, "period", "", "Time period in days (7 or 30)")
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number")
 	cmd.Flags().StringVar(&flagOrderBy, "order-by", "", "Sort videos by likes, views (hot), comments, or reposts")
 	cmd.Flags().StringVar(&flagCountryCode, "country-code", "", "Country code to get popular videos from")
 

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_list.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_list.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newTiktokListCmd(flags *rootFlags) *cobra.Command {
-	var flagPage float64
+	var flagPage string
 	var flagSortBy string
 	var flagFollowerCount string
 	var flagCreatorCountry string
@@ -32,7 +32,7 @@ func newTiktokListCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/v1/tiktok/creators/popular"
 			params := map[string]string{}
-			if flagPage != 0.0 {
+			if flagPage != "" {
 				params["page"] = fmt.Sprintf("%v", flagPage)
 			}
 			if flagSortBy != "" {
@@ -88,7 +88,7 @@ func newTiktokListCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		},
 	}
-	cmd.Flags().Float64Var(&flagPage, "page", 0.0, "Page number")
+	cmd.Flags().StringVar(&flagPage, "page", "", "Page number")
 	cmd.Flags().StringVar(&flagSortBy, "sort-by", "", "Sort creators by engagement, follower count, or average views")
 	cmd.Flags().StringVar(&flagFollowerCount, "follower-count", "", "Filter by follower count range")
 	cmd.Flags().StringVar(&flagCreatorCountry, "creator-country", "", "Country code of the creator")

--- a/library/developer-tools/scrape-creators/internal/client/client.go
+++ b/library/developer-tools/scrape-creators/internal/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -341,10 +342,21 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string) (json.RawMessage, int, error) {
 	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
 	if params != nil {
-		for k, v := range params {
-			if v != "" {
-				fmt.Fprintf(os.Stderr, "  ?%s=%s\n", k, v)
+		keys := make([]string, 0, len(params))
+		for k := range params {
+			if params[k] != "" {
+				keys = append(keys, k)
 			}
+		}
+		sort.Strings(keys)
+		queryPrinted := false
+		for _, k := range keys {
+			sep := "?"
+			if queryPrinted {
+				sep = "&"
+			}
+			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, params[k])
+			queryPrinted = true
 		}
 	}
 	if body != nil {


### PR DESCRIPTION
## Summary

- Scrape-creators-pp-cli declared 18 cursor, page, and min_time pagination flags as Float64Var. Go's float formatter renders values at or above 10^6 in scientific notation (1.740168616e+09), and the Scrape Creators proxy rejects those strings as invalid integer cursors with HTTP 500 "Request failed with status code 400". The bug stayed hidden during page 1 and during local testing with small literal cursors, then broke on every paginating call where the server returned a real Unix-second or Unix-millisecond cursor.
- Targeted hand-patch of the 18 affected files plus the dry-run printer in `internal/client/client.go`. Picks up the same fix that landed upstream in cli-printing-press#435 as the `isCursorParam` classifier; this PR applies it surgically rather than running a full regen, which would mix the bug fix with a 1.3.2 to 3.0.1 generator-version bump unrelated to this fix.
- Adds `internal/cli/cursor_flag_types_test.go` so any future regression that flips a cursor flag back to Float64Var fails CI.

## Why a hand-patch instead of a full regen

Per AGENTS.md: "Do not silently fork generated conventions here. If you hand-edit a generated CLI in `library/`, decide whether the same fix should be upstreamed to `cli-printing-press`. If it should and you have a local checkout, make the generator change there." The upstream fix is mvanhorn/cli-printing-press#435; this PR is the surgical local application so users on the existing 1.3.2-emit shape get the bug fix without absorbing a major-version regen they did not ask for. A clean regen produces a 208-file diff dominated by 1.3.2 to 3.0.1 scaffolding/MCP/template churn; that should land as its own PR when the maintainer is ready to absorb it.

## Reproduction (before)

```
$ scrape-creators-pp-cli tiktok user-following --handle <h> --min-time 1740168616 --dry-run --agent
GET https://api.scrapecreators.com/v1/tiktok/user/following
  ?handle=<h>
  ?min_time=1.740168616e+09        <- buggy: scientific notation
  Authorization: ****
```

```
$ scrape-creators-pp-cli tiktok user-following --handle <h> --min-time 1740168616
HTTP 500: "Request failed with status code 400"
```

## After this PR

```
$ scrape-creators-pp-cli tiktok user-following --handle <h> --min-time 1740168616 --dry-run --agent
GET https://api.scrapecreators.com/v1/tiktok/user/following
  ?handle=<h>
  &min_time=1740168616             <- fixed: integer, & separator
  Authorization: ****
```

```
$ scrape-creators-pp-cli tiktok user-following --handle <h> --min-time 1740168616 --agent
{"meta":{"source":"live"},"results":{"followings":[<20 entries>], "has_more":true, "min_time":1720361775, ...}}
```

Live-API end-to-end pagination works through the patched CLI.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go fmt ./...` clean
- [x] `go test ./...` passes (18 tests across 11 packages, includes the new regression test)
- [x] Live-API smoke: tiktok user-following min-time pagination returns 200 with valid cursor (verified above)
- [x] Dry-run preview matches the actual HTTP request shape

## Plan

`docs/plans/2026-04-30-001-fix-cli-float-pagination-encoding-plan.md`

## Companion PR

Generator root-fix: mvanhorn/cli-printing-press#435