### PR TITLE
chore(library): backfill mcp:read-only annotation across novel commands

### DIFF
--- a/library/commerce/dominos/internal/cli/compare_prices.go
+++ b/library/commerce/dominos/internal/cli/compare_prices.go
@@ -36,6 +36,7 @@ func newComparePricesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "compare-prices",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Compare nearby store pricing for a list of menu item codes",
 		Long:    "Find the cheapest nearby Domino's store for a given list of menu item codes by syncing menus from nearby stores and joining on item codes locally.",
 		Example: "  dominos-pp-cli compare-prices --address \"421 N 63rd St\" --city \"Seattle WA\" --items 14SCREEN,W08PHOTW\n  dominos-pp-cli compare-prices --address \"421 N 63rd St\" --city \"Seattle, WA 98103\" --items 14SCREEN,W08PHOTW,P_SAUCEEZE --service Carryout --max-stores 3 --json",

--- a/library/commerce/dominos/internal/cli/deals.go
+++ b/library/commerce/dominos/internal/cli/deals.go
@@ -41,6 +41,7 @@ func newDealsBestCmd(flags *rootFlags) *cobra.Command {
 	var topN int
 	cmd := &cobra.Command{
 		Use:   "best",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find the best deal for a cart",
 		Example: "  dominos-pp-cli deals best --cart cart.json\n" +
 			"  dominos-pp-cli deals best --store 7094 --include-loyalty=false",

--- a/library/commerce/dominos/internal/cli/nutrition.go
+++ b/library/commerce/dominos/internal/cli/nutrition.go
@@ -33,6 +33,7 @@ func newNutritionCmd(flags *rootFlags) *cobra.Command {
 	var cartPath, storeID string
 	cmd := &cobra.Command{
 		Use:   "nutrition",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Sum calories, fat, carbs, and protein for a cart",
 		Example: "  dominos-pp-cli nutrition --cart cart.json --store 7094\n" +
 			"  dominos-pp-cli nutrition --cart cart.json --json\n" +

--- a/library/commerce/instacart/internal/cli/auth.go
+++ b/library/commerce/instacart/internal/cli/auth.go
@@ -96,6 +96,7 @@ If the command fails with "database is locked", quit Chrome completely
 func newAuthStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show the current session (if any)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			asJSON, _ := cmd.Flags().GetBool("json")

--- a/library/commerce/instacart/internal/cli/carts.go
+++ b/library/commerce/instacart/internal/cli/carts.go
@@ -14,6 +14,7 @@ import (
 func newCartsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "carts",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List every active cart across your retailers",
 		Long: `Instacart users typically have one cart per retailer. This command lists
 every active cart on your account -- Costco, Sprouts, CVS, whatever you've
@@ -73,6 +74,7 @@ been shopping at -- with item counts.`,
 func newCartCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cart",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Inspect or modify a specific cart",
 	}
 	cmd.AddCommand(newCartShowCmd(), newCartRemoveCmd())
@@ -82,6 +84,7 @@ func newCartCmd() *cobra.Command {
 func newCartShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <retailer-slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show the contents of your cart at a retailer with real item names",
 		Long: `Lists every item in your active cart at <retailer> with its real product
 name, quantity, and item id. Chains CartData -> ShopCollectionScoped ->

--- a/library/commerce/instacart/internal/cli/doctor.go
+++ b/library/commerce/instacart/internal/cli/doctor.go
@@ -25,6 +25,7 @@ type checkResult struct {
 func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Diagnose config, session, and API reachability",
 		Long: `Run a full health check: config file, local database, Chrome cookie auth,
 and a live CurrentUserFields ping against Instacart. Useful as a first-run

--- a/library/commerce/instacart/internal/cli/history.go
+++ b/library/commerce/instacart/internal/cli/history.go
@@ -21,6 +21,7 @@ import (
 func newHistoryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "history",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Inspect, search, and sync your local Instacart purchase history",
 		Long: `Your Instacart order history mirrored to a local SQLite DB so the CLI
 can weight what you have actually bought before over live-catalog
@@ -159,6 +160,7 @@ func newHistoryListCmd() *cobra.Command {
 	var retailerOverride string
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show your most-purchased items from the local history",
 		Long: `Lists purchased_items sorted by purchase_count DESC then last_purchased_at DESC.
 Use --store to filter to one retailer. Default limit is 25.`,
@@ -210,6 +212,7 @@ func newHistorySearchCmd() *cobra.Command {
 	var retailerOverride string
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search your local purchase history",
 		Long: `Searches purchased_items_fts and returns the top N results ranked by
 FTS relevance then by recency. Filter to one retailer with --store.
@@ -281,6 +284,7 @@ Useful for diagnosing why 'add' did or did not resolve via history.`,
 func newHistoryStatsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stats",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show history sync state and row counts",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			app, err := newAppContext(cmd)

--- a/library/commerce/instacart/internal/cli/ops.go
+++ b/library/commerce/instacart/internal/cli/ops.go
@@ -25,6 +25,7 @@ func newOpsCmd() *cobra.Command {
 func newOpsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show all persisted GraphQL operations known to the CLI",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := newAppContext(cmd)

--- a/library/commerce/instacart/internal/cli/retailers.go
+++ b/library/commerce/instacart/internal/cli/retailers.go
@@ -15,6 +15,7 @@ import (
 func newRetailersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "retailers",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List and inspect retailers available at your address",
 	}
 	cmd.AddCommand(newRetailersListCmd(), newRetailersShowCmd())
@@ -24,6 +25,7 @@ func newRetailersCmd() *cobra.Command {
 func newRetailersListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List retailers that deliver to your saved address",
 		Long: `Shows retailers cached locally. If the cache is empty or stale, hits
 Instacart's ShopCollectionUnscoped query to refresh. Use --refresh to force.`,
@@ -60,6 +62,7 @@ Instacart's ShopCollectionUnscoped query to refresh. Use --refresh to force.`,
 func newRetailersShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Look up a retailer by slug and cache it locally",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/commerce/instacart/internal/cli/search.go
+++ b/library/commerce/instacart/internal/cli/search.go
@@ -24,6 +24,7 @@ func newSearchCmd() *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "search <query...>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search products at a retailer by natural language",
 		Long: `Search for products at a specific retailer. Uses your saved session to
 bootstrap a retailer inventory token (cached 6h), feeds the query through

--- a/library/commerce/yahoo-finance/internal/cli/watchlist.go
+++ b/library/commerce/yahoo-finance/internal/cli/watchlist.go
@@ -80,6 +80,7 @@ func openDB(flags *rootFlags) (*sql.DB, error) {
 func newWatchlistCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watchlist",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Create, manage, and query local watchlists of ticker symbols",
 		Long:  "Watchlists live in your local SQLite database. They power multi-symbol commands like `digest`, `compare`, and `watchlist show`.",
 		Example: `  # Create a watchlist and add symbols
@@ -180,6 +181,7 @@ func newWatchlistRemoveCmd(flags *rootFlags) *cobra.Command {
 func newWatchlistListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List all watchlists with member counts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			db, err := openDB(flags)
@@ -239,6 +241,7 @@ func watchlistSymbols(db *sql.DB, name string) ([]string, error) {
 func newWatchlistShowCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "show <name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show symbols in a watchlist with live quotes",
 		Args:    cobra.ExactArgs(1),
 		Example: "  yahoo-finance-pp-cli watchlist show tech",
@@ -419,6 +422,7 @@ func renderQuotes(cmd *cobra.Command, flags *rootFlags, label string, quotes []q
 func newPortfolioCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "portfolio",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Track holdings, cost basis, returns, and dividend income locally",
 		Long:  "Portfolios are a local SQLite concept. Each 'lot' records shares, cost basis, and purchase date. Commands compute P&L, YTD return, and dividend income against live quotes.",
 	}
@@ -473,6 +477,7 @@ func newPortfolioAddCmd(flags *rootFlags) *cobra.Command {
 func newPortfolioListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List all portfolio lots",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			db, err := openDB(flags)
@@ -545,6 +550,7 @@ func newPortfolioRemoveCmd(flags *rootFlags) *cobra.Command {
 func newPortfolioPerfCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "perf",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show current market value, cost basis, and unrealized P&L across all lots",
 		Example: "  yahoo-finance-pp-cli portfolio perf",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -660,6 +666,7 @@ func newPortfolioGainsCmd(flags *rootFlags) *cobra.Command {
 	var unrealized bool
 	cmd := &cobra.Command{
 		Use:   "gains",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Per-lot unrealized gain/loss sorted by magnitude",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = unrealized
@@ -765,6 +772,7 @@ func newDigestCmd(flags *rootFlags) *cobra.Command {
 	var symbolsFlag string
 	cmd := &cobra.Command{
 		Use:   "digest",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Morning briefing: biggest movers and headline quotes across a watchlist",
 		Example: `  yahoo-finance-pp-cli digest --watchlist tech
   yahoo-finance-pp-cli digest --symbols AAPL,MSFT,NVDA`,
@@ -874,6 +882,7 @@ func quoteRowsCompact(qs []quoteRow) [][]string {
 func newCompareCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "compare <symbol> <symbol> [symbol...]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Side-by-side quote comparison for 2+ symbols",
 		Args:    cobra.MinimumNArgs(2),
 		Example: "  yahoo-finance-pp-cli compare AAPL MSFT GOOG NVDA",
@@ -933,6 +942,7 @@ func newSparklineCmd(flags *rootFlags) *cobra.Command {
 	var interval string
 	cmd := &cobra.Command{
 		Use:     "sparkline <symbol>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Unicode sparkline of a symbol's recent price action",
 		Args:    cobra.ExactArgs(1),
 		Example: "  yahoo-finance-pp-cli sparkline AAPL --range 3mo",
@@ -1041,6 +1051,7 @@ func renderSparkline(data []float64) string {
 func newSQLCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "sql <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Run a raw SQL query against the local database",
 		Args:    cobra.ExactArgs(1),
 		Example: `  yahoo-finance-pp-cli sql "SELECT symbol, COUNT(*) FROM watchlist_members GROUP BY symbol"`,
@@ -1107,6 +1118,7 @@ func newFXCmd(flags *rootFlags) *cobra.Command {
 	var amount float64
 	cmd := &cobra.Command{
 		Use:     "fx <from> <to>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Quick currency conversion using Yahoo Finance FX pairs",
 		Args:    cobra.ExactArgs(2),
 		Example: "  yahoo-finance-pp-cli fx USD EUR --amount 100",
@@ -1156,6 +1168,7 @@ func newOptionsChainCmd(flags *rootFlags) *cobra.Command {
 	var minStrike, maxStrike float64
 	cmd := &cobra.Command{
 		Use:     "options-chain <symbol>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Options chain with moneyness, DTE, and strike filters",
 		Args:    cobra.ExactArgs(1),
 		Example: `  yahoo-finance-pp-cli options-chain AAPL --moneyness otm --max-dte 45 --type calls`,

--- a/library/developer-tools/agent-capture/internal/cli/batch.go
+++ b/library/developer-tools/agent-capture/internal/cli/batch.go
@@ -13,6 +13,7 @@ import (
 
 var batchCmd = &cobra.Command{
 	Use:   "batch",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Screenshot multiple apps in one command",
 	Long: `Capture screenshots of multiple applications in a single invocation.
 Useful for multi-app evidence where you need to show several windows.`,

--- a/library/developer-tools/agent-capture/internal/cli/doctor.go
+++ b/library/developer-tools/agent-capture/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Check permissions and environment for common issues",
 	Long: `Run diagnostic checks and provide fix instructions.
 Checks Screen Recording permission, ffmpeg availability, macOS version, and disk space.`,

--- a/library/developer-tools/agent-capture/internal/cli/evidence.go
+++ b/library/developer-tools/agent-capture/internal/cli/evidence.go
@@ -15,6 +15,7 @@ import (
 
 var evidenceCmd = &cobra.Command{
 	Use:   "evidence",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Capture a complete evidence bundle: screenshots + recording + GIF",
 	Long: `One command to produce a full PR evidence package.
 Takes N screenshots at intervals, records a video, converts to GIF, and bundles all outputs.`,

--- a/library/developer-tools/agent-capture/internal/cli/find.go
+++ b/library/developer-tools/agent-capture/internal/cli/find.go
@@ -10,6 +10,7 @@ import (
 
 var findCmd = &cobra.Command{
 	Use:   "find <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Fuzzy search window titles to find the right capture target",
 	Long: `Search across all window titles and app names for a match.
 Returns the best match with window ID, app name, and bounds.

--- a/library/developer-tools/agent-capture/internal/cli/health.go
+++ b/library/developer-tools/agent-capture/internal/cli/health.go
@@ -11,6 +11,7 @@ import (
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Machine-readable health check for CI and agent preflight",
 	Long:  `Verify that agent-capture can run: platform, permissions, dependencies, disk space.`,
 	Example: `  agent-capture health

--- a/library/developer-tools/agent-capture/internal/cli/list.go
+++ b/library/developer-tools/agent-capture/internal/cli/list.go
@@ -11,6 +11,7 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:   "list [windows|displays]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "List available capture targets (windows, displays)",
 	Long: `Enumerate macOS windows and displays available for capture.
 

--- a/library/developer-tools/agent-capture/internal/cli/ocr.go
+++ b/library/developer-tools/agent-capture/internal/cli/ocr.go
@@ -13,6 +13,7 @@ import (
 
 var ocrCmd = &cobra.Command{
 	Use:   "ocr",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Extract text from a window or image using macOS Vision framework",
 	Long: `Capture a screenshot and run OCR to extract visible text.
 Uses macOS Vision framework (VNRecognizeTextRequest) for accurate text recognition.`,

--- a/library/developer-tools/agent-capture/internal/cli/permissions.go
+++ b/library/developer-tools/agent-capture/internal/cli/permissions.go
@@ -12,6 +12,7 @@ import (
 
 var permissionsCmd = &cobra.Command{
 	Use:   "permissions",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Check and guide Screen Recording permission setup",
 	Long: `Check if Screen Recording permission is granted and provide step-by-step
 instructions to fix it if not. Includes deep links to System Settings.`,

--- a/library/developer-tools/agent-capture/internal/cli/pipeline.go
+++ b/library/developer-tools/agent-capture/internal/cli/pipeline.go
@@ -15,6 +15,7 @@ import (
 
 var pipelineCmd = &cobra.Command{
 	Use:   "pipeline [output]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Record, convert, and optimize in one command (no intermediate files)",
 	Long: `The pipeline command combines record + convert + optimize into a single invocation.
 Specify the output format via extension: .gif records then converts, .mp4/.mov records directly.`,

--- a/library/developer-tools/agent-capture/internal/cli/preset.go
+++ b/library/developer-tools/agent-capture/internal/cli/preset.go
@@ -26,6 +26,7 @@ var presetSaveCmd = &cobra.Command{
 
 var presetListCmd = &cobra.Command{
 	Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "List saved presets",
 	RunE:  runPresetList,
 }
@@ -39,6 +40,7 @@ var presetDeleteCmd = &cobra.Command{
 
 var presetShowCmd = &cobra.Command{
 	Use:   "show <name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Show details of a preset",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runPresetShow,

--- a/library/developer-tools/agent-capture/internal/cli/remotion.go
+++ b/library/developer-tools/agent-capture/internal/cli/remotion.go
@@ -14,6 +14,7 @@ import (
 
 var remotionCmd = &cobra.Command{
 	Use:   "remotion",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Render Remotion compositions as video or still frames",
 	Long: `Wrap Remotion as a capture source for simulated demo videos.
 Remotion and its dependencies must be installed in the project directory.`,
@@ -55,6 +56,7 @@ var (
 
 var remotionStillCmd = &cobra.Command{
 	Use:   "still [output]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Render a single frame from a Remotion composition",
 	Example: `  # Render frame 0 (default)
   agent-capture remotion still --entry src/index.ts --comp MyDemo hero.png

--- a/library/developer-tools/agent-capture/internal/cli/root.go
+++ b/library/developer-tools/agent-capture/internal/cli/root.go
@@ -14,6 +14,7 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "agent-capture",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
 	Long: `agent-capture consolidates macOS screen capture, window recording, GIF conversion,
 frame stitching, and styled code screenshots into one agent-native CLI.

--- a/library/developer-tools/agent-capture/internal/cli/screenshot.go
+++ b/library/developer-tools/agent-capture/internal/cli/screenshot.go
@@ -15,6 +15,7 @@ import (
 
 var screenshotCmd = &cobra.Command{
 	Use:   "screenshot [output]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Capture a screenshot of a window, app, display, or region",
 	Long: `Take a single-frame screenshot of a macOS window, application, display, or region.
 Supports PNG and JPG output formats.`,

--- a/library/developer-tools/agent-capture/internal/cli/stitch.go
+++ b/library/developer-tools/agent-capture/internal/cli/stitch.go
@@ -12,6 +12,7 @@ import (
 
 var stitchCmd = &cobra.Command{
 	Use:   "stitch <frame1.png> <frame2.png> ... -o <output.gif>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Stitch multiple screenshots into an animated GIF",
 	Long: `Combine multiple PNG/JPG screenshots into a single animated GIF.
 Frames are automatically normalized to the same dimensions with configurable padding.

--- a/library/developer-tools/agent-capture/internal/cli/vhs.go
+++ b/library/developer-tools/agent-capture/internal/cli/vhs.go
@@ -15,6 +15,7 @@ import (
 
 var vhsCmd = &cobra.Command{
 	Use:   "vhs <tape-file> [output]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 	Short: "Run a VHS tape file and produce a terminal recording GIF",
 	Long: `Wrap VHS (charmbracelet/vhs) as a capture source with --json output
 and optional GIF auto-reduce. VHS must be installed separately.`,

--- a/library/developer-tools/company-goat/internal/cli/company_engineering.go
+++ b/library/developer-tools/company-goat/internal/cli/company_engineering.go
@@ -41,6 +41,7 @@ func newEngineeringCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "engineering [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "GitHub org metadata: repo count, contributor count, commit cadence, top languages.",
 		Long: `engineering surfaces a GitHub org's public footprint: number of public repos, top repos by recent activity, language mix, and how many repos have seen commits in the last 90 days.
 

--- a/library/developer-tools/company-goat/internal/cli/company_funding.go
+++ b/library/developer-tools/company-goat/internal/cli/company_funding.go
@@ -91,6 +91,7 @@ func newFundingCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "funding [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "SEC EDGAR Form D filings + YC batch lookup. The killer feature for US private fundraising.",
 		Long: `funding fetches every Form D filing the SEC has for a company name, parses the structured XML, and reports offering amount, filing date, exemption claimed, and related persons.
 
@@ -718,6 +719,7 @@ func newFundingTrendCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "funding-trend [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Time series of Form D filings showing fundraising cadence over years.",
 		Long: `funding-trend renders a year-by-year count of Form D filings for a company. Useful for spotting fundraising gaps or a startup that quietly stopped raising.
 

--- a/library/developer-tools/company-goat/internal/cli/company_hn.go
+++ b/library/developer-tools/company-goat/internal/cli/company_hn.go
@@ -31,6 +31,7 @@ func newLaunchesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "launches [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show HN posts mentioning the company, sorted by points. Includes year hints to spot dead vs. active launches.",
 		Long: `launches searches the Hacker News Algolia index for "Show HN" posts where the title or content mentions the resolved company. Results are sorted by points descending.
 
@@ -128,6 +129,7 @@ func newMentionsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "mentions [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Hacker News mention timeline plus the top N stories by points, via Algolia full-text search.",
 		Long: `mentions searches HN's full-text Algolia index for any story containing the resolved company name. Returns two views in one call: a year-month histogram for a quick "is this still talked about?" view, and the top N stories sorted by points so an agent can dive into the most-discussed mentions without a second query.
 

--- a/library/developer-tools/company-goat/internal/cli/company_legal.go
+++ b/library/developer-tools/company-goat/internal/cli/company_legal.go
@@ -47,6 +47,7 @@ func newLegalCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "legal [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Legal entity lookup. UK via Companies House (optional COMPANIES_HOUSE_API_KEY); US via SEC EDGAR Form D issuer fields.",
 		Long: `legal returns the structured legal-entity record for a company.
 

--- a/library/developer-tools/company-goat/internal/cli/company_search.go
+++ b/library/developer-tools/company-goat/internal/cli/company_search.go
@@ -36,6 +36,7 @@ func newCompanySearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search across companies in the YC directory by name, description, industry, location.",
 		Long: `search finds companies in the YC directory snapshot (~5000+ companies) by query terms across name, one-liner description, industry, and location. Useful for "find the fintech with the strong London presence" or "companies in the AI batch with 'agent' in their description."
 

--- a/library/developer-tools/company-goat/internal/cli/company_snapshot.go
+++ b/library/developer-tools/company-goat/internal/cli/company_snapshot.go
@@ -46,6 +46,7 @@ func newSnapshotCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "snapshot [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fan out across all 7 sources in parallel and render a unified summary. The headline command.",
 		Long: `snapshot is the headline command. It runs every source query in parallel via cliutil.FanoutRun and renders a unified per-section summary.
 
@@ -454,6 +455,7 @@ type fmt_w = interface{ Write([]byte) (int, error) }
 func newCompareCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compare <a> <b>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Two snapshots aligned column-by-column for direct comparison.",
 		Long:  `compare runs snapshot for two companies and renders the results in side-by-side columns. Useful for evaluating which of two startups looks healthier — funding, engineering, launch story, etc.`,
 		Example: strings.Trim(`

--- a/library/developer-tools/company-goat/internal/cli/company_yc_wiki_domain.go
+++ b/library/developer-tools/company-goat/internal/cli/company_yc_wiki_domain.go
@@ -19,6 +19,7 @@ func newYCCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "yc [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Y Combinator directory entry if backed: batch, status, location, description.",
 		Long: `yc looks up the resolved company in the Y Combinator directory snapshot. Returns batch, status (Active/Acquired/Public/Inactive), location, team size, and the YC one-liner description.
 
@@ -97,6 +98,7 @@ func newWikiCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "wiki [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Wikidata company facts: founded date, founders, HQ, industry, key people.",
 		Long: `wiki looks up the resolved company on Wikidata via its official-website (P856) property. Returns structured facts: founded date, headquarters location, country, industry, founders.
 
@@ -172,6 +174,7 @@ func newDomainCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "domain [co]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Domain age via RDAP/WHOIS, DNS records, and CNAME-based hosting hint.",
 		Long: `domain returns RDAP registration data (age, registrar, status) plus DNS records (CNAME, A, NS) and a hosting hint derived from the CNAME (Vercel/Netlify/Heroku/Cloudflare Pages/AWS/GCP/etc.).
 

--- a/library/developer-tools/scrape-creators/internal/cli/agent.go
+++ b/library/developer-tools/scrape-creators/internal/cli/agent.go
@@ -31,6 +31,7 @@ var supportedTargets = []string{"claude-code", "claude-desktop", "codex", "curso
 func newAgentCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Manage AI agent integrations (MCP server wiring)",
 	}
 	cmd.AddCommand(newAgentAddCmd(flags))

--- a/library/developer-tools/scrape-creators/internal/cli/tiktok_transcendence.go
+++ b/library/developer-tools/scrape-creators/internal/cli/tiktok_transcendence.go
@@ -139,6 +139,7 @@ func newTiktokSpikesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "spikes",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find videos that outperformed a creator's average engagement rate",
 		Long: `Fetches all available videos for a creator, computes the average engagement
 rate (likes+comments+shares / views), then returns videos that exceeded the
@@ -262,6 +263,7 @@ func newTiktokAnalyzeCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "analyze",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Rank a creator's videos by engagement rate (likes+comments+shares / views)",
 		Example: `  scrape-creators-pp-cli tiktok analyze --handle charlidamelio --limit 10
   scrape-creators-pp-cli tiktok analyze --handle charlidamelio --json --select id,engagement_rate,play_count`,
@@ -348,6 +350,7 @@ func newTiktokCadenceCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "cadence",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a creator's posting frequency by day of week and hour of day",
 		Example: `  scrape-creators-pp-cli tiktok cadence --handle charlidamelio
   scrape-creators-pp-cli tiktok cadence --handle charlidamelio --json`,
@@ -450,6 +453,7 @@ func newTiktokCompareCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "compare",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare multiple TikTok creators side-by-side on followers, engagement, and posting cadence",
 		Example: `  scrape-creators-pp-cli tiktok compare --handle charlidamelio --handle addisonre
   scrape-creators-pp-cli tiktok compare --handle charlidamelio --handle addisonre --json`,
@@ -562,6 +566,7 @@ func newTiktokTranscriptsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "transcripts",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch and search across a creator's video transcripts",
 		Example: `  # Search transcripts for a keyword
   scrape-creators-pp-cli tiktok transcripts --handle charlidamelio --search "morning routine"
@@ -686,6 +691,7 @@ func newTiktokTranscriptsCmd(flags *rootFlags) *cobra.Command {
 func newAccountBudgetCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "budget",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show API credit balance and projected days remaining at current burn rate",
 		Example: `  scrape-creators-pp-cli account budget
   scrape-creators-pp-cli account budget --agent --select credits_remaining,days_remaining`,
@@ -1027,6 +1033,7 @@ func newSearchTrendsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "trends",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search a hashtag, record trend snapshots, and inspect stored history",
 		Example: `  scrape-creators-pp-cli search trends --hashtag BookTok
   scrape-creators-pp-cli search trends --hashtag BookTok --json

--- a/library/developer-tools/trigger-dev/internal/cli/costs.go
+++ b/library/developer-tools/trigger-dev/internal/cli/costs.go
@@ -16,6 +16,7 @@ func newCostsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "costs",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Analyze run costs by task, time period, and machine type",
 		Long: `Track spending by task and time period. Find cost spikes and anomalies before
 they hit your bill. Aggregates costInCents across runs.`,

--- a/library/developer-tools/trigger-dev/internal/cli/envvars_diff.go
+++ b/library/developer-tools/trigger-dev/internal/cli/envvars_diff.go
@@ -14,6 +14,7 @@ func newEnvvarsDiffCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "diff [env1] [env2]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare environment variables between two environments",
 		Long: `Side-by-side comparison of environment variables between two environments.
 Highlights missing, different, and matching values. Helps catch drift between

--- a/library/developer-tools/trigger-dev/internal/cli/failures.go
+++ b/library/developer-tools/trigger-dev/internal/cli/failures.go
@@ -17,6 +17,7 @@ func newFailuresCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "failures",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Analyze failure patterns across tasks and time periods",
 		Long: `Identify recurring failure patterns by analyzing failed runs across tasks,
 error types, and time-of-day. Helps you find systemic issues that one-off

--- a/library/developer-tools/trigger-dev/internal/cli/health.go
+++ b/library/developer-tools/trigger-dev/internal/cli/health.go
@@ -16,6 +16,7 @@ func newHealthCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "health",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Task health dashboard with success rates, durations, and cost trends",
 		Long: `Show per-task health metrics: success rate, failure rate, average duration,
 p95 duration, total cost, and run count. One command, full picture.

--- a/library/developer-tools/trigger-dev/internal/cli/queues_bottleneck.go
+++ b/library/developer-tools/trigger-dev/internal/cli/queues_bottleneck.go
@@ -12,6 +12,7 @@ import (
 func newQueuesBottleneckCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bottleneck",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Identify queues with growing backlogs and concurrency bottlenecks",
 		Long: `Analyze queue state to find bottlenecks: queues with high queued-to-running ratios,
 queues near or at their concurrency limits, and paused queues with pending work.`,

--- a/library/developer-tools/trigger-dev/internal/cli/runs_timeline.go
+++ b/library/developer-tools/trigger-dev/internal/cli/runs_timeline.go
@@ -16,6 +16,7 @@ func newRunsTimelineCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "timeline",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Visual ASCII timeline of run starts, completions, and failures",
 		Long: `Display an ASCII timeline of runs over a time period. Each character represents
 a time bucket. Shows patterns in run timing and failure clusters at a glance.

--- a/library/developer-tools/trigger-dev/internal/cli/schedules_stale.go
+++ b/library/developer-tools/trigger-dev/internal/cli/schedules_stale.go
@@ -14,6 +14,7 @@ func newSchedulesStaleCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find schedules that stopped producing runs or have high failure rates",
 		Long: `Detect stale schedules by cross-referencing schedule data with recent run history.
 Finds schedules with no recent runs, high failure rates, or that are disabled

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_browse.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_browse.go
@@ -88,6 +88,7 @@ func newBrowseCmd(flags *rootFlags, spec browseSpec) *cobra.Command {
 	var flagLimit int
 	cmd := &cobra.Command{
 		Use:     spec.use,
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   spec.short,
 		Example: fmt.Sprintf("  allrecipes-pp-cli %s %s --limit 20 --agent", strings.Fields(spec.use)[0], spec.exampleSlug),
 		Args:    cobra.MinimumNArgs(1),

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_cache.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_cache.go
@@ -14,6 +14,7 @@ import (
 func newCacheCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cache",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Inspect, list, or clear the local recipe cache",
 	}
 	cmd.AddCommand(newCacheStatsCmd(flags))
@@ -25,6 +26,7 @@ func newCacheCmd(flags *rootFlags) *cobra.Command {
 func newCacheStatsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "stats",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show summary stats for the local recipe cache",
 		Example: "  allrecipes-pp-cli cache stats --agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -52,6 +54,7 @@ func newCacheListCmd(flags *rootFlags) *cobra.Command {
 	var flagOrder string
 	cmd := &cobra.Command{
 		Use:     "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "List cached recipes",
 		Example: "  allrecipes-pp-cli cache list --limit 50 --order rating --agent",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_cookbook.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_cookbook.go
@@ -19,6 +19,7 @@ func newCookbookCmd(flags *rootFlags) *cobra.Command {
 	var flagTop int
 	cmd := &cobra.Command{
 		Use:   "cookbook",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compile top-rated cached recipes into a markdown cookbook",
 		Long: "Reads the local cache, picks the top-N recipes (by Bayesian-smoothed rating)\n" +
 			"in a category or cuisine, and writes a single markdown file with TOC,\n" +
@@ -121,6 +122,7 @@ func newGroceryListCmd(flags *rootFlags) *cobra.Command {
 	var flagOutput string
 	cmd := &cobra.Command{
 		Use:   "grocery-list <url> [<url>...]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Aggregate ingredients from many recipes into a deduped shopping list",
 		Long: "Fetches each recipe URL (from cache when available, live otherwise),\n" +
 			"parses ingredient lines into qty+unit+name, sums quantities for matching\n" +

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_fetch.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_fetch.go
@@ -19,6 +19,7 @@ import (
 func newArticleCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "article <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Extract metadata from an Allrecipes article page",
 		Long: "Returns the article title, description, canonical URL, and any recipe\n" +
 			"links the article references. Article body text extraction is best-effort\n" +
@@ -59,6 +60,7 @@ func newArticleCmd(flags *rootFlags) *cobra.Command {
 func newGalleryCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "gallery <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Extract recipe links from an Allrecipes round-up gallery",
 		Example: "  allrecipes-pp-cli gallery https://www.allrecipes.com/gallery/best-summer-salads/ --agent",
 		Args:    cobra.MinimumNArgs(1),

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_pantry.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_pantry.go
@@ -22,6 +22,7 @@ func newPantryCmd(flags *rootFlags) *cobra.Command {
 	var flagMaxMissing, flagLimit int
 	cmd := &cobra.Command{
 		Use:   "pantry",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Score cached recipes by overlap with a pantry of ingredients",
 		Long: `Reads --pantry-file (or --pantry as a comma-separated list of ingredients)
 and ranks cached recipes by how many of their ingredients you already have.
@@ -118,6 +119,7 @@ func newWithIngredientCmd(flags *rootFlags) *cobra.Command {
 	var flagMinRating float64
 	cmd := &cobra.Command{
 		Use:   "with-ingredient <name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Reverse index: cached recipes that use a given ingredient",
 		Long: `Searches the local recipe_ingredients_fts index for recipes containing the
 given ingredient name. Recipes only appear if their JSON-LD has been
@@ -178,6 +180,7 @@ func newDietaryCmd(flags *rootFlags) *cobra.Command {
 	var flagMaxMinutes int
 	cmd := &cobra.Command{
 		Use:   "dietary",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Filter cached recipes by gluten-free / vegan / low-carb / vegetarian / dairy-free",
 		Long: `Filters the local recipe cache by dietary heuristics:
   - gluten-free: excludes wheat, flour, bread, pasta, soy sauce, beer

--- a/library/food-and-dining/allrecipes/internal/cli/cmd_recipe.go
+++ b/library/food-and-dining/allrecipes/internal/cli/cmd_recipe.go
@@ -20,6 +20,7 @@ func newRecipeTopCmd(flags *rootFlags) *cobra.Command {
 	var flagMarkdown bool
 	cmd := &cobra.Command{
 		Use:   "recipe <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch a single recipe by URL, ID, or id/slug shorthand",
 		Example: "  allrecipes-pp-cli recipe https://www.allrecipes.com/recipe/9599/quick-and-easy-brownies/\n" +
 			"  allrecipes-pp-cli recipe 9599/quick-and-easy-brownies --agent\n" +
@@ -50,6 +51,7 @@ func newIngredientsCmd(flags *rootFlags) *cobra.Command {
 	var flagParsed bool
 	cmd := &cobra.Command{
 		Use:   "ingredients <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show parsed ingredients for a recipe",
 		Example: "  allrecipes-pp-cli ingredients 9599/quick-and-easy-brownies\n" +
 			"  allrecipes-pp-cli ingredients 9599/quick-and-easy-brownies --parsed --agent",
@@ -83,6 +85,7 @@ func newIngredientsCmd(flags *rootFlags) *cobra.Command {
 func newInstructionsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instructions <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show numbered instructions for a recipe",
 		Example: "  allrecipes-pp-cli instructions 9599/quick-and-easy-brownies\n" +
 			"  allrecipes-pp-cli instructions 9599/quick-and-easy-brownies --agent",
@@ -113,6 +116,7 @@ func newNutritionCmd(flags *rootFlags) *cobra.Command {
 	var flagServings int
 	cmd := &cobra.Command{
 		Use:   "nutrition <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show nutrition for a recipe (per serving by default)",
 		Example: "  allrecipes-pp-cli nutrition 9599/quick-and-easy-brownies\n" +
 			"  allrecipes-pp-cli nutrition 9599/quick-and-easy-brownies --servings 8 --agent",
@@ -151,6 +155,7 @@ func newNutritionCmd(flags *rootFlags) *cobra.Command {
 func newReviewsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reviews <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show review summary for a recipe",
 		Example: "  allrecipes-pp-cli reviews 9599/quick-and-easy-brownies\n" +
 			"  allrecipes-pp-cli reviews 9599/quick-and-easy-brownies --agent",
@@ -187,6 +192,7 @@ func newScaleCmd(flags *rootFlags) *cobra.Command {
 	var flagServings int
 	cmd := &cobra.Command{
 		Use:   "scale <url-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Rescale a recipe's ingredients to a target serving count",
 		Example: "  allrecipes-pp-cli scale 9599/quick-and-easy-brownies --servings 8\n" +
 			"  allrecipes-pp-cli scale 9599/quick-and-easy-brownies --servings 16 --agent",

--- a/library/food-and-dining/allrecipes/internal/cli/recipes_get.go
+++ b/library/food-and-dining/allrecipes/internal/cli/recipes_get.go
@@ -16,6 +16,7 @@ import (
 func newRecipesGetCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <recipe_id> <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch a recipe by ID + slug; returns parsed JSON-LD Recipe",
 		Example: "  allrecipes-pp-cli recipes get 9599 quick-and-easy-brownies\n" +
 			"  allrecipes-pp-cli recipes get 9599 quick-and-easy-brownies --agent --select recipeIngredient,totalTime,aggregateRating",

--- a/library/food-and-dining/allrecipes/internal/cli/recipes_search.go
+++ b/library/food-and-dining/allrecipes/internal/cli/recipes_search.go
@@ -23,6 +23,7 @@ func newRecipesSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Allrecipes for recipes matching a query",
 		Example: "  allrecipes-pp-cli recipes search --q brownies\n" +
 			"  allrecipes-pp-cli recipes search --q \"chicken thighs\" --limit 10 --agent",

--- a/library/food-and-dining/allrecipes/internal/cli/search.go
+++ b/library/food-and-dining/allrecipes/internal/cli/search.go
@@ -21,6 +21,7 @@ func newSearchTopCmd(flags *rootFlags) *cobra.Command {
 	var flagCacheOnly bool
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Allrecipes for recipes (live + cache)",
 		Example: "  allrecipes-pp-cli search brownies\n" +
 			"  allrecipes-pp-cli search \"chicken thighs\" --limit 10 --agent\n" +
@@ -129,6 +130,7 @@ func newTopRatedCmd(flags *rootFlags) *cobra.Command {
 	var flagEnrich bool
 	cmd := &cobra.Command{
 		Use:   "top-rated <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search and rank by Bayesian-smoothed rating",
 		Long: "Ranks search results by a Bayesian-smoothed estimate of the true rating:\n\n" +
 			"\tsmoothed = (C * priorMean + reviewCount * rating) / (C + reviewCount)\n\n" +
@@ -242,6 +244,7 @@ func newQuickCmd(flags *rootFlags) *cobra.Command {
 	var flagMinRating float64
 	cmd := &cobra.Command{
 		Use:   "quick",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Top-rated recipes from cache that fit a strict time cap",
 		Long: "Reads the local recipe cache and returns recipes whose total cook+prep time\n" +
 			"is at or below --max-minutes, ranked by Bayesian-smoothed rating. Allrecipes'\n" +

--- a/library/food-and-dining/food52/internal/cli/articles_browse.go
+++ b/library/food-and-dining/food52/internal/cli/articles_browse.go
@@ -17,6 +17,7 @@ func newArticlesBrowseCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "browse <vertical>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Browse the latest Food52 articles in a vertical (food, life)",
 		Example: strings.Trim(`
   food52-pp-cli articles browse food

--- a/library/food-and-dining/food52/internal/cli/articles_browse_sub.go
+++ b/library/food-and-dining/food52/internal/cli/articles_browse_sub.go
@@ -15,6 +15,7 @@ func newArticlesBrowseSubCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "browse-sub <vertical> <subvertical>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Browse Food52 articles in a vertical/subvertical (e.g. food baking, life travel)",
 		Example: strings.Trim(`
   food52-pp-cli articles browse-sub food baking

--- a/library/food-and-dining/food52/internal/cli/articles_for_recipe.go
+++ b/library/food-and-dining/food52/internal/cli/articles_for_recipe.go
@@ -15,6 +15,7 @@ import (
 func newArticlesForRecipeCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "for-recipe <slug-or-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find synced articles that mention a given recipe in their relatedReading",
 		Long: strings.TrimSpace(`
 Reverse-indexes the local store: for a given recipe slug, returns every

--- a/library/food-and-dining/food52/internal/cli/articles_get.go
+++ b/library/food-and-dining/food52/internal/cli/articles_get.go
@@ -15,6 +15,7 @@ import (
 func newArticlesGetCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <slug-or-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get a Food52 article (story) by slug or URL",
 		Example: strings.Trim(`
   food52-pp-cli articles get best-mothers-day-gift-ideas

--- a/library/food-and-dining/food52/internal/cli/pantry.go
+++ b/library/food-and-dining/food52/internal/cli/pantry.go
@@ -17,6 +17,7 @@ import (
 func newPantryCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pantry",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Manage a local pantry inventory and match it against synced Food52 recipes",
 		Long: strings.TrimSpace(`
 Track what's in your kitchen. Then run 'pantry match' to find synced Food52
@@ -79,6 +80,7 @@ func newPantryAddCmd(flags *rootFlags) *cobra.Command {
 func newPantryListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show all ingredients currently in your local pantry",
 		Example: strings.Trim(`
   food52-pp-cli pantry list
@@ -170,6 +172,7 @@ func newPantryMatchCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "match",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find synced Food52 recipes you can mostly make with what's in your pantry",
 		Long: strings.TrimSpace(`
 Joins your local pantry against every synced recipe and ranks recipes by

--- a/library/food-and-dining/food52/internal/cli/recipes_browse.go
+++ b/library/food-and-dining/food52/internal/cli/recipes_browse.go
@@ -17,6 +17,7 @@ func newRecipesBrowseCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "browse <tag>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Browse Food52 recipes filtered by a tag (e.g. chicken, breakfast, vegetarian)",
 		Example: strings.Trim(`
   food52-pp-cli recipes browse chicken

--- a/library/food-and-dining/food52/internal/cli/recipes_get.go
+++ b/library/food-and-dining/food52/internal/cli/recipes_get.go
@@ -15,6 +15,7 @@ import (
 func newRecipesGetCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <slug-or-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get full structured details for a single Food52 recipe by slug or URL",
 		Example: strings.Trim(`
   food52-pp-cli recipes get sarah-fennel-s-best-lunch-lady-brownie-recipe

--- a/library/food-and-dining/food52/internal/cli/recipes_search.go
+++ b/library/food-and-dining/food52/internal/cli/recipes_search.go
@@ -21,6 +21,7 @@ func newRecipesSearchCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Food52 recipes via Typesense (Food52's own search backend)",
 		Long: strings.TrimSpace(`
 Search Food52's recipe collection. Uses the public Typesense search-only key

--- a/library/food-and-dining/food52/internal/cli/recipes_top.go
+++ b/library/food-and-dining/food52/internal/cli/recipes_top.go
@@ -20,6 +20,7 @@ func newRecipesTopCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "top <tag>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show Food52 Test-Kitchen-approved + rating-floored recipes for a tag",
 		Long: strings.TrimSpace(`
 Filter recipes for a tag down to the editorially trusted set. By default

--- a/library/food-and-dining/food52/internal/cli/scale.go
+++ b/library/food-and-dining/food52/internal/cli/scale.go
@@ -17,6 +17,7 @@ func newScaleCmd(flags *rootFlags) *cobra.Command {
 	var servings int
 	cmd := &cobra.Command{
 		Use:   "scale <slug-or-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Scale a Food52 recipe's ingredients to a different number of servings",
 		Long: strings.TrimSpace(`
 Fetches a recipe, parses its yield from the JSON-LD recipeYield field, and

--- a/library/food-and-dining/food52/internal/cli/search.go
+++ b/library/food-and-dining/food52/internal/cli/search.go
@@ -20,6 +20,7 @@ func newLocalSearchCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search the local store across synced recipes and articles",
 		Long: strings.TrimSpace(`
 Searches every recipe and article you have synced into the local SQLite store

--- a/library/food-and-dining/food52/internal/cli/sync_articles.go
+++ b/library/food-and-dining/food52/internal/cli/sync_articles.go
@@ -21,6 +21,7 @@ func newSyncArticlesCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "articles <vertical> [<subvertical>]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Pull Food52 articles for a vertical (and optional subvertical) into the local store",
 		Long: strings.TrimSpace(`
 Walks /<vertical> (or /<vertical>/<subvertical>), then fetches each article's

--- a/library/food-and-dining/food52/internal/cli/sync_recipes.go
+++ b/library/food-and-dining/food52/internal/cli/sync_recipes.go
@@ -26,6 +26,7 @@ func newSyncRecipesCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "recipes <tag> [<tag>...]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Pull Food52 recipes for one or more tags into the local store (FTS-indexed)",
 		Long: strings.TrimSpace(`
 Walks one or more tag pages, fetches each recipe's full structured detail

--- a/library/food-and-dining/food52/internal/cli/tags.go
+++ b/library/food-and-dining/food52/internal/cli/tags.go
@@ -14,6 +14,7 @@ import (
 func newTagsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tags",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Discover Food52 recipe tags and filter the curated taxonomy",
 	}
 	cmd.AddCommand(newTagsListCmd(flags))
@@ -24,6 +25,7 @@ func newTagsListCmd(flags *rootFlags) *cobra.Command {
 	var kind string
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List Food52 recipe tags discovered from the homepage navigation, optionally filtered by kind",
 		Long: strings.TrimSpace(`
 List the curated Food52 tag taxonomy. Tags are grouped by kind:

--- a/library/food-and-dining/pagliacci-pizza/internal/cli/address_best_time.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/cli/address_best_time.go
@@ -157,6 +157,7 @@ func newAddressBestTimeCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "best-time",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Resolve a saved address label to the next available delivery (or pickup) slot",
 		Example: `  pagliacci-pizza-pp-cli address best-time --label home
   pagliacci-pizza-pp-cli address best-time --label work --limit 3 --json`,

--- a/library/food-and-dining/pagliacci-pizza/internal/cli/orders_summary.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/cli/orders_summary.go
@@ -214,6 +214,7 @@ func newOrdersSummaryCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "summary",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Aggregate order spend, order count, top items, and per-store breakdown from local sync data",
 		Example: `  pagliacci-pizza-pp-cli orders summary
   pagliacci-pizza-pp-cli orders summary --since 90d --json`,

--- a/library/food-and-dining/pagliacci-pizza/internal/cli/rewards_stack.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/cli/rewards_stack.go
@@ -162,6 +162,7 @@ func newRewardsStackCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stack",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Pick the best coupon + stored credit combination for a given order total",
 		Example: `  pagliacci-pizza-pp-cli rewards stack --order-total 45.00
   pagliacci-pizza-pp-cli rewards stack --order-total 45.00 --experimental --json`,

--- a/library/food-and-dining/pagliacci-pizza/internal/cli/slices.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/cli/slices.go
@@ -13,6 +13,7 @@ import (
 func newSlicesCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "slices",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Slice availability across stores (today's perishable rotation)",
 	}
 	cmd.AddCommand(newSlicesTodayCmd(flags))
@@ -114,6 +115,7 @@ func newSlicesTodayCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "today",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show slices available right now at every Pagliacci store, joined with store name and address",
 		Example: `  pagliacci-pizza-pp-cli slices today
   pagliacci-pizza-pp-cli slices today --store 492

--- a/library/food-and-dining/pagliacci-pizza/internal/cli/store_tonight.go
+++ b/library/food-and-dining/pagliacci-pizza/internal/cli/store_tonight.go
@@ -136,6 +136,7 @@ func newStoreTonightCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tonight",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List stores still open and able to deliver right now to your saved address",
 		Example: `  pagliacci-pizza-pp-cli store tonight --address-label home
   pagliacci-pizza-pp-cli store tonight --address "350 5th Ave, Seattle, WA"

--- a/library/marketing/dub/internal/cli/campaigns.go
+++ b/library/marketing/dub/internal/cli/campaigns.go
@@ -32,6 +32,7 @@ func newCampaignsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "campaigns",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Tag-grouped performance dashboard — clicks, leads, sales rolled up per tag",
 		Long: `Aggregate clicks, leads, and sales for every tag in your workspace. Joins the
 local link cache with each link's analytics fields. Surfaces the top campaign tag

--- a/library/marketing/dub/internal/cli/customers_journey.go
+++ b/library/marketing/dub/internal/cli/customers_journey.go
@@ -25,6 +25,7 @@ func newCustomersJourneyCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "journey",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "See every link a customer clicked, when they became a lead, and when they purchased",
 		Long: `Stitch together a single customer's full attribution timeline across links,
 events, leads, and sales. Live API call: pulls /events filtered by customerId

--- a/library/marketing/dub/internal/cli/domains_report.go
+++ b/library/marketing/dub/internal/cli/domains_report.go
@@ -27,6 +27,7 @@ type domainStat struct {
 func newDomainsReportCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "report",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Per-domain usage report — link counts and click distribution across custom domains",
 		Long: `Aggregate every link in the local store grouped by short domain. Surfaces
 over- and under-used custom domains so you know which ones are pulling weight

--- a/library/marketing/dub/internal/cli/funnel.go
+++ b/library/marketing/dub/internal/cli/funnel.go
@@ -21,6 +21,7 @@ func newFunnelCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "funnel",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Click → lead → sale conversion rates for a link or workspace",
 		Long: `Show clicks, leads, and sales counts plus the conversion percentage at each
 stage. Useful for finding where prospects drop off in the funnel.

--- a/library/marketing/dub/internal/cli/health.go
+++ b/library/marketing/dub/internal/cli/health.go
@@ -37,6 +37,7 @@ func newHealthCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "health",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Workspace health doctor — rate limit, expired-but-active links, dead destinations",
 		Long: `Cross-resource Monday-morning health report:
   - API reachability and current rate-limit headroom

--- a/library/marketing/dub/internal/cli/links_drift.go
+++ b/library/marketing/dub/internal/cli/links_drift.go
@@ -36,6 +36,7 @@ func newLinksDriftCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "drift",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Detect links whose click rate dropped beyond threshold week-over-week",
 		Long: `Compare per-link click counts across two adjacent windows and flag links whose
 click rate changed beyond --threshold percent. Surfaces silent campaign collapse

--- a/library/marketing/dub/internal/cli/links_duplicates.go
+++ b/library/marketing/dub/internal/cli/links_duplicates.go
@@ -27,6 +27,7 @@ func newLinksDuplicatesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "duplicates",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Aliases: []string{"dups"},
 		Short:   "Find links pointing to the same destination URL",
 		Long: `Group every link in the local store by its destination URL and surface every

--- a/library/marketing/dub/internal/cli/links_stale.go
+++ b/library/marketing/dub/internal/cli/links_stale.go
@@ -38,6 +38,7 @@ func newLinksStaleCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find links nobody clicks — dead-link detection",
 		Long: `Find links with zero or near-zero clicks. Combines several signals:
   - clicks below threshold over the last --days

--- a/library/marketing/dub/internal/cli/partners_audit_commissions.go
+++ b/library/marketing/dub/internal/cli/partners_audit_commissions.go
@@ -25,6 +25,7 @@ type auditFinding struct {
 func newPartnersAuditCommissionsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "audit-commissions",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Reconcile partners × commissions × payouts; flag stale rates and missing payouts",
 		Long: `Cross-resource audit:
   - commissions in 'pending' status older than 14 days (stuck payout)

--- a/library/marketing/dub/internal/cli/partners_leaderboard.go
+++ b/library/marketing/dub/internal/cli/partners_leaderboard.go
@@ -34,6 +34,7 @@ func newPartnersLeaderboardCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "leaderboard",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Aliases: []string{"top"},
 		Short:   "Rank partners by commission earned, conversion rate, and clicks",
 		Long: `Rank every partner in your workspace by performance metrics. Surfaces top

--- a/library/marketing/dub/internal/cli/since.go
+++ b/library/marketing/dub/internal/cli/since.go
@@ -29,6 +29,7 @@ func newSinceCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "since [duration]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Time-windowed change feed — what was created/updated in the last N",
 		Long: `Show every link, partner, customer, or commission that was created or updated
 within the given duration. Reads from the local store using each row's createdAt

--- a/library/marketing/producthunt/internal/cli/authors.go
+++ b/library/marketing/producthunt/internal/cli/authors.go
@@ -17,6 +17,7 @@ type coOccurrencePayload struct {
 func newAuthorsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "authors",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Query author-derived signals from your local snapshot store",
 		Long:  `Parent command for author-oriented queries. See subcommands.`,
 		Example: `  producthunt-pp-cli authors related --to 'Ryan Hoover' --since 90d
@@ -34,6 +35,7 @@ func newAuthorsRelatedCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "related",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Authors who repeatedly appeared in the same /feed snapshots as a given author",
 		Long: `A rough social signal from pure /feed data: for a target author, return
 the authors whose posts co-occurred in feed snapshots most often. Computed

--- a/library/marketing/producthunt/internal/cli/calendar.go
+++ b/library/marketing/producthunt/internal/cli/calendar.go
@@ -32,6 +32,7 @@ func newCalendarCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "calendar",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Week-at-a-glance: which products were featured each day",
 		Long: `Group the posts you've synced by their first-seen day and render a
 calendar-shaped payload. Requires first_seen data, which accumulates as

--- a/library/marketing/producthunt/internal/cli/info.go
+++ b/library/marketing/producthunt/internal/cli/info.go
@@ -20,6 +20,7 @@ func newGetCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "get <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Aliases: []string{"info"},
 		Short:   "Show the post for a given slug",
 		Long: `Return the stored post for a Product Hunt slug. By default reads from

--- a/library/marketing/producthunt/internal/cli/list.go
+++ b/library/marketing/producthunt/internal/cli/list.go
@@ -23,6 +23,7 @@ func newListCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List posts from the local store with filters",
 		Long: `Query the local store of posts the CLI has ever synced. Filter by author
 name, date range, or custom sort. Returns the stable post payload so --json

--- a/library/marketing/producthunt/internal/cli/makers.go
+++ b/library/marketing/producthunt/internal/cli/makers.go
@@ -22,6 +22,7 @@ func newMakersCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "makers",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Top authors (makers and hunters) across all synced snapshots",
 		Long: `Aggregate the author field across every snapshot in the window. Returns
 each author with total_count (how many snapshot appearances they logged)

--- a/library/marketing/producthunt/internal/cli/outbound_diff.go
+++ b/library/marketing/producthunt/internal/cli/outbound_diff.go
@@ -26,6 +26,7 @@ func newOutboundDiffCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "outbound-diff",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List posts whose external URL has changed across snapshots",
 		Long: `Find posts whose external landing URL (/r/p/{id} PH redirect) has been
 updated across syncs. Signals domain moves, beta-to-launch transitions,

--- a/library/marketing/producthunt/internal/cli/promoted_feed.go
+++ b/library/marketing/producthunt/internal/cli/promoted_feed.go
@@ -17,6 +17,7 @@ import (
 func newFeedPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feed",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch or inspect the public Product Hunt Atom feed",
 		Long: `The 'feed' group covers direct access to producthunt.com/feed (Atom 1.0,
 50 entries, no auth). See the subcommands below. For the default
@@ -36,6 +37,7 @@ func newFeedRawCmd(flags *rootFlags) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "raw",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Print the raw Atom XML body of /feed",
 		Long: `Fetch /feed and write the raw XML to stdout without parsing. Useful for
 piping into other XML tools or preserving exact-wire content.

--- a/library/marketing/producthunt/internal/cli/search.go
+++ b/library/marketing/producthunt/internal/cli/search.go
@@ -24,6 +24,7 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search the local post store",
 		Long: `Run an FTS5 match against every post ever synced. The index covers
 slug, title, tagline, and author. Works offline — empty store returns [].

--- a/library/marketing/producthunt/internal/cli/stubs.go
+++ b/library/marketing/producthunt/internal/cli/stubs.go
@@ -73,6 +73,7 @@ in a browser, use 'open <slug>'.`,
 func newCommentsCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "comments <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "(stub) Comments on a post — CF-gated, requires browser clearance",
 		Example: `  producthunt-pp-cli comments seeknal --json`,
 		Args:    cobra.ExactArgs(1),
@@ -88,6 +89,7 @@ func newCommentsCmd(flags *rootFlags) *cobra.Command {
 func newLeaderboardCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "leaderboard",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "(stub) Daily/weekly/monthly leaderboards — CF-gated, use local snapshots instead",
 		Long: `Historical leaderboard pages at producthunt.com/leaderboard/... are
 Cloudflare-gated. This build does not fetch them.
@@ -108,6 +110,7 @@ snapshot of the live /feed. Then query 'list --since <window>' or 'trend
 		p := period
 		cmd.AddCommand(&cobra.Command{
 			Use:     p,
+		Annotations: map[string]string{"mcp:read-only": "true"},
 			Short:   fmt.Sprintf("(stub) %s leaderboard — CF-gated", p),
 			Example: fmt.Sprintf("  producthunt-pp-cli leaderboard %s --json", p),
 			RunE: func(c *cobra.Command, args []string) error {
@@ -124,6 +127,7 @@ snapshot of the live /feed. Then query 'list --since <window>' or 'trend
 func newTopicCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "topic <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "(stub) Topic feed — CF-gated, no Atom alternative",
 		Example: `  producthunt-pp-cli topic artificial-intelligence --json`,
 		Long: `Topic pages at /topics/<slug> are Cloudflare-gated, and the /feed?category=
@@ -144,6 +148,7 @@ No Atom fallback exists. This stub documents the gap explicitly.`,
 func newUserCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "user <handle>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "(stub) User/maker profile — CF-gated",
 		Example: `  producthunt-pp-cli user rrhoover --json`,
 		Long: `Profile pages at /@<handle> are Cloudflare-gated.
@@ -178,6 +183,7 @@ func newCollectionCmd(flags *rootFlags) *cobra.Command {
 func newNewsletterCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "newsletter",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "(stub) Newsletter archive — CF-gated, no Atom alternative",
 		Example: `  producthunt-pp-cli newsletter --json`,
 		Long: `Newsletter archive pages at /newsletters/archive/... are Cloudflare-gated.

--- a/library/marketing/producthunt/internal/cli/tagline_grep.go
+++ b/library/marketing/producthunt/internal/cli/tagline_grep.go
@@ -18,6 +18,7 @@ func newTaglineGrepCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tagline-grep <pattern>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search every tagline the CLI has ever synced",
 		Long: `Grep the tagline field across your full local post store. Two modes:
 

--- a/library/marketing/producthunt/internal/cli/today.go
+++ b/library/marketing/producthunt/internal/cli/today.go
@@ -17,6 +17,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "today",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List the current featured launches on Product Hunt",
 		Long: `Show the top entries from the public Product Hunt Atom feed.
 
@@ -121,6 +122,7 @@ func newRecentCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	cmd := &cobra.Command{
 		Use:   "recent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Live-fetch /feed (bypass store) and return the newest entries",
 		Long: `Shortcut for 'today --live'. Always fetches /feed from the network and does
 not read from the local store. Useful when you want a fresh view without

--- a/library/marketing/producthunt/internal/cli/trend.go
+++ b/library/marketing/producthunt/internal/cli/trend.go
@@ -40,6 +40,7 @@ func newTrendCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "trend <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a post's rank trajectory across all synced snapshots",
 		Long: `Return the complete appearance history for a slug: every snapshot that
 captured it, the rank it held, best/worst rank, number of appearances,

--- a/library/media-and-entertainment/archive-is/internal/cli/read.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/read.go
@@ -709,6 +709,7 @@ func newReadCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "read <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find or create an archive of a paywalled URL (the hero command)",
 		Long: "Find an existing archive.today snapshot for the URL, or create one if none exists.\n\n" +
 			"Tries timegate lookup first (fast — usually under 500ms). Only submits a fresh capture\n" +
@@ -821,6 +822,7 @@ func newGetCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch the full archived article text as clean markdown",
 		Long: "Find or create an archive for the URL, then fetch the memento HTML and extract\n" +
 			"clean readable text. Perfect for piping into LLMs, notes, or terminal reading.\n\n" +
@@ -916,6 +918,7 @@ func newGetCmd(flags *rootFlags) *cobra.Command {
 func newHistoryCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "history <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "List all known archive snapshots for a URL, oldest to newest",
 		Long:    "Queries the Memento timemap endpoint and returns every snapshot ever taken of the URL, with timestamps.",
 		Example: "  archive-is-pp-cli history https://www.nytimes.com/\n  archive-is-pp-cli history https://example.com --json",
@@ -1027,6 +1030,7 @@ func newBulkCmd(flags *rootFlags) *cobra.Command {
 	var backend string
 	cmd := &cobra.Command{
 		Use:   "bulk [file]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Archive a list of URLs with built-in rate limiting",
 		Long: "Reads one URL per line from a file (or stdin if no file given) and runs\n" +
 			"'read' on each with a delay between requests to avoid rate limits.\n" +

--- a/library/media-and-entertainment/archive-is/internal/cli/tldr.go
+++ b/library/media-and-entertainment/archive-is/internal/cli/tldr.go
@@ -25,6 +25,7 @@ func newTldrCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tldr <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch an archived article and summarize it with an LLM",
 		Long: "Runs the full paywall-bypass pipeline: find or create an archive.today\n" +
 			"snapshot, fetch the body, extract clean text, and summarize via a locally\n" +

--- a/library/media-and-entertainment/espn/internal/cli/boxscore.go
+++ b/library/media-and-entertainment/espn/internal/cli/boxscore.go
@@ -22,6 +22,7 @@ func newBoxscoreCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "boxscore <event_id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full box score for a specific event id",
 		Example: `  espn-pp-cli boxscore 401547417 --sport football --league nfl
   espn-pp-cli boxscore 401584793 --sport basketball --league nba --agent

--- a/library/media-and-entertainment/espn/internal/cli/compare.go
+++ b/library/media-and-entertainment/espn/internal/cli/compare.go
@@ -17,6 +17,7 @@ func newCompareCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "compare <athlete1> <athlete2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Side-by-side athlete stat comparison",
 		Example: `  espn-pp-cli compare Mahomes Allen --sport football --league nfl
   espn-pp-cli compare LeBron Curry --sport basketball --league nba --agent`,

--- a/library/media-and-entertainment/espn/internal/cli/dashboard.go
+++ b/library/media-and-entertainment/espn/internal/cli/dashboard.go
@@ -61,6 +61,7 @@ func loadDashboardFavorites(path string) (map[string][]string, string, error) {
 func newDashboardCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dashboard",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Your favorite teams' status at a glance (reads [favorites] in config.toml)",
 		Example: `  espn-pp-cli dashboard
   espn-pp-cli dashboard --agent

--- a/library/media-and-entertainment/espn/internal/cli/h2h.go
+++ b/library/media-and-entertainment/espn/internal/cli/h2h.go
@@ -17,6 +17,7 @@ func newH2hCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "h2h <team1> <team2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Head-to-head detail between two teams",
 		Example: `  espn-pp-cli h2h KC BUF --sport football --league nfl
   espn-pp-cli h2h LAL BOS --sport basketball --league nba --agent

--- a/library/media-and-entertainment/espn/internal/cli/odds.go
+++ b/library/media-and-entertainment/espn/internal/cli/odds.go
@@ -13,6 +13,7 @@ import (
 func newOddsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "odds <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Spread, total, and moneyline lines for tonight's slate",
 		Example: `  espn-pp-cli odds basketball nba
   espn-pp-cli odds football nfl --agent

--- a/library/media-and-entertainment/espn/internal/cli/promoted_injuries.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_injuries.go
@@ -16,6 +16,7 @@ import (
 func newInjuriesPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "injuries <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Active injury reports for a league",
 		Example: `  espn-pp-cli injuries football nfl
   espn-pp-cli injuries basketball nba --agent

--- a/library/media-and-entertainment/espn/internal/cli/promoted_leaders.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_leaders.go
@@ -17,6 +17,7 @@ func newLeadersPromotedCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "leaders <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Statistical leaders across categories",
 		Example: `  espn-pp-cli leaders football nfl
   espn-pp-cli leaders basketball nba --category points

--- a/library/media-and-entertainment/espn/internal/cli/promoted_plays.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_plays.go
@@ -17,6 +17,7 @@ func newPlaysPromotedCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "plays <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Play-by-play feed for a specific event",
 		Example: `  espn-pp-cli plays football nfl --event 401547417
   espn-pp-cli plays basketball nba --event 401584793 --limit 50

--- a/library/media-and-entertainment/espn/internal/cli/promoted_transactions.go
+++ b/library/media-and-entertainment/espn/internal/cli/promoted_transactions.go
@@ -14,6 +14,7 @@ import (
 func newTransactionsPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transactions <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Recent league transactions (trades, signings, waivers)",
 		Example: `  espn-pp-cli transactions baseball mlb
   espn-pp-cli transactions football nfl --agent

--- a/library/media-and-entertainment/espn/internal/cli/recap.go
+++ b/library/media-and-entertainment/espn/internal/cli/recap.go
@@ -13,6 +13,7 @@ func newRecapCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "recap <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Game recap with box score and leaders",
 		Example: `  espn-pp-cli recap football nfl --event 401547417
   espn-pp-cli recap basketball nba --event 401584793 --json`,

--- a/library/media-and-entertainment/espn/internal/cli/rivals.go
+++ b/library/media-and-entertainment/espn/internal/cli/rivals.go
@@ -14,6 +14,7 @@ func newRivalsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "rivals <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Head-to-head record between two teams from synced data",
 		Example: `  espn-pp-cli rivals football nfl --teams KC,BUF
   espn-pp-cli rivals basketball nba --teams LAL,BOS --json

--- a/library/media-and-entertainment/espn/internal/cli/scores.go
+++ b/library/media-and-entertainment/espn/internal/cli/scores.go
@@ -25,6 +25,7 @@ func newScoresCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "scores <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Live scores and results for a sport and league",
 		Example: `  espn-pp-cli scores football nfl
   espn-pp-cli scores basketball nba --dates 20250115

--- a/library/media-and-entertainment/espn/internal/cli/search_cmd.go
+++ b/library/media-and-entertainment/espn/internal/cli/search_cmd.go
@@ -14,6 +14,7 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search across synced events and news",
 		Example: `  espn-pp-cli search "Lakers"
   espn-pp-cli search "touchdown" --sport football --limit 10

--- a/library/media-and-entertainment/espn/internal/cli/sql_cmd.go
+++ b/library/media-and-entertainment/espn/internal/cli/sql_cmd.go
@@ -14,6 +14,7 @@ func newSQLCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "sql <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Run read-only SQL queries against the local database",
 		Long: `Execute raw SQL SELECT queries against the local SQLite database.
 Write operations (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE) are blocked.

--- a/library/media-and-entertainment/espn/internal/cli/standings_cmd.go
+++ b/library/media-and-entertainment/espn/internal/cli/standings_cmd.go
@@ -16,6 +16,7 @@ func newStandingsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "standings <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Conference/division standings for a sport and league",
 		Example: `  espn-pp-cli standings football nfl
   espn-pp-cli standings basketball nba --season 2024

--- a/library/media-and-entertainment/espn/internal/cli/streak.go
+++ b/library/media-and-entertainment/espn/internal/cli/streak.go
@@ -15,6 +15,7 @@ func newStreakCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "streak <sport> <league>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Current win/loss streak for a team from synced data",
 		Example: `  espn-pp-cli streak football nfl --team KC
   espn-pp-cli streak basketball nba --team LAL --limit 30

--- a/library/media-and-entertainment/espn/internal/cli/today.go
+++ b/library/media-and-entertainment/espn/internal/cli/today.go
@@ -26,6 +26,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "today",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Today's scores across all major sports",
 		Example: `  espn-pp-cli today
   espn-pp-cli today --sport nba

--- a/library/media-and-entertainment/espn/internal/cli/trending.go
+++ b/library/media-and-entertainment/espn/internal/cli/trending.go
@@ -17,6 +17,7 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "trending",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Cross-league trending headlines (top stories across leagues)",
 		Example: `  espn-pp-cli trending
   espn-pp-cli trending --limit 20 --agent

--- a/library/media-and-entertainment/hackernews/internal/cli/bookmark.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/bookmark.go
@@ -110,6 +110,7 @@ type bookmarkRow struct {
 func newBookmarkListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List local bookmarks",
 		Example: strings.Trim(`
   hackernews-pp-cli bookmark list

--- a/library/media-and-entertainment/hackernews/internal/cli/comments.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/comments.go
@@ -21,6 +21,7 @@ func newCommentsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "comments <id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Print a thread's comment tree using Algolia's one-shot fetch",
 		Long: `Print a Hacker News thread's full comment tree in a single Algolia call.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/controversial.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/controversial.go
@@ -38,6 +38,7 @@ func newControversialCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "controversial",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find stories with the highest comment-to-point ratio (polarizing discussions)",
 		Long: `Rank locally synced stories by descendants/score.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/hiring.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/hiring.go
@@ -109,6 +109,7 @@ func displayStampUnix(ts int64) string {
 func newHiringCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hiring [regex]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Filter the latest 'Ask HN: Who is hiring' thread by regex",
 		Long: `Find the latest 'Ask HN: Who is hiring?' thread on HN and filter the
 top-level posts with a case-insensitive regex.
@@ -134,6 +135,7 @@ Each post is emitted with author, created date, body, and HN URL.`,
 func newFreelanceCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "freelance [regex]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Filter the latest 'Freelancer? Seeking freelancer?' thread by regex",
 		Example: strings.Trim(`
   hackernews-pp-cli freelance

--- a/library/media-and-entertainment/hackernews/internal/cli/hiring_stats.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/hiring_stats.go
@@ -48,6 +48,7 @@ func newHiringStatsCmd(flags *rootFlags) *cobra.Command {
 	var months int
 	cmd := &cobra.Command{
 		Use:   "hiring-stats",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Aggregate Who's Hiring threads across N months — top languages, remote ratio, top companies",
 		Long: `Walk the most recent N 'Who is hiring?' threads on HN and compute aggregate stats.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/hn_search.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/hn_search.go
@@ -29,6 +29,7 @@ func newLiveSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "live-search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Hacker News stories and comments live via the Algolia API",
 		Long: `Run a live search against the Hacker News Algolia index.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/local_search.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/local_search.go
@@ -20,6 +20,7 @@ func newLocalSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "local-search <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search across the local SQLite store of synced stories and comments",
 		Long: `Search locally synced HN data with SQLite FTS5.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/my.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/my.go
@@ -37,6 +37,7 @@ func newMyCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "my <username>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Track a user's submission history with score buckets, traction rate, and best posting time",
 		Long: `Pull a user's recent submissions from Algolia and compute structured stats.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/pulse.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/pulse.go
@@ -45,6 +45,7 @@ func newPulseCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "pulse <topic>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show what HN is saying about a topic this week — score, comment, frequency by day",
 		Long: `Run an Algolia query for a topic, scoped to the last N days, and bucket
 hits by UTC date.

--- a/library/media-and-entertainment/hackernews/internal/cli/repost.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/repost.go
@@ -31,6 +31,7 @@ func newRepostCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "repost <url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Has this URL been posted on HN before? Lists prior submissions with scores and dates",
 		Long: `Search Algolia for prior submissions of a URL.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/since.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/since.go
@@ -130,6 +130,7 @@ func newSinceCmd(flags *rootFlags) *cobra.Command {
 	var list string
 	cmd := &cobra.Command{
 		Use:   "since",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show what changed on the front page since last sync (added, removed, moved stories)",
 		Long: `Diff the most recent two front-page snapshots taken by sync.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/tldr.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/tldr.go
@@ -44,6 +44,7 @@ type tldrResult struct {
 func newTldrCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tldr <id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Print a deterministic thread digest (top authors, reply ratio, heat metric)",
 		Long: `Walk a thread's full comment tree and emit measurable signals.
 

--- a/library/media-and-entertainment/hackernews/internal/cli/velocity.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/velocity.go
@@ -23,6 +23,7 @@ type velocityRow struct {
 func newVelocityCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "velocity <id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a story's rank trajectory across local snapshots",
 		Long: `Read every front-page snapshot that contains the given item and
 emit (taken_at, list, rank) rows.

--- a/library/media-and-entertainment/movie-goat/internal/cli/blind.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/blind.go
@@ -21,6 +21,7 @@ func newBlindCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "blind",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get a random high-quality movie pick — the surprise me experience",
 		Long: `Can't decide what to watch? Let fate decide. Picks a random well-rated movie
 using TMDb's discover API with filters for genre, decade, minimum rating,

--- a/library/media-and-entertainment/movie-goat/internal/cli/career.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/career.go
@@ -16,6 +16,7 @@ func newCareerCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "career <person-name-or-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Explore a person's complete filmography with stats and highlights",
 		Long: `Look up an actor, director, or crew member's full career across movies and TV.
 Shows a filmography table sorted by year, rating, or popularity, plus career summary stats.`,

--- a/library/media-and-entertainment/movie-goat/internal/cli/marathon.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/marathon.go
@@ -12,6 +12,7 @@ import (
 func newMarathonCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "marathon <collection-name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Plan a franchise marathon with watch order and total runtime",
 		Long: `Search for a TMDb collection (e.g. "Star Wars", "The Dark Knight") and display
 the full franchise lineup in release order. Shows runtime for each entry,

--- a/library/media-and-entertainment/movie-goat/internal/cli/movies_get.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/movies_get.go
@@ -17,6 +17,7 @@ func newMoviesGetCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get <movieId>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get detailed info about a movie including cast, ratings, and streaming availability",
 		Example: `  movie-goat-pp-cli movies get 550
   movie-goat-pp-cli movies get 155 --json

--- a/library/media-and-entertainment/movie-goat/internal/cli/recommend_for_me.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/recommend_for_me.go
@@ -14,6 +14,7 @@ func newRecommendForMeCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "recommend-for-me <title1> [title2] [title3...]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get movie recommendations based on movies you love",
 		Long: `Provide 2 or more movies you enjoy. The algorithm fetches recommendations
 and similar movies for each, then scores candidates by how well they bridge

--- a/library/media-and-entertainment/movie-goat/internal/cli/tonight.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/tonight.go
@@ -15,6 +15,7 @@ func newTonightCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tonight",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Smart \"what should I watch tonight?\" recommendation",
 		Long: `Combines trending and popular movies to surface the best picks for tonight.
 Fetches today's trending movies and currently popular top-rated movies,

--- a/library/media-and-entertainment/movie-goat/internal/cli/versus.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/versus.go
@@ -13,6 +13,7 @@ import (
 func newVersusCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "versus <title1> <title2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare two movies side-by-side: ratings, box office, cast, streaming",
 		Long: `Compare two movies head-to-head across all dimensions: ratings (TMDb, IMDb,
 Rotten Tomatoes, Metacritic), runtime, budget, revenue, genres, streaming

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_achievements.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_achievements.go
@@ -13,6 +13,7 @@ func newAchievementsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "achievements <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a player's achievements for a game",
 		Long:  `List all achievements a player has earned (or not) for a specific game.`,
 		Example: `  # Show achievements for CS2 (appid 730)

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_api.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_api.go
@@ -11,6 +11,7 @@ import (
 func newAPICmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api [interface]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Access all 170 Steam Web API endpoints by interface name",
 		Long: `Browse and call any Steam Web API endpoint using the raw interface names.
 

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_badges.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_badges.go
@@ -11,6 +11,7 @@ import (
 func newBadgesCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "badges <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a player's badges",
 		Long:  `List all badges a player has earned, with XP and level info.`,
 		Example: `  # Show badges

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_bans.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_bans.go
@@ -11,6 +11,7 @@ import (
 func newBansCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bans <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Check a player's VAC and game ban status",
 		Long:  `Show whether a player has any VAC bans, game bans, or trade bans.`,
 		Example: `  # Check ban status

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_friends.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_friends.go
@@ -11,6 +11,7 @@ import (
 func newFriendsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "friends <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List a player's friends",
 		Long:  `Show all friends for a Steam user including relationship type and friend-since date.`,
 		Example: `  # List friends

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_games.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_games.go
@@ -14,6 +14,7 @@ func newGamesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "games <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List a player's owned games with playtime",
 		Long:  `Show all games owned by a Steam user, including playtime in minutes.`,
 		Example: `  # List owned games

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_level.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_level.go
@@ -10,6 +10,7 @@ import (
 func newLevelCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "level <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a player's Steam level",
 		Long:  `Get the Steam level for a player by their Steam ID.`,
 		Example: `  # Show Steam level

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_news.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_news.go
@@ -13,6 +13,7 @@ func newNewsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "news <appid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show news articles for a game",
 		Long:  `Fetch recent news and patch notes for a game by its App ID.`,
 		Example: `  # Show news for CS2

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_players.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_players.go
@@ -10,6 +10,7 @@ import (
 func newPlayersCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "players <appid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show the current number of players for a game",
 		Long:  `Get the current number of players online for a game by its App ID.`,
 		Example: `  # Show current players for CS2

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_profile.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_profile.go
@@ -11,6 +11,7 @@ import (
 func newProfileCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a Steam player's profile summary",
 		Long:  `Display player name, profile URL, avatar, online status, and other profile details.`,
 		Example: `  # Show a player's profile

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_recent.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_recent.go
@@ -11,6 +11,7 @@ import (
 func newRecentCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "recent <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a player's recently played games",
 		Long:  `List games the player has played in the last two weeks with playtime.`,
 		Example: `  # Show recently played games

--- a/library/media-and-entertainment/steam-web/internal/cli/cmd_stats.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/cmd_stats.go
@@ -13,6 +13,7 @@ func newStatsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stats <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show a player's stats for a game",
 		Long:  `Display detailed player statistics for a specific game (kills, deaths, playtime, etc.).`,
 		Example: `  # Show stats for CS2 (appid 730)

--- a/library/media-and-entertainment/steam-web/internal/cli/workflow_backlog.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/workflow_backlog.go
@@ -14,6 +14,7 @@ func newWorkflowBacklogCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "backlog <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find owned games with zero playtime (your backlog)",
 		Long: `Reads owned games from the local store and lists those with 0 playtime.
 Run 'steam-web-pp-cli sync' first to populate the local store, or use

--- a/library/media-and-entertainment/steam-web/internal/cli/workflow_compare.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/workflow_compare.go
@@ -13,6 +13,7 @@ func newWorkflowCompareCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "compare <steamid1> <steamid2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare two players' game libraries",
 		Long: `Reads owned games from the local store for two players and shows
 shared games, games unique to each player, and playtime differences.

--- a/library/media-and-entertainment/steam-web/internal/cli/workflow_playtime.go
+++ b/library/media-and-entertainment/steam-web/internal/cli/workflow_playtime.go
@@ -15,6 +15,7 @@ func newWorkflowPlaytimeCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "playtime <steamid>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show top games by playtime, leaderboard style",
 		Long: `Reads owned games from the local store and ranks them by total playtime.
 Run 'steam-web-pp-cli sync' first to populate the local store.`,

--- a/library/other/weather-goat/internal/cli/breathe.go
+++ b/library/other/weather-goat/internal/cli/breathe.go
@@ -15,6 +15,7 @@ func newBreatheCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "breathe [location]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Check air quality, pollen levels, and outdoor exercise safety",
 		Long:  "Fetch air quality data including AQI, PM2.5, PM10, UV index, and pollen levels. Provides a recommendation for outdoor activity safety.",
 		Example: `  weather-goat-pp-cli breathe

--- a/library/other/weather-goat/internal/cli/compare.go
+++ b/library/other/weather-goat/internal/cli/compare.go
@@ -10,6 +10,7 @@ import (
 func newCompareCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compare <location1> <location2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare weather between two locations side-by-side",
 		Long:  "Fetch current conditions for two locations and display a side-by-side comparison of temperature, wind, precipitation, and UV.",
 		Example: `  weather-goat-pp-cli compare "San Francisco" "Los Angeles"

--- a/library/other/weather-goat/internal/cli/config_location.go
+++ b/library/other/weather-goat/internal/cli/config_location.go
@@ -11,6 +11,7 @@ import (
 func newConfigCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Manage weather CLI configuration (location, commute times)",
 	}
 
@@ -86,6 +87,7 @@ func newSetCommuteCmd(flags *rootFlags) *cobra.Command {
 func newShowConfigCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "show",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Display current configuration",
 		Example: "  weather-goat-pp-cli config show",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/other/weather-goat/internal/cli/go_activity.go
+++ b/library/other/weather-goat/internal/cli/go_activity.go
@@ -16,6 +16,7 @@ func newGoCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "go <activity> [location]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get activity-specific weather verdicts: walk, bike, hike, commute, drive",
 		Long: `Check whether conditions are safe for an activity. Each mode applies
 domain-specific thresholds and returns a verdict: GO, CAUTION, or STOP.

--- a/library/other/weather-goat/internal/cli/normal.go
+++ b/library/other/weather-goat/internal/cli/normal.go
@@ -16,6 +16,7 @@ func newNormalCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "normal [location]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare today's temperature to the historical average for this date",
 		Long:  "Fetches today's conditions and compares them to the average temperature for the same date across recent years (proxy for 30-year climate normals).",
 		Example: `  weather-goat-pp-cli normal

--- a/library/payments/kalshi/internal/cli/auth.go
+++ b/library/payments/kalshi/internal/cli/auth.go
@@ -26,6 +26,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "status",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show authentication status",
 		Example: "  kalshi-pp-cli auth status",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/payments/kalshi/internal/cli/doctor.go
+++ b/library/payments/kalshi/internal/cli/doctor.go
@@ -16,6 +16,7 @@ import (
 func newDoctorCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Check CLI health",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			report := map[string]any{}

--- a/library/payments/kalshi/internal/cli/transcendence.go
+++ b/library/payments/kalshi/internal/cli/transcendence.go
@@ -24,6 +24,7 @@ func newPortfolioAttributionCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "attribution",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Break down P&L by category, series, or event over time",
 		Long:  "Analyze your portfolio performance by grouping settlements and fills by market category, series, or event. Requires synced portfolio and market data.",
 		Example: `  # P&L by category over the last 30 days
@@ -158,6 +159,7 @@ func newPortfolioWinrateCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "winrate",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Calculate win/loss ratio and ROI across settled positions",
 		Example: `  # Overall win rate
   kalshi-pp-cli portfolio winrate
@@ -278,6 +280,7 @@ func newMarketsMoversCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "movers",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show markets with the biggest price changes since last sync",
 		Example: `  # Top 10 movers
   kalshi-pp-cli markets movers
@@ -393,6 +396,7 @@ func newPortfolioCalendarCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "calendar",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show upcoming market settlements with your positions",
 		Example: `  # Next 7 days of settlements
   kalshi-pp-cli portfolio calendar
@@ -505,6 +509,7 @@ func newPortfolioExposureCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "exposure",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Analyze portfolio risk by category and concentration",
 		Example: `  # Show exposure breakdown
   kalshi-pp-cli portfolio exposure
@@ -628,6 +633,7 @@ func newPortfolioStalePositionsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find positions in markets approaching expiry",
 		Example: `  # Positions expiring in the next 3 days
   kalshi-pp-cli portfolio stale --days 3
@@ -741,6 +747,7 @@ func newMarketsHeatmapCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "heatmap",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show market activity by category (volume, open interest, avg price)",
 		Example: `  # Category heatmap
   kalshi-pp-cli markets heatmap
@@ -841,6 +848,7 @@ func newEventsLifecycleCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "lifecycle <event_ticker>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Track an event from creation through settlement",
 		Example: `  # View event lifecycle
   kalshi-pp-cli events lifecycle FED-24DEC
@@ -997,6 +1005,7 @@ func newMarketsCorrelateCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "correlate <ticker1> <ticker2>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Compare price histories of two markets",
 		Example: `  # Compare two markets
   kalshi-pp-cli markets correlate PRES-2028-R ECON-2026-GDP`,

--- a/library/productivity/cal-com/internal/cli/calcom_novel.go
+++ b/library/productivity/cal-com/internal/cli/calcom_novel.go
@@ -498,6 +498,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 	var tzName string
 	cmd := &cobra.Command{
 		Use:   "today",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show today's bookings (offline from local store, live fallback)",
 		Long:  `Read today's bookings from the local SQLite store. Falls back to a live /v2/bookings query when the store is empty. Use sync first to populate the store and avoid live calls.`,
 		Example: `  # Today's agenda
@@ -569,6 +570,7 @@ func newWeekCmd(flags *rootFlags) *cobra.Command {
 	var tzName string
 	cmd := &cobra.Command{
 		Use:   "week",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show 7 days of bookings starting from --start (default: this Monday)",
 		Long:  `Aggregate 7 days of bookings into per-day rollups, grouped by date. Useful as a one-look weekly view. Reads the local store; falls back to live API when empty.`,
 		Example: `  # Current week
@@ -665,6 +667,7 @@ func newSlotsFindCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "find",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find available slots across multiple event types (live fanout)",
 		Long: `The /v2/slots endpoint takes a single event-type ID. This command fans out one
 call per ID, merges results, deduplicates, and returns slots sorted by start time.
@@ -902,6 +905,7 @@ func newCalcomAnalyticsNoShowCmd(flags *rootFlags) *cobra.Command {
 	var groupBy string
 	cmd := &cobra.Command{
 		Use:     "no-show",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "No-show rate over a time window",
 		Long:    `Counts bookings explicitly marked no-show (status fields containing 'no-show' or noShowHost/noShowAttendee). Falls through to attendees[].noShow when present.`,
 		Example: `  cal-com-pp-cli analytics no-show --window 30d --by event-type --json`,
@@ -970,6 +974,7 @@ func newCalcomAnalyticsDensityCmd(flags *rootFlags) *cobra.Command {
 	var unit string
 	cmd := &cobra.Command{
 		Use:   "density",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Booking density per weekday/hour to find your busiest slots",
 		Long:  `Counts bookings per unit (weekday or hour-of-day) to surface peak times. Useful for capacity planning and identifying low-utilization windows.`,
 		Example: `  cal-com-pp-cli analytics density --unit weekday --json
@@ -1096,6 +1101,7 @@ func newGapsCmd(flags *rootFlags) *cobra.Command {
 	var tzName string
 	cmd := &cobra.Command{
 		Use:   "gaps",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find open windows in your schedule that are unbooked",
 		Long: `Scans booked bookings within --window and reports the gaps between them
 during business hours. Use --min-minutes to filter out short slivers.
@@ -1211,6 +1217,7 @@ func newWorkloadCmd(flags *rootFlags) *cobra.Command {
 	var window string
 	cmd := &cobra.Command{
 		Use:   "workload",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Booking distribution across team members (live API)",
 		Long: `Fetches the team's bookings via /v2/teams/{id}/bookings and groups by host
 or attendee email. Surfaces overloaded vs underutilized members for round-robin
@@ -1329,6 +1336,7 @@ var calComWebhookTriggers = []struct {
 func newWebhooksTriggersCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "triggers",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "List the canonical set of Cal.com webhook trigger constants",
 		Long:    `Static reference of every valid webhook trigger string accepted by Cal.com, grouped by lifecycle stage. Useful before scripting webhooks so trigger strings are exact.`,
 		Example: `  cal-com-pp-cli webhooks triggers --json`,
@@ -1350,6 +1358,7 @@ func newWebhooksTriggersCmd(flags *rootFlags) *cobra.Command {
 func newWebhooksCoverageCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "coverage",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Audit registered webhooks vs the canonical trigger set; flag missing subscribers",
 		Long:    `Lists Cal.com webhook triggers registered for this account against the canonical set and reports lifecycle events with no subscriber. Live API call (GET /v2/webhooks). Run before relying on webhooks in production.`,
 		Example: `  cal-com-pp-cli webhooks coverage --json`,
@@ -1420,6 +1429,7 @@ func newEventTypesStaleCmd(flags *rootFlags) *cobra.Command {
 	var days int
 	cmd := &cobra.Command{
 		Use:     "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "List event types with no bookings in the last N days",
 		Long:    `Cross-references local bookings against live event types and reports types with zero recent bookings — candidates for cleanup. Live call to /v2/event-types; reads bookings from the local store (fall back to live).`,
 		Example: `  cal-com-pp-cli event-types stale --days 30 --json`,

--- a/library/project-management/linear/internal/cli/analytics.go
+++ b/library/project-management/linear/internal/cli/analytics.go
@@ -19,6 +19,7 @@ func newAnalyticsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "analytics",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Run analytics queries on locally synced data",
 		Long: `Analyze locally synced data with count, group-by, and summary operations.
 Data must be synced first with the sync command.`,

--- a/library/project-management/linear/internal/cli/bottleneck.go
+++ b/library/project-management/linear/internal/cli/bottleneck.go
@@ -18,6 +18,7 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 	var teamFilter string
 	cmd := &cobra.Command{
 		Use:   "bottleneck",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find overloaded team members and blocked issues",
 		Long:  "Analyze issue distribution per assignee to find bottlenecks. Shows who has too many active issues and which issues are blocking others.",
 		Example: `  linear-pp-cli bottleneck

--- a/library/project-management/linear/internal/cli/issues.go
+++ b/library/project-management/linear/internal/cli/issues.go
@@ -48,6 +48,7 @@ func newIssuesCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	cmd := &cobra.Command{
 		Use:   "issues <ID>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get or list Linear issues",
 		Long: `Get a single issue by identifier (e.g. ESP-1155), or list issues with filters.
 
@@ -103,6 +104,7 @@ func newIssuesListCmd(flags *rootFlags, dbPath *string) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List issues from the local sqlite store with filters",
 		Long: `List issues from the local sqlite store. Requires a prior 'linear-pp-cli sync'.
 

--- a/library/project-management/linear/internal/cli/me.go
+++ b/library/project-management/linear/internal/cli/me.go
@@ -14,6 +14,7 @@ func newMeCmd(flags *rootFlags) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "me",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show current authenticated user",
 		Example: `  linear-pp-cli me
   linear-pp-cli me --json`,

--- a/library/project-management/linear/internal/cli/similar.go
+++ b/library/project-management/linear/internal/cli/similar.go
@@ -17,6 +17,7 @@ func newSimilarCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "similar <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find potentially duplicate issues using fuzzy text search",
 		Long:  "Search locally synced issues using FTS5 full-text search to find potential duplicates. Works offline.",
 		Example: `  linear-pp-cli similar "login bug"

--- a/library/project-management/linear/internal/cli/sqlcmd.go
+++ b/library/project-management/linear/internal/cli/sqlcmd.go
@@ -14,6 +14,7 @@ func newSQLCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	cmd := &cobra.Command{
 		Use:   "sql <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Run read-only SQL against the local store",
 		Long:  "Execute arbitrary SELECT queries against the local SQLite database. Useful for ad-hoc analysis and debugging.",
 		Example: `  linear-pp-cli sql "SELECT count(*) as cnt FROM issues"

--- a/library/project-management/linear/internal/cli/stale_custom.go
+++ b/library/project-management/linear/internal/cli/stale_custom.go
@@ -20,6 +20,7 @@ func newStaleCmd(flags *rootFlags) *cobra.Command {
 	var teamFilter string
 	cmd := &cobra.Command{
 		Use:   "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find issues not updated in N days",
 		Long:  "Scan locally synced issues for staleness. Groups by team and project. Requires a prior sync.",
 		Example: `  linear-pp-cli stale --days 30

--- a/library/project-management/linear/internal/cli/today.go
+++ b/library/project-management/linear/internal/cli/today.go
@@ -17,6 +17,7 @@ func newTodayCmd(flags *rootFlags) *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "today",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show your issues for today across all teams",
 		Long:  "Display all issues assigned to you in active cycles, sorted by priority. Requires a prior sync.",
 		Example: `  linear-pp-cli today

--- a/library/project-management/linear/internal/cli/velocity.go
+++ b/library/project-management/linear/internal/cli/velocity.go
@@ -18,6 +18,7 @@ func newVelocityCmd(flags *rootFlags) *cobra.Command {
 	var weeks int
 	cmd := &cobra.Command{
 		Use:   "velocity",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show sprint velocity trends over recent cycles",
 		Long:  "Display completed vs planned scope for recent cycles to track team velocity trends.",
 		Example: `  linear-pp-cli velocity

--- a/library/project-management/linear/internal/cli/workload.go
+++ b/library/project-management/linear/internal/cli/workload.go
@@ -18,6 +18,7 @@ func newWorkloadCmd(flags *rootFlags) *cobra.Command {
 	var teamFilter string
 	cmd := &cobra.Command{
 		Use:   "workload",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show issue and estimate distribution per team member",
 		Long:  "Analyze workload balance across team members, including issue counts and total estimates.",
 		Example: `  linear-pp-cli workload

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn.go
@@ -28,6 +28,7 @@ import (
 func newAPIHpnCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hpn",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Happenstance public REST API (bearer-auth, credit-priced)",
 		Long: `Call the Happenstance public REST API (https://api.happenstance.ai/v1)
 from the terminal. Bearer-auth via HAPPENSTANCE_API_KEY; provision and

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_groups.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_groups.go
@@ -18,6 +18,7 @@ import (
 func newAPIHpnGroupsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "groups",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List or fetch Happenstance groups (free probe)",
 		Long: `Calls /v1/groups and /v1/groups/{id}. Groups are the named cohorts
 the user has access to (e.g. an alumni network or company list).
@@ -32,6 +33,7 @@ Member names from a singular group fetch can be passed back into
 func newAPIHpnGroupsListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "List all Happenstance groups the caller can access (free)",
 		Example: `  contact-goat-pp-cli api hpn groups list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,6 +69,7 @@ func newAPIHpnGroupsListCmd(flags *rootFlags) *cobra.Command {
 func newAPIHpnGroupsGetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "get <group_id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Get a single Happenstance group by id, including members (free)",
 		Example: `  contact-goat-pp-cli api hpn groups get grp_abc123`,
 		Args:    cobra.ExactArgs(1),

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_research.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_research.go
@@ -55,6 +55,7 @@ func newAPIHpnResearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "research <description>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Run a Happenstance deep-research dossier (costs 1 credit on completion)",
 		Long: `Run a deep-research dossier against the Happenstance public API.
 
@@ -124,6 +125,7 @@ gather them later via ` + "`api hpn research get <id>`" + `.`,
 func newAPIHpnResearchGetCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <research_id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Re-fetch an existing research dossier by id (free)",
 		Long: `Calls GET /v1/research/{id} and renders the dossier in the same shape
 as ` + "`api hpn research`" + `. Free probe — no credits spent.`,

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
@@ -81,6 +81,7 @@ func newAPIHpnSearchCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search <text>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Run a Happenstance search via the public API (costs 2 credits)",
 		Long: `Run a search against the Happenstance public API.
 
@@ -169,6 +170,7 @@ func newAPIHpnSearchFindMoreCmd(flags *rootFlags) *cobra.Command {
 	var budget int
 	cmd := &cobra.Command{
 		Use:   "find-more <search_id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch the next page of an existing search (costs 2 credits)",
 		Long: `Calls POST /v1/search/{id}/find-more on a parent search. Returns the
 new page id; use it on a follow-up ` + "`api hpn search get <id> --page-id <page_id>`" + `
@@ -233,6 +235,7 @@ func newAPIHpnSearchGetCmd(flags *rootFlags) *cobra.Command {
 	var pageID string
 	cmd := &cobra.Command{
 		Use:   "get <search_id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Re-fetch an existing search by id (free)",
 		Long: `Calls GET /v1/search/{id} and renders the envelope in the same shape
 as ` + "`api hpn search`" + `. Free probe — no credits spent. Pass --page-id when

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_usage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_usage.go
@@ -14,6 +14,7 @@ import (
 func newAPIHpnUsageCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "usage",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show live Happenstance public-API credit balance and usage history (free)",
 		Long:    `Calls GET /v1/usage. Returns the live credit balance, purchase history, recent usage events, and auto-reload settings. Free probe — no credits spent.`,
 		Example: `  contact-goat-pp-cli api hpn usage --json`,
@@ -55,6 +56,7 @@ func newAPIHpnUsageCmd(flags *rootFlags) *cobra.Command {
 func newAPIHpnUserCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "user",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show the current Happenstance public-API user (email, name, friends) (free)",
 		Long:    `Calls GET /v1/users/me. Returns the email, name, and friends list. The canonical liveness probe — every doctor invocation hits this endpoint first to confirm the bearer key is valid. Free probe — no credits spent.`,
 		Example: `  contact-goat-pp-cli api hpn user --json`,

--- a/library/sales-and-crm/contact-goat/internal/cli/budget.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/budget.go
@@ -25,6 +25,7 @@ func newBudgetCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "budget",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Deepline credit spend: totals, top tools, and history",
 		Long: `Aggregate Deepline credit spend from the local log (no network calls).
 
@@ -148,6 +149,7 @@ The limit is stored at ~/.local/share/contact-goat-pp-cli/budget.toml.`,
 func newBudgetHistoryCmd(flags *rootFlags, limit *int) *cobra.Command {
 	return &cobra.Command{
 		Use:   "history",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Last N Deepline calls (tool, credits, status, timestamp)",
 		Example: `  contact-goat-pp-cli budget history
   contact-goat-pp-cli budget history --limit 100 --json`,

--- a/library/sales-and-crm/contact-goat/internal/cli/config_byok.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/config_byok.go
@@ -44,6 +44,7 @@ type byokFile struct {
 func newConfigCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Configure contact-goat-pp-cli (BYOK providers, defaults, etc.)",
 	}
 	cmd.AddCommand(newConfigBYOKCmd(flags))
@@ -143,6 +144,7 @@ func newConfigBYOKUnsetCmd(flags *rootFlags) *cobra.Command {
 func newConfigBYOKListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Show configured BYOK providers (env var names only, never values)",
 		Example: "  contact-goat-pp-cli config byok list",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage.go
@@ -26,6 +26,7 @@ func newCoverageCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "coverage <company>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show who you know at a company (LinkedIn + Happenstance)",
 		Long: `Cross-source "who do I know at X" query.
 

--- a/library/sales-and-crm/contact-goat/internal/cli/deepline.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/deepline.go
@@ -38,6 +38,7 @@ func newDeeplineCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "deepline",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Deepline contact-data API: email, phone, and company enrichment (credit-priced)",
 		Long: `Call Deepline (https://code.deepline.com/) contact-data tools from the terminal.
 
@@ -212,6 +213,7 @@ func newDeeplineFindEmailCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command
 	var company string
 	cmd := &cobra.Command{
 		Use:   "find-email <name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find a person's work email from name+domain",
 		Long: `Finds a single high-confidence work email for a person at a company using
 Deepline's dropleads_email_finder tool.
@@ -252,6 +254,7 @@ func newDeeplineSearchPeopleCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Comm
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "search-people",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Apollo for people matching title/location/industry",
 		Example: `  contact-goat-pp-cli deepline search-people --title "VP Engineering" --location "San Francisco" --limit 25 --yes
   contact-goat-pp-cli deepline search-people --industry fintech --limit 50 --dry-run`,
@@ -286,6 +289,7 @@ func newDeeplineEmailFindCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command
 	var domain string
 	cmd := &cobra.Command{
 		Use:   "email-find",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find public emails for a company domain",
 		Long: `Lists public/role emails at a domain via Hunter domain search. Returns
 role-filtered company emails (e.g. contact@, press@, named-person@) with
@@ -308,6 +312,7 @@ func newDeeplinePhoneFindCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command
 	var linkedinURL string
 	cmd := &cobra.Command{
 		Use:     "phone-find",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Find a phone number by LinkedIn URL",
 		Example: `  contact-goat-pp-cli deepline phone-find --linkedin-url https://www.linkedin.com/in/patrickcollison --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -326,6 +331,7 @@ func newDeeplineSearchCompaniesCmd(flags *rootFlags, dl *deeplineFlags) *cobra.C
 	var industry, size, location string
 	cmd := &cobra.Command{
 		Use:     "search-companies",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Search for companies by industry/size/location",
 		Example: `  contact-goat-pp-cli deepline search-companies --industry fintech --size 201-500 --location "United States" --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -428,6 +434,7 @@ Pass the payload inline as JSON, or read it from a file with @path.`,
 func newDeeplineCreditsCmd(flags *rootFlags, dl *deeplineFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "credits",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show credit balance (stub: upstream endpoint not confirmed)",
 		Long: `STUB. Deepline has no confirmed credit-balance endpoint at time of writing,
 so this command always exits with an error. See https://code.deepline.com/docs/quickstart

--- a/library/sales-and-crm/contact-goat/internal/cli/dossier.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/dossier.go
@@ -43,6 +43,7 @@ func newDossierCmd(flags *rootFlags) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "dossier <person>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Build a unified person dossier across LinkedIn, Happenstance, and Deepline",
 		Long: `Compose a single view of a person from all configured sources.
 

--- a/library/sales-and-crm/contact-goat/internal/cli/engagement.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/engagement.go
@@ -46,6 +46,7 @@ func newEngagementCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "engagement <person-id-or-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Score last-touch engagement with a person across all sources",
 		Long: `Compute a 0-100 engagement score based on the most recent interaction with
 a person across LinkedIn (messages, profile views), Happenstance (research,

--- a/library/sales-and-crm/contact-goat/internal/cli/graph.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/graph.go
@@ -30,6 +30,7 @@ const viewerNodeID = "me"
 func newGraphCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "graph",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Export or inspect the unified contact graph",
 	}
 	cmd.AddCommand(newGraphExportCmd(flags))

--- a/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
@@ -24,6 +24,7 @@ import (
 func newHPCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hp",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Happenstance graph commands (1st / 2nd / 3rd degree people-search)",
 		Long: `hp groups the Happenstance graph-search commands that wrap the web app's
 natural-language search. Unlike the narrow friends/list-backed coverage
@@ -47,6 +48,7 @@ func newHPPeopleCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "people <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Natural-language people-search across your Happenstance graph",
 		Long: `Runs a Happenstance people-search with the same endpoint the web app
 uses. Supports 1st-degree (your synced connections), 2nd-degree (your

--- a/library/sales-and-crm/contact-goat/internal/cli/intersect.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/intersect.go
@@ -50,6 +50,7 @@ func newIntersectCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "intersect",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find people in BOTH your LinkedIn 1st-degree AND Happenstance friends",
 		Long: `Find the highest-signal warm intros: people who appear in BOTH your
 LinkedIn 1st-degree network AND your Happenstance friends list.

--- a/library/sales-and-crm/contact-goat/internal/cli/linkedin.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/linkedin.go
@@ -29,6 +29,7 @@ import (
 func newLinkedInCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "linkedin",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "LinkedIn scraper powered by stickerdaniel/linkedin-mcp-server",
 		Long: "LinkedIn subcommands wrap the upstream linkedin-scraper-mcp Python MCP server.\n" +
 			"First-time setup: run `uvx linkedin-scraper-mcp@latest --login` to cache your\n" +
@@ -65,6 +66,7 @@ func newLISearchPeopleCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "search-people <keywords>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search LinkedIn people by keyword",
 		Example: "  contact-goat-pp-cli linkedin search-people \"VP engineering fintech\"\n" +
 			"  contact-goat-pp-cli linkedin search-people \"Staff eng\" --location \"New York\" --limit 50 --json",
@@ -89,6 +91,7 @@ func newLISearchJobsCmd(flags *rootFlags) *cobra.Command {
 	var maxPages int
 	cmd := &cobra.Command{
 		Use:   "search-jobs <keywords>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search LinkedIn job postings by keyword",
 		Example: "  contact-goat-pp-cli linkedin search-jobs \"senior backend engineer\"\n" +
 			"  contact-goat-pp-cli linkedin search-jobs \"product designer\" --location Remote --max-pages 5",
@@ -115,6 +118,7 @@ func newLIGetPersonCmd(flags *rootFlags) *cobra.Command {
 	var sections []string
 	cmd := &cobra.Command{
 		Use:   "get-person <url-or-slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch a LinkedIn profile",
 		Example: "  contact-goat-pp-cli linkedin get-person williamhgates\n" +
 			"  contact-goat-pp-cli linkedin get-person https://www.linkedin.com/in/satyanadella/ \\\n" +
@@ -139,6 +143,7 @@ func newLIGetCompanyCmd(flags *rootFlags) *cobra.Command {
 	var sections []string
 	cmd := &cobra.Command{
 		Use:   "get-company <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch a LinkedIn company profile",
 		Example: "  contact-goat-pp-cli linkedin get-company openai\n" +
 			"  contact-goat-pp-cli linkedin get-company stripe --sections posts,jobs",
@@ -161,6 +166,7 @@ func newLIInboxCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "inbox",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List recent LinkedIn conversations",
 		Example: "  contact-goat-pp-cli linkedin inbox\n" +
 			"  contact-goat-pp-cli linkedin inbox --limit 25 --json",
@@ -177,6 +183,7 @@ func newLIInboxCmd(flags *rootFlags) *cobra.Command {
 func newLIConversationCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conversation <user-or-thread-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Read a single LinkedIn conversation",
 		Long: "Read a single LinkedIn conversation.\n\n" +
 			"WARNING: upstream issue stickerdaniel/linkedin-mcp-server#307 reports\n" +
@@ -199,6 +206,7 @@ func newLIConversationCmd(flags *rootFlags) *cobra.Command {
 func newLISearchMessagesCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search-messages <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Full-text search your LinkedIn messages",
 		Example: "  contact-goat-pp-cli linkedin search-messages \"series A\"\n" +
 			"  contact-goat-pp-cli linkedin search-messages \"coffee chat\" --json",
@@ -216,6 +224,7 @@ func newLICompanyPostsCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "company-posts <slug>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List recent posts from a company page",
 		Example: "  contact-goat-pp-cli linkedin company-posts anthropic\n" +
 			"  contact-goat-pp-cli linkedin company-posts openai --limit 20",
@@ -234,6 +243,7 @@ func newLICompanyPostsCmd(flags *rootFlags) *cobra.Command {
 func newLIJobCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "job <job-id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch full detail for a single LinkedIn job posting",
 		Example: "  contact-goat-pp-cli linkedin job 3712345678\n" +
 			"  contact-goat-pp-cli linkedin job 3712345678 --json",
@@ -250,6 +260,7 @@ func newLIJobCmd(flags *rootFlags) *cobra.Command {
 func newLISidebarCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sidebar <person-url>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fetch the \"People also viewed\" sidebar for a profile",
 		Example: "  contact-goat-pp-cli linkedin sidebar https://www.linkedin.com/in/satyanadella/\n" +
 			"  contact-goat-pp-cli linkedin sidebar williamhgates",
@@ -266,6 +277,7 @@ func newLISidebarCmd(flags *rootFlags) *cobra.Command {
 func newLIListToolsCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list-tools",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List tools exposed by the underlying linkedin-scraper-mcp server",
 		Example: "  contact-goat-pp-cli linkedin list-tools\n" +
 			"  contact-goat-pp-cli linkedin list-tools --json",

--- a/library/sales-and-crm/contact-goat/internal/cli/promoted_groups.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/promoted_groups.go
@@ -19,6 +19,7 @@ import (
 func newGroupsCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "groups",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List your Happenstance groups (hpn-CLI parity, not in sniffed spec)",
 		Long: `List your Happenstance groups.
 
@@ -44,6 +45,7 @@ command will report that the endpoint is still a stub.`,
 func newGroupsGetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <id>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Get details for a single Happenstance group by id",
 		Example: `  contact-goat-pp-cli groups get grp_abc123
   contact-goat-pp-cli groups get grp_abc123 --json`,

--- a/library/sales-and-crm/contact-goat/internal/cli/prospect.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/prospect.go
@@ -28,6 +28,7 @@ func newProspectCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prospect <query>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Fan-out search across LinkedIn, Happenstance, and (opt-in) Deepline",
 		Long: `Run a single prospect query across every source simultaneously. Budget-gated:
 Deepline credits are only spent when --deepline is set AND --budget allows.

--- a/library/sales-and-crm/contact-goat/internal/cli/since.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/since.go
@@ -45,6 +45,7 @@ func newSinceCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "since <duration>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Time-windowed diff of new items across LinkedIn + Happenstance",
 		Long: `Show what's changed for you in the given time window (e.g. "24h", "7d", "2w").
 

--- a/library/sales-and-crm/contact-goat/internal/cli/stale.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/stale.go
@@ -39,6 +39,7 @@ func newStaleCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "stale",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find warm intros going cold - researched or looked up but not followed up on",
 		Long: `Find people you've recently shown interest in (via LinkedIn lookup or
 Happenstance research) but haven't touched in at least --days.

--- a/library/sales-and-crm/contact-goat/internal/cli/tail.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/tail.go
@@ -38,6 +38,7 @@ func newTailCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tail [resource]",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Stream NEW items across LinkedIn + Happenstance (and optionally Deepline)",
 		Long: `Tail polls each configured source at --interval and emits only items that
 weren't in the previous snapshot, as NDJSON on stdout. Gracefully shuts down

--- a/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/waterfall.go
@@ -58,6 +58,7 @@ func newWaterfallCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "waterfall <target>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Clay-style waterfall enrichment: free sources first, Deepline with BYOK or managed",
 		Long: `Enrich a person starting from the cheapest source and waterfalling into
 progressively more expensive ones.

--- a/library/sales-and-crm/hubspot/internal/cli/contacts_engagement.go
+++ b/library/sales-and-crm/hubspot/internal/cli/contacts_engagement.go
@@ -31,6 +31,7 @@ func newContactsEngagementCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "engagement",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Score contact engagement across all activity types",
 		Long:  "Analyze engagement frequency and gaps for contacts by correlating calls, emails, meetings, notes, and tasks from the local store.",
 		Example: "  hubspot-pp-cli contacts engagement --days 30\n" +

--- a/library/sales-and-crm/hubspot/internal/cli/deals_coverage.go
+++ b/library/sales-and-crm/hubspot/internal/cli/deals_coverage.go
@@ -27,6 +27,7 @@ func newDealsCoverageCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "coverage",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find open deals with low engagement coverage",
 		Long:  "Identify open deals where associated contacts have little or no recent engagement activity.",
 		Example: "  hubspot-pp-cli deals coverage\n" +

--- a/library/sales-and-crm/hubspot/internal/cli/owners_workload.go
+++ b/library/sales-and-crm/hubspot/internal/cli/owners_workload.go
@@ -26,6 +26,7 @@ func newOwnersWorkloadCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "workload",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Show team member workload across deals, tickets, and tasks",
 		Long:  "Cross-entity analysis showing which owners are overloaded with open deals, tickets, and overdue tasks.",
 		Example: "  hubspot-pp-cli owners workload\n" +

--- a/library/travel/flightgoat/internal/cli/digest.go
+++ b/library/travel/flightgoat/internal/cli/digest.go
@@ -19,6 +19,7 @@ import (
 func newDigestCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "digest <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "One-command daily brief: departures, delays, weather, disruptions",
 		Example: `  flightgoat-pp-cli digest SEA`,
 		Args:    cobra.ExactArgs(1),

--- a/library/travel/flightgoat/internal/cli/primary.go
+++ b/library/travel/flightgoat/internal/cli/primary.go
@@ -42,6 +42,7 @@ func newGfFlightsCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "flights <origin> <destination> <date>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Search Google Flights for a specific date (free, no API key required)",
 		Long: `flights is flightgoat's headline command. It queries Google Flights through
 the fli Python library (reverse-engineered, not scraped) and returns real prices,
@@ -157,6 +158,7 @@ func newGfDatesCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "dates <origin> <destination>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Find the cheapest dates to fly between two airports (free, no API key required)",
 		Long: `dates scans Google Flights for the cheapest days to travel a route over
 a range of dates. No API key required. Wraps the fli Python library.
@@ -264,6 +266,7 @@ func newKayakExploreCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "explore <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Every nonstop destination from an airport (free, via Kayak /direct)",
 		Long: `explore fetches Kayak's /direct/<airport> page and parses the nonstop
 destinations table that Kayak server-renders into the HTML. Same data you see
@@ -365,6 +368,7 @@ func newKayakLonghaulCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "longhaul <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Nonstop destinations from an airport filtered by minimum flight duration (free, via Kayak)",
 		Long: `longhaul is the headline flightgoat command. It answers the classic
 travel-hacker question: "show me every nonstop flight from my airport that's

--- a/library/travel/flightgoat/internal/cli/transcend.go
+++ b/library/travel/flightgoat/internal/cli/transcend.go
@@ -145,6 +145,7 @@ func newLonghaulCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "longhaul <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "List nonstop departures from an airport that are at least N hours long",
 		Long: `longhaul answers the classic travel-hacker question: "show me every nonstop
 flight from my airport that's at least N hours long over a given period."
@@ -255,6 +256,7 @@ func newExploreCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "explore <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Every nonstop destination from an airport with duration, airlines, frequency",
 		Long: `explore is the Kayak /direct nonstop matrix in your terminal.
 
@@ -366,6 +368,7 @@ func newCheapestLonghaulCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "cheapest-longhaul <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Cheapest dates to fly long nonstop routes from an airport",
 		Long: `cheapest-longhaul joins two data sources nobody else joins:
   1. FlightAware route catalog (which nonstop routes are at least N hours)
@@ -472,6 +475,7 @@ command lists the long routes and exits with a helpful message.`,
 func newOntimeNowCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ontime-now <airport>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Every departure from an airport today with live on-time status",
 		Example: `  flightgoat-pp-cli ontime-now SEA
   flightgoat-pp-cli ontime-now JFK --json`,
@@ -553,6 +557,7 @@ func newReliabilityCmd(flags *rootFlags) *cobra.Command {
 	var days int
 	cmd := &cobra.Command{
 		Use:   "reliability <origin> <destination>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Historical on-time percentage for a route over the last N days",
 		Long: `reliability queries FlightAware history for all flights on a route and
 computes an on-time percentage. On-time is defined as departure delay <= 15 minutes.`,
@@ -656,6 +661,7 @@ computes an on-time percentage. On-time is defined as departure delay <= 15 minu
 func newCompareCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compare <origin> <destination> <date>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Join Google Flights prices with AeroAPI reliability for the same route",
 		Long: `compare runs two queries in parallel: fli flights for Google Flights prices and
 reliability for AeroAPI historical on-time percentages. Output sorts by reliability
@@ -768,6 +774,7 @@ func newMonitorCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "monitor <ident>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Watch a flight through its lifecycle until landed",
 		Long: `monitor polls FlightAware at regular intervals and prints status changes.
 When --until-arrival is set (default), it exits when the flight lands.`,
@@ -834,6 +841,7 @@ func newHeatmapCmd(flags *rootFlags) *cobra.Command {
 	var region string
 	cmd := &cobra.Command{
 		Use:   "heatmap",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Where are delays happening right now across major airports",
 		Long: `heatmap calls /airports/delays and returns a single sorted table showing
 every airport with active delays. Useful for operators, travel hackers, and
@@ -911,6 +919,7 @@ func newResolveCmd(flags *rootFlags) *cobra.Command {
 func newAircraftBioCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "aircraft-bio <registration>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Full history of a tail number: recent flights + owner + last known flight",
 		Example: `  flightgoat-pp-cli aircraft-bio N12345`,
 		Args:    cobra.ExactArgs(1),
@@ -949,6 +958,7 @@ func newAircraftBioCmd(flags *rootFlags) *cobra.Command {
 func newEtaCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "eta <ident>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short:   "Weather-adjusted ETA: foresight prediction plus destination weather",
 		Example: `  flightgoat-pp-cli eta AA100`,
 		Args:    cobra.ExactArgs(1),
@@ -1005,6 +1015,7 @@ func newGfSearchCmd(flags *rootFlags) *cobra.Command {
 	var alertIfUnder float64
 	cmd := &cobra.Command{
 		Use:   "gf-search <origin> <destination> <date>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Short: "Google Flights search via fli (price + duration + airlines)",
 		Long: `gf-search delegates to the 'fli' Python CLI for Google Flights search.
 Install fli first: pipx install flights


### PR DESCRIPTION
## Summary

Adds `Annotations: map[string]string{"mcp:read-only": "true"}` to 314 hand-written novel cobra commands across 194 files in 24 CLIs. Closes the second work unit of [mvanhorn/cli-printing-press#388](https://github.com/mvanhorn/cli-printing-press/issues/388).

The `mcp:read-only` annotation lets MCP hosts (Claude Desktop, etc.) route read-only commands without per-call permission prompts. Templated commands already auto-emit it via the `IsReadOnly` classifier ([cli-printing-press PR #449](https://github.com/mvanhorn/cli-printing-press/pull/449)); this backfill covers the hand-written novel side that doesn't go through that path.

## Method

1. **Identified novel files by header marker.** Every templated file carries `// Generated by CLI Printing Press` on line 2; novel hand-authored files don't. More reliable than filename heuristics — cal-com has 368 templated files with arbitrary multi-underscore names that no pattern list catches cleanly.

2. **Extracted every `cobra.Command`'s `Use:` value** across the 266 novel files that define commands. 477 commands total; 46 already had `mcp:read-only`.

3. **Classified each `Use:` value conservatively.** The classifier covers ~270 read-only verbs (`list`, `get`, `search`, `browse`, `find`, `top`, `watch`, `stats`, etc.) and explicitly skips ~50 mutating verbs (`add`, `create`, `delete`, `save`, `login`, `sync`, etc.). Ambiguous cases (~20) are left un-annotated for future review — the cost of a missing annotation is one extra MCP permission prompt; the cost of a wrong annotation is silent privilege bypass.

4. **Surgical insertion.** For each APPLY action, the Python applier walks the surrounding `cobra.Command{}` block and skips when an `Annotations:` field already exists (1 case skipped this way), otherwise inserts the annotation line immediately after the `Use:` line.

## Verification

- 24 affected library CLIs all build cleanly after the change
- Each modification is a single-line insert (consistent shape across all 314)
- Sample diff:

  ```go
  cmd := &cobra.Command{
      Use:         "compare-prices",
  +   Annotations: map[string]string{"mcp:read-only": "true"},
      Short:       "Compare nearby store pricing for a list of menu item codes",
  ```

- 1 command was skipped because its block already had a different `Annotations:` field; manual merge needed there (out of scope).

## Out of scope

- **Ambiguous verbs** not auto-annotated: `auth`, `bid`, `bookings`, `check`, `clear`, `collection`, `convert`, `cook`, `instacart`, `lint`, `open`, `ops`, `pending`, `print`, `request`, `resolve`, `schema`, `version`, `watch`. These can be backfilled per-CLI by humans who know the command's actual behavior.
- **Likely-read-only verbs flagged as mutating** by the conservative classifier (e.g., `cancellations` as a list, `alerts` as a query, `signal` as a read in `company-goat`). Better to under-annotate than to mark a writing command as read-only.
- **Templated CRUD commands.** They already get the annotation via the generator; out of scope here.

## What's done in #388

This and [#163](https://github.com/mvanhorn/printing-press-library/pull/163) (already merged) together cover both work units of [mvanhorn/cli-printing-press#388](https://github.com/mvanhorn/cli-printing-press/issues/388):
1. ✅ `display_name` backfill across 27 specs (#163)
2. ✅ `mcp:read-only` backfill across 314 novel commands (this PR)