### PR TITLE
chore(pypi): regen to pick up wrapWithProvenance non-JSON fix

### DIFF
--- a/library/developer-tools/pypi/go.mod
+++ b/library/developer-tools/pypi/go.mod
@@ -3,26 +3,23 @@ module github.com/mvanhorn/printing-press-library/library/developer-tools/pypi
 go 1.23.0
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
 	modernc.org/sqlite v1.37.0
-)
-
-require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/spf13/cast v1.7.1 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	modernc.org/libc v1.62.1 // indirect
-	modernc.org/mathutil v1.7.1 // indirect
-	modernc.org/memory v1.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.47.0
+	github.com/spf13/pflag v1.0.6
+	github.com/dustin/go-humanize v1.0.1
+	github.com/google/jsonschema-go v0.4.2
+	github.com/google/uuid v1.6.0
+	github.com/inconshreveable/mousetrap v1.1.0
+	github.com/mattn/go-isatty v0.0.20
+	github.com/ncruces/go-strftime v0.1.9
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
+	github.com/spf13/cast v1.7.1
+	github.com/yosida95/uritemplate/v3 v3.0.2
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
+	golang.org/x/sys v0.31.0
+	modernc.org/libc v1.62.1
+	modernc.org/mathutil v1.7.1
+	modernc.org/memory v1.9.1
 )

--- a/library/developer-tools/pypi/internal/cli/helpers.go
+++ b/library/developer-tools/pypi/internal/cli/helpers.go
@@ -1070,7 +1070,12 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
-// wrapWithProvenance wraps JSON data in a provenance envelope: {"results": ..., "meta": {...}}.
+// wrapWithProvenance wraps response data in a provenance envelope:
+// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
+// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
+// text), it embeds as a JSON string so json.Marshal doesn't choke on
+// "invalid character '<'" while still passing the raw payload through to
+// the consumer.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -1085,8 +1090,12 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if prov.Freshness != nil {
 		meta["freshness"] = prov.Freshness
 	}
+	var results any = json.RawMessage(data)
+	if !json.Valid(data) {
+		results = string(data)
+	}
 	envelope := map[string]any{
-		"results": json.RawMessage(data),
+		"results": results,
 		"meta":    meta,
 	}
 	return json.Marshal(envelope)


### PR DESCRIPTION
Re-sweep with the new tools after [cli-printing-press#464](https://github.com/mvanhorn/cli-printing-press/pull/464) merged. Pure templated refresh — zero TEMPLATED-WITH-ADDITIONS this time around since #166 already cleaned them out.

The RSS XML bug surfaced during #166 verification is now fixed end-to-end:

```
$ pypi-pp-cli rss recent-updates --agent | jq -r '.meta.source, (.results | type), (.results | length)'
live
string
32227
```

Previously this errored with `json: invalid character '<' looking for beginning of value`. Now the XML payload reaches the consumer as a JSON string, the meta envelope is intact, and JSON-returning endpoints (e.g. `pypi json get-package-info`) continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)