### PR TITLE
chore(open-meteo): regen to pick up forecast-flag wiring fix

### DIFF
--- a/library/other/open-meteo/go.mod
+++ b/library/other/open-meteo/go.mod
@@ -3,26 +3,23 @@ module github.com/mvanhorn/printing-press-library/library/other/open-meteo
 go 1.23.0
 
 require (
-	github.com/mark3labs/mcp-go v0.47.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
 	modernc.org/sqlite v1.37.0
-)
-
-require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/spf13/cast v1.7.1 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	modernc.org/libc v1.62.1 // indirect
-	modernc.org/mathutil v1.7.1 // indirect
-	modernc.org/memory v1.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.47.0
+	github.com/spf13/pflag v1.0.6
+	github.com/dustin/go-humanize v1.0.1
+	github.com/google/jsonschema-go v0.4.2
+	github.com/google/uuid v1.6.0
+	github.com/inconshreveable/mousetrap v1.1.0
+	github.com/mattn/go-isatty v0.0.20
+	github.com/ncruces/go-strftime v0.1.9
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
+	github.com/spf13/cast v1.7.1
+	github.com/yosida95/uritemplate/v3 v3.0.2
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
+	golang.org/x/sys v0.31.0
+	modernc.org/libc v1.62.1
+	modernc.org/mathutil v1.7.1
+	modernc.org/memory v1.9.1
 )

--- a/library/other/open-meteo/internal/cli/channel_workflow.go
+++ b/library/other/open-meteo/internal/cli/channel_workflow.go
@@ -55,7 +55,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 			defer s.Close()
 
-			resources := []string{"forecast",  }
+			resources := []string{ }
 			totalSynced := 0
 
 			for _, resource := range resources {

--- a/library/other/open-meteo/internal/cli/helpers.go
+++ b/library/other/open-meteo/internal/cli/helpers.go
@@ -1134,7 +1134,12 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
-// wrapWithProvenance wraps JSON data in a provenance envelope: {"results": ..., "meta": {...}}.
+// wrapWithProvenance wraps response data in a provenance envelope:
+// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
+// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
+// text), it embeds as a JSON string so json.Marshal doesn't choke on
+// "invalid character '<'" while still passing the raw payload through to
+// the consumer.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -1149,8 +1154,12 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if prov.Freshness != nil {
 		meta["freshness"] = prov.Freshness
 	}
+	var results any = json.RawMessage(data)
+	if !json.Valid(data) {
+		results = string(data)
+	}
 	envelope := map[string]any{
-		"results": json.RawMessage(data),
+		"results": results,
 		"meta":    meta,
 	}
 	return json.Marshal(envelope)

--- a/library/other/open-meteo/internal/cli/promoted_forecast.go
+++ b/library/other/open-meteo/internal/cli/promoted_forecast.go
@@ -12,6 +12,16 @@ import (
 )
 
 func newForecastPromotedCmd(flags *rootFlags) *cobra.Command {
+	var flagHourly string
+	var flagDaily string
+	var flagLatitude float64
+	var flagLongitude float64
+	var flagCurrentWeather bool
+	var flagTemperatureUnit string
+	var flagWindSpeedUnit string
+	var flagTimeformat string
+	var flagTimezone string
+	var flagPastDays int
 
 	cmd := &cobra.Command{
 		Use:   "forecast",
@@ -20,6 +30,51 @@ func newForecastPromotedCmd(flags *rootFlags) *cobra.Command {
 		Example: "  open-meteo-pp-cli forecast",
 		Annotations: map[string]string{"pp:endpoint": "forecast.list", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("latitude") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "latitude")
+			}
+			if !cmd.Flags().Changed("longitude") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "longitude")
+			}
+			if cmd.Flags().Changed("temperature-unit") {
+				allowedTemperatureUnit := []string{ "celsius", "fahrenheit" }
+				validTemperatureUnit := false
+				for _, v := range allowedTemperatureUnit {
+					if flagTemperatureUnit == v {
+						validTemperatureUnit = true
+						break
+					}
+				}
+				if !validTemperatureUnit {
+					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "temperature-unit", flagTemperatureUnit, allowedTemperatureUnit)
+				}
+			}
+			if cmd.Flags().Changed("wind-speed-unit") {
+				allowedWindSpeedUnit := []string{ "kmh", "ms", "mph", "kn" }
+				validWindSpeedUnit := false
+				for _, v := range allowedWindSpeedUnit {
+					if flagWindSpeedUnit == v {
+						validWindSpeedUnit = true
+						break
+					}
+				}
+				if !validWindSpeedUnit {
+					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "wind-speed-unit", flagWindSpeedUnit, allowedWindSpeedUnit)
+				}
+			}
+			if cmd.Flags().Changed("timeformat") {
+				allowedTimeformat := []string{ "iso8601", "unixtime" }
+				validTimeformat := false
+				for _, v := range allowedTimeformat {
+					if flagTimeformat == v {
+						validTimeformat = true
+						break
+					}
+				}
+				if !validTimeformat {
+					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "timeformat", flagTimeformat, allowedTimeformat)
+				}
+			}
 			c, err := flags.newClient()
 			if err != nil {
 				return err
@@ -27,6 +82,36 @@ func newForecastPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/v1/forecast"
 			params := map[string]string{}
+			if flagHourly != "" {
+				params["hourly"] = fmt.Sprintf("%v", flagHourly)
+			}
+			if flagDaily != "" {
+				params["daily"] = fmt.Sprintf("%v", flagDaily)
+			}
+			if flagLatitude != 0.0 {
+				params["latitude"] = fmt.Sprintf("%v", flagLatitude)
+			}
+			if flagLongitude != 0.0 {
+				params["longitude"] = fmt.Sprintf("%v", flagLongitude)
+			}
+			if flagCurrentWeather != false {
+				params["current_weather"] = fmt.Sprintf("%v", flagCurrentWeather)
+			}
+			if flagTemperatureUnit != "" {
+				params["temperature_unit"] = fmt.Sprintf("%v", flagTemperatureUnit)
+			}
+			if flagWindSpeedUnit != "" {
+				params["wind_speed_unit"] = fmt.Sprintf("%v", flagWindSpeedUnit)
+			}
+			if flagTimeformat != "" {
+				params["timeformat"] = fmt.Sprintf("%v", flagTimeformat)
+			}
+			if flagTimezone != "" {
+				params["timezone"] = fmt.Sprintf("%v", flagTimezone)
+			}
+			if flagPastDays != 0 {
+				params["past_days"] = fmt.Sprintf("%v", flagPastDays)
+			}
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "forecast", false, path, params, nil)
 			if err != nil {
 				return classifyAPIError(err)
@@ -79,6 +164,16 @@ func newForecastPromotedCmd(flags *rootFlags) *cobra.Command {
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		},
 	}
+	cmd.Flags().StringVar(&flagHourly, "hourly", "", "Hourly")
+	cmd.Flags().StringVar(&flagDaily, "daily", "", "Daily")
+	cmd.Flags().Float64Var(&flagLatitude, "latitude", 0.0, "WGS84 coordinate")
+	cmd.Flags().Float64Var(&flagLongitude, "longitude", 0.0, "WGS84 coordinate")
+	cmd.Flags().BoolVar(&flagCurrentWeather, "current-weather", false, "Current weather")
+	cmd.Flags().StringVar(&flagTemperatureUnit, "temperature-unit", "celsius", "Temperature unit (one of: celsius, fahrenheit)")
+	cmd.Flags().StringVar(&flagWindSpeedUnit, "wind-speed-unit", "kmh", "Wind speed unit (one of: kmh, ms, mph, kn)")
+	cmd.Flags().StringVar(&flagTimeformat, "timeformat", "iso8601", "If format `unixtime` is selected, all time values are returned in UNIX epoch time in seconds. Please not that all... (one of: iso8601, unixtime)")
+	cmd.Flags().StringVar(&flagTimezone, "timezone", "", "If `timezone` is set, all timestamps are returned as local-time and data is returned starting at 0:00 local-time....")
+	cmd.Flags().IntVar(&flagPastDays, "past-days", 0, "If `past_days` is set, yesterdays or the day before yesterdays data are also returned. (one of: 1, 2)")
 
 	// Wire sibling endpoints and sub-resources as subcommands
 

--- a/library/other/open-meteo/internal/cli/sync.go
+++ b/library/other/open-meteo/internal/cli/sync.go
@@ -643,6 +643,8 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 	}
 
 	switch resource {
+	case "forecast":
+		return db.UpsertForecast(data)
 	default:
 		return db.Upsert(resource, id, data)
 	}
@@ -679,7 +681,6 @@ func parseSinceDuration(s string) (time.Time, error) {
 
 func defaultSyncResources() []string {
 	return []string{
-		"forecast",
 	}
 }
 
@@ -688,7 +689,6 @@ func defaultSyncResources() []string {
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) string {
 	paths := map[string]string{
-		"forecast": "/v1/forecast",
 	}
 	if p, ok := paths[resource]; ok {
 		return p

--- a/library/other/open-meteo/internal/client/client.go
+++ b/library/other/open-meteo/internal/client/client.go
@@ -215,7 +215,7 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		for k, v := range headerOverrides {
 			req.Header.Set(k, v)
 		}
-		req.Header.Set("User-Agent", "github.com/mvanhorn/printing-press-library/library/other/open-meteo/1.0")
+		req.Header.Set("User-Agent", "open-meteo-pp-cli/1.0")
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {

--- a/library/other/open-meteo/internal/mcp/tools.go
+++ b/library/other/open-meteo/internal/mcp/tools.go
@@ -26,7 +26,17 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("forecast_list",
-			mcplib.WithDescription("7 day weather variables in hourly and daily resolution for given WGS84 latitude and longitude coordinates. Available worldwide. Returns the ListResponse."),
+			mcplib.WithDescription("7 day weather variables in hourly and daily resolution for given WGS84 latitude and longitude coordinates. Available worldwide. Required: latitude, longitude. Optional: hourly, daily, current_weather (plus 5 more). Returns the ListResponse."),
+			mcplib.WithString("hourly", mcplib.Description("Hourly")),
+			mcplib.WithString("daily", mcplib.Description("Daily")),
+			mcplib.WithString("latitude", mcplib.Required(), mcplib.Description("WGS84 coordinate")),
+			mcplib.WithString("longitude", mcplib.Required(), mcplib.Description("WGS84 coordinate")),
+			mcplib.WithString("current_weather", mcplib.Description("Current weather")),
+			mcplib.WithString("temperature_unit", mcplib.Description("Temperature unit")),
+			mcplib.WithString("wind_speed_unit", mcplib.Description("Wind speed unit")),
+			mcplib.WithString("timeformat", mcplib.Description("If format `unixtime` is selected, all time values are returned in UNIX epoch time in seconds. Please not that all...")),
+			mcplib.WithString("timezone", mcplib.Description("If `timezone` is set, all timestamps are returned as local-time and data is returned starting at 0:00 local-time....")),
+			mcplib.WithString("past_days", mcplib.Description("If `past_days` is set, yesterdays or the day before yesterdays data are also returned.")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
@@ -247,7 +257,7 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 				"name": "forecast",
 				"description": "Manage forecast",
 				"endpoints": []string{"list",  },
-				"syncable": true,
+				"searchable": true,
 			},
 		},
 		"query_tips": []string{

--- a/library/other/open-meteo/internal/store/schema_version_test.go
+++ b/library/other/open-meteo/internal/store/schema_version_test.go
@@ -254,6 +254,75 @@ func TestSchemaVersion_ReopenIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestMigrate_AddsColumnsOnUpgrade_Forecast verifies that opening a
+// database created by an older binary succeeds and adds newly generated
+// columns before CREATE INDEX runs against the pre-existing table. Regression
+// coverage for parent_id upgrades and indexed generated columns.
+func TestMigrate_AddsColumnsOnUpgrade_Forecast(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	// Pre-create the DB with the older table shape: id, data, synced_at and
+	// none of the newer generated columns. user_version stays 0 (pre-gate).
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE forecast (
+		id TEXT PRIMARY KEY,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create old table: %v", err)
+	}
+	raw.Close()
+
+	// Opening with the new binary must run CREATE INDEX statements without
+	// erroring on missing generated columns.
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open upgraded db: %v", err)
+	}
+	defer s.Close()
+
+	// The migration must have added every generated column.
+	rows, err := s.DB().Query(`PRAGMA table_info(forecast)`)
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+
+	hasColumn := make(map[string]bool)
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		hasColumn[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	for _, want := range []string{
+		"latitude",
+		"longitude",
+		"current_weather",
+		"temperature_unit",
+		"wind_speed_unit",
+		"timeformat",
+		"timezone",
+		"past_days",
+	} {
+		if !hasColumn[want] {
+			t.Fatalf("%s column missing from forecast after migrate", want)
+		}
+	}
+}
+
 // TestMigrate_AddsColumnsOnUpgrade_SyncState verifies that opening a
 // database created by an older binary succeeds and adds newly generated
 // columns before CREATE INDEX runs against the pre-existing table. Regression

--- a/library/other/open-meteo/internal/store/store.go
+++ b/library/other/open-meteo/internal/store/store.go
@@ -184,6 +184,14 @@ func (s *Store) ensureColumn(ctx context.Context, conn *sql.Conn, table, column,
 // word.
 func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 	for _, c := range []struct{ table, column, decl string }{
+		{table: "forecast", column: "latitude", decl: "REAL"},
+		{table: "forecast", column: "longitude", decl: "REAL"},
+		{table: "forecast", column: "current_weather", decl: "INTEGER"},
+		{table: "forecast", column: "temperature_unit", decl: "TEXT"},
+		{table: "forecast", column: "wind_speed_unit", decl: "TEXT"},
+		{table: "forecast", column: "timeformat", decl: "TEXT"},
+		{table: "forecast", column: "timezone", decl: "TEXT"},
+		{table: "forecast", column: "past_days", decl: "INTEGER"},
 		{table: "sync_state", column: "last_cursor", decl: "TEXT"},
 		{table: "sync_state", column: "last_synced_at", decl: "DATETIME"},
 		{table: "sync_state", column: "total_count", decl: "INTEGER DEFAULT 0"},
@@ -239,7 +247,15 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE TABLE IF NOT EXISTS forecast (
 			id TEXT PRIMARY KEY,
 			data JSON NOT NULL,
-			synced_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			latitude REAL,
+			longitude REAL,
+			current_weather INTEGER,
+			temperature_unit TEXT,
+			wind_speed_unit TEXT,
+			timeformat TEXT,
+			timezone TEXT,
+			past_days INTEGER
 		)`,
 	}
 
@@ -555,6 +571,63 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 func lookupFieldValue(obj map[string]any, snakeKey string) any {
 	return LookupFieldValue(obj, snakeKey)
 }
+// upsertForecastTx writes the typed-table portion of a forecast upsert
+// inside an existing transaction. The caller is responsible for the generic
+// resources insert (via upsertGenericResourceTx) and for committing the tx.
+// Splitting this out lets UpsertBatch dispatch typed inserts per item without
+// opening a per-item transaction.
+func (s *Store) upsertForecastTx(tx *sql.Tx, id string, obj map[string]any, data json.RawMessage) error {
+	if _, err := tx.Exec(
+		`INSERT INTO forecast (id, data, synced_at, latitude, longitude, current_weather, temperature_unit, wind_speed_unit, timeformat, timezone, past_days)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET data = excluded.data, synced_at = excluded.synced_at, latitude = excluded.latitude, longitude = excluded.longitude, current_weather = excluded.current_weather, temperature_unit = excluded.temperature_unit, wind_speed_unit = excluded.wind_speed_unit, timeformat = excluded.timeformat, timezone = excluded.timezone, past_days = excluded.past_days`,
+		id,
+		string(data),
+		time.Now(),
+		lookupFieldValue(obj, "latitude"),
+		lookupFieldValue(obj, "longitude"),
+		lookupFieldValue(obj, "current_weather"),
+		lookupFieldValue(obj, "temperature_unit"),
+		lookupFieldValue(obj, "wind_speed_unit"),
+		lookupFieldValue(obj, "timeformat"),
+		lookupFieldValue(obj, "timezone"),
+		lookupFieldValue(obj, "past_days"),
+	); err != nil {
+		return fmt.Errorf("insert into forecast: %w", err)
+	}
+
+	return nil
+}
+
+// UpsertForecast inserts or updates a forecast record with domain-specific columns.
+func (s *Store) UpsertForecast(data json.RawMessage) error {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("unmarshaling forecast: %w", err)
+	}
+
+	id := extractObjectID(obj)
+	if id == "" {
+		return fmt.Errorf("missing id for forecast")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err := s.upsertGenericResourceTx(tx, "forecast", id, data); err != nil {
+		return err
+	}
+	if err := s.upsertForecastTx(tx, id, obj, data); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
 
 // resourceIDFieldOverrides projects per-resource IDField (set by the profiler
 // from x-resource-id or response-schema fallback) into a runtime lookup map.
@@ -637,6 +710,10 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		}
 
 		switch resourceType {
+		case "forecast":
+			if err := s.upsertForecastTx(tx, id, obj, item); err != nil {
+				return 0, extractFailures, fmt.Errorf("typed upsert for %s/%s: %w", resourceType, id, err)
+			}
 		}
 		stored++
 	}

--- a/library/other/open-meteo/internal/store/upsert_batch_test.go
+++ b/library/other/open-meteo/internal/store/upsert_batch_test.go
@@ -257,3 +257,45 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 		t.Fatalf("extractFailures = %d, want 2 (two items have no extractable PK)", extractFailures)
 	}
 }
+
+// TestUpsertBatch_PopulatesForecastTable verifies that UpsertBatch
+// dispatches paginated items into both the generic resources table AND the
+// typed forecast table. Regression for issue #268: before the fix, paginated
+// syncs only filled the generic resources table, so domain commands that
+// query the typed table saw zero rows.
+func TestUpsertBatch_PopulatesForecastTable(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "test-001"}`),
+		json.RawMessage(`{"id": "test-002"}`),
+		json.RawMessage(`{"id": "test-003"}`),
+	}
+	if _, _, err := s.UpsertBatch("forecast", items); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+
+	db := s.DB()
+
+	var generic int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "forecast").Scan(&generic); err != nil {
+		t.Fatalf("count resources: %v", err)
+	}
+	if generic != len(items) {
+		t.Fatalf("resources count = %d, want %d", generic, len(items))
+	}
+
+	var typed int
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "forecast")
+	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
+		t.Fatalf("count forecast: %v", err)
+	}
+	if typed != len(items) {
+		t.Fatalf("forecast count = %d, want %d (typed table not populated by UpsertBatch)", typed, len(items))
+	}
+}


### PR DESCRIPTION
Re-sweep with the new tools after [cli-printing-press#465](https://github.com/mvanhorn/cli-printing-press/pull/465) merged. Pure templated refresh — zero TEMPLATED-WITH-ADDITIONS this time since #171 already cleaned them out.

The forecast-no-flags bug surfaced during #171 verification is now fixed end-to-end. All 10 query parameters from the spec are wired:

```
$ open-meteo-pp-cli forecast --help | grep -E '^\s+--(latitude|longitude|hourly|daily|temperature-unit|timezone)'
      --daily string              Daily
      --hourly string             Hourly
      --latitude float            WGS84 coordinate
      --longitude float           WGS84 coordinate
      --temperature-unit string   Temperature unit (one of: celsius, fahrenheit) (default "celsius")
      --timezone timezone         If timezone is set, all timestamps are returned as local-time...
```

Real API call (with base_url override) returns live Seattle weather:

```
$ OPEN_METEO_CONFIG=/tmp/open-meteo-config.toml \
    open-meteo-pp-cli forecast --latitude 47.6 --longitude -122.3 \
      --hourly temperature_2m --agent | jq -r '.results | "\(.latitude),\(.longitude),\(.timezone)"'
47.60265,-122.28637,GMT
```

The pre-existing spec gap (no top-level `servers:` block) still requires users to set base_url in config.toml — that's a spec-fix follow-up, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)