### PR TITLE
docs(agents): add 'Preflight before opening a PR' section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,29 @@ Known pitfalls the verifier handles:
 - A subcommand sharing a leaf name with a top-level command (e.g. `profile save` vs. top-level `save`) — resolved via `rootCmd.AddCommand` lookup + constructor naming convention (`new{Parent1}{Parent2}{Leaf}Cmd`).
 - `$(...)` command substitution in recipes can look like positional args — reported as `[likely false positive]` and not blocking.
 
+## Preflight before opening a PR
+
+The following checks run in CI on every PR. Run them locally first; CI failures on these are slow-feedback (~minutes per push) and routinely catch the same drift you can catch in seconds.
+
+For any CLI you touched (`library/<category>/<slug>/`):
+
+```bash
+# 1. SKILL.md / README.md / source consistency — catches command renames,
+#    dropped commands, flag rename drift between docs and code.
+python3 .github/scripts/verify-skill/verify_skill.py --dir library/<category>/<slug>/
+
+# 2. Build, vet, test from the CLI root.
+cd library/<category>/<slug>/
+go build ./...
+go vet ./...
+go test ./...
+```
+
+Common failure shapes that CI surfaces but local runs catch first:
+- Resource renames driven by framework collisions (e.g., `search` → `<api>-search`, `auth` → `<api>-auth`) leave SKILL.md / README.md referencing the old command path. The verifier flags `[unknown-command]`.
+- A novel command's NOVEL helper file deleted but its `AddCommand` line still in `root.go` → build fail.
+- Body of a templated function modified to call a hand-written helper that got dropped during a regeneration → test fail.
+
 ## Pointers to deeper context
 
 - Generator internals, patcher behavior, and plan docs live in [cli-printing-press](https://github.com/mvanhorn/cli-printing-press).


### PR DESCRIPTION
## Summary

Three recent sweep PRs hit CI failures the local verifier would have caught in seconds:
- [#170 wikipedia](https://github.com/mvanhorn/printing-press-library/pull/170): SKILL.md / tools.go / which.go referenced `page get-related` after the spec dropped it
- [#177 coingecko](https://github.com/mvanhorn/printing-press-library/pull/177): SKILL.md / README.md referenced `search trending` after the framework-collision rename moved it to `coingecko-search-2`
- [#166-#178 sweep batch](https://github.com/mvanhorn/printing-press-library/pulls): take-fresh-wholesale flipped `hiten-shah` → `trevin-chow` (the printing-press generate default) across 11 CLIs

The existing 'SKILL.md verification' section in AGENTS.md describes what the verifier checks but doesn't tell agents to run it. This PR adds a prescriptive 'Preflight before opening a PR' section listing the exact commands and the failure shapes they catch.

## Test plan

- [x] Existing AGENTS.md content preserved verbatim
- [x] Section reads cleanly in markdown preview
- [ ] Future PRs (especially regen-merge sweeps) cite this section in their PR descriptions or commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)