### PR TITLE
feat(ci): build MCPB bundles in CI and publish as release assets

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -1,0 +1,206 @@
+name: Build MCPB bundles
+
+# Builds cross-platform .mcpb bundles for printed CLIs and uploads them as
+# release assets keyed by `<slug>-current` (a moving tag). The README in
+# each CLI links to releases/download/<slug>-current/<binary>-<os>-<arch>.mcpb,
+# so each push to main rebuilds and the URL stays stable forever.
+#
+# Triggers:
+#   - workflow_dispatch (manual): rebuild a specific CLI or "all"
+#   - push to main on library/** (excluding build/): rebuild affected CLIs
+#
+# Auth: requires GENERATOR_READ_TOKEN (fine-grained PAT with Contents:read on
+# mvanhorn/cli-printing-press) so `go install` can fetch the printing-press
+# generator from a private repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cli:
+        description: 'CLI to rebuild as <category>/<slug>, or "all" for every CLI in the library'
+        required: false
+        default: ''
+  push:
+    branches: [main]
+    paths:
+      - 'library/**'
+      - '!library/**/build/**'
+      - '.github/workflows/build-mcpb.yml'
+
+permissions:
+  contents: write  # for creating/updating releases
+
+jobs:
+  detect:
+    name: Detect affected CLIs
+    runs-on: ubuntu-latest
+    outputs:
+      affected: ${{ steps.detect.outputs.affected }}
+      count: ${{ steps.detect.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history to diff against parent commit
+      - id: detect
+        name: Determine affected CLIs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CLI: ${{ inputs.cli }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -z "$INPUT_CLI" ] || [ "$INPUT_CLI" = "all" ]; then
+              affected=$(find library -mindepth 2 -maxdepth 2 -type d \
+                | sed 's|library/||' \
+                | sort -u \
+                | jq -R . | jq -s -c .)
+            else
+              affected=$(printf '%s' "$INPUT_CLI" | jq -R . | jq -s -c .)
+            fi
+          else
+            # Push event: diff against parent commit. The all-zeros sentinel
+            # appears for initial branch pushes; fall back to HEAD^ then to
+            # listing all library entries so the workflow degrades gracefully.
+            if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE_SHA" ]; then
+              changed_paths=$(git diff --name-only "HEAD^" "HEAD" -- 'library/**' 2>/dev/null || git ls-files 'library/**')
+            else
+              changed_paths=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'library/**' || true)
+            fi
+            affected=$(printf '%s\n' "$changed_paths" \
+              | awk -F/ 'NF >= 3 && $1 == "library" { print $2"/"$3 }' \
+              | sort -u \
+              | jq -R . | jq -s -c .)
+          fi
+          # Filter out empty/null entries
+          affected=$(printf '%s' "$affected" | jq -c '[ .[] | select(. != null and . != "") ]')
+          count=$(printf '%s' "$affected" | jq 'length')
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Affected CLIs ($count): $affected"
+
+  bundle:
+    name: Bundle ${{ matrix.target }} (${{ matrix.platform }})
+    needs: detect
+    if: needs.detect.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.detect.outputs.affected) }}
+        platform:
+          - darwin/amd64
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64
+          - windows/amd64
+          - windows/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::GENERATOR_READ_TOKEN secret is not set. The workflow needs a fine-grained PAT with Contents:read on mvanhorn/cli-printing-press."
+            exit 1
+          fi
+          git config --global url."https://oauth2:${TOKEN}@github.com/".insteadOf "https://github.com/"
+      - name: Install printing-press
+        env:
+          GOPRIVATE: github.com/mvanhorn/*
+        run: |
+          go install github.com/mvanhorn/cli-printing-press/v3/cmd/printing-press@latest
+          printing-press --version
+      - name: Bundle MCPB
+        env:
+          CLI_TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          cli_dir="library/${CLI_TARGET}"
+          if [ ! -f "${cli_dir}/manifest.json" ]; then
+            echo "::warning::${cli_dir} has no manifest.json — skipping bundle (likely pre-v3.0.0; needs regen via printing-press-publish)."
+            exit 0
+          fi
+          os="${PLATFORM%/*}"
+          arch="${PLATFORM#*/}"
+          slug=$(basename "${CLI_TARGET}")
+          out="${RUNNER_TEMP}/out/${slug}-pp-mcp-${os}-${arch}.mcpb"
+          mkdir -p "$(dirname "$out")"
+          printing-press bundle "$cli_dir" --platform "${PLATFORM}" --output "$out"
+          ls -lh "$out"
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcpb-${{ matrix.target }}-${{ matrix.platform }}
+          path: ${{ runner.temp }}/out/*.mcpb
+          if-no-files-found: ignore
+          retention-days: 7
+
+  release:
+    name: Release ${{ matrix.target }}
+    needs: [detect, bundle]
+    if: needs.detect.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.detect.outputs.affected) }}
+    concurrency:
+      group: release-${{ matrix.target }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute slug
+        id: slug
+        env:
+          CLI_TARGET: ${{ matrix.target }}
+        run: |
+          slug=$(basename "${CLI_TARGET}")
+          echo "slug=${slug}" >> "$GITHUB_OUTPUT"
+      - name: Download bundle artifacts for this CLI
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/dl
+          pattern: mcpb-${{ matrix.target }}-*
+          merge-multiple: true
+      - name: List downloaded artifacts
+        run: |
+          ls -lh "${RUNNER_TEMP}/dl" || true
+          count=$(find "${RUNNER_TEMP}/dl" -name '*.mcpb' 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$count" = "0" ]; then
+            echo "::warning::No .mcpb files were produced for ${{ matrix.target }} — bundle job may have skipped (no manifest.json) or failed across all platforms."
+            exit 0
+          fi
+          echo "Found $count .mcpb files."
+      - name: Publish release ${{ steps.slug.outputs.slug }}-current
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLUG: ${{ steps.slug.outputs.slug }}
+          CLI_TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          tag="${SLUG}-current"
+          # If no .mcpb files were produced, skip release publish.
+          if ! find "${RUNNER_TEMP}/dl" -name '*.mcpb' -print -quit | grep -q .; then
+            echo "No bundles to publish for ${SLUG}; skipping release."
+            exit 0
+          fi
+          notes=$(printf 'Auto-built MCPB bundles for **%s** at commit %s.\n\nDownload the .mcpb file matching your platform and double-click it to install in Claude Desktop.\n\n_This is a moving tag — it always points at the latest bundle build. For a pinned version, install from the per-CLI Go module._' "${CLI_TARGET}" "${GITHUB_SHA}")
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "Updating existing release ${tag}"
+            gh release upload "${tag}" "${RUNNER_TEMP}"/dl/*.mcpb --clobber
+            gh release edit "${tag}" --notes "${notes}" --target "${GITHUB_SHA}"
+          else
+            echo "Creating new release ${tag}"
+            gh release create "${tag}" "${RUNNER_TEMP}"/dl/*.mcpb \
+              --title "${SLUG} (latest bundles)" \
+              --notes "${notes}" \
+              --target "${GITHUB_SHA}" \
+              --latest=false
+          fi

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -1,0 +1,126 @@
+name: Bundle audit
+
+# One-shot diagnostic that walks every CLI in the library and tries to
+# build a host-platform .mcpb. Reports which CLIs bundle cleanly today
+# vs which need regeneration (typically pre-v3.0.0 CLIs that lack the
+# manifest.json the MCPB packager expects).
+#
+# Updates a sticky issue with the latest results so progress against the
+# pre-v3.0.0 backlog is trackable across runs.
+#
+# This workflow is dispatch-only — it doesn't run on push.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Audit bundleability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::GENERATOR_READ_TOKEN secret is not set."
+            exit 1
+          fi
+          git config --global url."https://oauth2:${TOKEN}@github.com/".insteadOf "https://github.com/"
+      - name: Install printing-press
+        env:
+          GOPRIVATE: github.com/mvanhorn/*
+        run: |
+          go install github.com/mvanhorn/cli-printing-press/v3/cmd/printing-press@latest
+          printing-press --version
+      - name: Run audit
+        id: audit
+        run: |
+          set -uo pipefail
+          report="${RUNNER_TEMP}/audit.md"
+          {
+            echo "# Bundle Audit"
+            echo
+            printf '_Last run: %s (commit %s)_\n\n' "$(date -u +'%Y-%m-%d %H:%M UTC')" "${GITHUB_SHA::7}"
+            echo "| Status | CLI | printing-press version | Notes |"
+            echo "|--------|-----|------------------------|-------|"
+          } > "$report"
+
+          ok=0
+          fail=0
+          missing_manifest=0
+
+          while IFS= read -r cli_dir; do
+            target=${cli_dir#library/}
+            slug=$(basename "$cli_dir")
+            pp_version=""
+            if [ -f "${cli_dir}/.printing-press.json" ]; then
+              pp_version=$(jq -r '.printing_press_version // ""' "${cli_dir}/.printing-press.json" 2>/dev/null || echo "")
+            fi
+
+            if [ ! -f "${cli_dir}/manifest.json" ]; then
+              echo "| ⛔ regen | \`${target}\` | ${pp_version:-?} | no manifest.json (pre-MCPB) |" >> "$report"
+              missing_manifest=$((missing_manifest+1))
+              continue
+            fi
+
+            tmp_out="${RUNNER_TEMP}/${slug}.mcpb"
+            if printing-press bundle "$cli_dir" --output "$tmp_out" >/tmp/bundle.log 2>&1; then
+              size=$(du -h "$tmp_out" 2>/dev/null | awk '{print $1}')
+              echo "| ✅ ok | \`${target}\` | ${pp_version:-?} | ${size:-?} |" >> "$report"
+              ok=$((ok+1))
+              rm -f "$tmp_out"
+            else
+              # Quote the first error line so the table cell doesn't break on pipes/newlines
+              err=$(head -3 /tmp/bundle.log | tr '\n' ' ' | sed 's/|/\\|/g' | head -c 200)
+              echo "| ⛔ regen | \`${target}\` | ${pp_version:-?} | ${err} |" >> "$report"
+              fail=$((fail+1))
+            fi
+          done < <(find library -mindepth 2 -maxdepth 2 -type d | sort)
+
+          {
+            echo
+            echo "## Summary"
+            printf -- '- ✅ Bundles cleanly: **%d**\n' "$ok"
+            printf -- '- ⛔ Needs regen (no manifest): **%d**\n' "$missing_manifest"
+            printf -- '- ⛔ Bundle attempt failed: **%d**\n' "$fail"
+            echo
+            echo "## Remediation"
+            echo
+            echo "- ✅ rows: trigger \`build-mcpb.yml\` (\`gh workflow run build-mcpb.yml -f cli=<category>/<slug>\`) to publish a release."
+            echo "- ⛔ rows: regenerate the CLI through the full pipeline via the \`printing-press-publish\` skill, then republish."
+          } >> "$report"
+
+          cat "$report"
+          # Make the file content available to the next step
+          {
+            echo 'report<<REPORT_EOF'
+            cat "$report"
+            echo 'REPORT_EOF'
+          } >> "$GITHUB_OUTPUT"
+      - name: Update tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.audit.outputs.report }}
+        run: |
+          set -euo pipefail
+          title="Bundle Audit"
+          # Find existing issue (open or closed) authored by the workflow
+          existing=$(gh issue list --search "in:title \"${title}\"" --state all --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            echo "Updating issue #${existing}"
+            gh issue edit "${existing}" --body "${REPORT}"
+            gh issue reopen "${existing}" 2>/dev/null || true
+          else
+            echo "Creating new issue"
+            gh issue create --title "${title}" --body "${REPORT}" --label "bundle-audit" 2>/dev/null \
+              || gh issue create --title "${title}" --body "${REPORT}"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ __debug_bin*
 # Build artifacts from printing-press verify/scorecard
 *-validation
 
+# Local-dev MCPB scratch — autoBundleForHost writes here. CI publishes
+# canonical bundles to GitHub release assets keyed by <slug>-current.
+library/**/build/
+
 # Generator build artifacts (CI uses `go run`, these come from local `go build`)
 tools/generate-skills/generate-skills
 


### PR DESCRIPTION
## Summary

Takes ownership of MCPB bundle production from the publish flow and moves it into CI, with cross-platform fan-out and release-asset distribution.

Today, 5 of 37 published CLIs have a host-platform-only \`build/<binary>.mcpb\` committed at the CLI root, 32 don't, and the README's reference URL points at \`blob/main/.../build/...\` (which doesn't exist for most CLIs). This PR sets up the infrastructure to fix that.

## What's new

### \`.github/workflows/build-mcpb.yml\`

Triggers:
- \`push\` to \`main\` on \`library/**\` paths (excluding \`build/\`)
- \`workflow_dispatch\` with an optional \`cli\` input (\`<category>/<slug>\` or \`all\` to rebuild every CLI)

For each affected CLI, builds \`.mcpb\` across six platforms:
- \`darwin/amd64\`, \`darwin/arm64\`
- \`linux/amd64\`, \`linux/arm64\`
- \`windows/amd64\`, \`windows/arm64\`

Then uploads all six \`.mcpb\` files to a single GitHub release per CLI, tagged \`<slug>-current\`. The tag is moving — each build replaces assets in place — so the README's \`releases/download/<slug>-current/...\` URL stays stable.

### \`.github/workflows/bundle-audit.yml\`

\`workflow_dispatch\` only. Walks every CLI under \`library/\`, attempts a host-platform bundle, and updates a sticky issue titled \"Bundle Audit\" with a ✅/⛔ table. Drives the pre-v3.0.0 backlog so we know which CLIs need regen vs which can be re-bundled in place.

### \`.gitignore\`

Adds \`library/**/build/\` so future local-dev \`autoBundleForHost\` scratch output doesn't accidentally land in PRs.

## Auth

Both workflows install the \`printing-press\` generator from the private \`mvanhorn/cli-printing-press\` repo. They depend on a repo secret \`GENERATOR_READ_TOKEN\` — a fine-grained PAT with \`Contents:read\` on \`mvanhorn/cli-printing-press\` only. The admin has already created and stored this secret.

## Test plan

- [x] YAML lints cleanly (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [ ] After merge, manually trigger \`bundle-audit.yml\` to verify auth works and produce the first audit
- [ ] Manually trigger \`build-mcpb.yml -f cli=food-and-dining/food52\` (a known-bundleable v3.0.0+ CLI) to verify the release publish path end-to-end
- [ ] Verify a release at \`food52-current\` with six \`.mcpb\` assets, one per platform
- [ ] Manually download one .mcpb, double-click in Claude Desktop, confirm it installs

## Follow-up PRs

Sequenced after this lands and is verified:

1. Trigger \`build-mcpb.yml\` for the three v3.0.0+ CLIs that don't have \`build/\` in the repo today: \`pokeapi\`, \`shopify\`, \`food52\`. (No PR needed; manual workflow_dispatch.)
2. Single PR removing the five existing committed \`build/\` dirs (\`ebay\`, \`company-goat\`, \`postman-explore\`, \`scrape-creators\`, \`producthunt\`) plus per-CLI README URL updates pointing at the release URL. CI will rebuild and release them on merge.
3. Run \`bundle-audit.yml\`, work through the resulting issue: trigger \`build-mcpb.yml\` for ✅ rows, schedule regen for ⛔ rows.
4. PR in \`mvanhorn/cli-printing-press\` updating the README template URL from \`blob/main/.../build/{{.Name}}-pp-mcp-darwin-arm64.mcpb\` to \`releases/download/{{.Name}}-current/{{.Name}}-pp-mcp-darwin-arm64.mcpb\`.

Companion PR in \`mvanhorn/cli-printing-press\` (already open, https://github.com/mvanhorn/cli-printing-press/pull/502) strips \`build/\` from publish staging so future generations don't accidentally re-introduce committed bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)