### PR TITLE
fix(ci): trim mcpb matrix and sanitize artifact names

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -90,10 +90,11 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.detect.outputs.affected) }}
         platform:
-          - darwin/amd64
+          # Scoped to platforms Claude Desktop actually runs on. Intel Macs
+          # dropped because Apple Silicon dominates the install base; Linux
+          # dropped because Claude Desktop doesn't ship there at all (Linux
+          # Claude Code users have the focused skill path instead of MCPB).
           - darwin/arm64
-          - linux/amd64
-          - linux/arm64
           - windows/amd64
           - windows/arm64
     steps:
@@ -123,13 +124,20 @@ jobs:
         run: |
           set -euo pipefail
           cli_dir="library/${CLI_TARGET}"
+          os="${PLATFORM%/*}"
+          arch="${PLATFORM#*/}"
+          slug=$(basename "${CLI_TARGET}")
+          # Set artifact-name env vars unconditionally so the upload step
+          # always has valid values, even when we early-exit below.
+          # actions/upload-artifact@v4 rejects / in names; slugs are unique
+          # across the library (slug-keyed dirs), so slug + os-arch is a
+          # safe and stable artifact name.
+          echo "SLUG=${slug}" >> "$GITHUB_ENV"
+          echo "PLATFORM_TAG=${os}-${arch}" >> "$GITHUB_ENV"
           if [ ! -f "${cli_dir}/manifest.json" ]; then
             echo "::warning::${cli_dir} has no manifest.json — skipping bundle (likely pre-v3.0.0; needs regen via printing-press-publish)."
             exit 0
           fi
-          os="${PLATFORM%/*}"
-          arch="${PLATFORM#*/}"
-          slug=$(basename "${CLI_TARGET}")
           out="${RUNNER_TEMP}/out/${slug}-pp-mcp-${os}-${arch}.mcpb"
           mkdir -p "$(dirname "$out")"
           printing-press bundle "$cli_dir" --platform "${PLATFORM}" --output "$out"
@@ -137,7 +145,7 @@ jobs:
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mcpb-${{ matrix.target }}-${{ matrix.platform }}
+          name: mcpb-${{ env.SLUG }}-${{ env.PLATFORM_TAG }}
           path: ${{ runner.temp }}/out/*.mcpb
           if-no-files-found: ignore
           retention-days: 7
@@ -167,7 +175,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/dl
-          pattern: mcpb-${{ matrix.target }}-*
+          pattern: mcpb-${{ steps.slug.outputs.slug }}-*
           merge-multiple: true
       - name: List downloaded artifacts
         run: |


### PR DESCRIPTION
## Summary

Two follow-ups to #187, both small.

**1. Trim the platform matrix to what Claude Desktop runs on.**

Drops \`linux/{amd64,arm64}\` and \`darwin/amd64\`. Claude Desktop doesn't run on Linux, and the Intel Mac install base is dwindling fast enough that shipping a \`darwin/amd64\` .mcpb adds release-page noise without serving real users. Linux Claude Code users have the focused skill install path, which is the recommended integration anyway.

Remaining matrix (3 platforms):
- \`darwin/arm64\` — Apple Silicon Macs
- \`windows/amd64\` — Windows x86_64
- \`windows/arm64\` — Windows on ARM (Surface, Snapdragon X)

**2. Sanitize artifact names.**

The first food52 dispatch failed with:

\`\`\`
The artifact name is not valid: mcpb-food-and-dining/food52-linux/amd64.
Contains the following character: Forward slash /
\`\`\`

\`actions/upload-artifact@v4\` rejects \`/\` in names, but \`matrix.target\` (\`<category>/<slug>\`) and \`matrix.platform\` (\`<os>/<arch>\`) both contained them. Compute \`slug\` (basename of target) and \`platform_tag\` (\`<os>-<arch>\`) into \`\$GITHUB_ENV\` in the bundle step, then reference \`env.SLUG\` and \`env.PLATFORM_TAG\` in the upload. The release job's \`download-artifact\` pattern switches from \`mcpb-\${matrix.target}-*\` to \`mcpb-\${slug}-*\`. Slugs are unique across the library (slug-keyed dirs), so artifact names of the form \`mcpb-<slug>-<os>-<arch>\` are unambiguous.

Env vars are set before the manifest.json check so the upload step has valid values even when we early-exit on a pre-v3.0.0 CLI (which produces no .mcpb but should still complete cleanly).

## Test plan

- [x] YAML parses
- [ ] After merge, retry \`gh workflow run build-mcpb.yml -f cli=food-and-dining/food52\` — expect 3 successful platform builds and a \`food52-current\` release with 3 .mcpb assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)