### PR TITLE
ci: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -38,7 +38,7 @@ jobs:
       affected: ${{ steps.detect.outputs.affected }}
       count: ${{ steps.detect.outputs.count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # need history to diff against parent commit
       - id: detect
@@ -97,8 +97,8 @@ jobs:
           - windows/amd64
           - windows/arm64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Configure git for private modules
@@ -135,7 +135,7 @@ jobs:
           printing-press bundle "$cli_dir" --platform "${PLATFORM}" --output "$out"
           ls -lh "$out"
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcpb-${{ matrix.target }}-${{ matrix.platform }}
           path: ${{ runner.temp }}/out/*.mcpb
@@ -155,7 +155,7 @@ jobs:
       group: release-${{ matrix.target }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Compute slug
         id: slug
         env:
@@ -164,7 +164,7 @@ jobs:
           slug=$(basename "${CLI_TARGET}")
           echo "slug=${slug}" >> "$GITHUB_OUTPUT"
       - name: Download bundle artifacts for this CLI
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/dl
           pattern: mcpb-${{ matrix.target }}-*

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -22,8 +22,8 @@ jobs:
     name: Audit bundleability
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Configure git for private modules

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23'
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/verify-manifests.yml
+++ b/.github/workflows/verify-manifests.yml
@@ -18,8 +18,8 @@ jobs:
     name: Validate MCPB manifest contract
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Run manifest verifier

--- a/.github/workflows/verify-skills.yml
+++ b/.github/workflows/verify-skills.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout library
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
Updates the CI workflow action pins to Node 24-compatible majors so GitHub Actions stops warning about deprecated Node 20 runtimes. This keeps checkout, language setup, and artifact upload/download actions current across bundle, verification, skill generation, and npm publish workflows.

Validation: `actionlint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)