### PR TITLE
fix(ci): cancel stacked mcpb builds when newer push supersedes

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -97,6 +97,12 @@ jobs:
           - darwin/arm64
           - windows/amd64
           - windows/arm64
+    concurrency:
+      # Cancel in-flight bundles when a newer push for the same (cli, platform)
+      # lands. The newer source supersedes the older, so completing the older
+      # build would just produce assets we'd overwrite seconds later.
+      group: bundle-${{ matrix.target }}-${{ matrix.platform }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -160,8 +166,11 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.detect.outputs.affected) }}
     concurrency:
+      # Cancel in-flight releases for the same CLI when a newer push lands.
+      # gh release upload --clobber is per-asset, so a canceled mid-upload
+      # is recovered by the superseding run's upload pass.
       group: release-${{ matrix.target }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - name: Compute slug

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -21,6 +21,11 @@ jobs:
   audit:
     name: Audit bundleability
     runs-on: ubuntu-latest
+    concurrency:
+      # Audits take ~25 min; cancel any in-flight audit when a newer one
+      # is dispatched. The newer one's results supersede.
+      group: bundle-audit
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

Stacked pushes to the same CLI currently produce redundant work: two pushes touching food52 within minutes would build the same \`.mcpb\` twice in parallel and run two release uploads sequentially (the second overwriting the first). Adds concurrency cancellation so overlapping work collapses to \"latest wins.\"

## Changes

**\`build-mcpb.yml\` bundle job** — adds per-\`(target, platform)\` concurrency:

\`\`\`yaml
concurrency:
  group: bundle-\${{ matrix.target }}-\${{ matrix.platform }}
  cancel-in-progress: true
\`\`\`

Two pushes touching food52 within minutes no longer build the same \`(food52, darwin/arm64)\` twice. Pushes touching different CLIs are unaffected — different concurrency groups.

**\`build-mcpb.yml\` release job** — flips \`cancel-in-progress\` from \`false\` to \`true\`:

\`gh release upload --clobber\` is per-asset, so a canceled mid-upload is recovered by the superseding run's upload pass. Originally I set this to \`false\` out of caution; in practice there's no real risk of a partially-published release.

**\`bundle-audit.yml\`** — adds workflow-level concurrency:

\`\`\`yaml
concurrency:
  group: bundle-audit
  cancel-in-progress: true
\`\`\`

Audits take ~25 min and the newer results supersede the older.

## Net effect

- Stacked work for the same CLI collapses to one bundle + one release
- Cross-CLI parallelism preserved
- workflow_dispatch double-clicks for the same audit no longer pile up

## Test plan

- [x] YAML lints cleanly
- [ ] After merge, smoke test: trigger \`build-mcpb.yml -f cli=food-and-dining/food52\` twice in quick succession; verify only one run completes (the latest), with the other canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)