### PR TITLE
fix(ci): bump go-version to 1.26 to match cli-printing-press v3.4.3+

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Configure git for private modules
         env:
           TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Build CLI binary
         env:
           CLI_TARGET: ${{ matrix.target }}

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Configure git for private modules
         env:
           TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}


### PR DESCRIPTION
## Summary

CI was failing on \`go install\` of the printing-press generator:

\`\`\`
github.com/mvanhorn/cli-printing-press/v3@v3.4.3 requires go >= 1.26.1
(running go 1.25.9; GOTOOLCHAIN=local)
\`\`\`

\`cli-printing-press\`'s \`go.mod\` declares \`go 1.26.1\`, so the workflow runners need at least 1.26 to install it. Bumping \`setup-go\`'s \`go-version\` from \`'1.25'\` to \`'1.26'\` (latest 1.26.x).

Affects both \`build-mcpb.yml\` (bundle + build-cli + release jobs) and \`bundle-audit.yml\`.

## Notes

\`'1.26'\` selector resolves to the newest 1.26.x point release. Will keep satisfying any 1.26.x toolchain directive \`cli-printing-press\` ships without further workflow edits.

## Test plan

- [x] YAML lints
- [ ] After merge, retry food52: \`gh workflow run build-mcpb.yml -R mvanhorn/printing-press-library -f cli=food-and-dining/food52\` — expect success and 9 release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)