### PR TITLE
fix(ci): point setup-go cache-dependency-path at the right go.sum

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -112,6 +112,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          # Public library is a monorepo with per-CLI go.mod under library/<cat>/<slug>/.
+          # Point setup-go at this matrix entry's go.sum so its module cache is keyed
+          # correctly. Without this, setup-go warns "Dependencies file is not found".
+          cache-dependency-path: library/${{ matrix.target }}/go.sum
       - name: Configure git for private modules
         env:
           TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}
@@ -187,6 +191,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache-dependency-path: library/${{ matrix.target }}/go.sum
       - name: Build CLI binary
         env:
           CLI_TARGET: ${{ matrix.target }}

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -31,6 +31,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          # Audit walks every CLI; no single go.sum to key the module cache on,
+          # and the cache hit-rate would be near zero anyway (every CLI's go.sum
+          # differs). Disable caching to silence the "Dependencies file is not
+          # found" warning.
+          cache: false
       - name: Configure git for private modules
         env:
           TOKEN: ${{ secrets.GENERATOR_READ_TOKEN }}


### PR DESCRIPTION
## Summary

\`setup-go\` was warning on every job:

\`\`\`
Restore cache failed: Dependencies file is not found in /home/runner/...
Supported file pattern: go.mod
\`\`\`

The public library is a monorepo with no top-level \`go.mod\` — each printed CLI has its own at \`library/<cat>/<slug>/\`. \`setup-go\`'s default cache-key file pattern doesn't match. Builds still worked (caching was silently disabled), just noisy.

## Changes

**Bundle and build-cli jobs**: point \`cache-dependency-path\` at the matrix entry's \`go.sum\`:

\`\`\`yaml
cache-dependency-path: library/\${{ matrix.target }}/go.sum
\`\`\`

Caches per-CLI. Repeated runs of \`food52\` reuse the cached module state when \`go.sum\` is unchanged. \`cli-printing-press\`'s deps end up co-located in the same per-CLI cache (downloaded into \`\$GOPATH/pkg/mod\` alongside the CLI's own deps). Cross-CLI sharing isn't optimal but is fine for our scale.

**Audit job**: disable caching outright (\`cache: false\`). The audit walks every CLI sequentially; no single go.sum keys meaningfully and the hit-rate would be near zero.

## Net effect

- Warning gone
- Real speedup on repeated runs of the same CLI (cached module state restores in seconds vs re-downloading every dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)