### PR TITLE
fix(ci): use PAT for release creation instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -276,11 +276,21 @@ jobs:
           fi
       - name: Publish release ${{ steps.slug.outputs.slug }}-current
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a fine-grained PAT (Contents:write on this repo) instead of
+          # the default GITHUB_TOKEN. The workflow's GITHUB_TOKEN reports
+          # contents:write in its permissions log but the API still 403s on
+          # release creation — likely a silent installation-token cap from
+          # the GitHub Actions integration itself, invisible from the API.
+          # The PAT bypasses that cap by acting as the user who minted it.
+          GH_TOKEN: ${{ secrets.RELEASE_WRITE_TOKEN }}
           SLUG: ${{ steps.slug.outputs.slug }}
           CLI_TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_WRITE_TOKEN secret is not set. Without it, the release step cannot create or update releases. See the PR that introduced this for setup instructions."
+            exit 1
+          fi
           tag="${SLUG}-current"
           # Skip if neither bundle nor CLI artifacts were produced.
           if ! find "${RUNNER_TEMP}/dl" -type f -print -quit | grep -q .; then


### PR DESCRIPTION
## Summary

The release step in \`build-mcpb.yml\` was 403'ing on \`gh release create\` despite:

- Repo \"Workflow permissions\" set to \"Read and write permissions\"
- Workflow declaring \`permissions: contents: write\` at workflow level
- Token log showing \`Contents: write\` granted

Verified via local probe that a user-level PAT can create releases on this repo fine, so the repo isn't the blocker. Some installation- or integration-level cap is silently restricting the GitHub Actions \`GITHUB_TOKEN\` below what the configuration claims to grant. The cap is invisible through the API.

## Fix

Switch the release step to use a fine-grained PAT stored as repo secret \`RELEASE_WRITE_TOKEN\` (Contents:write on this repo only). Acts as the user who minted it, sidestepping whatever caps GITHUB_TOKEN.

Same pattern as \`GENERATOR_READ_TOKEN\` already used for fetching the printing-press generator from a private repo.

Adds a guard step that fails fast with a clear message if the secret is missing.

## Setup (already done)

- PAT created: scoped to \`mvanhorn/printing-press-library\` only, Contents:write
- Stored as repo secret \`RELEASE_WRITE_TOKEN\`

## Test plan

- [ ] After merge, retrigger one of the stuck CLIs: \`gh workflow run build-mcpb.yml -R mvanhorn/printing-press-library -f cli=commerce/ebay\`
- [ ] Verify the release \`ebay-current\` is created with 9 assets
- [ ] If green, retrigger remaining 4 stuck CLIs (company-goat, postman-explore, scrape-creators, producthunt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)