### PR TITLE
fix(ci): add release-write PAT verification before release step

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -274,6 +274,32 @@ jobs:
             echo "::warning::No artifacts were produced for ${{ matrix.target }} — bundle and build-cli jobs may have all failed."
             exit 0
           fi
+      - name: Verify release-write PAT
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_WRITE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_WRITE_TOKEN secret is not set. Without it, the release step cannot create or update releases. See the PR that introduced this for setup instructions."
+            exit 1
+          fi
+          # Probe the user identity. If the token is unrecognized, this 401s
+          # before the release step gets a chance to fail with a confusing
+          # "error checking for existing release". On success, prints the
+          # authenticated login so the runtime audit trail shows which
+          # account's PAT actually executed the release.
+          if ! resp=$(gh api /user --jq '.login' 2>&1); then
+            echo "::error::RELEASE_WRITE_TOKEN failed authentication. Verify the PAT exists, hasn't expired, and includes Contents:write on this repo. Raw error: ${resp}"
+            exit 1
+          fi
+          echo "Release token authenticated as: ${resp}"
+          # Verify the token has access to this specific repo. If the PAT
+          # was scoped to a different repo (e.g., the generator), this 404s.
+          if ! gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name' >/dev/null 2>&1; then
+            echo "::error::RELEASE_WRITE_TOKEN does not have access to ${GITHUB_REPOSITORY}. Re-scope the PAT to include this repo."
+            exit 1
+          fi
+          echo "PAT confirmed for repo ${GITHUB_REPOSITORY}."
       - name: Publish release ${{ steps.slug.outputs.slug }}-current
         env:
           # Use a fine-grained PAT (Contents:write on this repo) instead of
@@ -287,10 +313,6 @@ jobs:
           CLI_TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::RELEASE_WRITE_TOKEN secret is not set. Without it, the release step cannot create or update releases. See the PR that introduced this for setup instructions."
-            exit 1
-          fi
           tag="${SLUG}-current"
           # Skip if neither bundle nor CLI artifacts were produced.
           if ! find "${RUNNER_TEMP}/dl" -type f -print -quit | grep -q .; then


### PR DESCRIPTION
## Summary

Last run on the new PAT path failed with HTTP 401 on \`gh release create\`. The error was reported as \"error checking for existing release: HTTP 401\" — opaque enough that the auth root cause was easy to miss.

## Changes

Adds a dedicated verification step that runs immediately before the release step. Probes the token in two ways:

1. \`gh api /user\` — confirms the token resolves to a valid identity. Prints the login on success so the run log shows which account is executing the release. Fails with a clear actionable message if the secret is wrong/expired/revoked.

2. \`gh api /repos/\${GITHUB_REPOSITORY}\` — confirms the PAT has access to this specific repo. Fails fast if the PAT was scoped to a different repo (real risk, since GENERATOR_READ_TOKEN has the same shape but covers \`cli-printing-press\`).

Both checks emit explicit error messages so the next failure points the admin at the right thing to fix.

## Test plan

After merge, retrigger ebay:

\`\`\`bash
gh workflow run build-mcpb.yml -R mvanhorn/printing-press-library -f cli=commerce/ebay
\`\`\`

If the PAT is now valid → release succeeds, ebay-current populated with 9 assets.
If the PAT is still bad → \"Verify release-write PAT\" step fails with a clear message naming the specific problem (auth vs scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)