### PR TITLE
docs(readme): add airbnb to top-level catalog table

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Tools grouped by category, sourced from [`registry.json`](registry.json). Each r
 | Name | Skill | Auth | MCP | Slash install | What it does |
 |------|-------|------|-----|---------------|--------------|
 | [`agent-capture`](library/developer-tools/agent-capture/) | [`/pp-agent-capture`](cli-skills/pp-agent-capture/SKILL.md) | local only | no | `/ppl install agent-capture cli` | Record, screenshot, and convert macOS windows and screens for agent evidence. |
+| [`airbnb`](library/travel/airbnb/) | [`/pp-airbnb`](cli-skills/pp-airbnb/SKILL.md) | cookie (optional) | partial | `/ppl install airbnb cli` | Search Airbnb listings and find the host's direct booking site. VRBO disabled (Akamai). |
 | [`archive-is`](library/media-and-entertainment/archive-is/) | [`/pp-archive-is`](cli-skills/pp-archive-is/SKILL.md) | none | full | `/ppl install archive-is cli` | Find and create Archive.today snapshots for URLs. |
 | [`cal-com`](library/productivity/cal-com/) | [`/pp-cal-com`](cli-skills/pp-cal-com/SKILL.md) | API key | full | `/ppl install cal-com cli` | Manage bookings, schedules, event types, and availability. |
 | [`contact-goat`](library/sales-and-crm/contact-goat/) | [`/pp-contact-goat`](cli-skills/pp-contact-goat/SKILL.md) | mixed | full | `/ppl install contact-goat cli` | Cross-source warm-intro graph across LinkedIn, Happenstance, and Deepline with a unified local store. |


### PR DESCRIPTION
## Summary

- The airbnb CLI shipped in PR #217 and was renamed in PR #218, but neither PR added a row to the top-level README.md catalog table.
- The CLI is in registry.json, cli-skills/, and the install path works via /ppl, so this is a pure docs gap, not a packaging gap.
- Inserts the row in alphabetical position with mcp_ready: partial (matches registry) and notes the VRBO-disabled state so README readers get the same expectation the CLI's own README sets.

## Test plan

- [x] One-line addition; no code paths affected.
- [x] Row order: alphabetical, between agent-capture and archive-is.
- [x] Description matches the VRBO-disabled posture from PR #218.