### PR TITLE
fix(flightgoat): mark AeroAPI key optional and surface FlightAware branding

### DIFF
--- a/library/travel/flightgoat/manifest.json
+++ b/library/travel/flightgoat/manifest.json
@@ -22,10 +22,10 @@
   "user_config": {
     "flightgoat_api_key_auth": {
       "type": "string",
-      "title": "FLIGHTGOAT_API_KEY_AUTH",
-      "description": "Sets FLIGHTGOAT_API_KEY_AUTH for the Flight GOAT MCP server.",
+      "title": "FlightAware AeroAPI Key",
+      "description": "Optional. FlightGoat wraps FlightAware's AeroAPI; set this to your AeroAPI key (exposed to the server as FLIGHTGOAT_API_KEY_AUTH) to unlock the full tool set. Register at https://flightaware.com/commercial/aeroapi/.",
       "sensitive": true,
-      "required": true
+      "required": false
     }
   },
   "compatibility": {


### PR DESCRIPTION
## Summary

- Flip `flightgoat_api_key_auth.required` from `true` to `false` so users can install the MCPB without supplying a credential.
- Retitle from `FLIGHTGOAT_API_KEY_AUTH` to `FlightAware AeroAPI Key` and rewrite the description to point users at https://flightaware.com/commercial/aeroapi/.

## Why

When installing the FlightGoat MCPB in Claude Desktop, the dialog asked for `FLIGHTGOAT_API_KEY_AUTH` and refused to proceed without it. Two problems with that:

1. The credential is really a **FlightAware AeroAPI** key — FlightGoat is a value-add wrapper, not a standalone service. The label gave users no hint where to register or what they were really providing.
2. Some FlightGoat tools work with no key (the value-add ones that operate over locally-cached or cross-source data), and other openapi3-driven wrappers in this catalog already expose the credential as optional. There's no reason to gate install on the key being present.

## Why this is a stopgap, not a real fix

The root cause lives in `mvanhorn/cli-printing-press`. For openapi3-driven CLIs (like FlightGoat), the manifest.json fields here are auto-derived from the OpenAPI security scheme on every regen — there's no override hook. Internal-spec CLIs (recipe-goat, movie-goat, contact-goat) hand-author their auth block in the spec and get the right env var / optional / key_url for free. Until the override hook exists upstream, this hand-edit will be clobbered the next time the generator regenerates this CLI.

Tracked in upstream issue. Until then: leave this hand-edit in place; if regen wipes it, re-apply.

## Test plan

- [ ] Install the FlightGoat MCPB in Claude Desktop and confirm the install dialog shows "FlightAware AeroAPI Key" with the registration link in the help text.
- [ ] Confirm install proceeds without entering a key.
- [ ] Confirm the env var that reaches the binary is still `FLIGHTGOAT_API_KEY_AUTH` (binary code unchanged — only the user-facing label/required flag changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)