### PR TITLE
fix(ci): isolate release stage from sibling failures + strict per-app artifact gate

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -229,7 +229,12 @@ jobs:
   release:
     name: Release ${{ matrix.target }}
     needs: [detect, bundle, build-cli]
-    if: needs.detect.outputs.count != '0'
+    # !cancelled() so a single CLI's bundle/build failure doesn't cascade-skip
+    # release for every other successful CLI in the same matrix run. Each
+    # release matrix entry is per-app (keyed on matrix.target) and downloads
+    # only its own slug's artifacts, so apps don't share fate. Per-app
+    # success is then enforced by the strict gate inside the release script.
+    if: ${{ !cancelled() && needs.detect.outputs.count != '0' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -262,7 +267,10 @@ jobs:
           path: ${{ runner.temp }}/dl
           pattern: cli-${{ steps.slug.outputs.slug }}-*
           merge-multiple: true
-      - name: List downloaded artifacts
+      - name: List downloaded artifacts and enforce per-app gate
+        env:
+          CLI_TARGET: ${{ matrix.target }}
+          SLUG: ${{ steps.slug.outputs.slug }}
         run: |
           ls -lh "${RUNNER_TEMP}/dl" || true
           mcpb_count=$(find "${RUNNER_TEMP}/dl" -name '*.mcpb' 2>/dev/null | wc -l | tr -d ' ')
@@ -270,8 +278,20 @@ jobs:
           all_count=$(find "${RUNNER_TEMP}/dl" -type f 2>/dev/null | wc -l | tr -d ' ')
           cli_count=$((all_count - mcpb_count))
           echo "Found ${mcpb_count} .mcpb file(s) and ${cli_count} CLI binary file(s)."
-          if [ "$all_count" = "0" ]; then
-            echo "::warning::No artifacts were produced for ${{ matrix.target }} — bundle and build-cli jobs may have all failed."
+          # Strict per-app gate: an app's release only publishes when both
+          # its CLI binaries AND (if it ships an MCPB) its bundles produced
+          # at least one artifact. A partial release (CLI without MCPB or
+          # vice versa) confuses users by hiding the upstream build failure
+          # behind a moving "-current" tag that looks healthy. The
+          # manifest.json existence check on the MCPB side is forward-
+          # compatibility for future CLI-only entries that legitimately
+          # ship without a bundle.
+          if [ "$cli_count" = "0" ]; then
+            echo "::warning::Skipping release for ${SLUG}: no CLI binaries produced (build-cli matrix failed for this app)."
+            exit 0
+          fi
+          if [ -f "library/${CLI_TARGET}/manifest.json" ] && [ "$mcpb_count" = "0" ]; then
+            echo "::warning::Skipping release for ${SLUG}: app declares manifest.json (expects MCPB) but no .mcpb produced (bundle matrix failed for this app)."
             exit 0
           fi
       - name: Verify release-write PAT


### PR DESCRIPTION
## Summary

Two changes to `.github/workflows/build-mcpb.yml` that together fix a cascade-failure pattern in the build-mcpb workflow:

1. **`release.if: !cancelled()`** — release stage runs even when the `bundle` or `build-cli` jobs had partial failures. Previously, one CLI's bundle failure silently skipped release for *every* CLI in the same matrix run.
2. **Strict per-app artifact gate** — a release publishes for an app only when it produced at least one CLI binary AND (if it ships an MCPB) at least one .mcpb. Skips with an explicit `::warning::` otherwise.

## The bug this fixes

In run [25267774448](https://github.com/mvanhorn/printing-press-library/actions/runs/25267774448) (the NoCache backfill, #213), 38 CLIs were rebuilt:

- ESPN (and ~14 others): all 3 MCPB bundles + all 6 CLI builds succeeded. Should have released.
- pagliacci-pizza: all 3 MCPB bundles failed.
- **Release job: skipped entirely.** Only 1 "skipped" job recorded in the run, never expanded to matrix.

Why: `release.needs: [detect, bundle, build-cli]` is job-level, not matrix-aware. When pagliacci-pizza's matrix entries failed, the entire `bundle` job was marked failure → `release` skipped per default `needs:` semantics → ESPN never got an `espn-current` tag despite having all artifacts ready.

ESPN was the canary that surfaced this — it had no release in the catalog at all because every commit that touched it landed in a multi-CLI run that included at least one failure. Republished manually via `workflow_dispatch` in run [25286190388](https://github.com/mvanhorn/printing-press-library/actions/runs/25286190388) (✅ 9 assets) once we isolated it.

## Why per-app gate, not just `!cancelled()`

`!cancelled()` alone would publish whatever artifacts each app produced — including a CLI-only release for an app whose bundle failed (no `.mcpb`). That hides the build break behind a `-current` tag that looks healthy. The strict gate makes the failure explicit:

- An app produces 0 CLI binaries → skip with warning.
- An app declares `manifest.json` (expects MCPB) but produces 0 .mcpb files → skip with warning.
- Otherwise → publish whatever's there (allows degraded-platform partial publishes; if you want strict-per-platform, that's a separate decision).

The `manifest.json` existence check is forward-compat for future CLI-only library entries that ship without a bundle by design — they won't be blocked waiting for an MCPB that was never going to exist.

## Net effect on the original 38-CLI run

If this patch had been in place:
- ~14 all-success CLIs (incl. ESPN) → published `<slug>-current` tags ✅
- pagliacci-pizza → hit strict gate, skipped with `::warning::` in log (explicit failure signal)

vs current behavior: all 38 silently skipped.

## Test plan

- [ ] On the next push that touches multiple library/ paths and produces at least one bundle failure, confirm the release stage expands its matrix and publishes for the apps that succeeded.
- [ ] Confirm the strict gate fires with a visible `::warning::` for any app whose CLI builds or required MCPB bundles all failed (search workflow logs for "Skipping release for").
- [ ] Confirm a workflow_dispatch with `cli=` scoped to a single CLI still works (regression check — this is how I just republished ESPN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)