### PR TITLE
chore(registry): backfill 6 missing CLIs and rename hubspot entry

### DIFF
--- a/cli-skills/pp-coingecko/SKILL.md
+++ b/cli-skills/pp-coingecko/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: pp-coingecko
+description: "Printing Press CLI for Coingecko. CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["coingecko-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-cli@latest","bins":["coingecko-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Coingecko — Printing Press CLI
+
+CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.
+
+## When Not to Use This CLI
+
+Do not activate this CLI for requests that require creating, updating, deleting, publishing, commenting, upvoting, inviting, ordering, sending messages, booking, purchasing, or changing remote state. This printed CLI exposes read-only commands for inspection, export, sync, and analysis.
+
+## HTTP Transport
+
+This CLI uses Chrome-compatible HTTP transport for browser-facing endpoints. It does not require a resident browser process for normal API calls.
+
+## Command Reference
+
+**coins** — Manage coins
+
+- `coingecko-pp-cli coins detail` — Get current data for a coin
+- `coingecko-pp-cli coins list` — List all coins with id, symbol, and name
+- `coingecko-pp-cli coins markets` — List coins with market data
+
+**global** — Manage global
+
+- `coingecko-pp-cli global global` — Get global crypto market data
+
+**ping** — Manage ping
+
+- `coingecko-pp-cli ping ping` — Check API server status
+
+**search** — Manage search
+
+- `coingecko-pp-cli search search` — Search coins, categories, exchanges
+- `coingecko-pp-cli coingecko-search-2` — Get trending coins
+
+**simple** — Manage simple
+
+- `coingecko-pp-cli simple price` — Get price of coins
+- `coingecko-pp-cli simple supported-vs-currencies` — List supported vs currencies
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+coingecko-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+No authentication required.
+
+Run `coingecko-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  coingecko-pp-cli coins list --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+coingecko-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+coingecko-pp-cli feedback --stdin < notes.txt
+coingecko-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.coingecko-pp-cli/feedback.jsonl`. They are never POSTed unless `COINGECKO_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `COINGECKO_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+coingecko-pp-cli profile save briefing --json
+coingecko-pp-cli --profile briefing coins list
+coingecko-pp-cli profile list --json
+coingecko-pp-cli profile show briefing
+coingecko-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `coingecko-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.25+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-cli@main
+   ```
+3. Verify: `coingecko-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add coingecko-pp-mcp -- coingecko-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which coingecko-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   coingecko-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `coingecko-pp-cli <command> --help`.

--- a/cli-skills/pp-docker-hub/SKILL.md
+++ b/cli-skills/pp-docker-hub/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: pp-docker-hub
+description: "Printing Press CLI for Docker Hub. Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the..."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["docker-hub-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/docker-hub-pp-cli/cmd/docker-hub-pp-cli@latest","bins":["docker-hub-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Docker Hub — Printing Press CLI
+
+Docker Hub public API. Search container images, browse tags, check sizes,
+inspect Dockerfiles, and explore the world's largest container registry.
+No authentication required for public repositories (rate limited to ~18 req/min).
+
+## When Not to Use This CLI
+
+Do not activate this CLI for requests that require creating, updating, deleting, publishing, commenting, upvoting, inviting, ordering, sending messages, booking, purchasing, or changing remote state. This printed CLI exposes read-only commands for inspection, export, sync, and analysis.
+
+## Command Reference
+
+**docker-hub-search** — Manage docker hub search
+
+- `docker-hub-pp-cli docker-hub-search` — Full-text search across all Docker Hub repositories. Returns name, description, stars, and pull counts.
+
+**repositories** — Repository metadata and details
+
+- `docker-hub-pp-cli repositories <namespace> <repository>` — Full metadata for a Docker Hub repository including pull count, stars, description, and last update time.
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+docker-hub-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+No authentication required.
+
+Run `docker-hub-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  docker-hub-pp-cli docker-hub-search --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+docker-hub-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+docker-hub-pp-cli feedback --stdin < notes.txt
+docker-hub-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.docker-hub-pp-cli/feedback.jsonl`. They are never POSTed unless `DOCKER_HUB_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `DOCKER_HUB_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+docker-hub-pp-cli profile save briefing --json
+docker-hub-pp-cli --profile briefing docker-hub-search
+docker-hub-pp-cli profile list --json
+docker-hub-pp-cli profile show briefing
+docker-hub-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `docker-hub-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/docker-hub-pp-cli/cmd/docker-hub-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/docker-hub-pp-cli/cmd/docker-hub-pp-cli@main
+   ```
+3. Verify: `docker-hub-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/docker-hub-pp-cli/cmd/docker-hub-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/docker-hub-pp-cli/cmd/docker-hub-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add docker-hub-pp-mcp -- docker-hub-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which docker-hub-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   docker-hub-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `docker-hub-pp-cli <command> --help`.

--- a/cli-skills/pp-firecrawl/SKILL.md
+++ b/cli-skills/pp-firecrawl/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: pp-firecrawl
+description: "Printing Press CLI for Firecrawl. API for interacting with Firecrawl services to perform web scraping and crawling tasks."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["firecrawl-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/firecrawl-pp-cli/cmd/firecrawl-pp-cli@latest","bins":["firecrawl-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Firecrawl — Printing Press CLI
+
+API for interacting with Firecrawl services to perform web scraping and crawling tasks.
+
+## Command Reference
+
+**batch** — Manage batch
+
+- `firecrawl-pp-cli batch cancel-scrape` — Cancel a batch scrape job
+- `firecrawl-pp-cli batch get-scrape-errors` — Get the errors of a batch scrape job
+- `firecrawl-pp-cli batch get-scrape-status` — Get the status of a batch scrape job
+- `firecrawl-pp-cli batch scrape-and-extract-from-urls` — Scrape multiple URLs and optionally extract information using an LLM
+
+**crawl** — Manage crawl
+
+- `firecrawl-pp-cli crawl cancel` — Cancel a crawl job
+- `firecrawl-pp-cli crawl get-active` — Get all active crawls for the authenticated team
+- `firecrawl-pp-cli crawl get-status` — Get the status of a crawl job
+- `firecrawl-pp-cli crawl urls` — Crawl multiple URLs based on options
+
+**deep-research** — Manage deep research
+
+- `firecrawl-pp-cli deep-research get-status` — Get the status and results of a deep research operation
+- `firecrawl-pp-cli deep-research start` — Start a deep research operation on a query
+
+**extract** — Manage extract
+
+- `firecrawl-pp-cli extract data` — Extract structured data from pages using LLMs
+- `firecrawl-pp-cli extract get-status` — Get the status of an extract job
+
+**firecrawl-search** — Manage firecrawl search
+
+- `firecrawl-pp-cli firecrawl-search` — Search and optionally scrape search results
+
+**llmstxt** — Manage llmstxt
+
+- `firecrawl-pp-cli llmstxt generate-llms-txt` — Generate LLMs.txt for a website
+- `firecrawl-pp-cli llmstxt get-llms-txt-status` — Get the status and results of an LLMs.txt generation job
+
+**map** — Manage map
+
+- `firecrawl-pp-cli map` — Map multiple URLs based on options
+
+**scrape** — Manage scrape
+
+- `firecrawl-pp-cli scrape` — Scrape a single URL and optionally extract information using an LLM
+
+**team** — Manage team
+
+- `firecrawl-pp-cli team get-credit-usage` — Get remaining credits for the authenticated team
+- `firecrawl-pp-cli team get-token-usage` — Get remaining tokens for the authenticated team (Extract only)
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+firecrawl-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+Store your access token:
+
+```bash
+firecrawl-pp-cli auth set-token YOUR_TOKEN_HERE
+```
+
+Or set `FIRECRAWL_BEARER_AUTH` as an environment variable.
+
+Run `firecrawl-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  firecrawl-pp-cli batch cancel-scrape mock-value --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+firecrawl-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+firecrawl-pp-cli feedback --stdin < notes.txt
+firecrawl-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.firecrawl-pp-cli/feedback.jsonl`. They are never POSTed unless `FIRECRAWL_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `FIRECRAWL_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+firecrawl-pp-cli profile save briefing --json
+firecrawl-pp-cli --profile briefing batch cancel-scrape mock-value
+firecrawl-pp-cli profile list --json
+firecrawl-pp-cli profile show briefing
+firecrawl-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `firecrawl-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/firecrawl-pp-cli/cmd/firecrawl-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/firecrawl-pp-cli/cmd/firecrawl-pp-cli@main
+   ```
+3. Verify: `firecrawl-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/firecrawl-pp-cli/cmd/firecrawl-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/firecrawl-pp-cli/cmd/firecrawl-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add firecrawl-pp-mcp -- firecrawl-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which firecrawl-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   firecrawl-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `firecrawl-pp-cli <command> --help`.

--- a/cli-skills/pp-nvd/SKILL.md
+++ b/cli-skills/pp-nvd/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: pp-nvd
+description: "Printing Press CLI for Nvd. The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword,..."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["nvd-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/nvd-pp-cli/cmd/nvd-pp-cli@latest","bins":["nvd-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Nvd — Printing Press CLI
+
+The NVD is the U.S. government repository of standards-based vulnerability management data.
+Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores,
+affected versions, references, and severity ratings. No API key required (optional for higher rate limits).
+
+## When Not to Use This CLI
+
+Do not activate this CLI for requests that require creating, updating, deleting, publishing, commenting, upvoting, inviting, ordering, sending messages, booking, purchasing, or changing remote state. This printed CLI exposes read-only commands for inspection, export, sync, and analysis.
+
+## Command Reference
+
+**json** — Manage json
+
+- `nvd-pp-cli json search-cpes` — Search Common Platform Enumeration names to find exact product identifiers for vulnerability lookups.
+- `nvd-pp-cli json search-cves` — Search vulnerabilities by keyword, CVE ID, CPE name, publication date, or CVSS severity.
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+nvd-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+No authentication required.
+
+Run `nvd-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  nvd-pp-cli json search-cpes --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+nvd-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+nvd-pp-cli feedback --stdin < notes.txt
+nvd-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.nvd-pp-cli/feedback.jsonl`. They are never POSTed unless `NVD_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `NVD_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+nvd-pp-cli profile save briefing --json
+nvd-pp-cli --profile briefing json search-cpes
+nvd-pp-cli profile list --json
+nvd-pp-cli profile show briefing
+nvd-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `nvd-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/nvd-pp-cli/cmd/nvd-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/nvd-pp-cli/cmd/nvd-pp-cli@main
+   ```
+3. Verify: `nvd-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/nvd-pp-cli/cmd/nvd-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/nvd-pp-cli/cmd/nvd-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add nvd-pp-mcp -- nvd-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which nvd-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   nvd-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `nvd-pp-cli <command> --help`.

--- a/cli-skills/pp-pypi/SKILL.md
+++ b/cli-skills/pp-pypi/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: pp-pypi
+description: "Printing Press CLI for Pypi. PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent..."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["pypi-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/pypi-pp-cli/cmd/pypi-pp-cli@latest","bins":["pypi-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Pypi — Printing Press CLI
+
+PyPI JSON API. Look up Python package metadata, versions, release files,
+and vulnerability data. Browse recent updates and newest packages via RSS feeds.
+No authentication required — all endpoints are public.
+
+## When Not to Use This CLI
+
+Do not activate this CLI for requests that require creating, updating, deleting, publishing, commenting, upvoting, inviting, ordering, sending messages, booking, purchasing, or changing remote state. This printed CLI exposes read-only commands for inspection, export, sync, and analysis.
+
+## Command Reference
+
+**pypi** — Manage pypi
+
+
+**rss** — RSS feeds for recent updates and newest packages
+
+- `pypi-pp-cli rss newest-packages` — RSS feed of the newest packages added to PyPI.
+- `pypi-pp-cli rss recent-updates` — RSS feed of the most recently updated packages on PyPI.
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+pypi-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+No authentication required.
+
+Run `pypi-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  pypi-pp-cli rss newest-packages --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+pypi-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+pypi-pp-cli feedback --stdin < notes.txt
+pypi-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.pypi-pp-cli/feedback.jsonl`. They are never POSTed unless `PYPI_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PYPI_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+pypi-pp-cli profile save briefing --json
+pypi-pp-cli --profile briefing rss newest-packages
+pypi-pp-cli profile list --json
+pypi-pp-cli profile show briefing
+pypi-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `pypi-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/pypi-pp-cli/cmd/pypi-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/pypi-pp-cli/cmd/pypi-pp-cli@main
+   ```
+3. Verify: `pypi-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/pypi-pp-cli/cmd/pypi-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/pypi-pp-cli/cmd/pypi-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add pypi-pp-mcp -- pypi-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which pypi-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   pypi-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `pypi-pp-cli <command> --help`.

--- a/cli-skills/pp-wikipedia/SKILL.md
+++ b/cli-skills/pp-wikipedia/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: pp-wikipedia
+description: "Printing Press CLI for Wikipedia. Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No..."
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata: '{"openclaw":{"requires":{"bins":["wikipedia-pp-cli"]},"install":[{"id":"go","kind":"shell","command":"go install github.com/mvanhorn/printing-press-library/library/other/wikipedia-pp-cli/cmd/wikipedia-pp-cli@latest","bins":["wikipedia-pp-cli"],"label":"Install via go install"}]}}'
+---
+
+# Wikipedia — Printing Press CLI
+
+Wikipedia REST API. Get article summaries, search, browse related topics,
+and access on-this-day events. No authentication required.
+Uses a polite User-Agent header.
+
+## When Not to Use This CLI
+
+Do not activate this CLI for requests that require creating, updating, deleting, publishing, commenting, upvoting, inviting, ordering, sending messages, booking, purchasing, or changing remote state. This printed CLI exposes read-only commands for inspection, export, sync, and analysis.
+
+## Command Reference
+
+**feed** — Manage feed
+
+- `wikipedia-pp-cli feed <day>` — Returns events, births, deaths, or holidays that occurred on a given date.
+
+**page** — Article content and metadata
+
+- `wikipedia-pp-cli page get-html` — Returns the full article body as styled HTML.
+- `wikipedia-pp-cli page get-media` — Returns images, videos, and other media files associated with an article.
+- `wikipedia-pp-cli page get-random` — Returns a random Wikipedia article summary.
+- `wikipedia-pp-cli page get-summary` — Returns a page summary including title, extract text, thumbnail, and coordinates.
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+wikipedia-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Auth Setup
+
+No authentication required.
+
+Run `wikipedia-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  wikipedia-pp-cli feed mock-value --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+wikipedia-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+wikipedia-pp-cli feedback --stdin < notes.txt
+wikipedia-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.wikipedia-pp-cli/feedback.jsonl`. They are never POSTed unless `WIKIPEDIA_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `WIKIPEDIA_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+wikipedia-pp-cli profile save briefing --json
+wikipedia-pp-cli --profile briefing feed mock-value
+wikipedia-pp-cli profile list --json
+wikipedia-pp-cli profile show briefing
+wikipedia-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `wikipedia-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## CLI Installation
+
+1. Check Go is installed: `go version` (requires Go 1.23+)
+2. Install:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/wikipedia-pp-cli/cmd/wikipedia-pp-cli@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/wikipedia-pp-cli/cmd/wikipedia-pp-cli@main
+   ```
+3. Verify: `wikipedia-pp-cli --version`
+4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+## MCP Server Installation
+
+1. Install the MCP server:
+   ```bash
+   go install github.com/mvanhorn/printing-press-library/library/other/wikipedia-pp-cli/cmd/wikipedia-pp-mcp@latest
+   
+   # If `@latest` installs a stale build (Go module proxy cache lag), install from main:
+   GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
+     go install github.com/mvanhorn/printing-press-library/library/other/wikipedia-pp-cli/cmd/wikipedia-pp-mcp@main
+   ```
+2. Register with Claude Code:
+   ```bash
+   claude mcp add wikipedia-pp-mcp -- wikipedia-pp-mcp
+   ```
+3. Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which wikipedia-pp-cli`
+   If not found, offer to install (see CLI Installation above).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   wikipedia-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `wikipedia-pp-cli <command> --help`.

--- a/registry.json
+++ b/registry.json
@@ -48,7 +48,7 @@
       "name": "allrecipes",
       "category": "food-and-dining",
       "api": "Allrecipes",
-      "description": "Allrecipes Pocket \u2014 every Allrecipes recipe in your terminal: cached as data, with pantry-aware search, Bayesian-smoothed ranking, multi-recipe grocery lists, and clean markdown export.",
+      "description": "Allrecipes Pocket — every Allrecipes recipe in your terminal: cached as data, with pantry-aware search, Bayesian-smoothed ranking, multi-recipe grocery lists, and clean markdown export.",
       "path": "library/food-and-dining/allrecipes",
       "mcp": {
         "binary": "allrecipes-pp-mcp",
@@ -90,6 +90,22 @@
         "env_vars": [
           "CAL_COM_TOKEN"
         ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "coingecko",
+      "category": "payments",
+      "api": "Coingecko",
+      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
+      "path": "library/payments/coingecko",
+      "mcp": {
+        "binary": "coingecko-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "none",
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -147,6 +163,22 @@
       }
     },
     {
+      "name": "docker-hub",
+      "category": "developer-tools",
+      "api": "Docker Hub",
+      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
+      "path": "library/developer-tools/docker-hub",
+      "mcp": {
+        "binary": "docker-hub-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "dominos",
       "category": "commerce",
       "api": "Dominos Pizza",
@@ -169,7 +201,7 @@
       "name": "dub",
       "category": "marketing",
       "api": "Dub",
-      "description": "Modern link attribution platform \u2014 short links, conversion tracking, affiliate/partner programs.",
+      "description": "Modern link attribution platform — short links, conversion tracking, affiliate/partner programs.",
       "path": "library/marketing/dub",
       "mcp": {
         "binary": "dub-pp-mcp",
@@ -217,6 +249,24 @@
       }
     },
     {
+      "name": "firecrawl",
+      "category": "developer-tools",
+      "api": "Firecrawl",
+      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
+      "path": "library/developer-tools/firecrawl",
+      "mcp": {
+        "binary": "firecrawl-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 20,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "FIRECRAWL_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "flightgoat",
       "category": "travel",
       "api": "flightgoat",
@@ -239,7 +289,7 @@
       "name": "food52",
       "category": "food-and-dining",
       "api": "Food52",
-      "description": "Search, browse, and read Food52 from your terminal \u2014 with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
+      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
       "path": "library/food-and-dining/food52",
       "mcp": {
         "binary": "food52-pp-mcp",
@@ -256,7 +306,7 @@
       "name": "hackernews",
       "category": "media-and-entertainment",
       "api": "Hacker News",
-      "description": "Hacker News from your terminal \u2014 with a local store, full-text search, and agent-native output no other HN tool has",
+      "description": "Hacker News from your terminal — with a local store, full-text search, and agent-native output no other HN tool has",
       "path": "library/media-and-entertainment/hackernews",
       "mcp": {
         "binary": "hackernews-pp-mcp",
@@ -270,7 +320,7 @@
       }
     },
     {
-      "name": "hubspot-pp-cli",
+      "name": "hubspot",
       "category": "sales-and-crm",
       "api": "HubSpot",
       "description": "Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics",
@@ -369,6 +419,22 @@
       }
     },
     {
+      "name": "nvd",
+      "category": "developer-tools",
+      "api": "National Vulnerability Database",
+      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
+      "path": "library/developer-tools/nvd",
+      "mcp": {
+        "binary": "nvd-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 2,
+        "public_tool_count": 2,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "open-meteo",
       "category": "other",
       "api": "Open-Meteo",
@@ -388,7 +454,7 @@
       "name": "pagliacci",
       "category": "food-and-dining",
       "api": "Pagliacci Pizza",
-      "description": "Order Seattle's Pagliacci Pizza from the terminal \u2014 half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
+      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
       "path": "library/food-and-dining/pagliacci",
       "mcp": {
         "binary": "pagliacci-pp-mcp",
@@ -404,8 +470,8 @@
     {
       "name": "pokeapi",
       "category": "media-and-entertainment",
-      "api": "Pok\u00e9API",
-      "description": "Fully offline Pok\u00e9dex with SQL, full-text search, type math, and a damage calculator no other Pok\u00e9mon tool ships as a CLI.",
+      "api": "PokéAPI",
+      "description": "Fully offline Pokédex with SQL, full-text search, type math, and a damage calculator no other Pokémon tool ships as a CLI.",
       "path": "library/media-and-entertainment/pokeapi",
       "mcp": {
         "binary": "pokeapi-pp-mcp",
@@ -439,7 +505,7 @@
       "name": "producthunt",
       "category": "marketing",
       "api": "Product Hunt",
-      "description": "Read Product Hunt from your terminal \u2014 works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
+      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
       "path": "library/marketing/producthunt",
       "mcp": {
         "binary": "producthunt-pp-mcp",
@@ -455,10 +521,26 @@
       }
     },
     {
+      "name": "pypi",
+      "category": "developer-tools",
+      "api": "PyPI",
+      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
+      "path": "library/developer-tools/pypi",
+      "mcp": {
+        "binary": "pypi-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "recipe-goat",
       "category": "food-and-dining",
       "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
-      "description": "Find the best version of any recipe across 37 trusted sites \u2014 trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport \u2014 bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
+      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
       "path": "library/food-and-dining/recipe-goat",
       "mcp": {
         "binary": "recipe-goat-pp-mcp",
@@ -476,7 +558,7 @@
       "name": "scrape-creators",
       "category": "developer-tools",
       "api": "Scrape Creators",
-      "description": "Scrape public social media data from the terminal \u2014 profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
+      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
       "path": "library/developer-tools/scrape-creators",
       "mcp": {
         "binary": "scrape-creators-pp-mcp",
@@ -599,10 +681,26 @@
       }
     },
     {
+      "name": "wikipedia",
+      "category": "media-and-entertainment",
+      "api": "Wikipedia",
+      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
+      "path": "library/media-and-entertainment/wikipedia",
+      "mcp": {
+        "binary": "wikipedia-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "yahoo-finance",
       "category": "commerce",
       "api": "Yahoo Finance",
-      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance \u2014 no API key, with Chrome-session fallback for rate-limited IPs",
+      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
       "path": "library/commerce/yahoo-finance",
       "mcp": {
         "binary": "yahoo-finance-pp-mcp",

--- a/skills/ppl/references/registry.json
+++ b/skills/ppl/references/registry.json
@@ -48,7 +48,7 @@
       "name": "allrecipes",
       "category": "food-and-dining",
       "api": "Allrecipes",
-      "description": "Allrecipes Pocket \u2014 every Allrecipes recipe in your terminal: cached as data, with pantry-aware search, Bayesian-smoothed ranking, multi-recipe grocery lists, and clean markdown export.",
+      "description": "Allrecipes Pocket — every Allrecipes recipe in your terminal: cached as data, with pantry-aware search, Bayesian-smoothed ranking, multi-recipe grocery lists, and clean markdown export.",
       "path": "library/food-and-dining/allrecipes",
       "mcp": {
         "binary": "allrecipes-pp-mcp",
@@ -90,6 +90,22 @@
         "env_vars": [
           "CAL_COM_TOKEN"
         ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "coingecko",
+      "category": "payments",
+      "api": "Coingecko",
+      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
+      "path": "library/payments/coingecko",
+      "mcp": {
+        "binary": "coingecko-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "none",
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -147,6 +163,22 @@
       }
     },
     {
+      "name": "docker-hub",
+      "category": "developer-tools",
+      "api": "Docker Hub",
+      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
+      "path": "library/developer-tools/docker-hub",
+      "mcp": {
+        "binary": "docker-hub-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "dominos",
       "category": "commerce",
       "api": "Dominos Pizza",
@@ -169,7 +201,7 @@
       "name": "dub",
       "category": "marketing",
       "api": "Dub",
-      "description": "Modern link attribution platform \u2014 short links, conversion tracking, affiliate/partner programs.",
+      "description": "Modern link attribution platform — short links, conversion tracking, affiliate/partner programs.",
       "path": "library/marketing/dub",
       "mcp": {
         "binary": "dub-pp-mcp",
@@ -217,6 +249,24 @@
       }
     },
     {
+      "name": "firecrawl",
+      "category": "developer-tools",
+      "api": "Firecrawl",
+      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
+      "path": "library/developer-tools/firecrawl",
+      "mcp": {
+        "binary": "firecrawl-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 20,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "FIRECRAWL_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "flightgoat",
       "category": "travel",
       "api": "flightgoat",
@@ -239,7 +289,7 @@
       "name": "food52",
       "category": "food-and-dining",
       "api": "Food52",
-      "description": "Search, browse, and read Food52 from your terminal \u2014 with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
+      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
       "path": "library/food-and-dining/food52",
       "mcp": {
         "binary": "food52-pp-mcp",
@@ -256,7 +306,7 @@
       "name": "hackernews",
       "category": "media-and-entertainment",
       "api": "Hacker News",
-      "description": "Hacker News from your terminal \u2014 with a local store, full-text search, and agent-native output no other HN tool has",
+      "description": "Hacker News from your terminal — with a local store, full-text search, and agent-native output no other HN tool has",
       "path": "library/media-and-entertainment/hackernews",
       "mcp": {
         "binary": "hackernews-pp-mcp",
@@ -270,7 +320,7 @@
       }
     },
     {
-      "name": "hubspot-pp-cli",
+      "name": "hubspot",
       "category": "sales-and-crm",
       "api": "HubSpot",
       "description": "Manage HubSpot CRM contacts, companies, deals, tickets, engagements, pipelines, and associations with offline search and pipeline analytics",
@@ -369,6 +419,22 @@
       }
     },
     {
+      "name": "nvd",
+      "category": "developer-tools",
+      "api": "National Vulnerability Database",
+      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
+      "path": "library/developer-tools/nvd",
+      "mcp": {
+        "binary": "nvd-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 2,
+        "public_tool_count": 2,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "open-meteo",
       "category": "other",
       "api": "Open-Meteo",
@@ -388,7 +454,7 @@
       "name": "pagliacci",
       "category": "food-and-dining",
       "api": "Pagliacci Pizza",
-      "description": "Order Seattle's Pagliacci Pizza from the terminal \u2014 half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
+      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
       "path": "library/food-and-dining/pagliacci",
       "mcp": {
         "binary": "pagliacci-pp-mcp",
@@ -404,8 +470,8 @@
     {
       "name": "pokeapi",
       "category": "media-and-entertainment",
-      "api": "Pok\u00e9API",
-      "description": "Fully offline Pok\u00e9dex with SQL, full-text search, type math, and a damage calculator no other Pok\u00e9mon tool ships as a CLI.",
+      "api": "PokéAPI",
+      "description": "Fully offline Pokédex with SQL, full-text search, type math, and a damage calculator no other Pokémon tool ships as a CLI.",
       "path": "library/media-and-entertainment/pokeapi",
       "mcp": {
         "binary": "pokeapi-pp-mcp",
@@ -439,7 +505,7 @@
       "name": "producthunt",
       "category": "marketing",
       "api": "Product Hunt",
-      "description": "Read Product Hunt from your terminal \u2014 works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
+      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
       "path": "library/marketing/producthunt",
       "mcp": {
         "binary": "producthunt-pp-mcp",
@@ -455,10 +521,26 @@
       }
     },
     {
+      "name": "pypi",
+      "category": "developer-tools",
+      "api": "PyPI",
+      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
+      "path": "library/developer-tools/pypi",
+      "mcp": {
+        "binary": "pypi-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "recipe-goat",
       "category": "food-and-dining",
       "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
-      "description": "Find the best version of any recipe across 37 trusted sites \u2014 trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport \u2014 bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
+      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
       "path": "library/food-and-dining/recipe-goat",
       "mcp": {
         "binary": "recipe-goat-pp-mcp",
@@ -476,7 +558,7 @@
       "name": "scrape-creators",
       "category": "developer-tools",
       "api": "Scrape Creators",
-      "description": "Scrape public social media data from the terminal \u2014 profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
+      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
       "path": "library/developer-tools/scrape-creators",
       "mcp": {
         "binary": "scrape-creators-pp-mcp",
@@ -599,10 +681,26 @@
       }
     },
     {
+      "name": "wikipedia",
+      "category": "media-and-entertainment",
+      "api": "Wikipedia",
+      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
+      "path": "library/media-and-entertainment/wikipedia",
+      "mcp": {
+        "binary": "wikipedia-pp-mcp",
+        "transport": "stdio",
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "yahoo-finance",
       "category": "commerce",
       "api": "Yahoo Finance",
-      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance \u2014 no API key, with Chrome-session fallback for rate-limited IPs",
+      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
       "path": "library/commerce/yahoo-finance",
       "mcp": {
         "binary": "yahoo-finance-pp-mcp",


### PR DESCRIPTION
## Summary

`registry.json` was missing 6 CLIs that exist in `library/` and renamed `hubspot-pp-cli` → `hubspot` to match every other entry's slug-only naming convention.

## What changed

**Added to registry (6):**

| Slug | Category | State |
|---|---|---|
| docker-hub | developer-tools | v3.6.0, full MCP, released |
| firecrawl | developer-tools | v3.6.0, full MCP, released |
| nvd | developer-tools | v3.6.0, full MCP, released |
| pypi | developer-tools | v3.6.0, full MCP, released |
| wikipedia | media-and-entertainment | v3.6.0, full MCP, released |
| coingecko | payments | v2.3.7, full MCP, **no release yet** (will be picked up by the missing-releases backfill workflow) |

Each entry was built mechanically from the CLI's `.printing-press.json` (for MCP fields, display name) and `.goreleaser.yaml` brews block (for the curated description).

**Renamed (1):** `hubspot-pp-cli` → `hubspot`. Every other registry entry uses the bare slug; this was the lone outlier with the binary suffix in its name. MCP block left intact since the source has `cmd/hubspot-pp-mcp/`, even though `manifest.json` is missing — that's a separate source-side issue to address via regen.

**Side effects:** ran `go run ./tools/generate-skills/main.go` to regenerate `cli-skills/pp-<slug>/SKILL.md` mirrors for the six new entries, and synced `skills/ppl/references/registry.json` (per the generate-skills workflow's pattern).

## Why this happened

Mechanical drift, not anyone's mistake. I traced each missing CLI's first commit:

- 6 of the 7 affected ("add" or "regenerate" PRs for coingecko, docker-hub, firecrawl, nvd, pypi, wikipedia) landed without touching registry.json.
- 1 (hubspot) had a registry entry from PR #28 that drifted in the opposite direction — entry advertises richer state than what currently ships from disk.

Root cause: registry.json is purely manual. Nothing in this repo or `cli-printing-press` writes to it, and no CI gate fails when `library/` and `registry.json` disagree. The convention of "remember to update registry.json when publishing a CLI" gets skipped.

## Net result

Before: 36 entries (out of 42 library CLIs + 1 incorrect entry).
After: 42 entries, all matching `library/` slug-for-slug.

## Follow-up

I'll send a separate proposal for a structural fix — auto-generate registry.json from `library/**/.printing-press.json` post-merge with `[skip ci]` (same pattern as `cli-skills/`). That makes drift structurally impossible and avoids the merge-conflict risk you flagged when multiple in-flight PRs each touch registry.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)