### PR TITLE
fix(workflows): serialize generated artifact pushes

### DIFF
--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -43,12 +43,13 @@ jobs:
   regenerate:
     name: Regenerate and commit
     runs-on: ubuntu-latest
-    # Cancel an in-flight run when a newer commit lands. The newer
-    # source supersedes ours; finishing the older regen would just
-    # produce output we'd overwrite seconds later.
+    # Share one push lane with generate-skills.yml. Both workflows
+    # commit generated artifacts back to main after the same source
+    # changes, so letting them run concurrently causes non-fast-forward
+    # push failures when one generated commit lands first.
     concurrency:
-      group: regenerate-registry
-      cancel-in-progress: true
+      group: generated-artifact-push-main
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -13,9 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Share one push lane with generate-registry.yml. Both workflows
+    # commit generated artifacts back to main after library metadata
+    # changes, so queue them and check out main only after the lane is
+    # acquired.
+    concurrency:
+      group: generated-artifact-push-main
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

Generated-artifact workflows no longer race each other when they both need to commit back to `main`. The registry and per-app skill regeneration jobs now share one concurrency lane, and the skills workflow checks out live `main` after acquiring that lane so it pushes on top of any generated commit that landed first.

## Verification

- `rtk git diff --check`
- `rtk actionlint .github/workflows/generate-registry.yml .github/workflows/generate-skills.yml`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT-5-000000)
