### PR TITLE
fix(cli): preserve MCP query parameters

### DIFF
--- a/library/commerce/shopify/internal/mcp/tools.go
+++ b/library/commerce/shopify/internal/mcp/tools.go
@@ -182,23 +182,22 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 
 		// Build path by substituting positional params
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
+		// Collect non-path params as query params
 		params := make(map[string]string)
 		for k, v := range args {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
-			}
-			if !isPositional {
+			if !pathParams[k] {
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}

--- a/library/media-and-entertainment/archive-is/internal/mcp/tools.go
+++ b/library/media-and-entertainment/archive-is/internal/mcp/tools.go
@@ -102,23 +102,22 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 
 		// Build path by substituting positional params
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := req.Params.Arguments[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
+		// Collect non-path params as query params
 		params := make(map[string]string)
 		for k, v := range req.Params.Arguments {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
-			}
-			if !isPositional {
+			if !pathParams[k] {
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}

--- a/library/other/weather-goat/internal/mcp/tools.go
+++ b/library/other/weather-goat/internal/mcp/tools.go
@@ -119,23 +119,22 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 
 		// Build path by substituting positional params
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := req.Params.Arguments[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
+		// Collect non-path params as query params
 		params := make(map[string]string)
 		for k, v := range req.Params.Arguments {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
-			}
-			if !isPositional {
+			if !pathParams[k] {
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}

--- a/library/productivity/cal-com/internal/mcp/tools.go
+++ b/library/productivity/cal-com/internal/mcp/tools.go
@@ -3196,23 +3196,22 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 
 		// Build path by substituting positional params
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
+		// Collect non-path params as query params
 		params := make(map[string]string)
 		for k, v := range args {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
-			}
-			if !isPositional {
+			if !pathParams[k] {
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}

--- a/library/project-management/linear/internal/mcp/tools.go
+++ b/library/project-management/linear/internal/mcp/tools.go
@@ -389,23 +389,22 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 
 		// Build path by substituting positional params
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := req.Params.Arguments[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
+		// Collect non-path params as query params
 		params := make(map[string]string)
 		for k, v := range req.Params.Arguments {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
-			}
-			if !isPositional {
+			if !pathParams[k] {
 				params[k] = fmt.Sprintf("%v", v)
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes the shared typed-MCP handler in the other published CLIs that had Movie-Goat-style query parameter loss. The handler now distinguishes real URL path placeholders such as `{teamId}` from CLI positional/query arguments such as `id`, `q`, and `name`.

Affected tools include Shopify and Linear GraphQL `*_get` tools, Archive.is `feeds_search`, Weather Goat `geocoding_search`, and one Cal.com team event phone-call tool. Movie Goat is intentionally excluded here because it is covered by PR #232.

## Validation

- Static detector: no old-handler risky call sites remain except Movie Goat, which is in PR #232
- `python3 .github/scripts/verify-skill/verify_skill.py --dir ...` for Shopify, Archive.is, Weather Goat, Cal.com, and Linear
- `go build ./...` for Shopify, Archive.is, Weather Goat, Cal.com, and Linear
- `go vet ./...` for Shopify, Archive.is, Weather Goat, Cal.com, and Linear
- `go test ./...` for Shopify, Archive.is, Weather Goat, Cal.com, and Linear
