### PR TITLE
feat(cli): contact-goat friction-point fixes from SF-friends task

### DIFF
--- a/cli-skills/pp-contact-goat/SKILL.md
+++ b/cli-skills/pp-contact-goat/SKILL.md
@@ -154,17 +154,18 @@ Notes:
 | Command | What it does |
 |---------|--------------|
 | `coverage <company>` | Who you know at a company across LinkedIn + Happenstance, ranked by relationship strength |
-| `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree) |
+| `coverage --location <city>` | Who you know in a city. Bearer-only (cookie surface has no city-search); use `--source api`. |
+| `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree). `--csv` emits flat CSV with semicolon-joined bridges. |
 | `prospect <query>` | Fan-out search across LinkedIn + Happenstance (+ opt-in Deepline), deduped |
 | `warm-intro <target>` | Mutual connections across sources who could intro you to a target |
 | `waterfall <target> [--company X]` | Free-sources-first enrichment, falls through to Deepline provider chain. Requires DEEPLINE_API_KEY or --byok. Bare-name targets need --company |
 | `dossier <target> [--enrich-email]` | Unified LinkedIn + Happenstance + (optional) Deepline dossier. --enrich-email requires DEEPLINE_API_KEY |
 | `deepline find-email "<name>" --company <domain>` | Single-call work-email lookup via dropleads_email_finder |
 | `deepline enrich-person <linkedin-url>` | Full person record via apollo_people_match (includes personal_emails[]) |
-| `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll) |
+| `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll). `--first-degree-only` keeps only 1st-degree matches; `--min-score N` drops weak signals (see docs/scoring.md); `--all --max-results N` auto-paginates. |
 | `api hpn research <description>` | Bearer-API deep dossier (costs 1 credit on completion) |
 | `api hpn usage` | Live credit balance, purchases, recent usage events (free) |
-| `doctor` | Check CLI health, both Happenstance surfaces, LinkedIn, and Deepline |
+| `doctor` | Check CLI health, both Happenstance surfaces, LinkedIn, and Deepline. Reports `happenstance_graph_status` (ok / stale / very_stale) on the LinkedIn upload age. |
 
 Run any command with `--help` for full flag documentation.
 

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -154,17 +154,18 @@ Notes:
 | Command | What it does |
 |---------|--------------|
 | `coverage <company>` | Who you know at a company across LinkedIn + Happenstance, ranked by relationship strength |
-| `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree) |
+| `coverage --location <city>` | Who you know in a city. Bearer-only (cookie surface has no city-search); use `--source api`. |
+| `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree). `--csv` emits flat CSV with semicolon-joined bridges. |
 | `prospect <query>` | Fan-out search across LinkedIn + Happenstance (+ opt-in Deepline), deduped |
 | `warm-intro <target>` | Mutual connections across sources who could intro you to a target |
 | `waterfall <target> [--company X]` | Free-sources-first enrichment, falls through to Deepline provider chain. Requires DEEPLINE_API_KEY or --byok. Bare-name targets need --company |
 | `dossier <target> [--enrich-email]` | Unified LinkedIn + Happenstance + (optional) Deepline dossier. --enrich-email requires DEEPLINE_API_KEY |
 | `deepline find-email "<name>" --company <domain>` | Single-call work-email lookup via dropleads_email_finder |
 | `deepline enrich-person <linkedin-url>` | Full person record via apollo_people_match (includes personal_emails[]) |
-| `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll) |
+| `api hpn search <text>` | Bearer-API search (costs 2 credits, async with poll). `--first-degree-only` keeps only 1st-degree matches; `--min-score N` drops weak signals (see docs/scoring.md); `--all --max-results N` auto-paginates. |
 | `api hpn research <description>` | Bearer-API deep dossier (costs 1 credit on completion) |
 | `api hpn usage` | Live credit balance, purchases, recent usage events (free) |
-| `doctor` | Check CLI health, both Happenstance surfaces, LinkedIn, and Deepline |
+| `doctor` | Check CLI health, both Happenstance surfaces, LinkedIn, and Deepline. Reports `happenstance_graph_status` (ok / stale / very_stale) on the LinkedIn upload age. |
 
 Run any command with `--help` for full flag documentation.
 

--- a/library/sales-and-crm/contact-goat/docs/plans/2026-05-04-001-feat-contact-goat-friction-fixes-plan.md
+++ b/library/sales-and-crm/contact-goat/docs/plans/2026-05-04-001-feat-contact-goat-friction-fixes-plan.md
@@ -1,0 +1,588 @@
+---
+title: "feat(cli): contact-goat friction-point fixes from SF-friends task"
+type: feat
+status: active
+date: 2026-05-04
+deepened: 2026-05-04
+---
+
+# feat(cli): contact-goat friction-point fixes from SF-friends task
+
+## Summary
+
+Targeted fixes to contact-goat-pp-cli surfaced by a real "list my 1st-degree connections in SF and their company" task. Headline: `api hpn search`'s emit path passes an empty `currentUUID` into bridge normalization, which forces every bridge to `kind == "friend"` and erases the self_graph (1st-degree) signal that `coverage` uses correctly — that's the root reason an agent can't tell 1st-degree from 2nd-degree on the bearer surface. Plan plumbs the user UUID through, adds matching `--first-degree-only` and `--min-score` filters, fast-fails cookie broad-query timeouts, adds `coverage --location`, single-command pagination with hard credit safety, doctor stale-graph warning, native CSV for `hp people`, score docs. The terminology rename and the `sync linkedin-graph` subcommand are deferred — the rename amplifies confusion under "no deprecation" policy, and HP's upload-trigger endpoint isn't documented to exist.
+
+---
+
+## Problem Frame
+
+The CLI fans out across LinkedIn, Happenstance cookie + bearer, and Deepline, but when a user asked "list my 1st-degree friends in SF and their company" the assistant had to fight the tool: cookie timed out silently after 4 minutes on a broad query, `friends` returned 14 top connectors with no location, `graph export json` had no location field, the bearer search mixed score-2 weak-signal entries from the public graph alongside real 1st-degree matches, pagination was a two-step `find-more` then `get --page-id` poll loop, and the global `--csv` flag failed on the nested `bridges[]` array. Net effect: a task that should have been one command became ten manual retries plus hand-filtering. The CLI is internally well-structured (cobra commands, shared poll helper, fixture-backed tests); these are surface-level UX gaps, not architectural ones.
+
+---
+
+## Requirements
+
+- R1. `api hpn search` can be scoped to "only my 1st-degree connections" without weak-signal public-graph leak-through. The bearer emit path must preserve the self_graph bridge signal so downstream consumers can tell 1st-degree from 2nd-degree (today the path explicitly drops it).
+- R2. `api hpn search` supports a `--min-score` filter that drops results below a documented threshold.
+- R3. A single command paginates and polls `api hpn search` to completion or a `--max-results N` cap, without manual `find-more` + `get --page-id` choreography.
+- R4. `coverage` answers the symmetric "who do I know in city X" question.
+- R5. `doctor` warns visibly when the synced LinkedIn graph is older than a configurable threshold; a dedicated subcommand triggers a re-sync.
+- R6. When cookie-surface search hits its poll timeout or a known-broad-query failure, the CLI exits fast with a clear suggestion to retry with `--source api`.
+- R7. The three meanings of "friends" (top-connectors command, 2nd-degree tier flag, colloquial 1st-degree) are disambiguated in flag names, command names, and help text without breaking existing scripts.
+- R8. `hp people` produces native CSV (`--csv`) that flattens the `bridges[]` array into stable columns.
+- R9. The score field is documented: range, what 50 vs 9000+ mean, recommended `--min-score` thresholds.
+
+---
+
+## Scope Boundaries
+
+- Not changing the underlying Happenstance API contracts. The cookie and bearer endpoints behave as they do today; this plan adds CLI-side filtering, polling, and routing.
+- Not adding a local-data location index. Filtering by location continues to go through bearer search; making the synced LinkedIn graph location-aware is its own initiative.
+- Not refactoring `printCSV` for all flagship commands. Only `hp people` gets first-class CSV here; `coverage`, `prospect`, `warm-intro`, `dossier` stay table+JSON only and are deferred.
+- Not deprecating or renaming existing flags in this plan. Both the deprecation precedent and any rename of `--connections` / `--friends` / `friends` are deferred (see U6 and Deferred to Follow-Up Work).
+- Not adding a CLI re-sync subcommand. `sync linkedin-graph` is deferred until HP's upload-trigger endpoint is documented; doctor's stale-graph warning points at the web UI in the interim.
+- Not changing the bearer credit-cost model or the cookie-vs-bearer auto-routing default. Fast-fail in R6 only fires after the existing routing already chose cookie.
+
+### Deferred to Follow-Up Work
+
+- Terminology rename for `hp people --connections` / `--friends` / `friends` command (originally R7 / U6): separate plan that decides between (a) introducing `MarkDeprecated` as a precedent and renaming, or (b) help-text-only refresh on the existing flags. Either path is a deliberate plan-time decision and doesn't fit this plan's scope.
+- `sync linkedin-graph` CLI subcommand (originally part of R5 / U4): separate plan that fires after HP ships (or we sniff) an upload-trigger endpoint distinct from `GET /api/uploads/status/user`. Until then the user re-uploads via happenstance.ai/connections.
+- Native CSV for the other flagship commands (`coverage`, `prospect`, `warm-intro`, `dossier`): same `bridges[]`-style nesting issue, same fix shape, follow-up PR.
+- Generic `printCSV` upgrade in `helpers.go:481` to JSON-encode nested arrays: would let every command's `--csv` work without per-command emitters, but touches multiple flagship structs and is its own refactor.
+- Local-graph location index: would let `friends`, `coverage`, and `intersect` filter by city without spending bearer credits. Material refactor; separate plan.
+- `coverage --location` results caching: this plan keeps the existing 5-minute GET cache; a longer-lived "people I know in city X" cache is deferred.
+- Upstream the `Aliases` field generator support to `cli-printing-press` so future hand-edits to `promoted_*.go` survive regen — only relevant when the U6 follow-up actually picks a rename strategy.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/cli/api_hpn_search.go:72` `newAPIHpnSearchCmd`, line 168 `newAPIHpnSearchFindMoreCmd`, line 232 `newAPIHpnSearchGetCmd`, line 265 `runHpnSearch`, line 358 `buildPollSearchOptions`, line 398 `classifyHpnError`. Primary surface for R1-R3, R6.
+- `internal/cli/coverage.go:22` `newCoverageCmd`. Primary surface for R4. Today scopes by company; the location variant rides the same fan-out shape.
+- `internal/cli/doctor.go:24` `newDoctorCmd`, line 271 `checkHappenstanceGraphCoverage` (uses `humanAge`). Primary surface for R5 warning. Re-sync subcommand lands in `internal/cli/sync.go:29` `newSyncCmd` next to existing `defaultSyncResources` (line 449).
+- `internal/cli/hp_people.go:37` `newHPPeopleCmd` with `--connections` / `--friends` BoolVar pattern (lines 147-149) and `--no-*` alias merge in `PreRunE` (lines 156-168). Pattern for R7 aliases. `printHPPeopleTable` at line 252 is the today-bypass for CSV (R8).
+- `internal/cli/promoted_friends.go:14` `newFriendsPromotedCmd`. Primary surface for the `top-connectors` rename in R7. Note: this file is the generated promoted-command entrypoint; rename strategy must consider regen.
+- `internal/cli/helpers.go:481` `printCSV` flattens `[]map[string]any` via `fmt.Sprintf("%v", v)` (line 510). This is the line that produces `[{... ...}]` output for `bridges[]`. R8 fix lives here or as a per-command emitter.
+- `internal/cli/flagship_helpers.go` defines `bridgeRef`, `bearerRationale`, `bearerScore`. These are the structs that need flatten rules for R8.
+- `internal/cli/root.go:55-71` persistent flag declarations and `--agent` cascade in `PersistentPreRunE` (lines 73-90). R6 hint lives near this output layer.
+- `internal/happenstance/api/search.go:167` `Client.PollSearch`, lines 20-23 terminal status constants, line 215 `isTerminalStatus`. Shared poll helper for R3.
+- `internal/client/people_search.go:62` cookie-mirror poll-timeout (180s default). `TestDefaultPollTimeoutIs180s` at `people_search_test.go:15` regression-guards this. R6 surfaces the gap between this 180s and the http-client timeout in `client.New`.
+- `internal/cli/api_hpn_test.go` table-driven tests for `checkSearchBudget` (line 400), `classifyHpnError` (line 423). Pattern for R1-R3, R6 unit tests. `newFakeBearerServer` (line 305) is the standard fixture pattern.
+- `internal/happenstance/api/search_test.go` for the api-package poll-helper tests; relevant for R3.
+- `docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md` is the local plan precedent: section ordering, file-reference style with line ranges, regen-as-final-unit, decision-table style for Key Technical Decisions.
+- `.claude-plugin/plugin.json` and `cli-skills/pp-contact-goat/SKILL.md` are the regen targets that must stay in sync per AGENTS.md.
+
+### Institutional Learnings
+
+- AGENTS.md (repo root) requires `go run ./tools/generate-skills/main.go` after any change under `library/**/internal/cli/**`. The SKILL verifier (`.github/scripts/verify-skill/verify_skill.py`) checks every documented `--flag` resolves on the right cobra command. Any new flag in this plan must round-trip through SKILL.md before merge.
+- AGENTS.md also notes: prefer surgical edits over broad regen, conventional-commit scopes (`feat(cli)` / `fix(cli)` / `docs(cli)`), bump `.claude-plugin/plugin.json` only if `skills/ppl/**` or `.claude-plugin/**` changed.
+- `2026-04-19-001-fix-bearer-api-mutuals-plan.md` Unit 5 establishes the regen-and-bump as a dedicated terminal unit; this plan follows that pattern.
+- No `MarkDeprecated` precedent anywhere in the repo. The local idiom for renames is "add new alias, keep old one working, update help text" rather than formal deprecation.
+
+### External References
+
+- Cobra alias / persistent-flag docs (`spf13/cobra`): used to confirm that `cmd.Flags().BoolVar` followed by a second `BoolVar` pointing at the same destination variable is the local-idiom alias pattern; preferred over `Aliases` for flag-level renames.
+- No external references needed for the substantive changes; this is a UX surface refinement on a known codebase.
+
+---
+
+## Key Technical Decisions
+
+- R1 implementation: two-part fix. (a) **Plumb `currentUUID` through `api hpn search`'s emit path.** Today `internal/cli/api_hpn_search.go:300` calls `api.ToClientPersonWithBridges(r, env.Mutuals, "")` with an explicit empty `currentUUID`, which forces the retag in `internal/happenstance/api/normalize.go:99-102` to skip and every bridge to be tagged `BridgeKindFriend`. The fix passes the authenticated user's UUID (already available via the user/clerk endpoint and cached locally) so self-bridges retag to `BridgeKindSelfGraph`. This is the actual root cause the bearer surface couldn't distinguish 1st-degree from 2nd-degree. (b) **Add `--first-degree-only` filter** that drops results with no `BridgeKindSelfGraph` bridge (after the retag is in place). Mirrors `coverage.go:296`'s existing `hasSelfGraphBridge` predicate. Naming: `--first-degree-only` to match the codebase's internal vocabulary (`BridgeKindSelfGraph`) rather than introducing a third meaning of "connection". Bearer payload `include_my_connections=true` is implied by the flag (auto-set when `--first-degree-only` is passed); existing `--include-my-connections` continues to work standalone for the "include 1st-degree alongside others" case.
+
+- R2 default and threshold: `--min-score float` defaulting to 0 (no filter). Per `internal/cli/flagship_helpers.go:138-160` the score is `top.AffinityScore` directly (typical 10-100, observed up to ~300; weak-signal public-graph hits show as 0-2). Document `>= 5` as "drops weak-signal public-graph entries" in `--help` text. Do NOT recommend a "high-confidence 1st-degree" threshold — real 1st-degree bridges sit at 49.99 (medium affinity) or lower in captured fixtures, so any blanket high threshold would cut real matches. The flag is a noise filter, not a quality filter; pair it with `--first-degree-only` for the SF-task use case. Filter is post-fetch, applied after `--first-degree-only` if both set. No extra credits.
+
+- R3 pagination shape: extend the existing `api hpn search <text>` command with `--all` (bool) and `--max-results int` (cap). When set, the run loop calls POST search, polls, then loops `find-more` + `get --page-id` + poll until `has_more=false`, the cap is hit, or `--budget` would be exceeded. The two existing subcommands (`find-more`, `get`) stay untouched; this is purely additive. Rationale: the manual flow is still useful for scripted resumption, but the common case ("get me up to N matching results") deserves one command.
+
+- R3 budget interaction: `--all` MUST be paired with at least one of `--max-results` or `--budget`; passing `--all` alone with both unset returns a usage error suggesting an explicit cap. Rationale: an agent calling `--all --yes` against a broad query with default `--budget 0` could otherwise burn 100+ credits silently. Each `find-more` is 2 credits; the loop tracks running total and prints a per-page cost line on stderr matching the existing "cost spent" log convention. When the next `find-more` would exceed `--budget`, emit accumulated results plus a budget-exhausted notice rather than discarding.
+
+- R4 surface: extend `coverage` with a mutually-exclusive `--location <string>` flag rather than a new top-level command. Rationale: the user mental model is "coverage of <thing>" where <thing> is a company today and a city tomorrow. Argument-free positional with `--location` flag avoids a positional-vs-flag conflict. Help text gets a "scope: company or location" preamble.
+
+- R5 thresholds: `doctor` emits `WARN` (yellow text, status field `"stale"` in JSON) when `linkedin_ext.last_refreshed` is older than 90 days; `ERROR` (red, status `"very_stale"`) when older than 180 days. Hardcoded — no env override. Rationale: the SF task ran fine on a 9-month-old graph, so a 30-day threshold would have cried wolf on a working setup; 90/180 keeps the warning meaningful for a tool that's clearly degraded but doesn't fire on the routine "I haven't re-uploaded my LinkedIn export this quarter" case. A single env knob can't tune two thresholds independently anyway, so dropping the override removes a half-baked design surface.
+
+- R5 re-sync subcommand: deferred. The sniff at `.manuscripts/happenstance-sniff-2026-04-19/` only documents `GET /api/uploads/status/user`; no POST upload-trigger has been observed and the captured response's `s3_uri: "s3://connections-uploads/linkedin_ext/...csv"` suggests user-uploaded CSVs through the web UI rather than a triggerable endpoint. Adding a CLI command for an endpoint that may not exist is a fake feature. Doctor still gets the stale-graph warning (R5 partial); the suggested action it prints is "re-upload your LinkedIn export at happenstance.ai/connections" until an actual trigger endpoint is discovered.
+
+- R6 fast-fail trigger: classify cookie poll-timeout AND http-client timeout AND HTTP 524/502/503 upstream timeouts as `ErrCookieBroadQuery`. On hit, `runHpnSearch`, `runCoverage`, and `runHPPeople` print to stderr: `cookie surface timed out (likely a broad query). Retry with --source api to use the bearer surface (2 credits/call).` Exit code is `5` (API error / upstream issue) for all three flavors — a single consistent code, distinct from `7` (rate-limit, asserted by `api_hpn_test.go:433` for `RateLimitError`). Conflating cookie timeouts with rate-limit caused programmatic-consumer confusion in the prior decision matrix; using `5` keeps the rate-limit semantic clean. Rationale: 4-minute silent retry-loops are the worst observed UX; failing fast with the actionable next step is the cheapest fix.
+
+- R7 terminology strategy: deferred. Adding `--first-degree` / `--second-degree` aliases without deprecating `--connections` / `--friends` produces 4 flag names for 2 concepts, plus `top-connectors` alongside `friends` for one command — the cumulative confusion exceeds the readability win. Two paths forward, both deferred to a separate plan: (a) introduce `MarkDeprecated` as a precedent and rename properly, or (b) drop the rename and just expand existing `--help` text on `friends` (the `Long` already says "your network's top connectors"). The actual disambiguation work this plan needs from the SF-task — making 1st-degree distinguishable from 2nd-degree on the bearer surface — is solved by R1, not by flag renames.
+
+- R8 CSV flatten implementation: per-command emitter in `printHPPeopleTable`'s sibling, not a generic `printCSV` upgrade. Rationale: the nested-output problem touches multiple flagship structs (`bridgeRef`, etc.) and a generic flattener that handles all of them is the deferred follow-up. For `hp people`, define stable columns: `name, current_title, current_company, linkedin_url, score, relationship_tier, bridge_count, bridge_names, bridge_kinds, top_bridge_affinity, rationale`. `relationship_tier` derives from the strongest bridge's `kind` (`self_graph` -> `1st_degree`, `friend` -> `2nd_degree`, no bridge -> `3rd_degree`). `bridge_count` preserves cardinality; `bridge_names` and `bridge_kinds` are semicolon-joined to keep multi-bridge identity without going long-form. This avoids the lossy "collapse to single strongest bridge" silent-data-drop the earlier draft proposed.
+
+- R9 docs location: new `docs/scoring.md` (not in CLI tree, not regenerated) plus a brief expansion of `--help` text on `api hpn search`. Doc covers what the CLI does with the score (`--min-score N` drops rows with score < N), defers the score-semantics-and-range to Happenstance's own docs with a stable link, and explains that 1st-degree vs 2nd-degree should be filtered with `--first-degree-only` rather than via score thresholds. Rationale: hard-coding HP's scoring conventions in the CLI repo means stale guidance the moment HP changes its model; pointing at HP's docs keeps the CLI surface honest. Captures the observation that 0-2 range is weak-signal (public graph), 10-100 is typical (per `flagship_helpers.go:138-160`), with anything higher indicating a bridge-amplified signal.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- "Why couldn't the agent tell 1st-degree from 2nd-degree on the bearer surface?" Resolved: `internal/cli/api_hpn_search.go:300` calls `api.ToClientPersonWithBridges(r, env.Mutuals, "")` with empty `currentUUID`, which forces every bridge through `internal/happenstance/api/normalize.go:99-102` to `BridgeKindFriend`. The self_graph signal exists in the API response but is erased in the emit path. Fix is plumbing the user's UUID through; predicate becomes `hasSelfGraphBridge` matching `coverage.go:296`.
+
+- "What's the right name for the 1st-degree filter flag?" Resolved: `--first-degree-only`. The codebase's internal vocabulary is `BridgeKindSelfGraph` and `BridgeKindFriend`; "connection" doesn't exist as a kind, and `hp people --connections` already overloads the word. `--first-degree-only` is unambiguous against both.
+
+- "Should `--all` paginate `find-more` automatically or require explicit opt-in?" Resolved: explicit, plus a hard safety guard — `--all` requires at least one of `--max-results` or `--budget` to be non-zero. Implicit pagination or default-disabled budget would let an agent burn 100+ credits on a broad query.
+
+- "Should `coverage --location` use cookie or bearer?" Resolved: bearer-only via `--source api`. The cookie surface has no city-search semantic and the LinkedIn arm of the existing fan-out (which is company-keyword based) doesn't generalize to locations. `coverage --location` skips the LinkedIn arm and routes to bearer.
+
+- "How should `coverage` accept zero positional args for `--location` mode?" Resolved: change `Args: cobra.ExactArgs(1)` (`coverage.go:52`) to `Args: cobra.MaximumNArgs(1)` plus a `PreRunE` validator that requires exactly one of `<positional>` or `--location`. PreRunE alone can't accept zero positionals.
+
+- "Should the cookie fast-fail attempt automatic bearer fallback?" Resolved: no, hint only. Auto-fallback would silently spend credits the user didn't authorize. The hint is one keystroke away from a retry.
+
+- "What exit code should cookie-broad-query timeouts use?" Resolved: 5 (API error). Reusing 7 (rate-limit) confuses programmatic consumers since `api_hpn_test.go:433` already asserts `RateLimitError -> 7`. A consistent 5 across all three timeout flavors (poll-timeout, http-deadline, 5xx) keeps the rate-limit semantic clean.
+
+- "Should `sync linkedin-graph` ship in this plan?" Resolved: no. Sniff at `.manuscripts/happenstance-sniff-2026-04-19/` only documents `GET /api/uploads/status/user`; the captured `s3://connections-uploads/linkedin_ext/...csv` URI suggests user-uploaded CSVs through the web UI. Doctor's "suggested action" text points to happenstance.ai/connections instead of a CLI command until an upload-trigger endpoint is discovered.
+
+- "Should the terminology rename (R7) ship?" Resolved: no, deferred to a separate plan. Adding `--first-degree`/`--second-degree` as forever-aliases produces 4 names for 2 concepts; the right path is either a deprecation precedent or a help-text-only refresh, neither of which fits this plan's scope.
+
+### Deferred to Implementation
+
+- Exact wording of doctor's stale-graph warning line (text only; thresholds and color are decided here).
+- Whether to expose `--max-results` as `--limit` instead. `--limit` is taken in `hp people` but not in `api hpn search`; consistency check at implementation time.
+- Whether the `bridge_kind` CSV column should be `"connection"` / `"friend"` literally or normalized to `"1st-degree"` / `"2nd-degree"`. Consistency with score docs decides at implementation.
+- Generated-skill verifier failure modes when a flag is added but SKILL.md isn't yet regenerated. The regen unit handles the success case; the local pre-merge dance is an implementation detail.
+
+---
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+Filter pipeline for `api hpn search` after R1+R2+R3:
+
+```
+POST /v1/search                       (initial call, costs 2 credits)
+  payload includes:
+    include_my_connections=true       (when --first-degree-only or --include-my-connections set)
+    include_friends_connections=true  (when --include-friends-connections set)
+    group_id=...                      (when --group-id passed)
+  ->
+poll status: PENDING -> RUNNING -> COMPLETED   (existing PollSearch, 180s default)
+  ->
+emit envelope -> ToClientPersonWithBridges(results, env.Mutuals, currentUUID)
+  // KEY FIX: currentUUID is now the authenticated user's UUID, NOT "".
+  // Self-bridges retag to BridgeKindSelfGraph; everything else stays BridgeKindFriend.
+  ->
+results[] (now correctly tagged)
+  if --first-degree-only: drop where !hasSelfGraphBridge(p.Bridges)
+  if --min-score N:        drop where score < N
+  ->
+  if --all and (--max-results unset OR running_count < --max-results)
+            and (--budget unset OR running_credits + 2 <= --budget):
+    POST /v1/search/{id}/find-more   (costs 2 more credits per page)
+    poll page status to terminal
+    re-apply ToClientPersonWithBridges with currentUUID, then filters
+    accumulate results
+    loop
+  ->
+emit (table | json | csv)
+emit per-page cost lines on stderr (when --all)
+```
+
+Decision matrix for the cookie-vs-bearer fast-fail (R6):
+
+| Trigger                                   | Today behavior                            | New behavior                                                |
+|-------------------------------------------|-------------------------------------------|-------------------------------------------------------------|
+| Cookie poll exceeds 180s                  | Returns timeout error to caller, raw      | Classify as `ErrCookieBroadQuery`, exit 5, hint `--source api` |
+| http-client deadline exceeded (broad q)   | Silent 4-minute hang, then generic error  | Classify as `ErrCookieBroadQuery`, exit 5, hint `--source api` |
+| 524 / 502 / 503 from cookie               | Generic upstream error                    | Classify as `ErrCookieBroadQuery`, exit 5, hint `--source api` |
+| Cookie status stays `"Thinking"` > 90s    | Polled until 180s, then error             | Bail early as `ErrCookieBroadQuery`, exit 5, hint `--source api` |
+| Bearer 402 (out of credits)               | Existing handling                         | Unchanged                                                   |
+| Bearer 429 (rate limit)                   | Existing exit 7 via `RateLimitError`      | Unchanged — exit 7 reserved for rate-limit only             |
+
+Doctor stale-graph state machine (R5):
+
+| Age of `linkedin_ext.last_refreshed`    | doctor status | exit-code contribution     | Suggested action                                            |
+|-----------------------------------------|---------------|----------------------------|-------------------------------------------------------------|
+| < 90 days                               | `ok`          | none                       | none                                                        |
+| 90-179 days                             | `stale`       | none (warning, not error)  | re-upload your LinkedIn export at happenstance.ai/connections |
+| >= 180 days                             | `very_stale`  | adds 1 to overall doctor exit code | re-upload your LinkedIn export at happenstance.ai/connections (urgent) |
+| missing (never synced)                  | `never`       | adds 1 to overall doctor exit code | upload your LinkedIn export at happenstance.ai/connections  |
+
+---
+
+## Implementation Units
+
+- U1. **Plumb currentUUID through api hpn search; add --first-degree-only and --min-score**
+
+Goal: Restore the self_graph bridge signal in `api hpn search`'s emit path so 1st-degree is distinguishable from 2nd-degree, then add two filter flags. This is the root-cause fix the SF-friends task surfaced.
+
+Requirements: R1, R2
+
+Dependencies: none
+
+Files:
+- Modify: `internal/cli/api_hpn_search.go` (emit path at line 300; flag declarations near line 140-160; runHpnSearch handler)
+- Modify: `internal/happenstance/api/normalize.go` (only if call signature needs to change for safety — the existing function already accepts currentUUID)
+- Modify: `internal/cli/api_hpn_test.go`
+- Modify: `internal/cli/flagship_helpers.go` (if a shared `hasSelfGraphBridge` helper is extracted from `coverage.go:296` to be importable here)
+
+Approach:
+- **Pass the authenticated user's UUID into `ToClientPersonWithBridges`.** Today the call at `api_hpn_search.go:300` is `api.ToClientPersonWithBridges(r, env.Mutuals, "")` with a comment apologizing for the empty `currentUUID`. Look up the current user's UUID — `clerk` already retrieves user profiles (`internal/cli/clerk.go`) and the bearer surface returns the authenticated UUID via the user endpoint surfaced by `doctor.go`'s `happenstance_api_validity` check. Cache it on the bearer client (one-time fetch, no extra credits since user-info is free) and pass it on every emit.
+- **Verify the retag semantics with a unit test before adding flags.** Test that with the real UUID, a search response containing the user's own self-bridge results in `BridgeKindSelfGraph` on the emitted person; without the UUID (regression case), all bridges stay `BridgeKindFriend`.
+- Add `firstDegreeOnly bool` and `minScore float64` to the per-command flag struct.
+- When `firstDegreeOnly` is true: auto-set the bearer payload's `IncludeMyConnections=true` (so the API includes 1st-degree in the result set), AND post-filter using `hasSelfGraphBridge(p.Bridges)` matching `coverage.go:296`. The combined effect is the intuitive "give me only my 1st-degree connections" semantic.
+- When `minScore > 0`: post-filter dropping `score < minScore`. Documented threshold in `--help` is `>= 5` to drop weak-signal public-graph noise; no high-end recommendation (real 1st-degree bridges sit at 49.99 medium affinity per fixtures).
+- Apply both filters in the result-emit path so JSON / table / CSV all see the filtered set.
+
+Execution note: Plumb the currentUUID and add a regression test for the retag BEFORE adding the user-facing flags. The flags only work correctly once the retag is restored.
+
+Patterns to follow:
+- `internal/cli/coverage.go:296` `hasSelfGraphBridge` — the working predicate this plan extends to bearer search.
+- `internal/happenstance/api/normalize.go:99-102` for the retag logic the empty currentUUID currently bypasses.
+- `internal/cli/api_hpn_search.go:140-160` for the BoolVar / Float64Var declaration block.
+
+Test scenarios:
+- Happy path: with `currentUUID` plumbed, a fixture response containing a self-bridge entry retags to `BridgeKindSelfGraph`. Without the plumbing (regression test), the same fixture leaves all bridges as `BridgeKindFriend`. Confirms the root cause is fixed.
+- Happy path: `--first-degree-only` against a fixture with mixed self_graph / friend / no-bridge results returns only rows where at least one bridge has `kind == BridgeKindSelfGraph`.
+- Happy path: `--min-score 5` against a fixture with scores [50, 49.99, 12, 2, 0] returns [50, 49.99, 12].
+- Edge case: `--first-degree-only` with `--include-my-connections` already explicitly set is a no-op for the include-add (idempotent); the filter still applies.
+- Edge case: `--first-degree-only` against a fixture where the API returns no 1st-degree matches returns "0 results" with a clear message, not a silent empty array.
+- Edge case: `--min-score 0` (default) is a no-op.
+- Edge case: bearer surface returns an authenticated-user UUID that's the empty string (mock failure mode); fall back to today's behavior with a stderr warning rather than crashing.
+- Error path: `--min-score -1` is rejected at flag-parse time with a usage error.
+- Error path: bearer user-info lookup fails on first call; cache the failure for the session, log on stderr, fall back to empty-currentUUID behavior so the search still returns something.
+- Integration: `--first-degree-only --min-score 5` against the SF-task fixture (page 1 with 30 results, 6 of which were score-2 weak-signal) returns the 24 real 1st-degree rows the user actually wanted.
+
+Verification:
+- `go test ./internal/cli -run TestHpnSearchSelfGraphRetag` passes.
+- `go test ./internal/cli -run TestHpnSearchFilter` passes.
+- Running `contact-goat-pp-cli api hpn search "in San Francisco" --first-degree-only --min-score 5 --json` against the captured fixture returns only rows where the JSON output's `bridges[].kind` includes `"self_graph"`.
+
+---
+
+- U2. hpn search auto-paginate: --all and --max-results
+
+Goal: One command paginates and polls `api hpn search` to completion or a result cap, replacing the manual `find-more` + `get --page-id` + poll loop.
+
+Requirements: R3
+
+Dependencies: U1 (filters apply per page)
+
+Files:
+- Modify: `internal/cli/api_hpn_search.go`
+- Modify: `internal/cli/api_hpn_test.go`
+- Modify: `internal/happenstance/api/search.go` (if a new "iterator" helper is justified; otherwise stay in CLI layer)
+
+Approach:
+- Add `--all bool` and `--max-results int` to `newAPIHpnSearchCmd`.
+- New helper `runHpnSearchAll(ctx, ...)` wraps the existing single-page `runHpnSearch`. Loop: POST + poll first page; while `has_more && running < max && budget allows`, call `find-more`, then `get --page-id` with poll, accumulate, apply filters, repeat.
+- Surface per-page cost on stderr in the existing "cost spent" log convention.
+- Bail with a clear status when `--budget` would be exceeded by the next page; emit results so far rather than discarding.
+- `--all` REQUIRES at least one of `--max-results` or `--budget` to be non-zero; without either, return a usage error suggesting `--max-results 100` as a default cap. Rationale: an agent calling `--all --yes` against a broad query would otherwise burn unbounded credits.
+- `--max-results` without `--all` is an error (it only makes sense in pagination mode).
+
+Patterns to follow:
+- `api_hpn_search.go:265` `runHpnSearch` for the single-page shape.
+- `api_hpn_search.go:358` `buildPollSearchOptions` for poll-options threading.
+- `api/search.go:167` `Client.PollSearch` for the terminal-status check.
+
+Test scenarios:
+- Happy path: `--all` with a fixture that returns 3 pages then `has_more=false` accumulates all 90 results. Inputs: bearer fake server with seeded multi-page response; expect 90-row output.
+- Happy path: `--all --max-results 50` stops at 50, prints a "stopped at cap" notice on stderr.
+- Edge case: `--budget 4 --all` allows initial 2-credit call and one find-more (2 more = 4), then bails before the second find-more; emits results so far + budget warning.
+- Edge case: `has_more=false` on first page returns identically to single-page mode; no extra calls made.
+- Error path: `--all` alone (no `--max-results`, no `--budget`) returns a usage error suggesting `--max-results 100` as a default cap.
+- Error path: `--max-results` without `--all` returns a usage error.
+- Error path: `--all` with mid-pagination bearer 402 (out of credits) bails gracefully, emits accumulated results, exit code 5.
+- Integration: `--all --max-results 100 --first-degree-only --min-score 5` filters every page, accumulates only 1st-degree matches above the noise threshold.
+
+Verification:
+- `go test ./internal/cli -run TestHpnSearchAll` passes.
+- Running `contact-goat-pp-cli api hpn search "in San Francisco" --all --max-results 100 --first-degree-only --json` produces a single deduped, filtered, sorted result set.
+
+---
+
+- U3. coverage --location
+
+Goal: `coverage` answers "who do I know in city X" alongside its existing "who do I know at company X" semantics.
+
+Requirements: R4
+
+Dependencies: none
+
+Files:
+- Modify: `internal/cli/coverage.go`
+- Modify: `internal/cli/coverage_test.go` (create if absent; see existing nearby `flagship_helpers_test.go` for shape)
+
+Approach:
+- Add `--location string` flag.
+- Change `Args: cobra.ExactArgs(1)` (today at `coverage.go:52`) to `Args: cobra.MaximumNArgs(1)`. Add a `PreRunE` validator that requires exactly one of `<positional>` or `--location`; both or neither returns a usage error.
+- When `--location` is set, force `--source api` (bearer-only). Rationale: the cookie surface has no city-search semantic and the LinkedIn arm of today's fan-out is company-keyword-based and doesn't generalize to locations. The `--location` query goes only through bearer search with `--first-degree-only` auto-set so it returns my-network results, not the public graph.
+- Result schema is unchanged (name, title, company, linkedin URL, relationship tier, score). Add a `location` column when `--location` was set, populated from bearer's `current_location` field where available.
+- Help text gains a `Scope: <company> | --location <city>` preamble explaining the LinkedIn-arm restriction.
+
+Patterns to follow:
+- `coverage.go:22-275` for the existing fan-out and result-merge pattern.
+- `printCoverageTable` at `coverage.go:402` for the table extension.
+
+Test scenarios:
+- Happy path: `coverage --location "San Francisco"` returns rows from a fixture matching the location query (bearer arm only).
+- Happy path: `coverage Stripe` (existing) still works unchanged with the original ExactArgs-equivalent validation.
+- Edge case: positional arg + `--location` returns a usage error ("specify company or --location, not both").
+- Edge case: zero positionals AND no `--location` returns a usage error suggesting one or the other.
+- Edge case: empty location string is rejected.
+- Edge case: `--location "San Francisco" --source hp` is rejected with a usage error explaining cookie surface doesn't support city search.
+- Error path: location with no matches returns a clear "0 results" message not an empty table.
+- Integration: `coverage --location "San Francisco" --json` flows through to bearer search with `--first-degree-only` auto-set and returns my-network rows.
+
+Verification:
+- `go test ./internal/cli -run TestCoverageLocation` passes.
+- Running `contact-goat-pp-cli coverage --location "San Francisco" --json | jq '.results | length'` returns a positive number.
+- Running `contact-goat-pp-cli coverage` (no args, no flags) prints a usage error.
+
+---
+
+- U4. **doctor stale-graph warning**
+
+Goal: Doctor visibly flags an out-of-date LinkedIn graph and points the user at the web UI to refresh it. The CLI re-sync subcommand is deferred (see Scope Boundaries) until the upload-trigger endpoint is documented.
+
+Requirements: R5
+
+Dependencies: none
+
+Files:
+- Modify: `internal/cli/doctor.go` (extend `checkHappenstanceGraphCoverage` at line 271)
+- Modify: `internal/cli/doctor_test.go` (or add to a colocated test file)
+
+Approach:
+- In `checkHappenstanceGraphCoverage`, parse `last_refreshed` (the existing field name on the response, `doctor.go:308`); compute age in days.
+- Map to one of `ok | stale | very_stale | never` per the state machine table in High-Level Technical Design.
+- Emit a structured `{status, age_days, last_refreshed, suggested_action}` field on the doctor JSON. In human-friendly mode, render with color via the existing `humanAge` neighbor: `ok` is uncolored, `stale` prints with a yellow `WARN` prefix, `very_stale` and `never` print with a red `ERR` prefix and contribute 1 to the doctor exit code.
+- `suggested_action` text for non-`ok` states points to `https://happenstance.ai/connections` (the web UI for re-uploading the LinkedIn export). When/if HP ships a triggerable endpoint, this text becomes a CLI command in a follow-up plan.
+- Hardcoded thresholds 90/180; no env override.
+
+Patterns to follow:
+- `internal/cli/doctor.go:271` for the existing `checkHappenstanceGraphCoverage` extension shape.
+- `humanAge` neighbor in the same file for date-format rendering.
+
+Test scenarios:
+- Happy path: graph age 30 days returns `status: ok`, no warning, no exit-code contribution.
+- Happy path: graph age 120 days returns `status: stale`, `WARN` prefix, suggested action references happenstance.ai/connections.
+- Edge case: graph age 200 days returns `status: very_stale`, `ERR` prefix, doctor exit code includes 1.
+- Edge case: missing or empty `last_refreshed` (never synced) returns `status: never`, exit code includes 1.
+- Edge case: malformed `last_refreshed` timestamp (parse fails) returns `status: unknown`, no exit-code contribution, structured field includes the parse error.
+
+Verification:
+- `go test ./internal/cli -run TestDoctorStaleGraph` passes.
+- `contact-goat-pp-cli doctor --json | jq '.happenstance_graph_status'` returns one of `ok|stale|very_stale|never|unknown`.
+- `contact-goat-pp-cli doctor` against the captured fixture (graph age ~9 months) prints `WARN` + the happenstance.ai/connections URL and contributes 1 to the exit code.
+
+---
+
+- U5. cookie-timeout fast-fail with bearer-fallback hint
+
+Goal: Cookie surface fails fast with an actionable hint instead of hanging silently for 4 minutes on broad queries.
+
+Requirements: R6
+
+Dependencies: none (but interacts with U1-U2 since hpn search is one of the surfaces affected)
+
+Files:
+- Modify: `internal/client/people_search.go`
+- Modify: `internal/cli/api_hpn_search.go` (the source-routing path)
+- Modify: `internal/cli/coverage.go` (same routing)
+- Modify: `internal/cli/hp_people.go` (same routing)
+- Modify: `internal/client/people_search_test.go`
+
+Approach:
+- Declare `ErrCookieBroadQuery` as a sentinel error in `internal/client/people_search.go`.
+- In the cookie poll/request path, classify four conditions to that sentinel: poll exceeded with status still `"Thinking"`; http-client deadline exceeded; HTTP 524/502/503 upstream; non-terminal `"Thinking"` status persisting past 90 seconds (early-bail threshold below the 180s default poll timeout).
+- In each routing call site (`api_hpn_search.go`, `coverage.go`, `hp_people.go`), when `errors.Is(err, ErrCookieBroadQuery)`, print to stderr: `cookie surface timed out (likely a broad query). Retry with --source api to use the bearer surface (2 credits/call).` Return exit code 5 (API error) consistently across all four flavors. Exit 7 stays reserved for `RateLimitError`, asserted by the existing test at `api_hpn_test.go:433`.
+
+Patterns to follow:
+- `api_hpn_search.go:398` `classifyHpnError` for the error-classification idiom.
+- `client/client.go:134` for the http-client timeout source.
+- The existing "cost spent" stderr log convention for the hint format.
+
+Test scenarios:
+- Happy path: cookie returns COMPLETED before timeout; no hint emitted, normal output.
+- Edge case: cookie poll times out after 180s; `ErrCookieBroadQuery` returned, hint printed, exit 5.
+- Edge case: cookie stuck at `"Thinking"` for 90s; bail early, hint printed, exit 5.
+- Edge case: 524 from cookie surface; hint printed, exit 5.
+- Edge case: 502 from cookie surface; hint printed, exit 5.
+- Edge case: explicit `--source api` skips cookie entirely; no hint regardless of bearer behavior.
+- Edge case: bearer 429 returns exit 7 unchanged (rate-limit path); confirm not conflated with cookie timeout.
+- Error path: bearer 402 after the user takes the hint; existing handling, no double-hint.
+- Integration: `hp people "people in San Francisco"` (the original failing query) with cookie source bails in <=95s with the hint.
+
+Verification:
+- `go test ./internal/client -run TestErrCookieBroadQuery` passes.
+- `time contact-goat-pp-cli hp people "people in San Francisco" --source hp` exits in <=95s with the suggested hint.
+
+---
+
+- U6. **DEFERRED — terminology rename for hp people / friends**
+
+Deferred to a separate plan. Adding `--first-degree` / `--second-degree` as forever-aliases without deprecating `--connections` / `--friends` produces 4 flag names for 2 concepts, plus `top-connectors` alongside `friends` for one command. The cumulative confusion exceeds the readability win. Two paths for the follow-up plan: (a) introduce `MarkDeprecated` as a precedent and rename the originals, or (b) drop the rename and just expand `--help` text on the existing flags. The actual disambiguation work needed from the SF-task — making 1st-degree distinguishable from 2nd-degree on the bearer surface — is solved by U1, not by flag renames. See Scope Boundaries → Deferred to Follow-Up Work.
+
+The U-ID stays U6 (gap rule: never renumber); a follow-up plan would assign a new U-ID in its own document.
+
+---
+
+- U7. hp people native CSV with bridges flatten
+
+Goal: `hp people --csv` produces a clean, agent-pipeable CSV that flattens the nested `bridges[]` into stable columns.
+
+Requirements: R8
+
+Dependencies: none
+
+Files:
+- Modify: `internal/cli/hp_people.go` (add `printHPPeopleCSV` sibling to `printHPPeopleTable`)
+- Modify: `internal/cli/flagship_helpers.go` (small helper to pick strongest bridge)
+- Modify: `internal/cli/hp_people_test.go`
+
+Approach:
+- Hook `printHPPeopleCSV` into the output-mode branch in `runHPPeople` (parallel to existing `--json` and table branches). Today the global `--csv` flag is silently ignored by hp people; this routes it.
+- Columns (stable): `name, current_title, current_company, linkedin_url, score, relationship_tier, bridge_count, bridge_names, bridge_kinds, top_bridge_affinity, rationale`. `relationship_tier` derives from the strongest bridge's `kind`: `BridgeKindSelfGraph` -> `1st_degree`, `BridgeKindFriend` -> `2nd_degree`, no bridge -> `3rd_degree`. `bridge_count` preserves cardinality. `bridge_names` and `bridge_kinds` are semicolon-joined to keep multi-bridge identity without going long-form. `top_bridge_affinity` is the highest affinity score across bridges.
+- This avoids the lossy "collapse to single strongest bridge" the earlier draft proposed. Multi-bridge data is preserved in CSV; users who need the full structured form still use `--json`.
+- Use stdlib `encoding/csv` rather than handrolling.
+- Keep `printHPPeopleTable` and `--json` paths untouched.
+
+Patterns to follow:
+- `internal/cli/helpers.go:481` `printCSV` for stdlib `encoding/csv` usage.
+- `printHPPeopleTable` at `hp_people.go:252` for the per-mode emitter shape.
+
+Test scenarios:
+- Happy path: 3 results with single-bridge each produce 3 CSV rows + header; `bridge_count` is 1, `bridge_names` and `bridge_kinds` each have one value, `top_bridge_affinity` matches the single bridge's affinity.
+- Happy path: result with 3 bridges produces `bridge_count: 3`, `bridge_names: "Alice;Bob;Carol"`, `bridge_kinds: "self_graph;friend;friend"`, `top_bridge_affinity` is the max of the three.
+- Happy path: result with one self_graph bridge gives `relationship_tier: 1st_degree`; one friend bridge gives `2nd_degree`; no bridges gives `3rd_degree`.
+- Edge case: result with empty `bridges[]` produces empty `bridge_count: 0`, empty `bridge_names`, `bridge_kinds`, `top_bridge_affinity` cells; no panic.
+- Edge case: name or bridge_name containing a comma or semicolon is correctly quoted by stdlib csv writer.
+- Edge case: empty result set produces just the header row.
+- Integration: `hp people "..." --csv | wc -l` matches `--json | jq '.results | length'` + 1 for header.
+
+Verification:
+- `go test ./internal/cli -run TestHPPeopleCSV` passes.
+- `contact-goat-pp-cli hp people "people in SF" --csv | head -3` shows header + two data rows; no nested-array junk.
+
+---
+
+- U8. scoring docs + --help expansion
+
+Goal: Document the score field's semantics so users know what `--min-score 5` vs `--min-score 40` means.
+
+Requirements: R9
+
+Dependencies: U1 (the doc references `--min-score`)
+
+Files:
+- Create: `docs/scoring.md`
+- Modify: `internal/cli/api_hpn_search.go` (expand the `Long` help text on the search command)
+- Modify: `README.md` (add a one-line link to `docs/scoring.md` near the search command discussion)
+
+Approach:
+- `docs/scoring.md` covers: what the CLI does with the score (`--min-score N` drops rows where score < N), the observed range from local code (`flagship_helpers.go:138-160`: typical 10-100 with strong-graph signals observed up to ~300; weak-signal public-graph entries show as 0-2), and a recommendation that `--first-degree-only` (not `--min-score`) is the right tool for tier filtering. Defers scoring-model semantics to Happenstance's own docs with a stable link rather than re-documenting HP product behavior in the CLI repo.
+- Expand `api hpn search` `Long` help to include a brief paragraph linking to `docs/scoring.md` (one sentence, not the full doc).
+- Add a one-liner to README's existing "agent mode" section pointing at `docs/scoring.md`.
+
+Patterns to follow:
+- Local doc precedent: existing `README.md` and `SKILL.md` for tone and example formatting.
+- `api_hpn_search.go` Long-text format for the help expansion.
+
+Test scenarios:
+- Test expectation: none. This unit is documentation only with no behavioral change.
+
+Verification:
+- `docs/scoring.md` exists and is rendered correctly by GitHub markdown.
+- `contact-goat-pp-cli api hpn search --help` shows the new pointer line.
+- README diff is minimal and additive.
+
+---
+
+- U9. Skills regen + plugin bump
+
+Goal: Keep the CLI SKILL surface in sync with new flags and commands; verify SKILL.md docs all flags resolve.
+
+Requirements: all (every preceding unit changes the user-visible flag surface or command list)
+
+Dependencies: U1-U8
+
+Files:
+- Modify: `cli-skills/pp-contact-goat/SKILL.md` (regenerated)
+- Modify: `skills/ppl/references/registry.json` (regenerated)
+- Modify: `.claude-plugin/plugin.json` (bump only if `skills/ppl/**` or `.claude-plugin/**` changed)
+
+Approach:
+- Run `go run ./tools/generate-skills/main.go` from repo root.
+- Run `.github/scripts/verify-skill/verify_skill.py` locally; resolve any flag-mismatch failures by updating SKILL.md prose, not by reverting code.
+- Inspect the regen diff: confirm new flags (`--first-degree-only`, `--min-score`, `--all`, `--max-results`, `--location`) are documented. The deferred terminology rename (U6) and deferred sync subcommand mean no `--first-degree` / `--second-degree` / `top-connectors` / `sync linkedin-graph` entries should appear.
+- Commit regen as a separate commit after the substantive units land, matching the precedent set by `2026-04-19-001-fix-bearer-api-mutuals-plan.md` Unit 5.
+
+Patterns to follow:
+- `2026-04-19-001-fix-bearer-api-mutuals-plan.md` Unit 5 for the regen-as-final-unit shape.
+- AGENTS.md "regen step" guidance.
+
+Test scenarios:
+- Test expectation: none. This unit is regeneration only with no source code change.
+
+Verification:
+- `python3 .github/scripts/verify-skill/verify_skill.py` exits 0.
+- `go test ./...` passes (no unintended source changes).
+- The regen diff touches only `cli-skills/pp-contact-goat/SKILL.md` and `skills/ppl/references/registry.json` (and `.claude-plugin/plugin.json` only if applicable).
+
+---
+
+## System-Wide Impact
+
+- **Cross-cutting touch on `api_hpn_search.go`.** U1, U2, and U5 all modify `internal/cli/api_hpn_search.go` — the currentUUID plumbing, the `--all` loop, and the `ErrCookieBroadQuery` classification all live in or adjacent to `runHpnSearch`. **Recommended PR sequencing**: bundle U1 + U2 + U5 into a single PR rather than three. Three separate PRs against the same flag-declaration block and handler will produce textual conflicts in the same lines and risk one PR reverting another's filter logic. U3 (coverage), U4 (doctor), U7 (hp people CSV) are independent and can land in their own PRs.
+- **Interaction graph**: `runHpnSearch` is the central seam. `runCoverage` and `runHPPeople` get a parallel U5 hook because they share the cookie-vs-bearer routing decision. Doctor's `checkHappenstanceGraphCoverage` is independent.
+- **Error propagation**: U5 introduces a new sentinel `ErrCookieBroadQuery` in `internal/client/people_search.go` that propagates up through cobra `RunE` returns into stderr-printed hints. Exit codes: 5 (API error) for `ErrCookieBroadQuery`; 7 (rate-limit) reserved for `RateLimitError` only; no new codes.
+- **State lifecycle risks**: U2's `--all` loop accumulates results in memory; mitigated by the hard requirement that one of `--max-results` or `--budget` be set.
+- **API surface parity**: U1's currentUUID plumbing affects the bearer emit path only. Cookie surface for `hp people` is unaffected (cookie already retags correctly). `coverage` (U3) routes through the same auto-router; no payload change required.
+- **Integration coverage**: U2 + U1 together change the cost profile of a single command invocation. The existing budget check (`checkSearchBudget` at api_hpn_test.go:400) needs extension to account for projected pagination cost.
+- **Unchanged invariants**:
+  - The cookie-vs-bearer auto-routing default. U5 only fires after routing already chose cookie; it does not override routing.
+  - The 5-minute GET cache. None of the units change cache TTL or invalidation.
+  - The `--agent` cascade in `PersistentPreRunE`. New flags inherit the cascade automatically.
+  - The MCP server tool registry. None of these CLI changes ship as new MCP tools; the existing 16 tools' behavior is unchanged. (A follow-up plan can decide whether `--first-degree-only` becomes an MCP-exposed parameter.)
+  - The shared `PollSearch` helper at `api/search.go:167`. U2's auto-pagination wraps it; the helper itself is unchanged.
+  - Existing flag names (`--connections`, `--friends`, `friends` command) all keep working; the rename is deferred.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `--all` users misjudge the credit cost and burn through their balance. | `--all` requires at least one of `--max-results` or `--budget`; calling `--all --yes` alone returns a usage error. Per-page cost line on stderr. |
+| Currentuser-UUID lookup adds a network call to every `api hpn search`. | Cache the UUID on the bearer client at construction time (one-time fetch from a free user-info endpoint). Fall back to today's empty-UUID behavior with a stderr warning if the lookup fails. |
+| HP changes the bridge-kind enum in the API response, breaking the `BridgeKindSelfGraph` predicate. | Plan ties the predicate to the codebase's existing constants (`internal/client/people_search.go:151-154`); a HP enum change would already break `coverage`'s `hasSelfGraphBridge`, so this plan does not introduce a new contract surface. |
+| SKILL verifier fails after regen due to mismatch between new flag and SKILL.md prose. | U9's verification step explicitly runs `verify_skill.py` and resolves prose mismatches; the regen unit is the explicit place this happens. |
+| `coverage --location` fails to find rows because of cookie-side issues. | U3 routes `--location` to bearer-only via `--source api`; cookie surface is excluded from city searches by design. |
+| Stale-graph thresholds (90/180 days) miss someone who actively wants a tighter warning. | Threshold tuning is deferred follow-up; observed user data (the SF task ran fine on a 9-month graph) suggests 90/180 is the right starting bar, with room to add tunability later if needed. |
+| `--min-score` recommendation in docs ages poorly when HP changes scoring. | `docs/scoring.md` (U8) documents only the CLI's behavior (`--min-score N` drops rows with score < N), defers HP-specific score-semantics to HP's own docs. |
+| Multi-bridge data collapsed in CSV. | U7 preserves `bridge_count`, `bridge_names`, `bridge_kinds` (semicolon-joined) so cardinality and identity survive flattening. `--json` remains the structured-form fallback. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `README.md` Notable Commands table for the new behaviors (`--first-degree-only`, `--min-score`, `--all` with `--max-results`, `coverage --location`, `hp people --csv`) and the doctor stale-graph status field.
+- Update `SKILL.md` via the regen unit (U9). The SKILL verifier enforces flag-text consistency.
+- Add `docs/scoring.md` (U8). Link it from `README.md` and from `api hpn search --help`.
+- No migration steps required; all changes are additive.
+- No rollout monitoring required; this is a CLI surface, not a service.
+- `CHANGELOG.md` entry under `feat(cli)`: "contact-goat: bearer search now distinguishes 1st-degree from 2nd-degree (currentUUID plumbed through emit path), `--first-degree-only` and `--min-score` filters, `--all` auto-pagination with hard credit safety, `coverage --location`, doctor stale-graph warning, native CSV for `hp people`."
+
+---
+
+## Sources & References
+
+- Origin task: live SF-friends task (no upstream brainstorm doc; planning bootstrap from user request directly). The bug exposed by the task is the empty `currentUUID` in `api_hpn_search.go`'s emit path; doc-review surfaced it during deepening on 2026-05-04.
+- Prior plan precedent: `docs/plans/2026-04-19-001-fix-bearer-api-mutuals-plan.md` (mutuals-bearer fix; same surface area).
+- Repo guidance: `AGENTS.md` (regen requirement, conventional-commit scopes, no-broad-regen norm, SKILL verifier policy).
+- Bridge-kind constants and the working 1st-degree predicate: `internal/client/people_search.go:151-154` (`BridgeKindFriend`, `BridgeKindSelfGraph`); `internal/cli/coverage.go:296` (`hasSelfGraphBridge`).
+- Bridge retag logic gated on currentUUID: `internal/happenstance/api/normalize.go:99-102`.
+- Empty-UUID call site (the fix target): `internal/cli/api_hpn_search.go:300`.
+- Poll helper and terminal-status constants: `internal/happenstance/api/search.go:20-23, 167, 215`.
+- Cookie-mirror poll-timeout regression test: `internal/client/people_search_test.go:15`.
+- Score range observation: `internal/cli/flagship_helpers.go:138-160` ("typical 10-100 ... observed up to ~300").
+- Sniff archive (no upload-trigger endpoint observed): `.manuscripts/happenstance-sniff-2026-04-19/README.md`.
+- Happenstance public API surfaces: cookie web app + bearer REST API documented in `SKILL.md`.
+
+### Deepening notes
+
+- 2026-05-04 doc review: surfaced the empty-`currentUUID` root cause (P0, anchor 100), corrected the bridge-kind predicate from the imagined `"connection"` to the real `"self_graph"`, deferred U6 (terminology rename) and the U4 sync-subcommand half (no upload-trigger endpoint), tightened `--all` credit safety, fixed exit-code semantics (5 not 7 for cookie timeouts), corrected score-range claims to match `flagship_helpers.go`, dropped the `CONTACT_GOAT_GRAPH_STALE_DAYS` env override, bumped stale-graph thresholds from 30/90 to 90/180, replaced lossy bridge-collapse-by-affinity in CSV with multi-bridge preserving columns, and called for U1+U2+U5 to ship as a single PR.

--- a/library/sales-and-crm/contact-goat/docs/scoring.md
+++ b/library/sales-and-crm/contact-goat/docs/scoring.md
@@ -1,0 +1,46 @@
+# `score` field on `api hpn search` results
+
+The `score` field on each row is what the Happenstance public API
+returns plus a small CLI-side adjustment. This doc explains what
+contact-goat does with that score so users know when to use
+`--min-score` versus `--first-degree-only`.
+
+## What the CLI does with the score
+
+`--min-score N` drops rows where the rendered score is below `N`. It
+runs after the API call and bridge-affinity adjustment, so the
+threshold applies to what you actually see in the output. `0` (the
+default) is a no-op; `--min-score 5` typically drops weak-signal
+public-graph entries (rows where the bearer surface returned no graph
+affinity at all but kept the row in the result set anyway).
+
+`--first-degree-only` drops rows lacking any `self_graph` bridge after
+the per-row `currentUUID` retag. This is the right tool when you want
+"only my 1st-degree connections" - it filters by graph membership, not
+by score. Use `--min-score` for noise reduction; use
+`--first-degree-only` for tier filtering.
+
+The two filters compose. The intersection is the SF-task case: only
+1st-degree, with public-graph noise dropped.
+
+## Score range, observationally
+
+Per `internal/cli/flagship_helpers.go` (the file with the bridge-affinity
+math), typical scores sit between 10 and 100. The strongest signals
+observed in captured traffic reach around 300. Public-graph rows with
+no graph affinity show as 0 to 2.
+
+Do not encode "high-confidence 1st-degree" as a fixed threshold in
+your scripts. Real 1st-degree bridges sit at medium-affinity values
+(observed 49.99 in fixtures) and a high blanket cutoff would drop
+them.
+
+## Where the score actually comes from
+
+The score is a Happenstance product detail, not a CLI behavior. The
+canonical reference is Happenstance's own documentation. This doc is
+intentionally narrow: it describes only what the CLI does with the
+value (the `--min-score` filter, the bridge-affinity adjustment). If
+Happenstance changes the underlying scoring model, the CLI keeps
+working - the threshold semantics in the help text just become less
+useful until you re-tune.

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
@@ -99,7 +99,13 @@ GET /v1/search/{id} until the status is COMPLETED, FAILED, or
 FAILED_AMBIGUOUS — or the --poll-timeout fires.
 
 For paginating an existing search, see ` + "`api hpn search find-more <id>`" + `
-and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
+and ` + "`api hpn search get <id> [--page-id ID]`" + `. Use --all with
+--max-results or --budget to auto-paginate in one command.
+
+Filtering: --first-degree-only keeps only rows where you have a
+self_graph bridge (1st-degree). --min-score N drops rows whose score
+falls below N (use 5 to drop weak-signal noise). See docs/scoring.md
+for the rationale and observed ranges.`,
 		Example: `  contact-goat-pp-cli api hpn search "VPs at NBA" --yes
   contact-goat-pp-cli api hpn search "founders in Stripe's network" --include-friends-connections --yes
   contact-goat-pp-cli api hpn search "people in alumni" --group-id grp_abc123 --yes

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
@@ -73,6 +73,8 @@ func newAPIHpnSearchCmd(flags *rootFlags) *cobra.Command {
 	var (
 		includeFriendsConnections bool
 		includeMyConnections      bool
+		firstDegreeOnly           bool
+		minScore                  float64
 		groupIDs                  []string
 		budget                    int
 		pollTimeoutSec            int
@@ -106,6 +108,9 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 			if text == "" {
 				return usageErr(fmt.Errorf("search text is empty — pass a non-empty natural-language query"))
 			}
+			if minScore < 0 {
+				return usageErr(fmt.Errorf("--min-score must be >= 0 (got %g)", minScore))
+			}
 
 			c, err := flags.newHappenstanceAPIClient()
 			if err != nil {
@@ -135,10 +140,15 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 				}
 			}
 
+			// --first-degree-only auto-implies --include-my-connections at
+			// the API layer (otherwise the response will never contain
+			// 1st-degree rows for the post-fetch filter to keep).
+			effectiveIncludeMyConnections := includeMyConnections || firstDegreeOnly
+
 			opts := &api.SearchOptions{
 				GroupIDs:                  groupIDs,
 				IncludeFriendsConnections: includeFriendsConnections,
-				IncludeMyConnections:      includeMyConnections,
+				IncludeMyConnections:      effectiveIncludeMyConnections,
 			}
 			pollOpts := buildPollSearchOptions(pollTimeoutSec, pollIntervalSec, "")
 
@@ -146,12 +156,24 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 			if err != nil {
 				return classifyHpnError(err)
 			}
-			return emitHpnSearchEnvelope(cmd, flags, env, text)
+
+			// Best-effort fetch of the current user's UUID via the cookie
+			// surface so ToClientPersonWithBridges can retag self-bridges
+			// to BridgeKindSelfGraph. Without this the bearer surface
+			// cannot distinguish 1st-degree (you know them via your own
+			// synced contacts) from 2nd-degree (via a friend). When cookie
+			// auth is unavailable we fall back to "" — bridges all stay
+			// BridgeKindFriend, which matches today's behavior.
+			currentUUID := lookupCurrentUserUUID(flags)
+
+			return emitHpnSearchEnvelope(cmd, flags, env, text, currentUUID, firstDegreeOnly, minScore)
 		},
 	}
 
 	cmd.Flags().BoolVar(&includeFriendsConnections, "include-friends-connections", false, "Widen search to your Happenstance friends' connections (2nd-degree)")
 	cmd.Flags().BoolVar(&includeMyConnections, "include-my-connections", false, "Include your own LinkedIn-synced connections (1st-degree)")
+	cmd.Flags().BoolVar(&firstDegreeOnly, "first-degree-only", false, "Keep only results where you have a 1st-degree (self_graph) bridge. Implies --include-my-connections.")
+	cmd.Flags().Float64Var(&minScore, "min-score", 0, "Drop results with score below this threshold. 0 (default) disables the filter; >= 5 typically drops weak-signal public-graph hits. See docs/scoring.md.")
 	cmd.Flags().StringSliceVar(&groupIDs, "group-id", nil, "Group id to scope the search to (repeatable). Discover via 'api hpn groups list'")
 	cmd.Flags().IntVar(&budget, "budget", 0, "Max credits to spend per call. 0 disables the budget gate (default).")
 	cmd.Flags().IntVar(&pollTimeoutSec, "poll-timeout", int(api.DefaultPollTimeout.Seconds()), "Max seconds to wait for the async search to converge")
@@ -256,7 +278,10 @@ re-fetching after a find-more call to surface the additional results.`,
 			if err != nil {
 				return classifyHpnError(err)
 			}
-			return emitHpnSearchEnvelope(cmd, flags, env, env.Text)
+			// Re-fetch path: no filter flags, but still plumb currentUUID
+			// so the retag works correctly for the rendered output.
+			currentUUID := lookupCurrentUserUUID(flags)
+			return emitHpnSearchEnvelope(cmd, flags, env, env.Text, currentUUID, false, 0)
 		},
 	}
 	cmd.Flags().StringVar(&pageID, "page-id", "", "Page id from a previous find-more call (forwards as ?page_id=)")
@@ -293,14 +318,19 @@ func runHpnSearch(ctx context.Context, c *api.Client, text string, opts *api.Sea
 // emitHpnSearchEnvelope renders an api.SearchEnvelope to either a JSON
 // envelope (jq-friendly) or a human-readable table, honoring the
 // --json / --quiet / --compact root flags.
-func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchEnvelope, query string) error {
+//
+// currentUUID retags the user's own self-entry in envelope mutuals to
+// BridgeKindSelfGraph so renderers (and the --first-degree-only filter)
+// can distinguish 1st-degree from 2nd-degree. Pass "" to disable retag.
+//
+// firstDegreeOnly drops rows lacking any self_graph bridge after retag.
+// minScore drops rows with score < minScore (after bridge-affinity score
+// promotion). Both filters are post-fetch and cost no extra credits.
+func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchEnvelope, query string, currentUUID string, firstDegreeOnly bool, minScore float64) error {
 	results := make([]hpnSearchResult, 0, len(env.Results))
+	totalBeforeFilters := len(env.Results)
 	for _, r := range env.Results {
-		// `api hpn search` is a raw developer surface — the caller did
-		// not pass a currentUUID so we cannot retag the self-entry.
-		// Pass "" so every bridge shows up as a friend bridge (harmless;
-		// the raw endpoint JSON is meant to be grepped by humans).
-		p := api.ToClientPersonWithBridges(r, env.Mutuals, "")
+		p := api.ToClientPersonWithBridges(r, env.Mutuals, currentUUID)
 		row := hpnSearchResult{
 			Name:           p.Name,
 			CurrentTitle:   p.CurrentTitle,
@@ -315,7 +345,19 @@ func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchE
 				row.Score = score
 			}
 		}
+		if firstDegreeOnly && !hasSelfGraphBridge(p.Bridges) {
+			continue
+		}
+		if minScore > 0 && row.Score < minScore {
+			continue
+		}
 		results = append(results, row)
+	}
+	if (firstDegreeOnly || minScore > 0) && len(results) < totalBeforeFilters {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"filters dropped %d of %d results (--first-degree-only=%v, --min-score=%g)\n",
+			totalBeforeFilters-len(results), totalBeforeFilters, firstDegreeOnly, minScore,
+		)
 	}
 	out := hpnSearchEnvelope{
 		SearchID:  env.Id,
@@ -333,6 +375,20 @@ func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchE
 		return flags.printJSON(cmd, out)
 	}
 	return printHpnSearchTable(cmd.OutOrStdout(), out)
+}
+
+// lookupCurrentUserUUID best-effort fetches the authenticated user's
+// Happenstance UUID via the cookie surface so bearer searches can retag
+// self-bridges. Returns "" silently when cookie auth is unavailable or
+// the lookup fails — callers must tolerate empty currentUUID (every
+// bridge falls back to BridgeKindFriend, matching pre-2026-05 behavior).
+func lookupCurrentUserUUID(flags *rootFlags) string {
+	cookieClient, _ := flags.newClient()
+	if cookieClient == nil || !cookieClient.HasCookieAuth() {
+		return ""
+	}
+	uuid, _ := fetchCurrentUserUUID(cookieClient)
+	return uuid
 }
 
 func printHpnSearchTable(w io.Writer, env hpnSearchEnvelope) error {

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_search.go
@@ -79,6 +79,8 @@ func newAPIHpnSearchCmd(flags *rootFlags) *cobra.Command {
 		budget                    int
 		pollTimeoutSec            int
 		pollIntervalSec           int
+		allPages                  bool
+		maxResults                int
 	)
 
 	cmd := &cobra.Command{
@@ -110,6 +112,15 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 			}
 			if minScore < 0 {
 				return usageErr(fmt.Errorf("--min-score must be >= 0 (got %g)", minScore))
+			}
+			if maxResults < 0 {
+				return usageErr(fmt.Errorf("--max-results must be >= 0 (got %d)", maxResults))
+			}
+			if maxResults > 0 && !allPages {
+				return usageErr(fmt.Errorf("--max-results requires --all (it only caps the auto-pagination loop)"))
+			}
+			if allPages && maxResults == 0 && budget == 0 {
+				return usageErr(fmt.Errorf("--all requires at least one of --max-results N or --budget N to bound the credit spend"))
 			}
 
 			c, err := flags.newHappenstanceAPIClient()
@@ -152,7 +163,7 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 			}
 			pollOpts := buildPollSearchOptions(pollTimeoutSec, pollIntervalSec, "")
 
-			env, err := runHpnSearch(cmd.Context(), c, text, opts, pollOpts)
+			firstEnv, err := runHpnSearch(cmd.Context(), c, text, opts, pollOpts)
 			if err != nil {
 				return classifyHpnError(err)
 			}
@@ -166,7 +177,10 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 			// BridgeKindFriend, which matches today's behavior.
 			currentUUID := lookupCurrentUserUUID(flags)
 
-			return emitHpnSearchEnvelope(cmd, flags, env, text, currentUUID, firstDegreeOnly, minScore)
+			if !allPages {
+				return emitHpnSearchEnvelope(cmd, flags, firstEnv, text, currentUUID, firstDegreeOnly, minScore)
+			}
+			return runHpnSearchAll(cmd, flags, c, firstEnv, text, currentUUID, firstDegreeOnly, minScore, maxResults, budget, pollOpts)
 		},
 	}
 
@@ -174,6 +188,8 @@ and ` + "`api hpn search get <id> [--page-id ID]`" + `.`,
 	cmd.Flags().BoolVar(&includeMyConnections, "include-my-connections", false, "Include your own LinkedIn-synced connections (1st-degree)")
 	cmd.Flags().BoolVar(&firstDegreeOnly, "first-degree-only", false, "Keep only results where you have a 1st-degree (self_graph) bridge. Implies --include-my-connections.")
 	cmd.Flags().Float64Var(&minScore, "min-score", 0, "Drop results with score below this threshold. 0 (default) disables the filter; >= 5 typically drops weak-signal public-graph hits. See docs/scoring.md.")
+	cmd.Flags().BoolVar(&allPages, "all", false, "Auto-paginate via find-more until has_more=false, --max-results N, or --budget N. Each find-more spends 2 credits.")
+	cmd.Flags().IntVar(&maxResults, "max-results", 0, "Cap on raw results when --all is set. 0 (default) means unbounded; --all then requires --budget for safety.")
 	cmd.Flags().StringSliceVar(&groupIDs, "group-id", nil, "Group id to scope the search to (repeatable). Discover via 'api hpn groups list'")
 	cmd.Flags().IntVar(&budget, "budget", 0, "Max credits to spend per call. 0 disables the budget gate (default).")
 	cmd.Flags().IntVar(&pollTimeoutSec, "poll-timeout", int(api.DefaultPollTimeout.Seconds()), "Max seconds to wait for the async search to converge")
@@ -288,6 +304,81 @@ re-fetching after a find-more call to surface the additional results.`,
 	return cmd
 }
 
+// runHpnSearchAll wraps the single-page runHpnSearch + emit flow with an
+// auto-pagination loop. Each find-more call costs CreditCostPerFindMore
+// credits; the loop stops when has_more=false, the running raw-result
+// count reaches maxResults, the next call would exceed budget, or the
+// context is cancelled.
+//
+// Pre-conditions enforced upstream by RunE:
+//   - allPages is true
+//   - at least one of (maxResults > 0, budget > 0)
+//
+// On budget exhaustion or cap hit, accumulated results are still emitted
+// (rather than discarded) with a stderr notice explaining why pagination
+// stopped. Bearer 402 (out of credits) mid-loop bails the same way.
+func runHpnSearchAll(cmd *cobra.Command, flags *rootFlags, c *api.Client, firstEnv api.SearchEnvelope, query, currentUUID string, firstDegreeOnly bool, minScore float64, maxResults, budget int, pollOpts *api.PollSearchOptions) error {
+	allRows := normalizeHpnPage(firstEnv, currentUUID)
+	pagesFetched := 1
+	creditsSpent := CreditCostPerSearch
+
+	hasMore := firstEnv.HasMore
+	searchID := firstEnv.Id
+
+	for hasMore {
+		if maxResults > 0 && len(allRows) >= maxResults {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"reached --max-results %d after %d pages (%d credits spent); stopping pagination\n",
+				maxResults, pagesFetched, creditsSpent,
+			)
+			break
+		}
+		if budget > 0 && creditsSpent+CreditCostPerFindMore > budget {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"next find-more would exceed --budget %d (already spent %d); stopping pagination after %d pages\n",
+				budget, creditsSpent, pagesFetched,
+			)
+			break
+		}
+
+		fmEnv, fmErr := c.FindMore(cmd.Context(), searchID)
+		if fmErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"find-more failed after %d pages (%d credits spent), emitting accumulated results: %v\n",
+				pagesFetched, creditsSpent, fmErr,
+			)
+			break
+		}
+		creditsSpent += CreditCostPerFindMore
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"page %d: spent %d credits (%d total)\n",
+			pagesFetched+1, CreditCostPerFindMore, creditsSpent,
+		)
+
+		pageOpts := &api.PollSearchOptions{PageID: fmEnv.PageId}
+		if pollOpts != nil {
+			pageOpts.Timeout = pollOpts.Timeout
+			pageOpts.Interval = pollOpts.Interval
+		}
+		pageEnv, pollErr := c.PollSearch(cmd.Context(), searchID, pageOpts)
+		if pollErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"poll for page %d failed, emitting %d accumulated results: %v\n",
+				pagesFetched+1, len(allRows), pollErr,
+			)
+			break
+		}
+		allRows = append(allRows, normalizeHpnPage(pageEnv, currentUUID)...)
+		hasMore = pageEnv.HasMore
+		pagesFetched++
+	}
+
+	envMeta := firstEnv
+	envMeta.HasMore = hasMore
+	envMeta.NextPage = ""
+	return renderHpnEnvelope(cmd, flags, allRows, envMeta, query, firstDegreeOnly, minScore)
+}
+
 // runHpnSearch is the POST + poll loop, factored out so tests can drive
 // it directly against an httptest fixture without going through cobra.
 func runHpnSearch(ctx context.Context, c *api.Client, text string, opts *api.SearchOptions, pollOpts *api.PollSearchOptions) (api.SearchEnvelope, error) {
@@ -315,20 +406,12 @@ func runHpnSearch(ctx context.Context, c *api.Client, text string, opts *api.Sea
 	return final, nil
 }
 
-// emitHpnSearchEnvelope renders an api.SearchEnvelope to either a JSON
-// envelope (jq-friendly) or a human-readable table, honoring the
-// --json / --quiet / --compact root flags.
-//
-// currentUUID retags the user's own self-entry in envelope mutuals to
-// BridgeKindSelfGraph so renderers (and the --first-degree-only filter)
-// can distinguish 1st-degree from 2nd-degree. Pass "" to disable retag.
-//
-// firstDegreeOnly drops rows lacking any self_graph bridge after retag.
-// minScore drops rows with score < minScore (after bridge-affinity score
-// promotion). Both filters are post-fetch and cost no extra credits.
-func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchEnvelope, query string, currentUUID string, firstDegreeOnly bool, minScore float64) error {
-	results := make([]hpnSearchResult, 0, len(env.Results))
-	totalBeforeFilters := len(env.Results)
+// normalizeHpnPage projects one page's api.SearchResult rows into
+// hpnSearchResult rows. Bridge retag uses currentUUID; filters are NOT
+// applied here so the multi-page caller can accumulate raw rows then
+// filter once at emit time.
+func normalizeHpnPage(env api.SearchEnvelope, currentUUID string) []hpnSearchResult {
+	rows := make([]hpnSearchResult, 0, len(env.Results))
 	for _, r := range env.Results {
 		p := api.ToClientPersonWithBridges(r, env.Mutuals, currentUUID)
 		row := hpnSearchResult{
@@ -345,36 +428,85 @@ func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchE
 				row.Score = score
 			}
 		}
-		if firstDegreeOnly && !hasSelfGraphBridge(p.Bridges) {
-			continue
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// filterHpnRows applies --first-degree-only and --min-score to a row
+// slice, returning the surviving rows and the count dropped.
+func filterHpnRows(rows []hpnSearchResult, firstDegreeOnly bool, minScore float64) ([]hpnSearchResult, int) {
+	if !firstDegreeOnly && minScore <= 0 {
+		return rows, 0
+	}
+	out := make([]hpnSearchResult, 0, len(rows))
+	for _, row := range rows {
+		if firstDegreeOnly {
+			hasSelf := false
+			for _, b := range row.Bridges {
+				if b.Kind == "self_graph" {
+					hasSelf = true
+					break
+				}
+			}
+			if !hasSelf {
+				continue
+			}
 		}
 		if minScore > 0 && row.Score < minScore {
 			continue
 		}
-		results = append(results, row)
+		out = append(out, row)
 	}
-	if (firstDegreeOnly || minScore > 0) && len(results) < totalBeforeFilters {
+	return out, len(rows) - len(out)
+}
+
+// renderHpnEnvelope applies filters to a pre-normalized row slice and
+// writes the final JSON-or-table envelope. envMeta supplies envelope-level
+// metadata (search_id, status, has_more, etc.) since the caller may have
+// stitched multiple pages together.
+func renderHpnEnvelope(cmd *cobra.Command, flags *rootFlags, rows []hpnSearchResult, envMeta api.SearchEnvelope, query string, firstDegreeOnly bool, minScore float64) error {
+	totalBeforeFilters := len(rows)
+	filtered, dropped := filterHpnRows(rows, firstDegreeOnly, minScore)
+	if dropped > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"filters dropped %d of %d results (--first-degree-only=%v, --min-score=%g)\n",
-			totalBeforeFilters-len(results), totalBeforeFilters, firstDegreeOnly, minScore,
+			dropped, totalBeforeFilters, firstDegreeOnly, minScore,
 		)
 	}
 	out := hpnSearchEnvelope{
-		SearchID:  env.Id,
-		URL:       env.URL,
+		SearchID:  envMeta.Id,
+		URL:       envMeta.URL,
 		Query:     query,
-		Status:    env.Status,
+		Status:    envMeta.Status,
 		Source:    "api",
-		Completed: env.Status == api.StatusCompleted,
-		Count:     len(results),
-		Results:   results,
-		HasMore:   env.HasMore,
-		NextPage:  env.NextPage,
+		Completed: envMeta.Status == api.StatusCompleted,
+		Count:     len(filtered),
+		Results:   filtered,
+		HasMore:   envMeta.HasMore,
+		NextPage:  envMeta.NextPage,
 	}
 	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 		return flags.printJSON(cmd, out)
 	}
 	return printHpnSearchTable(cmd.OutOrStdout(), out)
+}
+
+// emitHpnSearchEnvelope renders an api.SearchEnvelope to either a JSON
+// envelope (jq-friendly) or a human-readable table, honoring the
+// --json / --quiet / --compact root flags. Single-page convenience that
+// composes normalizeHpnPage + renderHpnEnvelope.
+//
+// currentUUID retags the user's own self-entry in envelope mutuals to
+// BridgeKindSelfGraph so renderers (and the --first-degree-only filter)
+// can distinguish 1st-degree from 2nd-degree. Pass "" to disable retag.
+//
+// firstDegreeOnly drops rows lacking any self_graph bridge after retag.
+// minScore drops rows with score < minScore (after bridge-affinity score
+// promotion). Both filters are post-fetch and cost no extra credits.
+func emitHpnSearchEnvelope(cmd *cobra.Command, flags *rootFlags, env api.SearchEnvelope, query string, currentUUID string, firstDegreeOnly bool, minScore float64) error {
+	rows := normalizeHpnPage(env, currentUUID)
+	return renderHpnEnvelope(cmd, flags, rows, env, query, firstDegreeOnly, minScore)
 }
 
 // lookupCurrentUserUUID best-effort fetches the authenticated user's

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_test.go
@@ -323,7 +323,7 @@ func TestAPIHpnSearch_HappyPath(t *testing.T) {
 	cmd := &cobra.Command{}
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	if err := emitHpnSearchEnvelope(cmd, flags, env, "VPs at NBA"); err != nil {
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "VPs at NBA", "", false, 0); err != nil {
 		t.Fatalf("emitHpnSearchEnvelope: %v", err)
 	}
 	var decoded struct {
@@ -477,4 +477,242 @@ func runCmdWithStderrCapture(t *testing.T, root *cobra.Command, argv []string) (
 	os.Stderr = prev
 	captured, _ := io.ReadAll(r)
 	return out, string(captured), runErr
+}
+
+// --- 6. U1: currentUUID retag + --first-degree-only + --min-score ---
+
+// envelopeWithBridges builds a synthetic SearchEnvelope mirroring what
+// the bearer surface returns when both --include-my-connections and
+// --include-friends-connections are set. Three results, three mutuals:
+//
+//   - Carol (the caller) is index 0 in the envelope mutuals; Result[0]
+//     has a self-bridge to Carol (1st-degree, kind self_graph after retag).
+//   - Bob (a friend) is index 1; Result[1] has a friend bridge to Bob
+//     (2nd-degree, kind friend).
+//   - Eve (a public-graph match) is index 2; Result[2] has a weak
+//     bridge to Eve.
+//
+// Caller passes Carol's UUID as currentUUID to enable the self_graph retag.
+func envelopeWithBridges(t *testing.T) (api.SearchEnvelope, string) {
+	t.Helper()
+	carolUUID := "uuid-carol-self"
+	env := api.SearchEnvelope{
+		Id:     "srch_test",
+		Status: api.StatusCompleted,
+		Mutuals: []api.SearchMutual{
+			{Index: 0, Id: carolUUID, Name: "Carol Self"},
+			{Index: 1, Id: "uuid-bob-friend", Name: "Bob Friend"},
+			{Index: 2, Id: "uuid-eve-pub", Name: "Eve Public"},
+		},
+		Results: []api.SearchResult{
+			{
+				Name:                "Self-Bridged Person",
+				CurrentTitle:        "VP",
+				CurrentCompany:      "AcmeCo",
+				WeightedTraitsScore: 50.0,
+				Mutuals:             []api.ResultMutual{{Index: 0, AffinityScore: 50.0}},
+			},
+			{
+				Name:                "Friend-Bridged Person",
+				CurrentTitle:        "Director",
+				CurrentCompany:      "AcmeCo",
+				WeightedTraitsScore: 30.0,
+				Mutuals:             []api.ResultMutual{{Index: 1, AffinityScore: 30.0}},
+			},
+			{
+				Name:                "Weak-Signal Person",
+				CurrentTitle:        "Engineer",
+				CurrentCompany:      "OtherCo",
+				WeightedTraitsScore: 2.0,
+				Mutuals:             []api.ResultMutual{{Index: 2, AffinityScore: 0.0}},
+			},
+		},
+	}
+	return env, carolUUID
+}
+
+// decodedHpnBridge / decodedHpnResult / decodedHpnEnvelope are typed
+// projections of the JSON envelope emitHpnSearchEnvelope produces, used
+// by the U1 tests so assertions can target rows and bridge kinds without
+// juggling map[string]any.
+type decodedHpnBridge struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type decodedHpnResult struct {
+	Name    string             `json:"name"`
+	Score   float64            `json:"score"`
+	Bridges []decodedHpnBridge `json:"bridges"`
+}
+
+type decodedHpnEnvelope struct {
+	Count   int                `json:"count"`
+	Source  string             `json:"source"`
+	Results []decodedHpnResult `json:"results"`
+}
+
+// decodeHpnEnvelope walks the JSON output of emitHpnSearchEnvelope into
+// a typed struct so test assertions can target individual rows and
+// bridge kinds without juggling map[string]any.
+func decodeHpnEnvelope(t *testing.T, out *bytes.Buffer) decodedHpnEnvelope {
+	t.Helper()
+	var decoded decodedHpnEnvelope
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode envelope: %v\nout: %s", err, out.String())
+	}
+	return decoded
+}
+
+// TestEmitHpnSearchEnvelope_RetagsSelfGraphWithUUID is the regression
+// test for the U1 root-cause fix. With currentUUID plumbed, the self-bridge
+// retags to BridgeKindSelfGraph; without it (old behavior), all bridges
+// stay BridgeKindFriend and the agent cannot tell 1st-degree from 2nd.
+func TestEmitHpnSearchEnvelope_RetagsSelfGraphWithUUID(t *testing.T) {
+	env, currentUUID := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", currentUUID, false, 0); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 3 {
+		t.Fatalf("count = %d, want 3", got.Count)
+	}
+	// Result[0] must have a self_graph bridge after retag.
+	if len(got.Results[0].Bridges) != 1 || got.Results[0].Bridges[0].Kind != "self_graph" {
+		t.Errorf("results[0].bridges[0].kind = %v, want self_graph (carol's self-entry should retag)", got.Results[0].Bridges)
+	}
+	// Result[1] must remain a friend bridge (not the caller's self-entry).
+	if len(got.Results[1].Bridges) != 1 || got.Results[1].Bridges[0].Kind != "friend" {
+		t.Errorf("results[1].bridges[0].kind = %v, want friend", got.Results[1].Bridges)
+	}
+}
+
+// TestEmitHpnSearchEnvelope_RegressionEmptyUUIDForcesAllFriend documents
+// the pre-fix behavior so anyone reverting the U1 fix without realizing
+// it has a failing test to catch them. With currentUUID="", normalize.go's
+// retag is skipped and every bridge stays BridgeKindFriend — which is
+// why bearer-side searches couldn't tell 1st-degree from 2nd-degree.
+func TestEmitHpnSearchEnvelope_RegressionEmptyUUIDForcesAllFriend(t *testing.T) {
+	env, _ := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", "", false, 0); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	for i, r := range got.Results {
+		for j, b := range r.Bridges {
+			if b.Kind == "self_graph" {
+				t.Errorf("results[%d].bridges[%d].kind = self_graph; with empty currentUUID nothing should retag", i, j)
+			}
+		}
+	}
+}
+
+// TestEmitHpnSearchEnvelope_FirstDegreeOnly drops the friend-bridged and
+// weak-signal rows, keeping only the self-graph row.
+func TestEmitHpnSearchEnvelope_FirstDegreeOnly(t *testing.T) {
+	env, currentUUID := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", currentUUID, true, 0); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 1 {
+		t.Fatalf("count = %d, want 1 (only self-bridged kept)", got.Count)
+	}
+	if got.Results[0].Name != "Self-Bridged Person" {
+		t.Errorf("results[0].name = %q, want Self-Bridged Person", got.Results[0].Name)
+	}
+	if !strings.Contains(errBuf.String(), "filters dropped 2 of 3") {
+		t.Errorf("stderr should report 2 of 3 dropped, got: %s", errBuf.String())
+	}
+}
+
+// TestEmitHpnSearchEnvelope_MinScore drops below-threshold rows.
+func TestEmitHpnSearchEnvelope_MinScore(t *testing.T) {
+	env, currentUUID := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", currentUUID, false, 5); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	// Self-bridged (score 50) and friend-bridged (score 30) survive;
+	// weak-signal (score 2) is dropped.
+	if got.Count != 2 {
+		t.Fatalf("count = %d, want 2 (weak-signal score=2 dropped at min-score=5)", got.Count)
+	}
+	for _, r := range got.Results {
+		if r.Score < 5 {
+			t.Errorf("result %q score=%g below min-score=5", r.Name, r.Score)
+		}
+	}
+}
+
+// TestEmitHpnSearchEnvelope_FirstDegreeOnlyAndMinScore is the SF-task
+// shape: keep 1st-degree, drop weak-signal noise. Must intersect the
+// two filter outputs (only self-bridged AND score >= 5).
+func TestEmitHpnSearchEnvelope_FirstDegreeOnlyAndMinScore(t *testing.T) {
+	env, currentUUID := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", currentUUID, true, 5); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 1 || got.Results[0].Name != "Self-Bridged Person" {
+		t.Fatalf("count = %d (want 1), name = %q (want Self-Bridged Person)", got.Count, got.Results[0].Name)
+	}
+}
+
+// TestEmitHpnSearchEnvelope_MinScoreZeroIsNoOp confirms the default value
+// doesn't accidentally filter anything.
+func TestEmitHpnSearchEnvelope_MinScoreZeroIsNoOp(t *testing.T) {
+	env, currentUUID := envelopeWithBridges(t)
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := emitHpnSearchEnvelope(cmd, flags, env, "test", currentUUID, false, 0); err != nil {
+		t.Fatalf("emitHpnSearchEnvelope: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 3 {
+		t.Errorf("count = %d, want 3 (no filter)", got.Count)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("stderr should be empty when no filters set, got: %s", errBuf.String())
+	}
+}
+
+// TestAPIHpnSearch_NegativeMinScoreUsageErr confirms the flag-validation
+// path rejects --min-score values below 0 with a usage error. Sets
+// dryRun=true on rootFlags so the budget/credit-prompt paths short-circuit
+// before any client construction.
+func TestAPIHpnSearch_NegativeMinScoreUsageErr(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newAPIHpnRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"api", "hpn", "search", "--min-score", "-1", "test"})
+	if err == nil {
+		t.Fatal("want usage error for --min-score=-1")
+	}
+	if !strings.Contains(err.Error(), "--min-score") {
+		t.Errorf("error should mention --min-score, got: %v", err)
+	}
 }

--- a/library/sales-and-crm/contact-goat/internal/cli/api_hpn_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/api_hpn_test.go
@@ -28,11 +28,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -714,5 +716,198 @@ func TestAPIHpnSearch_NegativeMinScoreUsageErr(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--min-score") {
 		t.Errorf("error should mention --min-score, got: %v", err)
+	}
+}
+
+// --- 7. U2: --all auto-pagination + --max-results + budget gate ---
+
+// TestAPIHpnSearch_AllRequiresCap pins the safety guard: --all alone with
+// no --max-results AND no --budget is rejected as a usage error to prevent
+// unbounded credit spend.
+func TestAPIHpnSearch_AllRequiresCap(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newAPIHpnRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"api", "hpn", "search", "--all", "test"})
+	if err == nil {
+		t.Fatal("want usage error for --all without --max-results or --budget")
+	}
+	if !strings.Contains(err.Error(), "--all requires") {
+		t.Errorf("error should mention --all requires bound, got: %v", err)
+	}
+}
+
+// TestAPIHpnSearch_MaxResultsWithoutAllUsageErr: --max-results only makes
+// sense in pagination mode.
+func TestAPIHpnSearch_MaxResultsWithoutAllUsageErr(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newAPIHpnRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"api", "hpn", "search", "--max-results", "100", "test"})
+	if err == nil {
+		t.Fatal("want usage error for --max-results without --all")
+	}
+	if !strings.Contains(err.Error(), "--max-results requires --all") {
+		t.Errorf("error should mention --max-results requires --all, got: %v", err)
+	}
+}
+
+// newFakeBearerPaginatedServer stands up a multi-page fixture: each
+// page returns N rows with has_more=true until a configured page count
+// is reached. Tracks find-more invocations so tests can assert exact
+// pagination depth.
+type paginatedServer struct {
+	srv          *httptest.Server
+	findMoreHits *int32
+	pollHits     *int32
+}
+
+func newFakeBearerPaginatedServer(t *testing.T, pagesAvailable int, rowsPerPage int) *paginatedServer {
+	t.Helper()
+	var findMoreHits int32
+	var pollHits int32
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"srch_paginated","url":"https://h.ai/s/p"}`))
+	})
+	mux.HandleFunc("/search/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/find-more"):
+			n := atomic.AddInt32(&findMoreHits, 1)
+			pageID := fmt.Sprintf("page_%d", n)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"page_id":%q,"parent_search_id":"srch_paginated"}`, pageID)))
+		case r.Method == http.MethodGet:
+			n := atomic.AddInt32(&pollHits, 1)
+			pageID := r.URL.Query().Get("page_id")
+			pageNum := 1
+			if pageID != "" {
+				_, _ = fmt.Sscanf(pageID, "page_%d", &pageNum)
+				pageNum++ // page_1 is the second page
+			}
+			hasMore := pageNum < pagesAvailable
+			rows := make([]string, 0, rowsPerPage)
+			for i := 0; i < rowsPerPage; i++ {
+				rows = append(rows, fmt.Sprintf(`{"name":"P%d-R%d","weighted_traits_score":%d}`, pageNum, i+1, 50-i))
+			}
+			body := fmt.Sprintf(`{"id":"srch_paginated","status":"COMPLETED","results":[%s],"has_more":%v}`, strings.Join(rows, ","), hasMore)
+			_, _ = w.Write([]byte(body))
+			_ = n
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	return &paginatedServer{srv: srv, findMoreHits: &findMoreHits, pollHits: &pollHits}
+}
+
+// TestRunHpnSearchAll_HappyPath: 3 pages × 5 rows, no cap, accumulates
+// all 15 rows.
+func TestRunHpnSearchAll_HappyPath(t *testing.T) {
+	ps := newFakeBearerPaginatedServer(t, 3, 5)
+	defer ps.srv.Close()
+	c := api.NewClient("hpn_live_personal_test", api.WithBaseURL(ps.srv.URL))
+	firstEnv, err := runHpnSearch(context.Background(), c, "test", &api.SearchOptions{}, &api.PollSearchOptions{})
+	if err != nil {
+		t.Fatalf("runHpnSearch: %v", err)
+	}
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	if err := runHpnSearchAll(cmd, flags, c, firstEnv, "test", "", false, 0, 0, 100, &api.PollSearchOptions{}); err != nil {
+		t.Fatalf("runHpnSearchAll: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 15 {
+		t.Errorf("count = %d, want 15 (3 pages * 5 rows)", got.Count)
+	}
+	if atomic.LoadInt32(ps.findMoreHits) != 2 {
+		t.Errorf("find-more hits = %d, want 2 (pages 2 and 3 only; page 1 was the initial POST)", atomic.LoadInt32(ps.findMoreHits))
+	}
+}
+
+// TestRunHpnSearchAll_MaxResultsCap: hits the cap mid-pagination, emits
+// the partial set, prints a "reached --max-results" notice on stderr.
+func TestRunHpnSearchAll_MaxResultsCap(t *testing.T) {
+	ps := newFakeBearerPaginatedServer(t, 5, 5)
+	defer ps.srv.Close()
+	c := api.NewClient("hpn_live_personal_test", api.WithBaseURL(ps.srv.URL))
+	firstEnv, _ := runHpnSearch(context.Background(), c, "test", &api.SearchOptions{}, &api.PollSearchOptions{})
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	// Cap at 7: page 1 = 5 rows, page 2 brings total to 10 (>= 7), then
+	// loop checks the cap before fetching page 3.
+	if err := runHpnSearchAll(cmd, flags, c, firstEnv, "test", "", false, 0, 7, 0, &api.PollSearchOptions{}); err != nil {
+		t.Fatalf("runHpnSearchAll: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 10 {
+		t.Errorf("count = %d, want 10 (page 1 + page 2; loop stops before page 3 since count >= cap)", got.Count)
+	}
+	if !strings.Contains(errBuf.String(), "reached --max-results 7") {
+		t.Errorf("stderr should report cap reached, got: %s", errBuf.String())
+	}
+}
+
+// TestRunHpnSearchAll_BudgetExhaustion: budget allows 1 find-more; the
+// loop bails before the second find-more.
+func TestRunHpnSearchAll_BudgetExhaustion(t *testing.T) {
+	ps := newFakeBearerPaginatedServer(t, 5, 5)
+	defer ps.srv.Close()
+	c := api.NewClient("hpn_live_personal_test", api.WithBaseURL(ps.srv.URL))
+	firstEnv, _ := runHpnSearch(context.Background(), c, "test", &api.SearchOptions{}, &api.PollSearchOptions{})
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	// Budget 4: initial 2 + one find-more (2 more = 4). Next find-more
+	// would be 6, exceeding budget; loop bails.
+	if err := runHpnSearchAll(cmd, flags, c, firstEnv, "test", "", false, 0, 0, 4, &api.PollSearchOptions{}); err != nil {
+		t.Fatalf("runHpnSearchAll: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 10 {
+		t.Errorf("count = %d, want 10 (page 1 + page 2 = 10 rows; budget=4 stops before page 3)", got.Count)
+	}
+	if !strings.Contains(errBuf.String(), "exceed --budget 4") {
+		t.Errorf("stderr should report budget exceeded, got: %s", errBuf.String())
+	}
+}
+
+// TestRunHpnSearchAll_HasMoreFalseStopsImmediately: when the initial
+// page already has has_more=false, no find-more calls are made.
+func TestRunHpnSearchAll_HasMoreFalseStopsImmediately(t *testing.T) {
+	ps := newFakeBearerPaginatedServer(t, 1, 5)
+	defer ps.srv.Close()
+	c := api.NewClient("hpn_live_personal_test", api.WithBaseURL(ps.srv.URL))
+	firstEnv, _ := runHpnSearch(context.Background(), c, "test", &api.SearchOptions{}, &api.PollSearchOptions{})
+	if firstEnv.HasMore {
+		t.Fatalf("fixture seeded for single page should have HasMore=false, got true")
+	}
+	flags := &rootFlags{asJSON: true}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runHpnSearchAll(cmd, flags, c, firstEnv, "test", "", false, 0, 100, 100, &api.PollSearchOptions{}); err != nil {
+		t.Fatalf("runHpnSearchAll: %v", err)
+	}
+	got := decodeHpnEnvelope(t, &out)
+	if got.Count != 5 {
+		t.Errorf("count = %d, want 5 (single page only)", got.Count)
+	}
+	if atomic.LoadInt32(ps.findMoreHits) != 0 {
+		t.Errorf("find-more hits = %d, want 0 (has_more=false stops loop)", atomic.LoadInt32(ps.findMoreHits))
 	}
 }

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage.go
@@ -23,37 +23,80 @@ func newCoverageCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var sourceFlag string
 	var pollTimeoutSec int
+	var location string
 
 	cmd := &cobra.Command{
-		Use:   "coverage <company>",
+		Use:   "coverage [<company>]",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Show who you know at a company (LinkedIn + Happenstance)",
+		Short: "Show who you know at a company or in a location (LinkedIn + Happenstance)",
 		Long: `Cross-source "who do I know at X" query.
 
-Runs the following in parallel (source flag permitting):
+Scope: <company> positional OR --location <city>, not both. Company mode
+runs LinkedIn + Happenstance; location mode runs Happenstance bearer only
+(LinkedIn has no city-search semantic, and the cookie surface has no
+geographic primitive distinct from the keyword search the bearer surface
+already runs).
+
+Runs the following (in parallel where supported):
 
   1. Happenstance graph-search (/api/search + /api/dynamo): the real
      people-search the web app uses. Surfaces your 1st-degree (synced
      LinkedIn / Gmail contacts) and 2nd-degree (your friends' networks)
-     hits at the target company, with referrer rationale.
+     hits at the target, with referrer rationale.
   2. LinkedIn search_people scoped to the company name: a name-match
      fallback that catches people Happenstance doesn't have synced.
+     SKIPPED in --location mode.
 
 Results are deduped across sources and ranked:
   Happenstance 1st-degree  >  Happenstance 2nd-degree  >  LinkedIn 1st-degree  >  LinkedIn search hit.
 
-Use --source hp or --source li to isolate one side. JSON output gains a
-"source_errors" block whenever any upstream call errored, so callers can
-distinguish "empty because nobody is there" from "empty because the call
-failed".`,
+Use --source hp or --source li to isolate one side (company mode only).
+JSON output gains a "source_errors" block whenever any upstream call
+errored, so callers can distinguish "empty because nobody is there" from
+"empty because the call failed".`,
 		Example: `  contact-goat-pp-cli coverage stripe
   contact-goat-pp-cli coverage "OpenAI" --limit 10 --json
   contact-goat-pp-cli coverage airbnb --source hp
+  contact-goat-pp-cli coverage --location "San Francisco" --json
   contact-goat-pp-cli coverage disney --poll-timeout 300`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			hasPositional := len(args) == 1 && strings.TrimSpace(args[0]) != ""
+			loc := strings.TrimSpace(location)
+			if hasPositional && loc != "" {
+				return usageErr(fmt.Errorf("coverage: specify a company positional OR --location <city>, not both"))
+			}
+			if !hasPositional && loc == "" {
+				return usageErr(fmt.Errorf("coverage: specify a company positional or --location <city>"))
+			}
+			if loc != "" {
+				switch sourceFlag {
+				case SourceFlagAuto, SourceFlagAPI, SourceFlagBoth, "":
+					// ok - location mode silently routes to bearer-only.
+				case SourceFlagCookie:
+					return usageErr(fmt.Errorf("coverage --location: --source hp not supported (cookie surface has no city-search); use --source api or omit --source"))
+				case SourceFlagLI:
+					return usageErr(fmt.Errorf("coverage --location: --source li not supported (LinkedIn has no city-search); use --source api or omit --source"))
+				}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			company := args[0]
-			sources := parseSourceFlag(sourceFlag)
+			var company, locationQuery string
+			if loc := strings.TrimSpace(location); loc != "" {
+				locationQuery = loc
+			} else {
+				company = args[0]
+			}
+			isLocation := locationQuery != ""
+
+			effectiveSourceFlag := sourceFlag
+			if isLocation {
+				// Location mode: force bearer-only regardless of what the
+				// user passed (PreRunE already rejected hp / li).
+				effectiveSourceFlag = SourceFlagAPI
+			}
+			sources := parseSourceFlag(effectiveSourceFlag)
 			ctx, cancel := signalCtx(cmd.Context())
 			defer cancel()
 
@@ -68,7 +111,11 @@ failed".`,
 			// respective surface; --source both fans out cookie+LinkedIn
 			// with bearer used only on cookie 429.
 			if sources[SourceFlagCookie] || sources[SourceFlagAPI] {
-				graphPeople, hpErrs := runCoverageHappenstance(cmd, flags, company, pollTimeoutSec, sources)
+				bearerQuery := "people at " + company
+				if isLocation {
+					bearerQuery = "my connections in " + locationQuery
+				}
+				graphPeople, hpErrs := runCoverageHappenstance(cmd, flags, company, bearerQuery, pollTimeoutSec, sources)
 				for k, v := range hpErrs {
 					sourceErrors[k] = v
 				}
@@ -147,14 +194,26 @@ failed".`,
 
 			persistPeople(results)
 
+			scope := company
+			scopeKind := "company"
+			if isLocation {
+				scope = locationQuery
+				scopeKind = "location"
+			}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				out := map[string]any{
-					"company":   company,
 					"results":   results,
 					"count":     len(results),
 					"sources":   sourcesSummary(sources),
 					"timestamp": nowISO(),
 				}
+				if isLocation {
+					out["location"] = locationQuery
+				} else {
+					out["company"] = company
+				}
+				out["scope"] = scope
+				out["scope_kind"] = scopeKind
 				if len(sourceErrors) > 0 {
 					out["source_errors"] = sourceErrors
 				}
@@ -169,14 +228,15 @@ failed".`,
 				}
 				fmt.Fprintln(cmd.ErrOrStderr())
 			}
-			return printCoverageTable(cmd, company, results)
+			return printCoverageTable(cmd, scope, results)
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max people to return")
-	cmd.Flags().StringVar(&sourceFlag, "source", "both", "Sources: li | hp | api | both. hp = cookie/free quota; api = bearer/paid credits; both = LinkedIn + auto-routed Happenstance")
+	cmd.Flags().StringVar(&sourceFlag, "source", "both", "Sources: li | hp | api | both. hp = cookie/free quota; api = bearer/paid credits; both = LinkedIn + auto-routed Happenstance. Forced to api in --location mode.")
 	cmd.Flags().IntVar(&pollTimeoutSec, "poll-timeout", 0,
 		fmt.Sprintf("Seconds to wait for Happenstance graph-search (0 = use default %ds)",
 			int(client.DefaultPollTimeout.Seconds())))
+	cmd.Flags().StringVar(&location, "location", "", "Search by location instead of company; routes to bearer-only (--source api). Mutually exclusive with the company positional.")
 	return cmd
 }
 
@@ -194,7 +254,7 @@ failed".`,
 // The function takes a *cobra.Command for stderr-routed warnings (so
 // output stays consistent with the rest of coverage) and the parsed
 // sources map to honor the explicit --source api / --source hp overrides.
-func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company string, pollTimeoutSec int, sources map[string]bool) ([]flagshipPerson, map[string]string) {
+func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company, bearerQuery string, pollTimeoutSec int, sources map[string]bool) ([]flagshipPerson, map[string]string) {
 	errs := map[string]string{}
 
 	// Translate the parsed source flag into the explicit-source string
@@ -236,9 +296,14 @@ func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company strin
 	// Cookie runner reuses the existing SearchPeopleByCompanyWithOptions
 	// path so the rich /api/dynamo schema (referrers, current user uuid)
 	// keeps flowing through downstream renderers unchanged.
+	//
+	// In --location mode, sources[SourceFlagCookie] is false (PreRunE
+	// rejects --source hp with --location, and the explicit auto-route
+	// forces SourceFlagAPI), so cookieRun stays nil and only bearer is
+	// invoked. The bearer query carries the location-style text.
 	currentUUID := ""
 	cookieRun := CookieRunner(nil)
-	if cookieAvailable {
+	if cookieAvailable && company != "" {
 		currentUUID, _ = fetchCurrentUserUUID(cookieClient)
 		var hpOpts *client.SearchPeopleOptions
 		if pollTimeoutSec > 0 {
@@ -251,6 +316,10 @@ func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company strin
 		cookieRun = func() (*client.PeopleSearchResult, error) {
 			return cookieClient.SearchPeopleByCompanyWithOptions(company, hpOpts)
 		}
+	} else if cookieAvailable {
+		// Location mode: keep currentUUID for bearer retag even though
+		// cookieRun stays nil.
+		currentUUID, _ = fetchCurrentUserUUID(cookieClient)
 	}
 
 	// Bearer runner is constructed only when a key is configured.
@@ -261,7 +330,7 @@ func runCoverageHappenstance(cmd *cobra.Command, flags *rootFlags, company strin
 	var bearerRun BearerRunner
 	if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
 		bearerRun = func() (*client.PeopleSearchResult, error) {
-			return BearerSearchAdapter(cmd.Context(), bc, "people at "+company, currentUUID, nil)
+			return BearerSearchAdapter(cmd.Context(), bc, bearerQuery, currentUUID, nil)
 		}
 	}
 

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// coverage_test.go: PreRunE validation tests for the coverage command.
+// Full integration tests (cookie/bearer fan-out) live in source_selection_test.go;
+// this file is scoped to the U3 --location flag's argument-validation contract.
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newCoverageRootCmd builds a stripped-down root that mounts only the
+// coverage subcommand. Mirrors newAPIHpnRootCmd's pattern in
+// api_hpn_test.go so PreRunE validation can be exercised without
+// dragging in unrelated init.
+func newCoverageRootCmd(t *testing.T, flags *rootFlags) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "contact-goat-pp-cli", SilenceUsage: true, SilenceErrors: true}
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.AddCommand(newCoverageCmd(flags))
+	return root
+}
+
+// TestCoverage_RejectsBothPositionalAndLocation: cobra accepts the
+// invocation, PreRunE rejects with a usage error.
+func TestCoverage_RejectsBothPositionalAndLocation(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newCoverageRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"coverage", "Stripe", "--location", "San Francisco"})
+	if err == nil {
+		t.Fatal("want usage error when both positional and --location are set")
+	}
+	if !strings.Contains(err.Error(), "OR --location") {
+		t.Errorf("error should mention positional-or-location exclusivity, got: %v", err)
+	}
+}
+
+// TestCoverage_RejectsNeitherPositionalNorLocation: zero positional
+// args AND no --location is a usage error.
+func TestCoverage_RejectsNeitherPositionalNorLocation(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newCoverageRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"coverage"})
+	if err == nil {
+		t.Fatal("want usage error when neither positional nor --location is set")
+	}
+	if !strings.Contains(err.Error(), "company positional or --location") {
+		t.Errorf("error should mention positional-or-location requirement, got: %v", err)
+	}
+}
+
+// TestCoverage_RejectsLocationWithCookieSource: --location mode requires
+// bearer-only; explicit --source hp is a usage error.
+func TestCoverage_RejectsLocationWithCookieSource(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newCoverageRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"coverage", "--location", "San Francisco", "--source", "hp"})
+	if err == nil {
+		t.Fatal("want usage error for --location --source hp")
+	}
+	if !strings.Contains(err.Error(), "--source hp not supported") {
+		t.Errorf("error should explain cookie surface limitation, got: %v", err)
+	}
+}
+
+// TestCoverage_RejectsLocationWithLISource: --location mode rejects
+// --source li explicitly (LinkedIn has no city-search).
+func TestCoverage_RejectsLocationWithLISource(t *testing.T) {
+	flags := &rootFlags{dryRun: true, yes: true}
+	root := newCoverageRootCmd(t, flags)
+	_, _, err := runCmd(t, root, []string{"coverage", "--location", "San Francisco", "--source", "li"})
+	if err == nil {
+		t.Fatal("want usage error for --location --source li")
+	}
+	if !strings.Contains(err.Error(), "--source li not supported") {
+		t.Errorf("error should explain LinkedIn limitation, got: %v", err)
+	}
+}
+
+// TestCoverage_HelpRendersWithLocationFlag: smoke test that --help
+// surfaces the new flag without panic. Locks SKILL.md / verifier
+// expectations: --location must be a registered flag on the cobra
+// command.
+func TestCoverage_HelpRendersWithLocationFlag(t *testing.T) {
+	flags := &rootFlags{}
+	root := newCoverageRootCmd(t, flags)
+	out, _, err := runCmd(t, root, []string{"coverage", "--help"})
+	if err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out, "--location") {
+		t.Errorf("help should document --location, got:\n%s", out)
+	}
+	if !strings.Contains(out, "positional OR --location") {
+		t.Errorf("help should describe scope choice, got:\n%s", out)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/doctor.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/doctor.go
@@ -322,15 +322,62 @@ func checkHappenstanceGraphCoverage(flags *rootFlags, report map[string]any) {
 	}
 	entry := resp.Statuses.LinkedInExt[0]
 	age := ""
+	freshness := graphFreshnessUnknown
 	if ts, err := time.Parse(time.RFC3339, entry.LastRefreshed); err == nil {
-		age = fmt.Sprintf(" (%s ago)", humanAge(time.Since(ts)))
+		elapsed := time.Since(ts)
+		age = fmt.Sprintf(" (%s ago)", humanAge(elapsed))
+		freshness = classifyGraphFreshness(elapsed)
 	}
 	status := entry.Status
 	if entry.IsError {
 		status = "ERROR"
 	}
-	report["happenstance_graph"] = fmt.Sprintf("linkedin_ext: %s, last refreshed %s%s",
-		status, fallbackStr(entry.LastRefreshed, "unknown"), age)
+	freshnessTag := ""
+	switch freshness {
+	case graphFreshnessStale:
+		freshnessTag = " [STALE — re-upload at https://happenstance.ai/connections]"
+	case graphFreshnessVeryStale:
+		freshnessTag = " [VERY STALE — re-upload at https://happenstance.ai/connections]"
+	}
+	report["happenstance_graph"] = fmt.Sprintf("linkedin_ext: %s, last refreshed %s%s%s",
+		status, fallbackStr(entry.LastRefreshed, "unknown"), age, freshnessTag)
+	report["happenstance_graph_status"] = string(freshness)
+}
+
+// graphFreshness names the staleness bucket for the LinkedIn graph
+// upload. Surfaced on the doctor JSON envelope as
+// happenstance_graph_status so programmatic callers can react without
+// parsing prose.
+type graphFreshness string
+
+const (
+	graphFreshnessOK        graphFreshness = "ok"
+	graphFreshnessStale     graphFreshness = "stale"
+	graphFreshnessVeryStale graphFreshness = "very_stale"
+	graphFreshnessUnknown   graphFreshness = "unknown"
+)
+
+// graphStaleThreshold and graphVeryStaleThreshold gate the doctor's
+// stale-graph warning. 90/180 days are conservative defaults: the SF
+// tasks that motivated U4 ran fine on a 9-month-old graph, so a 30-day
+// trigger would have cried wolf on a working setup. 90 days catches
+// degradation before the 180-day "you really need to re-upload" mark.
+const (
+	graphStaleThreshold     = 90 * 24 * time.Hour
+	graphVeryStaleThreshold = 180 * 24 * time.Hour
+)
+
+// classifyGraphFreshness maps an elapsed-since-refresh duration to one
+// of the freshness buckets used by checkHappenstanceGraphCoverage.
+func classifyGraphFreshness(elapsed time.Duration) graphFreshness {
+	switch {
+	case elapsed >= graphVeryStaleThreshold:
+		return graphFreshnessVeryStale
+	case elapsed >= graphStaleThreshold:
+		return graphFreshnessStale
+	default:
+		return graphFreshnessOK
+	}
 }
 
 func trimErr(s string) string {

--- a/library/sales-and-crm/contact-goat/internal/cli/doctor_graph_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/doctor_graph_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// doctor_graph_test.go: unit tests for the U4 stale-graph classifier in
+// doctor.go. The full doctor flow has integration coverage in
+// doctor_happenstance_api_test.go; this file is scoped to the
+// classifyGraphFreshness boundary cases.
+
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassifyGraphFreshness(t *testing.T) {
+	cases := []struct {
+		name    string
+		elapsed time.Duration
+		want    graphFreshness
+	}{
+		{"fresh: 1 day", 1 * 24 * time.Hour, graphFreshnessOK},
+		{"fresh: 30 days (under stale threshold)", 30 * 24 * time.Hour, graphFreshnessOK},
+		{"fresh: 89 days (just under stale)", 89 * 24 * time.Hour, graphFreshnessOK},
+		{"stale boundary: exactly 90 days", graphStaleThreshold, graphFreshnessStale},
+		{"stale: 120 days", 120 * 24 * time.Hour, graphFreshnessStale},
+		{"stale: 179 days (just under very_stale)", 179 * 24 * time.Hour, graphFreshnessStale},
+		{"very_stale boundary: exactly 180 days", graphVeryStaleThreshold, graphFreshnessVeryStale},
+		{"very_stale: 9 months", 270 * 24 * time.Hour, graphFreshnessVeryStale},
+		{"very_stale: 1 year", 365 * 24 * time.Hour, graphFreshnessVeryStale},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyGraphFreshness(tc.elapsed)
+			if got != tc.want {
+				t.Errorf("classifyGraphFreshness(%s) = %q, want %q", tc.elapsed, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGraphFreshnessThresholds locks the 90/180-day choice. SF-task
+// evidence (live session 2026-04-19) shows queries succeed on a
+// 9-month-old graph, so a 30-day stale trigger would have falsely
+// flagged a working setup. 90 days catches genuine degradation; 180
+// days marks "definitely needs re-upload". If thresholds change, this
+// test forces the contributor to revisit the rationale.
+func TestGraphFreshnessThresholds(t *testing.T) {
+	if graphStaleThreshold != 90*24*time.Hour {
+		t.Errorf("graphStaleThreshold = %s, want 90 days (SF-task evidence; see U4 plan)", graphStaleThreshold)
+	}
+	if graphVeryStaleThreshold != 180*24*time.Hour {
+		t.Errorf("graphVeryStaleThreshold = %s, want 180 days", graphVeryStaleThreshold)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/hp_people.go
@@ -9,8 +9,10 @@ package cli
 // 3rd-degree tiers.
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,6 +138,9 @@ connected. The RELATIONSHIP column shows 1st_degree / 2nd_degree /
 				res.People = res.People[:limit]
 			}
 
+			if flags.csv {
+				return printHPPeopleCSV(cmd, res, currentUserUUID)
+			}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				out := buildHPPeopleJSON(res, currentUserUUID)
 				enc := json.NewEncoder(cmd.OutOrStdout())
@@ -272,6 +277,113 @@ func printHPPeopleTable(cmd *cobra.Command, res *client.PeopleSearchResult, curr
 		)
 	}
 	return tw.Flush()
+}
+
+// printHPPeopleCSV emits the people-search result as flat CSV with a
+// stable column contract designed for spreadsheet and agent piping.
+// The bridges[] array is denormalized into three semicolon-joined
+// columns (bridge_count, bridge_names, bridge_kinds) plus a
+// top_bridge_affinity scalar so cardinality and identity survive
+// flattening without going long-form. Consumers needing the structured
+// form should use --json instead.
+//
+// Columns (stable):
+//   name | current_title | current_company | linkedin_url | score |
+//   relationship_tier | bridge_count | bridge_names | bridge_kinds |
+//   top_bridge_affinity | rationale
+//
+// relationship_tier derives from the strongest bridge's kind:
+// self_graph -> 1st_degree, friend -> 2nd_degree, no bridge -> the
+// referrer-chain tier (or 3rd_degree when even that is empty).
+func printHPPeopleCSV(cmd *cobra.Command, res *client.PeopleSearchResult, currentUserUUID string) error {
+	w := csv.NewWriter(cmd.OutOrStdout())
+	header := []string{
+		"name", "current_title", "current_company", "linkedin_url", "score",
+		"relationship_tier", "bridge_count", "bridge_names", "bridge_kinds",
+		"top_bridge_affinity", "rationale",
+	}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, p := range res.People {
+		score := p.Score
+		rationale := ""
+		if len(p.Bridges) > 0 {
+			if bs := bearerScore(p.Bridges, p.Score); bs > score {
+				score = bs
+			}
+			rationale = bearerRationale(p.Bridges)
+		}
+		tier := relationshipTierForCSV(p, currentUserUUID)
+		bridgeCount, bridgeNames, bridgeKinds, topAffinity := summarizeBridges(p.Bridges)
+
+		row := []string{
+			p.Name,
+			p.CurrentTitle,
+			p.CurrentCompany,
+			p.LinkedInURL,
+			strconv.FormatFloat(score, 'f', -1, 64),
+			tier,
+			strconv.Itoa(bridgeCount),
+			bridgeNames,
+			bridgeKinds,
+			formatAffinity(topAffinity),
+			rationale,
+		}
+		if err := w.Write(row); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+// relationshipTierForCSV picks the strongest tier signal across both
+// the bridge list (bearer surface) and the referrer chain (cookie
+// surface). Bridges win when present because the bearer surface is the
+// only place self-graph signal lives explicitly.
+func relationshipTierForCSV(p client.Person, currentUserUUID string) string {
+	if hasSelfGraphBridge(p.Bridges) {
+		return string(client.TierFirstDegree)
+	}
+	for _, b := range p.Bridges {
+		if b.Kind == client.BridgeKindFriend {
+			return string(client.TierSecondDegree)
+		}
+	}
+	return string(p.Tier(currentUserUUID))
+}
+
+// summarizeBridges flattens a Bridge slice into the four CSV scalars
+// that preserve cardinality + identity without going long-form. Names
+// and kinds are semicolon-joined in the same order as the input slice
+// so callers can re-zip them. top_bridge_affinity is the max across
+// the slice (0 when the slice is empty).
+func summarizeBridges(bridges []client.Bridge) (count int, names string, kinds string, topAffinity float64) {
+	count = len(bridges)
+	if count == 0 {
+		return 0, "", "", 0
+	}
+	nameParts := make([]string, 0, count)
+	kindParts := make([]string, 0, count)
+	for _, b := range bridges {
+		nameParts = append(nameParts, b.Name)
+		kindParts = append(kindParts, b.Kind)
+		if b.AffinityScore > topAffinity {
+			topAffinity = b.AffinityScore
+		}
+	}
+	return count, strings.Join(nameParts, ";"), strings.Join(kindParts, ";"), topAffinity
+}
+
+// formatAffinity renders an affinity score for the CSV column. Empty
+// string for zero so spreadsheet consumers see a blank cell rather
+// than "0" when no bridges contributed signal.
+func formatAffinity(f float64) string {
+	if f == 0 {
+		return ""
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 // fetchCurrentUserUUID pulls the current user's Happenstance uuid from

--- a/library/sales-and-crm/contact-goat/internal/cli/hp_people_csv_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/hp_people_csv_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// hp_people_csv_test.go: tests for the U7 CSV emitter on hp people.
+// The CSV path replaces the silently-broken global --csv that produced
+// "[{...} {...}]" Go-slice junk for nested bridges; this file pins the
+// stable column contract and the bridge denormalization rules.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/internal/client"
+)
+
+// runHPPeopleCSVOnFixture is the test driver: build a cobra command,
+// pipe stdout into a buffer, run printHPPeopleCSV, return parsed rows.
+func runHPPeopleCSVOnFixture(t *testing.T, res *client.PeopleSearchResult, currentUUID string) [][]string {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := printHPPeopleCSV(cmd, res, currentUUID); err != nil {
+		t.Fatalf("printHPPeopleCSV: %v", err)
+	}
+	r := csv.NewReader(strings.NewReader(buf.String()))
+	r.FieldsPerRecord = -1
+	rows, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("parse CSV output: %v\nraw:\n%s", err, buf.String())
+	}
+	return rows
+}
+
+func TestPrintHPPeopleCSV_HeaderColumns(t *testing.T) {
+	rows := runHPPeopleCSVOnFixture(t, &client.PeopleSearchResult{}, "")
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1 (header only)", len(rows))
+	}
+	want := []string{
+		"name", "current_title", "current_company", "linkedin_url", "score",
+		"relationship_tier", "bridge_count", "bridge_names", "bridge_kinds",
+		"top_bridge_affinity", "rationale",
+	}
+	if len(rows[0]) != len(want) {
+		t.Fatalf("header has %d columns, want %d. got: %v", len(rows[0]), len(want), rows[0])
+	}
+	for i, name := range want {
+		if rows[0][i] != name {
+			t.Errorf("col[%d] = %q, want %q", i, rows[0][i], name)
+		}
+	}
+}
+
+func TestPrintHPPeopleCSV_SelfGraphIs1stDegree(t *testing.T) {
+	res := &client.PeopleSearchResult{
+		People: []client.Person{{
+			Name:           "Alice Self",
+			CurrentTitle:   "VP",
+			CurrentCompany: "Acme",
+			LinkedInURL:    "https://linkedin.com/in/alice",
+			Score:          50,
+			Bridges: []client.Bridge{
+				{Name: "Matt Self", Kind: client.BridgeKindSelfGraph, AffinityScore: 50},
+			},
+		}},
+	}
+	rows := runHPPeopleCSVOnFixture(t, res, "")
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (header + 1)", len(rows))
+	}
+	row := rows[1]
+	if got, want := row[5], string(client.TierFirstDegree); got != want {
+		t.Errorf("relationship_tier = %q, want %q (self_graph bridge present)", got, want)
+	}
+	if got, want := row[6], "1"; got != want {
+		t.Errorf("bridge_count = %q, want %q", got, want)
+	}
+	if got, want := row[7], "Matt Self"; got != want {
+		t.Errorf("bridge_names = %q, want %q", got, want)
+	}
+	if got, want := row[8], "self_graph"; got != want {
+		t.Errorf("bridge_kinds = %q, want %q", got, want)
+	}
+}
+
+func TestPrintHPPeopleCSV_MultipleBridgesSemicolonJoined(t *testing.T) {
+	res := &client.PeopleSearchResult{
+		People: []client.Person{{
+			Name:  "Bob Multi",
+			Score: 30,
+			Bridges: []client.Bridge{
+				{Name: "Carol", Kind: client.BridgeKindFriend, AffinityScore: 25},
+				{Name: "Dave", Kind: client.BridgeKindFriend, AffinityScore: 40},
+				{Name: "Eve", Kind: client.BridgeKindFriend, AffinityScore: 10},
+			},
+		}},
+	}
+	rows := runHPPeopleCSVOnFixture(t, res, "")
+	row := rows[1]
+	if got, want := row[6], "3"; got != want {
+		t.Errorf("bridge_count = %q, want %q", got, want)
+	}
+	if got, want := row[7], "Carol;Dave;Eve"; got != want {
+		t.Errorf("bridge_names = %q, want %q (semicolon-joined, original order)", got, want)
+	}
+	if got, want := row[8], "friend;friend;friend"; got != want {
+		t.Errorf("bridge_kinds = %q, want %q", got, want)
+	}
+	if got, want := row[9], "40"; got != want {
+		t.Errorf("top_bridge_affinity = %q, want %q (max of 25, 40, 10)", got, want)
+	}
+}
+
+func TestPrintHPPeopleCSV_NoBridgesEmptyCells(t *testing.T) {
+	res := &client.PeopleSearchResult{
+		People: []client.Person{{
+			Name:  "Carol Public",
+			Score: 2,
+		}},
+	}
+	rows := runHPPeopleCSVOnFixture(t, res, "")
+	row := rows[1]
+	if got, want := row[6], "0"; got != want {
+		t.Errorf("bridge_count = %q, want %q (no bridges)", got, want)
+	}
+	if row[7] != "" {
+		t.Errorf("bridge_names = %q, want empty string for zero bridges", row[7])
+	}
+	if row[9] != "" {
+		t.Errorf("top_bridge_affinity = %q, want empty string for zero bridges", row[9])
+	}
+}
+
+func TestPrintHPPeopleCSV_NameWithCommaIsQuoted(t *testing.T) {
+	res := &client.PeopleSearchResult{
+		People: []client.Person{{
+			Name: "Smith, John",
+		}},
+	}
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := printHPPeopleCSV(cmd, res, ""); err != nil {
+		t.Fatalf("printHPPeopleCSV: %v", err)
+	}
+	// stdlib encoding/csv quotes fields containing commas. Just confirm
+	// that the first data line begins with a quoted name.
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d output lines, want 2", len(lines))
+	}
+	if !strings.HasPrefix(lines[1], `"Smith, John"`) {
+		t.Errorf("expected first column to be quoted name, got: %q", lines[1])
+	}
+}
+
+func TestPrintHPPeopleCSV_EmptyResultProducesHeaderOnly(t *testing.T) {
+	rows := runHPPeopleCSVOnFixture(t, &client.PeopleSearchResult{}, "")
+	if len(rows) != 1 {
+		t.Errorf("got %d rows, want 1 (header only on empty result)", len(rows))
+	}
+}
+
+func TestSummarizeBridges_OrderPreservation(t *testing.T) {
+	in := []client.Bridge{
+		{Name: "B", Kind: "friend", AffinityScore: 5},
+		{Name: "A", Kind: "self_graph", AffinityScore: 50},
+		{Name: "C", Kind: "friend", AffinityScore: 12},
+	}
+	count, names, kinds, top := summarizeBridges(in)
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+	if names != "B;A;C" {
+		t.Errorf("names = %q, want B;A;C (preserve input order)", names)
+	}
+	if kinds != "friend;self_graph;friend" {
+		t.Errorf("kinds = %q, want friend;self_graph;friend (preserve input order)", kinds)
+	}
+	if top != 50 {
+		t.Errorf("top = %g, want 50", top)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
@@ -390,6 +390,16 @@ func ExecuteWithSourceFallback(
 	if err == nil {
 		return FallbackResult{Result: res, UsedSource: SourceCookie}, nil
 	}
+	if errors.Is(err, client.ErrCookieBroadQuery) {
+		// Cookie surface bailed early on a broad query (poll-timeout,
+		// 5xx upstream, or stuck "Thinking" status past 90s). Surface a
+		// hint pointing at the bearer surface and exit 5 (API error)
+		// rather than retrying or falling through to a generic error.
+		// Auto-fallback to bearer is intentionally not done: the user
+		// did not authorize spending credits on this call.
+		fmt.Fprintln(errOut, "cookie surface timed out (likely a broad query). Retry with --source api to use the bearer surface (2 credits/call).")
+		return FallbackResult{UsedSource: SourceCookie}, apiErr(err)
+	}
 	if !IsCookieRateLimitError(err) {
 		// Non-429 cookie error: surface verbatim. We do NOT silently fall
 		// back to the bearer surface on arbitrary cookie failures (auth

--- a/library/sales-and-crm/contact-goat/internal/cli/source_selection_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/source_selection_test.go
@@ -404,6 +404,47 @@ func TestExecuteWithSourceFallback_BearerSourceDirect(t *testing.T) {
 	}
 }
 
+// TestExecuteWithSourceFallback_CookieBroadQueryHint confirms that
+// ErrCookieBroadQuery from the cookie runner triggers the
+// bearer-fallback hint on stderr and exits 5 (apiErr) without invoking
+// the bearer runner. Auto-fallback to bearer is intentionally NOT done
+// because the user did not authorize spending credits.
+func TestExecuteWithSourceFallback_CookieBroadQueryHint(t *testing.T) {
+	bearerCalled := false
+	var errBuf bytes.Buffer
+	out, err := ExecuteWithSourceFallback(
+		context.Background(),
+		SourceCookie,
+		func() (*client.PeopleSearchResult, error) {
+			return nil, fmt.Errorf("%w: poll timeout", client.ErrCookieBroadQuery)
+		},
+		func() (*client.PeopleSearchResult, error) {
+			bearerCalled = true
+			return &client.PeopleSearchResult{}, nil
+		},
+		&errBuf,
+	)
+	if err == nil {
+		t.Fatal("want apiErr from broad-query failure")
+	}
+	var ce *cliError
+	if !errors.As(err, &ce) {
+		t.Fatalf("want *cliError, got %T (%v)", err, err)
+	}
+	if ce.code != 5 {
+		t.Errorf("exit code = %d, want 5 (apiErr)", ce.code)
+	}
+	if !strings.Contains(errBuf.String(), "--source api") {
+		t.Errorf("stderr should hint --source api, got: %s", errBuf.String())
+	}
+	if bearerCalled {
+		t.Error("bearer runner must NOT be auto-invoked on broad-query failure (would silently spend credits)")
+	}
+	if out.UsedSource != SourceCookie {
+		t.Errorf("UsedSource = %q, want SourceCookie", out.UsedSource)
+	}
+}
+
 // TestExecuteWithSourceFallback_BearerNilRunnerErrors guards against
 // the call site forgetting to construct a bearer runner when the
 // selected source is SourceAPI. The wrapper must surface the canonical

--- a/library/sales-and-crm/contact-goat/internal/client/people_search.go
+++ b/library/sales-and-crm/contact-goat/internal/client/people_search.go
@@ -61,6 +61,27 @@ type SearchPeopleOptions struct {
 // frequent false failures on legitimate queries.
 const DefaultPollTimeout = 180 * time.Second
 
+// BroadQueryStuckThreshold is the elapsed-time threshold past which a
+// search whose status string still indicates the server is "Thinking"
+// is treated as a broad-query failure rather than a slow-but-progressing
+// search. Bails at 90s (half the default poll timeout) so callers see the
+// bearer-fallback hint within ~1.5 minutes instead of hanging for 4.
+const BroadQueryStuckThreshold = 90 * time.Second
+
+// ErrCookieBroadQuery signals that a cookie-surface people-search hit a
+// broad-query failure mode: the poll exceeded the timeout, the underlying
+// HTTP client deadline fired, the upstream returned 5xx, or the server's
+// status string stayed in a non-terminal "Thinking..." state past
+// BroadQueryStuckThreshold. CLI layers detect this sentinel via
+// errors.Is and surface a fallback hint pointing at --source api;
+// exit code 5 (API error) is the canonical mapping.
+//
+// Distinct from rate-limit (429) errors, which keep their own typed
+// path through APIError and map to exit code 7. The two never overlap:
+// a 429 is "you tried too much"; ErrCookieBroadQuery is "this query is
+// too broad for the cookie surface to ever finish".
+var ErrCookieBroadQuery = errors.New("happenstance cookie: broad-query failure")
+
 // defaultSearchOptions returns the zero-config behavior: 1st + 2nd
 // degree, no public, 180-second timeout, 1-second poll.
 func defaultSearchOptions() SearchPeopleOptions {
@@ -391,8 +412,21 @@ func (c *Client) createSearch(query string, o SearchPeopleOptions) (string, erro
 // pollSearch polls /api/dynamo?requestId= until the search completes or
 // timeout fires. Returns the final dynamo entry even if the timeout
 // fired, so callers can see partial progress (with completed=false).
+//
+// Two broad-query bail-out paths produce ErrCookieBroadQuery:
+//   - Hard timeout: the configured PollTimeout elapsed without
+//     last.Completed=true.
+//   - Stuck "Thinking": elapsed exceeds BroadQueryStuckThreshold while
+//     last.RequestStatus still starts with "Thinking" (early-phase signal
+//     that the server hasn't even begun retrieval). Bails before the full
+//     timeout so the bearer-fallback hint surfaces faster.
+//
+// HTTP errors from the underlying GET (e.g. 5xx upstream timeouts) are
+// wrapped with ErrCookieBroadQuery in fetchDynamo before they reach
+// pollSearch.
 func (c *Client) pollSearch(requestID string, timeout, interval time.Duration) (*dynamoEntry, error) {
-	deadline := time.Now().Add(timeout)
+	start := time.Now()
+	deadline := start.Add(timeout)
 
 	var last dynamoEntry
 	for {
@@ -408,11 +442,14 @@ func (c *Client) pollSearch(requestID string, timeout, interval time.Duration) (
 			return &last, nil
 		}
 
+		elapsed := time.Since(start)
+		if elapsed > BroadQueryStuckThreshold && strings.HasPrefix(last.RequestStatus, "Thinking") {
+			return &last, fmt.Errorf("%w: status stuck at %q after %s (early-phase, query likely too broad for cookie surface)",
+				ErrCookieBroadQuery, last.RequestStatus, elapsed.Truncate(time.Second))
+		}
 		if time.Now().After(deadline) {
-			// Return partial result rather than the bare timeout error:
-			// callers may want to render what the server streamed so far.
-			return &last, fmt.Errorf("happenstance poll: timeout after %s waiting for requestId %s (last status: %q)",
-				timeout, requestID, last.RequestStatus)
+			return &last, fmt.Errorf("%w: poll timeout after %s waiting for requestId %s (last status: %q)",
+				ErrCookieBroadQuery, timeout, requestID, last.RequestStatus)
 		}
 		time.Sleep(interval)
 	}
@@ -421,6 +458,16 @@ func (c *Client) pollSearch(requestID string, timeout, interval time.Duration) (
 func (c *Client) fetchDynamo(requestID string) ([]dynamoEntry, error) {
 	raw, err := c.Get("/api/dynamo", map[string]string{"requestId": requestID})
 	if err != nil {
+		// 5xx upstream errors (Cloudflare 524, gateway 502/503, generic 500)
+		// during a cookie poll signal an upstream timeout on a broad query
+		// rather than a real client-side bug. Wrap with ErrCookieBroadQuery
+		// so callers can surface the bearer-fallback hint instead of just
+		// reporting the raw status code.
+		var apiE *APIError
+		if errors.As(err, &apiE) && apiE.StatusCode >= 500 && apiE.StatusCode < 600 {
+			return nil, fmt.Errorf("%w: GET /api/dynamo HTTP %d (upstream likely choked on a broad query)",
+				ErrCookieBroadQuery, apiE.StatusCode)
+		}
 		return nil, fmt.Errorf("happenstance GET /api/dynamo: %w", err)
 	}
 	var entries []dynamoEntry

--- a/library/sales-and-crm/contact-goat/internal/client/people_search_test.go
+++ b/library/sales-and-crm/contact-goat/internal/client/people_search_test.go
@@ -3,6 +3,12 @@
 package client
 
 import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -54,5 +60,115 @@ func TestSearchPeopleByCompanyHasOptionsOverload(t *testing.T) {
 		return c.SearchPeopleByCompanyWithOptions("Disney", &SearchPeopleOptions{
 			PollTimeout: 300 * time.Second,
 		})
+	}
+}
+
+// --- U5: cookie broad-query fast-fail ---
+
+// newTestClient builds a Client wired to the given httptest URL with
+// caching disabled. Used by U5 tests that drive fetchDynamo / pollSearch
+// without standing up real cookie auth.
+func newTestClient(srv *httptest.Server) *Client {
+	c := &Client{
+		BaseURL:    srv.URL,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		NoCache:    true,
+	}
+	return c
+}
+
+// TestErrCookieBroadQuery_5xxUpstream confirms that a 5xx response
+// from /api/dynamo wraps with ErrCookieBroadQuery so callers can
+// surface the bearer-fallback hint instead of a generic API error.
+func TestErrCookieBroadQuery_5xxUpstream(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+	}{
+		{"524 cloudflare", 524},
+		{"502 bad gateway", http.StatusBadGateway},
+		{"503 service unavailable", http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(`upstream timeout`))
+			}))
+			defer srv.Close()
+			c := newTestClient(srv)
+			_, err := c.fetchDynamo("any-id")
+			if err == nil {
+				t.Fatal("want error from 5xx response")
+			}
+			if !errors.Is(err, ErrCookieBroadQuery) {
+				t.Errorf("err = %v\nwant errors.Is(err, ErrCookieBroadQuery) = true", err)
+			}
+		})
+	}
+}
+
+// TestErrCookieBroadQuery_4xxNotWrapped: client errors (401, 404, etc.)
+// should NOT be classified as broad-query failures. Those map to the
+// existing auth/not-found exit codes through their own paths.
+func TestErrCookieBroadQuery_4xxNotWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`unauthorized`))
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	_, err := c.fetchDynamo("any-id")
+	if err == nil {
+		t.Fatal("want error from 401")
+	}
+	if errors.Is(err, ErrCookieBroadQuery) {
+		t.Errorf("4xx should NOT wrap as ErrCookieBroadQuery; got: %v", err)
+	}
+}
+
+// TestErrCookieBroadQuery_PollTimeout drives pollSearch against a
+// fixture that always returns non-completed status. With a short poll
+// timeout, the loop bails out and the error wraps ErrCookieBroadQuery.
+func TestErrCookieBroadQuery_PollTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always non-terminal.
+		_, _ = w.Write([]byte(`[{"request_id":"x","request_text":"q","request_status":"running","completed":false,"results":[]}]`))
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	_, err := c.pollSearch("x", 100*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("want timeout error")
+	}
+	if !errors.Is(err, ErrCookieBroadQuery) {
+		t.Errorf("err = %v\nwant errors.Is(err, ErrCookieBroadQuery) = true", err)
+	}
+	if !strings.Contains(err.Error(), "poll timeout") {
+		t.Errorf("error should mention poll timeout, got: %v", err)
+	}
+}
+
+// TestErrCookieBroadQuery_CompletedNoWrap: a search that completes
+// quickly never trips the broad-query path.
+func TestErrCookieBroadQuery_CompletedNoWrap(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Second request returns completed.
+		n := atomic.AddInt32(&hits, 1)
+		if n < 2 {
+			_, _ = w.Write([]byte(`[{"request_id":"x","request_text":"q","request_status":"running","completed":false,"results":[]}]`))
+			return
+		}
+		_, _ = w.Write([]byte(fmt.Sprintf(`[{"request_id":"x","request_text":"q","request_status":"Found 1","completed":true,"results":[{"author_name":"Alice"}]}]`)))
+	}))
+	defer srv.Close()
+	c := newTestClient(srv)
+	got, err := c.pollSearch("x", 5*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Completed {
+		t.Errorf("got.Completed = false, want true")
 	}
 }


### PR DESCRIPTION
## Summary

Real SF-friends task surfaced that ` + "`api hpn search`" + ` couldn't tell 1st-degree from 2nd-degree. Root cause: emit path passed empty currentUUID into bridge normalization, forcing every bridge to ` + "`kind: friend`" + `. This PR fixes that and seven adjacent friction points.

- **U1:** Plumb currentUUID through ` + "`api hpn search`" + ` emit path. Add ` + "`--first-degree-only`" + ` (filters on ` + "`hasSelfGraphBridge`" + `, mirroring ` + "`coverage.go:296`" + `) and ` + "`--min-score N`" + `.
- **U2:** ` + "`--all` + `--max-results`" + ` auto-pagination on ` + "`api hpn search`" + `. Hard safety: ` + "`--all`" + ` requires ` + "`--max-results`" + ` or ` + "`--budget`" + ` (no unbounded credit spend).
- **U3:** ` + "`coverage --location <city>`" + ` symmetric to ` + "`coverage <company>`" + `. Bearer-only (cookie has no city-search).
- **U4:** Doctor flags stale LinkedIn graph at 90 / 180 days with ` + "`happenstance_graph_status`" + ` JSON field.
- **U5:** ` + "`ErrCookieBroadQuery`" + ` sentinel; cookie poll-timeout / 5xx upstream / stuck "Thinking" >90s now exit 5 with a ` + "`--source api`" + ` hint instead of hanging 4 minutes silently.
- **U7:** Native CSV on ` + "`hp people`" + `. Stable column contract; bridges denormalize to semicolon-joined ` + "`bridge_count`" + ` / ` + "`bridge_names`" + ` / ` + "`bridge_kinds`" + ` + scalar ` + "`top_bridge_affinity`" + `.
- **U8:** ` + "`docs/scoring.md`" + ` + ` + "`--help`" + ` expansion.
- **U9:** Regen ` + "`cli-skills/pp-contact-goat/SKILL.md`" + `; library SKILL.md updated.

U6 (terminology rename for ` + "`hp people --connections` / `--friends`" + `) deferred to a separate plan per the U1 deepening review.

Plan and deepening notes at ` + "`library/sales-and-crm/contact-goat/docs/plans/2026-05-04-001-feat-contact-goat-friction-fixes-plan.md`" + `.

## Test plan

- [x] ` + "`go build ./...`" + ` clean
- [x] ` + "`go vet ./...`" + ` clean
- [x] ` + "`go test ./...`" + ` 285 passed (was 248 pre-PR)
- [x] ` + "`python3 .github/scripts/verify-skill/verify_skill.py --dir library/sales-and-crm/contact-goat`" + ` ✓ all checks passed
- [ ] Live: ` + "`contact-goat-pp-cli api hpn search 'in San Francisco' --first-degree-only --min-score 5 --json`" + ` returns only self_graph-bridged rows with score >= 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)