### PR TITLE
fix(library): point README binary links to per-CLI release tag

### DIFF
--- a/library/commerce/dominos/README.md
+++ b/library/commerce/dominos/README.md
@@ -14,7 +14,7 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/dominos/c
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/dominos-current).
 
 ## Authentication
 

--- a/library/commerce/ebay/README.md
+++ b/library/commerce/ebay/README.md
@@ -31,7 +31,7 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/ebay/cmd/
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/ebay-current).
 
 ## Quick Start
 

--- a/library/commerce/shopify/README.md
+++ b/library/commerce/shopify/README.md
@@ -14,7 +14,7 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/shopify/c
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/shopify-current).
 
 ## Quick Start
 

--- a/library/commerce/yahoo-finance/README.md
+++ b/library/commerce/yahoo-finance/README.md
@@ -34,7 +34,7 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-fin
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/yahoo-finance-current).
 
 ## Session Bootstrap
 

--- a/library/developer-tools/company-goat/README.md
+++ b/library/developer-tools/company-goat/README.md
@@ -59,7 +59,7 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/co
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/company-goat-current).
 
 ## Authentication
 

--- a/library/developer-tools/postman-explore/README.md
+++ b/library/developer-tools/postman-explore/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/po
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/postman-explore-current).
 
 ## Authentication
 

--- a/library/developer-tools/scrape-creators/README.md
+++ b/library/developer-tools/scrape-creators/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/sc
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/scrape-creators-current).
 
 ## Authentication
 

--- a/library/developer-tools/trigger-dev/README.md
+++ b/library/developer-tools/trigger-dev/README.md
@@ -12,7 +12,7 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/tr
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trigger-dev-current).
 
 ## Quick Start
 

--- a/library/food-and-dining/food52/README.md
+++ b/library/food-and-dining/food52/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/food-and-dining/fo
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/food52-current).
 
 ## Authentication
 

--- a/library/marketing/producthunt/README.md
+++ b/library/marketing/producthunt/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/marketing/producth
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/producthunt-current).
 
 ## Authentication
 

--- a/library/media-and-entertainment/archive-is/README.md
+++ b/library/media-and-entertainment/archive-is/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/other/archive-is/cmd/archi
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/archive-is-current).
 
 ### Authentication
 

--- a/library/media-and-entertainment/espn/README.md
+++ b/library/media-and-entertainment/espn/README.md
@@ -12,7 +12,7 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/espn-current).
 
 ## Authentication
 

--- a/library/media-and-entertainment/hackernews/README.md
+++ b/library/media-and-entertainment/hackernews/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/hackernews-current).
 
 ## Authentication
 

--- a/library/media-and-entertainment/pokeapi/README.md
+++ b/library/media-and-entertainment/pokeapi/README.md
@@ -16,7 +16,7 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/pokeapi-current).
 
 ## Authentication
 

--- a/library/media-and-entertainment/steam-web/README.md
+++ b/library/media-and-entertainment/steam-web/README.md
@@ -22,7 +22,7 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/steam-web-current).
 
 ## Quick Start
 

--- a/library/other/weather-goat/README.md
+++ b/library/other/weather-goat/README.md
@@ -14,7 +14,7 @@ go install github.com/mvanhorn/printing-press-library/library/other/weather-goat
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/weather-goat-current).
 
 ## Authentication
 

--- a/library/payments/coingecko/README.md
+++ b/library/payments/coingecko/README.md
@@ -14,7 +14,7 @@ go install github.com/mvanhorn/printing-press-library/library/payments/coingecko
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/coingecko-current).
 
 ## Quick Start
 

--- a/library/payments/kalshi/README.md
+++ b/library/payments/kalshi/README.md
@@ -12,7 +12,7 @@ go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cm
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/kalshi-current).
 
 ## Quick Start
 

--- a/library/productivity/cal-com/README.md
+++ b/library/productivity/cal-com/README.md
@@ -23,7 +23,7 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/cal-c
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/cal-com-current).
 
 ## Authentication
 

--- a/library/productivity/slack/README.md
+++ b/library/productivity/slack/README.md
@@ -12,7 +12,7 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/slack
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/slack-current).
 
 ## Quick Start
 

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -12,7 +12,7 @@ go install github.com/mvanhorn/printing-press-library/library/project-management
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/linear-current).
 
 ## Authentication
 

--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -21,7 +21,7 @@ GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod \
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/contact-goat-current).
 
 ## Authentication
 

--- a/library/sales-and-crm/hubspot/README.md
+++ b/library/sales-and-crm/hubspot/README.md
@@ -14,7 +14,7 @@ go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubs
 
 ### Binary
 
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/hubspot-current).
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

23 published CLIs link binary downloads to the bare `/releases` index instead of their own rolling release tag. The generator template was fixed in [printing-press#508](https://github.com/mvanhorn/cli-printing-press/pull/508) on 2026-05-02, but READMEs published before that date still carry the old link and haven't been refreshed since.

This PR surgically patches the affected READMEs to use `/releases/tag/<slug>-current` per CLI. No regeneration, no template re-run — single-line URL swap per file.

## What changed

For each affected README:

```diff
- Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
+ Download from [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/<slug>-current).
```

23 files modified, 23 lines changed (1 each).

## Files touched

- `commerce/`: dominos, ebay, shopify, yahoo-finance
- `developer-tools/`: company-goat, postman-explore, scrape-creators, trigger-dev
- `food-and-dining/`: food52
- `marketing/`: producthunt
- `media-and-entertainment/`: archive-is, espn, hackernews, pokeapi, steam-web
- `other/`: weather-goat
- `payments/`: coingecko, kalshi
- `productivity/`: cal-com, slack
- `project-management/`: linear
- `sales-and-crm/`: contact-goat, hubspot

## Verification

- All 23 `<slug>-current` tags already exist in this repo's release list — no broken targets.
- Post-patch grep confirms zero remaining bare `/releases` links under `library/`.
- CLIs published after 2026-05-02 already use this format and are not touched.

## Why surgical and not full republish

Re-running the publish flow per CLI would create 23 PRs and pull in unrelated drift (template changes, manifest updates, scoring recomputes) that reviewers would have to verify. The link rot is the only user-visible problem; future organic republishes will pick up the rest of the template naturally.