### PR TITLE
fix(cal-com): align book description with reframed help text

### DIFF
--- a/library/productivity/cal-com/.manuscripts/20260504-205634/research.json
+++ b/library/productivity/cal-com/.manuscripts/20260504-205634/research.json
@@ -88,10 +88,10 @@
     {
       "name": "One-shot booking",
       "command": "book",
-      "description": "Find a slot and create a booking in one composed command — slot check, optional reservation, create, optional confirm.",
-      "rationale": "Cal.com forces a 4-call dance to book; we compose the chain transactionally with --dry-run support.",
+      "description": "Schedule an attendee onto one of your event types in a single composed call — slot check, optional reservation, create, optional confirm. For the rare scripting case (admin onboarding, recruiter pre-fill, test fixtures); for the normal flow where the attendee picks their own time, share a URL from link list.",
+      "rationale": "Cal.com forces a 4-call dance to create a booking; we compose the chain transactionally with --dry-run support. Bearer-token auth means the caller is the host, so this fits the rare host-scripts-an-attendee case — not the normal attendee-picks-time-from-link flow.",
       "example": "cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attendee-name Guest --attendee-email guest@example.com --dry-run",
-      "why_it_matters": "Reach for this whenever you need to book a meeting; one call replaces four and is safe to dry-run.",
+      "why_it_matters": "Reach for this when you (the host) want to script a booking on the attendee's behalf rather than having them click your booking link. For the normal flow, share a `link list` URL.",
       "group": "Composed booking flows"
     },
     {
@@ -216,10 +216,10 @@
     {
       "name": "One-shot booking",
       "command": "book",
-      "description": "Find a slot and create a booking in one composed command — slot check, optional reservation, create, optional confirm.",
-      "rationale": "Cal.com forces a 4-call dance to book; we compose the chain transactionally with --dry-run support.",
+      "description": "Schedule an attendee onto one of your event types in a single composed call — slot check, optional reservation, create, optional confirm. For the rare scripting case (admin onboarding, recruiter pre-fill, test fixtures); for the normal flow where the attendee picks their own time, share a URL from link list.",
+      "rationale": "Cal.com forces a 4-call dance to create a booking; we compose the chain transactionally with --dry-run support. Bearer-token auth means the caller is the host, so this fits the rare host-scripts-an-attendee case — not the normal attendee-picks-time-from-link flow.",
       "example": "cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attendee-name Guest --attendee-email guest@example.com --dry-run",
-      "why_it_matters": "Reach for this whenever you need to book a meeting; one call replaces four and is safe to dry-run.",
+      "why_it_matters": "Reach for this when you (the host) want to script a booking on the attendee's behalf rather than having them click your booking link. For the normal flow, share a `link list` URL.",
       "group": "Composed booking flows"
     },
     {

--- a/library/productivity/cal-com/.printing-press.json
+++ b/library/productivity/cal-com/.printing-press.json
@@ -23,7 +23,7 @@
     {
       "name": "One-shot booking",
       "command": "book",
-      "description": "Find a slot and create a booking in one composed command — slot check, optional reservation, create, optional confirm."
+      "description": "Schedule an attendee onto one of your event types in a single composed call — slot check, optional reservation, create, optional confirm. For the rare scripting case (admin onboarding, recruiter pre-fill, test fixtures); for the normal flow where the attendee picks their own time, share a URL from link list."
     },
     {
       "name": "Unified agenda",

--- a/library/productivity/cal-com/README.md
+++ b/library/productivity/cal-com/README.md
@@ -55,9 +55,9 @@ cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attende
 These capabilities aren't available in any other tool for this API.
 
 ### Composed booking flows
-- **`book`** — Find a slot and create a booking in one composed command — slot check, optional reservation, create, optional confirm.
+- **`book`** — Schedule an attendee onto one of your event types in a single composed call — slot check, optional reservation, create, optional confirm.
 
-  _Reach for this whenever you need to book a meeting; one call replaces four and is safe to dry-run._
+  _For the host scripting an attendee onto their calendar (admin onboarding, recruiter pre-fill, test fixtures). For the normal flow where the attendee picks their own time, share a URL from `link list` instead._
 
   ```bash
   cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attendee-name Guest --attendee-email guest@example.com --dry-run

--- a/library/productivity/cal-com/SKILL.md
+++ b/library/productivity/cal-com/SKILL.md
@@ -19,9 +19,9 @@ Reach for cal-com-pp-cli whenever an agent needs to read or mutate a Cal.com cal
 These capabilities aren't available in any other tool for this API.
 
 ### Composed booking flows
-- **`book`** — Find a slot and create a booking in one composed command — slot check, optional reservation, create, optional confirm.
+- **`book`** — Schedule an attendee onto one of your event types in a single composed call — slot check, optional reservation, create, optional confirm.
 
-  _Reach for this whenever you need to book a meeting; one call replaces four and is safe to dry-run._
+  _For the host scripting an attendee onto their calendar (admin onboarding, recruiter pre-fill, test fixtures). For the normal flow where the attendee picks their own time, share a URL from `link list` instead._
 
   ```bash
   cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attendee-name Guest --attendee-email guest@example.com --dry-run


### PR DESCRIPTION
## What

PR #237 reframed `book` in the Go `Short`/`Long` help text — the command's real intent is "the host scripts an attendee onto their calendar" (admin onboarding, recruiter pre-fill, test fixtures), distinct from `link create`/`link list` which create the bookable URL the normal attendee-driven flow uses. That reframe missed syncing four downstream copies of the description that drive what users actually read.

## Drift before this PR

| Surface | Description |
|---|---|
| `cal-com-pp-cli book --help` (Go `Short`) | "Schedule an attendee onto your calendar without making them visit the booking link" ✅ (PR #237) |
| README.md Unique Features bullet | "Find a slot and create a booking in one composed command…" ❌ stale |
| SKILL.md Unique Capabilities bullet | "Find a slot and create a booking in one composed command…" ❌ stale |
| `.printing-press.json` `novel_features[book].description` | "Find a slot and create a booking…" ❌ stale |
| `.manuscripts/<run>/research.json` `novel_features[book]` + `novel_features_built[book]` | "Find a slot and create a booking…" ❌ stale |

An agent reading the SKILL got the wrong framing while `book --help` told the right story. The data-layer drift would also propagate into a future reprint via the novel-features subagent's Pass 2(d) reconciliation.

## Fix

- README.md + SKILL.md: bullet description + tip line replaced with the host-scripts-an-attendee framing, pointing users at `link list` for the normal flow.
- `research.json`: `description`, `rationale`, `why_it_matters` refreshed in both `novel_features` and `novel_features_built` so future reprints inherit the new framing.
- `.printing-press.json`: `novel_features[book].description` synced.

## What's NOT in this PR

No code changes — the Go `Short`/`Long` already had the right text from #237. No new commands. No flag changes. Just description sync.

## Verify

```bash
diff <(cal-com-pp-cli book --help | head -1) <(grep '^- \*\*`book`\*\*' README.md)
# Pre-fix: divergent. Post-fix: same framing.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)