### PR TITLE
fix(library): backfill invalidateCache to 40 CLIs

### DIFF
--- a/library/commerce/craigslist/internal/client/client.go
+++ b/library/commerce/craigslist/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -231,6 +241,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/commerce/dominos/internal/client/client.go
+++ b/library/commerce/dominos/internal/client/client.go
@@ -202,6 +202,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -316,6 +326,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/commerce/ebay/internal/client/client.go
+++ b/library/commerce/ebay/internal/client/client.go
@@ -132,6 +132,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -245,6 +255,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/commerce/fedex/internal/client/client.go
+++ b/library/commerce/fedex/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -232,6 +242,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/commerce/shopify/internal/client/client.go
+++ b/library/commerce/shopify/internal/client/client.go
@@ -144,6 +144,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -270,6 +280,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/commerce/yahoo-finance/internal/client/client.go
+++ b/library/commerce/yahoo-finance/internal/client/client.go
@@ -384,6 +384,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -509,6 +519,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/company-goat/internal/client/client.go
+++ b/library/developer-tools/company-goat/internal/client/client.go
@@ -202,6 +202,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -316,6 +326,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/docker-hub/internal/client/client.go
+++ b/library/developer-tools/docker-hub/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/firecrawl/internal/client/client.go
+++ b/library/developer-tools/firecrawl/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/nvd/internal/client/client.go
+++ b/library/developer-tools/nvd/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/postman-explore/internal/client/client.go
+++ b/library/developer-tools/postman-explore/internal/client/client.go
@@ -189,6 +189,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -300,6 +310,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/pypi/internal/client/client.go
+++ b/library/developer-tools/pypi/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/scrape-creators/internal/client/client.go
+++ b/library/developer-tools/scrape-creators/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -231,6 +241,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/developer-tools/trigger-dev/internal/client/client.go
+++ b/library/developer-tools/trigger-dev/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/food-and-dining/allrecipes/internal/client/client.go
+++ b/library/food-and-dining/allrecipes/internal/client/client.go
@@ -136,6 +136,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -249,6 +259,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/food-and-dining/food52/internal/client/client.go
+++ b/library/food-and-dining/food52/internal/client/client.go
@@ -135,6 +135,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -248,6 +258,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/food-and-dining/pagliacci/internal/client/client.go
+++ b/library/food-and-dining/pagliacci/internal/client/client.go
@@ -133,6 +133,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -246,6 +256,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/food-and-dining/recipe-goat/internal/client/client.go
+++ b/library/food-and-dining/recipe-goat/internal/client/client.go
@@ -135,6 +135,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -248,6 +258,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/marketing/ahrefs/internal/client/client.go
+++ b/library/marketing/ahrefs/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/marketing/dub/internal/client/client.go
+++ b/library/marketing/dub/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/marketing/klaviyo/internal/client/client.go
+++ b/library/marketing/klaviyo/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -232,6 +242,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/marketing/producthunt/internal/client/client.go
+++ b/library/marketing/producthunt/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -231,6 +241,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/archive-is/internal/client/client.go
+++ b/library/media-and-entertainment/archive-is/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/espn/internal/client/client.go
+++ b/library/media-and-entertainment/espn/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/hackernews/internal/client/client.go
+++ b/library/media-and-entertainment/hackernews/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/movie-goat/internal/client/client.go
+++ b/library/media-and-entertainment/movie-goat/internal/client/client.go
@@ -117,6 +117,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -234,6 +244,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/pokeapi/internal/client/client.go
+++ b/library/media-and-entertainment/pokeapi/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/steam-web/internal/client/client.go
+++ b/library/media-and-entertainment/steam-web/internal/client/client.go
@@ -189,6 +189,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body)
 }
@@ -279,6 +289,12 @@ func (c *Client) do(method, path string, params map[string]string, body any) (js
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/media-and-entertainment/wikipedia/internal/client/client.go
+++ b/library/media-and-entertainment/wikipedia/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/monitoring/sentry/internal/client/client.go
+++ b/library/monitoring/sentry/internal/client/client.go
@@ -135,6 +135,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -248,6 +258,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/other/open-meteo/internal/client/client.go
+++ b/library/other/open-meteo/internal/client/client.go
@@ -118,6 +118,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -248,6 +258,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/other/weather-goat/internal/client/client.go
+++ b/library/other/weather-goat/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/payments/coingecko/internal/client/client.go
+++ b/library/payments/coingecko/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/payments/kalshi/internal/client/client.go
+++ b/library/payments/kalshi/internal/client/client.go
@@ -174,6 +174,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -304,6 +314,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/productivity/slack/internal/client/client.go
+++ b/library/productivity/slack/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/project-management/linear/internal/client/client.go
+++ b/library/project-management/linear/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/sales-and-crm/contact-goat/internal/client/client.go
+++ b/library/sales-and-crm/contact-goat/internal/client/client.go
@@ -194,6 +194,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -330,6 +340,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/sales-and-crm/hubspot/internal/client/client.go
+++ b/library/sales-and-crm/hubspot/internal/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -302,6 +312,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/travel/airbnb/internal/client/client.go
+++ b/library/travel/airbnb/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 

--- a/library/travel/flightgoat/internal/client/client.go
+++ b/library/travel/flightgoat/internal/client/client.go
@@ -119,6 +119,16 @@ func (c *Client) writeCache(path string, params map[string]string, data json.Raw
 	os.WriteFile(cacheFile, []byte(data), 0o644)
 }
 
+// invalidateCache wholesale-removes the cache directory after a successful
+// non-GET request. Best-effort — ignores RemoveAll error per the design
+// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
+func (c *Client) invalidateCache() {
+	if c.cacheDir == "" {
+		return
+	}
+	_ = os.RemoveAll(c.cacheDir)
+}
+
 func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
 	return c.do("POST", path, nil, body, nil)
 }
@@ -233,6 +243,12 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Success
 		if resp.StatusCode < 400 {
 			c.limiter.OnSuccess()
+			// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
+			// is structurally redundant (dry-run short-circuits before the retry
+			// loop) but defends against future refactors.
+			if method != http.MethodGet && !c.DryRun {
+				c.invalidateCache()
+			}
 			return json.RawMessage(respBody), resp.StatusCode, nil
 		}
 


### PR DESCRIPTION
## Summary

Companion library backfill for [cli-printing-press#612](https://github.com/mvanhorn/cli-printing-press/pull/612) (the template fix).

Every published CLI's `internal/client/client.go` had a `writeCache` but no `invalidateCache`. The asymmetry meant `<cli> create` followed immediately by `<cli> list` (without `--no-cache`) returned the pre-mutation list — humans saw stale state for up to the cache TTL (5 min). [cli-printing-press#521](https://github.com/mvanhorn/cli-printing-press/pull/521) covered the MCP path with `NoCache=true`; [cli-printing-press#612](https://github.com/mvanhorn/cli-printing-press/pull/612) covers future regenerations via the template; this PR backfills the same change to the 40 already-published CLIs that pre-date the template fix so users installing today don't ship with the cache-leak hazard.

## Mechanical change per file

Two surgical insertions in each `internal/client/client.go`:

**1. New `invalidateCache` method**, appended after `writeCache`'s closing brace:

```go
// invalidateCache wholesale-removes the cache directory after a successful
// non-GET request. Best-effort — ignores RemoveAll error per the design
// pattern at https://github.com/mvanhorn/cli-printing-press/blob/main/docs/solutions/design-patterns/http-client-cache-invalidate-on-mutation-2026-05-05.md
func (c *Client) invalidateCache() {
	if c.cacheDir == "" {
		return
	}
	_ = os.RemoveAll(c.cacheDir)
}
```

**2. Hook in `do()`'s success branch**, between `c.limiter.OnSuccess()` and the success-return:

```go
// Cache-invalidate on successful non-GET requests. The !c.DryRun guard
// is structurally redundant (dry-run short-circuits before the retry
// loop) but defends against future refactors.
if method != http.MethodGet && !c.DryRun {
	c.invalidateCache()
}
```

## CLIs in this PR (40)

<details>
<summary>Click to expand</summary>

- **commerce**: craigslist, dominos, ebay, fedex, shopify, yahoo-finance
- **developer-tools**: company-goat, docker-hub, firecrawl, nvd, postman-explore, pypi, scrape-creators, trigger-dev
- **food-and-dining**: allrecipes, food52, pagliacci, recipe-goat
- **marketing**: ahrefs, dub, klaviyo, producthunt
- **media-and-entertainment**: archive-is, espn, hackernews, movie-goat, pokeapi, steam-web, wikipedia
- **monitoring**: sentry
- **other**: open-meteo, weather-goat
- **payments**: coingecko, kalshi
- **productivity**: slack
- **project-management**: linear
- **sales-and-crm**: contact-goat, hubspot
- **travel**: airbnb, flightgoat

</details>

**Skipped**: cal-com (already shipped with `invalidateCache` from #237 commit `d26a2862` — the original printed-CLI patch that motivated the template fix).

**Excluded**: tiktok-shop (HMAC-only signing client; ships without a response cache, so neither `writeCache` nor `invalidateCache` apply).

## Verification

- [x] Discovery filter: `writeCache` present AND `invalidateCache` absent → 40 CLIs match
- [x] Patch applied via Python script with two regex anchors (idempotent; refuses to mutate if either anchor doesn't match exactly once)
- [x] All 41 affected CLIs (40 patched + cal-com which already had it) pass `go build ./...`
- [x] Sanity-checked diff in 2 CLIs (shopify, linear) shows the expected two-hunk shape only — no unrelated changes
- [x] `git diff --name-only | wc -l` = 40 — exactly the CLIs the filter identified

## Refs

- [cli-printing-press#603](https://github.com/mvanhorn/cli-printing-press/issues/603) (issue)
- [cli-printing-press#612](https://github.com/mvanhorn/cli-printing-press/pull/612) (companion template fix)
- [cli-printing-press#597](https://github.com/mvanhorn/cli-printing-press/issues/597) (Cal.com retro that surfaced this)
- [#237](https://github.com/mvanhorn/printing-press-library/pull/237) (cal-com printed-CLI patch — the reference shape)
- [#213](https://github.com/mvanhorn/printing-press-library/pull/213) (companion shape — earlier MCP NoCache backfill)

Plan: cli-printing-press `docs/plans/2026-05-05-006-fix-wave-2-retro-blockers-plan.md` (U3 of Wave 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)