### PR TITLE
fix(cli): backfill agent-context annotations

### DIFF
--- a/library/commerce/craigslist/internal/cli/agent_context.go
+++ b/library/commerce/craigslist/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -143,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/commerce/dominos/internal/cli/agent_context.go
+++ b/library/commerce/dominos/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -144,6 +145,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/commerce/ebay/internal/cli/agent_context.go
+++ b/library/commerce/ebay/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -174,6 +175,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/commerce/fedex/internal/cli/agent_context.go
+++ b/library/commerce/fedex/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -146,6 +147,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/commerce/shopify/internal/cli/agent_context.go
+++ b/library/commerce/shopify/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/company-goat/internal/cli/agent_context.go
+++ b/library/developer-tools/company-goat/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -142,6 +143,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/docker-hub/internal/cli/agent_context.go
+++ b/library/developer-tools/docker-hub/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/firecrawl/internal/cli/agent_context.go
+++ b/library/developer-tools/firecrawl/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/nvd/internal/cli/agent_context.go
+++ b/library/developer-tools/nvd/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/postman-explore/internal/cli/agent_context.go
+++ b/library/developer-tools/postman-explore/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -145,8 +145,7 @@ func buildAgentDiscoveryContext() *agentContextDiscovery {
 			"no_auth_required",
 			"skip_clearance_cookie",
 		},
-		Warnings: []string{
-		},
+		Warnings: []string{},
 		CandidateCommands: []string{
 			"browse",
 			"get",
@@ -178,6 +177,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/pypi/internal/cli/agent_context.go
+++ b/library/developer-tools/pypi/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/developer-tools/scrape-creators/internal/cli/agent_context.go
+++ b/library/developer-tools/scrape-creators/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/food-and-dining/allrecipes/internal/cli/agent_context.go
+++ b/library/food-and-dining/allrecipes/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/food-and-dining/food52/internal/cli/agent_context.go
+++ b/library/food-and-dining/food52/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -179,6 +180,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/food-and-dining/pagliacci/internal/cli/agent_context.go
+++ b/library/food-and-dining/pagliacci/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -171,6 +172,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/food-and-dining/recipe-goat/internal/cli/agent_context.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/marketing/ahrefs/internal/cli/agent_context.go
+++ b/library/marketing/ahrefs/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/marketing/dub/internal/cli/agent_context.go
+++ b/library/marketing/dub/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/marketing/klaviyo/internal/cli/agent_context.go
+++ b/library/marketing/klaviyo/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/marketing/producthunt/internal/cli/agent_context.go
+++ b/library/marketing/producthunt/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/media-and-entertainment/hackernews/internal/cli/agent_context.go
+++ b/library/media-and-entertainment/hackernews/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/media-and-entertainment/movie-goat/internal/cli/agent_context.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/media-and-entertainment/pokeapi/internal/cli/agent_context.go
+++ b/library/media-and-entertainment/pokeapi/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/media-and-entertainment/wikipedia/internal/cli/agent_context.go
+++ b/library/media-and-entertainment/wikipedia/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/monitoring/sentry/internal/cli/agent_context.go
+++ b/library/monitoring/sentry/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/other/open-meteo/internal/cli/agent_context.go
+++ b/library/other/open-meteo/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -143,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/payments/coingecko/internal/cli/agent_context.go
+++ b/library/payments/coingecko/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -94,8 +95,7 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
-	envVars := []string{
-	}
+	envVars := []string{}
 	authMode := "none"
 	if authMode == "" {
 		authMode = "none"
@@ -144,6 +144,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/payments/kalshi/internal/cli/agent_context.go
+++ b/library/payments/kalshi/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/productivity/cal-com/internal/cli/agent_context.go
+++ b/library/productivity/cal-com/internal/cli/agent_context.go
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/travel/airbnb/internal/cli/agent_context.go
+++ b/library/travel/airbnb/internal/cli/agent_context.go
@@ -62,6 +62,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -197,6 +198,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/library/travel/flightgoat/internal/cli/agent_context.go
+++ b/library/travel/flightgoat/internal/cli/agent_context.go
@@ -22,13 +22,13 @@ const agentContextSchemaVersion = "2"
 // (2026-04-13 Wrangler post): agents can introspect the live CLI without
 // parsing --help or reading source.
 type agentContext struct {
-	SchemaVersion               string                `json:"schema_version"`
-	CLI                         agentContextCLI       `json:"cli"`
-	Auth                        agentContextAuth      `json:"auth"`
-	Discovery                   *agentContextDiscovery `json:"discovery,omitempty"`
-	Commands                    []agentContextCommand `json:"commands"`
-	AvailableProfiles           []string              `json:"available_profiles"`
-	FeedbackEndpointConfigured  bool                  `json:"feedback_endpoint_configured"`
+	SchemaVersion              string                 `json:"schema_version"`
+	CLI                        agentContextCLI        `json:"cli"`
+	Auth                       agentContextAuth       `json:"auth"`
+	Discovery                  *agentContextDiscovery `json:"discovery,omitempty"`
+	Commands                   []agentContextCommand  `json:"commands"`
+	AvailableProfiles          []string               `json:"available_profiles"`
+	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 }
 
 type agentContextCLI struct {
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -145,6 +146,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{


### PR DESCRIPTION
## Summary

- Backfill the merged agent-context annotation plumbing into every published CLI that currently ships `internal/cli/agent_context.go`.
- Preserve Cobra annotations such as `pp:endpoint` and `mcp:read-only` in the agent-context JSON so the live dogfood destructive-at-auth classifier can see promoted endpoint mirrors.
- Scope is based on current repo reality: 31 published CLIs have an agent-context file to patch, not the issue estimate of ~38-40.

## Validation

- Verified the issue is real against Cal.com: `promoted_api-keys.go` has `pp:endpoint: api-keys.keys-refresh`, while pre-patch `agent_context.go` dropped all command annotations.
- Static assertion: all 31 changed `agent_context.go` files now define the `annotations` JSON field and copy `sub.Annotations`.
- `git diff --check`
- `go build ./...` for all 31 touched CLIs
- `go vet ./...` for all 31 touched CLIs
- `go test -c ./internal/cli` for all 31 touched CLIs
- `go run ./tools/generate-skills/main.go` produced no committed skill mirror drift

## Note

Running compiled test binaries / `agent-context` directly hung in this local environment before output, so I validated runtime-facing behavior by compile checks plus source-level checks against Cobra annotations.

Closes mvanhorn/cli-printing-press#620.