### PR TITLE
fix(cli): align kalshi mcp bundle metadata

### DIFF
--- a/library/payments/kalshi/.printing-press.json
+++ b/library/payments/kalshi/.printing-press.json
@@ -8,7 +8,7 @@
   "spec_format": "openapi3",
   "spec_checksum": "sha256:dfcfa4e1d9ee14ad69c5c68f2407b132684c306616c62a0de7935250a15bac80",
   "run_id": "20260504-204550",
-  "mcp_binary": "kalshi-trade-manual-pp-mcp",
+  "mcp_binary": "kalshi-pp-mcp",
   "mcp_tool_count": 96,
   "mcp_ready": "full",
   "auth_type": "api_key",

--- a/library/payments/kalshi/manifest.json
+++ b/library/payments/kalshi/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "0.3",
-  "name": "kalshi-trade-manual-pp-mcp",
+  "name": "kalshi-pp-mcp",
   "display_name": "Kalshi Trade Manual",
   "version": "3.9.0",
   "description": "Kalshi Trade Manual API surface as MCP tools.",
@@ -10,9 +10,9 @@
   "license": "Apache-2.0",
   "server": {
     "type": "binary",
-    "entry_point": "bin/kalshi-trade-manual-pp-mcp",
+    "entry_point": "bin/kalshi-pp-mcp",
     "mcp_config": {
-      "command": "${__dirname}/bin/kalshi-trade-manual-pp-mcp",
+      "command": "${__dirname}/bin/kalshi-pp-mcp",
       "args": [],
       "env": {
         "KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY": "${user_config.kalshi_trade_manual_kalshi_access_key}"


### PR DESCRIPTION
## Summary

Kalshi MCPB bundling now uses the actual checked-in MCP binary path. The catalog metadata previously pointed at `cmd/kalshi-trade-manual-pp-mcp`, but the published Kalshi CLI ships `cmd/kalshi-pp-mcp`, so the release-artifact workflow failed while building Kalshi bundles.

This updates Kalshi's provenance and MCPB manifest to use `kalshi-pp-mcp`; the generated registry can then pick up the corrected binary from the normal post-merge registry regeneration.

## Verification

- `rtk python3 .github/scripts/verify-skill/verify_skill.py --dir library/payments/kalshi/`
- `rtk python3 .github/scripts/verify-manifest/verify_manifest.py`
- `rtk go build ./...`
- `rtk go vet ./...`
- `rtk go test ./...`
- `rtk printing-press bundle library/payments/kalshi --platform windows/amd64 --output /tmp/kalshi-pp-mcp-windows-amd64.mcpb`
- `rtk printing-press bundle library/payments/kalshi --platform windows/arm64 --output /tmp/kalshi-pp-mcp-windows-arm64.mcpb`
- `rtk printing-press bundle library/payments/kalshi --platform darwin/arm64 --output /tmp/kalshi-pp-mcp-darwin-arm64.mcpb`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
