### PR TITLE
fix(ci): drop renamed-away dirs from build-mcpb affected set

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -72,9 +72,18 @@ jobs:
             else
               changed_paths=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'library/**' || true)
             fi
+            # Filter to directories that still exist in the merged tree so a
+            # rename (which surfaces in `git diff` as deletions under the old
+            # slug + additions under the new slug) doesn't spawn a spurious
+            # matrix branch for the now-deleted directory. Without this, the
+            # bundle/build/release jobs run vacuously or fail noisily for the
+            # old slug. See issue #250 for the flightgoat -> flight-goat case.
             affected=$(printf '%s\n' "$changed_paths" \
               | awk -F/ 'NF >= 3 && $1 == "library" { print $2"/"$3 }' \
               | sort -u \
+              | while IFS= read -r entry; do
+                  [ -d "library/$entry" ] && printf '%s\n' "$entry"
+                done \
               | jq -R . | jq -s -c .)
           fi
           # Filter out empty/null entries


### PR DESCRIPTION
## Summary

- Filters the push-event "affected CLIs" detection in `.github/workflows/build-mcpb.yml` to drop `<category>/<slug>` entries whose directory no longer exists in the merged tree.
- Eliminates the spurious bundle/build/release matrix branches that PR #249's `flightgoat` → `flight-goat` rename surfaced (see [run 25423341361](https://github.com/mvanhorn/printing-press-library/actions/runs/25423341361)).
- Closes #250 (Fix 1). Fix 2 (deleting the orphan `flightgoat-current` release + tag) is a one-shot ops task; tracked separately so this PR stays code-only.

The other detection paths in the same step (`workflow_dispatch` with a specific CLI, all-zeros sentinel fallback) don't conjure phantom slugs from rename deletions, so the filter is scoped to the push-diff branch.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-mcpb.yml'))"`).
- [x] Filter pipeline locally simulated against a synthetic rename diff (`travel/flightgoat` deletions + `travel/flight-goat` additions + an unrelated `finance/wise` modification): output retains `travel/flight-goat` and `finance/wise`, drops `travel/flightgoat`.
- [ ] After merge, watch the next library/** push and confirm the `Detect affected CLIs` step's `affected` output excludes any rename-source slugs.
- [ ] Regression: a normal single-CLI modification still shows up in `affected` (filter is a no-op when the directory exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)