### PR TITLE
fix(ci): pin npm to 11.5.1 for OIDC publish; bump to v0.1.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,8 +32,12 @@ jobs:
           cache: 'npm'
           cache-dependency-path: npm/package-lock.json
 
-      - name: Upgrade npm so it supports Trusted Publishing
-        run: npm install -g npm@latest
+      # Pin to a specific npm version that supports OIDC Trusted Publishing.
+      # `npm install -g npm@latest` is flaky in CI — npm overwrites itself
+      # mid-install and can leave the global install in a broken state with
+      # a missing `promise-retry` module. Pinning avoids the race.
+      - name: Use npm 11.5.1+ for Trusted Publishing
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         working-directory: npm

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- CI fix: pin the npm version used for Trusted Publishing to `npm@11.5.1`. The previous `npm install -g npm@latest` step is flaky on Actions runners — npm overwrites itself mid-install and the global install ends up with a missing `promise-retry` module. v0.1.1 was tagged but never reached npmjs.com because of this; this is the first published release on the OIDC pipeline.
+
 ## 0.1.1
 
 - Rename binary from `pp` to `printing-press`. The previous two-letter name overlapped with our `pp-*` skill namespace, our `*-pp-cli` binary convention, and Perl's `pp` (PAR::Packer).

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- The `Publish npm package` workflow failed on the v0.1.1 tag because the `npm install -g npm@latest` step hit a known npm self-update flake (`Cannot find module 'promise-retry'`). Pinning to `npm@11.5.1` (the minimum version that supports OIDC Trusted Publishing) avoids the race.
- Bumps `npm/package.json` to `0.1.2`. v0.1.1 was tagged but never reached npmjs.com — v0.1.2 will be the first real published release on the OIDC pipeline. No code changes; same feature surface as v0.1.1.

## Failure log from #25424739026

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
##[error]Process completed with exit code 1.
```

## Test plan

- [x] `npm test` — 34 passing.
- [x] `npm run build` — clean tsc.

Post-merge OIDC smoke test (retry of v0.1.1):
- [ ] `git tag npm-v0.1.2 && git push --tags`
- [ ] Watch the `Publish npm package` workflow run.
- [ ] `npm view @mvanhorn/printing-press version` returns `0.1.2`.
- [ ] npmjs.com page shows the provenance attestation badge.
- [ ] `npx -y @mvanhorn/printing-press@0.1.2 install starter-pack` installs all four CLIs + skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)