### PR TITLE
fix(ci): only rebuild CLIs when build-relevant files change

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -27,8 +27,24 @@ on:
   push:
     branches: [main]
     paths:
-      - 'library/**'
-      - '!library/**/build/**'
+      # Inputs that actually affect the compiled CLI binary or MCPB
+      # bundle: Go source, module files, and the MCPB manifest. The
+      # //go:embed directive can include any file type, but in practice
+      # those files live inside cmd/ or internal/ (e.g. dub's
+      # internal/mcp/embedded_manifest.json), so this whitelist still
+      # catches them.
+      #
+      # Anything else under library/<cat>/<slug>/ — README.md, SKILL.md,
+      # LICENSE, NOTICE, Makefile, .golangci.yml, .goreleaser.yaml,
+      # .printing-press.json, spec.{yaml,json}, dogfood-results.json,
+      # workflow-verify-report.json, .manuscripts/** — is documentation,
+      # provenance, archived input, or post-build artifact and does not
+      # belong in the rebuild trigger.
+      - 'library/**/cmd/**'
+      - 'library/**/internal/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'library/**/manifest.json'
       - '.github/workflows/build-mcpb.yml'
 
 permissions:
@@ -67,10 +83,25 @@ jobs:
             # Push event: diff against parent commit. The all-zeros sentinel
             # appears for initial branch pushes; fall back to HEAD^ then to
             # listing all library entries so the workflow degrades gracefully.
+            #
+            # Pathspec is restricted to build-relevant files (Go source under
+            # cmd/ and internal/, module files, MCPB manifest). This mirrors
+            # the on.push.paths filter above so a mixed commit that touches
+            # build-relevant files in CLI A and only docs in CLI B rebuilds
+            # A only. Without this filter, the awk extraction would include
+            # B as affected because any path under library/<cat>/<slug>/
+            # surfaces the same <cat>/<slug>.
+            build_paths=(
+              'library/**/cmd/**'
+              'library/**/internal/**'
+              'library/**/go.mod'
+              'library/**/go.sum'
+              'library/**/manifest.json'
+            )
             if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE_SHA" ]; then
-              changed_paths=$(git diff --name-only "HEAD^" "HEAD" -- 'library/**' 2>/dev/null || git ls-files 'library/**')
+              changed_paths=$(git diff --name-only "HEAD^" "HEAD" -- "${build_paths[@]}" 2>/dev/null || git ls-files "${build_paths[@]}")
             else
-              changed_paths=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'library/**' || true)
+              changed_paths=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- "${build_paths[@]}" || true)
             fi
             # Filter to directories that still exist in the merged tree so a
             # rename (which surfaces in `git diff` as deletions under the old


### PR DESCRIPTION
## Summary

- `build-mcpb.yml` previously triggered on any `library/**` change (excluding `build/**`), so a README/SKILL/LICENSE/.printing-press.json/spec/dogfood/manuscripts edit fired the full 9-platform rebuild + release republish.
- Switch the `paths:` trigger to an allowlist of files that actually affect the compiled CLI binary or MCPB bundle: `cmd/**`, `internal/**`, `go.mod`, `go.sum`, `manifest.json`.
- Mirror the same allowlist in the `detect` step's `git diff --name-only` pathspec, so a mixed commit (Go source in CLI A + README in CLI B) only rebuilds A. Previously the awk extraction would surface both because any path under `library/<cat>/<slug>/` produced the same `<cat>/<slug>`.

## Coverage notes

- `//go:embed` files (e.g. `library/marketing/dub/internal/mcp/embedded_manifest.json`) live inside `cmd/` or `internal/`, so the allowlist still catches them.
- `.goreleaser.yaml` is intentionally excluded — this workflow uses direct `go build`, not goreleaser. If a separate goreleaser workflow ever lands, it should have its own trigger.
- `manifest.json` triggers both bundle and CLI matrices today; that's slightly broader than strictly needed but matches existing per-CLI fate-sharing.
- `workflow_dispatch` "all" path is unchanged — manual rebuild-everything still walks every CLI directory.

## Test plan

Verified locally with synthetic git history:

- [x] README-only commit → empty diff under build pathspec → no CLI detected
- [x] Go-source commit → file shows up → correct CLI detected
- [x] Mixed commit (README in CLI A + Go in CLI B) → old behavior listed both, new behavior lists only B
- [x] Embed JSON change under `internal/mcp/` → detected via `library/**/internal/**`
- [x] `git ls-files` against the new pathspec on this repo returns 4750 build-relevant files across 46 CLIs (sanity check)

## Verify after merge

- [ ] Push a docs-only PR to a CLI README (e.g. typo fix) and confirm `build-mcpb.yml` does not run.
- [ ] Push a Go-source PR to a CLI and confirm only that CLI's bundle/build/release matrix entries fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)