### PR TITLE
feat(registry): bump schema to v2 with detected MCP transports

### DIFF
--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -3,7 +3,7 @@ export const DEFAULT_REGISTRY_URL =
 
 export interface MCPBlock {
   binary: string;
-  transport: string;
+  transports: string[];
   tool_count: number;
   public_tool_count?: number;
   auth_type: string;
@@ -31,7 +31,7 @@ export function parseRegistry(value: unknown): Registry {
   if (!isRecord(value)) {
     throw new Error("registry payload must be an object");
   }
-  if (value.schema_version !== 1) {
+  if (value.schema_version !== 2) {
     throw new Error(`unsupported registry schema_version: ${String(value.schema_version)}`);
   }
   if (!Array.isArray(value.entries)) {
@@ -39,7 +39,7 @@ export function parseRegistry(value: unknown): Registry {
   }
 
   return {
-    schema_version: 1,
+    schema_version: 2,
     entries: value.entries.map(parseRegistryEntry),
   };
 }
@@ -114,7 +114,7 @@ function parseRegistryEntry(value: unknown): RegistryEntry {
         ...entry,
         mcp: {
           binary: requiredString(value.mcp, "binary"),
-          transport: requiredString(value.mcp, "transport"),
+          transports: requiredStringArray(value.mcp, "transports"),
           tool_count: requiredNumber(value.mcp, "tool_count"),
           public_tool_count:
             typeof value.mcp.public_tool_count === "number" ? value.mcp.public_tool_count : undefined,
@@ -142,6 +142,21 @@ function requiredNumber(value: Record<string, unknown>, key: string): number {
     throw new Error(`registry entry missing number field: ${key}`);
   }
   return value[key];
+}
+
+function requiredStringArray(value: Record<string, unknown>, key: string): string[] {
+  const raw = value[key];
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(`registry entry missing non-empty string array field: ${key}`);
+  }
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string" || item.trim() === "") {
+      throw new Error(`registry entry has non-string value in array field: ${key}`);
+    }
+    out.push(item);
+  }
+  return out;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -6,7 +6,7 @@ import type { RunResult } from "../src/process.js";
 import type { Registry } from "../src/registry.js";
 
 const registry: Registry = {
-  schema_version: 1,
+  schema_version: 2,
   entries: [
     {
       name: "espn",
@@ -16,7 +16,7 @@ const registry: Registry = {
       path: "library/sports/espn",
       mcp: {
         binary: "espn-pp-mcp",
-        transport: "stdio",
+        transports: ["stdio"],
         tool_count: 10,
         auth_type: "none",
         env_vars: [],
@@ -179,7 +179,7 @@ test("install command emits JSON when requested", async () => {
 
 test("install command uses go.mod module path when it differs from registry path", async () => {
   const hubspotRegistry: Registry = {
-    schema_version: 1,
+    schema_version: 2,
     entries: [
       {
         name: "hubspot-pp-cli",

--- a/npm/tests/registry.test.ts
+++ b/npm/tests/registry.test.ts
@@ -12,7 +12,7 @@ import {
 
 test("parseRegistry validates and returns registry entries", () => {
   const registry = parseRegistry({
-    schema_version: 1,
+    schema_version: 2,
     entries: [
       {
         name: "espn",
@@ -30,7 +30,7 @@ test("parseRegistry validates and returns registry entries", () => {
 
 test("lookupByName matches normalized CLI and API names", () => {
   const registry = parseRegistry({
-    schema_version: 1,
+    schema_version: 2,
     entries: [
       {
         name: "yahoo-finance-pp-cli",
@@ -50,7 +50,7 @@ test("lookupByName matches normalized CLI and API names", () => {
 
 test("cliSkillName preserves pp- naming convention", () => {
   const registry = parseRegistry({
-    schema_version: 1,
+    schema_version: 2,
     entries: [
       {
         name: "dominos-pp-cli",
@@ -67,7 +67,66 @@ test("cliSkillName preserves pp- naming convention", () => {
 });
 
 test("parseRegistry rejects unsupported schema versions", () => {
-  assert.throws(() => parseRegistry({ schema_version: 2, entries: [] }), /unsupported registry/);
+  assert.throws(() => parseRegistry({ schema_version: 1, entries: [] }), /unsupported registry/);
+  assert.throws(() => parseRegistry({ schema_version: 3, entries: [] }), /unsupported registry/);
+});
+
+test("parseRegistry parses transports as a non-empty string array", () => {
+  const registry = parseRegistry({
+    schema_version: 2,
+    entries: [
+      {
+        name: "ahrefs",
+        category: "marketing",
+        api: "Ahrefs",
+        description: "Backlinks and SEO",
+        path: "library/marketing/ahrefs",
+        mcp: {
+          binary: "ahrefs-pp-mcp",
+          transports: ["stdio", "http"],
+          tool_count: 29,
+          public_tool_count: 2,
+          auth_type: "api_key",
+          env_vars: ["AHREFS_API_KEY"],
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(registry.entries[0]?.mcp?.transports, ["stdio", "http"]);
+});
+
+test("parseRegistry rejects entries with empty or missing transports", () => {
+  const baseEntry = {
+    name: "demo",
+    category: "demo",
+    api: "Demo",
+    description: "Demo",
+    path: "library/demo/demo",
+  };
+  const baseMcp = {
+    binary: "demo-pp-mcp",
+    tool_count: 1,
+    auth_type: "none",
+    env_vars: [],
+  };
+
+  assert.throws(
+    () =>
+      parseRegistry({
+        schema_version: 2,
+        entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: [] } }],
+      }),
+    /transports/,
+  );
+  assert.throws(
+    () =>
+      parseRegistry({
+        schema_version: 2,
+        entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: ["stdio", 7] } }],
+      }),
+    /transports/,
+  );
 });
 
 test("fetchRegistry sends GitHub token when available", async () => {
@@ -81,7 +140,7 @@ test("fetchRegistry sends GitHub token when available", async () => {
         authHeader = new Headers(init?.headers).get("authorization");
         return new Response(
           JSON.stringify({
-            schema_version: 1,
+            schema_version: 2,
             entries: [],
           }),
           { status: 200 },
@@ -106,7 +165,7 @@ test("fetchRegistry does not send GitHub token to custom registry hosts", async 
   try {
     await fetchRegistry("https://registry.example.test/registry.json", async (_url, init) => {
       authHeader = new Headers(init?.headers).get("authorization");
-      return new Response(JSON.stringify({ schema_version: 1, entries: [] }), { status: 200 });
+      return new Response(JSON.stringify({ schema_version: 2, entries: [] }), { status: 200 });
     });
   } finally {
     if (previous === undefined) {

--- a/registry.json
+++ b/registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "entries": [
     {
       "name": "agent-capture",
@@ -16,7 +16,10 @@
       "path": "library/marketing/ahrefs",
       "mcp": {
         "binary": "ahrefs-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 29,
         "public_tool_count": 2,
         "auth_type": "api_key",
@@ -35,7 +38,9 @@
       "path": "library/travel/airbnb",
       "mcp": {
         "binary": "airbnb-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 6,
         "auth_type": "cookie",
@@ -52,7 +57,10 @@
       "path": "library/food-and-dining/allrecipes",
       "mcp": {
         "binary": "allrecipes-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 2,
         "public_tool_count": 1,
         "auth_type": "cookie",
@@ -71,7 +79,9 @@
       "path": "library/other/apartments",
       "mcp": {
         "binary": "apartments-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 2,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -88,7 +98,9 @@
       "path": "library/media-and-entertainment/archive-is",
       "mcp": {
         "binary": "archive-is-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 6,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -104,7 +116,9 @@
       "path": "library/productivity/cal-com",
       "mcp": {
         "binary": "cal-com-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 291,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -123,7 +137,9 @@
       "path": "library/payments/coingecko",
       "mcp": {
         "binary": "coingecko-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "none",
@@ -140,7 +156,9 @@
       "path": "library/developer-tools/company-goat",
       "mcp": {
         "binary": "company-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 1,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -157,7 +175,9 @@
       "path": "library/sales-and-crm/contact-goat",
       "mcp": {
         "binary": "contact-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 16,
         "public_tool_count": 0,
         "auth_type": "composed",
@@ -177,7 +197,10 @@
       "path": "library/commerce/craigslist",
       "mcp": {
         "binary": "craigslist-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 1,
         "public_tool_count": 1,
         "auth_type": "none",
@@ -194,7 +217,9 @@
       "path": "library/developer-tools/docker-hub",
       "mcp": {
         "binary": "docker-hub-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -211,7 +236,10 @@
       "path": "library/food-and-dining/dominos",
       "mcp": {
         "binary": "dominos-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 20,
         "public_tool_count": 11,
         "auth_type": "bearer_token",
@@ -232,7 +260,10 @@
       "path": "library/marketing/dub",
       "mcp": {
         "binary": "dub-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 53,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -251,7 +282,9 @@
       "path": "library/commerce/ebay",
       "mcp": {
         "binary": "ebay-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 1,
         "auth_type": "cookie",
@@ -268,7 +301,9 @@
       "path": "library/media-and-entertainment/espn",
       "mcp": {
         "binary": "espn-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 7,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -285,7 +320,10 @@
       "path": "library/commerce/fedex",
       "mcp": {
         "binary": "fedex-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 48,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -305,7 +343,9 @@
       "path": "library/developer-tools/firecrawl",
       "mcp": {
         "binary": "firecrawl-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 20,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -324,7 +364,9 @@
       "path": "library/travel/flight-goat",
       "mcp": {
         "binary": "flight-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 58,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -343,7 +385,9 @@
       "path": "library/food-and-dining/food52",
       "mcp": {
         "binary": "food52-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 4,
         "public_tool_count": 4,
         "auth_type": "none",
@@ -360,7 +404,10 @@
       "path": "library/media-and-entertainment/google-photos",
       "mcp": {
         "binary": "google-photos-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 19,
         "public_tool_count": 0,
         "auth_type": "oauth2",
@@ -379,7 +426,10 @@
       "path": "library/media-and-entertainment/hackernews",
       "mcp": {
         "binary": "hackernews-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 10,
         "public_tool_count": 10,
         "auth_type": "none",
@@ -396,7 +446,9 @@
       "path": "library/sales-and-crm/hubspot",
       "mcp": {
         "binary": "hubspot-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 62,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -421,7 +473,9 @@
       "path": "library/payments/kalshi",
       "mcp": {
         "binary": "kalshi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 96,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -440,7 +494,9 @@
       "path": "library/marketing/klaviyo",
       "mcp": {
         "binary": "klaviyo-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 308,
         "public_tool_count": 11,
         "auth_type": "api_key",
@@ -459,7 +515,9 @@
       "path": "library/project-management/linear",
       "mcp": {
         "binary": "linear-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 63,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -477,7 +535,10 @@
       "path": "library/media-and-entertainment/movie-goat",
       "mcp": {
         "binary": "movie-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 25,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -496,7 +557,9 @@
       "path": "library/developer-tools/nvd",
       "mcp": {
         "binary": "nvd-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 2,
         "public_tool_count": 2,
         "auth_type": "none",
@@ -513,7 +576,9 @@
       "path": "library/other/open-meteo",
       "mcp": {
         "binary": "open-meteo-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "none",
@@ -530,7 +595,10 @@
       "path": "library/food-and-dining/pagliacci",
       "mcp": {
         "binary": "pagliacci-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 57,
         "public_tool_count": 26,
         "auth_type": "composed",
@@ -547,7 +615,9 @@
       "path": "library/media-and-entertainment/pokeapi",
       "mcp": {
         "binary": "pokeapi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 98,
         "public_tool_count": 98,
         "auth_type": "none",
@@ -564,7 +634,9 @@
       "path": "library/developer-tools/postman-explore",
       "mcp": {
         "binary": "postman-explore-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 8,
         "auth_type": "none",
@@ -581,7 +653,10 @@
       "path": "library/marketing/producthunt",
       "mcp": {
         "binary": "producthunt-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 1,
         "public_tool_count": 1,
         "auth_type": "bearer_token",
@@ -600,7 +675,9 @@
       "path": "library/developer-tools/pypi",
       "mcp": {
         "binary": "pypi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 4,
         "public_tool_count": 4,
         "auth_type": "none",
@@ -617,7 +694,9 @@
       "path": "library/food-and-dining/recipe-goat",
       "mcp": {
         "binary": "recipe-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 3,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -636,7 +715,9 @@
       "path": "library/developer-tools/scrape-creators",
       "mcp": {
         "binary": "scrape-creators-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 114,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -655,7 +736,9 @@
       "path": "library/monitoring/sentry",
       "mcp": {
         "binary": "sentry-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 219,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -674,7 +757,9 @@
       "path": "library/commerce/shopify",
       "mcp": {
         "binary": "shopify-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 10,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -693,7 +778,9 @@
       "path": "library/productivity/slack",
       "mcp": {
         "binary": "slack-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 66,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -711,7 +798,9 @@
       "path": "library/media-and-entertainment/steam-web",
       "mcp": {
         "binary": "steam-web-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 161,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -730,7 +819,9 @@
       "path": "library/commerce/tiktok-shop",
       "mcp": {
         "binary": "tiktok-shop-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "signed_tiktok_shop_open_api",
@@ -753,7 +844,9 @@
       "path": "library/developer-tools/trigger-dev",
       "mcp": {
         "binary": "trigger-dev-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 41,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -771,7 +864,9 @@
       "path": "library/other/weather-goat",
       "mcp": {
         "binary": "weather-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -788,7 +883,9 @@
       "path": "library/media-and-entertainment/wikipedia",
       "mcp": {
         "binary": "wikipedia-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -805,7 +902,9 @@
       "path": "library/commerce/yahoo-finance",
       "mcp": {
         "binary": "yahoo-finance-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 0,
         "auth_type": "none",

--- a/skills/ppl/SKILL.md
+++ b/skills/ppl/SKILL.md
@@ -19,7 +19,7 @@ The registry contains entries with these fields:
 - `api` — human-readable API name (e.g., `ESPN`, `Linear`)
 - `description` — what the CLI does
 - `path` — repo-relative path to the CLI source (e.g., `library/media-and-entertainment/espn`)
-- `mcp` (optional) — MCP server metadata: `binary`, `transport`, `tool_count`, `auth_type`, `env_vars`
+- `mcp` (optional) — MCP server metadata: `binary`, `transports` (e.g., `["stdio"]` or `["stdio", "http"]`), `tool_count`, `auth_type`, `env_vars`
 
 ## Argument Parsing
 

--- a/skills/ppl/references/registry.json
+++ b/skills/ppl/references/registry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "entries": [
     {
       "name": "agent-capture",
@@ -16,7 +16,10 @@
       "path": "library/marketing/ahrefs",
       "mcp": {
         "binary": "ahrefs-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 29,
         "public_tool_count": 2,
         "auth_type": "api_key",
@@ -35,7 +38,9 @@
       "path": "library/travel/airbnb",
       "mcp": {
         "binary": "airbnb-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 6,
         "auth_type": "cookie",
@@ -52,7 +57,10 @@
       "path": "library/food-and-dining/allrecipes",
       "mcp": {
         "binary": "allrecipes-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 2,
         "public_tool_count": 1,
         "auth_type": "cookie",
@@ -71,7 +79,9 @@
       "path": "library/other/apartments",
       "mcp": {
         "binary": "apartments-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 2,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -88,7 +98,9 @@
       "path": "library/media-and-entertainment/archive-is",
       "mcp": {
         "binary": "archive-is-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 6,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -104,7 +116,9 @@
       "path": "library/productivity/cal-com",
       "mcp": {
         "binary": "cal-com-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 291,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -123,7 +137,9 @@
       "path": "library/payments/coingecko",
       "mcp": {
         "binary": "coingecko-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "none",
@@ -140,7 +156,9 @@
       "path": "library/developer-tools/company-goat",
       "mcp": {
         "binary": "company-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 1,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -157,7 +175,9 @@
       "path": "library/sales-and-crm/contact-goat",
       "mcp": {
         "binary": "contact-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 16,
         "public_tool_count": 0,
         "auth_type": "composed",
@@ -177,7 +197,10 @@
       "path": "library/commerce/craigslist",
       "mcp": {
         "binary": "craigslist-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 1,
         "public_tool_count": 1,
         "auth_type": "none",
@@ -194,7 +217,9 @@
       "path": "library/developer-tools/docker-hub",
       "mcp": {
         "binary": "docker-hub-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -211,7 +236,10 @@
       "path": "library/food-and-dining/dominos",
       "mcp": {
         "binary": "dominos-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 20,
         "public_tool_count": 11,
         "auth_type": "bearer_token",
@@ -232,7 +260,10 @@
       "path": "library/marketing/dub",
       "mcp": {
         "binary": "dub-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 53,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -251,7 +282,9 @@
       "path": "library/commerce/ebay",
       "mcp": {
         "binary": "ebay-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 1,
         "auth_type": "cookie",
@@ -268,7 +301,9 @@
       "path": "library/media-and-entertainment/espn",
       "mcp": {
         "binary": "espn-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 7,
         "public_tool_count": 0,
         "auth_type": "none",
@@ -285,7 +320,10 @@
       "path": "library/commerce/fedex",
       "mcp": {
         "binary": "fedex-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 48,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -305,7 +343,9 @@
       "path": "library/developer-tools/firecrawl",
       "mcp": {
         "binary": "firecrawl-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 20,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -324,7 +364,9 @@
       "path": "library/travel/flight-goat",
       "mcp": {
         "binary": "flight-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 58,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -343,7 +385,9 @@
       "path": "library/food-and-dining/food52",
       "mcp": {
         "binary": "food52-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 4,
         "public_tool_count": 4,
         "auth_type": "none",
@@ -360,7 +404,10 @@
       "path": "library/media-and-entertainment/google-photos",
       "mcp": {
         "binary": "google-photos-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 19,
         "public_tool_count": 0,
         "auth_type": "oauth2",
@@ -379,7 +426,10 @@
       "path": "library/media-and-entertainment/hackernews",
       "mcp": {
         "binary": "hackernews-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 10,
         "public_tool_count": 10,
         "auth_type": "none",
@@ -396,7 +446,9 @@
       "path": "library/sales-and-crm/hubspot",
       "mcp": {
         "binary": "hubspot-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 62,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -421,7 +473,9 @@
       "path": "library/payments/kalshi",
       "mcp": {
         "binary": "kalshi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 96,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -440,7 +494,9 @@
       "path": "library/marketing/klaviyo",
       "mcp": {
         "binary": "klaviyo-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 308,
         "public_tool_count": 11,
         "auth_type": "api_key",
@@ -459,7 +515,9 @@
       "path": "library/project-management/linear",
       "mcp": {
         "binary": "linear-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 63,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -477,7 +535,10 @@
       "path": "library/media-and-entertainment/movie-goat",
       "mcp": {
         "binary": "movie-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 25,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -496,7 +557,9 @@
       "path": "library/developer-tools/nvd",
       "mcp": {
         "binary": "nvd-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 2,
         "public_tool_count": 2,
         "auth_type": "none",
@@ -513,7 +576,9 @@
       "path": "library/other/open-meteo",
       "mcp": {
         "binary": "open-meteo-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "none",
@@ -530,7 +595,10 @@
       "path": "library/food-and-dining/pagliacci",
       "mcp": {
         "binary": "pagliacci-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 57,
         "public_tool_count": 26,
         "auth_type": "composed",
@@ -547,7 +615,9 @@
       "path": "library/media-and-entertainment/pokeapi",
       "mcp": {
         "binary": "pokeapi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 98,
         "public_tool_count": 98,
         "auth_type": "none",
@@ -564,7 +634,9 @@
       "path": "library/developer-tools/postman-explore",
       "mcp": {
         "binary": "postman-explore-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 8,
         "public_tool_count": 8,
         "auth_type": "none",
@@ -581,7 +653,10 @@
       "path": "library/marketing/producthunt",
       "mcp": {
         "binary": "producthunt-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio",
+          "http"
+        ],
         "tool_count": 1,
         "public_tool_count": 1,
         "auth_type": "bearer_token",
@@ -600,7 +675,9 @@
       "path": "library/developer-tools/pypi",
       "mcp": {
         "binary": "pypi-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 4,
         "public_tool_count": 4,
         "auth_type": "none",
@@ -617,7 +694,9 @@
       "path": "library/food-and-dining/recipe-goat",
       "mcp": {
         "binary": "recipe-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 3,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -636,7 +715,9 @@
       "path": "library/developer-tools/scrape-creators",
       "mcp": {
         "binary": "scrape-creators-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 114,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -655,7 +736,9 @@
       "path": "library/monitoring/sentry",
       "mcp": {
         "binary": "sentry-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 219,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
@@ -674,7 +757,9 @@
       "path": "library/commerce/shopify",
       "mcp": {
         "binary": "shopify-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 10,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -693,7 +778,9 @@
       "path": "library/productivity/slack",
       "mcp": {
         "binary": "slack-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 66,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -711,7 +798,9 @@
       "path": "library/media-and-entertainment/steam-web",
       "mcp": {
         "binary": "steam-web-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 161,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -730,7 +819,9 @@
       "path": "library/commerce/tiktok-shop",
       "mcp": {
         "binary": "tiktok-shop-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 11,
         "auth_type": "signed_tiktok_shop_open_api",
@@ -753,7 +844,9 @@
       "path": "library/developer-tools/trigger-dev",
       "mcp": {
         "binary": "trigger-dev-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 41,
         "public_tool_count": 0,
         "auth_type": "api_key",
@@ -771,7 +864,9 @@
       "path": "library/other/weather-goat",
       "mcp": {
         "binary": "weather-goat-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -788,7 +883,9 @@
       "path": "library/media-and-entertainment/wikipedia",
       "mcp": {
         "binary": "wikipedia-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 5,
         "public_tool_count": 5,
         "auth_type": "none",
@@ -805,7 +902,9 @@
       "path": "library/commerce/yahoo-finance",
       "mcp": {
         "binary": "yahoo-finance-pp-mcp",
-        "transport": "stdio",
+        "transports": [
+          "stdio"
+        ],
         "tool_count": 11,
         "public_tool_count": 0,
         "auth_type": "none",

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -34,12 +34,18 @@ import (
 )
 
 const (
-	libraryDir       = "library"
-	registryPath     = "registry.json"
-	mirrorPath       = "skills/ppl/references/registry.json"
-	readmePath       = "README.md"
-	schemaVersion    = 1
-	defaultTransport = "stdio"
+	libraryDir    = "library"
+	registryPath  = "registry.json"
+	mirrorPath    = "skills/ppl/references/registry.json"
+	readmePath    = "README.md"
+	schemaVersion = 2
+	// stdioTransport / httpTransport are the registry-side names for the
+	// MCP transports an emitted binary can serve. Detection of which
+	// transports a CLI actually supports happens in detectMCPTransports
+	// by inspecting cmd/<binary>/main.go: every server links ServeStdio,
+	// only the streamable-HTTP-capable ones reference NewStreamableHTTPServer.
+	stdioTransport = "stdio"
+	httpTransport  = "http"
 
 	// README sentinel markers. The generator only rewrites bytes
 	// between matching begin/end markers; surrounding prose stays
@@ -84,7 +90,7 @@ type RegistryEntry struct {
 // would be misleading.
 type MCPBlock struct {
 	Binary          string   `json:"binary"`
-	Transport       string   `json:"transport"`
+	Transports      []string `json:"transports"`
 	ToolCount       int      `json:"tool_count"`
 	PublicToolCount int      `json:"public_tool_count"`
 	AuthType        string   `json:"auth_type,omitempty"`
@@ -308,9 +314,11 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	// This avoids regressing accurate registry values to 0/empty when
 	// only some fields drift forward.
 	if pp.MCPBinary != "" {
-		entry.MCP = buildMCPBlock(pp, prior.MCP)
+		entry.MCP = buildMCPBlock(pp, prior.MCP, dir)
 	} else if prior.MCP != nil {
-		entry.MCP = prior.MCP
+		preserved := *prior.MCP
+		preserved.Transports = detectMCPTransports(dir, preserved.Binary)
+		entry.MCP = &preserved
 	}
 
 	return &entry, nil
@@ -359,11 +367,11 @@ func apiDisplayName(pp printingPressManifest, prior RegistryEntry, slug string) 
 // Field-level fallbacks deliberately mix authoritative (pp) and
 // preserved (prior) signals; full-block preservation for legacy CLIs
 // happens upstream in buildEntry.
-func buildMCPBlock(pp printingPressManifest, prior *MCPBlock) *MCPBlock {
+func buildMCPBlock(pp printingPressManifest, prior *MCPBlock, cliDir string) *MCPBlock {
 	mcp := &MCPBlock{
-		Binary:    pp.MCPBinary,
-		Transport: defaultTransport,
-		ToolCount: pp.MCPToolCount,
+		Binary:     pp.MCPBinary,
+		Transports: detectMCPTransports(cliDir, pp.MCPBinary),
+		ToolCount:  pp.MCPToolCount,
 		// EnvVars must be a non-nil slice so JSON encodes as `[]`
 		// rather than `null`; this matches the historical hand-edited
 		// registry shape where every MCP entry has an env_vars array
@@ -392,6 +400,36 @@ func buildMCPBlock(pp printingPressManifest, prior *MCPBlock) *MCPBlock {
 		mcp.SpecFormat = prior.SpecFormat
 	}
 	return mcp
+}
+
+// detectMCPTransports inspects a CLI's MCP binary main.go to determine
+// which MCP transports the compiled server can serve. Every emitted MCP
+// binary links ServeStdio so stdio is always reported; streamable HTTP
+// is reported only when main.go references NewStreamableHTTPServer
+// (the streamable-HTTP entry point from mark3labs/mcp-go).
+//
+// Detection by source-grep matches the runtime truth: the transport
+// switch in cmd/<binary>/main.go is the only place that wires either
+// ServeStdio or NewStreamableHTTPServer. If the file is missing
+// (e.g., a legacy CLI whose MCP source was never copied here), we
+// degrade to ["stdio"] — the historical default registry value.
+//
+// The returned slice is always non-nil so callers can rely on it
+// encoding as a real JSON array rather than null.
+func detectMCPTransports(cliDir, binary string) []string {
+	transports := []string{stdioTransport}
+	if binary == "" {
+		return transports
+	}
+	mainPath := filepath.Join(cliDir, "cmd", binary, "main.go")
+	data, err := os.ReadFile(mainPath)
+	if err != nil {
+		return transports
+	}
+	if bytes.Contains(data, []byte("NewStreamableHTTPServer")) {
+		transports = append(transports, httpTransport)
+	}
+	return transports
 }
 
 // readGoreleaserDescription returns the first non-empty `description`

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -140,6 +142,101 @@ Trailing prose.
 	}
 	if strings.Contains(string(first), "old table") || strings.Contains(string(first), "old counts") {
 		t.Errorf("updateReadme failed to replace sentinel content; got:\n%s", first)
+	}
+}
+
+// TestDetectMCPTransports covers the source-grep detection logic.
+// Encoding the detection rule in tests guards against two regressions:
+// (a) a future generator template renaming NewStreamableHTTPServer to a
+//     differently-named entry point would silently flip every dual-transport
+//     CLI back to stdio-only, and the test fails before the registry is
+//     re-emitted.
+// (b) the missing-binary fallback returning nil would cause the registry
+//     to emit `"transports": null` instead of `["stdio"]`; we lock in the
+//     non-nil ["stdio"] default so the JSON shape stays a real array.
+func TestDetectMCPTransports(t *testing.T) {
+	stdioOnlyMain := `package main
+
+import "github.com/mark3labs/mcp-go/server"
+
+func main() {
+	s := server.NewMCPServer("Demo", "1.0.0")
+	server.ServeStdio(s)
+}
+`
+	dualTransportMain := `package main
+
+import "github.com/mark3labs/mcp-go/server"
+
+func main() {
+	s := server.NewMCPServer("Demo", "1.0.0")
+	switch *transport {
+	case "stdio":
+		server.ServeStdio(s)
+	case "http":
+		httpSrv := server.NewStreamableHTTPServer(s)
+		_ = httpSrv.Start(":7777")
+	}
+}
+`
+
+	cases := []struct {
+		name    string
+		binary  string
+		writeAt string // relative to cliDir; "" means don't write
+		body    string
+		want    []string
+	}{
+		{
+			name:    "stdio-only binary",
+			binary:  "demo-pp-mcp",
+			writeAt: "cmd/demo-pp-mcp/main.go",
+			body:    stdioOnlyMain,
+			want:    []string{"stdio"},
+		},
+		{
+			name:    "dual transport binary",
+			binary:  "demo-pp-mcp",
+			writeAt: "cmd/demo-pp-mcp/main.go",
+			body:    dualTransportMain,
+			want:    []string{"stdio", "http"},
+		},
+		{
+			name:    "missing binary file falls back to stdio",
+			binary:  "demo-pp-mcp",
+			writeAt: "",
+			want:    []string{"stdio"},
+		},
+		{
+			name:    "empty binary name returns stdio without filesystem read",
+			binary:  "",
+			writeAt: "",
+			want:    []string{"stdio"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cliDir := t.TempDir()
+			if tc.writeAt != "" {
+				path := filepath.Join(cliDir, tc.writeAt)
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+					t.Fatalf("write main.go: %v", err)
+				}
+			}
+			got := detectMCPTransports(cliDir, tc.binary)
+			if len(got) != len(tc.want) {
+				t.Fatalf("transports = %v, want %v", got, tc.want)
+			}
+			for i, v := range tc.want {
+				if got[i] != v {
+					t.Errorf("transports[%d] = %q, want %q", i, got[i], v)
+				}
+			}
+		})
 	}
 }
 

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -19,7 +19,7 @@ const skillOutputDir = "cli-skills"
 
 type MCPBlock struct {
 	Binary          string   `json:"binary"`
-	Transport       string   `json:"transport"`
+	Transports      []string `json:"transports"`
 	ToolCount       int      `json:"tool_count"`
 	PublicToolCount int      `json:"public_tool_count"`
 	AuthType        string   `json:"auth_type"`


### PR DESCRIPTION
## Summary

- Replace `mcp.transport` (a string always set to `"stdio"`) with `mcp.transports` (a string array per CLI). Detected by reading each binary's `cmd/<binary>/main.go` for `NewStreamableHTTPServer`; every server links `ServeStdio` so stdio is always reported.
- 11 dual-transport CLIs now truthfully advertise `["stdio", "http"]`: ahrefs, allrecipes, craigslist, dominos, dub, fedex, google-photos, hackernews, movie-goat, pagliacci, producthunt. The remaining 33 stdio-only entries stay `["stdio"]`.
- Bump `schema_version` 1 → 2 and update consumers (npm parser, generate-skills struct, skills/ppl SKILL.md schema doc).
- Backfill `registry.json` + `skills/ppl/references/registry.json` mirror.

## Why

The field today is inventory-only and inaccurate. Every entry was hardcoded `"stdio"` regardless of the actual binary, so anything keying off it (a hosted-agent client picking a transport, an installer emitting MCP config) would be wrong for the 11 streamable-HTTP-capable servers. Making it a list and grounding it in the source code lets future consumers trust the value.

No runtime behavior changes today — the field still has no consumer. This PR establishes the truth so downstream tooling can rely on it.

## Test plan

- [x] `cd tools/generate-registry && go test ./...` — 19 passed (4 new for `detectMCPTransports`)
- [x] `cd tools/generate-skills && go test ./...` — 15 passed
- [x] `cd npm && npm test` — 29 passed (3 new for `transports` parsing + schema_version 2)
- [x] `go run ./tools/generate-registry/main.go --check` — clean
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/ahrefs/` — pass
- [x] Spot-checked regenerated `registry.json`: 44 mcp entries, 11 contain `"http"`, mirror is byte-identical.

## Notes for reviewers

- Schema bump means old npm package versions (v0.1.0) will reject the new `registry.json` until republished. Per AGENTS.md the package is internal-only today, so this is safe.
- `cli-skills/pp-*` SKILL.md files are unchanged — generate-skills doesn't read this field.
- The detector lives in this repo because the source-of-truth signal is observation of already-shipped `cmd/*-pp-mcp/main.go`. A longer-term cleanup would have `cli-printing-press` emit `mcp_transports` into `.printing-press.json` so this generator just reads it; until then, source-grep is honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)