### PR TITLE
chore(npm): drop auth env vars line from install output (v0.1.3)

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- Drop the `auth env vars: …` line from `install` output. The data was a bare list of env var names without the surrounding context (where to get the token, how to set it, what command verifies it) — that context lives in each CLI's `--help`, `doctor` command, and authenticated-error messages, which is the natural moment to discover auth requirements. JSON output no longer carries `authEnvVars` either; consumers that genuinely need a structured env-var list can read `mcp.env_vars` directly from `registry.json`.
+
 ## 0.1.2
 
 - CI fix: pin the npm version used for Trusted Publishing to `npm@11.5.1`. The previous `npm install -g npm@latest` step is flaky on Actions runners — npm overwrites itself mid-install and the global install ends up with a missing `promise-retry` module. v0.1.1 was tagged but never reached npmjs.com because of this; this is the first published release on the OIDC pipeline.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -38,7 +38,6 @@ interface InstallSummary {
   modulePath?: string;
   skill?: string;
   binaryPath?: string;
-  authEnvVars: string[];
 }
 
 interface InstallOutcome {
@@ -108,7 +107,6 @@ async function installOne(
 
   const summary: InstallSummary = {
     name: entry.name,
-    authEnvVars: entry.mcp?.env_vars ?? [],
   };
 
   if (!options.skillOnly) {
@@ -167,9 +165,6 @@ async function installOne(
     }
     if (summary.skill) {
       deps.stdout(`  skill: ${summary.skill}`);
-    }
-    if (summary.authEnvVars.length > 0) {
-      deps.stdout(`  auth env vars: ${summary.authEnvVars.join(", ")}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove the `auth env vars: …` line from `printing-press install` output, both human and JSON. The surrounding context (where to get a token, how to set it, what command verifies it) lives in each CLI's `--help`, `doctor` command, and error messages — which is the natural moment to discover auth requirements. Surfacing a bare list of env var names at install time is noise without that context.
- Bumps version to `0.1.3`. v0.1.2 is on npm and working — this is incremental cleanup riding the now-validated OIDC pipeline.

## Test plan

- [x] `npm test` — 34 passing.
- [x] `npm run build` — clean tsc.

Post-merge:
- [ ] `gh workflow run npm-publish.yml --ref main` (or `git tag npm-v0.1.3 && git push --tags`)
- [ ] `npm view @mvanhorn/printing-press version` → `0.1.3`.
- [ ] Spot-check that `npx -y @mvanhorn/printing-press@0.1.3 install slack` (a CLI with auth requirements) no longer prints the auth env vars line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)