### PR TITLE
ci(release): auto-tag npm release on version bump

### DIFF
--- a/.github/workflows/auto-tag-npm.yml
+++ b/.github/workflows/auto-tag-npm.yml
@@ -1,0 +1,66 @@
+name: Auto-tag npm release on version bump
+
+# When npm/package.json's "version" field changes on main, push a matching
+# `npm-v<version>` tag. The existing npm-publish.yml workflow listens for that
+# tag and publishes via OIDC.
+#
+# This means the entire release rhythm is:
+#   1. Bump npm/package.json version in a PR (alongside any code change).
+#   2. Merge the PR.
+#   3. This workflow tags. npm-publish.yml publishes. Done.
+#
+# Things that intentionally do NOT trigger a release:
+#   - Library / SKILL.md / registry.json / cli-skills changes (sourced live by
+#     the orchestrator at install time, not bundled in the npm tarball).
+#   - Root README, AGENTS.md, CI workflow tweaks (not in the npm tarball).
+#   - npm/package.json changes that don't bump the version (metadata polish
+#     only ships when packaged with an intentional version bump — re-publishing
+#     the same version would fail at npm anyway).
+#
+# Bot regen commits with `[skip ci]` (registry / skill regenerations) skip
+# this workflow entirely, by design.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'npm/package.json'
+
+permissions:
+  contents: write   # needs to push the tag
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2   # need previous commit to diff against
+
+      - id: check
+        name: Detect version bump
+        run: |
+          set -euo pipefail
+          new=$(jq -r .version npm/package.json)
+          if old=$(git show HEAD~1:npm/package.json 2>/dev/null | jq -r .version); then
+            :
+          else
+            old=""
+          fi
+          echo "old=$old" >> "$GITHUB_OUTPUT"
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          if [ -n "$new" ] && [ "$new" != "null" ] && [ "$old" != "$new" ]; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $old → $new"
+          else
+            echo "No version bump (old=$old, new=$new); skipping tag."
+          fi
+
+      - name: Push npm-v<new> tag
+        if: steps.check.outputs.bumped == 'true'
+        run: |
+          set -euo pipefail
+          tag="npm-v${{ steps.check.outputs.new }}"
+          git tag "$tag"
+          git push origin "$tag"
+          echo "Pushed tag $tag — npm-publish.yml will run on the tag event."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-tag-npm.yml`: when `npm/package.json`'s `"version"` field changes on main, push a matching `npm-v<version>` tag. The existing `npm-publish.yml` workflow listens for that tag and publishes via OIDC.
- Net effect: bump version in your release PR → merge → publish chain runs automatically. No manual `git tag && git push --tags` step.

## What does and does not auto-publish

| Change | Triggers publish? | Why |
|---|---|---|
| `npm/package.json` version bump | ✅ | The version is the explicit "ship it" signal |
| `npm/src/**` + version bump | ✅ | Real code change, intentional release |
| `npm/README.md` (no version bump) | ❌ | npmjs.com page only updates on republish; bump version intentionally if you want it refreshed |
| `library/**` (Go code, SKILL.md) | ❌ | Fetched live by `go install` / `skills add`, not bundled in the npm tarball |
| `cli-skills/**` (skill mirrors) | ❌ | Fetched live by `skills add` |
| `registry.json` | ❌ | Fetched live at install time |
| Root `README.md` / `AGENTS.md` / `CONTRIBUTING.md` | ❌ | Not in the npm tarball |
| `.github/workflows/**` (other than `npm/package.json`) | ❌ | CI infra, not in the tarball |
| Bot regen commits (`[skip ci]`) | ❌ | GitHub Actions skips them by design |

The single rule: **publish iff `npm/package.json`'s version field changed.** That captures every case correctly.

## Test plan

This PR doesn't bump the version, so on merge the auto-tag workflow:
- Will run (since `npm/package.json` is in the trigger paths)... actually no, it won't, because this PR doesn't touch `npm/package.json`. The trigger only fires on changes to that file.
- The next real version bump on main will be the genuine test.

`workflow_dispatch` on `npm-publish.yml` stays as the retry path if a tagged release fails partway.

## One subtle thing

If a future PR ever bumps the version backwards (e.g., reverting a release), the auto-tag step tries to create a tag that already exists and fails loudly. That's the right failure mode — better to halt and require manual intervention than silently misbehave. The fix in that rare case is to delete the old tag manually before re-tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)