### PR TITLE
chore(skills): drop version: from SKILL.md frontmatter across library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,8 @@ Two files in this repo are **generated outputs**, regenerated post-merge by CI w
 
 **When you change `library/**/SKILL.md` or `library/**/internal/cli/**`:**
 
+**Edit `library/<cat>/<slug>/SKILL.md`, never `cli-skills/pp-<slug>/SKILL.md` directly.** The mirror is verbatim-regenerated from the library copy — any direct edit to `cli-skills/` will be silently overwritten on the next regen. Same rule for README.md.
+
 The workflow's trigger paths don't include SKILL.md or `internal/cli/**`. Until those triggers expand, run the generator locally and commit the result alongside your library change:
 
 ```bash
@@ -166,6 +168,20 @@ Then commit the regenerated `cli-skills/pp-*/SKILL.md` files alongside your libr
 Don't touch `registry.json`. The post-merge regen handles it. Your PR's diff stays focused on the actual library change. After your PR merges, `generate-registry.yml` runs, regenerates `registry.json`, and commits with `[skip ci]`. The regen-generated commit shows up on main within a minute or two.
 
 **When does this fail?** If the generator itself is broken (compile error, panic) or the source files have invalid JSON, the post-merge run will fail and `registry.json` will go stale. Watch for `generate-registry.yml` failures in the Actions tab after merging library/** changes.
+
+## Bulk SKILL.md/README.md retrofits: `tools/sweep-frontmatter/`
+
+When a frontmatter or section-shape change must propagate across **all library CLIs at once** — Hermes/OpenClaw shape alignment, stripping a deprecated field, normalizing an install command — edit and run this tool rather than hand-touching every entry. Don't use it for one-CLI-specific changes (edit `library/<cat>/<slug>/SKILL.md` directly), and don't use it for shape changes that belong upstream in `cli-printing-press/internal/generator/templates/skill.md.tmpl` — fix the template first so future fresh prints get it right, then run the sweep here to retrofit existing entries.
+
+**The `cliAuthorByAPIName` map is curated.** Don't replace it with a git-history lookup or operator-config fallback — that silently flips attribution on the published CLIs. Add a new entry when adding a new library CLI; correct one only when the actual author was misrecorded.
+
+**Idempotency is a hard requirement** — running the tool twice with the same inputs must produce zero diff. Tests at `tools/sweep-frontmatter/main_test.go` enforce this; run them before opening a sweep PR:
+
+```bash
+cd tools/sweep-frontmatter && GO111MODULE=off go test .
+```
+
+The tool runs in GOPATH mode (no `go.mod`) so it stays decoupled from the rest of the repo's module graph. After running the sweep, regenerate `cli-skills/` so the mirror reflects the updated library content (see the section above).
 
 ## Commit style
 

--- a/cli-skills/pp-agent-capture/SKILL.md
+++ b/cli-skills/pp-agent-capture/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-agent-capture
 description: "macOS screen capture, window recording, GIF conversion, and agent evidence bundles from the terminal. Built on ScreenCaptureKit for window-level targeting ffmpeg cannot do. Use when the user wants a screenshot of a specific window or app, a screen recording, a GIF conversion, a before/after diff, an evidence bundle for a PR, OCR text from a window, a terminal VHS recording, a Remotion render, or wants to watch a UI for changes. Requires macOS Screen Recording permission on first run."
-version: "0.4.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-ahrefs/SKILL.md
+++ b/cli-skills/pp-ahrefs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-ahrefs
 description: "Printing Press CLI for Ahrefs. SEO and competitive intelligence API for backlinks, keywords, rank tracking, site audit, and SERP data."
-version: "3.4.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-airbnb/SKILL.md
+++ b/cli-skills/pp-airbnb/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-airbnb
 description: "Skip the Airbnb platform fee. Find the host's direct booking site for any Airbnb listing. Trigger phrases: `find the direct booking site`, `skip the airbnb fee`, `vacation rental cheapest`, `book direct`, `use airbnb-pp`, `run airbnb-pp`. NOTE: VRBO support is currently disabled — pending Akamai workaround."
-version: "3.6.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-allrecipes/SKILL.md
+++ b/cli-skills/pp-allrecipes/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-allrecipes
 description: "Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, one-line grocery lists, and Cloudflare clearance. Trigger phrases: `search Allrecipes for X`, `find a recipe for brownies`, `scale this Allrecipes recipe`, `build a grocery list from these recipes`, `what can I cook with what I have`, `use allrecipes-pp-cli`, `run allrecipes`."
-version: "3.8.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-amazon-seller/SKILL.md
+++ b/cli-skills/pp-amazon-seller/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-amazon-seller
 description: "Printing Press CLI for Amazon Seller. Read FBA inventory, orders, sales reports, listings, and catalog data for an Amazon seller account."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-apartments/SKILL.md
+++ b/cli-skills/pp-apartments/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-apartments
 description: "The apartment-hunt CLI that actually works in 2026 — Surf-cleared bot protection plus a local SQLite store the website itself doesn't have. Trigger phrases: `find apartments in <city>`, `watch apartment listings for <area>`, `rank rentals by price per square foot`, `compare these apartments`, `use apartments-pp-cli`, `run apartments`."
-version: "3.8.0"
 author: "rderwin"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-archive-is/SKILL.md
+++ b/cli-skills/pp-archive-is/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-archive-is
 description: "Use this skill whenever the user wants to archive a URL, bypass a paywall, look up an existing archive, view a cached version of a webpage, pull article text from archive.today or the Wayback Machine, or batch-archive a list of URLs. archive.today + Wayback Machine CLI with lookup-before-submit, automatic fallback when one backend is down, and agent-friendly output. No API key required. Triggers on phrasings like 'archive this article', 'bypass the paywall on this link', 'grab the cached text', 'save this url to archive.today', 'check if this was already archived', 'bulk archive these 20 URLs'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-cal-com/SKILL.md
+++ b/cli-skills/pp-cal-com/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-cal-com
 description: "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships. Trigger phrases: `book a meeting on cal.com`, `what's on my calendar today`, `find an open slot`, `reschedule my next booking`, `audit my cal.com webhooks`, `use cal-com`, `run cal-com-pp-cli`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-coingecko/SKILL.md
+++ b/cli-skills/pp-coingecko/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-coingecko
 description: "Printing Press CLI for Coingecko. CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints."
-version: "2.3.7"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-company-goat/SKILL.md
+++ b/cli-skills/pp-company-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-company-goat
 description: "Look up startups across SEC Form D, GitHub, Hacker News, Companies House, YC, and Wikidata in one command — including the SEC fundraising data hidden behind paid Crunchbase tiers. Trigger phrases: `look up this startup`, `research <company>`, `what does <company> do`, `form D for <company>`, `is <company> still active`, `compare <a> and <b>`, `use company-goat`, `run company-goat-pp-cli`."
-version: "2.3.9"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-contact-goat/SKILL.md
+++ b/cli-skills/pp-contact-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-contact-goat
 description: "Super LinkedIn for the terminal. Search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (cookie-first free quota with bearer-API fallback), and Deepline (paid enrichment). Two Happenstance auth surfaces coexist: Chrome cookie session (free monthly allocation) and HAPPENSTANCE_API_KEY bearer (paid credits, deeper schema). Use when the user asks who they know at a company, how to get a warm intro, who to prospect, or wants cross-source dossiers, network diffs, or waterfall enrichment."
-version: "1.3.2"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-craigslist/SKILL.md
+++ b/cli-skills/pp-craigslist/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-craigslist
 description: "The local-first Craigslist watcher and triage tool that knows what's a repost, what's a scam, and what just dropped in price. Trigger phrases: `watch craigslist for`, `find new listings on craigslist`, `craigslist deal alert`, `scan craigslist across cities`, `craigslist repost`, `craigslist scam check`, `use craigslist-pp-cli`, `run craigslist-pp`."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-docker-hub/SKILL.md
+++ b/cli-skills/pp-docker-hub/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-docker-hub
 description: "Printing Press CLI for Docker Hub. Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-dominos/SKILL.md
+++ b/cli-skills/pp-dominos/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-dominos
 description: "Order pizza, browse menus, optimize deals, and track delivery from the terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers. Trigger phrases: `order a pizza`, `find a domino's near me`, `track my pizza`, `what's my pizza usual`, `best deal on my pizza order`, `compare pizza prices`, `use dominos`, `run dominos`."
-version: "3.9.1+pr639+dominos-rebase"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-dub/SKILL.md
+++ b/cli-skills/pp-dub/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-dub
 description: "Every Dub feature, plus offline search, agent-native output, and a local SQLite store no other Dub tool has. Trigger phrases: `shorten a link with Dub`, `audit my Dub links`, `find dormant Dub links`, `review Dub bounty submissions`, `Dub partner leaderboard`, `use dub-pp-cli`, `run dub-pp-cli`."
-version: "3.6.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-ebay/SKILL.md
+++ b/cli-skills/pp-ebay/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-ebay
 description: "Printing Press CLI for eBay. Discovery and intelligence: sold-comp pricing (average sale price over 90 days with outlier trim), auctions filtered by bid count and ending window (the query the eBay site can no longer answer), watchlists, saved searches, and a local SQLite store for cross-listing analytics. Trigger phrases: 'comp this card', 'find ebay auctions ending soon', 'what did this sell for', 'find listings under $X for ...'. Bid placement (bid, snipe, bid-group) is experimental and currently fails because eBay step-ups auth on /bfl/placebid -- direct the user to bid in the browser."
-version: "3.0.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-espn/SKILL.md
+++ b/cli-skills/pp-espn/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-espn
 description: "Use this skill whenever the user asks about live sports scores, standings, team stats, game summaries (with box score, leaders, scoring plays, odds, and win probability), NFL / NBA / MLB / NHL / NCAA / MLS / EPL / WNBA games, team schedules, polls, or rankings. ESPN sports CLI with live scores across 10 leagues, offline search, head-to-head comparisons, and rich per-game summary payloads. No API key required. Triggers on natural phrasings like 'what's the score of the Lakers game', 'Patriots schedule this week', 'NFL standings', 'box score for tonight's Mavs game', 'Chiefs vs Eagles head to head', 'who's on top of the AP poll'."
-version: "1.2.1-0.20260409145412-b1128d0e07fd+dirty"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-fedex/SKILL.md
+++ b/cli-skills/pp-fedex/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-fedex
 description: "REST-native FedEx CLI for small business shippers, with rate-shopping, bulk CSV labels, an address book, and a local SQLite ledger no other tool has. Trigger phrases: `ship a package via FedEx`, `rate-shop FedEx services`, `bulk-print FedEx labels from CSV`, `save a FedEx recipient`, `issue a FedEx return label`, `FedEx spend this month`, `track a FedEx shipment`, `use fedex-pp-cli`, `run fedex`."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-firecrawl/SKILL.md
+++ b/cli-skills/pp-firecrawl/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-firecrawl
 description: "Printing Press CLI for Firecrawl. API for interacting with Firecrawl services to perform web scraping and crawling tasks."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-flight-goat/SKILL.md
+++ b/cli-skills/pp-flight-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-flight-goat
 description: "Printing Press CLI for Flight Goat. # Introduction AeroAPI is a simple, query-based API that gives software developers access to a variety of..."
-version: "3.6.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-food52/SKILL.md
+++ b/cli-skills/pp-food52/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-food52
 description: "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away. Trigger phrases: `find me a food52 recipe for X`, `scale this food52 recipe to N servings`, `what can I cook from food52 with what's in my pantry`, `use food52`, `run food52`."
-version: "3.2.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-google-photos/SKILL.md
+++ b/cli-skills/pp-google-photos/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-google-photos
 description: "Printing Press CLI for Google Photos. Google Photos Library and Picker APIs for app-created media, albums, uploads, and user-selected media."
-version: "3.9.1"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-hackernews/SKILL.md
+++ b/cli-skills/pp-hackernews/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-hackernews
 description: "Hacker News from your terminal — with a local SQLite store, snapshot history, and agent-native output no other HN tool has. Trigger phrases: `check hacker news`, `search hn`, `what is hn saying about`, `diff the hn front page`, `pulse on hn`, `look up hn user`, `hn who is hiring`, `hn top stories`, `use hackernews`, `run hackernews`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-hubspot/SKILL.md
+++ b/cli-skills/pp-hubspot/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-hubspot
 description: "Use this skill whenever the user asks about HubSpot CRM contacts, companies, deals, tickets, tasks, calls, emails, meetings, engagements, pipelines, deal velocity / stale deals / coverage, or wants to search across their CRM data. Also for creating / updating / deleting any HubSpot record or managing associations between objects. HubSpot CLI covering 15 HubSpot APIs with offline SQLite search and pipeline analytics. Requires a HubSpot access token. Triggers on phrasings like 'find contacts at Acme', 'show deals closing this month', 'which deals are stale', 'pipeline velocity this quarter', 'log a call for contact X', 'create a task for tomorrow'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-instacart/SKILL.md
+++ b/cli-skills/pp-instacart/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-instacart
 description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco', 'backfill my instacart history', 'sync my instacart orders', 'download my order history', 'save my instacart history locally'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp | backfill"

--- a/cli-skills/pp-kalshi/SKILL.md
+++ b/cli-skills/pp-kalshi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-kalshi
 description: "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot. Trigger phrases: `kalshi market price`, `track prediction market`, `kalshi portfolio P&L`, `kalshi correlate markets`, `use kalshi`, `run kalshi`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-klaviyo/SKILL.md
+++ b/cli-skills/pp-klaviyo/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-klaviyo
 description: "Klaviyo from the shell, with local customer-behavior analytics layered on top. Trigger phrases: `inspect a Klaviyo profile`, `deploy a Klaviyo campaign`, `check Klaviyo flow decay`, `reconcile Klaviyo campaign revenue`."
-version: "3.5.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-linear/SKILL.md
+++ b/cli-skills/pp-linear/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-linear
 description: "Linear project-management CLI for the terminal. Manage issues, projects, cycles, teams, initiatives, roadmaps, and customer records via the Linear GraphQL API with offline-capable SQLite sync. Use when the user asks about their Linear issues, wants today's queue, sprint velocity, team workload, bottlenecks, duplicate / stale / orphaned issues, release pipelines, or wants to create, update, or search Linear items from the terminal. Offline search and analytics work without an API round-trip after a one-time sync."
-version: "1.2.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-mercury/SKILL.md
+++ b/cli-skills/pp-mercury/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-mercury
 description: "Printing Press CLI for Mercury. Streamline financial tasks with secure account management and transaction processing. Enables user registration,..."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-movie-goat/SKILL.md
+++ b/cli-skills/pp-movie-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-movie-goat
 description: "The movie CLI that combines TMDb's discovery engine with OMDb's multi-source ratings — and ships a SQLite watchlist that flags what's streaming on your services right now. Trigger phrases: `what should I watch tonight`, `where can I stream <title>`, `rate <title>`, `compare <title> and <title>`, `what's <person>'s filmography`, `plan a <franchise> marathon`, `use movie-goat`, `run movie-goat`."
-version: "3.8.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-nvd/SKILL.md
+++ b/cli-skills/pp-nvd/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-nvd
 description: "Printing Press CLI for Nvd. The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword,..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-open-meteo/SKILL.md
+++ b/cli-skills/pp-open-meteo/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-open-meteo
 description: "Every Open-Meteo endpoint family in one CLI — forecast, archive, marine, air quality, flood, climate, ensemble, seasonal, geocoding, elevation. Trigger phrases: `what's the weather in`, `forecast for`, `is it going to rain`, `marine forecast`, `air quality in`, `historical weather`, `climate normal`, `use open-meteo`, `run open-meteo`."
-version: "3.6.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-pagliacci/SKILL.md
+++ b/cli-skills/pp-pagliacci/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pagliacci
 description: "Order Seattle's favorite pizza from the terminal — every endpoint, plus discount stacking, slice rotation across stores, half-and-half pies, and a small-party planner nobody else has. Trigger phrases: `order from pagliacci`, `what pagliacci slices are available`, `plan a pagliacci order for the family`, `build a half-and-half pagliacci pizza`, `pagliacci rewards balance`, `use pagliacci`, `run pagliacci`."
-version: "3.7.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-pokeapi/SKILL.md
+++ b/cli-skills/pp-pokeapi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pokeapi
 description: "PokéAPI as a fully offline Pokédex with SQL, full-text search, type math, and a damage calculator no other Pokémon tool ships as a CLI. Trigger phrases: `look up a pokemon`, `what beats charizard`, `build a pokemon team`, `type matchup`, `evolution chain`, `use pokeapi`, `run pokeapi-pp-cli`."
-version: "3.0.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-postman-explore/SKILL.md
+++ b/cli-skills/pp-postman-explore/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-postman-explore
 description: "The CLI for the public API directory at postman.com/explore — search, rank, and watch community-contributed Postman Collections, agent-native and offline. Trigger phrases: `find a postman collection for`, `what postman collection should i fork for`, `is there a postman collection for`, `browse postman api network`, `compare postman publishers`, `what changed on the postman network`, `use postman-explore`, `run postman-explore`."
-version: "3.0.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-producthunt/SKILL.md
+++ b/cli-skills/pp-producthunt/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-producthunt
 description: "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step. Trigger phrases: `what launched on product hunt today`, `find ai launches on product hunt this week`, `how is my product hunt launch tracking`, `compare these product hunt launches`, `summarize the comments on this product hunt post`, `what does a good product hunt launch look like at hour 6`, `use producthunt`, `run producthunt`."
-version: "3.2.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-pypi/SKILL.md
+++ b/cli-skills/pp-pypi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pypi
 description: "Printing Press CLI for Pypi. PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-recipe-goat/SKILL.md
+++ b/cli-skills/pp-recipe-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-recipe-goat
 description: "Printing Press CLI for Recipe Goat. Recipe GOAT — find the best version of any recipe across 37 trusted sites, with offline cookbook, pantry match,..."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-scrape-creators/SKILL.md
+++ b/cli-skills/pp-scrape-creators/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-scrape-creators
 description: "Every Scrape Creators endpoint, plus offline search, cross-platform compounding, and a local store no other Scrape Creators tool ships with. Trigger phrases: `scrape creators`, `tiktok profile`, `instagram profile`, `youtube channel`, `facebook ad library`, `creator on every platform`, `social media transcript search`, `use scrape-creators`, `run scrape-creators`."
-version: "3.2.1"
 author: "Adrian Horning"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-seats-aero/SKILL.md
+++ b/cli-skills/pp-seats-aero/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-seats-aero
 description: "Printing Press CLI for Seats Aero. Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-sentry/SKILL.md
+++ b/cli-skills/pp-sentry/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-sentry
 description: "A broad Sentry API CLI with local search, SQL, export, and MCP surfaces for incident work. Trigger phrases: `check Sentry issues`, `list Sentry projects`, `debug a Sentry event`, `audit Sentry releases`, `search Sentry incidents`, `use Sentry`, `run Sentry`."
-version: "3.4.3"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-shopify/SKILL.md
+++ b/cli-skills/pp-shopify/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-shopify
 description: "Printing Press CLI for Shopify. Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk operations via the Shopify Admin..."
-version: "3.2.1"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-slack/SKILL.md
+++ b/cli-skills/pp-slack/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-slack
 description: "Slack workspace CLI for the terminal. Send messages, search channels and DMs, list conversations, get user/bot/emoji info, analyze channel health, find stale threads, and sync the workspace locally for fast offline queries. Two auth surfaces coexist: SLACK_BOT_TOKEN (xoxb-, for workspace-wide read + post) and SLACK_USER_TOKEN (xoxp-, for user-scoped actions like DM history or search). Use when the user asks to send a Slack message, search Slack, check channel activity, summarize a digest, find who's on a team, find stale threads, analyze channel health, list users / emoji / reminders / pinned items, or wants offline-capable Slack queries."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-steam-web/SKILL.md
+++ b/cli-skills/pp-steam-web/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-steam-web
 description: "Steam player and game lookup via the Steam Web API. Look up player profiles, owned games, recent playtime, achievements, stats, badges, friend lists, VAC/game ban status, and game schemas. Use when the user asks about their Steam library, a friend's achievements, who's playing a game, compare two players' stats, a player's Steam level or badges, VAC status, or wants to resolve a vanity URL to a Steam ID."
-version: "0.4.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-tiktok-shop/SKILL.md
+++ b/cli-skills/pp-tiktok-shop/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-tiktok-shop
 description: "Printing Press CLI/MCP for confirmed TikTok Shop Seller APIs. Safe v1 supports auth readiness, token exchange/refresh, read-only shops/orders/products/inventory/package/warehouse commands, and defers risky mutations."
-version: "3.8.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-trigger-dev/SKILL.md
+++ b/cli-skills/pp-trigger-dev/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-trigger-dev
 description: "Trigger.dev background-job monitoring and observability from the terminal. List runs, analyze failures, watch live for failures, inspect queues, schedules, deployments, batches, cost by task, and task health. Use when the user wants to check Trigger.dev status, find failing tasks, watch runs live, audit schedules, look up a specific run, compare cost across tasks or machine types, or debug a stuck batch. Offline search via local SQLite sync."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-weather-goat/SKILL.md
+++ b/cli-skills/pp-weather-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-weather-goat
 description: "Use this skill whenever the user asks about weather, forecasts, temperature, rain, storms, severe weather alerts, air quality, pollen, UV, or wants an activity recommendation (can I walk / bike / hike / commute / drive given the weather). Weather CLI powered by Open-Meteo (global, no auth, unlimited) + NWS (US severe weather). No API key. Triggers on phrasings like 'what's the weather', 'is it going to rain today', 'any storms coming', 'should I bike to work', 'how's the air quality', 'compare NYC and LA weather this weekend', 'is this unusually hot for April'."
-version: "1.3.3-0.20260411222622-065697576de1+dirty"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-wikipedia/SKILL.md
+++ b/cli-skills/pp-wikipedia/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-wikipedia
 description: "Printing Press CLI for Wikipedia. Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-yahoo-finance/SKILL.md
+++ b/cli-skills/pp-yahoo-finance/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-yahoo-finance
 description: "Use Yahoo Finance CLI for stock and ETF quotes, charts, fundamentals, options chains, symbol search, trending tickers, local watchlists, portfolio lots, and market digests. Use when the user asks about a ticker, portfolio performance, option filtering, market movers, or wants Yahoo Finance data in a terminal or agent-friendly format."
-version: "1.3.2"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/amazon-seller/SKILL.md
+++ b/library/commerce/amazon-seller/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-amazon-seller
 description: "Printing Press CLI for Amazon Seller. Read FBA inventory, orders, sales reports, listings, and catalog data for an Amazon seller account."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/craigslist/SKILL.md
+++ b/library/commerce/craigslist/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-craigslist
 description: "The local-first Craigslist watcher and triage tool that knows what's a repost, what's a scam, and what just dropped in price. Trigger phrases: `watch craigslist for`, `find new listings on craigslist`, `craigslist deal alert`, `scan craigslist across cities`, `craigslist repost`, `craigslist scam check`, `use craigslist-pp-cli`, `run craigslist-pp`."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/ebay/SKILL.md
+++ b/library/commerce/ebay/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-ebay
 description: "Printing Press CLI for eBay. Discovery and intelligence: sold-comp pricing (average sale price over 90 days with outlier trim), auctions filtered by bid count and ending window (the query the eBay site can no longer answer), watchlists, saved searches, and a local SQLite store for cross-listing analytics. Trigger phrases: 'comp this card', 'find ebay auctions ending soon', 'what did this sell for', 'find listings under $X for ...'. Bid placement (bid, snipe, bid-group) is experimental and currently fails because eBay step-ups auth on /bfl/placebid -- direct the user to bid in the browser."
-version: "3.0.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/fedex/SKILL.md
+++ b/library/commerce/fedex/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-fedex
 description: "REST-native FedEx CLI for small business shippers, with rate-shopping, bulk CSV labels, an address book, and a local SQLite ledger no other tool has. Trigger phrases: `ship a package via FedEx`, `rate-shop FedEx services`, `bulk-print FedEx labels from CSV`, `save a FedEx recipient`, `issue a FedEx return label`, `FedEx spend this month`, `track a FedEx shipment`, `use fedex-pp-cli`, `run fedex`."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-instacart
 description: "Printing Press CLI for Instacart. Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation. Also caches your purchase history locally so 'add' resolves items you have bought before instead of guessing from live search. Trigger phrases: 'install instacart', 'use instacart', 'run instacart', 'add X to my Safeway cart', 'what did I buy last time', 'order the usual', 'add my regulars to Costco', 'backfill my instacart history', 'sync my instacart orders', 'download my order history', 'save my instacart history locally'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp | backfill"

--- a/library/commerce/shopify/SKILL.md
+++ b/library/commerce/shopify/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-shopify
 description: "Printing Press CLI for Shopify. Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk operations via the Shopify Admin..."
-version: "3.2.1"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/tiktok-shop/SKILL.md
+++ b/library/commerce/tiktok-shop/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-tiktok-shop
 description: "Printing Press CLI/MCP for confirmed TikTok Shop Seller APIs. Safe v1 supports auth readiness, token exchange/refresh, read-only shops/orders/products/inventory/package/warehouse commands, and defers risky mutations."
-version: "3.8.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/commerce/yahoo-finance/SKILL.md
+++ b/library/commerce/yahoo-finance/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-yahoo-finance
 description: "Use Yahoo Finance CLI for stock and ETF quotes, charts, fundamentals, options chains, symbol search, trending tickers, local watchlists, portfolio lots, and market digests. Use when the user asks about a ticker, portfolio performance, option filtering, market movers, or wants Yahoo Finance data in a terminal or agent-friendly format."
-version: "1.3.2"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/agent-capture/SKILL.md
+++ b/library/developer-tools/agent-capture/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-agent-capture
 description: "macOS screen capture, window recording, GIF conversion, and agent evidence bundles from the terminal. Built on ScreenCaptureKit for window-level targeting ffmpeg cannot do. Use when the user wants a screenshot of a specific window or app, a screen recording, a GIF conversion, a before/after diff, an evidence bundle for a PR, OCR text from a window, a terminal VHS recording, a Remotion render, or wants to watch a UI for changes. Requires macOS Screen Recording permission on first run."
-version: "0.4.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/company-goat/SKILL.md
+++ b/library/developer-tools/company-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-company-goat
 description: "Look up startups across SEC Form D, GitHub, Hacker News, Companies House, YC, and Wikidata in one command — including the SEC fundraising data hidden behind paid Crunchbase tiers. Trigger phrases: `look up this startup`, `research <company>`, `what does <company> do`, `form D for <company>`, `is <company> still active`, `compare <a> and <b>`, `use company-goat`, `run company-goat-pp-cli`."
-version: "2.3.9"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/docker-hub/SKILL.md
+++ b/library/developer-tools/docker-hub/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-docker-hub
 description: "Printing Press CLI for Docker Hub. Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/firecrawl/SKILL.md
+++ b/library/developer-tools/firecrawl/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-firecrawl
 description: "Printing Press CLI for Firecrawl. API for interacting with Firecrawl services to perform web scraping and crawling tasks."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/nvd/SKILL.md
+++ b/library/developer-tools/nvd/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-nvd
 description: "Printing Press CLI for Nvd. The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword,..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/postman-explore/SKILL.md
+++ b/library/developer-tools/postman-explore/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-postman-explore
 description: "The CLI for the public API directory at postman.com/explore — search, rank, and watch community-contributed Postman Collections, agent-native and offline. Trigger phrases: `find a postman collection for`, `what postman collection should i fork for`, `is there a postman collection for`, `browse postman api network`, `compare postman publishers`, `what changed on the postman network`, `use postman-explore`, `run postman-explore`."
-version: "3.0.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/pypi/SKILL.md
+++ b/library/developer-tools/pypi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pypi
 description: "Printing Press CLI for Pypi. PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/scrape-creators/SKILL.md
+++ b/library/developer-tools/scrape-creators/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-scrape-creators
 description: "Every Scrape Creators endpoint, plus offline search, cross-platform compounding, and a local store no other Scrape Creators tool ships with. Trigger phrases: `scrape creators`, `tiktok profile`, `instagram profile`, `youtube channel`, `facebook ad library`, `creator on every platform`, `social media transcript search`, `use scrape-creators`, `run scrape-creators`."
-version: "3.2.1"
 author: "Adrian Horning"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/trigger-dev/SKILL.md
+++ b/library/developer-tools/trigger-dev/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-trigger-dev
 description: "Trigger.dev background-job monitoring and observability from the terminal. List runs, analyze failures, watch live for failures, inspect queues, schedules, deployments, batches, cost by task, and task health. Use when the user wants to check Trigger.dev status, find failing tasks, watch runs live, audit schedules, look up a specific run, compare cost across tasks or machine types, or debug a stuck batch. Offline search via local SQLite sync."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/allrecipes/SKILL.md
+++ b/library/food-and-dining/allrecipes/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-allrecipes
 description: "Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, one-line grocery lists, and Cloudflare clearance. Trigger phrases: `search Allrecipes for X`, `find a recipe for brownies`, `scale this Allrecipes recipe`, `build a grocery list from these recipes`, `what can I cook with what I have`, `use allrecipes-pp-cli`, `run allrecipes`."
-version: "3.8.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/dominos/SKILL.md
+++ b/library/food-and-dining/dominos/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-dominos
 description: "Order pizza, browse menus, optimize deals, and track delivery from the terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers. Trigger phrases: `order a pizza`, `find a domino's near me`, `track my pizza`, `what's my pizza usual`, `best deal on my pizza order`, `compare pizza prices`, `use dominos`, `run dominos`."
-version: "3.9.1+pr639+dominos-rebase"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/food52/SKILL.md
+++ b/library/food-and-dining/food52/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-food52
 description: "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away. Trigger phrases: `find me a food52 recipe for X`, `scale this food52 recipe to N servings`, `what can I cook from food52 with what's in my pantry`, `use food52`, `run food52`."
-version: "3.2.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/pagliacci/SKILL.md
+++ b/library/food-and-dining/pagliacci/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pagliacci
 description: "Order Seattle's favorite pizza from the terminal — every endpoint, plus discount stacking, slice rotation across stores, half-and-half pies, and a small-party planner nobody else has. Trigger phrases: `order from pagliacci`, `what pagliacci slices are available`, `plan a pagliacci order for the family`, `build a half-and-half pagliacci pizza`, `pagliacci rewards balance`, `use pagliacci`, `run pagliacci`."
-version: "3.7.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-recipe-goat
 description: "Printing Press CLI for Recipe Goat. Recipe GOAT — find the best version of any recipe across 37 trusted sites, with offline cookbook, pantry match,..."
-version: "3.6.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/marketing/ahrefs/SKILL.md
+++ b/library/marketing/ahrefs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-ahrefs
 description: "Printing Press CLI for Ahrefs. SEO and competitive intelligence API for backlinks, keywords, rank tracking, site audit, and SERP data."
-version: "3.4.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/marketing/dub/SKILL.md
+++ b/library/marketing/dub/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-dub
 description: "Every Dub feature, plus offline search, agent-native output, and a local SQLite store no other Dub tool has. Trigger phrases: `shorten a link with Dub`, `audit my Dub links`, `find dormant Dub links`, `review Dub bounty submissions`, `Dub partner leaderboard`, `use dub-pp-cli`, `run dub-pp-cli`."
-version: "3.6.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/marketing/klaviyo/SKILL.md
+++ b/library/marketing/klaviyo/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-klaviyo
 description: "Klaviyo from the shell, with local customer-behavior analytics layered on top. Trigger phrases: `inspect a Klaviyo profile`, `deploy a Klaviyo campaign`, `check Klaviyo flow decay`, `reconcile Klaviyo campaign revenue`."
-version: "3.5.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/marketing/producthunt/SKILL.md
+++ b/library/marketing/producthunt/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-producthunt
 description: "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step. Trigger phrases: `what launched on product hunt today`, `find ai launches on product hunt this week`, `how is my product hunt launch tracking`, `compare these product hunt launches`, `summarize the comments on this product hunt post`, `what does a good product hunt launch look like at hour 6`, `use producthunt`, `run producthunt`."
-version: "3.2.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/archive-is/SKILL.md
+++ b/library/media-and-entertainment/archive-is/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-archive-is
 description: "Use this skill whenever the user wants to archive a URL, bypass a paywall, look up an existing archive, view a cached version of a webpage, pull article text from archive.today or the Wayback Machine, or batch-archive a list of URLs. archive.today + Wayback Machine CLI with lookup-before-submit, automatic fallback when one backend is down, and agent-friendly output. No API key required. Triggers on phrasings like 'archive this article', 'bypass the paywall on this link', 'grab the cached text', 'save this url to archive.today', 'check if this was already archived', 'bulk archive these 20 URLs'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/espn/SKILL.md
+++ b/library/media-and-entertainment/espn/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-espn
 description: "Use this skill whenever the user asks about live sports scores, standings, team stats, game summaries (with box score, leaders, scoring plays, odds, and win probability), NFL / NBA / MLB / NHL / NCAA / MLS / EPL / WNBA games, team schedules, polls, or rankings. ESPN sports CLI with live scores across 10 leagues, offline search, head-to-head comparisons, and rich per-game summary payloads. No API key required. Triggers on natural phrasings like 'what's the score of the Lakers game', 'Patriots schedule this week', 'NFL standings', 'box score for tonight's Mavs game', 'Chiefs vs Eagles head to head', 'who's on top of the AP poll'."
-version: "1.2.1-0.20260409145412-b1128d0e07fd+dirty"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/google-photos/SKILL.md
+++ b/library/media-and-entertainment/google-photos/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-google-photos
 description: "Printing Press CLI for Google Photos. Google Photos Library and Picker APIs for app-created media, albums, uploads, and user-selected media."
-version: "3.9.1"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/hackernews/SKILL.md
+++ b/library/media-and-entertainment/hackernews/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-hackernews
 description: "Hacker News from your terminal — with a local SQLite store, snapshot history, and agent-native output no other HN tool has. Trigger phrases: `check hacker news`, `search hn`, `what is hn saying about`, `diff the hn front page`, `pulse on hn`, `look up hn user`, `hn who is hiring`, `hn top stories`, `use hackernews`, `run hackernews`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/movie-goat/SKILL.md
+++ b/library/media-and-entertainment/movie-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-movie-goat
 description: "The movie CLI that combines TMDb's discovery engine with OMDb's multi-source ratings — and ships a SQLite watchlist that flags what's streaming on your services right now. Trigger phrases: `what should I watch tonight`, `where can I stream <title>`, `rate <title>`, `compare <title> and <title>`, `what's <person>'s filmography`, `plan a <franchise> marathon`, `use movie-goat`, `run movie-goat`."
-version: "3.8.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/pokeapi/SKILL.md
+++ b/library/media-and-entertainment/pokeapi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-pokeapi
 description: "PokéAPI as a fully offline Pokédex with SQL, full-text search, type math, and a damage calculator no other Pokémon tool ships as a CLI. Trigger phrases: `look up a pokemon`, `what beats charizard`, `build a pokemon team`, `type matchup`, `evolution chain`, `use pokeapi`, `run pokeapi-pp-cli`."
-version: "3.0.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/steam-web/SKILL.md
+++ b/library/media-and-entertainment/steam-web/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-steam-web
 description: "Steam player and game lookup via the Steam Web API. Look up player profiles, owned games, recent playtime, achievements, stats, badges, friend lists, VAC/game ban status, and game schemas. Use when the user asks about their Steam library, a friend's achievements, who's playing a game, compare two players' stats, a player's Steam level or badges, VAC status, or wants to resolve a vanity URL to a Steam ID."
-version: "0.4.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/wikipedia/SKILL.md
+++ b/library/media-and-entertainment/wikipedia/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-wikipedia
 description: "Printing Press CLI for Wikipedia. Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No..."
-version: "3.6.0"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/monitoring/sentry/SKILL.md
+++ b/library/monitoring/sentry/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-sentry
 description: "A broad Sentry API CLI with local search, SQL, export, and MCP surfaces for incident work. Trigger phrases: `check Sentry issues`, `list Sentry projects`, `debug a Sentry event`, `audit Sentry releases`, `search Sentry incidents`, `use Sentry`, `run Sentry`."
-version: "3.4.3"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/other/apartments/SKILL.md
+++ b/library/other/apartments/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-apartments
 description: "The apartment-hunt CLI that actually works in 2026 — Surf-cleared bot protection plus a local SQLite store the website itself doesn't have. Trigger phrases: `find apartments in <city>`, `watch apartment listings for <area>`, `rank rentals by price per square foot`, `compare these apartments`, `use apartments-pp-cli`, `run apartments`."
-version: "3.8.0"
 author: "rderwin"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/other/open-meteo/SKILL.md
+++ b/library/other/open-meteo/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-open-meteo
 description: "Every Open-Meteo endpoint family in one CLI — forecast, archive, marine, air quality, flood, climate, ensemble, seasonal, geocoding, elevation. Trigger phrases: `what's the weather in`, `forecast for`, `is it going to rain`, `marine forecast`, `air quality in`, `historical weather`, `climate normal`, `use open-meteo`, `run open-meteo`."
-version: "3.6.1"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/other/weather-goat/SKILL.md
+++ b/library/other/weather-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-weather-goat
 description: "Use this skill whenever the user asks about weather, forecasts, temperature, rain, storms, severe weather alerts, air quality, pollen, UV, or wants an activity recommendation (can I walk / bike / hike / commute / drive given the weather). Weather CLI powered by Open-Meteo (global, no auth, unlimited) + NWS (US severe weather). No API key. Triggers on phrasings like 'what's the weather', 'is it going to rain today', 'any storms coming', 'should I bike to work', 'how's the air quality', 'compare NYC and LA weather this weekend', 'is this unusually hot for April'."
-version: "1.3.3-0.20260411222622-065697576de1+dirty"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/payments/coingecko/SKILL.md
+++ b/library/payments/coingecko/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-coingecko
 description: "Printing Press CLI for Coingecko. CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints."
-version: "2.3.7"
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/payments/kalshi/SKILL.md
+++ b/library/payments/kalshi/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-kalshi
 description: "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot. Trigger phrases: `kalshi market price`, `track prediction market`, `kalshi portfolio P&L`, `kalshi correlate markets`, `use kalshi`, `run kalshi`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/payments/mercury/SKILL.md
+++ b/library/payments/mercury/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-mercury
 description: "Printing Press CLI for Mercury. Streamline financial tasks with secure account management and transaction processing. Enables user registration,..."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/productivity/cal-com/SKILL.md
+++ b/library/productivity/cal-com/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-cal-com
 description: "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships. Trigger phrases: `book a meeting on cal.com`, `what's on my calendar today`, `find an open slot`, `reschedule my next booking`, `audit my cal.com webhooks`, `use cal-com`, `run cal-com-pp-cli`."
-version: "3.9.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/productivity/slack/SKILL.md
+++ b/library/productivity/slack/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-slack
 description: "Slack workspace CLI for the terminal. Send messages, search channels and DMs, list conversations, get user/bot/emoji info, analyze channel health, find stale threads, and sync the workspace locally for fast offline queries. Two auth surfaces coexist: SLACK_BOT_TOKEN (xoxb-, for workspace-wide read + post) and SLACK_USER_TOKEN (xoxp-, for user-scoped actions like DM history or search). Use when the user asks to send a Slack message, search Slack, check channel activity, summarize a digest, find who's on a team, find stale threads, analyze channel health, list users / emoji / reminders / pinned items, or wants offline-capable Slack queries."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-linear
 description: "Linear project-management CLI for the terminal. Manage issues, projects, cycles, teams, initiatives, roadmaps, and customer records via the Linear GraphQL API with offline-capable SQLite sync. Use when the user asks about their Linear issues, wants today's queue, sprint velocity, team workload, bottlenecks, duplicate / stale / orphaned issues, release pipelines, or wants to create, update, or search Linear items from the terminal. Offline search and analytics work without an API round-trip after a one-time sync."
-version: "1.2.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-contact-goat
 description: "Super LinkedIn for the terminal. Search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (cookie-first free quota with bearer-API fallback), and Deepline (paid enrichment). Two Happenstance auth surfaces coexist: Chrome cookie session (free monthly allocation) and HAPPENSTANCE_API_KEY bearer (paid credits, deeper schema). Use when the user asks who they know at a company, how to get a warm intro, who to prospect, or wants cross-source dossiers, network diffs, or waterfall enrichment."
-version: "1.3.2"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/sales-and-crm/hubspot/SKILL.md
+++ b/library/sales-and-crm/hubspot/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-hubspot
 description: "Use this skill whenever the user asks about HubSpot CRM contacts, companies, deals, tickets, tasks, calls, emails, meetings, engagements, pipelines, deal velocity / stale deals / coverage, or wants to search across their CRM data. Also for creating / updating / deleting any HubSpot record or managing associations between objects. HubSpot CLI covering 15 HubSpot APIs with offline SQLite search and pipeline analytics. Requires a HubSpot access token. Triggers on phrasings like 'find contacts at Acme', 'show deals closing this month', 'which deals are stale', 'pipeline velocity this quarter', 'log a call for contact X', 'create a task for tomorrow'."
-version: "1.2.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/travel/airbnb/SKILL.md
+++ b/library/travel/airbnb/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-airbnb
 description: "Skip the Airbnb platform fee. Find the host's direct booking site for any Airbnb listing. Trigger phrases: `find the direct booking site`, `skip the airbnb fee`, `vacation rental cheapest`, `book direct`, `use airbnb-pp`, `run airbnb-pp`. NOTE: VRBO support is currently disabled — pending Akamai workaround."
-version: "3.6.1"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-flight-goat
 description: "Printing Press CLI for Flight Goat. # Introduction AeroAPI is a simple, query-based API that gives software developers access to a variety of..."
-version: "3.6.0"
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/travel/seats-aero/SKILL.md
+++ b/library/travel/seats-aero/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pp-seats-aero
 description: "Printing Press CLI for Seats Aero. Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details."
-version: "3.10.0"
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/tools/sweep-frontmatter/main.go
+++ b/tools/sweep-frontmatter/main.go
@@ -5,8 +5,12 @@
 //
 //   - Strips legacy OpenClaw env-var declarations (requires.env, envVars,
 //     primaryEnv) from each library/<cat>/<api>/SKILL.md frontmatter.
-//   - Adds the Hermes-recognized top-level fields (version, author,
-//     license) after the description: line.
+//   - Adds the Hermes-recognized top-level fields (author, license) after
+//     the description: line. Strips any pre-existing `version:` line —
+//     it was emitted by an earlier sweep but tracked the Press version,
+//     conflating generator with skill. Hermes lists `version` as
+//     optional; omission is the honest move until per-CLI release
+//     versions can be stamped at library CI time from goreleaser tags.
 //   - Moves the existing `## CLI Installation` section to immediately
 //     after the H1 and rewrites it as `## Prerequisites: Install the
 //     CLI` with imperative "you must verify ... do not proceed" wording.
@@ -42,10 +46,9 @@ import (
 )
 
 type manifest struct {
-	CLIName              string `json:"cli_name"`
-	APIName              string `json:"api_name"`
-	PrintingPressVersion string `json:"printing_press_version"`
-	OwnerName            string `json:"owner_name"`
+	CLIName   string `json:"cli_name"`
+	APIName   string `json:"api_name"`
+	OwnerName string `json:"owner_name"`
 }
 
 // cliAuthorByAPIName is the canonical author display name for every
@@ -228,14 +231,6 @@ func sweepCLI(cliDir, ownerName string) (sweepStatus, error) {
 		category = "other"
 	}
 
-	pressVersion := mf.PrintingPressVersion
-	if pressVersion == "" {
-		// Should not happen for any current library entry, but guard
-		// anyway — a sweep that emits version: "" silently is worse
-		// than one that fails loudly.
-		return statusUnchanged, fmt.Errorf("manifest missing printing_press_version")
-	}
-
 	// Authorship resolution:
 	//  1. cliAuthorByAPIName — the curated per-CLI mapping; the source
 	//     of truth for the existing 49 published CLIs. Honors actual
@@ -263,11 +258,10 @@ func sweepCLI(cliDir, ownerName string) (sweepStatus, error) {
 	}
 
 	skillAfter, err := patchSkill(string(skillBefore), patchSkillCtx{
-		CLIName:      mf.CLIName,
-		APIName:      mf.APIName,
-		Category:     category,
-		PressVersion: pressVersion,
-		AuthorName:   authorName,
+		CLIName:    mf.CLIName,
+		APIName:    mf.APIName,
+		Category:   category,
+		AuthorName: authorName,
 	})
 	if err != nil {
 		return statusUnchanged, fmt.Errorf("patch SKILL.md: %w", err)
@@ -326,11 +320,10 @@ func sweepCLI(cliDir, ownerName string) (sweepStatus, error) {
 }
 
 type patchSkillCtx struct {
-	CLIName      string // e.g. "shopify-pp-cli"
-	APIName      string // e.g. "shopify"
-	Category     string // e.g. "commerce"
-	PressVersion string // e.g. "3.10.0"
-	AuthorName   string // display name, e.g. "Trevin Chow"
+	CLIName    string // e.g. "shopify-pp-cli"
+	APIName    string // e.g. "shopify"
+	Category   string // e.g. "commerce"
+	AuthorName string // display name, e.g. "Trevin Chow"
 }
 
 // patchSkill applies the canonical Hermes/OpenClaw shape to a SKILL.md
@@ -349,8 +342,9 @@ func patchSkill(body string, ctx patchSkillCtx) (string, error) {
 //     single inline, block-style, absent).
 //   - Strips entire `    envVars:` block including all indented children.
 //   - Strips `    primaryEnv: ...` line.
-//   - Adds `version`, `author`, `license` top-level fields after the
-//     `description:` line if not already present.
+//   - Adds `author`, `license` top-level fields after the `description:`
+//     line. Strips any pre-existing `version:` line — see top-of-file
+//     comment for why version is omitted.
 //
 // Body content (after the closing ---) is byte-preserved.
 func patchSkillFrontmatter(body string, ctx patchSkillCtx) string {
@@ -435,35 +429,29 @@ func leadingSpaces(s string) int {
 	return len(s)
 }
 
-// ensureFrontmatterTopLevelFields normalizes `version`, `author`, and
-// `license` to the canonical "after description" position with a
-// canonical version → author → license order. All three are stripped
-// first (capturing existing values when present) and re-inserted as
-// a contiguous block, so:
+// ensureFrontmatterTopLevelFields normalizes `author` and `license` to
+// the canonical "after description" position. Both are stripped first
+// and re-inserted as a contiguous block, so:
 //
 //   * Author always reflects the per-CLI authorship mapping
 //     (cliAuthorByAPIName) — overrides any stale value from a
 //     previous sweep run with a wrong default.
-//   * Version preserves the existing value when present (regen path:
-//     the file was produced by a specific Press version, and we
-//     don't want a re-sweep to bump it). Otherwise uses ctx.PressVersion.
 //   * License is always "Apache-2.0" — the constant for every printed
 //     CLI per LICENSE.tmpl.
+//
+// Also strips any pre-existing `version:` line (legacy from an earlier
+// sweep that emitted the Press version) without re-emitting one. See
+// top-of-file comment for the rationale.
 //
 // Idempotent in the second-run-zero-diff sense — running with the
 // same ctx produces the same output.
 func ensureFrontmatterTopLevelFields(fm string, ctx patchSkillCtx) string {
-	pressVersion := extractTopLevelFieldValue(fm, "version")
-	if pressVersion == "" {
-		pressVersion = ctx.PressVersion
-	}
-
 	fm = stripTopLevelField(fm, "version")
 	fm = stripTopLevelField(fm, "author")
 	fm = stripTopLevelField(fm, "license")
 
-	block := fmt.Sprintf("version: %q\nauthor: %q\nlicense: %q\n",
-		pressVersion, ctx.AuthorName, "Apache-2.0")
+	block := fmt.Sprintf("author: %q\nlicense: %q\n",
+		ctx.AuthorName, "Apache-2.0")
 
 	descRe := regexp.MustCompile(`(?m)^description: ".*"\n`)
 	return descRe.ReplaceAllStringFunc(fm, func(match string) string {

--- a/tools/sweep-frontmatter/main_test.go
+++ b/tools/sweep-frontmatter/main_test.go
@@ -113,7 +113,7 @@ metadata:
 }
 
 func TestEnsureFrontmatterTopLevelFields(t *testing.T) {
-	ctx := patchSkillCtx{PressVersion: "3.10.0", AuthorName: "Trevin Chow"}
+	ctx := patchSkillCtx{AuthorName: "Trevin Chow"}
 
 	t.Run("inserts after description when fields absent", func(t *testing.T) {
 		in := `name: pp-test
@@ -122,7 +122,6 @@ argument-hint: "..."
 `
 		want := `name: pp-test
 description: "a CLI"
-version: "3.10.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "..."
@@ -135,7 +134,6 @@ argument-hint: "..."
 	t.Run("idempotent when fields match canonical values", func(t *testing.T) {
 		in := `name: pp-test
 description: "a CLI"
-version: "3.10.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "..."
@@ -147,12 +145,10 @@ argument-hint: "..."
 
 	t.Run("rewrites author when ctx differs (per-CLI map correction)", func(t *testing.T) {
 		in := `description: "a CLI"
-version: "3.10.0"
 author: "Wrong Operator"
 license: "Apache-2.0"
 `
 		want := `description: "a CLI"
-version: "3.10.0"
 author: "Trevin Chow"
 license: "Apache-2.0"
 `
@@ -161,8 +157,26 @@ license: "Apache-2.0"
 		}
 	})
 
+	t.Run("strips legacy version: line without re-emitting", func(t *testing.T) {
+		// Earlier sweep emitted `version:` tracking the Press version.
+		// That decision was reverted (see top-of-file comment); a re-sweep
+		// must drop the line and not re-add it.
+		in := `description: "a CLI"
+version: "3.10.0"
+author: "Trevin Chow"
+license: "Apache-2.0"
+`
+		want := `description: "a CLI"
+author: "Trevin Chow"
+license: "Apache-2.0"
+`
+		if got := ensureFrontmatterTopLevelFields(in, ctx); got != want {
+			t.Errorf("expected version: line stripped;\nwant: %q\ngot:  %q", want, got)
+		}
+	})
+
 	t.Run("escapes special characters via fmt %q", func(t *testing.T) {
-		ctxQuoted := patchSkillCtx{PressVersion: "3.10.0", AuthorName: `Trevin "Quoted" Chow`}
+		ctxQuoted := patchSkillCtx{AuthorName: `Trevin "Quoted" Chow`}
 		in := `description: "a CLI"
 `
 		got := ensureFrontmatterTopLevelFields(in, ctxQuoted)


### PR DESCRIPTION
## Summary
- Removes the top-level \`version:\` line from all 49 library SKILL.md files and their \`cli-skills/pp-*\` mirrors. The field tracked the Press's \`printing_press_version\` — conflating generator version with CLI version, which Hermes treats as describing the skill itself.
- Updates \`tools/sweep-frontmatter/\` to stop emitting \`version:\` while still stripping any pre-existing line on re-sweep, so retrofits don't re-introduce it.
- Adds two AGENTS.md sections that were missing: an explicit \"edit \`library/\` not \`cli-skills/\`\" rule, and a new \"Bulk SKILL.md/README.md retrofits\" section documenting the sweep tool (when to reach for it, the curated authorship map's authority, idempotency requirements, GO111MODULE=off discipline).

## Companion PR
[mvanhorn/cli-printing-press#656](https://github.com/mvanhorn/cli-printing-press/pull/656) removes the same field from the upstream template so future fresh prints don't re-introduce it.

## Commits
1. \`chore(skills): drop version: emission from sweep tool, document tooling\` — tool + AGENTS.md changes (3 files)
2. \`chore(skills): sweep version: line out of all 49 library + mirror SKILL.md files\` — applied output (98 files, 1-line deletion each)

## Test plan
- [x] \`GO111MODULE=off go test .\` in \`tools/sweep-frontmatter/\` — 16 pass
- [x] Sweep run produced 49 patches (skill-only)
- [x] Idempotency verified: second sweep run = 0 patched, 49 already up-to-date
- [x] cli-skills mirror regenerated via \`tools/generate-skills/\` — 49 mirrored
- [ ] CI \`verify-skills.yml\` should pass — frontmatter shape change is removal only, no new constraint added

🤖 Generated with [Claude Code](https://claude.com/claude-code)