### PR TITLE
docs(skills): group install paths at top of library READMEs

### DIFF
--- a/library/commerce/amazon-seller/README.md
+++ b/library/commerce/amazon-seller/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/amazon-seller-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-seller --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-seller --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-amazon-seller skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-seller. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -114,7 +137,6 @@ Verify seller authorization and list marketplace participations.
 
 - **`amazon-seller-pp-cli sellers marketplaces`** - List marketplace participations for the authorized seller account.
 
-
 ## Output Formats
 
 ```bash
@@ -177,29 +199,6 @@ claude mcp add amazon-seller amazon-seller-pp-mcp -e SP_API_LWA_CLIENT_ID=<clien
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-seller --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-seller --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-amazon-seller skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-seller. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/commerce/craigslist/README.md
+++ b/library/commerce/craigslist/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/craigslist-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-craigslist skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-craigslist. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No authentication required. Craigslist's read endpoints (sapi.craigslist.org/web/v8, rapi.craigslist.org/web/v8, reference.craigslist.org) are public. The CLI sets a polite User-Agent and reuses the cl_b cookie Craigslist auto-issues. Posting and account management are intentionally out of scope for v1.
@@ -44,26 +67,20 @@ No authentication required. Craigslist's read endpoints (sapi.craigslist.org/web
 # Pull the 178-category and 707-area reference taxonomy into the local store; refreshed at most every 30 days per Craigslist's own Cache-Control.
 craigslist-pp-cli catalog refresh
 
-
 # Single-city search with a price cap; default human table output.
 craigslist-pp-cli search 'ipad' --site sfbay --category sss --max-price 300
-
 
 # Cross-city hunt for a rare item — fans out parallel sapi calls, source-attributes results.
 craigslist-pp-cli search 'leica m6' --sites sfbay,nyc,seattle,losangeles,chicago --category pho --json
 
-
 # Populate the local store before running snapshot-driven commands (drift, scam-score, dupe-cluster, median, reposts).
 craigslist-pp-cli cl-sync --site sfbay --category apa --since 7d
-
 
 # Save a smart search with negative keywords Craigslist's own search doesn't support.
 craigslist-pp-cli watch save apartments --query 1BR --negate furnished,sublet --sites sfbay --category apa --max-price 2500
 
-
 # Stream new-listing events as JSON lines: [NEW] (new posts) and [PRICE-DROP] (sellers dropped the price).
 craigslist-pp-cli watch tail apartments --interval 5m --json
-
 
 # Rule-based scam triage on a listing (requires `cl-sync` to have synced the listing first).
 craigslist-pp-cli scam-score 7915891289 --json
@@ -169,7 +186,6 @@ The full command tree is discoverable via `craigslist-pp-cli --help`. Headline g
 - **Local-state CRUD** — `favorite add|list|remove`
 - **Framework helpers** — `doctor`, `version`, `which`, `agent-context`, `analytics`, `export`, `import`, `feedback`, `profile`, `tail`, `sync`, `workflow`
 
-
 ## Output Formats
 
 ```bash
@@ -240,29 +256,6 @@ claude mcp add craigslist craigslist-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-craigslist skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-craigslist. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/commerce/ebay/README.md
+++ b/library/commerce/ebay/README.md
@@ -49,6 +49,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/ebay-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-ebay skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ebay. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Authenticate
@@ -211,29 +234,6 @@ claude mcp add ebay ebay-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-ebay skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ebay. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/commerce/fedex/README.md
+++ b/library/commerce/fedex/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/fedex-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-fedex skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-fedex. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 FedEx uses OAuth2 client_credentials. Run `fedex auth login` once with your sandbox or production Client ID and Client Secret; the CLI mints a 1-hour bearer token, caches it on disk, and refreshes proactively before expiry. Production label printing requires per-project Bar Code Analysis Group (BAG) approval from FedEx — `fedex doctor` surfaces approval status before you hit it.
@@ -44,18 +67,14 @@ FedEx uses OAuth2 client_credentials. Run `fedex auth login` once with your sand
 # Mint a bearer token from FedEx OAuth2 client_credentials and cache it
 fedex auth login --client-id $FEDEX_API_KEY --client-secret $FEDEX_SECRET_KEY --env sandbox
 
-
 # Verify auth, sandbox/prod routing, and surface any BAG approval gaps before you hit them at ship-time
 fedex doctor
-
 
 # Compare every applicable service type ranked by cost — the most useful one-liner this CLI offers
 fedex rate shop --from 90210 --to 10001 --weight 5lb --json --select rates.serviceType,rates.totalNetCharge
 
-
 # Save a recipient to the local address book so you do not retype it for every shipment
 fedex address save --name acme --street '500 Main St' --city Denver --state CO --zip 80202 --country US
-
 
 # Batch-create labels with adaptive rate limiting; resumable on partial failure
 fedex ship bulk --csv orders.csv --service GROUND --resume
@@ -294,7 +313,6 @@ Track shipments by tracking number, reference, TCN, or associated shipment; retr
 - **`fedex-pp-cli track reference`** - Track by reference number (PO/customer ref/RMA)
 - **`fedex-pp-cli track tcn`** - Track by Transportation Control Number (military/government use)
 
-
 ## Cookbook
 
 Patterns combining multiple commands to solve real shipping workflows.
@@ -476,29 +494,6 @@ claude mcp add fedex fedex-pp-mcp -e FEDEX_API_KEY=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-fedex skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-fedex. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/commerce/instacart/README.md
+++ b/library/commerce/instacart/README.md
@@ -250,29 +250,6 @@ available for offline reads.
   top result may not match your intent. Use `instacart search` first to see
   the ranked list, then pass `--item-id` to `add` for precision.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-instacart skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-instacart. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `instacart-pp-cli` binary and the `pp-instacart` agent skill in one shot:
@@ -300,4 +277,28 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/instacart-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-instacart skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-instacart. The skill defines how its required CLI can be installed.
+```
 

--- a/library/commerce/shopify/README.md
+++ b/library/commerce/shopify/README.md
@@ -4,29 +4,6 @@ Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk o
 
 Learn more at [Shopify](https://shopify.dev/docs/api/admin-graphql).
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-shopify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-shopify. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `shopify-pp-cli` binary and the `pp-shopify` agent skill in one shot:
@@ -54,6 +31,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/shopify-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-shopify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-shopify. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 

--- a/library/commerce/tiktok-shop/README.md
+++ b/library/commerce/tiktok-shop/README.md
@@ -4,29 +4,6 @@ Safe v1 CLI and MCP server for confirmed TikTok Shop Seller APIs.
 
 This package intentionally exposes a conservative surface based only on official TikTok Shop Partner Center docs: auth readiness, token exchange and refresh, shop discovery, read-only orders, products, inventory search, fulfillment packages, and warehouses. Inventory update is documented as confirmed but remains deferred until idempotency, retry, and operator-confirmation safety are designed.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-tiktok-shop skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tiktok-shop. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `tiktok-shop-pp-cli` binary and the `pp-tiktok-shop` agent skill in one shot:
@@ -54,6 +31,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/tiktok-shop-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-tiktok-shop skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tiktok-shop. The skill defines how its required CLI can be installed.
+```
 
 ## Configure
 

--- a/library/commerce/yahoo-finance/README.md
+++ b/library/commerce/yahoo-finance/README.md
@@ -24,29 +24,6 @@ This CLI combines:
 - derived workflows like `digest`, `compare`, `sparkline`, `fx`, and filtered `options-chain`
 - a Chrome-session import fallback when Yahoo blocks the automatic crumb bootstrap from your IP
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-finance --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-finance --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-yahoo-finance skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-yahoo-finance. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `yahoo-finance-pp-cli` binary and the `pp-yahoo-finance` agent skill in one shot:
@@ -74,6 +51,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/yahoo-finance-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-finance --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-finance --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-yahoo-finance skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-yahoo-finance. The skill defines how its required CLI can be installed.
+```
 
 ## Session Bootstrap
 

--- a/library/developer-tools/company-goat/README.md
+++ b/library/developer-tools/company-goat/README.md
@@ -77,6 +77,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/company-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-company-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-company-goat. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No API keys required for the killer feature. Optional GITHUB_TOKEN raises engineering-signal rate limits from 60/hr to 5000/hr (works with `gh auth token`). Optional COMPANIES_HOUSE_API_KEY enables UK legal entity lookup; without it, `legal --region uk` prints setup instructions and other commands work normally.
@@ -175,7 +198,6 @@ SEC EDGAR Form D filings — the primary data source for US private fundraising 
 
 - **`company-goat-pp-cli filings list`** - Fetch all SEC submissions for a given CIK (Central Index Key). Used as the seed call when resolving a company's filing history.
 
-
 ## Output Formats
 
 ```bash
@@ -235,29 +257,6 @@ claude mcp add company-goat company-goat-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-company-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-company-goat. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/docker-hub/README.md
+++ b/library/developer-tools/docker-hub/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/docker-hub-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-docker-hub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-docker-hub. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -69,7 +92,6 @@ Manage docker hub search
 Repository metadata and details
 
 - **`docker-hub-pp-cli repositories get-repository`** - Full metadata for a Docker Hub repository including pull count, stars, description, and last update time.
-
 
 ## Output Formats
 
@@ -130,29 +152,6 @@ claude mcp add docker-hub docker-hub-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-docker-hub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-docker-hub. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/firecrawl/README.md
+++ b/library/developer-tools/firecrawl/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/firecrawl-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-firecrawl skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-firecrawl. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -136,7 +159,6 @@ Manage team
 - **`firecrawl-pp-cli team get-credit-usage`** - Get remaining credits for the authenticated team
 - **`firecrawl-pp-cli team get-token-usage`** - Get remaining tokens for the authenticated team (Extract only)
 
-
 ## Output Formats
 
 ```bash
@@ -198,29 +220,6 @@ claude mcp add firecrawl firecrawl-pp-mcp -e FIRECRAWL_BEARER_AUTH=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-firecrawl skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-firecrawl. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/nvd/README.md
+++ b/library/developer-tools/nvd/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/nvd-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-nvd skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nvd. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -64,7 +87,6 @@ Manage json
 
 - **`nvd-pp-cli json search-cpes`** - Search Common Platform Enumeration names to find exact product identifiers for vulnerability lookups.
 - **`nvd-pp-cli json search-cves`** - Search vulnerabilities by keyword, CVE ID, CPE name, publication date, or CVSS severity.
-
 
 ## Output Formats
 
@@ -125,29 +147,6 @@ claude mcp add nvd nvd-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-nvd skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nvd. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/postman-explore/README.md
+++ b/library/developer-tools/postman-explore/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/postman-explore-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-postman-explore --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-postman-explore --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-postman-explore skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-postman-explore. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No authentication required. The CLI uses a Surf HTTP transport with Chrome TLS fingerprinting to clear Cloudflare's HTML challenge gate; the proxy API itself is open.
@@ -44,22 +67,17 @@ No authentication required. The CLI uses a Surf HTTP transport with Chrome TLS f
 # Confirm reachability and see network-wide entity counts in one call.
 postman-explore-pp-cli networkentity get-network-entity-counts
 
-
 # Populate the local store so search, top, drift, canonical, and publishers all work offline.
 postman-explore-pp-cli sync --all-types --limit 200
-
 
 # The headline command — the best community Postman Collection for a known vendor.
 postman-explore-pp-cli canonical stripe
 
-
 # Trend ranking by metric, narrowed to a category.
 postman-explore-pp-cli top --metric weekForkCount --type collection --category payments --limit 5 --json
 
-
 # Compare publishers across a category by aggregate fork count.
 postman-explore-pp-cli publishers top --category developer-productivity --limit 5
-
 
 # What changed on the network this week?
 postman-explore-pp-cli drift --since 7d --type collection
@@ -191,7 +209,6 @@ For full workspace listing use `/v1/api/team?publicHandle=`.
 its `publicHandle` (e.g., `stripedev`, `salesforce-developers`,
 `meta`). Use `/v1/api/networkentity/{id}` for individual entity detail.
 
-
 ## Output Formats
 
 ```bash
@@ -251,29 +268,6 @@ claude mcp add postman-explore postman-explore-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-postman-explore --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-postman-explore --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-postman-explore skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-postman-explore. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/pypi/README.md
+++ b/library/developer-tools/pypi/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/pypi-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-pypi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pypi. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -62,14 +85,12 @@ Run `pypi-pp-cli --help` for the full command reference and flag list.
 
 Manage pypi
 
-
 ### rss
 
 RSS feeds for recent updates and newest packages
 
 - **`pypi-pp-cli rss newest-packages`** - RSS feed of the newest packages added to PyPI.
 - **`pypi-pp-cli rss recent-updates`** - RSS feed of the most recently updated packages on PyPI.
-
 
 ## Output Formats
 
@@ -130,29 +151,6 @@ claude mcp add pypi pypi-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-pypi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pypi. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/scrape-creators/README.md
+++ b/library/developer-tools/scrape-creators/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/scrape-creators-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creators --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creators --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-scrape-creators skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-scrape-creators. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Set SCRAPE_CREATORS_API_KEY (get one at https://scrapecreators.com). One header, no OAuth handshake.
@@ -44,22 +67,17 @@ Set SCRAPE_CREATORS_API_KEY (get one at https://scrapecreators.com). One header,
 # Verify auth and see remaining credits.
 scrape-creators-pp-cli account balance --json
 
-
 # Cross-platform presence — see every platform a creator is on.
 scrape-creators-pp-cli creator find mrbeast --json
-
 
 # Pull a single profile (any of 23 platforms supported).
 scrape-creators-pp-cli tiktok profile mrbeast --json
 
-
 # Persist tiktok resources to local SQLite (use --resources for any platform).
 scrape-creators-pp-cli sync --resources tiktok
 
-
 # FTS5 across every synced transcript, offline.
 scrape-creators-pp-cli transcripts search "giveaway" --json
-
 
 # Unified Facebook + Google + LinkedIn ad library search.
 scrape-creators-pp-cli ads search "Liquid Death" --json
@@ -402,7 +420,6 @@ Scrape YouTube channels, videos, and more
 - **`scrape-creators-pp-cli youtube list-video-3`** - Retrieves the captions, subtitles, or transcript of a YouTube video or short. Returns both a timestamped transcript array with start/end times and a plain-text version in transcript_only_text. Supports specifying a language code. Note: the video must be under 2 minutes for transcript extraction to work.
 - **`scrape-creators-pp-cli youtube list-video-4`** - Fetches replies to a specific comment on a YouTube video, including each reply's text content, author details (name, channel ID, avatar, verified/creator status), like count, and publish date. Requires a continuationToken obtained from the 'repliesContinuationToken' field on comments returned by the Comments endpoint. Supports paginating through additional replies with the continuationToken returned in each response.
 
-
 ## Output Formats
 
 ```bash
@@ -462,29 +479,6 @@ claude mcp add scrape-creators scrape-creators-pp-mcp -e SCRAPE_CREATORS_API_KEY
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creators --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creators --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-scrape-creators skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-scrape-creators. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/trigger-dev/README.md
+++ b/library/developer-tools/trigger-dev/README.md
@@ -2,29 +2,6 @@
 
 Monitor runs, trigger tasks, manage schedules, and detect failures via the Trigger.dev API
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-trigger-dev skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trigger-dev. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `trigger-dev-pp-cli` binary and the `pp-trigger-dev` agent skill in one shot:
@@ -52,6 +29,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trigger-dev-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-trigger-dev skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trigger-dev. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 

--- a/library/food-and-dining/allrecipes/README.md
+++ b/library/food-and-dining/allrecipes/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/allrecipes-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-allrecipes skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-allrecipes. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Browse and search work without any auth. Recipe detail pages need a Cloudflare clearance cookie — run `allrecipes-pp-cli auth login --chrome` once to capture one from your browser. This is bot-protection clearance, not an Allrecipes account login: no username, no password, no token tied to a user. The CLI does not support saved-recipes / meal-plan / profile features that require an actual Allrecipes account.
@@ -44,18 +67,14 @@ Browse and search work without any auth. Recipe detail pages need a Cloudflare c
 # One-time: capture a Cloudflare clearance cookie from your browser. Required for recipe detail pages.
 allrecipes-pp-cli auth login --chrome
 
-
 # Search the live site; results land in your local cache for offline reuse. Browse/search work without clearance.
 allrecipes-pp-cli search "brownies" --limit 5 --agent
-
 
 # Fetch a full recipe as parsed JSON-LD; --select narrows the payload.
 allrecipes-pp-cli recipe https://www.allrecipes.com/recipe/9599/quick-and-easy-brownies/ --agent --select recipeIngredient,totalTime,aggregateRating
 
-
 # Rescale ingredients by servings.
 allrecipes-pp-cli scale https://www.allrecipes.com/recipe/9599/quick-and-easy-brownies/ --servings 16
-
 
 # Match cached recipes against what you already have.
 allrecipes-pp-cli pantry --pantry-file ~/pantry.txt --query chicken --agent
@@ -271,29 +290,6 @@ claude mcp add allrecipes allrecipes-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-allrecipes skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-allrecipes. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/dominos/README.md
+++ b/library/food-and-dining/dominos/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/dominos-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-dominos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dominos. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Most commands work without authentication: store locator, menu browse, cart building, anonymous order placement, and tracking-by-phone all succeed unauthenticated. For loyalty rewards, member-exclusive deals, and order history, run `dominos-pp-cli auth login` — it spawns a Chrome window pointed at dominos.com sign-in, waits for you to complete a normal login (handles captcha and 2FA), then reads the bearer token from sessionStorage and saves it to `~/.config/dominos-pp-cli/config.toml`. The token persists until Domino's expires it (~1 hour). Run `auth status` to confirm; `auth logout` to clear.
@@ -80,7 +103,6 @@ dominos-pp-cli track --phone 2065551234 --watch --interval 30s
 dominos-pp-cli order-quick --template friday-night --json
 dominos-pp-cli order-quick --template friday-night --confirm --eta-watch --json
 ```
-
 
 ## Unique Features
 
@@ -211,7 +233,6 @@ Track active orders
 
 - **`dominos-pp-cli tracking track`** - Track an order by phone number
 
-
 ## Output Formats
 
 ```bash
@@ -272,29 +293,6 @@ claude mcp add dominos dominos-pp-mcp -e DOMINOS_USERNAME=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-dominos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dominos. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/food52/README.md
+++ b/library/food-and-dining/food52/README.md
@@ -6,29 +6,6 @@ Every recipe and article on Food52, queryable without a browser. Ships with `pan
 
 Learn more at [Food52](https://food52.com).
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-food52 skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-food52. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `food52-pp-cli` binary and the `pp-food52` agent skill in one shot:
@@ -57,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/food52-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-food52 skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-food52. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No Food52 sign-in required. Food52 sits behind Vercel bot mitigation, but the challenge is passive (TLS-fingerprint), not JS-active — Surf with Chrome impersonation clears it without cookies or setup. Search uses a Typesense search-only key the CLI auto-discovers from Food52's public JS bundle, so users never see a key prompt or env var.
@@ -67,22 +67,17 @@ No Food52 sign-in required. Food52 sits behind Vercel bot mitigation, but the ch
 # Live Typesense search; sub-second results.
 food52-pp-cli recipes search "brownies" --limit 5 --json
 
-
 # Full structured recipe (ingredients, steps, ratings, kitchen notes) for one recipe.
 food52-pp-cli recipes get sarah-fennel-s-best-lunch-lady-brownie-recipe --json
-
 
 # Seed the local store with two tags worth of recipes — required for offline search and pantry match.
 food52-pp-cli sync recipes chicken vegetarian --limit 100
 
-
 # Tell the CLI what's in your kitchen.
 food52-pp-cli pantry add chicken garlic lemon thyme
 
-
 # Find synced recipes you can mostly make right now.
 food52-pp-cli pantry match --min-coverage 0.6 --json
-
 
 # Clean cooking-friendly view, ready to pipe to lp or paste.
 food52-pp-cli print sarah-fennel-s-best-lunch-lady-brownie-recipe
@@ -167,7 +162,6 @@ Browse Food52 recipes by tag and fetch single recipe details (extracted from Nex
 
 - **`food52-pp-cli recipes browse`** - Browse Food52 recipes filtered by a tag (e.g. chicken, breakfast, vegetarian)
 - **`food52-pp-cli recipes get`** - Get full structured details for a single Food52 recipe by slug
-
 
 ## Output Formats
 

--- a/library/food-and-dining/pagliacci/README.md
+++ b/library/food-and-dining/pagliacci/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/pagliacci-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-pagliacci skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pagliacci. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Pagliacci has no public API and uses a custom composed `PagliacciAuth {customerId}|{authToken}` header constructed from cookies. Run `pagliacci-pp-cli auth login --chrome` while logged into pagliacci.com in Chrome — the CLI reads the auth cookies and constructs the header for you. Public commands (menu, stores, slices, time-windows) work without login; authenticated commands (order history, rewards, saved addresses) require the Chrome session.
@@ -42,18 +65,14 @@ Pagliacci has no public API and uses a custom composed `PagliacciAuth {customerI
 # Log in by reading cookies from your active Chrome session
 pagliacci-pp-cli auth login --chrome
 
-
 # Sync stores, menu, slices, orders, rewards into the local SQLite store
 pagliacci-pp-cli sync --full
-
 
 # See what slices are available right now across every Seattle store
 pagliacci-pp-cli slices today --agent
 
-
 # Plan a small-party order: store, time slot, cart contents, best discount
 pagliacci-pp-cli orders plan --people 6 --address-label home --json
-
 
 # Re-create the household's last order as a priced cart, without sending
 pagliacci-pp-cli orders reorder --last --dry-run
@@ -253,7 +272,6 @@ System information and announcements
 
 - **`pagliacci-pp-cli system site_wide_message`** - Get site-wide announcement banner text (closures, holiday hours, etc.)
 - **`pagliacci-pp-cli system version`** - Get the current API version
-
 
 ## Output Formats
 
@@ -469,29 +487,6 @@ claude mcp add pagliacci pagliacci-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-pagliacci skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pagliacci. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/recipe-goat/README.md
+++ b/library/food-and-dining/recipe-goat/README.md
@@ -30,6 +30,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/recipe-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-recipe-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-recipe-goat. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -73,7 +96,6 @@ USDA FoodData Central — ingredient nutrition lookups
 - **`recipe-goat-pp-cli foods get`** - Get a specific food by FDC ID
 - **`recipe-goat-pp-cli foods list`** - List foods paginated
 - **`recipe-goat-pp-cli foods search`** - Search USDA FoodData Central for foods matching a query
-
 
 ## Output Formats
 
@@ -134,29 +156,6 @@ claude mcp add recipe-goat recipe-goat-pp-mcp -e USDA_FDC_API_KEY=<your-key>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-recipe-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-recipe-goat. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/marketing/ahrefs/README.md
+++ b/library/marketing/ahrefs/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/ahrefs-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-ahrefs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ahrefs. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -132,7 +155,6 @@ Subscription Info endpoints.
 
 - **`ahrefs-pp-cli subscription-info`** - Limits and usage
 
-
 ## Output Formats
 
 ```bash
@@ -192,29 +214,6 @@ claude mcp add ahrefs ahrefs-pp-mcp -e AHREFS_API_KEY=<your-key>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-ahrefs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ahrefs. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/marketing/dub/README.md
+++ b/library/marketing/dub/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/dub-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-dub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dub. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 dub-pp-cli reads DUB_API_KEY from the environment (Speakeasy convention; DUB_TOKEN also accepted for compatibility with prior community CLIs). The key is workspace-scoped — the workspace is implicit in the key. Get one from dub.co/settings/tokens and run `dub-pp-cli doctor` to verify connectivity.
@@ -44,18 +67,14 @@ dub-pp-cli reads DUB_API_KEY from the environment (Speakeasy convention; DUB_TOK
 # Verify API key, base URL, and rate-limit headroom.
 dub-pp-cli doctor
 
-
 # Populate the local SQLite store so search and transcendence commands work offline.
 dub-pp-cli sync
-
 
 # List the workspace's links with the fields agents care about.
 dub-pp-cli links list --json --select id,key,url,clicks
 
-
 # Find dormant links — the headline transcendence feature.
 dub-pp-cli links stale --days 90 --json
-
 
 # Cross-resource Monday-morning report: rate-limit headroom, expiring links, bounty triage backlog.
 dub-pp-cli health --json
@@ -180,7 +199,6 @@ Run `dub-pp-cli --help` for the full command reference and flag list.
 
 Manage bounties
 
-
 ### commissions
 
 Manage commissions
@@ -296,7 +314,6 @@ Manage track
 - **`dub-pp-cli track open`** - This endpoint is used to track when a user opens your app via a Dub-powered deep link (for both iOS and Android).
 - **`dub-pp-cli track sale`** - Track a sale for a short link.
 
-
 ## Output Formats
 
 ```bash
@@ -384,29 +401,6 @@ Default is `thin` because the agent's tool catalog is loaded every conversation 
 Pattern source: Anthropic 2026-04 "Building agents that reach production systems with MCP" (Cloudflare's MCP server uses the same search+execute shape for ~2,500 endpoints in ~1K tokens).
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-dub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dub. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/marketing/klaviyo/README.md
+++ b/library/marketing/klaviyo/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/klaviyo-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-klaviyo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-klaviyo. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Set KLAVIYO_API_KEY to a private Klaviyo API key. Requests send Authorization: Klaviyo-API-Key <token> and use the revision pinned by the generated OpenAPI spec.
@@ -44,14 +67,11 @@ Set KLAVIYO_API_KEY to a private Klaviyo API key. Requests send Authorization: K
 # Check that KLAVIYO_API_KEY is present and accepted.
 klaviyo-pp-cli auth doctor
 
-
 # Fetch one profile and keep the response small for agents.
 klaviyo-pp-cli profiles list --limit 1 --json --select data.id,data.email
 
-
 # Populate local metric data for search and analytics.
 klaviyo-pp-cli sync metrics
-
 
 # Use the local mirror for a compound revenue view.
 klaviyo-pp-cli attribution --metric "Placed Order" --group-by flow --since 2026-01-01 --json
@@ -1681,7 +1701,6 @@ webhooks
 **Scopes:**
 `webhooks:write`
 
-
 ## Output Formats
 
 ```bash
@@ -1743,29 +1762,6 @@ claude mcp add klaviyo klaviyo-pp-mcp -e KLAVIYO_API_KEY=<your-key>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-klaviyo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-klaviyo. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/marketing/producthunt/README.md
+++ b/library/marketing/producthunt/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/producthunt-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-producthunt skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-producthunt. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Product Hunt's GraphQL API supports two auth modes; the CLI handles both. Recommended for personal use: visit https://www.producthunt.com/v2/oauth/applications, create an application (the redirect URL field is required by the form but unused for personal-token flow — set it to `https://localhost/callback`), then scroll to the bottom of the app page and click `Create Token` to generate a developer token that never expires. Set `PRODUCT_HUNT_TOKEN=<your-token>` or run `producthunt auth onboard` for an interactive walkthrough. For CI/automation, the alternate mode is OAuth `client_credentials`: set `PRODUCT_HUNT_CLIENT_ID` and `PRODUCT_HUNT_CLIENT_SECRET` from the same app page; the CLI exchanges them for an access token internally and refreshes on 401 (note: under OAuth client_credentials, the `whoami` command returns null because the public scope has no user context). The public Atom feed (`producthunt feed`) needs no token at all.
@@ -44,22 +67,17 @@ Product Hunt's GraphQL API supports two auth modes; the CLI handles both. Recomm
 # Token-free first read — the public Atom feed surfaces the latest 5 launches
 producthunt feed --count 5
 
-
 # Interactive setup for the personal developer token (includes the callback URL trick)
 producthunt auth onboard
-
 
 # Confirms the token works and shows your remaining complexity-points budget
 producthunt doctor
 
-
 # GraphQL-backed snapshot of today's top launches with votes, comments, and topics
 producthunt today
 
-
 # Full detail for a single launch by slug — agent-friendly JSON
 producthunt posts get notion --json
-
 
 # Backfill the local store so trajectories, benchmarks, and offline search work
 producthunt sync --resource posts --posted-after 2026-04-01
@@ -174,7 +192,6 @@ Public Atom feed of featured Product Hunt launches (no auth required)
 
 - **`producthunt-pp-cli feed get`** - Fetch the public Atom feed of recent featured launches; needs no token
 
-
 ## Output Formats
 
 ```bash
@@ -234,29 +251,6 @@ claude mcp add producthunt producthunt-pp-mcp -e PRODUCT_HUNT_TOKEN=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-producthunt skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-producthunt. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/archive-is/README.md
+++ b/library/media-and-entertainment/archive-is/README.md
@@ -6,29 +6,6 @@ Bypass paywalls and look up web archives via archive.today. Looks up existing sn
 
 > **About archive.today:** On February 21, 2026, Wikipedia formally blacklisted archive.today after evidence of DDoS activity and snapshot tampering. This CLI is intended for personal paywall reading. Do NOT use it for legal evidence, academic citation, or anything requiring a trustworthy archive — use the Wayback Machine for that. This CLI ships with Wayback as a built-in fallback backend for that reason.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-archive-is skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-archive-is. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `archive-is-pp-cli` binary and the `pp-archive-is` agent skill in one shot:
@@ -56,6 +33,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/archive-is-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-archive-is skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-archive-is. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 
@@ -203,7 +203,6 @@ The six hand-built commands below are the hero features. They're optimized for o
 | `doctor` | Check configuration, auth, and API reachability. |
 | `auth` | Manage authentication tokens (archive.today needs none). |
 | `version` | Print CLI version. |
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/espn/README.md
+++ b/library/media-and-entertainment/espn/README.md
@@ -2,29 +2,6 @@
 
 Live scores, standings, news, and game history across 17 sports from ESPN
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-espn skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-espn. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `espn-pp-cli` binary and the `pp-espn` agent skill in one shot:
@@ -52,6 +29,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/espn-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-espn skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-espn. The skill defines how its required CLI can be installed.
+```
 
 ## Authentication
 

--- a/library/media-and-entertainment/google-photos/README.md
+++ b/library/media-and-entertainment/google-photos/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/google-photos-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-google-photos --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-google-photos --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-google-photos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-google-photos. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -228,29 +251,6 @@ claude mcp add google-photos google-photos-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-google-photos --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-google-photos --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-google-photos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-google-photos. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/hackernews/README.md
+++ b/library/media-and-entertainment/hackernews/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/hackernews-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-hackernews skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hackernews. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No authentication needed — both the Firebase and Algolia HN APIs are free and public.
@@ -44,18 +67,14 @@ No authentication needed — both the Firebase and Algolia HN APIs are free and 
 # Pull current top/new/best/show/ask/job lists plus recent items into the local store
 hackernews-pp-cli sync
 
-
 # Browse the freshest top stories
 hackernews-pp-cli stories top --limit 10
-
 
 # Track a topic's per-day mentions, score, and comment volume
 hackernews-pp-cli pulse rust --days 7 --agent
 
-
 # See exactly what changed on the front page since the last sync
 hackernews-pp-cli since --json
-
 
 # Aggregate the last 3 months of Who-is-Hiring — languages, remote ratio, top companies
 hackernews-pp-cli hiring stats --months 3 --agent
@@ -184,7 +203,6 @@ Recently changed items and profiles
 Look up Hacker News user profiles
 
 - **`hackernews-pp-cli users get`** - Get a user's profile including karma and submission history
-
 
 ## Output Formats
 
@@ -362,29 +380,6 @@ claude mcp add hackernews hackernews-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-hackernews skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hackernews. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/movie-goat/README.md
+++ b/library/media-and-entertainment/movie-goat/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/movie-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-movie-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-movie-goat. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 TMDb v3 API key (free, https://www.themoviedb.org/settings/api) is required and goes in `TMDB_API_KEY` — used as a query parameter, not a Bearer header. OMDb key (free, http://www.omdbapi.com/apikey.aspx) is optional and goes in `OMDB_API_KEY`; without it, `ratings` and `versus` show TMDb-only and gracefully omit the IMDb/RT/Metacritic columns.
@@ -44,22 +67,17 @@ TMDb v3 API key (free, https://www.themoviedb.org/settings/api) is required and 
 # The fastest path to the value: a streaming-filtered, well-rated shortlist for tonight.
 movie-goat-pp-cli tonight --providers "Netflix,Max" --region US
 
-
 # Multi-type search across movies, TV, and people.
 movie-goat-pp-cli multi "the bear"
-
 
 # Cross-source rating card for Fight Club (TMDb id 550).
 movie-goat-pp-cli ratings 550
 
-
 # Add Inception to the local SQLite watchlist.
 movie-goat-pp-cli watchlist add 27205 --kind movie
 
-
 # Show which saved titles are streamable on your services right now.
 movie-goat-pp-cli watchlist list --available --providers netflix,max --region US
-
 
 # Plan a franchise marathon with totalled runtime.
 movie-goat-pp-cli marathon "The Avengers" --order release
@@ -195,7 +213,6 @@ Search and browse TV shows
 - **`movie-goat-pp-cli tv search`** - Search for TV shows by title
 - **`movie-goat-pp-cli tv top-rated`** - Get the highest rated TV shows
 
-
 ## Cookbook
 
 Real-world recipes using verified flag names. Pipe `--json` and chain with
@@ -299,29 +316,6 @@ claude mcp add movie-goat movie-goat-pp-mcp -e TMDB_API_KEY=<your-key>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-movie-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-movie-goat. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/pokeapi/README.md
+++ b/library/media-and-entertainment/pokeapi/README.md
@@ -6,29 +6,6 @@ Most PokéAPI clients cache one request at a time. This CLI syncs the entire dat
 
 Learn more at [PokéAPI](https://pokeapi.co/docs/v2).
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-pokeapi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pokeapi. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `pokeapi-pp-cli` binary and the `pp-pokeapi` agent skill in one shot:
@@ -57,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/pokeapi-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-pokeapi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pokeapi. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 PokéAPI is a public, read-only API. No keys, no tokens, no login. Run `pokeapi-pp-cli sync` once and you have the whole Pokédex on disk.
@@ -67,18 +67,14 @@ PokéAPI is a public, read-only API. No keys, no tokens, no login. Run `pokeapi-
 # First — fetch every resource into the local SQLite store. Takes a few minutes; you only do this once per release of the API.
 pokeapi-pp-cli sync
 
-
 # Core agent-friendly profile: types, abilities, stats, key moves — one local query.
 pokeapi-pp-cli pokemon profile pikachu --json
-
 
 # Build a balanced team starting from a partial roster. Selects only the high-gravity fields.
 pokeapi-pp-cli team suggest pikachu,charizard --slots 6 --json --select name,types,score
 
-
 # Reverse search by effect — moves that paralyze a Steel-type. The live API can't do this in any single call.
 pokeapi-pp-cli move find --effect paralyze --type-target steel --json
-
 
 # Damage calculator — expected damage range factoring in STAB, type effectiveness, level, and stats.
 pokeapi-pp-cli damage charizard blastoise hydro-pump --json
@@ -533,7 +529,6 @@ Manage version group
 
 - **`pokeapi-pp-cli version-group list`** - Version groups categorize highly similar versions of the games.
 - **`pokeapi-pp-cli version-group retrieve`** - Version groups categorize highly similar versions of the games.
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/steam-web/README.md
+++ b/library/media-and-entertainment/steam-web/README.md
@@ -12,29 +12,6 @@ You need a Steam Web API key. Get one at [steamcommunity.com/dev/apikey](https:/
 export STEAM_API_KEY="your-key-here"
 ```
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-steam-web skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-steam-web. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `steam-web-pp-cli` binary and the `pp-steam-web` agent skill in one shot:
@@ -62,6 +39,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/steam-web-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-steam-web skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-steam-web. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 

--- a/library/media-and-entertainment/wikipedia/README.md
+++ b/library/media-and-entertainment/wikipedia/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/wikipedia-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-wikipedia skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wikipedia. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -72,7 +95,6 @@ Article content and metadata
 - **`wikipedia-pp-cli page get-media`** - Returns images, videos, and other media files associated with an article.
 - **`wikipedia-pp-cli page get-random`** - Returns a random Wikipedia article summary.
 - **`wikipedia-pp-cli page get-summary`** - Returns a page summary including title, extract text, thumbnail, and coordinates.
-
 
 ## Output Formats
 
@@ -133,29 +155,6 @@ claude mcp add wikipedia wikipedia-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-wikipedia skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wikipedia. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/monitoring/sentry/README.md
+++ b/library/monitoring/sentry/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/sentry-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-sentry skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sentry. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Set SENTRY_AUTH_TOKEN to a Sentry user or organization token with read scopes such as org:read, project:read, and event:read. Set SENTRY_REGION=de for EU-region SaaS organizations, or configure the base URL for self-hosted Sentry if supported by the generated config.
@@ -44,18 +67,14 @@ Set SENTRY_AUTH_TOKEN to a Sentry user or organization token with read scopes su
 # Confirm token and API reachability before running endpoint commands.
 sentry-pp-cli doctor --json
 
-
 # Find the organization slug used by most Sentry API calls.
 sentry-pp-cli organizations list --json --select slug,name
-
 
 # List projects once you know the organization slug.
 sentry-pp-cli organizations projects list-an-organization-s my-org --json --select slug,name
 
-
 # Start incident triage with organization issues.
 sentry-pp-cli organizations issues list-an-organization-s my-org --json --select shortId,title,count,userCount
-
 
 # Search synced local data when you need offline or repeated context.
 sentry-pp-cli search timeout --json --select title,url,resource
@@ -132,7 +151,6 @@ eg. `us.sentry.io` or `de.sentry.io`
 
 Manage sentry app installations
 
-
 ### sentry-apps
 
 Manage sentry apps
@@ -152,7 +170,6 @@ immediate. Teams will have their slug released while waiting for deletion.
 - **`sentry-pp-cli teams retrieve-a`** - Return details on an individual team.
 - **`sentry-pp-cli teams update-a`** - Update various attributes and configurable settings for the given
 team.
-
 
 ## Output Formats
 
@@ -215,29 +232,6 @@ claude mcp add sentry sentry-pp-mcp -e SENTRY_AUTH_TOKEN=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-sentry skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sentry. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/other/apartments/README.md
+++ b/library/other/apartments/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/apartments-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-apartments --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-apartments --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-apartments skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-apartments. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No authentication required. Apartments.com's anonymous search and listing pages are the entire API surface this CLI uses; saved-search login (cookie session) is intentionally out of scope. Surf with Chrome TLS fingerprint clears the Akamai-style protection at runtime — no clearance cookie capture, no resident browser.
@@ -44,18 +67,14 @@ No authentication required. Apartments.com's anonymous search and listing pages 
 # First search — verifies Surf transport clears protection and JSON output is well-formed.
 apartments-pp-cli rentals --city austin --state TX --beds 2 --price-max 2500 --pets dog --json
 
-
 # Persist that search to the local store under the slug 'austin-2br' so transcendence commands can read it.
 apartments-pp-cli sync-search austin-2br --city austin --state TX --beds 2 --price-max 2500 --pets dog
-
 
 # Rank the synced listings by $/sqft — the ratio metric apartments.com's sort omits.
 apartments-pp-cli rank --by sqft --beds 2 --price-max 2500 --json --limit 10
 
-
 # After a few days, run this — `watch` diffs against the previous sync and emits NEW / REMOVED / PRICE-CHANGED sets.
 apartments-pp-cli watch austin-2br --since 7d --json
-
 
 # The Monday-morning digest: new + removed + price drops + top-by-$/sqft + stale + phantoms in one structured output.
 apartments-pp-cli digest --saved-search austin-2br --since 7d --format md
@@ -237,7 +256,6 @@ Run `apartments-pp-cli --help` for the full command reference and flag list.
 | `feedback` | Record feedback about this CLI (local by default; upstream opt-in). |
 | `version` | Print version. |
 
-
 ## Cookbook
 
 Recipes use verified flag names and the local store. Run `apartments-pp-cli sync-search <slug> --city <city> --state <st>` once before any "synced data" recipe.
@@ -360,29 +378,6 @@ claude mcp add apartments apartments-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-apartments --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-apartments --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-apartments skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-apartments. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/other/open-meteo/README.md
+++ b/library/other/open-meteo/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/open-meteo-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-open-meteo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-open-meteo. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 No API key required. The free tier supports up to ~10,000 requests per day for non-commercial use. If you have an Open-Meteo customer-tier subscription, set OPEN_METEO_API_KEY in the environment and the CLI auto-routes to customer-*.open-meteo.com with the apikey appended — same commands, same flags, higher limits, commercial use allowed.
@@ -44,22 +67,17 @@ No API key required. The free tier supports up to ~10,000 requests per day for n
 # accuracy, is-good-for) accept --place natively.
 open-meteo-pp-cli geocode search --name Seattle --count 1 --json
 
-
 # Current conditions for a city by name (panel takes --place natively).
 open-meteo-pp-cli panel --place Seattle --current temperature_2m,weather_code --humanize
-
 
 # 7-day daily forecast as JSON.
 open-meteo-pp-cli forecast --latitude 47.6062 --longitude -122.3321 --daily temperature_2m_max,temperature_2m_min,precipitation_sum --forecast-days 7 --json
 
-
 # Historical ERA5 data — works for any date back to 1940.
 open-meteo-pp-cli archive --latitude 47.6062 --longitude -122.3321 --start-date 2024-01-01 --end-date 2024-01-31 --daily temperature_2m_max --json
 
-
 # Climate-vs-now anomaly: how today compares to the 30-year normal (--place native).
 open-meteo-pp-cli compare --place Seattle --metric temperature_2m_mean --years 30 --json
-
 
 # Side-by-side multi-location panel in one batched call.
 open-meteo-pp-cli panel --place Seattle,Berlin,Tokyo --current temperature_2m,weather_code --json
@@ -192,7 +210,6 @@ Seasonal forecasts (up to 9 months) using NCEP CFSv2.
 
 - **`open-meteo-pp-cli seasonal get`** - 9-month seasonal forecast at six-hourly resolution. Default model is NCEP CFSv2.
 
-
 ## Output Formats
 
 ```bash
@@ -260,29 +277,6 @@ claude mcp add open-meteo open-meteo-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-open-meteo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-open-meteo. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/other/weather-goat/README.md
+++ b/library/other/weather-goat/README.md
@@ -4,29 +4,6 @@ The weather CLI that answers the questions you actually ask: Should I bike today
 
 Powered by Open-Meteo (global forecasts, 80 years of history, air quality) and NWS (severe weather alerts). No API key required.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-weather-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-weather-goat. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `weather-goat-pp-cli` binary and the `pp-weather-goat` agent skill in one shot:
@@ -54,6 +31,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/weather-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-weather-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-weather-goat. The skill defines how its required CLI can be installed.
+```
 
 ## Authentication
 

--- a/library/payments/coingecko/README.md
+++ b/library/payments/coingecko/README.md
@@ -4,29 +4,6 @@ CoinGecko public API for cryptocurrency data. Free tier, no API key required for
 
 Learn more at [Coingecko](https://www.coingecko.com).
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-coingecko skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-coingecko. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `coingecko-pp-cli` binary and the `pp-coingecko` agent skill in one shot:
@@ -54,6 +31,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/coingecko-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-coingecko skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-coingecko. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 
@@ -114,7 +114,6 @@ Manage simple
 
 - **`coingecko-pp-cli simple price`** - Get price of coins
 - **`coingecko-pp-cli simple supported-vs-currencies`** - List supported vs currencies
-
 
 ## Output Formats
 

--- a/library/payments/kalshi/README.md
+++ b/library/payments/kalshi/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/kalshi-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-kalshi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-kalshi. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Kalshi requires composed RSA-PSS signature auth: a UUID access key id (KALSHI_API_KEY) plus an RSA private key file (KALSHI_PRIVATE_KEY_PATH or KALSHI_PRIVATE_KEY). Kalshi issues two key tiers — read-only and read/write — and the CLI honors KALSHI_READ_ONLY=1 (or --read-only) as a client-side lock that blocks every POST/PUT/PATCH/DELETE before signing, regardless of which tier is loaded. Write commands run against a read-only key will surface a 403 from Kalshi; pair with --dry-run while debugging.
@@ -42,18 +65,14 @@ Kalshi requires composed RSA-PSS signature auth: a UUID access key id (KALSHI_AP
 # verify your key id + private key are loaded; reports configured/source
 kalshi-pp-cli auth status
 
-
 # populate the local SQLite store including the market_price_history snapshot table
 kalshi-pp-cli sync
-
 
 # browse open markets from the live API (sync first for offline filtering)
 kalshi-pp-cli markets get --status open --limit 10 --json
 
-
 # render the captured price history with an inline sparkline
 kalshi-pp-cli markets history KXPRES-2028-DJT --sparkline
-
 
 # compute realized P&L by Kalshi taxonomy
 kalshi-pp-cli portfolio attribution --by category --since 2026-01-01 --json
@@ -284,7 +303,6 @@ Structured targets endpoints
 - **`kalshi-pp-cli structured-targets get`** - Page size (min: 1, max: 2000)
 - **`kalshi-pp-cli structured-targets get-structuredtargets`** - Endpoint for getting data about a specific structured target by its ID.
 
-
 ## Output Formats
 
 ```bash
@@ -346,29 +364,6 @@ claude mcp add kalshi kalshi-pp-mcp -e KALSHI_API_KEY=<your-key>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-kalshi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-kalshi. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/payments/mercury/README.md
+++ b/library/payments/mercury/README.md
@@ -32,6 +32,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/mercury-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-mercury skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-mercury. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -213,7 +236,6 @@ Manage SAFE (Simple Agreement for Future Equity) requests
 
 Download account statements
 
-
 ### transaction
 
 Manage transactions
@@ -255,7 +277,6 @@ Manage webhooks
 - **`mercury-pp-cli webhooks get`** - Retrieve a paginated list of all webhook endpoints for your organization. Supports filtering by status.
 - **`mercury-pp-cli webhooks get-webhookendpointid`** - Retrieve details of a specific webhook endpoint by ID
 - **`mercury-pp-cli webhooks update`** - Update the configuration of an existing webhook endpoint. A webhook that has been disabled due to consecutive delivery failures can be reactivated by setting its status to 'active'.
-
 
 ## Output Formats
 
@@ -318,29 +339,6 @@ claude mcp add mercury mercury-pp-mcp -e MERCURY_BEARER_AUTH=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-mercury skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-mercury. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/productivity/cal-com/README.md
+++ b/library/productivity/cal-com/README.md
@@ -34,6 +34,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/cal-com-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-cal-com skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-cal-com. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Cal.com uses bearer tokens prefixed with `cal_live_` (live) or `cal_test_` (test). Set `CAL_COM_TOKEN` in your environment, or run `auth set-token` once. The CLI also accepts managed-user access tokens and OAuth access tokens through the same Authorization header. Per-resource API-version pinning via `cal-api-version` is handled automatically by the client.
@@ -44,22 +67,17 @@ Cal.com uses bearer tokens prefixed with `cal_live_` (live) or `cal_test_` (test
 # Confirm CAL_COM_TOKEN is loaded; use auth set-token <token> to save one to the config
 cal-com-pp-cli auth status
 
-
 # Confirm the token works against /v2/me
 cal-com-pp-cli doctor
-
 
 # Pull bookings, event types, schedules, teams, and webhooks into the local store
 cal-com-pp-cli sync
 
-
 # See today's bookings without an API call
 cal-com-pp-cli agenda --window today --json
 
-
 # Fan out the slot search across event-type IDs
 cal-com-pp-cli slots find --event-type-ids 96531 --start tomorrow --end "tomorrow 23:59" --json
-
 
 # Compose slot check + reservation + create + confirm in one call
 cal-com-pp-cli book --event-type-id 96531 --start 2026-05-06T17:00:00Z --attendee-name Guest --attendee-email guest@example.com --dry-run
@@ -445,7 +463,6 @@ Manage notifications
 
 Manage oauth
 
-
 ### oauth-clients
 
 Manage oauth clients
@@ -460,11 +477,9 @@ Manage oauth clients
 
 Manage organizations
 
-
 ### routing-forms
 
 Manage routing forms
-
 
 ### schedules
 
@@ -596,7 +611,6 @@ Manage webhooks
 - **`cal-com-pp-cli webhooks get-webhookid`** - If accessed using an OAuth access token, the `WEBHOOK_READ` scope is required.
 - **`cal-com-pp-cli webhooks update`** - If accessed using an OAuth access token, the `WEBHOOK_WRITE` scope is required.
 
-
 ## Output Formats
 
 ```bash
@@ -658,29 +672,6 @@ claude mcp add cal-com cal-com-pp-mcp -e CAL_COM_TOKEN=<your-token>
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-cal-com skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-cal-com. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/productivity/slack/README.md
+++ b/library/productivity/slack/README.md
@@ -2,29 +2,6 @@
 
 Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-slack --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-slack --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-slack skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-slack. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `slack-pp-cli` binary and the `pp-slack` agent skill in one shot:
@@ -52,6 +29,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/slack-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-slack --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-slack --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-slack skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-slack. The skill defines how its required CLI can be installed.
+```
 
 ## Quick Start
 

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -2,29 +2,6 @@
 
 Manage issues, projects, cycles, and teams via the Linear API with offline search and analytics.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-linear --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-linear --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-linear skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-linear. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `linear-pp-cli` binary and the `pp-linear` agent skill in one shot:
@@ -52,6 +29,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/linear-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-linear --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-linear --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-linear skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-linear. The skill defines how its required CLI can be installed.
+```
 
 ## Authentication
 

--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -3,29 +3,6 @@
 Super LinkedIn for the terminal. Search, enrich, and map warm-intro paths
 across LinkedIn, Happenstance, and Deepline from one SQLite-backed CLI.
 
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-contact-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-contact-goat. The skill defines how its required CLI can be installed.
-```
-
 ## Install
 
 The recommended path installs both the `contact-goat-pp-cli` binary and the `pp-contact-goat` agent skill in one shot:
@@ -53,6 +30,29 @@ This installs the CLI only — no skill.
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/contact-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-contact-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-contact-goat. The skill defines how its required CLI can be installed.
+```
 
 ## Authentication
 

--- a/library/travel/airbnb/README.md
+++ b/library/travel/airbnb/README.md
@@ -36,6 +36,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/airbnb-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-airbnb skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-airbnb. The skill defines how its required CLI can be installed.
+```
+
 ## Authentication
 
 Public search and listing detail need no auth. Authenticated features (Airbnb wishlists, trip history) use cookie import via auth login --chrome. The web-search backend is pluggable: Parallel.ai (paid, best), DuckDuckGo HTML (free default), Brave Search API (free tier), or Tavily (free tier).
@@ -46,18 +69,14 @@ Public search and listing detail need no auth. Authenticated features (Airbnb wi
 # Verify reachability and which search backend is active.
 airbnb-pp-cli doctor
 
-
 # Find listings on Airbnb.
 airbnb-pp-cli airbnb search 'Lake Tahoe' --checkin 2026-05-16 --checkout 2026-05-19 --guests 4
-
 
 # Same query, VRBO side.
 airbnb-pp-cli vrbo search 'Lake Tahoe' --checkin 2026-05-16 --checkout 2026-05-19 --guests 4
 
-
 # The headline command. Find the host's direct booking site and the cheapest of three sources.
 airbnb-pp-cli cheapest 'https://www.airbnb.com/rooms/37124493?check_in=2026-05-16&check_out=2026-05-19'
-
 
 # One call: search both platforms, find direct sites, return ranked-by-savings list.
 airbnb-pp-cli plan 'Lake Tahoe' --checkin 2026-05-16 --checkout 2026-05-19 --guests 4 --budget 1500
@@ -171,7 +190,6 @@ VRBO listings (search and detail) via /graphql with Akamai warmup pattern.
 - **`airbnb-pp-cli vrbo_listing get`** - Get full VRBO property detail via the propertyDetail GraphQL operation (operation name discovered at runtime). Falls back to __PLUGIN_STATE__ SSR scrape for basic fields.
 - **`airbnb-pp-cli vrbo_listing search`** - Search VRBO properties via the propertySearch GraphQL operation. Uses Akamai warmup (GET / first, wait 1.5s, then POST).
 
-
 ## Output Formats
 
 ```bash
@@ -247,29 +265,6 @@ claude mcp add airbnb-pp airbnb-pp-mcp
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-airbnb skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-airbnb. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -73,6 +73,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/flight-goat-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-flight-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-flight-goat. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -430,7 +453,6 @@ Manage schedules
 schedules are available for up to three months in the past as well as
 one year into the future.
 
-
 ## Output Formats
 
 ```bash
@@ -492,29 +514,6 @@ claude mcp add flight-goat flight-goat-pp-mcp -e FLIGHT_GOAT_API_KEY_AUTH=<your-
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-flight-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-flight-goat. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/library/travel/seats-aero/README.md
+++ b/library/travel/seats-aero/README.md
@@ -30,6 +30,29 @@ This installs the CLI only — no skill.
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/seats-aero-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-seats-aero skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-seats-aero. The skill defines how its required CLI can be installed.
+```
+
 ## Quick Start
 
 ### 1. Install
@@ -90,7 +113,6 @@ Manage trips
 
 - **`seats-aero-pp-cli trips get`** - Get detailed trip information by revalidation/trip ID from search or availability results.
 
-
 ## Output Formats
 
 ```bash
@@ -150,29 +172,6 @@ claude mcp add seats-aero seats-aero-pp-mcp -e SEATS_AERO_PARTNER_PARTNER_AUTHOR
 ```
 
 </details>
-
-<!-- pp-hermes-install-anchor -->
-## Install via Hermes
-
-From the Hermes CLI:
-
-```bash
-hermes skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero --force
-```
-
-Inside a Hermes chat session:
-
-```bash
-/skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero --force
-```
-
-## Install via OpenClaw
-
-Tell your OpenClaw agent (copy this):
-
-```
-Install the pp-seats-aero skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-seats-aero. The skill defines how its required CLI can be installed.
-```
 
 ## Use with Claude Desktop
 

--- a/tools/sweep-canonical/main.go
+++ b/tools/sweep-canonical/main.go
@@ -761,66 +761,109 @@ Download a pre-built binary for your platform from the [latest release](https://
 `, ctx.CLIName, ctx.APIName, ctx.APIName, ctx.APIName, module, ctx.APIName)
 }
 
-// patchReadmeHermesOpenClaw inserts the Install via Hermes / Install
-// via OpenClaw sections into a README.md. Idempotent: skips if `##
-// Install via Hermes` is already present.
+// patchReadmeHermesOpenClaw enforces the canonical position and
+// naming for the Hermes and OpenClaw install sections:
 //
-// Insertion-point fallback chain for legacy READMEs without the
-// `<!-- pp-hermes-install-anchor -->` HTML comment:
+//  1. Strips any existing Hermes/OpenClaw sections and the
+//     pp-hermes-install-anchor comment from wherever they currently
+//     are. Handles both legacy "Install via X" naming and current
+//     "Install for X" naming, so the function is forward- and
+//     backward-compatible across template versions.
+//  2. Re-inserts the canonical "Install for X" blocks (preceded by
+//     the anchor comment) immediately after the `## Install` section
+//     ends, so all install paths sit grouped at the top of the
+//     README.
 //
-//  1. Right before `## Use with Claude Desktop` (most common)
-//  2. Right before `## Use with Claude Code`
-//  3. Right before `## Install` (older READMEs)
-//  4. End of file
+// Idempotent: running with body that already has the canonical shape
+// strips and re-inserts identical content, producing zero diff.
 //
-// "Right before" means: the new sections appear above the matched
-// heading, so they show up in the same neighborhood as related
-// install-and-setup content.
+// READMEs without a `## Install` heading (only agent-capture in the
+// live library) are left unchanged — their hand-shaped install
+// guidance doesn't fit the template, and dropping the Hermes/OpenClaw
+// blocks at an arbitrary position would be worse than leaving them
+// off entirely.
 func patchReadmeHermesOpenClaw(body string, ctx patchReadmeCtx) string {
-	if strings.Contains(body, "## Install via Hermes") {
+	// If there's no ## Install heading to anchor on, don't touch the
+	// README — stripping existing Hermes/OpenClaw blocks without being
+	// able to re-insert them would silently delete install
+	// instructions. Only agent-capture among 49 live CLIs falls in
+	// this branch; its README has hand-shaped install guidance that
+	// doesn't fit the template.
+	const installHeading = "## Install\n"
+	if !strings.Contains(body, installHeading) {
 		return body
 	}
 
-	insert := buildReadmeInstallSections(ctx)
-
-	// Anchor wins if present (only fresh prints from the post-U3
-	// template have it; legacy READMEs do not).
-	const anchor = "<!-- pp-hermes-install-anchor -->"
-	if idx := strings.Index(body, anchor); idx >= 0 {
-		// The anchor in the live template is followed by a newline
-		// then the Hermes heading. We insert right after the anchor's
-		// newline so subsequent sweeps find their own emitted sections.
-		end := idx + len(anchor)
-		if end < len(body) && body[end] == '\n' {
-			end++
-		}
-		return body[:end] + insert + body[end:]
-	}
-
-	// Fallback chain: insert before the first matching heading.
-	for _, heading := range []string{
-		"\n## Use with Claude Desktop",
-		"\n## Use with Claude Code",
-		"\n## Install\n",
+	// Strip stale Hermes/OpenClaw sections. List both naming variants
+	// so we can migrate "via" to "for" without a separate code path.
+	for _, h := range []string{
+		"## Install via Hermes",
+		"## Install via OpenClaw",
+		"## Install for Hermes",
+		"## Install for OpenClaw",
 	} {
-		if idx := strings.Index(body, heading); idx >= 0 {
-			// Insert anchor + sections + blank line before the heading.
-			pre := body[:idx+1] // include the leading \n
-			post := body[idx+1:]
-			return pre + anchor + "\n" + insert + post
-		}
+		body = stripH2Section(body, h)
+	}
+	// Strip the anchor comment with or without trailing newline.
+	body = strings.ReplaceAll(body, "<!-- pp-hermes-install-anchor -->\n", "")
+	body = strings.ReplaceAll(body, "<!-- pp-hermes-install-anchor -->", "")
+	// Collapse any blank-line gaps left by stripping (e.g. two adjacent
+	// stripped sections leave `\n\n\n` between surrounding content).
+	for strings.Contains(body, "\n\n\n") {
+		body = strings.ReplaceAll(body, "\n\n\n", "\n\n")
 	}
 
-	// No match — append at EOF.
-	suffix := body
-	if !strings.HasSuffix(suffix, "\n") {
-		suffix += "\n"
+	// Re-insert canonical anchor + "for"-named blocks immediately after
+	// the `## Install` section ends.
+	canonical := "<!-- pp-hermes-install-anchor -->\n" + buildReadmeInstallSections(ctx)
+
+	installIdx := strings.Index(body, installHeading)
+	if installIdx < 0 {
+		// Defensive: shouldn't reach here given the early-return above,
+		// but keep the guard in case body got transformed unexpectedly.
+		return body
 	}
-	return suffix + "\n" + anchor + "\n" + insert
+	// Find the next H2 after ## Install. That's the section boundary
+	// where we insert (right before whatever comes next, typically
+	// ## Authentication or ## Quick Start).
+	tail := body[installIdx+len(installHeading):]
+	nextH2Idx := strings.Index(tail, "\n## ")
+	if nextH2Idx < 0 {
+		// ## Install is the last section in the README. Append at
+		// EOF, ensuring a trailing newline boundary.
+		if !strings.HasSuffix(body, "\n") {
+			body += "\n"
+		}
+		return body + "\n" + canonical
+	}
+	insertPos := installIdx + len(installHeading) + nextH2Idx + 1
+	return body[:insertPos] + canonical + body[insertPos:]
+}
+
+// stripH2Section removes a `## <heading>` section (heading line + body
+// up to the next `## ` heading or EOF) from body. Returns body
+// unchanged if the heading is not present. Preserves the blank line
+// from the previous section's trailing content; surrounding content
+// is otherwise byte-preserved.
+func stripH2Section(body, heading string) string {
+	needle := heading + "\n"
+	idx := strings.Index(body, needle)
+	if idx < 0 {
+		return body
+	}
+	rest := body[idx+len(needle):]
+	nextIdx := strings.Index(rest, "\n## ")
+	var sectionEnd int
+	if nextIdx < 0 {
+		sectionEnd = len(body)
+	} else {
+		sectionEnd = idx + len(needle) + nextIdx + 1
+	}
+	return body[:idx] + body[sectionEnd:]
 }
 
 func buildReadmeInstallSections(ctx patchReadmeCtx) string {
-	return fmt.Sprintf("## Install via Hermes\n\n"+
+	return fmt.Sprintf("## Install for Hermes\n\n"+
 		"From the Hermes CLI:\n\n"+
 		"```bash\n"+
 		"hermes skills install mvanhorn/printing-press-library/cli-skills/pp-%s --force\n"+
@@ -829,7 +872,7 @@ func buildReadmeInstallSections(ctx patchReadmeCtx) string {
 		"```bash\n"+
 		"/skills install mvanhorn/printing-press-library/cli-skills/pp-%s --force\n"+
 		"```\n\n"+
-		"## Install via OpenClaw\n\n"+
+		"## Install for OpenClaw\n\n"+
 		"Tell your OpenClaw agent (copy this):\n\n"+
 		"```\n"+
 		"Install the pp-%s skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-%s. The skill defines how its required CLI can be installed.\n"+

--- a/tools/sweep-canonical/main_test.go
+++ b/tools/sweep-canonical/main_test.go
@@ -292,74 +292,167 @@ stuff.
 	}
 }
 
-func TestPatchReadme_AnchorBased(t *testing.T) {
-	// When the anchor is present (post-U3 fresh print), insert right after it.
-	body := `Some content.
+func TestPatchReadmeHermesOpenClaw_OrderAfterInstall(t *testing.T) {
+	// Canonical layout: ## Install → ## Install for Hermes → ## Install for OpenClaw → next section.
+	body := `# X CLI
 
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for...
+## Install
 
-<!-- pp-hermes-install-anchor -->
-<details>
-<summary>Manual JSON config (advanced)</summary>
+[install body]
+
+## Authentication
+
+stuff.
 `
 	ctx := patchReadmeCtx{CLIName: "x-pp-cli", APIName: "x", Category: "other"}
-	got, err := patchReadme(body, ctx)
-	if err != nil {
-		t.Fatal(err)
+	got := patchReadmeHermesOpenClaw(body, ctx)
+
+	installIdx := strings.Index(got, "## Install\n")
+	hermesIdx := strings.Index(got, "## Install for Hermes")
+	openclawIdx := strings.Index(got, "## Install for OpenClaw")
+	authIdx := strings.Index(got, "## Authentication")
+
+	if installIdx < 0 || hermesIdx < 0 || openclawIdx < 0 || authIdx < 0 {
+		t.Fatalf("missing expected section: install=%d hermes=%d openclaw=%d auth=%d\n%s",
+			installIdx, hermesIdx, openclawIdx, authIdx, got)
 	}
-	if !strings.Contains(got, "## Install via Hermes") {
-		t.Errorf("Install via Hermes section must be inserted")
+	if !(installIdx < hermesIdx && hermesIdx < openclawIdx && openclawIdx < authIdx) {
+		t.Errorf("expected order Install → Install for Hermes → Install for OpenClaw → Authentication; got positions %d/%d/%d/%d:\n%s",
+			installIdx, hermesIdx, openclawIdx, authIdx, got)
 	}
-	if !strings.Contains(got, "## Install via OpenClaw") {
-		t.Errorf("Install via OpenClaw section must be inserted")
+}
+
+func TestPatchReadmeHermesOpenClaw_MovesFromBottomToAfterInstall(t *testing.T) {
+	// Fedex-shape: Install at top, Hermes/OpenClaw deep in the file
+	// near Use with Claude Desktop. Sweep moves them up.
+	body := `# Fedex CLI
+
+## Install
+
+cli body.
+
+## Authentication
+
+auth body.
+
+## Use with Claude Code
+
+claude code body.
+
+<!-- pp-hermes-install-anchor -->
+## Install via Hermes
+
+hermes body.
+
+## Install via OpenClaw
+
+openclaw body.
+
+## Use with Claude Desktop
+
+desktop body.
+`
+	ctx := patchReadmeCtx{CLIName: "fedex-pp-cli", APIName: "fedex", Category: "commerce"}
+	got := patchReadmeHermesOpenClaw(body, ctx)
+
+	hermesIdx := strings.Index(got, "## Install for Hermes")
+	authIdx := strings.Index(got, "## Authentication")
+	codeIdx := strings.Index(got, "## Use with Claude Code")
+
+	if hermesIdx < 0 || authIdx < 0 || codeIdx < 0 {
+		t.Fatalf("missing expected section: hermes=%d auth=%d code=%d\n%s", hermesIdx, authIdx, codeIdx, got)
 	}
-	// Anchor must not be duplicated.
+	// Hermes must now be BEFORE Authentication (i.e. moved to top), not BEFORE Use with Claude Code (its old neighbor).
+	if !(hermesIdx < authIdx) {
+		t.Errorf("Hermes must appear before Authentication after sweep; hermes=%d auth=%d:\n%s", hermesIdx, authIdx, got)
+	}
+	// Old "via" naming gone.
+	if strings.Contains(got, "## Install via Hermes") || strings.Contains(got, "## Install via OpenClaw") {
+		t.Errorf("legacy 'via' headings still present:\n%s", got)
+	}
+	// Anchor still present, exactly once.
 	if strings.Count(got, "<!-- pp-hermes-install-anchor -->") != 1 {
 		t.Errorf("anchor should appear exactly once; got %d", strings.Count(got, "<!-- pp-hermes-install-anchor -->"))
 	}
 }
 
-func TestPatchReadme_FallbackToClaudeDesktop(t *testing.T) {
-	body := `Some content.
+func TestPatchReadmeHermesOpenClaw_MovesFromTopToAfterInstall(t *testing.T) {
+	// ESPN-shape: Hermes/OpenClaw are FIRST (above Install), need to move down.
+	body := `# ESPN CLI
 
-## Use with Claude Code
-
-stuff.
-
-## Use with Claude Desktop
-
-other stuff.
-`
-	ctx := patchReadmeCtx{CLIName: "x-pp-cli", APIName: "x", Category: "other"}
-	got, err := patchReadme(body, ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Insertion must be BEFORE Use with Claude Desktop.
-	hermesIdx := strings.Index(got, "## Install via Hermes")
-	desktopIdx := strings.Index(got, "## Use with Claude Desktop")
-	if hermesIdx < 0 || desktopIdx < 0 || hermesIdx >= desktopIdx {
-		t.Errorf("Install via Hermes must appear before Use with Claude Desktop; hermes=%d desktop=%d", hermesIdx, desktopIdx)
-	}
-}
-
-func TestPatchReadme_Idempotent(t *testing.T) {
-	body := `Some content.
+A summary.
 
 <!-- pp-hermes-install-anchor -->
 ## Install via Hermes
 
-stuff.
+hermes body.
 
-## Use with Claude Desktop
+## Install via OpenClaw
+
+openclaw body.
+
+## Install
+
+cli body.
+
+## Authentication
+
+auth body.
+`
+	ctx := patchReadmeCtx{CLIName: "espn-pp-cli", APIName: "espn", Category: "media-and-entertainment"}
+	got := patchReadmeHermesOpenClaw(body, ctx)
+
+	installIdx := strings.Index(got, "## Install\n")
+	hermesIdx := strings.Index(got, "## Install for Hermes")
+	openclawIdx := strings.Index(got, "## Install for OpenClaw")
+	authIdx := strings.Index(got, "## Authentication")
+
+	if installIdx < 0 || hermesIdx < 0 || openclawIdx < 0 || authIdx < 0 {
+		t.Fatalf("missing expected section: install=%d hermes=%d openclaw=%d auth=%d\n%s",
+			installIdx, hermesIdx, openclawIdx, authIdx, got)
+	}
+	if !(installIdx < hermesIdx && hermesIdx < openclawIdx && openclawIdx < authIdx) {
+		t.Errorf("expected order Install → Install for Hermes → Install for OpenClaw → Authentication; got positions %d/%d/%d/%d:\n%s",
+			installIdx, hermesIdx, openclawIdx, authIdx, got)
+	}
+	// Old "via" naming gone.
+	if strings.Contains(got, "## Install via Hermes") || strings.Contains(got, "## Install via OpenClaw") {
+		t.Errorf("legacy 'via' headings still present:\n%s", got)
+	}
+}
+
+func TestPatchReadmeHermesOpenClaw_Idempotent(t *testing.T) {
+	body := `# X CLI
+
+## Install
+
+cli body.
+
+## Authentication
+
+auth body.
 `
 	ctx := patchReadmeCtx{CLIName: "x-pp-cli", APIName: "x", Category: "other"}
-	got, err := patchReadme(body, ctx)
-	if err != nil {
-		t.Fatal(err)
+	first := patchReadmeHermesOpenClaw(body, ctx)
+	second := patchReadmeHermesOpenClaw(first, ctx)
+	if second != first {
+		t.Errorf("second run should produce zero diff;\nfirst:\n%s\nsecond:\n%s", first, second)
 	}
+}
+
+func TestPatchReadmeHermesOpenClaw_NoOpWhenInstallSectionAbsent(t *testing.T) {
+	// agent-capture has no ## Install heading. Tool should leave it
+	// alone rather than insert at an arbitrary position.
+	body := `# agent-capture
+
+## Quick Start
+
+stuff.
+`
+	ctx := patchReadmeCtx{CLIName: "agent-capture-pp-cli", APIName: "agent-capture", Category: "developer-tools"}
+	got := patchReadmeHermesOpenClaw(body, ctx)
 	if got != body {
-		t.Errorf("expected idempotent no-op when Install via Hermes already present;\ngot diff:\n%s", got)
+		t.Errorf("expected no-op when ## Install absent;\ngot:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Sweeps 47 published library READMEs to group all install paths at the top in a fixed order:

```
## Install            ← CLI + agent skill via npx (default)
## Install for Hermes
## Install for OpenClaw
## Authentication / ## Quick Start / ... (untouched)
## Use with Claude Code     ← stays where it is
## Use with Claude Desktop  ← stays where it is
```

Pairs with [mvanhorn/cli-printing-press#660](https://github.com/mvanhorn/cli-printing-press/pull/660) (forthcoming, the same shape in `readme.md.tmpl` for fresh prints).

## Why

The previous shape was inconsistent. Most READMEs had `## Install via Hermes` / `## Install via OpenClaw` buried hundreds of lines below `## Install`. **ESPN** and a handful of others ended up with Hermes/OpenClaw at the very **top**, before `## Install`, because the original sweep's fallback chain landed them there when the README lacked `## Use with Claude Desktop` / `Code` sections to anchor on. Both shapes were confusing. Grouping all install paths at the top in a fixed order resolves the inconsistency.

`## Use with Claude Code` and `## Use with Claude Desktop` stay in their existing positions — they describe **application-specific usage patterns** (slash command invocation, `.mcpb` bundle drag-and-drop) with install steps as a side effect, not alternative agent-skill install paths.

## Why "for" not "via"

"Via" reads like a transport mechanism ("install via FTP") and is awkward paired with named ecosystems. "Install for Hermes" / "Install for OpenClaw" reads naturally and matches the `## Use with Claude Code` connector already used elsewhere.

## Tooling changes

- **`patchReadme` split** into `patchReadmeInstall` (rewrites `## Install`, landed in #270) and `patchReadmeHermesOpenClaw` (this PR — strips legacy "via" and current "for" sections wherever they are, re-inserts canonical "for" blocks immediately after `## Install`).
- **`stripH2Section`** helper extracts the section-strip pattern.
- **Early-return guard** for READMEs without `## Install` (only `agent-capture` in the live library) — stripping without being able to re-insert would silently delete install instructions. agent-capture's hand-shaped install guidance stays untouched.
- **5 new tests** covering layout order, move-from-bottom (fedex shape), move-from-top (ESPN shape), via-to-for migration, and idempotency. **23 tests pass** (18 from prior PRs + 5 new).

## Sweep results

- **47 patched, 1 already up-to-date** (`agent-capture`)
- **Second sweep run: `0 patched, 48 already up-to-date`** — idempotent

## Spot checks

```
$ grep -n "^## " library/media-and-entertainment/espn/README.md | head -5
5:## Install
34:## Install for Hermes
48:## Install for OpenClaw
56:## Authentication
66:## Quick Start
```

```
$ grep -n "^## " library/commerce/fedex/README.md | head -8
9:## Install
38:## Install for Hermes
52:## Install for OpenClaw
60:## Authentication
64:## Quick Start
84:## Unique Features
192:## Usage
196:## Commands
```

## Test plan

- [x] `cd tools/sweep-canonical && GO111MODULE=off go test .` — 23 tests pass
- [x] Two-run idempotency check — second sweep run touches nothing
- [x] Spot-checked ESPN (the previously-broken case) and fedex
- [x] agent-capture confirmed unchanged (no `## Install` heading)
- [ ] No `cli-skills/` regen needed (no README mirror there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)