### PR TITLE
fix(skills): discover mirrors from library manifests

### DIFF
--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -1,46 +1,38 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
 const skillOutputDir = "cli-skills"
 
-// Registry schema (only the fields this mirror needs).
-
-type RegistryEntry struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+type PrintManifest struct {
+	APIName string `json:"api_name"`
 }
 
-type Registry struct {
-	SchemaVersion int             `json:"schema_version"`
-	Entries       []RegistryEntry `json:"entries"`
+type LibrarySkill struct {
+	Name string
+	Path string
 }
 
 func main() {
-	// Read registry.json from current working directory (repo root)
-	registryPath := "registry.json"
-	registryData, err := os.ReadFile(registryPath)
+	librarySkills, err := discoverLibrarySkills("library")
 	if err != nil {
-		log.Fatalf("Error reading %s: %v\nRun this program from the repo root.", registryPath, err)
+		log.Fatal(err)
 	}
 
-	var registry Registry
-	if err := json.Unmarshal(registryData, &registry); err != nil {
-		log.Fatalf("Error parsing %s: %v", registryPath, err)
-	}
-
-	// Track every skill name the registry asks for so we can prune
+	// Track every skill name the library asks for so we can prune
 	// pp-<oldslug>/ directories left behind by renames or removals. Filled
 	// at the top of the loop (before any error paths) so a transient write
 	// failure for an entry doesn't make us delete its existing skill.
-	expectedSkills := make(map[string]struct{}, len(registry.Entries))
+	expectedSkills := make(map[string]struct{}, len(librarySkills))
 
 	var (
 		copiedCount int
@@ -48,9 +40,8 @@ func main() {
 		writeErrors []string
 	)
 
-	for _, entry := range registry.Entries {
-		baseName := strings.TrimSuffix(entry.Name, "-pp-cli")
-		skillName := "pp-" + baseName
+	for _, entry := range librarySkills {
+		skillName := "pp-" + entry.Name
 		expectedSkills[skillName] = struct{}{}
 
 		skillDir := filepath.Join(skillOutputDir, skillName)
@@ -73,7 +64,7 @@ func main() {
 
 	fmt.Printf("\nMirrored %d skill(s) from library/ to %s/\n", copiedCount, skillOutputDir)
 	if prunedCount > 0 {
-		fmt.Printf("Pruned %d orphan skill dir(s) with no registry entry.\n", prunedCount)
+		fmt.Printf("Pruned %d orphan skill dir(s) with no library manifest.\n", prunedCount)
 	}
 
 	if len(writeErrors) > 0 {
@@ -95,6 +86,44 @@ func main() {
 	}
 }
 
+func discoverLibrarySkills(libraryRoot string) ([]LibrarySkill, error) {
+	manifestPaths, err := filepath.Glob(filepath.Join(libraryRoot, "*", "*", ".printing-press.json"))
+	if err != nil {
+		return nil, fmt.Errorf("discover library manifests: %w", err)
+	}
+	if len(manifestPaths) == 0 {
+		return nil, fmt.Errorf("no .printing-press.json files found under %s/*/*; run this program from the repo root", libraryRoot)
+	}
+
+	skills := make([]LibrarySkill, 0, len(manifestPaths))
+	for _, manifestPath := range manifestPaths {
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", manifestPath, err)
+		}
+		var manifest PrintManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", manifestPath, err)
+		}
+		apiName := strings.TrimSpace(manifest.APIName)
+		if apiName == "" {
+			return nil, fmt.Errorf("%s is missing api_name", manifestPath)
+		}
+		skills = append(skills, LibrarySkill{
+			Name: apiName,
+			Path: filepath.ToSlash(filepath.Dir(manifestPath)),
+		})
+	}
+
+	sort.Slice(skills, func(i, j int) bool {
+		if skills[i].Name == skills[j].Name {
+			return skills[i].Path < skills[j].Path
+		}
+		return skills[i].Name < skills[j].Name
+	})
+	return skills, nil
+}
+
 // copyUpstreamSkill copies <entryPath>/SKILL.md to skillFile if it exists and
 // is non-empty. Returns (true, nil) on successful copy, (false, nil) when
 // upstream is missing or empty/whitespace-only (caller reports it as missing),
@@ -112,7 +141,7 @@ func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
 		}
 		return false, fmt.Errorf("read %s: %w", upstreamPath, err)
 	}
-	if len(strings.TrimSpace(string(data))) == 0 {
+	if len(bytes.TrimSpace(data)) == 0 {
 		return false, nil
 	}
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
@@ -125,9 +154,9 @@ func copyUpstreamSkill(entryPath, skillDir, skillFile string) (bool, error) {
 }
 
 // pruneOrphanSkills removes cli-skills/pp-<slug>/ directories whose pp-<slug>
-// is not in the expected set (i.e., the registry has no corresponding entry).
+// is not in the expected set (i.e., the library has no corresponding manifest).
 // Without this, renaming a CLI's slug leaves the old mirror behind: the
-// registry generator drops the old entry, the main loop above only writes the
+// library drops the old manifest, the main loop above only writes the
 // new entry, and `git add cli-skills/` in CI sees no working-tree change for
 // the orphan dir. See issue #250 for the flightgoat -> flight-goat case.
 //
@@ -159,7 +188,7 @@ func pruneOrphanSkills(dir string, expected map[string]struct{}) int {
 			log.Printf("Warning: could not remove orphan %s: %v", target, err)
 			continue
 		}
-		fmt.Printf("  removed orphan %s (no registry entry)\n", target)
+		fmt.Printf("  removed orphan %s (no library manifest)\n", target)
 		removed++
 	}
 	return removed

--- a/tools/generate-skills/main_test.go
+++ b/tools/generate-skills/main_test.go
@@ -1,13 +1,22 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+)
+
+var (
+	toolBinOnce sync.Once
+	toolBinPath string
+	toolBinDir  string
+	toolBinErr  error
 )
 
 func TestCopyUpstreamSkill_Present(t *testing.T) {
@@ -134,40 +143,57 @@ func TestCopyUpstreamSkill_EmptyTreatedAsMissing(t *testing.T) {
 // buildTool compiles the generate-skills binary into a tempdir and returns its path.
 func buildTool(t *testing.T) string {
 	t.Helper()
-	srcDir, err := os.Getwd()
+	toolBinOnce.Do(func() {
+		srcDir, err := os.Getwd()
+		if err != nil {
+			toolBinErr = err
+			return
+		}
+		binName := "generate-skills"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		toolBinDir, err = os.MkdirTemp("", "generate-skills-test-*")
+		if err != nil {
+			toolBinErr = err
+			return
+		}
+		toolBinPath = filepath.Join(toolBinDir, binName)
+		cmd := exec.Command("go", "build", "-o", toolBinPath, ".")
+		cmd.Dir = srcDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			toolBinErr = fmt.Errorf("go build failed: %v\n%s", err, out)
+		}
+	})
+	if toolBinErr != nil {
+		t.Fatal(toolBinErr)
+	}
+	return toolBinPath
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if toolBinDir != "" {
+		_ = os.RemoveAll(toolBinDir)
+	}
+	os.Exit(code)
+}
+
+// writeManifest writes a minimal .printing-press.json fixture for a library CLI.
+func writeManifest(t *testing.T, root, category, slug, apiName string) string {
+	t.Helper()
+	dir := filepath.Join(root, "library", category, slug)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := json.Marshal(PrintManifest{APIName: apiName})
 	if err != nil {
 		t.Fatal(err)
 	}
-	binName := "generate-skills"
-	if runtime.GOOS == "windows" {
-		binName += ".exe"
-	}
-	binPath := filepath.Join(t.TempDir(), binName)
-	cmd := exec.Command("go", "build", "-o", binPath, ".")
-	cmd.Dir = srcDir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, out)
-	}
-	return binPath
-}
-
-// writeRegistry writes a minimal registry.json fixture at root.
-func writeRegistry(t *testing.T, root string, entries []RegistryEntry) {
-	t.Helper()
-	regJSON := `{"schema_version":1,"entries":[`
-	for i, e := range entries {
-		if i > 0 {
-			regJSON += ","
-		}
-		regJSON += fmt.Sprintf(`{"name":%q,"path":%q}`, e.Name, e.Path)
-	}
-	regJSON += `]}`
-	if err := os.WriteFile(filepath.Join(root, "registry.json"), []byte(regJSON), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), manifest, 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(root, "cli-skills"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	return dir
 }
 
 func TestIntegration_CopiesUpstreamVerbatim(t *testing.T) {
@@ -177,15 +203,7 @@ func TestIntegration_CopiesUpstreamVerbatim(t *testing.T) {
 	bin := buildTool(t)
 	root := t.TempDir()
 
-	entries := []RegistryEntry{
-		{Name: "yahoo-finance-pp-cli", Path: "library/commerce/yahoo-finance"},
-	}
-	writeRegistry(t, root, entries)
-
-	upstreamDir := filepath.Join(root, "library", "commerce", "yahoo-finance")
-	if err := os.MkdirAll(upstreamDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	upstreamDir := writeManifest(t, root, "commerce", "yahoo-finance", "yahoo-finance")
 	upstreamContent := "---\nname: pp-yahoo-finance\ndescription: \"Authored upstream with research context.\"\n---\n\n# Upstream Skill\n\nNovel features and narrative.\n"
 	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte(upstreamContent), 0644); err != nil {
 		t.Fatal(err)
@@ -210,6 +228,35 @@ func TestIntegration_CopiesUpstreamVerbatim(t *testing.T) {
 	}
 }
 
+func TestIntegration_DiscoversNewCLIWithoutRegistry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	bin := buildTool(t)
+	root := t.TempDir()
+
+	upstreamDir := writeManifest(t, root, "marketing", "customer-io", "customer-io")
+	upstreamContent := "---\nname: pp-customer-io\n---\n\n# Customer.io\n"
+	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte(upstreamContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("tool exited with error: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(root, "cli-skills", "pp-customer-io", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading copied skill: %v", err)
+	}
+	if string(got) != upstreamContent {
+		t.Errorf("new CLI skill not copied byte-for-byte\nwant: %q\ngot:  %q", upstreamContent, got)
+	}
+}
+
 func TestIntegration_FailsWhenUpstreamMissing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in -short mode")
@@ -217,23 +264,11 @@ func TestIntegration_FailsWhenUpstreamMissing(t *testing.T) {
 	bin := buildTool(t)
 	root := t.TempDir()
 
-	entries := []RegistryEntry{
-		{Name: "with-upstream-pp-cli", Path: "library/commerce/with-upstream"},
-		{Name: "no-upstream-pp-cli", Path: "library/commerce/no-upstream"},
-	}
-	writeRegistry(t, root, entries)
-
-	upstreamDir := filepath.Join(root, "library", "commerce", "with-upstream")
-	if err := os.MkdirAll(upstreamDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	upstreamDir := writeManifest(t, root, "commerce", "with-upstream", "with-upstream")
 	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte("---\nname: pp-with-upstream\n---\n\n# Has Upstream\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	noUpstreamDir := filepath.Join(root, "library", "commerce", "no-upstream")
-	if err := os.MkdirAll(noUpstreamDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeManifest(t, root, "commerce", "no-upstream", "no-upstream")
 
 	cmd := exec.Command(bin)
 	cmd.Dir = root
@@ -242,7 +277,7 @@ func TestIntegration_FailsWhenUpstreamMissing(t *testing.T) {
 		t.Fatalf("tool should have exited non-zero when an entry has no upstream SKILL.md\noutput:\n%s", out)
 	}
 	outStr := string(out)
-	if !strings.Contains(outStr, "no-upstream-pp-cli") {
+	if !strings.Contains(outStr, "no-upstream") {
 		t.Errorf("expected missing entry to be named in error output, got:\n%s", outStr)
 	}
 	if !strings.Contains(outStr, "Missing or empty library SKILL.md") {
@@ -257,11 +292,6 @@ func TestIntegration_UpstreamOverwritesStaleMirror(t *testing.T) {
 	bin := buildTool(t)
 	root := t.TempDir()
 
-	entries := []RegistryEntry{
-		{Name: "api-pp-cli", Path: "library/commerce/api"},
-	}
-	writeRegistry(t, root, entries)
-
 	staleDir := filepath.Join(root, "cli-skills", "pp-api")
 	if err := os.MkdirAll(staleDir, 0755); err != nil {
 		t.Fatal(err)
@@ -270,10 +300,7 @@ func TestIntegration_UpstreamOverwritesStaleMirror(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upstreamDir := filepath.Join(root, "library", "commerce", "api")
-	if err := os.MkdirAll(upstreamDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	upstreamDir := writeManifest(t, root, "commerce", "api", "api")
 	upstreamContent := "---\nname: pp-api\ndescription: \"Fresh upstream.\"\n---\n\n# Fresh\n"
 	if err := os.WriteFile(filepath.Join(upstreamDir, "SKILL.md"), []byte(upstreamContent), 0644); err != nil {
 		t.Fatal(err)
@@ -307,8 +334,8 @@ func TestPruneOrphanSkills(t *testing.T) {
 	}
 	mustMkdir("pp-flight-goat")
 	mustMkdir("pp-recipe-goat")
-	mustMkdir("pp-flightgoat")     // orphan: registry no longer has it
-	mustMkdir("not-a-pp-dir")      // unrelated content, must be preserved
+	mustMkdir("pp-flightgoat") // orphan: library no longer has it
+	mustMkdir("not-a-pp-dir")  // unrelated content, must be preserved
 	if err := os.WriteFile(filepath.Join(tmp, "stray.txt"), []byte("x"), 0644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Brand-new CLI publishes can now pass `cli-skills` mirror parity even before `registry.json` has been regenerated. `tools/generate-skills` now discovers published CLIs from `library/*/*/.printing-press.json`, uses each manifest's `api_name` for the `pp-<slug>` mirror name, and keeps pruning scoped to mirrors whose library manifest no longer exists.

This keeps the existing strict failure for missing or empty library `SKILL.md` files while removing registry lag as a precondition for first-publish PRs. The tests now cover the no-registry path, manifest-backed fixtures, stale mirror overwrite behavior, and orphan pruning.

Refs mvanhorn/cli-printing-press#682

## Validation

- `rtk go vet .` in `tools/generate-skills`
- `rtk go test .` in `tools/generate-skills`
- `rtk go test .` in `tools/generate-registry`
- `rtk npm test` in `npm` after `rtk npm ci`
- `go run ./tools/generate-skills/main.go` leaves `cli-skills/` clean
- Library `go.mod` path convention check
- `rtk git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)
