### PR TITLE
fix(dominos): expose street and city locator params

### DIFF
--- a/cli-skills/pp-dominos/SKILL.md
+++ b/cli-skills/pp-dominos/SKILL.md
@@ -81,14 +81,14 @@ These capabilities aren't available in any other tool for this API.
   _Reach for this when latency-or-price tradeoffs across nearby stores matter (delivery fee + wait time can offset a cheaper menu)._
 
   ```bash
-  dominos-pp-cli compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
+  dominos-pp-cli compare-prices --street "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
   ```
 - **`stores wait`** — Pull CartEtaMinutes for every store in radius and rank by ETA — the unique GraphQL BFF op every other wrapper ignores.
 
   _Reach for this when busy-hour delivery decisions need accurate wait estimates rather than a phone call to the store._
 
   ```bash
-  dominos-pp-cli stores wait --address "421 N 63rd St" --city "Seattle WA" --agent
+  dominos-pp-cli stores wait --street "421 N 63rd St" --city "Seattle WA" --agent
   ```
 - **`deals eligible`** — List which advertised deals actually apply to your current cart and explain why each non-matching one fails.
 
@@ -157,7 +157,7 @@ This CLI was generated with browser-observed traffic context.
 
 **stores** — Find and get information about Domino's stores
 
-- `dominos-pp-cli stores find` — Find nearby Domino's stores by address
+- `dominos-pp-cli stores find` — Find nearby Domino's stores by street and city
 - `dominos-pp-cli stores get` — Get detailed store information including hours, capabilities, and wait times
 
 **tracking** — Track active orders
@@ -182,7 +182,7 @@ dominos-pp-cli which "<capability in your own words>"
 
 ```bash
 # 1. Find closest store (no auth needed)
-dominos-pp-cli stores find --address "709 19th Ave" --city "Seattle WA 98122" --json
+dominos-pp-cli stores find --street "709 19th Ave" --city "Seattle WA 98122" --json
 
 # 2. List all coupons available at that store (no auth needed; 58 coupons)
 dominos-pp-cli deals list --store-id 7144 --json
@@ -222,7 +222,7 @@ Customer ID is the long base64-style identifier from your sign-in. Once `auth lo
 ### Find the cheapest store for tonight's order (agent + select for narrow output)
 
 ```bash
-dominos-pp-cli compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent --select results[].store_id,results[].total_cents
+dominos-pp-cli compare-prices --street "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent --select results[].store_id,results[].total_cents
 ```
 
 Surveys nearby stores and returns only the comparison fields the agent needs.

--- a/library/food-and-dining/dominos/README.md
+++ b/library/food-and-dining/dominos/README.md
@@ -66,7 +66,7 @@ Most commands work without authentication: store locator, menu browse, cart buil
 dominos-pp-cli auth login
 
 # 2. Find your closest stores (no auth needed)
-dominos-pp-cli stores find --address "709 19th Ave" --city "Seattle WA 98122"
+dominos-pp-cli stores find --street "709 19th Ave" --city "Seattle WA 98122"
 
 # 3. Get a specific store's profile
 dominos-pp-cli stores get 7144
@@ -144,14 +144,14 @@ These capabilities aren't available in any other tool for this API.
   _Reach for this when latency-or-price tradeoffs across nearby stores matter (delivery fee + wait time can offset a cheaper menu)._
 
   ```bash
-  dominos-pp-cli compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
+  dominos-pp-cli compare-prices --street "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
   ```
 - **`stores wait`** — Pull CartEtaMinutes for every store in radius and rank by ETA — the unique GraphQL BFF op every other wrapper ignores.
 
   _Reach for this when busy-hour delivery decisions need accurate wait estimates rather than a phone call to the store._
 
   ```bash
-  dominos-pp-cli stores wait --address "421 N 63rd St" --city "Seattle WA" --agent
+  dominos-pp-cli stores wait --street "421 N 63rd St" --city "Seattle WA" --agent
   ```
 - **`deals eligible`** — List which advertised deals actually apply to your current cart and explain why each non-matching one fails.
 
@@ -224,7 +224,7 @@ Create, validate, price, and place orders
 
 Find and get information about Domino's stores
 
-- **`dominos-pp-cli stores find`** - Find nearby Domino's stores by address
+- **`dominos-pp-cli stores find`** - Find nearby Domino's stores by street and city
 - **`dominos-pp-cli stores get`** - Get detailed store information including hours, capabilities, and wait times
 
 ### tracking
@@ -362,7 +362,7 @@ Environment variables:
 
 ### API-specific
 
-- **Store finder returns no results** — Domino's geocoder is strict; pass street and city/state separately: `--address "350 5th Ave" --city "New York NY 10118"`.
+- **Store finder returns no results** — Domino's geocoder is strict; pass street and city/state separately: `--street "350 5th Ave" --city "New York NY 10118"`.
 - **Authenticated commands return 401** — Bearer token expired or missing. Run `auth login` again (token TTL is ~1 hour). Check with `auth status`.
 - **auth login times out without harvesting** — Increase `--timeout` (default 5m). Make sure you're actually completing sign-in in the spawned Chrome window.
 - **Track command shows order not found** — Use the phone number tied to the order, not your account phone. The tracker is keyed on the order phone field.

--- a/library/food-and-dining/dominos/SKILL.md
+++ b/library/food-and-dining/dominos/SKILL.md
@@ -81,14 +81,14 @@ These capabilities aren't available in any other tool for this API.
   _Reach for this when latency-or-price tradeoffs across nearby stores matter (delivery fee + wait time can offset a cheaper menu)._
 
   ```bash
-  dominos-pp-cli compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
+  dominos-pp-cli compare-prices --street "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent
   ```
 - **`stores wait`** — Pull CartEtaMinutes for every store in radius and rank by ETA — the unique GraphQL BFF op every other wrapper ignores.
 
   _Reach for this when busy-hour delivery decisions need accurate wait estimates rather than a phone call to the store._
 
   ```bash
-  dominos-pp-cli stores wait --address "421 N 63rd St" --city "Seattle WA" --agent
+  dominos-pp-cli stores wait --street "421 N 63rd St" --city "Seattle WA" --agent
   ```
 - **`deals eligible`** — List which advertised deals actually apply to your current cart and explain why each non-matching one fails.
 
@@ -157,7 +157,7 @@ This CLI was generated with browser-observed traffic context.
 
 **stores** — Find and get information about Domino's stores
 
-- `dominos-pp-cli stores find` — Find nearby Domino's stores by address
+- `dominos-pp-cli stores find` — Find nearby Domino's stores by street and city
 - `dominos-pp-cli stores get` — Get detailed store information including hours, capabilities, and wait times
 
 **tracking** — Track active orders
@@ -182,7 +182,7 @@ dominos-pp-cli which "<capability in your own words>"
 
 ```bash
 # 1. Find closest store (no auth needed)
-dominos-pp-cli stores find --address "709 19th Ave" --city "Seattle WA 98122" --json
+dominos-pp-cli stores find --street "709 19th Ave" --city "Seattle WA 98122" --json
 
 # 2. List all coupons available at that store (no auth needed; 58 coupons)
 dominos-pp-cli deals list --store-id 7144 --json
@@ -222,7 +222,7 @@ Customer ID is the long base64-style identifier from your sign-in. Once `auth lo
 ### Find the cheapest store for tonight's order (agent + select for narrow output)
 
 ```bash
-dominos-pp-cli compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent --select results[].store_id,results[].total_cents
+dominos-pp-cli compare-prices --street "421 N 63rd St" --city "Seattle WA" --items S_PIZPH,S_LAVA --agent --select results[].store_id,results[].total_cents
 ```
 
 Surveys nearby stores and returns only the comparison fields the agent needs.

--- a/library/food-and-dining/dominos/internal/cli/compare_prices.go
+++ b/library/food-and-dining/dominos/internal/cli/compare_prices.go
@@ -26,7 +26,7 @@ type priceCompareRow struct {
 // range and ranks by total. This composes store-locator + price-order
 // across N stores; only feasible with our local fan-out helper.
 func newComparePricesCmd(flags *rootFlags) *cobra.Command {
-	var address, city, items, svc string
+	var street, city, items, svc string
 	cmd := &cobra.Command{
 		Use:   "compare-prices",
 		Short: "Price the same cart at every nearby store and rank by total",
@@ -35,7 +35,7 @@ func newComparePricesCmd(flags *rootFlags) *cobra.Command {
 Builds a one-of-each cart from --items (a comma-separated list of product
 codes) and calls /power/price-order against each store from the locator,
 then sorts by total including delivery fee.`,
-		Example:     "  dominos-pp-cli compare-prices --address \"421 N 63rd St\" --city \"Seattle, WA\" --items 14SCREEN,20BCOKE",
+		Example:     "  dominos-pp-cli compare-prices --street \"421 N 63rd St\" --city \"Seattle, WA\" --items 14SCREEN,20BCOKE",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if svc == "" {
@@ -46,7 +46,7 @@ then sorts by total including delivery fee.`,
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"action":  "compare_prices",
 					"dry_run": true,
-					"address": address,
+					"street":  street,
 					"city":    city,
 					"items":   codes,
 				}, flags)
@@ -55,8 +55,8 @@ then sorts by total including delivery fee.`,
 			// verifier's single-probe inferRequiredFlags can supply
 			// synthetic values for every one in one pass.
 			var missing []string
-			if address == "" {
-				missing = append(missing, `"address"`)
+			if street == "" {
+				missing = append(missing, `"street"`)
 			}
 			if city == "" {
 				missing = append(missing, `"city"`)
@@ -72,7 +72,7 @@ then sorts by total including delivery fee.`,
 				return err
 			}
 			locatorData, err := c.Get("/power/store-locator", map[string]string{
-				"s": address, "c": city, "type": svc,
+				"s": street, "c": city, "type": svc,
 			})
 			if err != nil {
 				return classifyAPIError(err, flags)
@@ -81,14 +81,14 @@ then sorts by total including delivery fee.`,
 			if len(storeIDs) == 0 {
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"results": []priceCompareRow{},
-					"hint":    "no stores returned by locator; try a broader address",
+					"hint":    "no stores returned by locator; try a broader street/city search",
 				}, flags)
 			}
 			ctx := context.Background()
 			results, errs := cliutil.FanoutRun(ctx, storeIDs,
 				func(s string) string { return s },
 				func(_ context.Context, storeID string) (priceCompareRow, error) {
-					return priceCartAtStore(c, storeID, address, codes, svc)
+					return priceCartAtStore(c, storeID, street, codes, svc)
 				},
 			)
 			cliutil.FanoutReportErrors(cmd.ErrOrStderr(), errs)
@@ -100,10 +100,12 @@ then sorts by total including delivery fee.`,
 			return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
 		},
 	}
-	cmd.Flags().StringVar(&address, "address", "", "Street address (required)")
+	cmd.Flags().StringVar(&street, "street", "", "Street address (required)")
 	cmd.Flags().StringVar(&city, "city", "", "City, state, zip (required)")
 	cmd.Flags().StringVar(&items, "items", "", "Comma-separated product codes (required)")
 	cmd.Flags().StringVar(&svc, "service", "Delivery", "Service method: Delivery or Carryout")
+	cmd.Flags().StringVar(&street, "address", "", "")
+	_ = cmd.Flags().MarkHidden("address")
 	return cmd
 }
 
@@ -122,7 +124,7 @@ func splitCSV(s string) []string {
 // priceCartAtStore builds the minimal Order body the /power/price-order
 // endpoint accepts and pulls the totals out. Field names follow the
 // Domino's power-API casing (StoreID, OrderChannel, Products, etc.).
-func priceCartAtStore(c *client.Client, storeID, address string, codes []string, svc string) (priceCompareRow, error) {
+func priceCartAtStore(c *client.Client, storeID, street string, codes []string, svc string) (priceCompareRow, error) {
 	products := make([]map[string]any, 0, len(codes))
 	for _, code := range codes {
 		products = append(products, map[string]any{"Code": code, "Qty": 1})
@@ -134,7 +136,7 @@ func priceCartAtStore(c *client.Client, storeID, address string, codes []string,
 			"OrderMethod":   "Web",
 			"ServiceMethod": svc,
 			"Products":      products,
-			"Address":       map[string]any{"Street": address},
+			"Address":       map[string]any{"Street": street},
 		},
 	}
 	data, _, err := c.Post("/power/price-order", body)

--- a/library/food-and-dining/dominos/internal/cli/stores_find.go
+++ b/library/food-and-dining/dominos/internal/cli/stores_find.go
@@ -12,23 +12,23 @@ import (
 )
 
 func newStoresFindCmd(flags *rootFlags) *cobra.Command {
-	var flagS string
+	var flagStreet string
 	var flagC string
 	var flagType string
 
 	cmd := &cobra.Command{
-		Use:   "find",
-		Short: "Find nearby Domino's stores by address",
-		Example: "  dominos-pp-cli stores find",
+		Use:         "find",
+		Short:       "Find nearby Domino's stores by street and city",
+		Example:     "  dominos-pp-cli stores find",
 		Annotations: map[string]string{"pp:endpoint": "stores.find", "pp:method": "GET", "pp:path": "/power/store-locator", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Friendly aliases (--address / --city) bind to the same vars as
-			// --s / --c. Either flag form satisfies the required-flag check;
-			// agents reading --help will pick the descriptive long names.
+			// Friendly aliases (--street / --city) bind to the same vars as
+			// --s / --c. Compat aliases also work, but agents reading --help
+			// should pick the descriptive long names.
 			// Manual back-port of the proposed Param.Aliases generator field
 			// (see PR #639 handoff doc, Bug G).
-			if !cmd.Flags().Changed("s") && !cmd.Flags().Changed("address") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set (alias: --address)", "s")
+			if !cmd.Flags().Changed("s") && !cmd.Flags().Changed("street") && !cmd.Flags().Changed("address") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set (alias: --street)", "s")
 			}
 			if !cmd.Flags().Changed("c") && !cmd.Flags().Changed("city") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set (alias: --city)", "c")
@@ -40,8 +40,8 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/power/store-locator"
 			params := map[string]string{}
-			if flagS != "" {
-				params["s"] = fmt.Sprintf("%v", flagS)
+			if flagStreet != "" {
+				params["s"] = fmt.Sprintf("%v", flagStreet)
 			}
 			if flagC != "" {
 				params["c"] = fmt.Sprintf("%v", flagC)
@@ -69,7 +69,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	// User-facing flags — what --help shows. Agents and humans should use these.
-	cmd.Flags().StringVar(&flagS, "address", "", "Street address (e.g., '350 5th Ave')")
+	cmd.Flags().StringVar(&flagStreet, "street", "", "Street address (e.g., '350 5th Ave')")
 	cmd.Flags().StringVar(&flagC, "city", "", "City, state, zip (e.g., 'New York NY 10118')")
 	cmd.Flags().StringVar(&flagType, "type", "Delivery", "Service type: Delivery, Carryout, or DriveUpCarryout")
 	// Hidden backward-compat aliases — bind to the same variables as their
@@ -77,8 +77,10 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	// query params; we keep them functional but hide from --help so agents
 	// see the descriptive long names. The API call sends ?s=...&c=...
 	// regardless of which flag form the user passed.
-	cmd.Flags().StringVar(&flagS, "s", "", "")
+	cmd.Flags().StringVar(&flagStreet, "address", "", "")
+	cmd.Flags().StringVar(&flagStreet, "s", "", "")
 	cmd.Flags().StringVar(&flagC, "c", "", "")
+	_ = cmd.Flags().MarkHidden("address")
 	_ = cmd.Flags().MarkHidden("s")
 	_ = cmd.Flags().MarkHidden("c")
 

--- a/library/food-and-dining/dominos/internal/cli/stores_wait.go
+++ b/library/food-and-dining/dominos/internal/cli/stores_wait.go
@@ -25,19 +25,19 @@ type storeWaitRow struct {
 // CartEtaMinutes operation but uses the public REST profile endpoint so it
 // works without auth.
 func newStoresWaitCmd(flags *rootFlags) *cobra.Command {
-	var address, city, svc string
+	var street, city, svc string
 	cmd := &cobra.Command{
 		Use:   "wait",
 		Short: "Rank nearby stores by estimated wait time",
 		Long: `Rank nearby stores by estimated wait time.
 
-Calls the public store-locator with the supplied address, then fans out to
+Calls the public store-locator with the supplied street and city, then fans out to
 each store's profile endpoint and sorts by EstimatedWaitMinutes.`,
-		Example:     "  dominos-pp-cli stores wait --address \"421 N 63rd St\" --city \"Seattle, WA\"",
+		Example:     "  dominos-pp-cli stores wait --street \"421 N 63rd St\" --city \"Seattle, WA\"",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if address == "" {
-				return usageErr(fmt.Errorf("--address is required"))
+			if street == "" {
+				return usageErr(fmt.Errorf("--street is required"))
 			}
 			if city == "" {
 				return usageErr(fmt.Errorf("--city is required (city, state, zip)"))
@@ -49,7 +49,7 @@ each store's profile endpoint and sorts by EstimatedWaitMinutes.`,
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"action":  "stores_wait",
 					"dry_run": true,
-					"address": address,
+					"street":  street,
 					"city":    city,
 					"type":    svc,
 				}, flags)
@@ -58,7 +58,7 @@ each store's profile endpoint and sorts by EstimatedWaitMinutes.`,
 			if err != nil {
 				return err
 			}
-			locatorParams := map[string]string{"s": address, "c": city, "type": svc}
+			locatorParams := map[string]string{"s": street, "c": city, "type": svc}
 			locatorData, err := c.Get("/power/store-locator", locatorParams)
 			if err != nil {
 				return classifyAPIError(err, flags)
@@ -67,7 +67,7 @@ each store's profile endpoint and sorts by EstimatedWaitMinutes.`,
 			if len(storeIDs) == 0 {
 				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 					"results": []storeWaitRow{},
-					"hint":    "no stores returned by locator; try a broader address",
+					"hint":    "no stores returned by locator; try a broader street/city search",
 				}, flags)
 			}
 			ctx := context.Background()
@@ -86,9 +86,11 @@ each store's profile endpoint and sorts by EstimatedWaitMinutes.`,
 			return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
 		},
 	}
-	cmd.Flags().StringVar(&address, "address", "", "Street address (required)")
+	cmd.Flags().StringVar(&street, "street", "", "Street address (required)")
 	cmd.Flags().StringVar(&city, "city", "", "City, state, zip (required)")
 	cmd.Flags().StringVar(&svc, "type", "Delivery", "Service type: Delivery or Carryout")
+	cmd.Flags().StringVar(&street, "address", "", "")
+	_ = cmd.Flags().MarkHidden("address")
 	return cmd
 }
 

--- a/library/food-and-dining/dominos/internal/mcp/tools.go
+++ b/library/food-and-dining/dominos/internal/mcp/tools.go
@@ -171,15 +171,18 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("stores_find",
-			mcplib.WithDescription("Find nearby Domino's stores by address. Required: s, c. Optional: type (default: Delivery). Returns array of Store. (public)"),
-			mcplib.WithString("s", mcplib.Required(), mcplib.Description("Street address (e.g., '350 5th Ave')")),
-			mcplib.WithString("c", mcplib.Required(), mcplib.Description("City, state, zip (e.g., 'New York NY 10118')")),
+			mcplib.WithDescription("Find nearby Domino's stores by street and city. Required: street, city. Optional: type (default: Delivery). Returns array of Store. (public)"),
+			mcplib.WithString("street", mcplib.Required(), mcplib.Description("Street address (e.g., '350 5th Ave')")),
+			mcplib.WithString("city", mcplib.Required(), mcplib.Description("City, state, zip (e.g., 'New York NY 10118')")),
 			mcplib.WithString("type", mcplib.Description("Service type: Delivery, Carryout, or DriveUpCarryout")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/power/store-locator", []string{ }),
+		makeAPIHandlerWithQueryAliases("GET", "/power/store-locator", []string{ }, map[string]string{
+			"street": "s",
+			"city":   "c",
+		}),
 	)
 	s.AddTool(
 		mcplib.NewTool("stores_get",
@@ -220,6 +223,10 @@ func RegisterTools(s *server.MCPServer) {
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, positionalParams []string) server.ToolHandlerFunc {
+	return makeAPIHandlerWithQueryAliases(method, pathTemplate, positionalParams, nil)
+}
+
+func makeAPIHandlerWithQueryAliases(method, pathTemplate string, positionalParams []string, queryAliases map[string]string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -252,7 +259,17 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 			if pathParams[k] {
 				continue
 			}
+			if _, ok := queryAliases[k]; ok {
+				continue
+			}
 			params[k] = fmt.Sprintf("%v", v)
+		}
+		for publicName, queryName := range queryAliases {
+			v, ok := args[publicName]
+			if !ok {
+				continue
+			}
+			params[queryName] = fmt.Sprintf("%v", v)
 		}
 
 		var data json.RawMessage


### PR DESCRIPTION
## Summary

Domino's locator workflows now use `street` and `city` as the public inputs, matching how users describe the split location fields instead of exposing ambiguous `address` or raw wire params. The CLI keeps hidden compatibility aliases for `--address`, `--s`, and `--c`, while typed MCP maps `street` and `city` back to Domino's `s` and `c` query parameters.

The generated Domino's skill mirror was refreshed so installed agent docs match the library copy.

## Verification

- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/food-and-dining/dominos/`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/dominos-pp-cli/main.go compare-prices --address "421 N 63rd St" --city "Seattle WA" --items S_PIZPH --dry-run --json`
- `go run ./cmd/dominos-pp-cli/main.go stores wait --address "421 N 63rd St" --city "Seattle WA" --dry-run --json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
