### PR TITLE
fix(ci): add MCPB release security gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/npm"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directories:
+      - "/library/*/*"
+      - "/tools/generate-registry"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"

--- a/.github/scripts/verify-manifest/verify_manifest.py
+++ b/.github/scripts/verify-manifest/verify_manifest.py
@@ -60,11 +60,25 @@ def validate(cli_dir: Path) -> list[str]:
     if server.get("type") != "binary":
         problems.append(f'server.type != "binary" (got {server.get("type")!r})')
     entry = server.get("entry_point", "")
+    expected_mcp = pp.get("mcp_binary")
+    expected_entry = f"bin/{expected_mcp}" if expected_mcp else ""
     if not entry.startswith("bin/"):
         problems.append(f'server.entry_point should start with "bin/" (got {entry!r})')
+    if expected_entry and entry != expected_entry:
+        problems.append(
+            f"server.entry_point should be {expected_entry!r} from .printing-press.json mcp_binary (got {entry!r})"
+        )
     cmd = (server.get("mcp_config") or {}).get("command", "")
     if "${__dirname}" not in cmd:
         problems.append(f'server.mcp_config.command should contain ${{__dirname}} (got {cmd!r})')
+    expected_cmd = f"${{__dirname}}/{expected_entry}" if expected_entry else ""
+    if expected_cmd and cmd != expected_cmd:
+        problems.append(
+            f"server.mcp_config.command should be {expected_cmd!r} (got {cmd!r})"
+        )
+    args = (server.get("mcp_config") or {}).get("args")
+    if args not in ([], None):
+        problems.append(f"server.mcp_config.args should be empty for generated binary MCPBs (got {args!r})")
 
     # user_config keys must match declared auth env vars (when both present).
     declared_envs = set(pp.get("auth_env_vars") or [])
@@ -75,6 +89,18 @@ def validate(cli_dir: Path) -> list[str]:
         missing = declared_envs - uc_envs
         if missing:
             problems.append(f"user_config missing entries for {sorted(missing)}")
+    mcp_env = (server.get("mcp_config") or {}).get("env") or {}
+    for env_name, env_value in mcp_env.items():
+        expected_key = env_name.lower()
+        expected_ref = f"${{user_config.{expected_key}}}"
+        if expected_key not in user_config:
+            problems.append(
+                f"server.mcp_config.env {env_name!r} references missing user_config key {expected_key!r}"
+            )
+        if env_value != expected_ref:
+            problems.append(
+                f"server.mcp_config.env {env_name!r} should map to {expected_ref!r} (got {env_value!r})"
+            )
 
     # cli_binary should match .printing-press.json's cli_name when set.
     cli_binary = m.get("cli_binary")

--- a/.github/scripts/verify-mcpb-policy/verify_mcpb_policy.py
+++ b/.github/scripts/verify-mcpb-policy/verify_mcpb_policy.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""PR-time MCPB release policy checks.
+
+This intentionally checks the cheap adversarial cases before signing ever
+touches a release artifact:
+- do not accept newly committed MCPB/native binary payloads under library/
+- keep manifest.json pinned to the generated binary entrypoint shape
+
+The manifest contract is also covered by verify-manifest; this script exists as
+the release-signing policy guard and focuses on contributor-supplied payloads.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+BINARY_SUFFIXES = {
+    ".mcpb",
+    ".dylib",
+    ".so",
+    ".dll",
+    ".exe",
+}
+
+MAGIC_PREFIXES = {
+    b"\x7fELF": "ELF executable/shared object",
+    b"MZ": "Windows PE executable",
+    b"\xca\xfe\xba\xbe": "Mach-O universal binary",
+    b"\xbe\xba\xfe\xca": "Mach-O universal binary",
+    b"\xfe\xed\xfa\xce": "Mach-O executable",
+    b"\xfe\xed\xfa\xcf": "Mach-O executable",
+    b"\xce\xfa\xed\xfe": "Mach-O executable",
+    b"\xcf\xfa\xed\xfe": "Mach-O executable",
+}
+
+
+def run(args: list[str]) -> str:
+    return subprocess.check_output(args, cwd=REPO_ROOT, text=True, stderr=subprocess.DEVNULL)
+
+
+def changed_library_paths() -> list[Path]:
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+
+    if event_name == "pull_request" and base_ref:
+        try:
+            run(["git", "fetch", "--no-tags", "--depth=1", "origin", base_ref])
+        except subprocess.CalledProcessError:
+            pass
+        try:
+            base = run(["git", "merge-base", f"origin/{base_ref}", "HEAD"]).strip()
+            diff = run(
+                [
+                    "git",
+                    "diff",
+                    "--name-only",
+                    "--diff-filter=AMR",
+                    f"{base}...HEAD",
+                    "--",
+                    "library/",
+                ]
+            )
+            return [REPO_ROOT / line for line in diff.splitlines() if line]
+        except subprocess.CalledProcessError:
+            return []
+
+    paths: set[Path] = set()
+    for cmd in (
+        ["git", "diff", "--name-only", "--diff-filter=AMR", "--", "library/"],
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=AMR", "--", "library/"],
+        ["git", "ls-files", "--others", "--exclude-standard", "--", "library/"],
+    ):
+        try:
+            paths.update(REPO_ROOT / line for line in run(cmd).splitlines() if line)
+        except subprocess.CalledProcessError:
+            continue
+    return sorted(paths)
+
+
+def binary_kind(path: Path) -> str | None:
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return f"{path.suffix} artifact"
+    try:
+        prefix = path.read_bytes()[:4]
+    except OSError:
+        return None
+    for magic, label in MAGIC_PREFIXES.items():
+        if prefix.startswith(magic):
+            return label
+    if prefix.startswith(b"PK\x03\x04") and path.name.endswith(".mcpb"):
+        return "MCPB zip bundle"
+    return None
+
+
+def main() -> int:
+    problems: list[str] = []
+    for path in changed_library_paths():
+        if not path.is_file():
+            continue
+        kind = binary_kind(path)
+        if kind:
+            rel = path.relative_to(REPO_ROOT)
+            problems.append(
+                f"::error file={rel}::Do not commit {kind} payloads under library/. "
+                "MCPB and native binaries must be built from source in GitHub Actions before signing."
+            )
+
+    if problems:
+        for problem in problems:
+            print(problem)
+        return 1
+
+    print("No newly added or modified MCPB/native binary payloads under library/.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -49,6 +49,8 @@ on:
 
 permissions:
   contents: write  # for creating/updating releases
+  id-token: write  # for provenance attestations
+  attestations: write
 
 jobs:
   detect:
@@ -308,6 +310,7 @@ jobs:
           pattern: cli-${{ steps.slug.outputs.slug }}-*
           merge-multiple: true
       - name: List downloaded artifacts and enforce per-app gate
+        id: gate
         env:
           CLI_TARGET: ${{ matrix.target }}
           SLUG: ${{ steps.slug.outputs.slug }}
@@ -328,13 +331,17 @@ jobs:
           # ship without a bundle.
           if [ "$cli_count" = "0" ]; then
             echo "::warning::Skipping release for ${SLUG}: no CLI binaries produced (build-cli matrix failed for this app)."
+            echo "publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ -f "library/${CLI_TARGET}/manifest.json" ] && [ "$mcpb_count" = "0" ]; then
             echo "::warning::Skipping release for ${SLUG}: app declares manifest.json (expects MCPB) but no .mcpb produced (bundle matrix failed for this app)."
+            echo "publishable=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "publishable=true" >> "$GITHUB_OUTPUT"
       - name: Verify release-write PAT
+        if: steps.gate.outputs.publishable == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_WRITE_TOKEN }}
         run: |
@@ -360,7 +367,13 @@ jobs:
             exit 1
           fi
           echo "PAT confirmed for repo ${GITHUB_REPOSITORY}."
+      - name: Attest release artifacts
+        if: steps.gate.outputs.publishable == 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ runner.temp }}/dl/*
       - name: Publish release ${{ steps.slug.outputs.slug }}-current
+        if: steps.gate.outputs.publishable == 'true'
         env:
           # Use a fine-grained PAT (Contents:write on this repo) instead of
           # the default GITHUB_TOKEN. The workflow's GITHUB_TOKEN reports
@@ -379,6 +392,7 @@ jobs:
             echo "No artifacts to publish for ${SLUG}; skipping release."
             exit 0
           fi
+          # shellcheck disable=SC2016
           notes=$(printf 'Auto-built artifacts for **%s** at commit %s.\n\n**Claude Desktop:** download the matching `.mcpb` file and double-click to install.\n\n**Terminal CLI:** download the binary matching your platform. On macOS you may need to clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, `chmod +x <binary>`.\n\n_This is a moving tag — it always points at the latest build._' "${CLI_TARGET}" "${GITHUB_SHA}")
           if gh release view "${tag}" >/dev/null 2>&1; then
             echo "Updating existing release ${tag}"

--- a/.github/workflows/codeql-scripts.yml
+++ b/.github/workflows/codeql-scripts.yml
@@ -1,0 +1,41 @@
+name: CodeQL scripts
+
+on:
+  pull_request:
+    paths:
+      - 'npm/**'
+      - '.github/scripts/**'
+      - '.github/workflows/codeql-scripts.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'npm/**'
+      - '.github/scripts/**'
+      - '.github/workflows/codeql-scripts.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - python
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,93 @@
+name: CodeQL Go
+
+on:
+  pull_request:
+    paths:
+      - 'library/**/cmd/**'
+      - 'library/**/internal/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'tools/**/*.go'
+      - 'tools/**/go.mod'
+      - 'tools/**/go.sum'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'library/**/cmd/**'
+      - 'library/**/internal/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'tools/**/*.go'
+      - 'tools/**/go.mod'
+      - 'tools/**/go.sum'
+      - '.github/workflows/codeql.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-go:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          build-mode: manual
+          queries: security-extended
+      - name: Build touched Go modules for CodeQL
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${BASE_REF:-}" ]; then
+            git fetch --no-tags --depth=1 origin "${BASE_REF}" || true
+            base=$(git merge-base "origin/${BASE_REF}" HEAD || true)
+            if [ -n "$base" ]; then
+              changed=$(git diff --name-only "${base}...HEAD" -- library tools)
+            else
+              changed=$(git ls-files 'library/**/go.mod' 'tools/**/go.mod')
+            fi
+          elif [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            changed=$(git diff --name-only "${BEFORE_SHA}...HEAD" -- library tools || true)
+          else
+            changed=$(git ls-files 'library/**/go.mod' 'tools/**/go.mod')
+          fi
+
+          modules=$(printf '%s\n' "$changed" \
+            | awk -F/ '
+                $1 == "library" && NF >= 3 { print $1"/"$2"/"$3 }
+                $1 == "tools" && NF >= 2 { print $1"/"$2 }
+              ' \
+            | sort -u \
+            | while IFS= read -r dir; do
+                [ -f "${dir}/go.mod" ] && printf '%s\n' "$dir"
+              done)
+
+          if [ -z "$modules" ]; then
+            echo "No touched Go modules found; building all modules for workflow_dispatch fallback."
+            modules=$(find library tools -name go.mod -print | sed 's|/go.mod$||' | sort)
+          fi
+
+          printf 'Building modules:\n%s\n' "$modules"
+          while IFS= read -r dir; do
+            echo "::group::go build ${dir}"
+            (cd "$dir" && go build ./...)
+            echo "::endgroup::"
+          done <<< "$modules"
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    paths:
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'npm/package.json'
+      - 'npm/package-lock.json'
+      - 'tools/**/go.mod'
+      - 'tools/**/go.sum'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,77 @@
+name: Go vulnerability check
+
+on:
+  pull_request:
+    paths:
+      - 'library/**/cmd/**'
+      - 'library/**/internal/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'tools/**/*.go'
+      - 'tools/**/go.mod'
+      - 'tools/**/go.sum'
+      - '.github/workflows/govulncheck.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck touched modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck for touched Go modules
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${BASE_REF:-}" ]; then
+            git fetch --no-tags --depth=1 origin "${BASE_REF}" || true
+            base=$(git merge-base "origin/${BASE_REF}" HEAD || true)
+          else
+            base=""
+          fi
+
+          if [ -n "$base" ]; then
+            changed=$(git diff --name-only "${base}...HEAD" -- library tools)
+          else
+            changed=$(git ls-files 'library/**/go.mod' 'tools/**/go.mod')
+          fi
+
+          modules=$(printf '%s\n' "$changed" \
+            | awk -F/ '
+                $1 == "library" && NF >= 3 { print $1"/"$2"/"$3 }
+                $1 == "tools" && NF >= 2 { print $1"/"$2 }
+              ' \
+            | sort -u \
+            | while IFS= read -r dir; do
+                [ -f "${dir}/go.mod" ] && printf '%s\n' "$dir"
+              done)
+
+          if [ -z "$modules" ]; then
+            echo "No touched Go modules to scan."
+            exit 0
+          fi
+
+          printf 'Scanning modules:\n%s\n' "$modules"
+          fail=0
+          while IFS= read -r dir; do
+            echo "::group::govulncheck ${dir}"
+            if ! (cd "$dir" && govulncheck ./...); then
+              fail=1
+            fi
+            echo "::endgroup::"
+          done <<< "$modules"
+
+          exit "$fail"

--- a/.github/workflows/mcpb-security.yml
+++ b/.github/workflows/mcpb-security.yml
@@ -1,0 +1,30 @@
+name: MCPB security policy
+
+on:
+  pull_request:
+    paths:
+      - 'library/**'
+      - '.github/scripts/verify-manifest/**'
+      - '.github/scripts/verify-mcpb-policy/**'
+      - '.github/workflows/mcpb-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: Bundle policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Validate MCPB manifests
+        run: python3 .github/scripts/verify-manifest/verify_manifest.py
+      - name: Block committed MCPB/native binary payloads
+        run: python3 .github/scripts/verify-mcpb-policy/verify_mcpb_policy.py

--- a/.github/workflows/verify-manifests.yml
+++ b/.github/workflows/verify-manifests.yml
@@ -11,7 +11,11 @@ on:
     branches: [main]
     paths:
       - 'library/**/manifest.json'
+      - 'library/**/.printing-press.json'
       - '.github/scripts/verify-manifest/**'
+
+permissions:
+  contents: read
 
 jobs:
   verify:

--- a/library/travel/seats-aero/manifest.json
+++ b/library/travel/seats-aero/manifest.json
@@ -15,7 +15,7 @@
       "command": "${__dirname}/bin/seats-aero-pp-mcp",
       "args": [],
       "env": {
-        "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION": "${user_config.seats_aero_partner_partner_authorization}"
+        "SEATS_AERO_API_KEY": "${user_config.seats_aero_api_key}"
       }
     }
   },


### PR DESCRIPTION
## Summary

MCPB release artifacts now have pre-signing CI gates for provenance, dependency risk, bundle shape, and newly committed binary payloads. This makes future macOS signing safer: artifacts can be signed only after GitHub-native security checks and a custom MCPB policy verify they were built from source.

## What Changed

This adds GitHub-native guardrails for dependency review, Dependabot updates, CodeQL scanning, reachable Go vulnerability checks, and release artifact attestations. The MCPB-specific policy now rejects newly committed bundle/native binary payloads under `library/`, and the manifest verifier pins generated MCPB manifests to the expected binary entrypoint, empty args, and exact `${user_config.*}` env references.

The stricter verifier also caught and fixes the Seats Aero MCP manifest env mapping, so its bundled server now receives `SEATS_AERO_API_KEY` from the declared user config.

## Test Plan

- `python3 .github/scripts/verify-manifest/verify_manifest.py`
- `python3 .github/scripts/verify-mcpb-policy/verify_mcpb_policy.py`
- `python3 -m py_compile .github/scripts/verify-manifest/verify_manifest.py .github/scripts/verify-mcpb-policy/verify_mcpb_policy.py`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml .github/dependabot.yml`
- `actionlint .github/workflows/*.yml`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
