### PR TITLE
fix(kalshi): patch sync correctness bugs from cli-printing-press#689

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,45 @@ Inside any published CLI directory, `.printing-press.json` is machine-readable p
 
 Some CLIs have no archived spec on disk (docs-driven, sniff-driven, plan-driven). Tooling that assumes `spec.json` exists breaks on those — check before reading.
 
+## `.printing-press-patches.json` records library-side customizations
+
+If you modify a published CLI under `library/<cat>/<slug>/` beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader. SKILL.md / README.md edits are owned by `tools/sweep-canonical/` or direct edit and don't need a patch manifest; this convention is for code-level customizations.
+
+1. **Mark every changed site** in source with a comment summarizing the deviation:
+
+    ```
+    // PATCH: <one-line summary>
+    ```
+
+    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#689): …`). `grep -rn 'PATCH' library/` then surfaces every customization.
+
+2. **Catalog the change** in a `.printing-press-patches.json` at the CLI's root (parallel to `.printing-press.json`). Minimum shape:
+
+    ```json
+    {
+      "schema_version": 1,
+      "applied_at": "YYYY-MM-DD",
+      "base_run_id": "<copy from .printing-press.json>",
+      "base_printing_press_version": "<copy from .printing-press.json>",
+      "patches": [
+        {
+          "id": "short-identifier",
+          "summary": "What changed (one sentence).",
+          "reason": "Why this customization was needed (one or two sentences).",
+          "files": ["internal/cli/foo.go"],
+          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+        }
+      ]
+    }
+    ```
+
+    Optional top-level fields the kalshi example uses when relevant: `upstream_tracking[]`, `deferred_to_upstream[]`.
+
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short — if you find yourself writing tables of field renames or SQL transformations, that detail belongs in the source comment or commit message, not here. A fresh print from the generator overwrites this tree, and the manifest is what tells the next agent (or regeneration tooling) what was customized and why.
+
+A worked example lives at `library/payments/kalshi/.printing-press-patches.json`.
+
 ## CLI `root.go` shape
 
 The generator's standard shape (which all newer CLIs follow):

--- a/library/payments/kalshi/.printing-press-patches.json
+++ b/library/payments/kalshi/.printing-press-patches.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-05-07",
+  "base_run_id": "20260504-204550",
+  "base_printing_press_version": "3.9.0",
+  "upstream_tracking": [
+    "https://github.com/mvanhorn/cli-printing-press/issues/689"
+  ],
+  "patches": [
+    {
+      "id": "689-bug1-resource-id-overrides",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/689",
+      "files": [
+        "internal/cli/sync.go",
+        "internal/store/store.go"
+      ],
+      "summary": "Replace `cursor` with real array-element PKs in resourceIDFieldOverrides.",
+      "reason": "Generator profiler picked the response-wrapper pagination field instead of descending into the array-element schema, so every synced row was silently dropped at upsert time.",
+      "validated_outcome": "events 0 → ~10000 rows, markets 0 → ~10000, portfolio 0 → ~2698, series 0 → ~10021, historical 0 → ~8878 (per upstream issue's debug session)."
+    },
+    {
+      "id": "689-bug2-portfolio-settlements-resource",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/689",
+      "files": [
+        "internal/cli/sync.go"
+      ],
+      "summary": "Add `portfolio-settlements` as a sibling sync resource bound to /portfolio/settlements.",
+      "reason": "resourcePathMap is 1:1 — `portfolio` only targets /portfolio/fills, so settlements never landed in the store and novel-feature commands had no data to query."
+    },
+    {
+      "id": "689-bug4-novel-feature-sql-fields",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/689",
+      "files": [
+        "internal/cli/transcendence.go"
+      ],
+      "summary": "Rewrite queryAttribution + queryWinRate against the real Settlement schema and filter on resource_type.",
+      "reason": "Generated SQL referenced fields that don't exist in Kalshi's response shape (`$.type='settlement'`, `$.settled_at`, `$.cost`); queries returned [] even after settlements were synced.",
+      "validated_outcome": "1404 settlements, 63.5% win rate, $226.04 revenue, $323.60 cost, net P&L -$97.56 (per upstream issue's debug session)."
+    }
+  ],
+  "deferred_to_upstream": [
+    {
+      "summary": "Bug 3 — multi-array envelope support for /portfolio/positions",
+      "reason": "Architectural; needs spec annotation or generator heuristic. `portfolio exposure` can't return real data until then."
+    },
+    {
+      "summary": "Bug 5 — Kalshi RSA-PSS auth specialization (doctor hint, set-token slot, auth_source labeling)",
+      "reason": "Cosmetic; touches generator auth-emission templates."
+    }
+  ]
+}

--- a/library/payments/kalshi/internal/cli/sync.go
+++ b/library/payments/kalshi/internal/cli/sync.go
@@ -822,6 +822,13 @@ func parseSinceDuration(s string) (time.Time, error) {
 }
 
 func defaultSyncResources() []string {
+	// PATCH(upstream cli-printing-press#689): Added "portfolio-settlements"
+	// as a sibling sync resource. The generator emits one endpoint per
+	// resource family, so `portfolio` was bound to /portfolio/fills only —
+	// settlements never landed in the store, leaving novel-feature commands
+	// (portfolio winrate / attribution) with nothing to query. The upstream
+	// fix is multi-endpoint resource families; until then, this entry plus
+	// its row in syncResourcePath is the manual workaround.
 	return []string{
 		"account",
 		"api-keys",
@@ -837,6 +844,7 @@ func defaultSyncResources() []string {
 		"milestones",
 		"multivariate-event-collections",
 		"portfolio",
+		"portfolio-settlements",
 		"series",
 		"structured-targets",
 	}
@@ -861,8 +869,14 @@ func syncResourcePath(resource string) (string, error) {
 		"milestones":                     "/milestones",
 		"multivariate-event-collections": "/multivariate_event_collections",
 		"portfolio":                      "/portfolio/fills",
-		"series":                         "/series",
-		"structured-targets":             "/structured_targets",
+		// PATCH(upstream cli-printing-press#689): sibling endpoint added so
+		// settlements get synced into the resources table; required by
+		// portfolio winrate / attribution. Remove if the upstream
+		// multi-endpoint-per-resource generator fix lands and this CLI is
+		// regenerated.
+		"portfolio-settlements": "/portfolio/settlements",
+		"series":                "/series",
+		"structured-targets":    "/structured_targets",
 	}
 	if p, ok := paths[resource]; ok {
 		return p, nil
@@ -879,14 +893,24 @@ func syncResourcePath(resource string) (string, error) {
 // Includes both flat resources and dependent (parent-child) resources so
 // annotations on a child path-item are honored at runtime, not just on
 // flat paths.
+//
+// PATCH(upstream cli-printing-press#689): The generator profiler picked
+// `cursor` (the pagination wrapper field) instead of descending into the
+// array-element schema. At runtime extractID looked for `cursor` on each
+// item, missed, fell through to generic fallbacks, missed those too, and
+// dropped every row. Hand-patched to the array-element PKs from spec.yaml
+// (Event.event_ticker, Market.ticker, Order.order_id, Settlement.ticker,
+// Fill.fill_id) until the upstream profiler fix lands and we regenerate.
 var resourceIDFieldOverrides = map[string]string{
-	"account":        "usage_tier",
-	"communications": "communications_id",
-	"events":         "cursor",
-	"fcm":            "cursor",
-	"historical":     "cursor",
-	"markets":        "cursor",
-	"portfolio":      "cursor",
+	"account":               "usage_tier",
+	"communications":        "communications_id",
+	"events":                "event_ticker",
+	"fcm":                   "order_id",
+	"historical":            "fill_id",
+	"markets":               "ticker",
+	"portfolio":             "fill_id",
+	"portfolio-settlements": "ticker",
+	"series":                "series_ticker",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did

--- a/library/payments/kalshi/internal/cli/transcendence.go
+++ b/library/payments/kalshi/internal/cli/transcendence.go
@@ -118,17 +118,28 @@ func queryAttribution(db *sql.DB, byField, sinceTS string) ([]attributionRow, er
 		groupExpr = "COALESCE(json_extract(m.data, '$.category'), SUBSTR(m.id, 1, INSTR(m.id, '-')-1))"
 	}
 
+	// PATCH(upstream cli-printing-press#689 Bug 4): The generated SQL was
+	// written against a generic settlement mental model (`$.type='settlement'`,
+	// `$.settled_at`, `$.cost` in cents) that doesn't match Kalshi's Settlement
+	// schema. Real fields per spec.yaml: settled_time (date-time), revenue
+	// (integer cents), yes_total_cost_dollars + no_total_cost_dollars (string
+	// dollars-as-string via FixedPointDollars). Won = revenue > 0 (settlement
+	// paid out), lost = revenue == 0. Settlements live in their own
+	// resource_type now (see portfolio-settlements in sync.go).
 	query := fmt.Sprintf(`
 		SELECT
 			COALESCE(%s, 'unknown') as grp,
 			COUNT(*) as trades,
-			SUM(CASE WHEN json_extract(p.data, '$.revenue') > json_extract(p.data, '$.cost') THEN 1 ELSE 0 END) as won,
-			SUM(CASE WHEN json_extract(p.data, '$.revenue') <= json_extract(p.data, '$.cost') THEN 1 ELSE 0 END) as lost,
-			SUM(COALESCE(json_extract(p.data, '$.revenue'), 0) - COALESCE(json_extract(p.data, '$.cost'), 0)) / 100.0 as net_pnl
+			SUM(CASE WHEN COALESCE(json_extract(p.data, '$.revenue'), 0) > 0 THEN 1 ELSE 0 END) as won,
+			SUM(CASE WHEN COALESCE(json_extract(p.data, '$.revenue'), 0) = 0 THEN 1 ELSE 0 END) as lost,
+			SUM(
+				COALESCE(json_extract(p.data, '$.revenue'), 0) / 100.0
+				- COALESCE(CAST(json_extract(p.data, '$.yes_total_cost_dollars') AS REAL), 0)
+				- COALESCE(CAST(json_extract(p.data, '$.no_total_cost_dollars') AS REAL), 0)
+			) as net_pnl
 		FROM resources p
-		LEFT JOIN resources m ON m.resource_type = 'markets' AND json_extract(p.data, '$.market_ticker') = m.id
-		WHERE json_extract(p.data, '$.type') = 'settlement'
-			OR json_extract(p.data, '$.settled_at') IS NOT NULL
+		LEFT JOIN resources m ON m.resource_type = 'markets' AND p.id = m.id
+		WHERE p.resource_type = 'portfolio-settlements'
 	`, groupExpr)
 
 	if sinceTS != "" {
@@ -244,21 +255,28 @@ func queryWinRate(db *sql.DB, byField string) ([]winRateRow, error) {
 		groupExpr = "COALESCE(json_extract(m.data, '$.series_ticker'), 'unknown')"
 	}
 
+	// PATCH(upstream cli-printing-press#689 Bug 4): see queryAttribution above
+	// for the full note. Won = revenue > 0; cost is the sum of the two
+	// FixedPointDollars cost legs (already in dollars, parsed via CAST AS
+	// REAL); revenue is in cents and converted with /100.0. Settlements
+	// filter on resource_type rather than the synthetic $.type='settlement'.
 	query := fmt.Sprintf(`
 		SELECT
 			%s as grp,
 			COUNT(*) as total,
-			SUM(CASE WHEN json_extract(p.data, '$.revenue') > json_extract(p.data, '$.cost') THEN 1 ELSE 0 END) as won,
-			SUM(CASE WHEN json_extract(p.data, '$.revenue') <= json_extract(p.data, '$.cost') THEN 1 ELSE 0 END) as lost,
+			SUM(CASE WHEN COALESCE(json_extract(p.data, '$.revenue'), 0) > 0 THEN 1 ELSE 0 END) as won,
+			SUM(CASE WHEN COALESCE(json_extract(p.data, '$.revenue'), 0) = 0 THEN 1 ELSE 0 END) as lost,
 			CASE WHEN COUNT(*) > 0
-				THEN CAST(SUM(CASE WHEN json_extract(p.data, '$.revenue') > json_extract(p.data, '$.cost') THEN 1 ELSE 0 END) AS REAL) / COUNT(*) * 100
+				THEN CAST(SUM(CASE WHEN COALESCE(json_extract(p.data, '$.revenue'), 0) > 0 THEN 1 ELSE 0 END) AS REAL) / COUNT(*) * 100
 				ELSE 0 END as win_rate,
-			SUM(COALESCE(json_extract(p.data, '$.cost'), 0)) / 100.0 as total_cost,
+			SUM(
+				COALESCE(CAST(json_extract(p.data, '$.yes_total_cost_dollars') AS REAL), 0)
+				+ COALESCE(CAST(json_extract(p.data, '$.no_total_cost_dollars') AS REAL), 0)
+			) as total_cost,
 			SUM(COALESCE(json_extract(p.data, '$.revenue'), 0)) / 100.0 as total_revenue
 		FROM resources p
-		LEFT JOIN resources m ON m.resource_type = 'markets' AND json_extract(p.data, '$.market_ticker') = m.id
-		WHERE json_extract(p.data, '$.type') = 'settlement'
-			OR json_extract(p.data, '$.settled_at') IS NOT NULL
+		LEFT JOIN resources m ON m.resource_type = 'markets' AND p.id = m.id
+		WHERE p.resource_type = 'portfolio-settlements'
 		GROUP BY grp
 		ORDER BY win_rate DESC
 	`, groupExpr)

--- a/library/payments/kalshi/internal/store/store.go
+++ b/library/payments/kalshi/internal/store/store.go
@@ -2072,14 +2072,22 @@ func (s *Store) UpsertApiKeys(data json.RawMessage) error {
 // Includes both flat resources and dependent (parent-child) resources so a
 // child path-item annotated with x-resource-id resolves the same as a flat
 // path-item.
+//
+// PATCH(upstream cli-printing-press#689): Mirror of the same map in
+// internal/cli/sync.go — must stay in sync. See that file for the full
+// note. The generator emitted `cursor` (a wrapper-level pagination token)
+// for these resources, which is not a per-item PK; rows were silently
+// dropped. Replaced with the real array-element PKs from spec.yaml.
 var resourceIDFieldOverrides = map[string]string{
-	"account":        "usage_tier",
-	"communications": "communications_id",
-	"events":         "cursor",
-	"fcm":            "cursor",
-	"historical":     "cursor",
-	"markets":        "cursor",
-	"portfolio":      "cursor",
+	"account":               "usage_tier",
+	"communications":        "communications_id",
+	"events":                "event_ticker",
+	"fcm":                   "order_id",
+	"historical":            "fill_id",
+	"markets":                "ticker",
+	"portfolio":             "fill_id",
+	"portfolio-settlements": "ticker",
+	"series":                "series_ticker",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did


### PR DESCRIPTION
## Summary

`kalshi-pp-cli sync` silently dropped every row into its typed tables, and novel-feature commands like `portfolio winrate` and `portfolio attribution` returned `[]`. The chained defects all trace back to generator bugs tracked upstream in [`mvanhorn/cli-printing-press#689`](https://github.com/mvanhorn/cli-printing-press/issues/689); this PR applies the three workarounds the upstream debug session validated against a real Kalshi account, and establishes a convention for recording library-side customizations so they survive (and stay visible across) future regens.

## Patches applied to kalshi-pp-cli

- **PK overrides (Bug 1).** `resourceIDFieldOverrides` now uses real array-element PKs (`event_ticker`, `ticker`, `order_id`, `fill_id`, `series_ticker`) instead of the wrapper-level `cursor` pagination token. Sync now lands the rows that previously dropped silently.
- **Sibling settlements resource (Bug 2).** Added `portfolio-settlements` bound to `/portfolio/settlements`; settlement data now reaches the store.
- **Settlement SQL rewrite (Bug 4).** `queryAttribution` and `queryWinRate` now match Kalshi's real `Settlement` schema (`revenue` in cents; `yes_total_cost_dollars` + `no_total_cost_dollars` as FixedPointDollars; `won = revenue > 0`) and filter on `resource_type = 'portfolio-settlements'`. Validated against the upstream debug session: 1404 settlements, 63.5% win rate, net P&L -$97.56.

Every patched site carries a `// PATCH(upstream cli-printing-press#689): …` comment so `grep -rn 'PATCH' library/` finds every deviation. Bug 3 (multi-array envelope for `/portfolio/positions`) and Bug 5 (Kalshi RSA-PSS auth specialization) are deferred to the upstream generator fix.

## New convention: `.printing-press-patches.json`

`AGENTS.md` documents a manifest format for any future library-side customization: a sibling `.printing-press-patches.json` at the CLI's root that indexes what changed and why (`id` / `summary` / `reason` / `files[]`), paired with inline `// PATCH:` comments at each changed site. The manifest is an index, not a second copy of the diff. `library/payments/kalshi/.printing-press-patches.json` is the worked example. [`mvanhorn/cli-printing-press#703`](https://github.com/mvanhorn/cli-printing-press/issues/703) tracks mirroring this guidance into the printed-CLI `AGENTS.md` once [`#681`](https://github.com/mvanhorn/cli-printing-press/pull/681) lands.

## Validation

`go build ./...` and `go test ./...` (122 passed across 11 packages) clean inside `library/payments/kalshi/`. `verify_skill.py` for the kalshi SKILL: all checks passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
