### PR TITLE
fix(cli): backport amazon seller pagination fix

### DIFF
--- a/library/commerce/amazon-seller/.printing-press-patches.json
+++ b/library/commerce/amazon-seller/.printing-press-patches.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-05-08",
+  "base_run_id": "2026-05-06T17:12:38.566433Z",
+  "base_printing_press_version": "3.10.0",
+  "patches": [
+    {
+      "id": "296-fba-pagination-wrapper",
+      "summary": "Teach paginatedGet to collect resource-named arrays and follow dotted cursor paths.",
+      "reason": "Amazon SP-API FBA inventory returns rows under inventorySummaries and the next page cursor under pagination.nextToken, but the generated helper only checked generic array keys and literal top-level cursor keys.",
+      "files": [
+        "internal/cli/helpers.go"
+      ],
+      "validated_outcome": "go test ./internal/cli -run TestPaginatedGetFollowsNestedNextTokenAndCollectsResourceArray -count=1",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/pull/731"
+    }
+  ]
+}

--- a/library/commerce/amazon-seller/AGENTS.md
+++ b/library/commerce/amazon-seller/AGENTS.md
@@ -1,0 +1,71 @@
+# Amazon Seller Printed CLI Agent Guide
+
+This directory is a generated `amazon-seller-pp-cli` printed CLI. It was produced by [CLI Printing Press](https://github.com/mvanhorn/cli-printing-press), so treat systemic fixes as upstream Printing Press fixes first. Keep local edits narrow and document why a generated-tree patch belongs here.
+
+## Local Operating Contract
+
+Start by asking the generated CLI for current runtime truth:
+
+```bash
+amazon-seller-pp-cli doctor --json
+amazon-seller-pp-cli agent-context --pretty
+```
+
+Use runtime discovery instead of relying on a copied command list:
+
+```bash
+amazon-seller-pp-cli which "<capability>" --json
+amazon-seller-pp-cli <command> --help
+```
+
+Add `--agent` to command invocations for JSON, compact output, non-interactive defaults, no color, and confirmation-safe scripting:
+
+```bash
+amazon-seller-pp-cli <command> --agent
+```
+
+Before running an unfamiliar command that may mutate remote state, inspect its help and prefer a dry run:
+
+```bash
+amazon-seller-pp-cli <command> --help
+amazon-seller-pp-cli <command> --dry-run --agent
+```
+
+Use `--yes --no-input` only after the target, arguments, and side effects are clear.
+
+For install, auth, examples, and longer product guidance, read `README.md` and `SKILL.md`. This file intentionally stays small so repo-local agents get invariant local guidance without duplicating the generated docs.
+
+## Local Customizations
+
+If you modify this CLI beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader.
+
+1. **Mark every changed site** in source with a comment summarizing the deviation:
+
+    ```
+    // PATCH: <one-line summary>
+    ```
+
+    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#<issue>): ...`). `grep -rn 'PATCH' .` from this directory then surfaces every customization.
+
+2. **Catalog the change** in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`). Minimum shape:
+
+    ```json
+    {
+      "schema_version": 1,
+      "applied_at": "YYYY-MM-DD",
+      "base_run_id": "<copy from .printing-press.json>",
+      "base_printing_press_version": "<copy from .printing-press.json>",
+      "patches": [
+        {
+          "id": "short-identifier",
+          "summary": "What changed (one sentence).",
+          "reason": "Why this customization was needed (one or two sentences).",
+          "files": ["internal/cli/foo.go"],
+          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+        }
+      ]
+    }
+    ```
+
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the source comment or commit message, not here.

--- a/library/commerce/amazon-seller/internal/cli/helpers.go
+++ b/library/commerce/amazon-seller/internal/cli/helpers.go
@@ -7,6 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-seller/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-seller/internal/cliutil"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,10 +20,6 @@ import (
 	"text/tabwriter"
 	"time"
 	"unicode"
-	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-seller/internal/cliutil"
-	"github.com/mvanhorn/printing-press-library/library/commerce/amazon-seller/internal/client"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var As = errors.As
@@ -93,11 +93,11 @@ type cliError struct {
 func (e *cliError) Error() string { return e.err.Error() }
 func (e *cliError) Unwrap() error { return e.err }
 
-func usageErr(err error) error    { return &cliError{code: 2, err: err} }
-func notFoundErr(err error) error { return &cliError{code: 3, err: err} }
-func authErr(err error) error     { return &cliError{code: 4, err: err} }
-func apiErr(err error) error      { return &cliError{code: 5, err: err} }
-func configErr(err error) error   { return &cliError{code: 10, err: err} }
+func usageErr(err error) error     { return &cliError{code: 2, err: err} }
+func notFoundErr(err error) error  { return &cliError{code: 3, err: err} }
+func authErr(err error) error      { return &cliError{code: 4, err: err} }
+func apiErr(err error) error       { return &cliError{code: 5, err: err} }
+func configErr(err error) error    { return &cliError{code: 10, err: err} }
 func rateLimitErr(err error) error { return &cliError{code: 7, err: err} }
 
 // dryRunOK reports whether the command should short-circuit without doing any
@@ -287,7 +287,7 @@ func paginatedGet(c interface {
 	}
 
 	// Fetch all pages
-	var allItems []json.RawMessage
+	allItems := make([]json.RawMessage, 0)
 	page := 0
 	for {
 		page++
@@ -310,20 +310,16 @@ func paginatedGet(c interface {
 			// Response is an object - look for array inside
 			var obj map[string]json.RawMessage
 			if json.Unmarshal(data, &obj) == nil {
-				// Try common data fields
-				for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
-					if arr, ok := obj[field]; ok {
-						var nested []json.RawMessage
-						if json.Unmarshal(arr, &nested) == nil {
-							allItems = append(allItems, nested...)
-							break
-						}
-					}
+				// PATCH(upstream cli-printing-press#731): support Amazon SP-API
+				// response wrappers such as inventorySummaries/orders plus dotted
+				// cursor paths like pagination.nextToken.
+				if nested, ok := extractPaginatedItems(obj); ok {
+					allItems = append(allItems, nested...)
 				}
 
 				// Check for next cursor
 				if nextCursorPath != "" {
-					if tokenRaw, ok := obj[nextCursorPath]; ok {
+					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
 						var token string
 						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
 							clean[cursorParam] = token
@@ -334,7 +330,7 @@ func paginatedGet(c interface {
 
 				// Check has_more
 				if hasMoreField != "" {
-					if moreRaw, ok := obj[hasMoreField]; ok {
+					if moreRaw, ok := rawAtPath(obj, hasMoreField); ok {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil && more {
 							continue
@@ -357,6 +353,53 @@ func paginatedGet(c interface {
 	}
 	result, _ := json.Marshal(allItems)
 	return json.RawMessage(result), nil
+}
+
+func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {
+	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		if arr, ok := obj[field]; ok {
+			var nested []json.RawMessage
+			if json.Unmarshal(arr, &nested) == nil {
+				return nested, true
+			}
+		}
+	}
+
+	var onlyArray []json.RawMessage
+	arrayCount := 0
+	for _, raw := range obj {
+		var candidate []json.RawMessage
+		if json.Unmarshal(raw, &candidate) == nil {
+			onlyArray = candidate
+			arrayCount++
+		}
+	}
+	if arrayCount == 1 {
+		return onlyArray, true
+	}
+	return nil, false
+}
+
+func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bool) {
+	if raw, ok := obj[path]; ok {
+		return raw, true
+	}
+
+	current := obj
+	parts := strings.Split(path, ".")
+	for i, part := range parts {
+		raw, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		if i == len(parts)-1 {
+			return raw, true
+		}
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return nil, false
+		}
+	}
+	return nil, false
 }
 
 // printJSONFiltered marshals a Go-typed value through the same output
@@ -1120,12 +1163,13 @@ func findField(obj map[string]any, names ...string) string {
 	}
 	return ""
 }
+
 // DataProvenance describes where data came from and when it was last synced.
 type DataProvenance struct {
 	Source       string     `json:"source"`                  // "live" or "local"
-	SyncedAt    *time.Time `json:"synced_at,omitempty"`     // when local data was last synced
-	Reason      string     `json:"reason,omitempty"`        // why local was used: "user_requested", "api_unreachable", "no_search_endpoint"
-	ResourceType string    `json:"resource_type,omitempty"` // which resource type was queried
+	SyncedAt     *time.Time `json:"synced_at,omitempty"`     // when local data was last synced
+	Reason       string     `json:"reason,omitempty"`        // why local was used: "user_requested", "api_unreachable", "no_search_endpoint"
+	ResourceType string     `json:"resource_type,omitempty"` // which resource type was queried
 	Freshness    any        `json:"freshness,omitempty"`     // optional machine-owned freshness metadata for covered command paths
 }
 

--- a/library/commerce/amazon-seller/internal/cli/helpers_test.go
+++ b/library/commerce/amazon-seller/internal/cli/helpers_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type paginatedGetTestClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *paginatedGetTestClient) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	copied := make(map[string]string, len(params))
+	for k, v := range params {
+		copied[k] = v
+	}
+	c.params = append(c.params, copied)
+
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	return response, nil
+}
+
+func TestPaginatedGetFollowsNestedNextTokenAndCollectsResourceArray(t *testing.T) {
+	client := &paginatedGetTestClient{
+		responses: []json.RawMessage{
+			json.RawMessage(`{"inventorySummaries":[{"sellerSku":"sku-1"}],"pagination":{"nextToken":"page-2"}}`),
+			json.RawMessage(`{"inventorySummaries":[{"sellerSku":"sku-2"}],"pagination":{}}`),
+		},
+	}
+
+	got, err := paginatedGet(client, "/fba/inventory/v1/summaries", map[string]string{
+		"granularityType": "Marketplace",
+	}, nil, true, "nextToken", "pagination.nextToken", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+
+	var items []map[string]string
+	if err := json.Unmarshal(got, &items); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2; raw = %s", len(items), got)
+	}
+	if items[0]["sellerSku"] != "sku-1" || items[1]["sellerSku"] != "sku-2" {
+		t.Fatalf("items = %#v, want both inventory summaries", items)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("requests = %d, want 2", len(client.params))
+	}
+	if client.params[1]["nextToken"] != "page-2" {
+		t.Fatalf("second request nextToken = %q, want page-2", client.params[1]["nextToken"])
+	}
+}


### PR DESCRIPTION
## Summary
- backport the paginated helper fix for Amazon Seller so `--all` collects resource-named arrays like `inventorySummaries` and follows dotted cursors like `pagination.nextToken`
- add a focused regression test for the FBA inventory response shape from #296
- add the generated-style `AGENTS.md` and `.printing-press-patches.json` local customization index per cli-printing-press#728, with the upstream template fix linked to cli-printing-press#731

## Validation
- `go test ./internal/cli -run TestPaginatedGetFollowsNestedNextTokenAndCollectsResourceArray -count=1`
- `go test ./...` from `library/commerce/amazon-seller` (99 passed across 11 packages)
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/commerce/amazon-seller/`
- `go build ./...` from `library/commerce/amazon-seller`
- `go vet ./...` from `library/commerce/amazon-seller`
- `govulncheck ./...` from `library/commerce/amazon-seller`
- `go run ./tools/generate-skills/main.go` (no `cli-skills/` diff)
- `git diff --check`

Closes #296.
