### PR TITLE
fix(cli): fix slack sync for private channels and scope errors

### DIFF
--- a/library/productivity/slack/.printing-press-patches.json
+++ b/library/productivity/slack/.printing-press-patches.json
@@ -3,5 +3,25 @@
   "applied_at": "2026-05-08",
   "base_run_id": "20260409-073625",
   "base_printing_press_version": "1.2.1",
-  "patches": []
+  "patches": [
+    {
+      "id": "fix-conversations-types-scope",
+      "summary": "Remove mpim,im from conversations.list types to avoid missing_scope errors.",
+      "reason": "Bot tokens typically lack mpim:read scope. Including mpim,im in the types param causes Slack to return ok:false with missing_scope, which was silently stored as a single corrupt record instead of surfacing as an error. Removing those types allows public_channel and private_channel to sync correctly.",
+      "files": ["internal/cli/sync.go"],
+      "validated_outcome": "conversations sync went from 1 (corrupt error object) to 56 real channels including private ones."
+    },
+    {
+      "id": "fix-ok-false-detection",
+      "summary": "Detect Slack ok:false API errors before attempting to store the response as a record.",
+      "reason": "The generic syncResource loop had no Slack-specific error detection. When Slack returned {ok:false, error:\"missing_scope\"}, it was stored as a valid record and counted as a successful sync. This masked real failures and corrupted the store.",
+      "files": ["internal/cli/sync.go"]
+    },
+    {
+      "id": "fix-cursor-pagination-param",
+      "summary": "Change pagination cursor param from 'after' to 'cursor' for Slack API compatibility.",
+      "reason": "The generated determinePaginationDefaults() returned cursorParam: 'after', but Slack's conversations.list uses 'cursor'. This caused pagination to silently restart from page 1 on every request, making it impossible to sync more than one page of results.",
+      "files": ["internal/cli/sync.go"]
+    }
+  ]
 }

--- a/library/productivity/slack/internal/cli/sync.go
+++ b/library/productivity/slack/internal/cli/sync.go
@@ -247,6 +247,23 @@ func syncResource(c interface {
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
+		// PATCH: detect Slack ok:false errors (e.g. missing_scope) before attempting to store.
+		// Without this, error objects get stored as a single "record" and silently corrupt the store.
+		var slackStatus struct {
+			OK    bool   `json:"ok"`
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(data, &slackStatus); err == nil && !slackStatus.OK {
+			errMsg := slackStatus.Error
+			if errMsg == "" {
+				errMsg = "unknown Slack API error"
+			}
+			if !humanFriendly {
+				fmt.Fprintf(os.Stderr, `{"event":"sync_error","resource":"%s","error":"%s"}`+"\n", resource, errMsg)
+			}
+			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("Slack API error for %s: %s", resource, errMsg), Duration: time.Since(started)}
+		}
+
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -329,11 +346,11 @@ type paginationDefaults struct {
 	limit       int
 }
 
-// determinePaginationDefaults returns the pagination parameter names to use.
-// Values are detected from the API spec by the profiler at generation time.
+// PATCH: Slack uses "cursor" as the pagination param for conversations.list, not "after".
+// Using "after" causes Slack to ignore the cursor and re-fetch the first page on every request.
 func determinePaginationDefaults() paginationDefaults {
 	return paginationDefaults{
-		cursorParam: "after",
+		cursorParam: "cursor",
 		limitParam:  "limit",
 		limit:       100,
 	}
@@ -498,7 +515,9 @@ func defaultSyncResources() []string {
 // this preserves the actual endpoint path like "/ISteamApps/GetAppList/v2".
 func syncResourcePath(resource string) string {
 	paths := map[string]string{
-		"conversations": "/conversations.list?types=public_channel,private_channel,mpim,im",
+		// PATCH: exclude mpim,im types — they require mpim:read scope which typical bot tokens lack.
+		// Slack returns ok:false with missing_scope error for those types, causing a corrupt single-record store.
+		"conversations": "/conversations.list?types=public_channel,private_channel",
 		"emoji":         "/emoji.list",
 		"files":         "/files.list",
 		"reactions":     "/reactions.list",


### PR DESCRIPTION
## Problem

Three bugs in `slack-pp-cli sync` prevented private channel messages from being pulled, even when the bot token had access to those channels.

### Bug 1: `mpim,im` types cause `missing_scope` → silent store corruption

`syncResourcePath` requested `types=public_channel,private_channel,mpim,im`. Bot tokens typically lack `mpim:read`, so Slack returned `{ok:false, error:"missing_scope"}`. This was stored as the single conversation record instead of surfacing as an error. Result: 1 corrupt record, 0 messages.

**Fix:** Removed `mpim,im` from the types param.

### Bug 2: No `ok:false` detection in `syncResource`

The generic sync loop had no Slack-specific error detection. Any `{ok:false}` response was treated as a valid record and stored, masking real failures.

**Fix:** Added `ok:false` check immediately after each API call.

### Bug 3: Wrong pagination cursor param (`after` → `cursor`)

`determinePaginationDefaults()` returned `cursorParam: "after"`, but Slack's `conversations.list` uses `cursor`. Pagination silently restarted from page 1 on every request.

**Fix:** Changed `cursorParam` to `"cursor"`.

## Validation

- Before: 1 conversation (corrupt error object), 0 messages
- After: **56 conversations (public + private), 5,956 messages, 7,106 total records**

## Files Changed

- `internal/cli/sync.go` — three targeted fixes, each marked with `// PATCH:` comment
- `.printing-press-patches.json` — patch manifest per AGENTS.md convention

---
*— HermesVonNikica*