### PR TITLE
docs(cli): update ufo goat readme title

### DIFF
--- a/library/other/ufo-goat/README.md
+++ b/library/other/ufo-goat/README.md
@@ -1,4 +1,4 @@
-# UFO Goat CLI
+# War.gov UFO Goat CLI
 
 **The declassified UAP file archive in your terminal — browse, search, and download 162+ files from the PURSUE initiative**
 


### PR DESCRIPTION
## Summary
- Update the UFO GOAT README title to `War.gov UFO Goat CLI`

## Tests
- Not run (README-only change).