### PR TITLE
fix(cli): send Clarity country dimension correctly

### DIFF
--- a/library/marketing/clarity/.printing-press-patches.json
+++ b/library/marketing/clarity/.printing-press-patches.json
@@ -3,5 +3,15 @@
   "applied_at": "2026-05-08",
   "base_run_id": "20260508-113436",
   "base_printing_press_version": "4.0.1",
-  "patches": []
+  "patches": [
+    {
+      "id": "308-clarity-country-dimension",
+      "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/308",
+      "files": [
+        "internal/cli/insights.go"
+      ],
+      "summary": "Send Country on the wire for country dimension aliases.",
+      "reason": "Microsoft Clarity documents Country/Region, but the live Data Export API silently drops that dimension; empirical verification shows Country is the working wire value."
+    }
+  ]
 }

--- a/library/marketing/clarity/internal/cli/insights.go
+++ b/library/marketing/clarity/internal/cli/insights.go
@@ -16,11 +16,12 @@ import (
 const clarityExportEndpoint = "https://www.clarity.ms/export-data/api/v1/project-live-insights"
 
 var clarityDimensionNames = map[string]string{
-	"browser":        "Browser",
-	"device":         "Device",
-	"country/region": "Country/Region",
-	"country":        "Country/Region",
-	"region":         "Country/Region",
+	"browser": "Browser",
+	"device":  "Device",
+	// PATCH(printing-press-library#308): Clarity documents Country/Region, but the live API only returns the requested geography for Country.
+	"country/region": "Country",
+	"country":        "Country",
+	"region":         "Country",
 	"os":             "OS",
 	"source":         "Source",
 	"medium":         "Medium",
@@ -123,7 +124,7 @@ The API token is generated in Microsoft Clarity under Settings -> Data Export
 		},
 	}
 	cmd.Flags().IntVar(&days, "days", 1, "Number of recent days to export: 1, 2, or 3")
-	cmd.Flags().StringArrayVar(&dimensions, "dimension", nil, "Dimension to break down insights by; repeat up to three times")
+	cmd.Flags().StringArrayVar(&dimensions, "dimension", nil, "Dimension to break down insights by; repeat up to three times; country aliases send Country because Clarity drops Country/Region")
 	return cmd
 }
 
@@ -154,7 +155,7 @@ func normalizeClarityDimension(value string) (string, error) {
 	if canonical, ok := clarityDimensionNames[strings.ToLower(value)]; ok {
 		return canonical, nil
 	}
-	return "", fmt.Errorf("invalid --dimension %q: use Browser, Device, Country/Region, OS, Source, Medium, Campaign, Channel, or URL", value)
+	return "", fmt.Errorf("invalid --dimension %q: use Browser, Device, Country, OS, Source, Medium, Campaign, Channel, or URL", value)
 }
 
 func clarityAPITokenFromEnv() (string, string) {

--- a/library/marketing/clarity/internal/cli/snippet_test.go
+++ b/library/marketing/clarity/internal/cli/snippet_test.go
@@ -60,7 +60,19 @@ func TestBuildInsightsQuery(t *testing.T) {
 	if got.Get("dimension1") != "OS" {
 		t.Fatalf("dimension1 = %q, want OS", got.Get("dimension1"))
 	}
-	if got.Get("dimension2") != "Country/Region" {
-		t.Fatalf("dimension2 = %q, want Country/Region", got.Get("dimension2"))
+	if got.Get("dimension2") != "Country" {
+		t.Fatalf("dimension2 = %q, want Country", got.Get("dimension2"))
+	}
+}
+
+func TestNormalizeClarityCountryDimensionAliases(t *testing.T) {
+	for _, input := range []string{"Country", "country/region", "region"} {
+		got, err := normalizeClarityDimension(input)
+		if err != nil {
+			t.Fatalf("normalizeClarityDimension(%q) returned error: %v", input, err)
+		}
+		if got != "Country" {
+			t.Fatalf("normalizeClarityDimension(%q) = %q, want Country", input, got)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- send `Country` instead of `Country/Region` for Clarity country dimension aliases
- document the published-library patch in `.printing-press-patches.json`
- add regression coverage for `Country`, `country/region`, and `region` aliases

Fixes #308

## Tests

- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/marketing/clarity/`
- `go test ./...` (in `library/marketing/clarity`)
- `go build ./...` (in `library/marketing/clarity`)
- `go vet ./...` (in `library/marketing/clarity`)
- `GOTOOLCHAIN=go1.26.3 govulncheck ./...` (in `library/marketing/clarity`)
- `go run ./cmd/clarity-pp-cli insights live --dimension Country --dry-run`
- `go run ./cmd/clarity-pp-cli insights live --dimension country/region --dry-run`
