### PR TITLE
feat(cli): surface printer attribution in registry and root README catalog

### DIFF
--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -66,11 +66,23 @@ type Registry struct {
 }
 
 type RegistryEntry struct {
-	Name        string    `json:"name"`
-	Category    string    `json:"category"`
-	API         string    `json:"api"`
-	Description string    `json:"description"`
-	Path        string    `json:"path"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	API         string `json:"api"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	// Printer is the GitHub @handle of the human who originally ran the
+	// press for this CLI. Sourced verbatim from .printing-press.json's
+	// `printer` field; never derived from operator git config or curated
+	// from a prior registry value. Manifest is the only source of
+	// truth so attribution survives across regenerations and across
+	// operator changes.
+	Printer string `json:"printer,omitempty"`
+	// PrinterName is the prose-shaped display name of the printer.
+	// Sourced from .printing-press.json's `printer_name` field. Empty
+	// values are valid; the per-CLI README byline renders without a
+	// parenthetical and the catalog row renders only the @handle.
+	PrinterName string    `json:"printer_name,omitempty"`
 	MCP         *MCPBlock `json:"mcp,omitempty"`
 }
 
@@ -104,6 +116,8 @@ type MCPBlock struct {
 type printingPressManifest struct {
 	APIName            string   `json:"api_name"`
 	DisplayName        string   `json:"display_name"`
+	Printer            string   `json:"printer"`
+	PrinterName        string   `json:"printer_name"`
 	MCPBinary          string   `json:"mcp_binary"`
 	MCPToolCount       int      `json:"mcp_tool_count"`
 	MCPPublicToolCount *int     `json:"mcp_public_tool_count"`
@@ -283,6 +297,15 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 		Category: category,
 		API:      apiDisplayName(pp, prior, slug),
 		Path:     filepath.ToSlash(dir),
+		// Printer attribution: always derive from the manifest. Do not
+		// honor a curated prior.Printer value — the manifest is the
+		// only source of truth, and a curated map would re-introduce
+		// the multi-author retrofit footgun the cliAuthorByAPIName map
+		// in tools/sweep-canonical/ exists to manage carefully.
+		// Existing CLIs without a printer field in their manifest will
+		// emit registry entries with omitempty (no printer key).
+		Printer:     pp.Printer,
+		PrinterName: pp.PrinterName,
 	}
 
 	// Description preference: existing registry value (curated) > goreleaser
@@ -569,11 +592,25 @@ func renderCatalogTable(entries []RegistryEntry) string {
 	buf.WriteString("|------|-------|---------|--------------|\n")
 	for _, e := range entries {
 		fmt.Fprintf(&buf,
-			"| [`%s`](%s/) | [`/pp-%s`](cli-skills/pp-%s/SKILL.md) | [latest](%s%s-current) | %s |\n",
-			e.Name, e.Path, e.Name, e.Name, releaseTagURLBase, e.Name, formatDescription(e.Description),
+			"| [`%s`](%s/) | [`/pp-%s`](cli-skills/pp-%s/SKILL.md) | [latest](%s%s-current) | %s%s |\n",
+			e.Name, e.Path, e.Name, e.Name, releaseTagURLBase, e.Name, formatDescription(e.Description), printerSuffix(e),
 		)
 	}
 	return buf.String()
+}
+
+// printerSuffix returns the markdown suffix that visibly credits the
+// printer in the catalog row's description cell. Renders as
+// `<br><sub>Printed by @handle</sub>` when a Printer is set; empty
+// otherwise. Folded into the description cell rather than added as a
+// new column to avoid widening the existing 4-column table (every
+// entry has a description; not every entry has a printer until the
+// backfill follow-up issue ships).
+func printerSuffix(e RegistryEntry) string {
+	if e.Printer == "" {
+		return ""
+	}
+	return fmt.Sprintf("<br><sub>Printed by [@%s](https://github.com/%s)</sub>", e.Printer, e.Printer)
 }
 
 // renderCatalogCounts returns the "N CLIs across M categories." line


### PR DESCRIPTION
Library-side half of [mvanhorn/cli-printing-press#745](https://github.com/mvanhorn/cli-printing-press/issues/745) and the cross-repo coordination partner of [mvanhorn/cli-printing-press#748](https://github.com/mvanhorn/cli-printing-press/pull/748).

Lands FIRST per the cross-repo rollout order: this PR teaches `tools/generate-registry` to read the new `printer` and `printer_name` fields from each library CLI's `.printing-press.json` and surface them in `registry.json` and the root README catalog. Once this merges, the cli-printing-press side can land — its generator will start emitting those manifest fields, and the post-merge regen workflow here will pick them up automatically.

## What changes

- `RegistryEntry` gains `Printer string` and `PrinterName string` (both `omitempty`).
- `printingPressManifest` reads the same two fields from `.printing-press.json`.
- `buildEntry` always derives both from the manifest. No curated `prior.Printer` fallback — manifest is the only source of truth, mirroring the discipline `tools/sweep-canonical/`'s curated `cliAuthorByAPIName` map enforces for SKILL.md `author:`.
- `renderCatalogTable` folds `<br><sub>Printed by [@handle](https://github.com/handle)</sub>` into the description cell when a printer is set. Folded into the existing 4-column layout rather than a 5th column to avoid horizontal scrolling.

## Behavior on existing 49 CLIs

`go run ./tools/generate-registry --check` reports zero diff against the current `registry.json` and root README. Existence proof for the no-regression claim: none of the 49 published CLIs have a `printer` field in their manifest yet, so `omitempty` keeps every entry's shape identical. Once new CLIs ship with the field, only those rows gain the attribution suffix.

## Downstream consumer audit

- `tools/generate-skills/main.go` — reads only `api_name`; no strict unmarshal; tolerates new fields silently.
- `npm/src/registry.ts` — `parseRegistryEntry` extracts only enumerated fields; schema_version stays at 2 (no bump).
- `.github/scripts/verify-skill` — scans `library/` directly; does not read `registry.json`.

No registry `schema_version` bump required.

## Test plan

- [x] `GO111MODULE=off go build ./tools/generate-registry/`
- [x] `GO111MODULE=off go test ./tools/generate-registry/`
- [x] `go run ./tools/generate-registry --check` (no-op against current state)
- [x] Manual positive test: inject `printer: "mvanhorn"` into one fixture, run generator, observe expected `registry.json` field and rendered catalog row, revert fixture