### PR TITLE
feat(library): backfill printer attribution on 55 published CLIs

### DIFF
--- a/library/cloud/cloud-run-admin/.printing-press.json
+++ b/library/cloud/cloud-run-admin/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Google Cloud Run",
   "cli_name": "cloud-run-admin-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_url": "https://api.apis.guru/v2/specs/googleapis.com/run/v2/openapi.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:1fcc20da6d89b529216363e66a4e8fd916b2cd0e096da2c02603c9f8fff61c2c",

--- a/library/commerce/amazon-seller/.printing-press.json
+++ b/library/commerce/amazon-seller/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Amazon Seller",
   "cli_name": "amazon-seller-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": "catalog/specs/amazon-seller.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:ba9358084b986d7a89f96663d04cd0f66ab78f724b905db5aa98bd6a867715e4",

--- a/library/commerce/craigslist/.printing-press.json
+++ b/library/commerce/craigslist/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "craigslist",
   "display_name": "Craigslist",
   "cli_name": "craigslist-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/hidden-brewing-turtle-68cd6401/runs/20260502-152300/research/craigslist-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:a4e6c94678f3c43e28e118ba4bc8cfd7c8811008c0e1405b23d6ea3b6277b8ff",

--- a/library/commerce/ebay/.printing-press.json
+++ b/library/commerce/ebay/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "ebay",
   "display_name": "eBay",
   "cli_name": "ebay-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_format": "internal",
   "spec_checksum": "sha256:007a051ab0034a82890f11831ab713349e0335fb31526abcf82dcb6df5805fce",
   "mcp_binary": "ebay-pp-mcp",

--- a/library/commerce/fedex/.printing-press.json
+++ b/library/commerce/fedex/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "fedex",
   "display_name": "FedEx",
   "cli_name": "fedex-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_format": "internal",
   "spec_checksum": "sha256:cc42c84fbfa7c3233e2261ae223d582be7a76800142317bb2395e1c5b9499cc8",
   "run_id": "20260502-152509",

--- a/library/commerce/instacart/.printing-press.json
+++ b/library/commerce/instacart/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "1.2.1",
   "api_name": "instacart",
   "cli_name": "instacart-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "description": "Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation.",
   "category": "commerce",
   "spec_format": "internal",

--- a/library/commerce/shopify/.printing-press.json
+++ b/library/commerce/shopify/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Shopify",
   "cli_name": "shopify-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": "catalog/specs/shopify-2026-04-wrapper.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:4e5ca1c0c251eed7ac5fce5c7bcf974c584bcdea07ffb495eb6c5dd37fe00d69",

--- a/library/commerce/tiktok-shop/.printing-press.json
+++ b/library/commerce/tiktok-shop/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "TikTok Shop",
   "cli_name": "tiktok-shop-pp-cli",
   "owner": "cathryn-lavery",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": "library/commerce/tiktok-shop/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:81f4420a65ed74b213a5512ac56073aab47a2b21d425b459957b0fa9e483783f",

--- a/library/commerce/yahoo-finance/.printing-press.json
+++ b/library/commerce/yahoo-finance/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "1.3.2",
   "api_name": "yahoo-finance",
   "cli_name": "yahoo-finance-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/cli-printing-press-8bdedb85/runs/20260411-210148/research/yahoo-finance-spec.yaml",
   "run_id": "20260411-210148",
   "mcp_binary": "yahoo-finance-pp-mcp",

--- a/library/developer-tools/agent-capture/.printing-press.json
+++ b/library/developer-tools/agent-capture/.printing-press.json
@@ -1,5 +1,7 @@
 {
   "cli_name": "agent-capture-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "api_name": "agent-capture",
   "printing_press_version": "0.4.0",
   "generated_at": "2026-04-05T19:25:10Z",

--- a/library/developer-tools/company-goat/.printing-press.json
+++ b/library/developer-tools/company-goat/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "2.3.9",
   "api_name": "company-goat",
   "cli_name": "company-goat-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/purring-leaping-taco-1b9d73bb/runs/20260427-121015/research/company-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:ac94644063a200514928b494b035d020c1b94efd27e96d6d73d1bd445f16a2a8",

--- a/library/developer-tools/docker-hub/.printing-press.json
+++ b/library/developer-tools/docker-hub/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Docker Hub",
   "cli_name": "docker-hub-pp-cli",
   "owner": "hiten-shah",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/developer-tools/docker-hub/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:e8a403eb6f13e16107c7fcdc32074ab006cbe6a28327a0ae8498a25533d521e5",

--- a/library/developer-tools/firecrawl/.printing-press.json
+++ b/library/developer-tools/firecrawl/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Firecrawl",
   "cli_name": "firecrawl-pp-cli",
   "owner": "hiten-shah",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/developer-tools/firecrawl/spec.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:49990c59f5e6ddccc24dd2deff027166cacc5cb19ff41b1e954d87838ce88be2",

--- a/library/developer-tools/nvd/.printing-press.json
+++ b/library/developer-tools/nvd/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "National Vulnerability Database",
   "cli_name": "nvd-pp-cli",
   "owner": "hiten-shah",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/developer-tools/nvd/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:05342c422436dda237046f5788cb35d6a4ebba2530f9609d8b1fc79888c5b02e",

--- a/library/developer-tools/postman-explore/.printing-press.json
+++ b/library/developer-tools/postman-explore/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "postman-explore",
   "display_name": "Postman Explore",
   "cli_name": "postman-explore-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/parsed-exploring-penguin-5c956a6b/runs/20260429-230407/working/postman-explore-pp-cli/spec.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:2b27b48db619ed0b9a6789d1c054e2567e0fa74f60a445327234308667b499b8",

--- a/library/developer-tools/pypi/.printing-press.json
+++ b/library/developer-tools/pypi/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "PyPI",
   "cli_name": "pypi-pp-cli",
   "owner": "hiten-shah",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/developer-tools/pypi/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:5a9434e35edb3ca73dce4387aa6c184f7a7b44d9c82ccc63d21c9ad1a3c92da7",

--- a/library/developer-tools/scrape-creators/.printing-press.json
+++ b/library/developer-tools/scrape-creators/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "scrape-creators",
   "display_name": "Scrape Creators",
   "cli_name": "scrape-creators-pp-cli",
+  "printer": "adrianhorning08",
+  "printer_name": "Adrian Horning",
   "spec_path": "https://docs.scrapecreators.com/openapi.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:84d94e42d427fc09a88d36afa5f0524d824f4a6e69e7aa138e69bed51f99121d",

--- a/library/developer-tools/trigger-dev/.printing-press.json
+++ b/library/developer-tools/trigger-dev/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "trigger-dev",
   "display_name": "Trigger.dev",
   "cli_name": "trigger-dev-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:da5ab4a4da676213595e1d92ae5d9ccf1c419e9c9836c3b9c35cc3e3383025ef",
   "run_id": "20260507-000200",

--- a/library/food-and-dining/allrecipes/.printing-press.json
+++ b/library/food-and-dining/allrecipes/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "allrecipes",
   "display_name": "Allrecipes",
   "cli_name": "allrecipes-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_format": "internal",
   "spec_checksum": "sha256:6fe5f749adf60b8f8a16c426255d8df4e709a09084bd8992ff81350b82b67f21",
   "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",

--- a/library/food-and-dining/dominos/.printing-press.json
+++ b/library/food-and-dining/dominos/.printing-press.json
@@ -2,6 +2,8 @@
   "schema_version": 1,
   "api_name": "dominos",
   "cli_name": "dominos-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "display_name": "Domino's",
   "description": "Order pizza, browse menus, optimize deals, and track delivery from your terminal \u2014 with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers.",
   "category": "food-and-dining",

--- a/library/food-and-dining/food52/.printing-press.json
+++ b/library/food-and-dining/food52/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "food52",
   "display_name": "Food52",
   "cli_name": "food52-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/swirling-spinning-blum-1bac0b4e/runs/20260501-164925/research/food52-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:0805a98dce1a73403398a4ed9ef2e01e992e6229ad61989afa69be24c3963581",

--- a/library/food-and-dining/pagliacci/.printing-press.json
+++ b/library/food-and-dining/pagliacci/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "pagliacci",
   "display_name": "Pagliacci Pizza",
   "cli_name": "pagliacci-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/eager-crafting-bengio-5a1d4594/runs/20260503-000558/research/pagliacci-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:667b9f080b678cf797a833ebde38348eed7882d47b4c7ab14a2df954a091bbb8",

--- a/library/food-and-dining/recipe-goat/.printing-press.json
+++ b/library/food-and-dining/recipe-goat/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Recipe GOAT",
   "cli_name": "recipe-goat-pp-cli",
   "owner": "trevin-chow",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/food-and-dining/recipe-goat/spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:6cc89de634abce15d2612148b24c64f157fe6700532a7e18cfa1edc19b3def73",

--- a/library/marketing/ahrefs/.printing-press.json
+++ b/library/marketing/ahrefs/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Ahrefs",
   "cli_name": "ahrefs-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": "catalog/specs/ahrefs-v3.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:ec46e6814b3488f73dbd28e779bc2bcdc88c8ed4cba54141b0d9d5b28a4c14cc",

--- a/library/marketing/clarity/.printing-press.json
+++ b/library/marketing/clarity/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "PP Clarity",
   "cli_name": "clarity-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": "/Users/cathrynlavery/printing-press/.runstate/cli-printing-press-23b02465/current/clarity/clarity.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:fddb81e9af3a7ab38cd7dd8b5d0f70479791d87b5e535e7c2cf7cd9edf56c02f",

--- a/library/marketing/customer-io/.printing-press.json
+++ b/library/marketing/customer-io/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "customer-io",
   "display_name": "Customer.io",
   "cli_name": "customer-io-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/piped-strolling-bird-5ebb1b07/runs/20260507-031036/research/customer-io-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:4fba0ae2479fab0298ff6328d0f222af669178131983975773f567e2d5dff0ab",

--- a/library/marketing/dub/.printing-press.json
+++ b/library/marketing/dub/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "dub",
   "display_name": "Dub",
   "cli_name": "dub-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/majestic-giggling-lollipop-a96356fc/runs/20260502-153038/research/dub-openapi.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:fd86be0f4bd214c47fe2720a40ed0074c774b225cde931b11d49be31e56ae386",

--- a/library/marketing/google-ads/.printing-press.json
+++ b/library/marketing/google-ads/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Google Ads",
   "cli_name": "google-ads-pp-cli",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_path": ".context/google-ads/google-ads-press-spec.json",
   "spec_format": "internal",
   "spec_checksum": "sha256:dbef066a5b9e8e8dae3d0fc8f914c0663ecc06434d7c43c917d7cec2641ce5ec",

--- a/library/marketing/klaviyo/.printing-press.json
+++ b/library/marketing/klaviyo/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Klaviyo",
   "cli_name": "klaviyo-pp-cli",
   "owner": "cathryn-lavery",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_url": "https://raw.githubusercontent.com/klaviyo/openapi/3fb87e6042183f6c790c60f2473e4c254efe81b3/openapi/stable.json",
   "spec_path": "/Users/cathrynlavery/printing-press/.runstate/cli-printing-press-klaviyo-b1952ca2/runs/20260502T175749Z-699b4af1/specs/klaviyo-stable.preprocessed.json",
   "spec_format": "openapi3",

--- a/library/marketing/producthunt/.printing-press.json
+++ b/library/marketing/producthunt/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "producthunt",
   "display_name": "Producthunt",
   "cli_name": "producthunt-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/linear-herding-lollipop-44b2f933/runs/20260501-170103/research/producthunt-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:e20ac1a69cdcfd625920685a15f895430747fb554548a2b1ba5bd395b1a4a355",

--- a/library/media-and-entertainment/archive-is/.printing-press.json
+++ b/library/media-and-entertainment/archive-is/.printing-press.json
@@ -1,6 +1,8 @@
 {
   "api_name": "archive-is",
   "cli_name": "archive-is-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "printing_press_version": "1.2.1",
   "generated_at": "2026-04-11T04:05:33Z",
   "run_id": "20260410-233336",

--- a/library/media-and-entertainment/espn/.printing-press.json
+++ b/library/media-and-entertainment/espn/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "1.2.1-0.20260409145412-b1128d0e07fd+dirty",
   "api_name": "espn",
   "cli_name": "espn-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_path": "/tmp/espn-spec.yaml",
   "run_id": "20260409-121709",
   "mcp_binary": "espn-pp-mcp",

--- a/library/media-and-entertainment/google-photos/.printing-press.json
+++ b/library/media-and-entertainment/google-photos/.printing-press.json
@@ -7,6 +7,8 @@
   "cli_name": "google-photos-pp-cli",
   "run_id": "20260505-152800",
   "owner": "user",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_url": "https://developers.google.com/photos",
   "spec_path": "catalog/specs/google-photos.yaml",
   "spec_format": "internal",

--- a/library/media-and-entertainment/hackernews/.printing-press.json
+++ b/library/media-and-entertainment/hackernews/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "hackernews",
   "display_name": "Hackernews",
   "cli_name": "hackernews-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/drifting-hugging-phoenix-78b7f75a/runs/20260504-190931/research/hackernews-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:189a4a6421c32058b7fff4c42aede5242981d42faee67433ed8a298ebbf21d95",

--- a/library/media-and-entertainment/movie-goat/.printing-press.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "movie-goat",
   "display_name": "Movie Goat",
   "cli_name": "movie-goat-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_format": "internal",
   "spec_checksum": "sha256:968d04f13cef942f404e0dcd7f9d5a4c5fe70858be8fdecad480a12e93a84198",
   "run_id": "20260504-004256",

--- a/library/media-and-entertainment/pokeapi/.printing-press.json
+++ b/library/media-and-entertainment/pokeapi/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "pokeapi",
   "display_name": "Pokeapi",
   "cli_name": "pokeapi-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_url": "https://raw.githubusercontent.com/PokeAPI/pokeapi/master/openapi.yml",
   "spec_path": "/Users/tmchow/printing-press/.runstate/lazy-hugging-lighthouse-2520149b/runs/20260429-230641/research/pokeapi-spec.yaml",
   "spec_format": "openapi3",

--- a/library/media-and-entertainment/steam-web/.printing-press.json
+++ b/library/media-and-entertainment/steam-web/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "steam-web",
   "display_name": "Steam Web",
   "cli_name": "steam-web-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/manuscripts/steam-web-pp-cli/20260404-003212/research/steam-public-spec.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:33ba9314554101d758965dcd8d023f6333add0492dd67e21c1e25c1f4fb08082",

--- a/library/media-and-entertainment/wikipedia/.printing-press.json
+++ b/library/media-and-entertainment/wikipedia/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Wikipedia",
   "cli_name": "wikipedia-pp-cli",
   "owner": "hiten-shah",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/media-and-entertainment/wikipedia/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:2665a92c5652d080a55a02a059b2e1beb5f52a0d3b012802cc6aeb095691db75",

--- a/library/monitoring/sentry/.printing-press.json
+++ b/library/monitoring/sentry/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "sentry",
   "display_name": "Sentry",
   "cli_name": "sentry-pp-cli",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_url": "https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json",
   "spec_path": "/Users/cathrynlavery/printing-press/.runstate/cli-printing-press-23b02465/runs/20260502-124520/research/sentry-openapi-normalized.json",
   "spec_format": "openapi3",

--- a/library/other/apartments/.printing-press.json
+++ b/library/other/apartments/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "apartments",
   "display_name": "Apartments",
   "cli_name": "apartments-pp-cli",
+  "printer": "rderwin",
+  "printer_name": "rderwin",
   "spec_format": "internal",
   "spec_checksum": "sha256:b9a554bf8d6f2b53d86037a9df8e29e3b04af01b0bd83a4f51599b6c5c2e12cf",
   "run_id": "20260503-193955",

--- a/library/other/open-meteo/.printing-press.json
+++ b/library/other/open-meteo/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "open-meteo",
   "display_name": "Open-Meteo",
   "cli_name": "open-meteo-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/nifty-nibbling-toucan-ab654d77/runs/20260502-155141/research/open-meteo-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:7596374aa55bc8956aa988381c666dcbd3390f7b1def57c4aa9c7c89315819b4",

--- a/library/other/redfin/.printing-press.json
+++ b/library/other/redfin/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "redfin",
   "display_name": "Redfin",
   "cli_name": "redfin-pp-cli",
+  "printer": "rderwin",
+  "printer_name": "rderwin",
   "spec_format": "internal",
   "spec_checksum": "sha256:b3bd1d6d2195efc401d2679e5da6fbde774c990a3d1ae536a8ff489799847313",
   "run_id": "20260504-175601",

--- a/library/other/ufo-goat/.printing-press.json
+++ b/library/other/ufo-goat/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "ufo-goat",
   "display_name": "War.gov UFO",
   "cli_name": "ufo-goat-pp-cli",
+  "printer": "davemorin",
+  "printer_name": "Dave Morin",
   "spec_format": "internal",
   "spec_checksum": "sha256:ec5d430ebefe8b5c7ca2ed4177fb00a1d2cdbefe8eac571baff38c116bac1464",
   "mcp_binary": "ufo-goat-pp-mcp",

--- a/library/other/weather-goat/.printing-press.json
+++ b/library/other/weather-goat/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "1.3.3-0.20260411222622-065697576de1+dirty",
   "api_name": "weather-goat",
   "cli_name": "weather-goat-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/cli-printing-press-8bdedb85/runs/20260411-153728/research/weather-spec.yaml",
   "run_id": "20260411-153728",
   "mcp_binary": "weather-goat-pp-mcp",

--- a/library/payments/coingecko/.printing-press.json
+++ b/library/payments/coingecko/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "2.3.7",
   "api_name": "coingecko",
   "cli_name": "coingecko-pp-cli",
+  "printer": "hnshah",
+  "printer_name": "Hiten Shah",
   "spec_path": "/tmp/coingecko-spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:b696bc534d8059addb9aaadb23dc324cfcd0bd119f7b8eefdc951a63f27fdff5",

--- a/library/payments/kalshi/.printing-press.json
+++ b/library/payments/kalshi/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "kalshi",
   "display_name": "Kalshi Trade Manual",
   "cli_name": "kalshi-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:dfcfa4e1d9ee14ad69c5c68f2407b132684c306616c62a0de7935250a15bac80",
   "run_id": "20260504-204550",

--- a/library/payments/mercury/.printing-press.json
+++ b/library/payments/mercury/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "mercury",
   "display_name": "Mercury",
   "cli_name": "mercury-pp-cli",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:635273f9f79349e3e3e39690d47215bdd1611ccd31f146e39f70b807a7487c29",
   "run_id": "20260506-161557",

--- a/library/productivity/cal-com/.printing-press.json
+++ b/library/productivity/cal-com/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "cal-com",
   "display_name": "Cal.com",
   "cli_name": "cal-com-pp-cli",
+  "printer": "tmchow",
+  "printer_name": "Trevin Chow",
   "spec_path": "/Users/tmchow/printing-press/.runstate/calm-scribbling-glacier-fb2ca6fd/runs/20260504-205634/research/cal-com-openapi-enriched.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:569c5b2d8a7bf1efa931662520f6153f0f0904528b2bc73e00cd4a1fe8240e22",

--- a/library/productivity/slack/.printing-press.json
+++ b/library/productivity/slack/.printing-press.json
@@ -1,6 +1,8 @@
 {
   "api_name": "slack",
   "cli_name": "slack-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "printing_press_version": "1.2.1",
   "generated_at": "2026-04-09T23:03:49Z",
   "spec_source": "internal-yaml",

--- a/library/project-management/linear/.printing-press.json
+++ b/library/project-management/linear/.printing-press.json
@@ -5,6 +5,8 @@
   "api_name": "linear",
   "display_name": "Linear",
   "cli_name": "linear-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_url": "https://github.com/linear/linear/blob/master/packages/sdk/src/schema.graphql",
   "run_id": "20260507-000328",
   "mcp_binary": "linear-pp-mcp",

--- a/library/sales-and-crm/contact-goat/.printing-press.json
+++ b/library/sales-and-crm/contact-goat/.printing-press.json
@@ -4,6 +4,8 @@
   "printing_press_version": "1.3.2",
   "api_name": "contact-goat",
   "cli_name": "contact-goat-pp-cli",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "category": "sales-and-crm",
   "description": "Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has.",
   "mcp_binary": "contact-goat-pp-mcp",

--- a/library/travel/airbnb/.printing-press.json
+++ b/library/travel/airbnb/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Airbnb Vrbo",
   "cli_name": "airbnb-pp-cli",
   "owner": "matt-van-horn",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_path": "/Users/mvanhorn/printing-press/.runstate/mvanhorn-eb6a05f2/runs/20260502-210359/discovery/airbnb-vrbo-synthetic-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:50d48d1dd906565680c69eb5cffda6d7d605d751410e83368790efcca48bae04",

--- a/library/travel/flight-goat/.printing-press.json
+++ b/library/travel/flight-goat/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Flight GOAT",
   "cli_name": "flight-goat-pp-cli",
   "owner": "matt-van-horn",
+  "printer": "mvanhorn",
+  "printer_name": "Matt Van Horn",
   "spec_path": "/Users/tmchow/Code/printing-press-library/library/travel/flight-goat/spec.yaml",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:94fe4ec3b81edf5bb13ecf259afde3f7f17a83af4d6feb3cba28a51385009e4c",

--- a/library/travel/seats-aero/.printing-press.json
+++ b/library/travel/seats-aero/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Seats Aero Partner",
   "cli_name": "seats-aero-pp-cli",
   "owner": "cathryn-lavery",
+  "printer": "cathrynlavery",
+  "printer_name": "Cathryn Lavery",
   "spec_url": "https://developers.seats.aero/reference",
   "spec_path": "/Users/knox/Developer/PrintingPress/seats-specs/seats-aero-openapi.yaml",
   "spec_format": "openapi3",

--- a/library/travel/wanderlust-goat/.printing-press.json
+++ b/library/travel/wanderlust-goat/.printing-press.json
@@ -6,6 +6,8 @@
   "display_name": "Wanderlust GOAT",
   "cli_name": "wanderlust-goat-pp-cli",
   "owner": "joe-heitzeberg",
+  "printer": "jheitzeb",
+  "printer_name": "Joe Heitzeberg",
   "spec_path": "/Users/joeheitzeberg/printing-press/.runstate/cli-printing-press-5f1d6c25/runs/20260507-163338/research/wanderlust-goat-spec.yaml",
   "spec_format": "internal",
   "spec_checksum": "sha256:06eef0b93df219981e2c1d36f44a172b975613352b591672ed3c5959705ae62b",


### PR DESCRIPTION
Closes [mvanhorn/cli-printing-press#752](https://github.com/mvanhorn/cli-printing-press/issues/752). Adds `printer` (GitHub @handle) and `printer_name` (display name) to every `library/<cat>/<api>/.printing-press.json`.

Once [#313](https://github.com/mvanhorn/printing-press-library/pull/313) and [mvanhorn/cli-printing-press#748](https://github.com/mvanhorn/cli-printing-press/pull/748) merge, the post-merge `generate-registry.yml` workflow will regenerate `registry.json` and the root README catalog with attribution rows like `Printed by [@handle](https://github.com/handle)`.

## Method

For each of the 55 CLIs, the printer was identified by the **earliest `feat(<api>): add <api>` PR commit**, cross-referenced across all historical paths the CLI lived under (so renames like `flightgoat -> flight-goat` and category moves like `commerce/dominos -> food-and-dining/dominos` do not obscure the original printer). PR-author @handles came from the GitHub noreply email on the commit, or `gh api .../pulls` for non-noreply commits. For CLIs already in `tools/sweep-canonical/main.go`'s curated `cliAuthorByAPIName` map (47 entries), the curated display name was preferred when it agreed with the PR-author signal.

The hard rule from #752 was followed: **no operator `git config` was used as the source for any printer value.**

## One mis-claim corrected

`food-and-dining/dominos`: curated map says "Trevin Chow", but earliest commit was Matt's `feat(dominos): add dominos-pp-cli` (PR #8 by `mvanhorn`). Matt's local manuscripts archive records a 2026-04-26 print run (run-state `mvanhorn-eb6a05f2`). Trevin's later "comprehensive rework" PR #248 does not change original-printer attribution per the single-string `printer` rule shipped in mvanhorn/cli-printing-press#748.

This PR sets `printer: mvanhorn` and `printer_name: Matt Van Horn` on dominos. **The dominos SKILL.md `author:` field still reads "Trevin Chow"** via the curated map in `tools/sweep-canonical/main.go:107` — that's a separate field and a separate fix, deferred so this PR stays scoped to the printer field.

## Not mis-claims (intentionally Trevin's despite earlier hnshah commits)

`pokeapi` and `open-meteo` had earlier `add(<api>)` commits by hnshah, but per [Trevin's own audit in PR #180](https://github.com/mvanhorn/printing-press-library/pull/180), both were comprehensively regenerated-from-scratch by Trevin (pokeapi in #158, open-meteo in #211). Confirmed via current `Copyright trevin-chow` headers.

## Six attributions added (not previously in curated map)

| CLI | Printer | Source |
|---|---|---|
| cloud-run-admin | @cathrynlavery | PR #279 |
| clarity | @cathrynlavery | PR #301 |
| google-ads | @cathrynlavery | PR #274 |
| customer-io | @tmchow | PR #278 |
| redfin | @rderwin | PR #245 |
| ufo-goat | @davemorin | PR #302 |
| wanderlust-goat | @jheitzeb | PR #282 |

## Final attribution distribution

| Printer | @handle | Count | Delta vs curated map |
|---|---|---|---|
| Matt Van Horn | @mvanhorn | 12 | +1 (dominos flipped from Trevin) |
| Trevin Chow | @tmchow | 20 | -1 (dominos) |
| Cathryn Lavery | @cathrynlavery | 12 | +3 (clarity, cloud-run-admin, google-ads) |
| Hiten Shah | @hnshah | 6 | unchanged |
| Adrian Horning | @adrianhorning08 | 1 | unchanged |
| rderwin | @rderwin | 2 | +1 (redfin) |
| Dave Morin | @davemorin | 1 | new |
| Joe Heitzeberg | @jheitzeb | 1 | new |

## Diff shape

110 lines added, 0 deleted, across 55 files. Every file gets exactly two new lines inserted after the `owner` field (or `cli_name` if no `owner`). The backfill script preserves each manifest's existing key ordering and em-dash encoding byte-for-byte. Re-running the script is a no-op (idempotent).

## Test plan

- [x] All 55 manifests parse as valid JSON post-backfill
- [x] Re-running the backfill script produces zero diff (idempotent)
- [x] Locally rendered `tools/generate-registry` (with #313's changes) produces catalog rows with `Printed by [@handle](...)` for every entry
- [ ] After #313 merges, the post-merge `generate-registry.yml` workflow regenerates `registry.json` + root `README.md` with attribution surfaces

## Known follow-up (deferred to keep this PR scoped)

`tools/sweep-canonical/main.go:107` still has `"dominos": "Trevin Chow"`. Flipping that to `"Matt Van Horn"` plus running the sweep to update `library/food-and-dining/dominos/SKILL.md`'s `author:` field is the corollary of the printer-side fix. Same pattern for the 7 newly-attributed CLIs that aren't in the curated map yet.