### PR TITLE
feat(marginalrevolution): add marginalrevolution

### DIFF
--- a/cli-skills/pp-marginalrevolution/SKILL.md
+++ b/cli-skills/pp-marginalrevolution/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pp-marginalrevolution
+description: "Marginal Revolution from your terminal via the public RSS feed. Trigger phrases: `check marginal revolution`, `search marginal revolution`, `latest MR posts`, `marginal revolution links`, `use marginalrevolution`, `run marginalrevolution`."
+author: "Nuri Chang"
+license: "Apache-2.0"
+argument-hint: "<command> [args] | install cli"
+allowed-tools: "Read Bash"
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - marginalrevolution-pp-cli
+    install:
+      - kind: go
+        bins: [marginalrevolution-pp-cli]
+        module: github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli
+---
+
+# Marginal Revolution - Printing Press CLI
+
+## Prerequisites: Install the CLI
+
+This skill drives the `marginalrevolution-pp-cli` binary. Verify it is installed before invoking commands:
+
+```bash
+marginalrevolution-pp-cli --version
+```
+
+If missing, install it:
+
+```bash
+npx -y @mvanhorn/printing-press install marginalrevolution --cli-only
+```
+
+Fallback direct install:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli@latest
+```
+
+## When to Use This CLI
+
+Use this CLI when you need recent Marginal Revolution posts in structured form, including author/category filtering, recent-feed search, post text, comment counts, and outbound links.
+
+## When Not to Use This CLI
+
+Do not use it for full historical archive search. The command-line-safe surface is the public RSS feed, so `search` is intentionally scoped to posts currently present in that feed.
+
+## Command Reference
+
+- `marginalrevolution-pp-cli latest --limit 10 --json` - list recent posts
+- `marginalrevolution-pp-cli latest --author Tyler --category Economics` - filter recent posts
+- `marginalrevolution-pp-cli search "ai" --agent` - search current feed title/body/category text
+- `marginalrevolution-pp-cli read <url|guid|title>` - read a current-feed post
+- `marginalrevolution-pp-cli links --limit 5` - extract outbound links from recent posts
+- `marginalrevolution-pp-cli categories` - show category counts in the current feed
+- `marginalrevolution-pp-cli authors` - show author counts in the current feed
+- `marginalrevolution-pp-cli doctor --json` - verify RSS feed reachability
+- `marginalrevolution-pp-cli which "<capability>"` - choose a command from a plain-language request
+
+## Recipes
+
+### Get the latest posts for an agent
+
+```bash
+marginalrevolution-pp-cli latest --limit 5 --agent
+```
+
+### Find recent posts mentioning AI
+
+```bash
+marginalrevolution-pp-cli search "ai" --agent
+```
+
+### Extract cited links for follow-up reading
+
+```bash
+marginalrevolution-pp-cli links --limit 3 --json
+```

--- a/library/media-and-entertainment/marginalrevolution/.goreleaser.yaml
+++ b/library/media-and-entertainment/marginalrevolution/.goreleaser.yaml
@@ -1,0 +1,36 @@
+version: 2
+project_name: marginalrevolution-pp-cli
+changelog:
+  disable: true
+builds:
+  - id: marginalrevolution-pp-cli
+    main: ./cmd/marginalrevolution-pp-cli
+    binary: marginalrevolution-pp-cli
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/internal/cli.version={{ .Version }}
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_amd64
+      - linux_arm64
+      - windows_amd64
+      - windows_arm64
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+checksum:
+  name_template: checksums.txt
+brews:
+  - name: marginalrevolution-pp-cli
+    repository:
+      owner: hinuri
+      name: homebrew-tap
+    homepage: "https://github.com/mvanhorn/printing-press-library"
+    description: "Read, filter, and extract links from Marginal Revolution through its public RSS feed"
+    install: |
+      bin.install "marginalrevolution-pp-cli"

--- a/library/media-and-entertainment/marginalrevolution/.printing-press.json
+++ b/library/media-and-entertainment/marginalrevolution/.printing-press.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-09T16:02:27Z",
+  "printing_press_version": "3.9.0",
+  "api_name": "marginalrevolution",
+  "display_name": "Marginal Revolution",
+  "cli_name": "marginalrevolution-pp-cli",
+  "printer": "hinuri",
+  "printer_name": "Nuri Chang",
+  "spec_format": "internal",
+  "run_id": "20260509-160227",
+  "description": "Read, filter, and extract links from Marginal Revolution through its public RSS feed",
+  "auth_type": "none",
+  "novel_features": [
+    {
+      "name": "Recent-feed search",
+      "command": "search",
+      "description": "Search the current public RSS feed by title, excerpt, body text, author, and category."
+    },
+    {
+      "name": "Outbound link extraction",
+      "command": "links",
+      "description": "Extract external links from recent posts so agents can quickly follow cited sources."
+    },
+    {
+      "name": "Feed taxonomy scan",
+      "command": "categories",
+      "description": "Summarize category counts in the current feed for quick topical orientation."
+    }
+  ]
+}

--- a/library/media-and-entertainment/marginalrevolution/AGENTS.md
+++ b/library/media-and-entertainment/marginalrevolution/AGENTS.md
@@ -1,0 +1,26 @@
+# Marginal Revolution Printed CLI Agent Guide
+
+This directory contains the `marginalrevolution-pp-cli` printed CLI. It follows the published-library layout used by other Printing Press CLIs, with a read-only surface backed by Marginal Revolution's public RSS feed.
+
+## Local Operating Contract
+
+Start by asking the CLI for current runtime truth:
+
+```bash
+marginalrevolution-pp-cli doctor --json
+```
+
+Use runtime discovery before assuming a command shape:
+
+```bash
+marginalrevolution-pp-cli which "<capability>"
+marginalrevolution-pp-cli <command> --help
+```
+
+Add `--agent` to command invocations for JSON output:
+
+```bash
+marginalrevolution-pp-cli latest --agent
+```
+
+The normal site search and WordPress JSON endpoints may present Cloudflare browser challenges to non-browser clients. Keep automated workflows on the RSS-backed commands unless a future patch adds a verified browser-capable transport.

--- a/library/media-and-entertainment/marginalrevolution/LICENSE
+++ b/library/media-and-entertainment/marginalrevolution/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 trevin-chow
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/library/media-and-entertainment/marginalrevolution/Makefile
+++ b/library/media-and-entertainment/marginalrevolution/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test doctor
+
+build:
+	go build ./cmd/marginalrevolution-pp-cli
+
+test:
+	go test ./...
+
+doctor:
+	go run ./cmd/marginalrevolution-pp-cli doctor --json

--- a/library/media-and-entertainment/marginalrevolution/NOTICE
+++ b/library/media-and-entertainment/marginalrevolution/NOTICE
@@ -1,0 +1,4 @@
+marginalrevolution-pp-cli
+Copyright 2026 hinuri
+
+This CLI was created for the Printing Press published library.

--- a/library/media-and-entertainment/marginalrevolution/README.md
+++ b/library/media-and-entertainment/marginalrevolution/README.md
@@ -1,0 +1,32 @@
+# Marginal Revolution CLI
+
+`marginalrevolution-pp-cli` reads Marginal Revolution through its public RSS feed. It is read-only, unauthenticated, and useful for agent workflows that need recent posts, authors, categories, comment counts, and outbound links without browser automation.
+
+## Install
+
+```bash
+npx -y @mvanhorn/printing-press install marginalrevolution --cli-only
+```
+
+Direct Go install:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli@latest
+```
+
+## Commands
+
+```bash
+marginalrevolution-pp-cli latest --limit 5
+marginalrevolution-pp-cli latest --author Tyler --json
+marginalrevolution-pp-cli search "ai" --category Web/Tech --agent
+marginalrevolution-pp-cli read "self-fulfilling-misalignment"
+marginalrevolution-pp-cli links --limit 3
+marginalrevolution-pp-cli categories
+marginalrevolution-pp-cli authors
+marginalrevolution-pp-cli doctor --json
+```
+
+## Notes
+
+Marginal Revolution's public RSS feed is available at `https://marginalrevolution.com/feed`. The normal WordPress JSON and site-search endpoints can return Cloudflare browser challenges to command-line clients, so this CLI intentionally keeps search scoped to the current feed.

--- a/library/media-and-entertainment/marginalrevolution/SKILL.md
+++ b/library/media-and-entertainment/marginalrevolution/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pp-marginalrevolution
+description: "Marginal Revolution from your terminal via the public RSS feed. Trigger phrases: `check marginal revolution`, `search marginal revolution`, `latest MR posts`, `marginal revolution links`, `use marginalrevolution`, `run marginalrevolution`."
+author: "Nuri Chang"
+license: "Apache-2.0"
+argument-hint: "<command> [args] | install cli"
+allowed-tools: "Read Bash"
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - marginalrevolution-pp-cli
+    install:
+      - kind: go
+        bins: [marginalrevolution-pp-cli]
+        module: github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli
+---
+
+# Marginal Revolution - Printing Press CLI
+
+## Prerequisites: Install the CLI
+
+This skill drives the `marginalrevolution-pp-cli` binary. Verify it is installed before invoking commands:
+
+```bash
+marginalrevolution-pp-cli --version
+```
+
+If missing, install it:
+
+```bash
+npx -y @mvanhorn/printing-press install marginalrevolution --cli-only
+```
+
+Fallback direct install:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli@latest
+```
+
+## When to Use This CLI
+
+Use this CLI when you need recent Marginal Revolution posts in structured form, including author/category filtering, recent-feed search, post text, comment counts, and outbound links.
+
+## When Not to Use This CLI
+
+Do not use it for full historical archive search. The command-line-safe surface is the public RSS feed, so `search` is intentionally scoped to posts currently present in that feed.
+
+## Command Reference
+
+- `marginalrevolution-pp-cli latest --limit 10 --json` - list recent posts
+- `marginalrevolution-pp-cli latest --author Tyler --category Economics` - filter recent posts
+- `marginalrevolution-pp-cli search "ai" --agent` - search current feed title/body/category text
+- `marginalrevolution-pp-cli read <url|guid|title>` - read a current-feed post
+- `marginalrevolution-pp-cli links --limit 5` - extract outbound links from recent posts
+- `marginalrevolution-pp-cli categories` - show category counts in the current feed
+- `marginalrevolution-pp-cli authors` - show author counts in the current feed
+- `marginalrevolution-pp-cli doctor --json` - verify RSS feed reachability
+- `marginalrevolution-pp-cli which "<capability>"` - choose a command from a plain-language request
+
+## Recipes
+
+### Get the latest posts for an agent
+
+```bash
+marginalrevolution-pp-cli latest --limit 5 --agent
+```
+
+### Find recent posts mentioning AI
+
+```bash
+marginalrevolution-pp-cli search "ai" --agent
+```
+
+### Extract cited links for follow-up reading
+
+```bash
+marginalrevolution-pp-cli links --limit 3 --json
+```

--- a/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli/main.go
+++ b/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/internal/cli"
+)
+
+func main() {
+	if err := cli.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/library/media-and-entertainment/marginalrevolution/go.mod
+++ b/library/media-and-entertainment/marginalrevolution/go.mod
@@ -1,0 +1,10 @@
+module github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution
+
+go 1.26.3
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/library/media-and-entertainment/marginalrevolution/go.sum
+++ b/library/media-and-entertainment/marginalrevolution/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/library/media-and-entertainment/marginalrevolution/internal/cli/root.go
+++ b/library/media-and-entertainment/marginalrevolution/internal/cli/root.go
@@ -1,0 +1,281 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/internal/mr"
+	"github.com/spf13/cobra"
+)
+
+var version = "1.0.0"
+
+type rootFlags struct {
+	json    bool
+	plain   bool
+	agent   bool
+	timeout time.Duration
+	limit   int
+}
+
+func Execute() error {
+	return RootCmd().Execute()
+}
+
+func RootCmd() *cobra.Command {
+	flags := &rootFlags{}
+	cmd := &cobra.Command{
+		Use:   "marginalrevolution-pp-cli",
+		Short: "Read and filter Marginal Revolution from its public RSS feed",
+		Long: `Read and filter Marginal Revolution from its public RSS feed.
+
+The feed endpoint is stable and does not require authentication. The normal
+site search and WordPress JSON endpoints may present Cloudflare challenges to
+non-browser clients, so this CLI keeps searches bounded to the current feed.`,
+		SilenceUsage: true,
+		Version:      version,
+	}
+	cmd.SetVersionTemplate("marginalrevolution-pp-cli {{ .Version }}\n")
+	cmd.PersistentFlags().BoolVar(&flags.json, "json", false, "Output JSON")
+	cmd.PersistentFlags().BoolVar(&flags.plain, "plain", false, "Output tab-separated plain text")
+	cmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Agent defaults: --json and non-interactive behavior")
+	cmd.PersistentFlags().DurationVar(&flags.timeout, "timeout", 20*time.Second, "HTTP request timeout")
+	cmd.PersistentFlags().IntVar(&flags.limit, "limit", 10, "Maximum posts to return")
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if flags.agent {
+			flags.json = true
+		}
+	}
+
+	cmd.AddCommand(newLatestCmd(flags))
+	cmd.AddCommand(newSearchCmd(flags))
+	cmd.AddCommand(newReadCmd(flags))
+	cmd.AddCommand(newCategoriesCmd(flags))
+	cmd.AddCommand(newAuthorsCmd(flags))
+	cmd.AddCommand(newLinksCmd(flags))
+	cmd.AddCommand(newDoctorCmd(flags))
+	cmd.AddCommand(newWhichCmd())
+	return cmd
+}
+
+func newLatestCmd(flags *rootFlags) *cobra.Command {
+	var author, category string
+	cmd := &cobra.Command{
+		Use:   "latest",
+		Short: "List recent Marginal Revolution posts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			return printItems(cmd, flags, mr.Filter(feed.Items, "", author, category, flags.limit))
+		},
+	}
+	cmd.Flags().StringVar(&author, "author", "", "Filter by author name")
+	cmd.Flags().StringVar(&category, "category", "", "Filter by category")
+	return cmd
+}
+
+func newSearchCmd(flags *rootFlags) *cobra.Command {
+	var author, category string
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search titles and body text in the current RSS feed",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			return printItems(cmd, flags, mr.Filter(feed.Items, args[0], author, category, flags.limit))
+		},
+	}
+	cmd.Flags().StringVar(&author, "author", "", "Filter by author name")
+	cmd.Flags().StringVar(&category, "category", "", "Filter by category")
+	return cmd
+}
+
+func newReadCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "read <url|guid|title>",
+		Short: "Read a post currently present in the RSS feed",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			item, ok := mr.Find(feed.Items, args[0])
+			if !ok {
+				return fmt.Errorf("post not found in current feed: %s", args[0])
+			}
+			return printJSONOrText(cmd, flags, item, func() {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\n%s\n%s\n\n%s\n", item.Title, item.Author, item.Link, item.ContentText)
+			})
+		},
+	}
+}
+
+func newCategoriesCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "categories",
+		Short: "Show category counts in the current feed",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			return printJSONOrTable(cmd, flags, mr.SortedCounts(mr.CategoryCounts(feed.Items)))
+		},
+	}
+}
+
+func newAuthorsCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "authors",
+		Short: "Show author counts in the current feed",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			return printJSONOrTable(cmd, flags, mr.SortedCounts(mr.AuthorCounts(feed.Items)))
+		},
+	}
+}
+
+func newLinksCmd(flags *rootFlags) *cobra.Command {
+	var query string
+	return &cobra.Command{
+		Use:   "links",
+		Short: "Extract outbound links from recent posts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			items := mr.Filter(feed.Items, query, "", "", flags.limit)
+			type row struct {
+				PostTitle string `json:"post_title"`
+				Text      string `json:"text,omitempty"`
+				URL       string `json:"url"`
+			}
+			var rows []row
+			for _, item := range items {
+				for _, link := range item.Links {
+					if strings.Contains(link.URL, "marginalrevolution.com") {
+						continue
+					}
+					rows = append(rows, row{PostTitle: item.Title, Text: link.Text, URL: link.URL})
+				}
+			}
+			return printJSONOrText(cmd, flags, rows, func() {
+				w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "POST\tTEXT\tURL")
+				for _, row := range rows {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", row.PostTitle, row.Text, row.URL)
+				}
+				w.Flush()
+			})
+		},
+	}
+}
+
+func newDoctorCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Check RSS feed reachability",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			feed, err := loadFeed(cmd.Context(), flags)
+			if err != nil {
+				return err
+			}
+			result := map[string]any{
+				"ok":         true,
+				"feed_url":   mr.FeedURL,
+				"title":      feed.Title,
+				"item_count": len(feed.Items),
+				"last_build": feed.LastBuild,
+			}
+			return printJSONOrText(cmd, flags, result, func() {
+				fmt.Fprintf(cmd.OutOrStdout(), "ok: %d items from %s\n", len(feed.Items), mr.FeedURL)
+			})
+		},
+	}
+}
+
+func newWhichCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "which <capability>",
+		Short: "Suggest the best Marginal Revolution command for a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.ToLower(args[0])
+			switch {
+			case strings.Contains(query, "link"):
+				fmt.Fprintln(cmd.OutOrStdout(), "links")
+			case strings.Contains(query, "category"):
+				fmt.Fprintln(cmd.OutOrStdout(), "categories")
+			case strings.Contains(query, "author") || strings.Contains(query, "tyler") || strings.Contains(query, "alex"):
+				fmt.Fprintln(cmd.OutOrStdout(), "authors or latest --author <name>")
+			case strings.Contains(query, "search") || strings.Contains(query, "find"):
+				fmt.Fprintln(cmd.OutOrStdout(), "search <query>")
+			case strings.Contains(query, "read"):
+				fmt.Fprintln(cmd.OutOrStdout(), "read <url|guid|title>")
+			default:
+				fmt.Fprintln(cmd.OutOrStdout(), "latest")
+			}
+			return nil
+		},
+	}
+}
+
+func loadFeed(ctx context.Context, flags *rootFlags) (mr.Feed, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return mr.Fetch(ctx, flags.timeout)
+}
+
+func printItems(cmd *cobra.Command, flags *rootFlags, items []mr.Item) error {
+	return printJSONOrText(cmd, flags, items, func() {
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "DATE\tAUTHOR\tCOMMENTS\tTITLE\tURL")
+		for _, item := range items {
+			date := ""
+			if !item.Published.IsZero() {
+				date = item.Published.Format("2006-01-02")
+			}
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", date, item.Author, item.CommentCount, item.Title, item.Link)
+		}
+		w.Flush()
+	})
+}
+
+func printJSONOrTable(cmd *cobra.Command, flags *rootFlags, rows []struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}) error {
+	return printJSONOrText(cmd, flags, rows, func() {
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tCOUNT")
+		for _, row := range rows {
+			fmt.Fprintf(w, "%s\t%d\n", row.Name, row.Count)
+		}
+		w.Flush()
+	})
+}
+
+func printJSONOrText(cmd *cobra.Command, flags *rootFlags, value any, printText func()) error {
+	if flags.json {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(value)
+	}
+	printText()
+	return nil
+}

--- a/library/media-and-entertainment/marginalrevolution/internal/mr/feed.go
+++ b/library/media-and-entertainment/marginalrevolution/internal/mr/feed.go
@@ -1,0 +1,291 @@
+package mr
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const FeedURL = "https://marginalrevolution.com/feed"
+
+type Feed struct {
+	Title       string    `json:"title"`
+	Link        string    `json:"link"`
+	Description string    `json:"description"`
+	LastBuild   time.Time `json:"last_build,omitempty"`
+	Items       []Item    `json:"items"`
+}
+
+type Item struct {
+	Title        string    `json:"title"`
+	Link         string    `json:"link"`
+	Author       string    `json:"author,omitempty"`
+	Published    time.Time `json:"published,omitempty"`
+	Categories   []string  `json:"categories,omitempty"`
+	GUID         string    `json:"guid,omitempty"`
+	CommentsURL  string    `json:"comments_url,omitempty"`
+	CommentFeed  string    `json:"comment_feed,omitempty"`
+	CommentCount int       `json:"comment_count,omitempty"`
+	Summary      string    `json:"summary,omitempty"`
+	ContentText  string    `json:"content_text,omitempty"`
+	Links        []Link    `json:"links,omitempty"`
+}
+
+type Link struct {
+	Text string `json:"text,omitempty"`
+	URL  string `json:"url"`
+}
+
+type rawRSS struct {
+	Channel rawChannel `xml:"channel"`
+}
+
+type rawChannel struct {
+	Title       string    `xml:"title"`
+	Link        string    `xml:"link"`
+	Description string    `xml:"description"`
+	LastBuild   string    `xml:"lastBuildDate"`
+	Items       []rawItem `xml:"item"`
+}
+
+type rawItem struct {
+	Title       string   `xml:"title"`
+	Link        string   `xml:"link"`
+	Comments    []string `xml:"comments"`
+	Creator     string   `xml:"http://purl.org/dc/elements/1.1/ creator"`
+	PubDate     string   `xml:"pubDate"`
+	Categories  []string `xml:"category"`
+	GUID        string   `xml:"guid"`
+	Description string   `xml:"description"`
+	Content     string   `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
+	CommentFeed string   `xml:"http://wellformedweb.org/CommentAPI/ commentRss"`
+}
+
+func Fetch(ctx context.Context, timeout time.Duration) (Feed, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, FeedURL, nil)
+	if err != nil {
+		return Feed{}, err
+	}
+	req.Header.Set("Accept", "application/rss+xml, application/xml;q=0.9, */*;q=0.8")
+	req.Header.Set("User-Agent", "marginalrevolution-pp-cli/1.0")
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Feed{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Feed{}, fmt.Errorf("feed returned HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Feed{}, err
+	}
+
+	var raw rawRSS
+	if err := xml.Unmarshal(body, &raw); err != nil {
+		return Feed{}, fmt.Errorf("parsing RSS: %w", err)
+	}
+
+	build, _ := parseRSSDate(raw.Channel.LastBuild)
+	feed := Feed{
+		Title:       strings.TrimSpace(raw.Channel.Title),
+		Link:        strings.TrimSpace(raw.Channel.Link),
+		Description: strings.TrimSpace(raw.Channel.Description),
+		LastBuild:   build,
+	}
+	for _, item := range raw.Channel.Items {
+		published, _ := parseRSSDate(item.PubDate)
+		content := cleanHTML(item.Content)
+		summary := cleanHTML(item.Description)
+		commentsURL, commentCount := splitComments(item.Comments)
+		feed.Items = append(feed.Items, Item{
+			Title:        strings.TrimSpace(item.Title),
+			Link:         stripTracking(strings.TrimSpace(item.Link)),
+			Author:       strings.TrimSpace(item.Creator),
+			Published:    published,
+			Categories:   cleanStrings(item.Categories),
+			GUID:         strings.TrimSpace(item.GUID),
+			CommentsURL:  commentsURL,
+			CommentFeed:  strings.TrimSpace(item.CommentFeed),
+			CommentCount: commentCount,
+			Summary:      summary,
+			ContentText:  content,
+			Links:        extractLinks(item.Content),
+		})
+	}
+	return feed, nil
+}
+
+func splitComments(values []string) (string, int) {
+	var commentsURL string
+	var commentCount int
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+			commentsURL = value
+			continue
+		}
+		if n, err := strconv.Atoi(value); err == nil {
+			commentCount = n
+		}
+	}
+	return commentsURL, commentCount
+}
+
+func Filter(items []Item, query, author, category string, limit int) []Item {
+	query = strings.ToLower(strings.TrimSpace(query))
+	author = strings.ToLower(strings.TrimSpace(author))
+	category = strings.ToLower(strings.TrimSpace(category))
+	var out []Item
+	for _, item := range items {
+		if query != "" {
+			haystack := strings.ToLower(item.Title + "\n" + item.Summary + "\n" + item.ContentText + "\n" + strings.Join(item.Categories, " "))
+			if !strings.Contains(haystack, query) {
+				continue
+			}
+		}
+		if author != "" && !strings.Contains(strings.ToLower(item.Author), author) {
+			continue
+		}
+		if category != "" && !hasCategory(item.Categories, category) {
+			continue
+		}
+		out = append(out, item)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func CategoryCounts(items []Item) map[string]int {
+	counts := map[string]int{}
+	for _, item := range items {
+		for _, category := range item.Categories {
+			counts[category]++
+		}
+	}
+	return counts
+}
+
+func AuthorCounts(items []Item) map[string]int {
+	counts := map[string]int{}
+	for _, item := range items {
+		if item.Author != "" {
+			counts[item.Author]++
+		}
+	}
+	return counts
+}
+
+func SortedCounts(counts map[string]int) []struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+} {
+	out := make([]struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}, 0, len(counts))
+	for name, count := range counts {
+		out = append(out, struct {
+			Name  string `json:"name"`
+			Count int    `json:"count"`
+		}{Name: name, Count: count})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count == out[j].Count {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}
+
+func Find(items []Item, needle string) (Item, bool) {
+	needle = strings.TrimSpace(needle)
+	for _, item := range items {
+		if item.Link == needle || item.GUID == needle || strings.EqualFold(item.Title, needle) {
+			return item, true
+		}
+		if strings.Contains(strings.ToLower(item.Link), strings.ToLower(needle)) {
+			return item, true
+		}
+	}
+	return Item{}, false
+}
+
+func parseRSSDate(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC1123Z, value); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC1123, value)
+}
+
+func hasCategory(categories []string, needle string) bool {
+	for _, category := range categories {
+		if strings.Contains(strings.ToLower(category), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+var (
+	linkRE  = regexp.MustCompile(`(?is)<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)</a>`)
+	tagRE   = regexp.MustCompile(`(?is)<[^>]+>`)
+	spaceRE = regexp.MustCompile(`\s+`)
+)
+
+func cleanHTML(value string) string {
+	value = strings.ReplaceAll(value, "\u00a0", " ")
+	value = tagRE.ReplaceAllString(value, " ")
+	value = html.UnescapeString(value)
+	return strings.TrimSpace(spaceRE.ReplaceAllString(value, " "))
+}
+
+func extractLinks(value string) []Link {
+	matches := linkRE.FindAllStringSubmatch(value, -1)
+	links := make([]Link, 0, len(matches))
+	seen := map[string]bool{}
+	for _, match := range matches {
+		url := stripTracking(strings.TrimSpace(html.UnescapeString(match[1])))
+		if url == "" || seen[url] {
+			continue
+		}
+		seen[url] = true
+		links = append(links, Link{Text: cleanHTML(match[2]), URL: url})
+	}
+	return links
+}
+
+func stripTracking(raw string) string {
+	if idx := strings.Index(raw, "?utm_"); idx >= 0 {
+		return raw[:idx]
+	}
+	return strings.ReplaceAll(raw, "&#038;", "&")
+}

--- a/library/media-and-entertainment/marginalrevolution/internal/mr/feed_test.go
+++ b/library/media-and-entertainment/marginalrevolution/internal/mr/feed_test.go
@@ -1,0 +1,48 @@
+package mr
+
+import "testing"
+
+func TestFilterMatchesTitleBodyAuthorAndCategory(t *testing.T) {
+	items := []Item{
+		{
+			Title:       "Assorted links",
+			Author:      "Tyler Cowen",
+			Categories:  []string{"Economics", "Web/Tech"},
+			ContentText: "An item about productivity and institutions.",
+		},
+		{
+			Title:       "Book notes",
+			Author:      "Alex Tabarrok",
+			Categories:  []string{"Books"},
+			ContentText: "A paragraph about history.",
+		},
+	}
+
+	got := Filter(items, "institutions", "tyler", "economics", 10)
+	if len(got) != 1 || got[0].Title != "Assorted links" {
+		t.Fatalf("unexpected filter result: %#v", got)
+	}
+}
+
+func TestSortedCountsOrdersByCountThenName(t *testing.T) {
+	got := SortedCounts(map[string]int{"Books": 1, "Economics": 2, "Data Source": 2})
+	if got[0].Name != "Data Source" || got[1].Name != "Economics" || got[2].Name != "Books" {
+		t.Fatalf("unexpected order: %#v", got)
+	}
+}
+
+func TestFindMatchesURLGuidTitleAndSlug(t *testing.T) {
+	item := Item{
+		Title: "Self-fulfilling misalignment?",
+		Link:  "https://marginalrevolution.com/marginalrevolution/2026/05/self-fulfilling-misalignment.html",
+		GUID:  "https://marginalrevolution.com/?p=92970",
+	}
+	items := []Item{item}
+
+	for _, needle := range []string{item.Link, item.GUID, item.Title, "self-fulfilling-misalignment"} {
+		got, ok := Find(items, needle)
+		if !ok || got.Title != item.Title {
+			t.Fatalf("Find(%q) = %#v, %v", needle, got, ok)
+		}
+	}
+}


### PR DESCRIPTION
## marginalrevolution

Read and filter Marginal Revolution from the command line through its public RSS feed.

**API:** marginalrevolution | **Category:** media-and-entertainment | **Press version:** 4.2.1
**Spec:** `library/media-and-entertainment/marginalrevolution/spec.yaml` (`https://marginalrevolution.com/feed`)

### What changed after review

Regenerated the CLI with CLI Printing Press **4.2.1** in response to the review comment. The PR now includes the v4.2 generated scaffold: MCP binary, MCPB manifest, agent-context/profile/deliver/feedback commands, generated cache/store helpers, `idempotent`, runtime Cobra-tree MCP mirror, generated dogfood/workflow reports, and the source OpenAPI spec.

The generated `/feed` wrapper returns the raw RSS XML through the standard v4.2 provenance envelope. A documented local patch layers RSS-native commands on top of that generated base because the useful command-line-safe surface is parsed post data, not raw XML.

### What this CLI does

`marginalrevolution-pp-cli` provides a read-only, no-auth CLI for recent Marginal Revolution posts. It uses the public RSS feed because that endpoint is stable for non-browser clients; direct site search and WordPress JSON endpoints returned Cloudflare browser challenges during implementation.

It supports the workflows an agent needs for current MR monitoring:

- `feed` - generated v4.2 wrapper for the raw public RSS feed
- `latest` - list recent posts with dates, authors, categories, comment counts, and canonical URLs
- `search <query>` - search current-feed title, excerpt, body text, author, and category text
- `read <url|guid|title>` - print the body text for a post currently present in the feed
- `links` - extract outbound cited links from recent posts for follow-up reading
- `categories` - summarize current-feed category counts
- `authors` - summarize current-feed author counts
- `doctor` - verify feed reachability and report generated v4.2 health metadata
- `which` - map a plain-language request to the best command

### Unique capabilities

| Command | What it does | Why it matters |
|---|---|---|
| `links` | Extracts external links from recent MR posts, grouped by source post | Lets agents quickly follow cited papers, essays, and datasets without scraping article HTML |
| `search <query>` | Searches title, summary, full RSS body text, author, and categories in the current feed | Gives a command-line-safe search path when the browser-only site search is Cloudflare challenged |
| `categories` | Counts the taxonomy represented in the live feed | Gives quick topical orientation before deeper reading |
| `read <url|guid|title>` | Resolves a feed item by canonical URL, GUID, exact title, or slug fragment | Lets follow-up prompts use natural identifiers from prior command output |

### Data source and scope

The CLI is intentionally RSS-backed. The public feed returned HTTP 200 and parsed successfully in local validation. The WordPress JSON API and normal site-search URL returned Cloudflare challenge pages from command-line requests, so this first version does not claim full archive search.

This is read-only: no authentication, no mutation commands, and no remote state changes.

### Validation results

| Check | Result |
|---|---|
| Regenerated with Printing Press 4.2.1 | PASS |
| Shipcheck | PASS - 6/6 legs |
| Dogfood | PASS |
| Runtime verify | PASS - 94% pass rate, 16/17 passed, 0 critical |
| workflow-verify | PASS - no workflow manifest, skipped |
| verify-skill | PASS - canonical sections passed |
| validate-narrative | PASS - skipped because no research.json |
| scorecard | PASS - 81/100, Grade A |
| go mod tidy | PASS |
| go test | PASS |
| go vet | PASS |
| govulncheck | PASS - no vulnerabilities found |
| go build | PASS - CLI and MCP binaries |
| verify-manifest | PASS |
| RSS doctor | PASS |
| latest live smoke test | PASS |
| search live smoke test | PASS |
| links live smoke test | PASS |
| categories live smoke test | PASS |
| which live smoke test | PASS |
| cli-skills mirror parity | PASS |
| registry generated-file rule | PASS - `registry.json` intentionally not edited; post-merge generator owns it |

Commands run:

```bash
go run ./cmd/printing-press generate \
  --spec library/media-and-entertainment/marginalrevolution/spec.yaml \
  --name marginalrevolution \
  --output /tmp/codex-oss/fresh-marginalrevolution \
  --owner hinuri \
  --spec-source official \
  --spec-url https://marginalrevolution.com/feed \
  --validate=false

go test ./...
go vet ./...
go run golang.org/x/vuln/cmd/govulncheck@latest ./...
go build ./cmd/marginalrevolution-pp-cli
go build ./cmd/marginalrevolution-pp-mcp
python3 .github/scripts/verify-manifest/verify_manifest.py
go run ./tools/generate-skills/main.go

go run ./cmd/printing-press shipcheck \
  --dir /tmp/codex-oss/printing-press-library/library/media-and-entertainment/marginalrevolution \
  --spec /tmp/codex-oss/printing-press-library/library/media-and-entertainment/marginalrevolution/spec.yaml \
  --no-live-check

go run ./cmd/marginalrevolution-pp-cli doctor --json
go run ./cmd/marginalrevolution-pp-cli latest --limit 2 --json
go run ./cmd/marginalrevolution-pp-cli search ai --agent --limit 2
go run ./cmd/marginalrevolution-pp-cli links --limit 2 --json
go run ./cmd/marginalrevolution-pp-cli categories --json
go run ./cmd/marginalrevolution-pp-cli which links --json
```

### Manuscripts and generated artifacts

- `library/media-and-entertainment/marginalrevolution/spec.yaml`
- `library/media-and-entertainment/marginalrevolution/.printing-press.json`
- `library/media-and-entertainment/marginalrevolution/.printing-press-patches.json`
- `library/media-and-entertainment/marginalrevolution/manifest.json`
- `library/media-and-entertainment/marginalrevolution/dogfood-results.json`
- `library/media-and-entertainment/marginalrevolution/workflow-verify-report.json`
- `library/media-and-entertainment/marginalrevolution/README.md`
- `library/media-and-entertainment/marginalrevolution/SKILL.md`
- `cli-skills/pp-marginalrevolution/SKILL.md`

### Notable carry-forward gaps (not blockers)

1. **Full archive search is deferred.** The command-line-safe source is the RSS feed. Site search and WordPress JSON returned Cloudflare challenges, so claiming archive search would be unreliable.
2. **No historical local corpus yet.** The v4.2 scaffold includes generated store/sync support, but the useful RSS-native workflows are current-feed reads. A later version could add persisted post history if reviewers want parity with larger content CLIs like `hackernews`.
3. **Runtime verify marks `read` dry-run/exec as failed in mock mode.** This is non-critical in shipcheck and the leg still passes. The command requires a real feed item identifier, and live smoke coverage verifies the RSS parser and lookup path.

### CLI Shape (top of `--help`)

```text
Read and filter Marginal Revolution through its public RSS feed.

The feed endpoint is stable and does not require authentication. The normal
site search and WordPress JSON endpoints may present Cloudflare challenges to
non-browser clients, so RSS-native search stays bounded to the current feed.

Add --agent to any command for JSON output + non-interactive mode.
Run 'marginalrevolution-pp-cli doctor' to verify auth and connectivity.

Usage:
  marginalrevolution-pp-cli [command]

Available Commands:
  agent-context Emit structured JSON describing this CLI for agents
  api           Browse all API endpoints by interface name
  authors       Show author counts in the current feed
  categories    Show category counts in the current feed
  completion    Generate the autocompletion script for the specified shell
  doctor        Check CLI health
  export        Export data to JSONL or JSON for backup, migration, or analysis
  feed          Returns the current public RSS feed. The feed is XML/RSS and does not require authentication.
  feedback      Record feedback about this CLI (local by default; upstream opt-in)
  import        Import data from JSONL file via API create/upsert calls
  latest        List recent Marginal Revolution posts
  links         Extract outbound links from recent posts
  profile       Named sets of flags saved for reuse
  read          Read a post currently present in the RSS feed
  search        Search titles and body text in the current RSS feed
  sync          Sync API data to local SQLite for offline search and analysis
  which         Find the command that implements a capability
  workflow      Compound workflows that combine multiple API operations
```
