### PR TITLE
fix(ci): Enforce cli-skills mirror parity in SKILL verification CI

### DIFF
--- a/.github/workflows/verify-skills.yml
+++ b/.github/workflows/verify-skills.yml
@@ -3,16 +3,22 @@ name: Verify SKILL.md
 on:
   pull_request:
     paths:
+      - 'cli-skills/**'
+      - 'library/**/.printing-press.json'
       - 'library/**/SKILL.md'
       - 'library/**/internal/cli/**'
       - '.github/workflows/verify-skills.yml'
       - '.github/scripts/verify-skill/**'
+      - 'tools/generate-skills/**'
   push:
     branches: [main]
     paths:
+      - 'cli-skills/**'
+      - 'library/**/.printing-press.json'
       - 'library/**/SKILL.md'
       - 'library/**/internal/cli/**'
       - '.github/scripts/verify-skill/**'
+      - 'tools/generate-skills/**'
 
 jobs:
   verify:
@@ -30,6 +36,27 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.23'
+
+      - name: Verify cli-skills mirror is generated
+        run: |
+          set -euo pipefail
+          go run ./tools/generate-skills/main.go
+
+          drift=$(git status --porcelain -- cli-skills/)
+          if [ -n "$drift" ]; then
+            echo "::error title=cli-skills mirror is stale::cli-skills/ must be generated from library/<category>/<slug>/SKILL.md. Run \`go run ./tools/generate-skills/main.go\` and commit the generated mirror changes."
+            echo "Out-of-sync cli-skills entries:"
+            echo "$drift"
+            git diff -- cli-skills/
+            exit 1
+          fi
+
+          echo "cli-skills/ matches generated output."
 
       - name: Run verifier against affected CLI skills
         id: verify


### PR DESCRIPTION
## Summary
- Add a PR and push-time `verify-skills` check that regenerates `cli-skills/` from `library/**/SKILL.md`.
- Fail the workflow when the generated mirror differs from the committed tree, so direct edits to `cli-skills/` cannot drift from the library source.
- Extend the workflow triggers to cover `cli-skills/`, library manifests, and the skill generator.

## Testing
- Not run (not requested)
- Existing local validation for the change passed, including generator execution and workflow linting.