### PR TITLE
fix(flight-goat): add currency support

### DIFF
--- a/cli-skills/pp-flight-goat/SKILL.md
+++ b/cli-skills/pp-flight-goat/SKILL.md
@@ -48,6 +48,21 @@ discover.
 - History: Historical flight access for various endpoints
 - Miscellaneous: Flight disruption, future schedule information, and aircraft owner information
 
+## Google Flights Currency
+
+Use `--currency <ISO-4217-code>` when the user wants Google Flights prices in a
+specific currency. Omit it for the default USD behavior.
+
+```bash
+flight-goat-pp-cli flights MAN AGP 2026-05-10 --currency GBP --sort cheapest --agent
+flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --currency EUR --sort --agent
+flight-goat-pp-cli compare SEA LHR 2026-06-15 --currency GBP --agent
+```
+
+The flag is only valid on Google Flights price commands: `flights`, `dates`,
+`compare`, `gf-search`, and `cheapest-longhaul`. Do not add it to AeroAPI or
+Kayak-only commands.
+
 ## Development Tools
 AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
 imported into tools like Postman. To get started try importing the API

--- a/library/travel/flight-goat/.printing-press-patches.json
+++ b/library/travel/flight-goat/.printing-press-patches.json
@@ -4,7 +4,8 @@
   "base_run_id": "2026-05-02T22:09:06.820184Z",
   "base_printing_press_version": "3.6.0",
   "upstream_tracking": [
-    "https://github.com/mvanhorn/printing-press-library/issues/293"
+    "https://github.com/mvanhorn/printing-press-library/issues/293",
+    "https://github.com/mvanhorn/cli-printing-press/issues/804"
   ],
   "patches": [
     {
@@ -16,6 +17,19 @@
       "summary": "Substitute `date_start` and `date_end` into the schedules URL path.",
       "reason": "The promoted schedules shortcut received these values as flags, but AeroAPI defines them as path parameters; sending them as query parameters left literal placeholders in the request URL.",
       "validated_outcome": "go test ./internal/cli -run TestSchedulesDryRunSubstitutesDatePathParams -count=1"
+    },
+    {
+      "id": "804-google-flights-currency",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/804",
+      "files": [
+        "internal/gflights/gflights.go",
+        "internal/gflights/dates_native.go",
+        "internal/cli/primary.go",
+        "internal/cli/transcend.go"
+      ],
+      "summary": "Add command-scoped ISO 4217 currency support for Google Flights price commands.",
+      "reason": "Flight GOAT's Google Flights backend hard-coded USD, so international users could not request native Google Flights prices in their preferred currency.",
+      "validated_outcome": "go test ./...; go build ./...; go vet ./...; govulncheck ./...; python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/flight-goat/"
     }
   ]
 }

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -130,6 +130,22 @@ flight-goat-pp-cli airports get mock-value
 
 Run `flight-goat-pp-cli --help` for the full command reference and flag list.
 
+### Google Flights Currency
+
+Google Flights price commands accept `--currency <ISO-4217-code>` for native
+Google Flights prices in that currency. The default is USD when the flag is
+omitted.
+
+```bash
+flight-goat-pp-cli flights MAN AGP 2026-05-10 --currency GBP --sort cheapest
+flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --currency EUR --sort
+flight-goat-pp-cli compare SEA LHR 2026-06-15 --currency GBP
+```
+
+`--currency` is intentionally command-scoped. It is available on commands that
+ask Google Flights for prices (`flights`, `dates`, `compare`, `gf-search`, and
+`cheapest-longhaul`), not on AeroAPI or Kayak-only commands.
+
 ## Commands
 
 ### aircraft

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -48,6 +48,21 @@ discover.
 - History: Historical flight access for various endpoints
 - Miscellaneous: Flight disruption, future schedule information, and aircraft owner information
 
+## Google Flights Currency
+
+Use `--currency <ISO-4217-code>` when the user wants Google Flights prices in a
+specific currency. Omit it for the default USD behavior.
+
+```bash
+flight-goat-pp-cli flights MAN AGP 2026-05-10 --currency GBP --sort cheapest --agent
+flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --currency EUR --sort --agent
+flight-goat-pp-cli compare SEA LHR 2026-06-15 --currency GBP --agent
+```
+
+The flag is only valid on Google Flights price commands: `flights`, `dates`,
+`compare`, `gf-search`, and `cheapest-longhaul`. Do not add it to AeroAPI or
+Kayak-only commands.
+
 ## Development Tools
 AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
 imported into tools like Postman. To get started try importing the API

--- a/library/travel/flight-goat/internal/cli/currency_test.go
+++ b/library/travel/flight-goat/internal/cli/currency_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGoogleFlightsPriceCommandsExposeCurrencyFlag(t *testing.T) {
+	var flags rootFlags
+	commands := map[string]func(*rootFlags) *cobra.Command{
+		"flights":           newGfFlightsCmd,
+		"dates":             newGfDatesCmd,
+		"compare":           newCompareCmd,
+		"gf-search":         newGfSearchCmd,
+		"cheapest-longhaul": newCheapestLonghaulCmd,
+	}
+
+	for name, build := range commands {
+		cmd := build(&flags)
+		if cmd.Flags().Lookup("currency") == nil {
+			t.Fatalf("%s command missing --currency flag", name)
+		}
+	}
+}
+
+func TestFormatPriceDefaultsToUSD(t *testing.T) {
+	if got := formatPrice("", 123); got != "USD 123" {
+		t.Fatalf("formatPrice(empty, 123) = %q, want USD 123", got)
+	}
+	if got := formatPrice("gbp", 45); got != "GBP 45" {
+		t.Fatalf("formatPrice(gbp, 45) = %q, want GBP 45", got)
+	}
+}
+
+func TestCheapestLonghaulRejectsInvalidCurrencyBeforeAPISetup(t *testing.T) {
+	var flags rootFlags
+	cmd := newCheapestLonghaulCmd(&flags)
+	cmd.SetArgs([]string{
+		"SEA",
+		"--from", "2026-05-01",
+		"--to", "2026-05-31",
+		"--currency", "NOTACODE",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("cheapest-longhaul accepted invalid currency, want error")
+	}
+	if !strings.Contains(err.Error(), "ISO 4217") {
+		t.Fatalf("error %q did not mention ISO 4217", err)
+	}
+}

--- a/library/travel/flight-goat/internal/cli/primary.go
+++ b/library/travel/flight-goat/internal/cli/primary.go
@@ -35,7 +35,9 @@ func registerPrimaryCommands(rootCmd *cobra.Command, flags *rootFlags) {
 // ----- search: Google Flights one-shot search -----
 
 func newGfFlightsCmd(flags *rootFlags) *cobra.Command {
-	var returnDate, timeWindow, cabin, stops, sortBy string
+	// PATCH(upstream cli-printing-press#804): expose currency only on Google
+	// Flights-backed price commands, not as a misleading root flag.
+	var returnDate, timeWindow, cabin, stops, sortBy, currencyCode string
 	var airlines []string
 	var passengers int
 	var excludeBasic bool
@@ -56,6 +58,9 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
   # Morning departures on British Airways or KLM
   flight-goat-pp-cli flights JFK LHR 2026-07-01 --time 6-12 --airlines BA,KL
 
+  # Show prices in GBP
+  flight-goat-pp-cli flights MAN AGP 2026-05-10 --currency GBP --sort cheapest
+
   # Round trip with return date
   flight-goat-pp-cli flights SEA HNL 2026-08-01 --return 2026-08-10`,
 		Args: cobra.ExactArgs(3),
@@ -72,6 +77,7 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 				SortBy:        sortBy,
 				Passengers:    passengers,
 				ExcludeBasic:  excludeBasic,
+				Currency:      currencyCode,
 			}
 			if flags.dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "gflights.Search(%s -> %s on %s)", opts.Origin, opts.Destination, opts.DepartureDate)
@@ -83,6 +89,9 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 				}
 				if len(opts.Airlines) > 0 {
 					fmt.Fprintf(cmd.OutOrStdout(), " airlines=%s", strings.Join(opts.Airlines, ","))
+				}
+				if opts.Currency != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), " currency=%s", strings.ToUpper(strings.TrimSpace(opts.Currency)))
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), "\n(dry run - no request sent)")
 				return nil
@@ -127,8 +136,8 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 					depart = trimTime(f.Legs[0].DepartureTime)
 					arrive = trimTime(f.Legs[len(f.Legs)-1].ArrivalTime)
 				}
-				fmt.Fprintf(tw, "$%.0f\t%s\t%d\t%s\t%s\t%s\n",
-					f.Price, minutesToHM(f.DurationMinutes), f.Stops, strings.Join(carrierList, ","), depart, arrive)
+				fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\n",
+					formatPrice(f.Currency, f.Price), minutesToHM(f.DurationMinutes), f.Stops, strings.Join(carrierList, ","), depart, arrive)
 			}
 			tw.Flush()
 			return nil
@@ -142,13 +151,16 @@ durations, airlines, and leg details. No API key. No auth. Just results.`,
 	cmd.Flags().StringVar(&sortBy, "sort", "", "Sort by: cheapest, duration, departure_time, arrival_time")
 	cmd.Flags().IntVarP(&passengers, "passengers", "p", 1, "Number of passengers")
 	cmd.Flags().BoolVar(&excludeBasic, "exclude-basic", false, "Exclude basic economy fares")
+	cmd.Flags().StringVar(&currencyCode, "currency", "", "Currency for prices (ISO 4217, e.g. GBP, EUR, USD; default USD)")
 	return cmd
 }
 
 // ----- dates: cheapest-dates discovery -----
 
 func newGfDatesCmd(flags *rootFlags) *cobra.Command {
-	var from, to, cabin, stops string
+	// PATCH(upstream cli-printing-press#804): mirror the flights currency flag
+	// on the calendar-price command that uses the same Google Flights backend.
+	var from, to, cabin, stops, currencyCode string
 	var duration int
 	var round, doSort bool
 	var airlines []string
@@ -167,6 +179,9 @@ a range of dates. No API key required. Uses flight-goat's native Go backend
   # Non-stop business class, next month only
   flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --stops non_stop --class business
 
+  # Cheapest dates priced in EUR
+  flight-goat-pp-cli dates JFK CDG --from 2026-07-01 --to 2026-07-31 --currency EUR --sort
+
   # Round trip with 7-day duration
   flight-goat-pp-cli dates SEA HNL --round --duration 7 --sort`,
 		Args: cobra.ExactArgs(2),
@@ -182,9 +197,14 @@ a range of dates. No API key required. Uses flight-goat's native Go backend
 				MaxStops:    stops,
 				CabinClass:  cabin,
 				Sort:        doSort,
+				Currency:    currencyCode,
 			}
 			if flags.dryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "gflights.Dates(%s -> %s from=%s to=%s)\n", opts.Origin, opts.Destination, opts.From, opts.To)
+				fmt.Fprintf(cmd.OutOrStdout(), "gflights.Dates(%s -> %s from=%s to=%s", opts.Origin, opts.Destination, opts.From, opts.To)
+				if opts.Currency != "" {
+					fmt.Fprintf(cmd.OutOrStdout(), " currency=%s", strings.ToUpper(strings.TrimSpace(opts.Currency)))
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), ")")
 				fmt.Fprintln(cmd.OutOrStdout(), "(dry run - no request sent)")
 				return nil
 			}
@@ -218,7 +238,7 @@ a range of dates. No API key required. Uses flight-goat's native Go backend
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			fmt.Fprintln(tw, "DATE\tPRICE")
 			for _, p := range dates {
-				fmt.Fprintf(tw, "%s\t$%.0f\n", p.DepartureDate, p.Price)
+				fmt.Fprintf(tw, "%s\t%s\n", p.DepartureDate, formatPrice(p.Currency, p.Price))
 			}
 			tw.Flush()
 			return nil
@@ -233,10 +253,19 @@ a range of dates. No API key required. Uses flight-goat's native Go backend
 	cmd.Flags().StringVarP(&cabin, "class", "c", "", "Cabin class: economy, premium_economy, business, first")
 	cmd.Flags().BoolVar(&doSort, "sort", false, "Sort by price ascending")
 	cmd.Flags().IntVarP(&limit, "limit", "l", 0, "Limit to top N dates (0 = all)")
+	cmd.Flags().StringVar(&currencyCode, "currency", "", "Currency for prices (ISO 4217, e.g. GBP, EUR, USD; default USD)")
 	return cmd
 }
 
 // ----- shared helpers -----
+
+func formatPrice(code string, price float64) string {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	if code == "" {
+		code = "USD"
+	}
+	return fmt.Sprintf("%s %.0f", code, price)
+}
 
 func minutesToHM(m int) string {
 	if m <= 0 {

--- a/library/travel/flight-goat/internal/cli/transcend.go
+++ b/library/travel/flight-goat/internal/cli/transcend.go
@@ -144,9 +144,9 @@ func newLonghaulCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 
 	cmd := &cobra.Command{
-		Use:   "longhaul <airport>",
+		Use:         "longhaul <airport>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "List nonstop departures from an airport that are at least N hours long",
+		Short:       "List nonstop departures from an airport that are at least N hours long",
 		Long: `longhaul answers the classic travel-hacker question: "show me every nonstop
 flight from my airport that's at least N hours long over a given period."
 
@@ -172,7 +172,6 @@ Pair with --json and pipe to jq for custom filtering.`,
 			if err != nil {
 				return err
 			}
-
 			c, err := flags.newClient()
 			if err != nil {
 				return err
@@ -255,9 +254,9 @@ func newExploreCmd(flags *rootFlags) *cobra.Command {
 	var minFrequency int
 
 	cmd := &cobra.Command{
-		Use:   "explore <airport>",
+		Use:         "explore <airport>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Every nonstop destination from an airport with duration, airlines, frequency",
+		Short:       "Every nonstop destination from an airport with duration, airlines, frequency",
 		Long: `explore is the Kayak /direct nonstop matrix in your terminal.
 
 Given an airport code, it aggregates scheduled departures into a destination
@@ -363,13 +362,16 @@ frequency. Answers "where can I fly nonstop from here, and how long does it take
 // ----- T3: cheapest-longhaul (requires fli for prices) -----
 
 func newCheapestLonghaulCmd(flags *rootFlags) *cobra.Command {
+	// PATCH(upstream cli-printing-press#804): let the Google-priced longhaul
+	// scan request native currency while leaving AeroAPI-only commands alone.
 	var minHours float64
 	var startDate, endDate string
+	var currencyCode string
 
 	cmd := &cobra.Command{
-		Use:   "cheapest-longhaul <airport>",
+		Use:         "cheapest-longhaul <airport>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Cheapest dates to fly long nonstop routes from an airport",
+		Short:       "Cheapest dates to fly long nonstop routes from an airport",
 		Long: `cheapest-longhaul joins two data sources nobody else joins:
   1. FlightAware route catalog (which nonstop routes are at least N hours)
   2. Google Flights price data via the 'fli' Python CLI (cheapest dates per route)
@@ -383,6 +385,9 @@ command lists the long routes and exits with a helpful message.`,
 			airport := upperCode(args[0])
 			start, end, err := resolveDateWindow("", startDate, endDate)
 			if err != nil {
+				return err
+			}
+			if _, err := gflights.NormalizeCurrencyCode(currencyCode); err != nil {
 				return err
 			}
 
@@ -432,6 +437,7 @@ command lists the long routes and exits with a helpful message.`,
 					Destination: dest,
 					From:        start[:10],
 					To:          end[:10],
+					Currency:    currencyCode,
 				})
 				cancel()
 				if err == nil && dr != nil && len(dr.Dates) > 0 {
@@ -443,7 +449,7 @@ command lists the long routes and exits with a helpful message.`,
 					}
 					if cheapest.Price > 0 {
 						r.CheapestDate = cheapest.DepartureDate
-						r.CheapestPrice = fmt.Sprintf("$%.0f", cheapest.Price)
+						r.CheapestPrice = formatPrice(cheapest.Currency, cheapest.Price)
 						r.Source = "google-flights-native"
 					}
 				}
@@ -466,6 +472,7 @@ command lists the long routes and exits with a helpful message.`,
 	cmd.Flags().Float64Var(&minHours, "min-hours", 8, "Minimum flight duration in hours")
 	cmd.Flags().StringVar(&startDate, "from", "", "Start date YYYY-MM-DD (required)")
 	cmd.Flags().StringVar(&endDate, "to", "", "End date YYYY-MM-DD (required)")
+	cmd.Flags().StringVar(&currencyCode, "currency", "", "Currency for Google Flights prices (ISO 4217, e.g. GBP, EUR, USD; default USD)")
 	return cmd
 }
 
@@ -473,9 +480,9 @@ command lists the long routes and exits with a helpful message.`,
 
 func newOntimeNowCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ontime-now <airport>",
+		Use:         "ontime-now <airport>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Every departure from an airport today with live on-time status",
+		Short:       "Every departure from an airport today with live on-time status",
 		Example: `  flight-goat-pp-cli ontime-now SEA
   flight-goat-pp-cli ontime-now JFK --json`,
 		Args: cobra.ExactArgs(1),
@@ -555,9 +562,9 @@ func newOntimeNowCmd(flags *rootFlags) *cobra.Command {
 func newReliabilityCmd(flags *rootFlags) *cobra.Command {
 	var days int
 	cmd := &cobra.Command{
-		Use:   "reliability <origin> <destination>",
+		Use:         "reliability <origin> <destination>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Historical on-time percentage for a route over the last N days",
+		Short:       "Historical on-time percentage for a route over the last N days",
 		Long: `reliability queries FlightAware history for all flights on a route and
 computes an on-time percentage. On-time is defined as departure delay <= 15 minutes.`,
 		Example: `  flight-goat-pp-cli reliability SEA LHR --days 30
@@ -658,10 +665,14 @@ computes an on-time percentage. On-time is defined as departure delay <= 15 minu
 // ----- T6: compare (fli + reliability) -----
 
 func newCompareCmd(flags *rootFlags) *cobra.Command {
+	// PATCH(upstream cli-printing-press#804): compare joins Google prices with
+	// AeroAPI reliability, so the currency flag belongs on this command too.
+	var currencyCode string
+
 	cmd := &cobra.Command{
-		Use:   "compare <origin> <destination> <date>",
+		Use:         "compare <origin> <destination> <date>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Join Google Flights prices with AeroAPI reliability for the same route",
+		Short:       "Join Google Flights prices with AeroAPI reliability for the same route",
 		Long: `compare runs two queries in parallel: fli flights for Google Flights prices and
 reliability for AeroAPI historical on-time percentages. Output sorts by reliability
 so you can pick the cheapest flight that's likely to actually run on time.
@@ -675,7 +686,11 @@ Requires 'fli' (pipx install flights) for pricing.`,
 			date := args[2]
 
 			if flags.dryRun {
-				fmt.Fprintf(cmd.ErrOrStderr(), "gflights.Search(%s -> %s on %s)\n", origin, dest, date)
+				fmt.Fprintf(cmd.ErrOrStderr(), "gflights.Search(%s -> %s on %s", origin, dest, date)
+				if currencyCode != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), " currency=%s", strings.ToUpper(strings.TrimSpace(currencyCode)))
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(), ")")
 				fmt.Fprintf(cmd.ErrOrStderr(), "GET /airports/%s/flights/to/%s?start=<last30d>&end=<now>&max_pages=3\n", origin, dest)
 				fmt.Fprintln(cmd.ErrOrStderr(), "\n(dry run - no requests sent; would join Google Flights prices with AeroAPI reliability)")
 				return nil
@@ -687,6 +702,7 @@ Requires 'fli' (pipx install flights) for pricing.`,
 				Origin:        origin,
 				Destination:   dest,
 				DepartureDate: date,
+				Currency:      currencyCode,
 			})
 			if err != nil {
 				return fmt.Errorf("google flights search failed: %w", err)
@@ -727,6 +743,7 @@ Requires 'fli' (pipx install flights) for pricing.`,
 
 			type row struct {
 				Price         float64 `json:"price"`
+				Currency      string  `json:"currency"`
 				Airline       string  `json:"airline"`
 				Duration      int     `json:"duration_minutes"`
 				Stops         int     `json:"stops"`
@@ -740,6 +757,7 @@ Requires 'fli' (pipx install flights) for pricing.`,
 				}
 				results = append(results, row{
 					Price:         f.Price,
+					Currency:      f.Currency,
 					Airline:       airline,
 					Duration:      f.DurationMinutes,
 					Stops:         f.Stops,
@@ -754,12 +772,13 @@ Requires 'fli' (pipx install flights) for pricing.`,
 				tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 				fmt.Fprintln(tw, "PRICE\tAIRLINE\tDURATION\tSTOPS\tON_TIME_%_30D")
 				for _, r := range results {
-					fmt.Fprintf(tw, "%v\t%s\t%v\t%v\t%.1f\n", r.Price, r.Airline, r.Duration, r.Stops, r.OnTimePercent)
+					fmt.Fprintf(tw, "%s\t%s\t%v\t%v\t%.1f\n", formatPrice(r.Currency, r.Price), r.Airline, r.Duration, r.Stops, r.OnTimePercent)
 				}
 				tw.Flush()
 			})
 		},
 	}
+	cmd.Flags().StringVar(&currencyCode, "currency", "", "Currency for Google Flights prices (ISO 4217, e.g. GBP, EUR, USD; default USD)")
 	return cmd
 }
 
@@ -771,9 +790,9 @@ func newMonitorCmd(flags *rootFlags) *cobra.Command {
 	var maxChecks int
 
 	cmd := &cobra.Command{
-		Use:   "monitor <ident>",
+		Use:         "monitor <ident>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Watch a flight through its lifecycle until landed",
+		Short:       "Watch a flight through its lifecycle until landed",
 		Long: `monitor polls FlightAware at regular intervals and prints status changes.
 When --until-arrival is set (default), it exits when the flight lands.`,
 		Example: `  flight-goat-pp-cli monitor UA123
@@ -838,9 +857,9 @@ When --until-arrival is set (default), it exits when the flight lands.`,
 func newHeatmapCmd(flags *rootFlags) *cobra.Command {
 	var region string
 	cmd := &cobra.Command{
-		Use:   "heatmap",
+		Use:         "heatmap",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Where are delays happening right now across major airports",
+		Short:       "Where are delays happening right now across major airports",
 		Long: `heatmap calls /airports/delays and returns a single sorted table showing
 every airport with active delays. Useful for operators, travel hackers, and
 anyone deciding whether to reroute.`,
@@ -892,11 +911,11 @@ anyone deciding whether to reroute.`,
 
 func newResolveCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "resolve <ident>",
+		Use:         "resolve <ident>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short:   "Show every code (codeshare, canonical, operator) for one flight",
-		Example: `  flight-goat-pp-cli resolve UA123`,
-		Args:    cobra.ExactArgs(1),
+		Short:       "Show every code (codeshare, canonical, operator) for one flight",
+		Example:     `  flight-goat-pp-cli resolve UA123`,
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ident := args[0]
 			c, err := flags.newClient()
@@ -917,11 +936,11 @@ func newResolveCmd(flags *rootFlags) *cobra.Command {
 
 func newAircraftBioCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "aircraft-bio <registration>",
+		Use:         "aircraft-bio <registration>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short:   "Full history of a tail number: recent flights + owner + last known flight",
-		Example: `  flight-goat-pp-cli aircraft-bio N12345`,
-		Args:    cobra.ExactArgs(1),
+		Short:       "Full history of a tail number: recent flights + owner + last known flight",
+		Example:     `  flight-goat-pp-cli aircraft-bio N12345`,
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reg := args[0]
 			c, err := flags.newClient()
@@ -956,11 +975,11 @@ func newAircraftBioCmd(flags *rootFlags) *cobra.Command {
 
 func newEtaCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "eta <ident>",
+		Use:         "eta <ident>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short:   "Weather-adjusted ETA: foresight prediction plus destination weather",
-		Example: `  flight-goat-pp-cli eta AA100`,
-		Args:    cobra.ExactArgs(1),
+		Short:       "Weather-adjusted ETA: foresight prediction plus destination weather",
+		Example:     `  flight-goat-pp-cli eta AA100`,
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ident := args[0]
 
@@ -1011,11 +1030,14 @@ func newEtaCmd(flags *rootFlags) *cobra.Command {
 // ----- T12: gf-search (Google Flights via fli) -----
 
 func newGfSearchCmd(flags *rootFlags) *cobra.Command {
+	// PATCH(upstream cli-printing-press#804): legacy Google Flights search gets
+	// the same command-scoped currency behavior as the headline flights command.
 	var alertIfUnder float64
+	var currencyCode string
 	cmd := &cobra.Command{
-		Use:   "gf-search <origin> <destination> <date>",
+		Use:         "gf-search <origin> <destination> <date>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Google Flights search (price + duration + airlines)",
+		Short:       "Google Flights search (price + duration + airlines)",
 		Long: `gf-search runs a Google Flights search through flight-goat's native
 Go backend (no Python dependency). Returns price, duration, airline, and
 leg details.
@@ -1027,9 +1049,13 @@ price is below the threshold.`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.dryRun {
-				fmt.Fprintf(cmd.ErrOrStderr(), "gflights.Search(%s -> %s on %s)\n", args[0], args[1], args[2])
+				fmt.Fprintf(cmd.ErrOrStderr(), "gflights.Search(%s -> %s on %s", args[0], args[1], args[2])
+				if currencyCode != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), " currency=%s", strings.ToUpper(strings.TrimSpace(currencyCode)))
+				}
+				fmt.Fprintln(cmd.ErrOrStderr(), ")")
 				if alertIfUnder > 0 {
-					fmt.Fprintf(cmd.ErrOrStderr(), "(would emit alert if any result price < $%.0f)\n", alertIfUnder)
+					fmt.Fprintf(cmd.ErrOrStderr(), "(would emit alert if any result price < %s)\n", formatPrice(currencyCode, alertIfUnder))
 				}
 				fmt.Fprintln(cmd.ErrOrStderr(), "\n(dry run - no network call)")
 				return nil
@@ -1041,6 +1067,7 @@ price is below the threshold.`,
 				Origin:        args[0],
 				Destination:   args[1],
 				DepartureDate: args[2],
+				Currency:      currencyCode,
 			})
 			if err != nil {
 				return fmt.Errorf("google flights search failed: %w", err)
@@ -1053,8 +1080,8 @@ price is below the threshold.`,
 			if alertIfUnder > 0 {
 				for _, f := range result.Flights {
 					if f.Price > 0 && f.Price < alertIfUnder {
-						fmt.Fprintf(cmd.ErrOrStderr(), "Found %s %s %s at $%.0f (under $%.0f threshold)\n",
-							args[0], args[1], args[2], f.Price, alertIfUnder)
+						fmt.Fprintf(cmd.ErrOrStderr(), "Found %s %s %s at %s (under %s threshold)\n",
+							args[0], args[1], args[2], formatPrice(f.Currency, f.Price), formatPrice(f.Currency, alertIfUnder))
 						break
 					}
 				}
@@ -1063,6 +1090,7 @@ price is below the threshold.`,
 		},
 	}
 	cmd.Flags().Float64Var(&alertIfUnder, "alert-if-under", 0, "Emit a notice if a result is below this price")
+	cmd.Flags().StringVar(&currencyCode, "currency", "", "Currency for Google Flights prices (ISO 4217, e.g. GBP, EUR, USD; default USD)")
 	return cmd
 }
 

--- a/library/travel/flight-goat/internal/gflights/currency_test.go
+++ b/library/travel/flight-goat/internal/gflights/currency_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeCurrency(t *testing.T) {
+	unit, code, err := normalizeCurrency(" gbp ")
+	if err != nil {
+		t.Fatalf("normalizeCurrency(GBP): %v", err)
+	}
+	if code != "GBP" || unit.String() != "GBP" {
+		t.Fatalf("normalizeCurrency(GBP) = (%s, %s), want GBP", unit, code)
+	}
+
+	_, code, err = normalizeCurrency("")
+	if err != nil {
+		t.Fatalf("normalizeCurrency(empty): %v", err)
+	}
+	if code != "USD" {
+		t.Fatalf("normalizeCurrency(empty) code = %q, want USD", code)
+	}
+}
+
+func TestNormalizeCurrencyRejectsInvalidCodes(t *testing.T) {
+	_, _, err := normalizeCurrency("peanuts")
+	if err == nil {
+		t.Fatal("normalizeCurrency(peanuts) succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "ISO 4217") {
+		t.Fatalf("error %q did not mention ISO 4217", err)
+	}
+}
+
+func TestGoogleFlightsCurrencyHeaderIncludesCode(t *testing.T) {
+	header := googleFlightsCurrencyHeader("EUR")
+	if !strings.Contains(header, `"EUR"`) {
+		t.Fatalf("currency header %q did not include EUR", header)
+	}
+}

--- a/library/travel/flight-goat/internal/gflights/dates_native.go
+++ b/library/travel/flight-goat/internal/gflights/dates_native.go
@@ -61,6 +61,14 @@ const (
 // datesNative is the native-Go replacement for the fli subprocess. Returns
 // the same DatesResult shape so callers don't care which backend ran.
 func datesNative(ctx context.Context, opts DatesOptions) (*DatesResult, error) {
+	// PATCH(upstream cli-printing-press#804): the native calendar endpoint
+	// reads currency from Google's JSPB extension header, matching the
+	// krisukox PriceGraph path this code was ported around.
+	_, currencyCode, err := normalizeCurrency(opts.Currency)
+	if err != nil {
+		return nil, err
+	}
+
 	from, err := time.Parse("2006-01-02", opts.From)
 	if err != nil {
 		return nil, fmt.Errorf("parsing from date %q: %w", opts.From, err)
@@ -101,6 +109,7 @@ func datesNative(ctx context.Context, opts DatesOptions) (*DatesResult, error) {
 		Query: SearchQuery{
 			Origin:      opts.Origin,
 			Destination: opts.Destination,
+			Currency:    currencyCode,
 		},
 		Count: len(all),
 		Dates: all,
@@ -124,6 +133,8 @@ func datesChunk(ctx context.Context, opts DatesOptions, from, to time.Time) ([]D
 	req.Header.Set("User-Agent", chromeUserAgent)
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	_, currencyCode, _ := normalizeCurrency(opts.Currency)
+	req.Header.Set("x-goog-ext-259736195-jspb", googleFlightsCurrencyHeader(currencyCode))
 
 	resp, err := utlsClient().Do(req)
 	if err != nil {
@@ -143,7 +154,7 @@ func datesChunk(ctx context.Context, opts DatesOptions, from, to time.Time) ([]D
 		return nil, fmt.Errorf("calendar endpoint returned HTTP %d: %s", resp.StatusCode, snippet)
 	}
 
-	return parseDatesResponse(respBody)
+	return parseDatesResponse(respBody, currencyCode)
 }
 
 // buildDatesPayload constructs the URL-encoded `f.req` value for a single
@@ -273,7 +284,7 @@ func mapMaxStops(s string) (int, error) {
 // parseDatesResponse unwraps Google's )]}' prefix, drills into the wrb.fr
 // envelope, and returns one DatePrice per date that came back with a price.
 // Items with null price are silently skipped (mirrors fli).
-func parseDatesResponse(body []byte) ([]DatePrice, error) {
+func parseDatesResponse(body []byte, defaultCurrency string) ([]DatePrice, error) {
 	stripped := strings.TrimPrefix(string(body), googleResponsePrefix)
 	stripped = strings.TrimSpace(stripped)
 
@@ -316,6 +327,9 @@ func parseDatesResponse(body []byte) ([]DatePrice, error) {
 		price, currency := parsePriceAndCurrency(item[2])
 		if price <= 0 {
 			continue
+		}
+		if currency == "" {
+			currency = defaultCurrency
 		}
 		out = append(out, DatePrice{
 			DepartureDate: dateStr,

--- a/library/travel/flight-goat/internal/gflights/gflights.go
+++ b/library/travel/flight-goat/internal/gflights/gflights.go
@@ -58,14 +58,14 @@ type Flight struct {
 
 // SearchResult is the normalized envelope returned by Search.
 type SearchResult struct {
-	Success    bool     `json:"success"`
-	Source     string   `json:"source"` // "native-go" — krisukox/google-flights-api
-	DataSource string   `json:"data_source"`
-	SearchType string   `json:"search_type"`
-	TripType   string   `json:"trip_type"`
+	Success    bool        `json:"success"`
+	Source     string      `json:"source"` // "native-go" — krisukox/google-flights-api
+	DataSource string      `json:"data_source"`
+	SearchType string      `json:"search_type"`
+	TripType   string      `json:"trip_type"`
 	Query      SearchQuery `json:"query"`
-	Count      int      `json:"count"`
-	Flights    []Flight `json:"flights"`
+	Count      int         `json:"count"`
+	Flights    []Flight    `json:"flights"`
 }
 
 // SearchQuery echoes the user's query back in the response envelope.
@@ -76,6 +76,7 @@ type SearchQuery struct {
 	ReturnDate    string `json:"return_date,omitempty"`
 	CabinClass    string `json:"cabin_class"`
 	MaxStops      string `json:"max_stops"`
+	Currency      string `json:"currency,omitempty"`
 }
 
 // DatePrice is one row in the cheapest-dates output.
@@ -110,6 +111,7 @@ type SearchOptions struct {
 	SortBy        string
 	Passengers    int
 	ExcludeBasic  bool
+	Currency      string
 }
 
 // Search runs a flight search via the native Go backend (krisukox).
@@ -171,6 +173,13 @@ func searchNative(ctx context.Context, opts SearchOptions) (*SearchResult, error
 		passengers = opts.Passengers
 	}
 
+	// PATCH(upstream cli-printing-press#804): honor per-command ISO 4217
+	// currency requests instead of hard-coding Google Flights searches to USD.
+	currencyUnit, currencyCode, err := normalizeCurrency(opts.Currency)
+	if err != nil {
+		return nil, err
+	}
+
 	offers, _, err := session.GetOffers(ctx, krisukox.Args{
 		Date:        depDate,
 		ReturnDate:  retDate,
@@ -178,7 +187,7 @@ func searchNative(ctx context.Context, opts SearchOptions) (*SearchResult, error
 		DstAirports: []string{opts.Destination},
 		Options: krisukox.Options{
 			Travelers: krisukox.Travelers{Adults: passengers},
-			Currency:  currency.USD,
+			Currency:  currencyUnit,
 			Stops:     stops,
 			Class:     cabin,
 			TripType:  tripType,
@@ -195,7 +204,7 @@ func searchNative(ctx context.Context, opts SearchOptions) (*SearchResult, error
 			DurationMinutes: int(o.FlightDuration.Minutes()),
 			Stops:           len(o.Flight) - 1,
 			Price:           o.Price,
-			Currency:        "USD",
+			Currency:        currencyCode,
 		}
 		for _, leg := range o.Flight {
 			f.Legs = append(f.Legs, Leg{
@@ -224,6 +233,7 @@ func searchNative(ctx context.Context, opts SearchOptions) (*SearchResult, error
 			ReturnDate:    opts.ReturnDate,
 			CabinClass:    strings.ToUpper(opts.CabinClass),
 			MaxStops:      strings.ToUpper(opts.MaxStops),
+			Currency:      currencyCode,
 		},
 		Count:   len(flights),
 		Flights: flights,
@@ -249,6 +259,7 @@ type DatesOptions struct {
 	MaxStops    string
 	CabinClass  string
 	Sort        bool
+	Currency    string
 }
 
 // Dates runs a cheapest-dates query against Google Flights' GetCalendarGraph
@@ -264,3 +275,29 @@ func Dates(ctx context.Context, opts DatesOptions) (*DatesResult, error) {
 	return datesNative(ctx, opts)
 }
 
+func normalizeCurrency(code string) (currency.Unit, string, error) {
+	normalized, err := NormalizeCurrencyCode(code)
+	if err != nil {
+		return currency.Unit{}, "", err
+	}
+	unit, err := currency.ParseISO(normalized)
+	if err != nil {
+		return currency.Unit{}, "", fmt.Errorf("invalid currency %q: must be an ISO 4217 code (e.g. USD, GBP, EUR)", code)
+	}
+	return unit, normalized, nil
+}
+
+func NormalizeCurrencyCode(code string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	if normalized == "" {
+		return "USD", nil
+	}
+	if _, err := currency.ParseISO(normalized); err != nil {
+		return "", fmt.Errorf("invalid currency %q: must be an ISO 4217 code (e.g. USD, GBP, EUR)", code)
+	}
+	return normalized, nil
+}
+
+func googleFlightsCurrencyHeader(code string) string {
+	return fmt.Sprintf(`["en-US","US","%s",1,null,[-120],null,[[48764689,47907128,48676280,48710756,48627726,48480739,48593234,48707380]],1,[]]`, code)
+}


### PR DESCRIPTION
## Summary
- Add `--currency` to Google Flights price commands in Flight GOAT, defaulting to USD when omitted
- Thread the selected currency through native Google Flights requests and format returned prices with the active currency code
- Document the new flag in the library README and skill mirror, and add targeted tests for flag exposure, normalization, and formatting

## Testing
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `govulncheck ./...`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/flight-goat/`