### PR TITLE
Add attribution guard and backfill missing printer fields

### DIFF
--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Guard per-CLI attribution against accidental ownership flips.
+
+This check is intentionally PR-scoped. It compares the pull request head to
+the base branch and enforces three rules:
+
+1. Every CLI manifest in the PR head must include non-empty printer fields.
+2. Existing CLIs may not change attribution fields in the same PR that changes
+   the CLI surface. Attribution corrections are allowed, but they must be
+   reviewable as attribution-only changes.
+3. Newly-added CLIs must carry explicit printer attribution in
+   .printing-press.json.
+
+The check does not try to rediscover the original author from git history on
+every PR. The manifests and curated sweep map are the source of truth; this
+script only prevents a normal CLI improvement PR from rewriting them.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ATTRIBUTION_FIELDS = {"printer", "printer_name"}
+PLACEHOLDER_PRINTERS = {"", "USER", "user"}
+SWEEP_CANONICAL_PATH = "tools/sweep-canonical/main.go"
+
+
+def git(*args: str, allow_error: bool = False) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0 and not allow_error:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed with exit {proc.returncode}: {proc.stderr.strip()}"
+        )
+    return proc.stdout
+
+
+def path_exists(ref: str, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}:{path}"],
+            cwd=REPO_ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def read_file(ref: str, path: str) -> str | None:
+    if not path_exists(ref, path):
+        return None
+    return git("show", f"{ref}:{path}")
+
+
+def read_json(ref: str, path: str) -> dict[str, Any] | None:
+    text = read_file(ref, path)
+    if text is None:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"::error file={path}::{path} is not valid JSON at {ref}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        print(f"::error file={path}::{path} is not a JSON object at {ref}")
+        return None
+    return data
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    out = git("diff", "--name-only", f"{base}...{head}")
+    return [line for line in out.splitlines() if line]
+
+
+def manifest_paths(head: str) -> list[str]:
+    out = git("ls-tree", "-r", "--name-only", head, "--", "library")
+    return [line for line in out.splitlines() if line.endswith("/.printing-press.json")]
+
+
+def cli_root_for_path(path: str) -> tuple[str, str] | None:
+    parts = path.split("/")
+    if len(parts) < 4 or parts[0] != "library":
+        return None
+    root = "/".join(parts[:3])
+    rest = "/".join(parts[3:])
+    return root, rest
+
+
+def cli_skill_api_for_path(path: str) -> str | None:
+    match = re.fullmatch(r"cli-skills/pp-([^/]+)/SKILL\.md", path)
+    return match.group(1) if match else None
+
+
+def api_name_for_root(ref: str, root: str) -> str:
+    manifest = read_json(ref, f"{root}/.printing-press.json") or {}
+    return str(manifest.get("api_name") or Path(root).name)
+
+
+def unquote_scalar(raw: str) -> str:
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw[1:-1]
+    if len(raw) >= 2 and raw[0] == raw[-1] == "'":
+        return raw[1:-1]
+    return raw
+
+
+FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)(?:\n---\n|\n---\Z)", re.DOTALL)
+AUTHOR_LINE_RE = re.compile(r"(?m)^author:\s*(?P<value>.+?)\s*$")
+
+
+def skill_author(text: str | None) -> str | None:
+    if text is None:
+        return None
+    fm = FRONTMATTER_RE.match(text)
+    if not fm:
+        return None
+    author = AUTHOR_LINE_RE.search(fm.group("body"))
+    if not author:
+        return None
+    return unquote_scalar(author.group("value"))
+
+
+def normalize_skill_author(text: str | None) -> str | None:
+    if text is None:
+        return None
+    fm = FRONTMATTER_RE.match(text)
+    if not fm:
+        return text
+    body = AUTHOR_LINE_RE.sub("author: <ATTRIBUTION>", fm.group("body"))
+    return text[: fm.start("body")] + body + text[fm.end("body") :]
+
+
+def manifest_without_attribution(manifest: dict[str, Any] | None) -> dict[str, Any] | None:
+    if manifest is None:
+        return None
+    return {k: v for k, v in manifest.items() if k not in ATTRIBUTION_FIELDS}
+
+
+MAP_BLOCK_RE = re.compile(
+    r"var\s+cliAuthorByAPIName\s*=\s*map\[string\]string\s*\{(?P<body>.*?)\n\}",
+    re.DOTALL,
+)
+MAP_ENTRY_RE = re.compile(r'^\s*"(?P<api>[^"]+)"\s*:\s*"(?P<author>(?:\\.|[^"])*)"', re.MULTILINE)
+
+
+def parse_cli_author_map(ref: str) -> dict[str, str]:
+    text = read_file(ref, SWEEP_CANONICAL_PATH)
+    if text is None:
+        return {}
+    block = MAP_BLOCK_RE.search(text)
+    if not block:
+        return {}
+    entries: dict[str, str] = {}
+    for match in MAP_ENTRY_RE.finditer(block.group("body")):
+        try:
+            author = json.loads(f'"{match.group("author")}"')
+        except json.JSONDecodeError:
+            author = match.group("author")
+        entries[match.group("api")] = author
+    return entries
+
+
+@dataclass
+class CLIChange:
+    api_name: str
+    root: str
+    existing: bool
+    changed_files: list[str] = field(default_factory=list)
+    attribution_changes: list[str] = field(default_factory=list)
+    surface_changes: list[str] = field(default_factory=list)
+
+
+def add_attribution_change(changes: dict[str, CLIChange], api: str, detail: str) -> None:
+    change = changes.get(api)
+    if change is None:
+        change = CLIChange(api_name=api, root=f"library/*/{api}", existing=True)
+        changes[api] = change
+    change.attribution_changes.append(detail)
+
+
+def analyze_library_file(
+    base: str,
+    head: str,
+    change: CLIChange,
+    path: str,
+    rest: str,
+) -> None:
+    if rest == ".printing-press.json":
+        before = read_json(base, path)
+        after = read_json(head, path)
+        if before is None or after is None:
+            change.surface_changes.append(path)
+            return
+        for field_name in sorted(ATTRIBUTION_FIELDS):
+            if before.get(field_name) != after.get(field_name):
+                change.attribution_changes.append(f"{path} {field_name}")
+        if manifest_without_attribution(before) != manifest_without_attribution(after):
+            change.surface_changes.append(path)
+        return
+
+    if rest == "SKILL.md":
+        before = read_file(base, path)
+        after = read_file(head, path)
+        if skill_author(before) != skill_author(after):
+            change.attribution_changes.append(f"{path} author")
+        if normalize_skill_author(before) != normalize_skill_author(after):
+            change.surface_changes.append(path)
+        return
+
+    change.surface_changes.append(path)
+
+
+def validate_new_cli(head: str, change: CLIChange) -> list[str]:
+    manifest_path = f"{change.root}/.printing-press.json"
+    manifest = read_json(head, manifest_path)
+    if manifest is None:
+        return [f"::error file={manifest_path}::new CLI {change.root} must include .printing-press.json"]
+
+    problems: list[str] = []
+    printer = str(manifest.get("printer") or "")
+    printer_name = str(manifest.get("printer_name") or "")
+    owner = str(manifest.get("owner") or "")
+    api_name = str(manifest.get("api_name") or change.api_name)
+
+    if printer in PLACEHOLDER_PRINTERS:
+        problems.append(
+            f"::error file={manifest_path}::new CLI {api_name} must set .printing-press.json printer to a real GitHub handle"
+        )
+    if printer_name in PLACEHOLDER_PRINTERS:
+        problems.append(
+            f"::error file={manifest_path}::new CLI {api_name} must set .printing-press.json printer_name to the printer display name"
+        )
+    if printer and owner and printer == owner:
+        problems.append(
+            f"::error file={manifest_path}::new CLI {api_name} has printer equal to owner ({printer}); this usually means the generator fallback claimed no real printer"
+        )
+    if printer and printer == api_name:
+        problems.append(
+            f"::error file={manifest_path}::new CLI {api_name} has printer equal to api_name; set the human GitHub handle instead"
+        )
+
+    return problems
+
+
+def validate_manifest_attribution_presence(head: str) -> list[str]:
+    problems: list[str] = []
+    for manifest_path in manifest_paths(head):
+        manifest = read_json(head, manifest_path)
+        if manifest is None:
+            problems.append(
+                f"::error file={manifest_path}::unable to verify printer attribution because manifest JSON could not be read"
+            )
+            continue
+        api_name = str(manifest.get("api_name") or Path(manifest_path).parent.name)
+        for field_name in ("printer", "printer_name"):
+            value = str(manifest.get(field_name) or "")
+            if value in PLACEHOLDER_PRINTERS:
+                problems.append(
+                    f"::error file={manifest_path}::{api_name} is missing .printing-press.json {field_name}; every published CLI must preserve original printer attribution"
+                )
+    return problems
+
+
+def run(base: str, head: str) -> int:
+    files = changed_files(base, head)
+    changes_by_api: dict[str, CLIChange] = {}
+    failures = validate_manifest_attribution_presence(head)
+
+    for path in files:
+        root_info = cli_root_for_path(path)
+        if root_info is None:
+            continue
+        root, rest = root_info
+        base_manifest_path = f"{root}/.printing-press.json"
+        head_manifest_path = f"{root}/.printing-press.json"
+        existing = path_exists(base, base_manifest_path)
+        api_name = api_name_for_root(base if existing else head, root)
+        change = changes_by_api.setdefault(
+            api_name,
+            CLIChange(api_name=api_name, root=root, existing=existing),
+        )
+        change.changed_files.append(path)
+        if existing:
+            analyze_library_file(base, head, change, path, rest)
+        elif rest != ".printing-press.json" or path_exists(head, head_manifest_path):
+            change.surface_changes.append(path)
+
+    # cli-skills mirrors are generated, but an author flip there is still an
+    # attribution-sensitive change. Pair it with library surface changes below.
+    for path in files:
+        api_name = cli_skill_api_for_path(path)
+        if not api_name:
+            continue
+        before = read_file(base, path)
+        after = read_file(head, path)
+        if skill_author(before) != skill_author(after):
+            add_attribution_change(changes_by_api, api_name, f"{path} author")
+
+    if SWEEP_CANONICAL_PATH in files:
+        before_map = parse_cli_author_map(base)
+        after_map = parse_cli_author_map(head)
+        for api_name in sorted(set(before_map) | set(after_map)):
+            if before_map.get(api_name) != after_map.get(api_name):
+                add_attribution_change(
+                    changes_by_api,
+                    api_name,
+                    f"{SWEEP_CANONICAL_PATH} cliAuthorByAPIName[{api_name!r}]",
+                )
+
+    for change in sorted(changes_by_api.values(), key=lambda item: item.api_name):
+        if not change.existing:
+            failures.extend(validate_new_cli(head, change))
+            continue
+
+        if change.attribution_changes and change.surface_changes:
+            detail = "; ".join(change.attribution_changes)
+            surface = ", ".join(change.surface_changes[:5])
+            if len(change.surface_changes) > 5:
+                surface += ", ..."
+            failures.append(
+                f"::error file={change.root}/.printing-press.json::existing CLI {change.api_name} changes attribution ({detail}) while also changing CLI surface ({surface}). Split attribution corrections into a dedicated PR with primary evidence."
+            )
+
+    if failures:
+        print("Attribution guard failed:")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    checked = len(changes_by_api)
+    print(f"Attribution guard passed for {checked} affected CLI(s).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="base ref to compare against")
+    parser.add_argument("--head", default="HEAD", help="head ref to compare (default: HEAD)")
+    args = parser.parse_args()
+
+    try:
+        return run(args.base, args.head)
+    except RuntimeError as exc:
+        print(f"::error::{exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -1,6 +1,6 @@
 name: Verify library conventions
 
-# PR-time guards for three invariants that local builds and the existing
+# PR-time guards for four invariants that local builds and the existing
 # verify-skills.yml / verify-manifests.yml workflows do not catch:
 #
 # 1. cli-skills/<slug>/SKILL.md must equal what
@@ -24,6 +24,12 @@ name: Verify library conventions
 #    required as Y" error after the proxy has already served the zip.
 #    The hubspot CLI shipped with this exact bug for some time before
 #    being caught.
+#
+# 4. Every published CLI manifest must carry printer attribution, and
+#    existing CLI attribution must not change in the same PR as CLI
+#    behavior or docs. The printer / author fields are reviewable when
+#    corrected in an attribution-only PR, but a normal CLI improvement
+#    PR should never accidentally claim ownership of someone else's CLI.
 
 on:
   pull_request:
@@ -32,6 +38,8 @@ on:
       - 'cli-skills/**'
       - 'registry.json'
       - 'tools/generate-skills/**'
+      - 'tools/sweep-canonical/**'
+      - '.github/scripts/verify-attribution/**'
       - '.github/workflows/verify-library-conventions.yml'
   workflow_dispatch:
 
@@ -85,6 +93,15 @@ jobs:
         run: |
           echo "::error file=registry.json::registry.json is generated on main from library metadata. Remove it from this fork PR and let generate-registry.yml update it after merge."
           exit 1
+
+      - name: Guard CLI attribution
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          base_remote_ref="refs/remotes/base/${BASE_REF}"
+          python3 .github/scripts/verify-attribution/verify_attribution.py --base "${base_remote_ref}"
 
       - uses: actions/setup-go@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ __debug_bin*
 # Local vulnerability scan reports
 .govulncheck/
 
+# Python bytecode caches from local verifier runs
+__pycache__/
+*.py[cod]
+
 # Build artifacts from printing-press verify/scorecard
 *-validation
 

--- a/library/productivity/fireflies/.printing-press.json
+++ b/library/productivity/fireflies/.printing-press.json
@@ -6,6 +6,8 @@
   "category": "productivity",
   "display_name": "Fireflies Pp Cli",
   "cli_name": "fireflies-pp-cli",
+  "printer": "neektza",
+  "printer_name": "Nikica Jokic",
   "spec_path": "/Users/neektza/printing-press/.runstate/cli-printing-press-c22e9309/runs/20260509-005754/fireflies.graphql",
   "spec_format": "graphql",
   "spec_checksum": "sha256:cdd93e3e4c75aede548dac509a8591939f9d0316e6a3cc8f507b2493dac98ba8",

--- a/library/productivity/notion/.printing-press.json
+++ b/library/productivity/notion/.printing-press.json
@@ -6,6 +6,8 @@
   "category": "productivity",
   "display_name": "Notion",
   "cli_name": "notion-pp-cli",
+  "printer": "neektza",
+  "printer_name": "Nikica Jokic",
   "spec_path": "https://developers.notion.com/openapi.json",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:ce5ab87e48809531d4553438d3fb8655716cd527740dda1e99f6b03f1fd214c7",


### PR DESCRIPTION
## Summary
- Added a PR-scoped attribution verifier that blocks bundled ownership flips on existing CLIs and requires `printer` / `printer_name` on new manifests.
- Wired the check into `verify-library-conventions.yml` so it runs alongside the other library CI guards.
- Backfilled the two missing manifests for `notion` and `fireflies` with the original printer attribution.
- Added root `.gitignore` entries for Python bytecode caches so local verifier runs stay clean.

## Testing
- `python3 -m py_compile .github/scripts/verify-attribution/verify_attribution.py`
- `actionlint .github/workflows/verify-library-conventions.yml` when available
- Verified all published library manifests now include `printer` and `printer_name`
- Exercised the verifier against the current worktree and a synthetic bundled attribution-flip case