### PR TITLE
fix(ci): Add PR-time publish-package completeness checks

### DIFF
--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -4,7 +4,7 @@
 This check is intentionally PR-scoped. It compares the pull request head to
 the base branch and enforces three rules:
 
-1. Every CLI manifest in the PR head must include non-empty printer fields.
+1. Every touched CLI manifest in the PR head must include non-empty printer fields.
 2. Existing CLIs may not change attribution fields in the same PR that changes
    the CLI surface. Attribution corrections are allowed, but they must be
    reviewable as attribution-only changes.
@@ -85,11 +85,6 @@ def read_json(ref: str, path: str) -> dict[str, Any] | None:
 def changed_files(base: str, head: str) -> list[str]:
     out = git("diff", "--name-only", f"{base}...{head}")
     return [line for line in out.splitlines() if line]
-
-
-def manifest_paths(head: str) -> list[str]:
-    out = git("ls-tree", "-r", "--name-only", head, "--", "library")
-    return [line for line in out.splitlines() if line.endswith("/.printing-press.json")]
 
 
 def cli_root_for_path(path: str) -> tuple[str, str] | None:
@@ -261,9 +256,12 @@ def validate_new_cli(head: str, change: CLIChange) -> list[str]:
     return problems
 
 
-def validate_manifest_attribution_presence(head: str) -> list[str]:
+def validate_manifest_attribution_presence(head: str, roots: list[str]) -> list[str]:
     problems: list[str] = []
-    for manifest_path in manifest_paths(head):
+    for root in roots:
+        manifest_path = f"{root}/.printing-press.json"
+        if not path_exists(head, manifest_path):
+            continue
         manifest = read_json(head, manifest_path)
         if manifest is None:
             problems.append(
@@ -283,7 +281,7 @@ def validate_manifest_attribution_presence(head: str) -> list[str]:
 def run(base: str, head: str) -> int:
     files = changed_files(base, head)
     changes_by_api: dict[str, CLIChange] = {}
-    failures = validate_manifest_attribution_presence(head)
+    failures: list[str] = []
 
     for path in files:
         root_info = cli_root_for_path(path)
@@ -303,6 +301,11 @@ def run(base: str, head: str) -> int:
             analyze_library_file(base, head, change, path, rest)
         elif rest != ".printing-press.json" or path_exists(head, head_manifest_path):
             change.surface_changes.append(path)
+
+    changed_existing_roots = sorted(
+        {change.root for change in changes_by_api.values() if change.existing}
+    )
+    failures.extend(validate_manifest_attribution_presence(head, changed_existing_roots))
 
     # cli-skills mirrors are generated, but an author flip there is still an
     # attribution-sensitive change. Pair it with library surface changes below.

--- a/.github/scripts/verify-attribution/verify_attribution_test.py
+++ b/.github/scripts/verify-attribution/verify_attribution_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_attribution as verifier
+
+
+class AttributionVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="verify-attribution-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+        self.old_root = verifier.REPO_ROOT
+        verifier.REPO_ROOT = self.tmp
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.com")
+        self.git("config", "user.name", "Test User")
+
+    def tearDown(self) -> None:
+        verifier.REPO_ROOT = self.old_root
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.tmp,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, rel: str, content: str) -> None:
+        path = self.tmp / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def write_manifest(self, root: str, **overrides: object) -> None:
+        data = {
+            "api_name": Path(root).name,
+            "cli_name": f"{Path(root).name}-pp-cli",
+            "printer": "tmchow",
+            "printer_name": "Trevin Chow",
+        }
+        data.update(overrides)
+        self.write(f"{root}/.printing-press.json", json.dumps(data))
+
+    def commit_base_with_stale_manifest(self) -> str:
+        self.write_manifest("library/search/google-search-console", printer_name="")
+        self.write("library/search/google-search-console/README.md", "# Google Search Console\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "base")
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def test_non_library_pr_ignores_unrelated_baseline_attribution_gaps(self) -> None:
+        base = self.commit_base_with_stale_manifest()
+        self.git("switch", "-c", "feature")
+        self.write(".github/workflows/verify-library-conventions.yml", "name: Verify\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "update workflow")
+
+        self.assertEqual(0, verifier.run(base, "HEAD"))
+
+    def test_touched_existing_cli_still_requires_attribution(self) -> None:
+        base = self.commit_base_with_stale_manifest()
+        self.git("switch", "-c", "feature")
+        self.write("library/search/google-search-console/README.md", "# Updated\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "update cli docs")
+
+        self.assertEqual(1, verifier.run(base, "HEAD"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""PR-time checks for newly published library CLI packages.
+
+This verifier is intentionally scoped to library CLIs touched by a PR. It
+applies strict publish-package checks only to newly added CLI directories, while
+still validating cheap provenance consistency for touched existing entries.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+ROOT_ARTIFACTS = (
+    ".printing-press.json",
+    ".printing-press-patches.json",
+    "AGENTS.md",
+    "README.md",
+    "SKILL.md",
+    "go.mod",
+    ".goreleaser.yaml",
+    "LICENSE",
+    "NOTICE",
+)
+
+PRINTER_SENTINELS = {"", "USER", "user", "unknown", "UNKNOWN", "changeme", "CHANGE_ME"}
+
+
+@dataclass(frozen=True)
+class Problem:
+    file: Path | None
+    message: str
+
+
+def annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_error(problem: Problem) -> None:
+    message = annotation_escape(problem.message)
+    if problem.file is None:
+        print(f"::error::{message}")
+        return
+    print(f"::error file={rel(problem.file)}::{message}")
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def git_exists(base_ref: str, path: Path) -> bool:
+    result = run_git(["cat-file", "-e", f"{base_ref}:{rel(path)}"])
+    return result.returncode == 0
+
+
+def library_cli_dir_for(path: str) -> Path | None:
+    parts = PurePosixPath(path).parts
+    if len(parts) < 3 or parts[0] != "library":
+        return None
+    return REPO_ROOT / parts[0] / parts[1] / parts[2]
+
+
+def changed_cli_dirs(base_ref: str) -> list[Path]:
+    result = run_git(["diff", "--name-status", "-z", f"{base_ref}...HEAD", "--", "library"])
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+    fields = result.stdout.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+
+    dirs: set[Path] = set()
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        i += 1
+        if not status:
+            continue
+
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        paths = fields[i : i + path_count]
+        i += path_count
+        for path in paths:
+            cli_dir = library_cli_dir_for(path)
+            if cli_dir is not None and cli_dir.is_dir():
+                dirs.add(cli_dir)
+
+    return sorted(dirs, key=rel)
+
+
+def is_new_cli(base_ref: str, cli_dir: Path) -> bool:
+    return not (
+        git_exists(base_ref, cli_dir)
+        and git_exists(base_ref, cli_dir / ".printing-press.json")
+        and git_exists(base_ref, cli_dir / "go.mod")
+    )
+
+
+def read_json(path: Path, problems: list[Problem]) -> dict | None:
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        problems.append(Problem(path, f"{path.name} is missing"))
+        return None
+    except json.JSONDecodeError as exc:
+        problems.append(Problem(path, f"{path.name} is not valid JSON: {exc}"))
+        return None
+
+    if not isinstance(data, dict):
+        problems.append(Problem(path, f"{path.name} must contain a JSON object"))
+        return None
+    return data
+
+
+def validate_required_artifacts(cli_dir: Path, manifest: dict | None) -> list[Problem]:
+    problems: list[Problem] = []
+    for artifact in ROOT_ARTIFACTS:
+        path = cli_dir / artifact
+        if not path.exists():
+            if artifact == "AGENTS.md":
+                problems.append(
+                    Problem(
+                        path,
+                        "new library CLI is missing AGENTS.md. Re-run the publish skill with a current Printing Press build so reviewers and future agents get the generated per-CLI operating guide.",
+                    )
+                )
+            elif artifact == ".printing-press-patches.json":
+                problems.append(
+                    Problem(
+                        path,
+                        "new library CLI is missing .printing-press-patches.json. Fresh prints should include the empty patch index; hand-authored customizations should be recorded there with matching PATCH comments.",
+                    )
+                )
+            else:
+                problems.append(Problem(path, f"new library CLI is missing required publish artifact {artifact}"))
+
+    cli_name = manifest.get("cli_name") if manifest else None
+    if isinstance(cli_name, str) and cli_name:
+        main_path = cli_dir / "cmd" / cli_name / "main.go"
+        if not main_path.exists():
+            problems.append(
+                Problem(
+                    main_path,
+                    f"new library CLI is missing cmd/{cli_name}/main.go. Re-run the publish package step instead of assembling the tree by hand.",
+                )
+            )
+
+    return problems
+
+
+def validate_manifest_identity(cli_dir: Path, manifest: dict | None, strict: bool) -> list[Problem]:
+    problems: list[Problem] = []
+    manifest_path = cli_dir / ".printing-press.json"
+    category = cli_dir.parent.name
+    slug = cli_dir.name
+
+    if manifest is None:
+        return problems
+
+    api_name = manifest.get("api_name")
+    if api_name != slug:
+        problems.append(
+            Problem(
+                manifest_path,
+                f'api_name {api_name!r} does not match the library directory slug {slug!r}. Re-run the publish package step instead of moving files by hand.',
+            )
+        )
+
+    manifest_category = manifest.get("category")
+    if manifest_category and manifest_category != category:
+        problems.append(
+            Problem(
+                manifest_path,
+                f'category {manifest_category!r} does not match the library category directory {category!r}.',
+            )
+        )
+
+    cli_name = manifest.get("cli_name")
+    if not cli_name:
+        problems.append(Problem(manifest_path, "cli_name is empty"))
+    elif not (cli_dir / "cmd" / str(cli_name) / "main.go").exists():
+        problems.append(
+            Problem(
+                cli_dir / "cmd" / str(cli_name) / "main.go",
+                f'cli_name {cli_name!r} does not have a matching cmd/{cli_name}/main.go entry point.',
+            )
+        )
+
+    if strict:
+        run_id = manifest.get("run_id")
+        if not run_id:
+            problems.append(
+                Problem(
+                    manifest_path,
+                    "new library CLI is missing run_id, so CI cannot verify the matching manuscript bundle. Reprint or republish with current Printing Press metadata.",
+                )
+            )
+
+        printer = manifest.get("printer")
+        if not isinstance(printer, str) or printer in PRINTER_SENTINELS:
+            problems.append(
+                Problem(
+                    manifest_path,
+                    "printer is empty or a USER sentinel. Configure git user attribution and reprint before publishing so registry attribution is correct.",
+                )
+            )
+
+        if not manifest.get("printing_press_version"):
+            problems.append(
+                Problem(
+                    manifest_path,
+                    "new library CLI is missing printing_press_version. Re-run the publish package step with current Printing Press metadata.",
+                )
+            )
+
+    return problems
+
+
+def validate_manuscripts(cli_dir: Path, manifest: dict | None) -> list[Problem]:
+    problems: list[Problem] = []
+    manifest_path = cli_dir / ".printing-press.json"
+    run_id = manifest.get("run_id") if manifest else None
+    if not run_id:
+        return problems
+
+    manuscript_dir = cli_dir / ".manuscripts" / str(run_id)
+    if not manuscript_dir.is_dir():
+        problems.append(
+            Problem(
+                cli_dir / ".manuscripts",
+                f"new library CLI is missing manuscripts for run_id {run_id}. Re-run /printing-press publish from the promoted local library so research and proof artifacts are packaged with the public-library PR.",
+            )
+        )
+        return problems
+
+    research_dir = manuscript_dir / "research"
+    if not research_dir.is_dir():
+        problems.append(
+            Problem(
+                research_dir,
+                f"new library CLI is missing .manuscripts/{run_id}/research/. Package the research artifacts from the promoted print.",
+            )
+        )
+
+    proofs_dir = manuscript_dir / "proofs"
+    proof_files = [p for p in proofs_dir.rglob("*") if p.is_file()] if proofs_dir.is_dir() else []
+    if not proofs_dir.is_dir() or not proof_files:
+        problems.append(
+            Problem(
+                proofs_dir,
+                f"new library CLI is missing .manuscripts/{run_id}/proofs/ outputs. Package the acceptance or shipcheck proof artifacts from the promoted print.",
+            )
+        )
+    elif not any(("acceptance" in p.name or "shipcheck" in p.name) for p in proof_files):
+        problems.append(
+            Problem(
+                proofs_dir,
+                f"new library CLI has manuscripts for run_id {run_id}, but proofs/ does not contain an acceptance or shipcheck artifact.",
+            )
+        )
+
+    if not manifest_path.exists():
+        problems.append(Problem(manifest_path, "new library CLI is missing .printing-press.json"))
+
+    return problems
+
+
+def validate_novel_features(cli_dir: Path, manifest: dict | None) -> list[Problem]:
+    problems: list[Problem] = []
+    manifest_path = cli_dir / ".printing-press.json"
+    features = manifest.get("novel_features") if manifest else None
+
+    if not isinstance(features, list) or not features:
+        return [
+            Problem(
+                manifest_path,
+                "new printed CLI has no novel_features entries. Run dogfood/shipcheck and publish with the current skill so reviewers can see the verified novel commands.",
+            )
+        ]
+
+    for idx, feature in enumerate(features, start=1):
+        if not isinstance(feature, dict):
+            problems.append(Problem(manifest_path, f"novel_features[{idx}] must be an object"))
+            continue
+        if not feature.get("name"):
+            problems.append(Problem(manifest_path, f"novel_features[{idx}] is missing name"))
+        if not feature.get("command"):
+            problems.append(Problem(manifest_path, f"novel_features[{idx}] is missing command"))
+        if not (feature.get("description") or feature.get("rationale")):
+            problems.append(Problem(manifest_path, f"novel_features[{idx}] is missing description or rationale"))
+
+    return problems
+
+
+def candidate_patch_marker_files(cli_dir: Path) -> Iterable[Path]:
+    skip_parts = {".git", ".manuscripts"}
+    skip_names = {".printing-press-patches.json"}
+    for path in cli_dir.rglob("*"):
+        if not path.is_file() or path.name in skip_names:
+            continue
+        if skip_parts.intersection(path.relative_to(cli_dir).parts):
+            continue
+        if path.suffix == ".go":
+            yield path
+
+
+def has_patch_marker(path: Path) -> bool:
+    try:
+        return "PATCH" in path.read_text(errors="ignore")
+    except OSError:
+        return False
+
+
+def validate_patch_manifest(cli_dir: Path) -> list[Problem]:
+    problems: list[Problem] = []
+    patch_path = cli_dir / ".printing-press-patches.json"
+    if not patch_path.exists():
+        return problems
+
+    manifest = read_json(patch_path, problems)
+    if manifest is None:
+        return problems
+
+    patches = manifest.get("patches", [])
+    if patches is None:
+        patches = []
+    if not isinstance(patches, list):
+        problems.append(Problem(patch_path, "patches must be an array"))
+        return problems
+
+    source_markers = [path for path in candidate_patch_marker_files(cli_dir) if has_patch_marker(path)]
+    if source_markers and not patches:
+        problems.append(
+            Problem(
+                patch_path,
+                "source files contain PATCH markers but patches[] is empty. Record the customization so regen reviewers can preserve it.",
+            )
+        )
+
+    for idx, patch in enumerate(patches, start=1):
+        if not isinstance(patch, dict):
+            problems.append(Problem(patch_path, f"patches[{idx}] must be an object"))
+            continue
+
+        files = patch.get("files")
+        if not isinstance(files, list) or not files:
+            problems.append(Problem(patch_path, f"patches[{idx}] must list one or more files"))
+            continue
+
+        referenced_files: list[Path] = []
+        for file_name in files:
+            if not isinstance(file_name, str) or not file_name:
+                problems.append(Problem(patch_path, f"patches[{idx}] has an invalid file entry {file_name!r}"))
+                continue
+            file_path = cli_dir / file_name
+            referenced_files.append(file_path)
+            if not file_path.exists():
+                problems.append(
+                    Problem(
+                        patch_path,
+                        f"patch entry references {file_name}, but that file does not exist in the published CLI package.",
+                    )
+                )
+
+        if referenced_files and not any(path.exists() and has_patch_marker(path) for path in referenced_files):
+            problems.append(
+                Problem(
+                    patch_path,
+                    f"patches[{idx}] does not point at a file containing a PATCH marker.",
+                )
+            )
+
+    return problems
+
+
+def manifest_advertises_mcp(manifest: dict | None) -> bool:
+    if not manifest:
+        return False
+    if manifest.get("mcp_binary") or manifest.get("mcp_tool_count"):
+        return True
+    return bool(manifest.get("mcp_ready") and manifest.get("mcp_ready") != "none")
+
+
+def validate_mcp_artifacts(cli_dir: Path, manifest: dict | None) -> list[Problem]:
+    if not manifest_advertises_mcp(manifest):
+        return []
+
+    problems: list[Problem] = []
+    for artifact in ("manifest.json", "tools-manifest.json"):
+        path = cli_dir / artifact
+        if not path.exists():
+            problems.append(
+                Problem(
+                    path,
+                    f"new CLI advertises an MCP surface but has no {artifact}. Re-run the current publish package flow so MCP metadata is included.",
+                )
+            )
+    return problems
+
+
+def read_pr_body(args: argparse.Namespace) -> str | None:
+    if args.pr_body_file:
+        return Path(args.pr_body_file).read_text()
+
+    event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+
+    try:
+        event = json.loads(Path(event_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return None
+    body = pull_request.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def validate_pr_body(body: str | None, new_dirs: list[Path]) -> list[Problem]:
+    if not new_dirs or body is None:
+        return []
+
+    problems: list[Problem] = []
+    if "### Novel Commands" not in body:
+        problems.append(
+            Problem(
+                None,
+                'PR body is missing "### Novel Commands". New CLI PRs should be created or updated with the current printing-press-publish skill so reviewers can inspect the verified novel command table from .printing-press.json.',
+            )
+        )
+    if "### Publication Path" not in body:
+        problems.append(
+            Problem(
+                None,
+                'PR body is missing "### Publication Path". Re-run the publish skill or update the PR body to state whether this is a new print, reprint, replacement, or existing-PR update.',
+            )
+        )
+    return problems
+
+
+def validate_cli_dir(cli_dir: Path, strict: bool) -> list[Problem]:
+    problems: list[Problem] = []
+    pp_path = cli_dir / ".printing-press.json"
+    manifest = read_json(pp_path, problems) if pp_path.exists() else None
+
+    if strict:
+        problems.extend(validate_required_artifacts(cli_dir, manifest))
+
+    problems.extend(validate_manifest_identity(cli_dir, manifest, strict))
+    problems.extend(validate_patch_manifest(cli_dir))
+
+    if strict:
+        problems.extend(validate_manuscripts(cli_dir, manifest))
+        problems.extend(validate_novel_features(cli_dir, manifest))
+        problems.extend(validate_mcp_artifacts(cli_dir, manifest))
+
+    return problems
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True, help="Base git ref to compare against, e.g. refs/remotes/base/main")
+    parser.add_argument("--event-path", help="GitHub event JSON path. Defaults to GITHUB_EVENT_PATH.")
+    parser.add_argument("--pr-body-file", help="Read pull request body from this file instead of the GitHub event.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    touched_dirs = changed_cli_dirs(args.base_ref)
+    if not touched_dirs:
+        print("No changed library CLI packages to validate.")
+        return 0
+
+    new_dirs = [cli_dir for cli_dir in touched_dirs if is_new_cli(args.base_ref, cli_dir)]
+    print(f"Publish-package verifier selected {len(touched_dirs)} touched CLI dir(s); {len(new_dirs)} new.")
+
+    problems: list[Problem] = []
+    for cli_dir in touched_dirs:
+        strict = cli_dir in new_dirs
+        print(f"::group::{rel(cli_dir)}")
+        problems.extend(validate_cli_dir(cli_dir, strict))
+        print("::endgroup::")
+
+    problems.extend(validate_pr_body(read_pr_body(args), new_dirs))
+
+    for problem in problems:
+        emit_error(problem)
+
+    if problems:
+        print(f"Publish-package verifier found {len(problems)} problem(s).")
+        return 1
+
+    print("Publish-package verifier passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_publish_package as verifier
+
+
+class PublishPackageVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="verify-publish-package-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+        self.old_root = verifier.REPO_ROOT
+        verifier.REPO_ROOT = self.tmp
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.com")
+        self.git("config", "user.name", "Test User")
+        self.git("commit", "--allow-empty", "-m", "base")
+        self.base = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("switch", "-c", "feature")
+
+    def tearDown(self) -> None:
+        verifier.REPO_ROOT = self.old_root
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.tmp,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, rel: str, content: str = "") -> None:
+        path = self.tmp / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def write_valid_cli(self) -> Path:
+        cli_dir = self.tmp / "library" / "cloud" / "example"
+        manifest = {
+            "schema_version": 1,
+            "api_name": "example",
+            "category": "cloud",
+            "cli_name": "example-pp-cli",
+            "printer": "tmchow",
+            "printing_press_version": "4.0.1",
+            "run_id": "20260509T010203Z-test",
+            "mcp_binary": "example-pp-mcp",
+            "mcp_tool_count": 1,
+            "novel_features": [
+                {
+                    "name": "Example search",
+                    "command": "search",
+                    "description": "Searches example data.",
+                }
+            ],
+        }
+        patch_manifest = {"schema_version": 1, "applied_at": "2026-05-09", "patches": []}
+        files = {
+            ".printing-press.json": json.dumps(manifest),
+            ".printing-press-patches.json": json.dumps(patch_manifest),
+            "AGENTS.md": "# Agents\n",
+            "README.md": "# Example\n",
+            "SKILL.md": "---\nname: pp-example\n---\n",
+            "go.mod": "module github.com/mvanhorn/printing-press-library/library/cloud/example\n",
+            ".goreleaser.yaml": "version: 2\n",
+            "LICENSE": "MIT\n",
+            "NOTICE": "Example\n",
+            "manifest.json": "{}\n",
+            "tools-manifest.json": "{}\n",
+            "cmd/example-pp-cli/main.go": "package main\n",
+            "cmd/example-pp-mcp/main.go": "package main\n",
+            ".manuscripts/20260509T010203Z-test/research/research.json": "{}\n",
+            ".manuscripts/20260509T010203Z-test/proofs/shipcheck.json": "{}\n",
+        }
+        for name, content in files.items():
+            self.write(f"library/cloud/example/{name}", content)
+        return cli_dir
+
+    def test_new_cli_missing_publish_artifacts_fails(self) -> None:
+        self.write("library/cloud/bad/.printing-press.json", '{"api_name": "bad", "cli_name": "bad-pp-cli"}')
+        self.write("library/cloud/bad/go.mod", "module github.com/mvanhorn/printing-press-library/library/cloud/bad\n")
+
+        cli_dir = self.tmp / "library" / "cloud" / "bad"
+        problems = verifier.validate_cli_dir(cli_dir, strict=True)
+        messages = [p.message for p in problems]
+
+        self.assertTrue(any("AGENTS.md" in msg for msg in messages))
+        self.assertTrue(any(".printing-press-patches.json" in msg for msg in messages))
+        self.assertTrue(any("run_id" in msg for msg in messages))
+
+    def test_valid_new_cli_and_pr_body_pass(self) -> None:
+        self.write_valid_cli()
+        self.git("add", ".")
+        self.git("commit", "-m", "add example")
+
+        touched = verifier.changed_cli_dirs(self.base)
+        new_dirs = [d for d in touched if verifier.is_new_cli(self.base, d)]
+        body = "### Publication Path\nnew print\n\n### Novel Commands\n- search\n"
+        problems = []
+        for cli_dir in touched:
+            problems.extend(verifier.validate_cli_dir(cli_dir, strict=cli_dir in new_dirs))
+        problems.extend(verifier.validate_pr_body(body, new_dirs))
+
+        self.assertEqual([], problems)
+
+    def test_pr_body_sections_required_for_new_cli(self) -> None:
+        self.write_valid_cli()
+        self.git("add", ".")
+        self.git("commit", "-m", "add example")
+
+        touched = verifier.changed_cli_dirs(self.base)
+        new_dirs = [d for d in touched if verifier.is_new_cli(self.base, d)]
+        problems = verifier.validate_pr_body("", new_dirs)
+
+        self.assertEqual(2, len(problems))
+        self.assertTrue(any("Novel Commands" in p.message for p in problems))
+        self.assertTrue(any("Publication Path" in p.message for p in problems))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -1,6 +1,6 @@
 name: Verify library conventions
 
-# PR-time guards for four invariants that local builds and the existing
+# PR-time guards for five invariants that local builds and the existing
 # verify-skills.yml / verify-manifests.yml workflows do not catch:
 #
 # 1. cli-skills/<slug>/SKILL.md must equal what
@@ -30,6 +30,12 @@ name: Verify library conventions
 #    behavior or docs. The printer / author fields are reviewable when
 #    corrected in an attribution-only PR, but a normal CLI improvement
 #    PR should never accidentally claim ownership of someone else's CLI.
+#
+# 5. Newly added library CLI packages must include the publish-package
+#    artifacts and provenance that reviewers need to audit the print:
+#    per-CLI AGENTS.md, patch manifest, manuscripts tied to run_id,
+#    novel feature metadata, MCP manifests when advertised, and the
+#    publish-skill PR body sections.
 
 on:
   pull_request:
@@ -40,6 +46,7 @@ on:
       - 'tools/generate-skills/**'
       - 'tools/sweep-canonical/**'
       - '.github/scripts/verify-attribution/**'
+      - '.github/scripts/verify-publish-package/**'
       - '.github/workflows/verify-library-conventions.yml'
   workflow_dispatch:
 
@@ -102,6 +109,22 @@ jobs:
           set -euo pipefail
           base_remote_ref="refs/remotes/base/${BASE_REF}"
           python3 .github/scripts/verify-attribution/verify_attribution.py --base "${base_remote_ref}"
+
+      - name: Publish package completeness
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
+          base_remote_ref="refs/remotes/base/${BASE_REF}"
+          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
+            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
+          fi
+
+          python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref "${base_remote_ref}"
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary
- Adds a PR-scoped verifier for changed `library/<category>/<slug>/` directories to catch incomplete published CLI packages.
- Checks required publish artifacts, manifest/provenance consistency, manuscript bundles, novel feature metadata, MCP artifacts when advertised, and publish-skill PR body sections.
- Wires the verifier into `verify-library-conventions.yml` so new CLI packages fail fast with actionable annotations.

## Testing
- Added focused unit tests for valid and failing publish-package cases.
- Ran Python compile checks, the new verifier tests, `actionlint` on the workflow, and a dry run of the verifier against `origin/main`.