### PR TITLE
fix(ci): Make publish-package PR prose advisory and artifact-driven

### DIFF
--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -52,6 +52,10 @@ def emit_error(problem: Problem) -> None:
     print(f"::error file={rel(problem.file)}::{message}")
 
 
+def emit_notice(message: str) -> None:
+    print(f"::notice::{annotation_escape(message)}")
+
+
 def rel(path: Path) -> str:
     return path.relative_to(REPO_ROOT).as_posix()
 
@@ -438,26 +442,54 @@ def read_pr_body(args: argparse.Namespace) -> str | None:
     return body if isinstance(body, str) else ""
 
 
-def validate_pr_body(body: str | None, new_dirs: list[Path]) -> list[Problem]:
+def markdown_table_cell(value: object) -> str:
+    return str(value or "").replace("\n", " ").replace("|", r"\|")
+
+
+def novel_commands_markdown(manifest: dict | None) -> str:
+    features = manifest.get("novel_features") if manifest else None
+    if not isinstance(features, list) or not features:
+        return "No novel commands recorded in .printing-press.json."
+
+    rows = ["| Command | Name | Description |", "|---------|------|-------------|"]
+    for feature in features:
+        if not isinstance(feature, dict):
+            continue
+        command = markdown_table_cell(feature.get("command"))
+        name = markdown_table_cell(feature.get("name"))
+        description = markdown_table_cell(feature.get("description") or feature.get("rationale"))
+        rows.append(f"| `{command}` | {name} | {description} |")
+    return "\n".join(rows)
+
+
+def pr_body_suggestions(body: str | None, new_dirs: list[Path]) -> list[str]:
     if not new_dirs or body is None:
         return []
 
-    problems: list[Problem] = []
-    if "### Novel Commands" not in body:
-        problems.append(
-            Problem(
-                None,
-                'PR body is missing "### Novel Commands". New CLI PRs should be created or updated with the current printing-press-publish skill so reviewers can inspect the verified novel command table from .printing-press.json.',
-            )
-        )
-    if "### Publication Path" not in body:
-        problems.append(
-            Problem(
-                None,
-                'PR body is missing "### Publication Path". Re-run the publish skill or update the PR body to state whether this is a new print, reprint, replacement, or existing-PR update.',
-            )
-        )
-    return problems
+    missing_publication_path = "### Publication Path" not in body
+    missing_novel_commands = "### Novel Commands" not in body
+    if not missing_publication_path and not missing_novel_commands:
+        return []
+
+    suggestions: list[str] = []
+    for cli_dir in new_dirs:
+        problems: list[Problem] = []
+        manifest = read_json(cli_dir / ".printing-press.json", problems)
+        if manifest is None:
+            continue
+
+        sections: list[str] = []
+        if missing_publication_path:
+            sections.extend(["### Publication Path", "", "New print"])
+        if missing_novel_commands:
+            if sections:
+                sections.append("")
+            sections.extend(["### Novel Commands", "", novel_commands_markdown(manifest)])
+
+        if sections:
+            suggestions.append(f"{rel(cli_dir)} PR body suggestion:\n" + "\n".join(sections))
+
+    return suggestions
 
 
 def validate_cli_dir(cli_dir: Path, strict: bool) -> list[Problem]:
@@ -504,10 +536,18 @@ def main(argv: list[str]) -> int:
         problems.extend(validate_cli_dir(cli_dir, strict))
         print("::endgroup::")
 
-    problems.extend(validate_pr_body(read_pr_body(args), new_dirs))
+    suggestions = pr_body_suggestions(read_pr_body(args), new_dirs)
 
     for problem in problems:
         emit_error(problem)
+    for suggestion in suggestions:
+        emit_notice(
+            "New CLI package artifacts are present, but the PR body does not include the current publish-summary sections. "
+            "This is advisory; CI gates the artifacts as the source of truth."
+        )
+        print("::group::Suggested PR body section")
+        print(suggestion)
+        print("::endgroup::")
 
     if problems:
         print(f"Publish-package verifier found {len(problems)} problem(s).")

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -96,7 +96,7 @@ class PublishPackageVerifierTest(unittest.TestCase):
         self.assertTrue(any(".printing-press-patches.json" in msg for msg in messages))
         self.assertTrue(any("run_id" in msg for msg in messages))
 
-    def test_valid_new_cli_and_pr_body_pass(self) -> None:
+    def test_valid_new_cli_and_pr_body_has_no_suggestions(self) -> None:
         self.write_valid_cli()
         self.git("add", ".")
         self.git("commit", "-m", "add example")
@@ -107,22 +107,24 @@ class PublishPackageVerifierTest(unittest.TestCase):
         problems = []
         for cli_dir in touched:
             problems.extend(verifier.validate_cli_dir(cli_dir, strict=cli_dir in new_dirs))
-        problems.extend(verifier.validate_pr_body(body, new_dirs))
+        suggestions = verifier.pr_body_suggestions(body, new_dirs)
 
         self.assertEqual([], problems)
+        self.assertEqual([], suggestions)
 
-    def test_pr_body_sections_required_for_new_cli(self) -> None:
+    def test_missing_pr_body_sections_are_advisory_for_new_cli(self) -> None:
         self.write_valid_cli()
         self.git("add", ".")
         self.git("commit", "-m", "add example")
 
         touched = verifier.changed_cli_dirs(self.base)
         new_dirs = [d for d in touched if verifier.is_new_cli(self.base, d)]
-        problems = verifier.validate_pr_body("", new_dirs)
+        suggestions = verifier.pr_body_suggestions("", new_dirs)
 
-        self.assertEqual(2, len(problems))
-        self.assertTrue(any("Novel Commands" in p.message for p in problems))
-        self.assertTrue(any("Publication Path" in p.message for p in problems))
+        self.assertEqual(1, len(suggestions))
+        self.assertIn("### Novel Commands", suggestions[0])
+        self.assertIn("### Publication Path", suggestions[0])
+        self.assertIn("| `search` | Example search | Searches example data. |", suggestions[0])
 
 
 if __name__ == "__main__":

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -34,8 +34,9 @@ name: Verify library conventions
 # 5. Newly added library CLI packages must include the publish-package
 #    artifacts and provenance that reviewers need to audit the print:
 #    per-CLI AGENTS.md, patch manifest, manuscripts tied to run_id,
-#    novel feature metadata, MCP manifests when advertised, and the
-#    publish-skill PR body sections.
+#    novel feature metadata, and MCP manifests when advertised. The
+#    publish-skill PR body sections are suggested from these artifacts,
+#    but artifact completeness remains the source of truth.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Keep hard CI gates on publish artifacts and provenance for new library CLIs.
- Stop failing PRs solely for missing publish-skill prose headings; instead emit a generated notice from `.printing-press.json`.
- Update the verifier tests and workflow comment to reflect that artifact completeness is the source of truth.

## Testing
- `python3 .github/scripts/verify-publish-package/verify_publish_package_test.py`
- `python3 -m py_compile .github/scripts/verify-publish-package/verify_publish_package.py .github/scripts/verify-publish-package/verify_publish_package_test.py`
- `git diff --check`