### PR TITLE
fix(postman-explore): share db path and serialize sqlite writes

### DIFF
--- a/library/developer-tools/postman-explore/.printing-press-patches.json
+++ b/library/developer-tools/postman-explore/.printing-press-patches.json
@@ -20,6 +20,32 @@
         "workflow-verify-report.json"
       ],
       "validated_outcome": "go test ./... passed; go build ./cmd/postman-explore-pp-cli succeeded; --version reports 3.0.1; sync help shows Postman Explore resource examples."
+    },
+    {
+      "id": "shared-db-path-root-env-mcp",
+      "summary": "Made the local SQLite DB path shared across CLI root flags, local read commands, doctor/workflow helpers, and MCP.",
+      "reason": "Previously sync/search/workflow could use one DB while novel commands and MCP silently read the default DB, making --db unreliable for agents and tests.",
+      "files": [
+        "internal/cli/root.go",
+        "internal/cli/novel_helpers.go",
+        "internal/cli/data_source.go",
+        "internal/cli/search.go",
+        "internal/cli/sync.go",
+        "internal/cli/doctor.go",
+        "internal/cli/channel_workflow.go",
+        "internal/mcp/tools.go",
+        "internal/store/path.go"
+      ],
+      "validated_outcome": "go test ./... passed; live smoke confirmed top --db reads the DB populated by sync --db; POSTMAN_EXPLORE_DB works for sync and top."
+    },
+    {
+      "id": "sqlite-write-serialization",
+      "summary": "Serialized Store write transactions to prevent SQLITE_BUSY failures during default parallel sync.",
+      "reason": "Default sync concurrency can run multiple resource writers against the same SQLite database; WAL does not allow concurrent writers, so one resource can fail with database is locked.",
+      "files": [
+        "internal/store/store.go"
+      ],
+      "validated_outcome": "Fresh-head repro failed with SQLITE_BUSY; patched live smoke synced category,collection,workspace,api,flow with default concurrency: success=5 errored=0 total_records=412."
     }
   ]
 }

--- a/library/developer-tools/postman-explore/internal/cli/category_landscape.go
+++ b/library/developer-tools/postman-explore/internal/cli/category_landscape.go
@@ -72,7 +72,7 @@ Run 'sync' first; the publisher and entity rankings come from the local store.`,
 				return notFoundErr(fmt.Errorf("category %q not found on the network", slug))
 			}
 
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}

--- a/library/developer-tools/postman-explore/internal/cli/channel_workflow.go
+++ b/library/developer-tools/postman-explore/internal/cli/channel_workflow.go
@@ -25,7 +25,6 @@ func newWorkflowCmd(flags *rootFlags) *cobra.Command {
 }
 
 func newWorkflowArchiveCmd(flags *rootFlags) *cobra.Command {
-	var dbPath string
 	var full bool
 
 	cmd := &cobra.Command{
@@ -46,16 +45,14 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 			c.NoCache = true
 
-			if dbPath == "" {
-				dbPath = defaultDBPath("postman-explore-pp-cli")
-			}
+			dbPath := localStorePath(flags)
 			s, err := store.Open(dbPath)
 			if err != nil {
 				return fmt.Errorf("opening store: %w", err)
 			}
 			defer s.Close()
 
-			resources := []string{"api", "category", "collection", "flow", "networkentity", "workspace",  }
+			resources := []string{"api", "category", "collection", "flow", "networkentity", "workspace"}
 			totalSynced := 0
 
 			for _, resource := range resources {
@@ -94,7 +91,9 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 						break
 					}
 					for _, item := range items {
-						var obj struct{ ID string `json:"id"` }
+						var obj struct {
+							ID string `json:"id"`
+						}
 						json.Unmarshal(item, &obj)
 						id := obj.ID
 						if id == "" {
@@ -135,14 +134,12 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/postman-explore-pp-cli/data.db)")
 	cmd.Flags().BoolVar(&full, "full", false, "Full re-archive (ignore previous sync state)")
 
 	return cmd
 }
 
 func newWorkflowStatusCmd(flags *rootFlags) *cobra.Command {
-	var dbPath string
 
 	cmd := &cobra.Command{
 		Use:         "status",
@@ -154,9 +151,7 @@ func newWorkflowStatusCmd(flags *rootFlags) *cobra.Command {
   # Show status as JSON
   postman-explore-pp-cli workflow status --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if dbPath == "" {
-				dbPath = defaultDBPath("postman-explore-pp-cli")
-			}
+			dbPath := localStorePath(flags)
 			s, err := store.Open(dbPath)
 			if err != nil {
 				return fmt.Errorf("opening store: %w", err)
@@ -190,8 +185,6 @@ func newWorkflowStatusCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
-
-	cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
 
 	return cmd
 }

--- a/library/developer-tools/postman-explore/internal/cli/data_source.go
+++ b/library/developer-tools/postman-explore/internal/cli/data_source.go
@@ -46,8 +46,8 @@ func isNetworkError(err error) bool {
 
 // openStoreForRead opens the local SQLite store for reading.
 // Returns nil, nil if the database file does not exist (no sync has been run).
-func openStoreForRead(cliName string) (*store.Store, error) {
-	dbPath := defaultDBPath(cliName)
+func openStoreForRead(flags *rootFlags) (*store.Store, error) {
+	dbPath := localStorePath(flags)
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -93,7 +93,7 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string) (json.RawMessage, DataProvenance, error) {
 	switch flags.dataSource {
 	case "local":
-		data, prov, err := resolveLocal(resourceType, isList, path, params, "user_requested")
+		data, prov, err := resolveLocal(flags, resourceType, isList, path, params, "user_requested")
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
@@ -106,7 +106,7 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 	default: // "auto"
 		data, err := c.GetWithHeaders(path, params, headers)
 		if err == nil {
-			writeThroughCache(resourceType, data)
+			writeThroughCache(flags, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {
@@ -114,7 +114,7 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 			return nil, DataProvenance{}, err
 		}
 		// Network error — try local fallback
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(resourceType, isList, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(flags, resourceType, isList, path, params, "api_unreachable")
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'postman-explore-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -129,7 +129,7 @@ func resolveRead(c *client.Client, flags *rootFlags, resourceType string, isList
 func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType string, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, DataProvenance, error) {
 	switch flags.dataSource {
 	case "local":
-		data, prov, err := resolveLocal(resourceType, true, path, params, "user_requested")
+		data, prov, err := resolveLocal(flags, resourceType, true, path, params, "user_requested")
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
@@ -142,13 +142,13 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 	default: // "auto"
 		data, err := paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
-			writeThroughCache(resourceType, data)
+			writeThroughCache(flags, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
 		if !isNetworkError(err) {
 			return nil, DataProvenance{}, err
 		}
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(resourceType, true, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(flags, resourceType, true, path, params, "api_unreachable")
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'postman-explore-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -159,8 +159,8 @@ func resolvePaginatedRead(c *client.Client, flags *rootFlags, resourceType strin
 // writeThroughCache upserts live API results into the local SQLite store so
 // FTS search covers everything the user has looked up — not just explicit syncs.
 // Best-effort: failures are silently ignored (the live result already succeeded).
-func writeThroughCache(resourceType string, data json.RawMessage) {
-	db, err := store.Open(defaultDBPath("postman-explore-pp-cli"))
+func writeThroughCache(flags *rootFlags, resourceType string, data json.RawMessage) {
+	db, err := store.Open(localStorePath(flags))
 	if err != nil {
 		return
 	}
@@ -212,8 +212,8 @@ func writeThroughCache(resourceType string, data json.RawMessage) {
 // Note: local reads return ALL synced data for the resource type. Endpoint-specific
 // filters (query params, path scoping like /teams/{id}/users) are NOT applied locally.
 // The provenance metadata includes "unscoped":true when params were present but not applied.
-func resolveLocal(resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
-	db, err := openStoreForRead("postman-explore-pp-cli")
+func resolveLocal(flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, reason string) (json.RawMessage, DataProvenance, error) {
+	db, err := openStoreForRead(flags)
 	if err != nil {
 		return nil, DataProvenance{}, fmt.Errorf("opening local database: %w\nRun 'postman-explore-pp-cli sync' first.", err)
 	}

--- a/library/developer-tools/postman-explore/internal/cli/doctor.go
+++ b/library/developer-tools/postman-explore/internal/cli/doctor.go
@@ -174,7 +174,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
-			report["cache"] = collectCacheReport("")
+			report["cache"] = collectCacheReport(flags, "")
 
 			report["version"] = version
 
@@ -289,9 +289,9 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 // staleAfterSpec is the CLI's configured threshold (e.g. "6h"); empty means
 // use the runtime default. The default is deliberately conservative (6h)
 // because the alternative is no freshness story at all.
-func collectCacheReport(staleAfterSpec string) map[string]any {
+func collectCacheReport(flags *rootFlags, staleAfterSpec string) map[string]any {
 	report := map[string]any{}
-	dbPath := defaultDBPath("postman-explore-pp-cli")
+	dbPath := localStorePath(flags)
 	report["db_path"] = dbPath
 
 	fi, err := os.Stat(dbPath)

--- a/library/developer-tools/postman-explore/internal/cli/drift.go
+++ b/library/developer-tools/postman-explore/internal/cli/drift.go
@@ -51,7 +51,7 @@ Run 'sync' first; this command reads the local store.`,
 			}
 			cutoff := time.Now().Add(-window)
 
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}

--- a/library/developer-tools/postman-explore/internal/cli/helpers.go
+++ b/library/developer-tools/postman-explore/internal/cli/helpers.go
@@ -7,16 +7,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/internal/store"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
 	"unicode"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var As = errors.As
@@ -90,11 +91,11 @@ type cliError struct {
 func (e *cliError) Error() string { return e.err.Error() }
 func (e *cliError) Unwrap() error { return e.err }
 
-func usageErr(err error) error    { return &cliError{code: 2, err: err} }
-func notFoundErr(err error) error { return &cliError{code: 3, err: err} }
-func authErr(err error) error     { return &cliError{code: 4, err: err} }
-func apiErr(err error) error      { return &cliError{code: 5, err: err} }
-func configErr(err error) error   { return &cliError{code: 10, err: err} }
+func usageErr(err error) error     { return &cliError{code: 2, err: err} }
+func notFoundErr(err error) error  { return &cliError{code: 3, err: err} }
+func authErr(err error) error      { return &cliError{code: 4, err: err} }
+func apiErr(err error) error       { return &cliError{code: 5, err: err} }
+func configErr(err error) error    { return &cliError{code: 10, err: err} }
 func rateLimitErr(err error) error { return &cliError{code: 7, err: err} }
 
 // dryRunOK reports whether the command should short-circuit without doing any
@@ -1016,12 +1017,13 @@ func findField(obj map[string]any, names ...string) string {
 	}
 	return ""
 }
+
 // DataProvenance describes where data came from and when it was last synced.
 type DataProvenance struct {
 	Source       string     `json:"source"`                  // "live" or "local"
-	SyncedAt    *time.Time `json:"synced_at,omitempty"`     // when local data was last synced
-	Reason      string     `json:"reason,omitempty"`        // why local was used: "user_requested", "api_unreachable", "no_search_endpoint"
-	ResourceType string    `json:"resource_type,omitempty"` // which resource type was queried
+	SyncedAt     *time.Time `json:"synced_at,omitempty"`     // when local data was last synced
+	Reason       string     `json:"reason,omitempty"`        // why local was used: "user_requested", "api_unreachable", "no_search_endpoint"
+	ResourceType string     `json:"resource_type,omitempty"` // which resource type was queried
 	Freshness    any        `json:"freshness,omitempty"`     // optional machine-owned freshness metadata for covered command paths
 }
 
@@ -1082,6 +1084,5 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 
 // defaultDBPath returns the canonical path for the local SQLite database.
 func defaultDBPath(name string) string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", name, "data.db")
+	return store.DefaultPath(name)
 }

--- a/library/developer-tools/postman-explore/internal/cli/novel_helpers.go
+++ b/library/developer-tools/postman-explore/internal/cli/novel_helpers.go
@@ -58,8 +58,15 @@ func extractMetricValue(data json.RawMessage, metricName string) int64 {
 
 // openLocalStore opens the standard CLI database. Centralized so every novel
 // command uses the same default path and error message.
-func openLocalStore() (*store.Store, error) {
-	return store.Open(defaultDBPath("postman-explore-pp-cli"))
+func localStorePath(flags *rootFlags) string {
+	if flags != nil {
+		return store.ResolvePath("postman-explore-pp-cli", flags.dbPath)
+	}
+	return store.DefaultPath("postman-explore-pp-cli")
+}
+
+func openLocalStore(flags *rootFlags) (*store.Store, error) {
+	return store.Open(localStorePath(flags))
 }
 
 // queryNetworkEntities runs a SELECT against the synced entity rows and

--- a/library/developer-tools/postman-explore/internal/cli/publishers.go
+++ b/library/developer-tools/postman-explore/internal/cli/publishers.go
@@ -54,7 +54,7 @@ Run 'sync' first; this command reads the local store.`,
 			if entityType != "" && !validEntityType(entityType) {
 				return usageErr(fmt.Errorf("invalid --type %q (use one of collection, workspace, api, flow, or omit for all)", entityType))
 			}
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}
@@ -197,9 +197,9 @@ func lookupPublisherHandles(db *sql.DB) map[string]string {
 		}
 		var doc struct {
 			Meta struct {
-				PublisherID     string `json:"publisherId"`
-				PublicHandle    string `json:"workspaceSlug"`
-				PublisherType   string `json:"publisherType"`
+				PublisherID   string `json:"publisherId"`
+				PublicHandle  string `json:"workspaceSlug"`
+				PublisherType string `json:"publisherType"`
 			} `json:"meta"`
 		}
 		if err := json.Unmarshal([]byte(dataText), &doc); err != nil {

--- a/library/developer-tools/postman-explore/internal/cli/root.go
+++ b/library/developer-tools/postman-explore/internal/cli/root.go
@@ -22,23 +22,25 @@ import (
 var version = "3.0.1"
 
 type rootFlags struct {
-	asJSON        bool
-	compact       bool
-	csv           bool
-	plain         bool
-	quiet         bool
-	dryRun        bool
-	noCache       bool
-	noInput       bool
-	yes           bool
-	agent         bool
-	selectFields  string
-	configPath    string
-	profileName   string
-	deliverSpec   string
-	timeout       time.Duration
-	rateLimit     float64
-	dataSource    string
+	asJSON       bool
+	compact      bool
+	csv          bool
+	plain        bool
+	quiet        bool
+	dryRun       bool
+	noCache      bool
+	noInput      bool
+	yes          bool
+	agent        bool
+	selectFields string
+	configPath   string
+	profileName  string
+	deliverSpec  string
+	timeout      time.Duration
+	rateLimit    float64
+	dataSource   string
+	// PATCH: promote the local SQLite store path to a root flag so every local command shares the same DB.
+	dbPath        string
 	freshnessMeta any
 
 	// deliverBuf captures command output when --deliver is set to a
@@ -120,6 +122,8 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().BoolVar(&humanFriendly, "human-friendly", false, "Enable colored output and rich formatting")
 	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
+	// PATCH: root-level --db replaces drifted per-command DB flags.
+	rootCmd.PersistentFlags().StringVar(&flags.dbPath, "db", "", "Database path for local cache/store commands (default: ~/.local/share/postman-explore-pp-cli/data.db)")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'postman-explore-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 2, "Max requests per second (0 to disable, default 2 for sniffed APIs)")

--- a/library/developer-tools/postman-explore/internal/cli/search.go
+++ b/library/developer-tools/postman-explore/internal/cli/search.go
@@ -82,7 +82,6 @@ func extractSearchResults(data json.RawMessage) []json.RawMessage {
 func newSearchCmd(flags *rootFlags) *cobra.Command {
 	var resourceType string
 	var limit int
-	var dbPath string
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
@@ -118,13 +117,13 @@ In local mode: searches locally synced data only.`,
 					return err
 				}
 				data, _, getErr := c.Post("/search-all", map[string]any{
-					"queryText": query,
-					"domain": "public",
-					"from": 0,
-					"mergeEntities": true,
+					"queryText":         query,
+					"domain":            "public",
+					"from":              0,
+					"mergeEntities":     true,
 					"nonNestedRequests": true,
-					"queryIndices": []any{"runtime.collection", "collaboration.workspace", "apinetwork.team", "flow.flow", "runtime.request"},
-					"size": 10,
+					"queryIndices":      []any{"runtime.collection", "collaboration.workspace", "apinetwork.team", "flow.flow", "runtime.request"},
+					"size":              10,
 				})
 				if getErr == nil {
 					// Live search succeeded
@@ -141,9 +140,7 @@ In local mode: searches locally synced data only.`,
 			}
 
 			// Local FTS search
-			if dbPath == "" {
-				dbPath = defaultDBPath("postman-explore-pp-cli")
-			}
+			dbPath := localStorePath(flags)
 
 			db, err := store.Open(dbPath)
 			if err != nil {
@@ -177,7 +174,6 @@ In local mode: searches locally synced data only.`,
 
 	cmd.Flags().StringVar(&resourceType, "type", "", "Filter by resource type")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum results to return")
-	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/postman-explore-pp-cli/data.db)")
 
 	return cmd
 }

--- a/library/developer-tools/postman-explore/internal/cli/similar.go
+++ b/library/developer-tools/postman-explore/internal/cli/similar.go
@@ -44,7 +44,7 @@ Run 'sync' first; this command reads the local store.`,
 				return usageErr(fmt.Errorf("invalid --type %q (use one of collection, workspace, api, flow)", entityType))
 			}
 
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}

--- a/library/developer-tools/postman-explore/internal/cli/store_path_test.go
+++ b/library/developer-tools/postman-explore/internal/cli/store_path_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStorePathExplicitWinsOverEnv(t *testing.T) {
+	t.Setenv("POSTMAN_EXPLORE_DB", filepath.Join(t.TempDir(), "env.db"))
+	explicit := filepath.Join(t.TempDir(), "explicit.db")
+	if got := localStorePath(&rootFlags{dbPath: explicit}); got != explicit {
+		t.Fatalf("localStorePath = %q, want %q", got, explicit)
+	}
+}
+
+func TestLocalStorePathUsesEnvWithoutExplicitFlag(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), "env.db")
+	t.Setenv("POSTMAN_EXPLORE_DB", envPath)
+	if got := localStorePath(&rootFlags{}); got != envPath {
+		t.Fatalf("localStorePath = %q, want %q", got, envPath)
+	}
+}

--- a/library/developer-tools/postman-explore/internal/cli/sync.go
+++ b/library/developer-tools/postman-explore/internal/cli/sync.go
@@ -32,7 +32,6 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var full bool
 	var since string
 	var concurrency int
-	var dbPath string
 	var maxPages int
 	var latestOnly bool
 
@@ -76,9 +75,7 @@ Exit codes & warnings:
 			}
 			c.NoCache = true
 
-			if dbPath == "" {
-				dbPath = defaultDBPath("postman-explore-pp-cli")
-			}
+			dbPath := localStorePath(flags)
 
 			db, err := store.Open(dbPath)
 			if err != nil {
@@ -216,7 +213,6 @@ Exit codes & warnings:
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
-	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/postman-explore-pp-cli/data.db)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 

--- a/library/developer-tools/postman-explore/internal/cli/top.go
+++ b/library/developer-tools/postman-explore/internal/cli/top.go
@@ -46,7 +46,7 @@ Run 'sync' first; this command reads from the local store.`,
 				return usageErr(fmt.Errorf("invalid --type %q (use one of collection, workspace, api, flow)", entityType))
 			}
 
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}

--- a/library/developer-tools/postman-explore/internal/cli/velocity.go
+++ b/library/developer-tools/postman-explore/internal/cli/velocity.go
@@ -42,7 +42,7 @@ Run 'sync' first; this command reads the local store.`,
 			if !validEntityType(entityType) {
 				return usageErr(fmt.Errorf("invalid --type %q (use one of collection, workspace, api, flow)", entityType))
 			}
-			db, err := openLocalStore()
+			db, err := openLocalStore(flags)
 			if err != nil {
 				return fmt.Errorf("opening local store: %w", err)
 			}

--- a/library/developer-tools/postman-explore/internal/mcp/tools.go
+++ b/library/developer-tools/postman-explore/internal/mcp/tools.go
@@ -31,7 +31,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v2/api/category/{slug}", []string{"slug", }),
+		makeAPIHandler("GET", "/v2/api/category/{slug}", []string{"slug"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("category_list-categories",
@@ -41,7 +41,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v2/api/category", []string{ }),
+		makeAPIHandler("GET", "/v2/api/category", []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("networkentity_get-network-entity",
@@ -51,7 +51,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/api/networkentity/{id}", []string{"id", }),
+		makeAPIHandler("GET", "/v1/api/networkentity/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("networkentity_get-network-entity-counts",
@@ -61,7 +61,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/api/networkentity/count", []string{ }),
+		makeAPIHandler("GET", "/v1/api/networkentity/count", []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("networkentity_list-network-entities",
@@ -76,7 +76,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/api/networkentity", []string{ }),
+		makeAPIHandler("GET", "/v1/api/networkentity", []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("search-all_search_all",
@@ -84,7 +84,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/search-all", []string{ }),
+		makeAPIHandler("POST", "/search-all", []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("team_get",
@@ -94,7 +94,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/api/team/{id}", []string{"id", }),
+		makeAPIHandler("GET", "/v1/api/team/{id}", []string{"id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("team_get-workspaces",
@@ -104,7 +104,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/v1/api/team", []string{ }),
+		makeAPIHandler("GET", "/v1/api/team", []string{}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -260,12 +260,10 @@ func newMCPClient() (*client.Client, error) {
 	return c, nil
 }
 
+// PATCH: MCP shares the same default/env-overridden SQLite path as the CLI.
 func dbPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", "postman-explore-pp-cli", "data.db")
+	return store.DefaultPath("postman-explore-pp-cli")
 }
-// Note: MCP tools use their own dbPath() because they are in a separate package (main, not cli).
-// The CLI's defaultDBPath() in the cli package uses the same canonical path.
 
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
@@ -351,30 +349,30 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 		"tool_surface": "MCP exposes typed endpoint tools plus a runtime mirror of user-facing CLI commands. Endpoint tools keep typed schemas; command-mirror tools shell out to the companion postman-explore-pp-cli binary.",
 		"resources": []map[string]any{
 			{
-				"name": "category",
+				"name":        "category",
 				"description": "Manage category",
-				"endpoints": []string{"get", "list-categories",  },
-				"syncable": true,
-				"searchable": true,
+				"endpoints":   []string{"get", "list-categories"},
+				"syncable":    true,
+				"searchable":  true,
 			},
 			{
-				"name": "networkentity",
+				"name":        "networkentity",
 				"description": "Manage networkentity",
-				"endpoints": []string{"get-network-entity", "get-network-entity-counts", "list-network-entities",  },
-				"syncable": true,
-				"searchable": true,
+				"endpoints":   []string{"get-network-entity", "get-network-entity-counts", "list-network-entities"},
+				"syncable":    true,
+				"searchable":  true,
 			},
 			{
-				"name": "search-all",
+				"name":        "search-all",
 				"description": "Manage search all",
-				"endpoints": []string{"search_all",  },
-				"searchable": true,
+				"endpoints":   []string{"search_all"},
+				"searchable":  true,
 			},
 			{
-				"name": "team",
+				"name":        "team",
 				"description": "Publisher teams on the API network",
-				"endpoints": []string{"get", "get-workspaces",  },
-				"searchable": true,
+				"endpoints":   []string{"get", "get-workspaces"},
+				"searchable":  true,
 			},
 		},
 		"query_tips": []string{

--- a/library/developer-tools/postman-explore/internal/store/path.go
+++ b/library/developer-tools/postman-explore/internal/store/path.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PATCH: shared path resolver used by CLI and MCP so custom stores do not drift.
+// DefaultPath returns the canonical SQLite store path for a generated CLI.
+// POSTMAN_EXPLORE_DB is an explicit override for non-Cobra entry points such
+// as MCP tools, where there is no root --db flag to inherit.
+func DefaultPath(name string) string {
+	if v := strings.TrimSpace(os.Getenv("POSTMAN_EXPLORE_DB")); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", name, "data.db")
+}
+
+// ResolvePath returns explicit when non-empty, otherwise the default path.
+func ResolvePath(name, explicit string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return explicit
+	}
+	return DefaultPath(name)
+}

--- a/library/developer-tools/postman-explore/internal/store/path_test.go
+++ b/library/developer-tools/postman-explore/internal/store/path_test.go
@@ -1,0 +1,22 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePathExplicitWins(t *testing.T) {
+	t.Setenv("POSTMAN_EXPLORE_DB", filepath.Join(t.TempDir(), "env.db"))
+	explicit := filepath.Join(t.TempDir(), "explicit.db")
+	if got := ResolvePath("postman-explore-pp-cli", explicit); got != explicit {
+		t.Fatalf("ResolvePath explicit = %q, want %q", got, explicit)
+	}
+}
+
+func TestDefaultPathHonorsEnv(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), "env.db")
+	t.Setenv("POSTMAN_EXPLORE_DB", envPath)
+	if got := DefaultPath("postman-explore-pp-cli"); got != envPath {
+		t.Fatalf("DefaultPath = %q, want env override %q", got, envPath)
+	}
+}

--- a/library/developer-tools/postman-explore/internal/store/store.go
+++ b/library/developer-tools/postman-explore/internal/store/store.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -37,6 +38,9 @@ const StoreSchemaVersion = 1
 type Store struct {
 	db   *sql.DB
 	path string
+
+	// PATCH: serialize SQLite write transactions so default parallel sync does not trip SQLITE_BUSY.
+	writeMu sync.Mutex
 }
 
 func Open(dbPath string) (*Store, error) {
@@ -318,6 +322,9 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 }
 
 func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -434,6 +441,7 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 	}
 	return nil
 }
+
 // upsertSearchAllTx writes the typed-table portion of a search_all upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -462,6 +470,9 @@ func (s *Store) upsertSearchAllTx(tx *sql.Tx, id string, obj map[string]any, dat
 
 // UpsertSearchAll inserts or updates a search_all record with domain-specific columns.
 func (s *Store) UpsertSearchAll(data json.RawMessage) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return fmt.Errorf("unmarshaling search_all: %w", err)
@@ -487,6 +498,7 @@ func (s *Store) UpsertSearchAll(data json.RawMessage) error {
 
 	return tx.Commit()
 }
+
 // upsertNetworkentityTx writes the typed-table portion of a networkentity upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -516,6 +528,9 @@ func (s *Store) upsertNetworkentityTx(tx *sql.Tx, id string, obj map[string]any,
 
 // UpsertNetworkentity inserts or updates a networkentity record with domain-specific columns.
 func (s *Store) UpsertNetworkentity(data json.RawMessage) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return fmt.Errorf("unmarshaling networkentity: %w", err)
@@ -541,6 +556,7 @@ func (s *Store) UpsertNetworkentity(data json.RawMessage) error {
 
 	return tx.Commit()
 }
+
 // upsertTeamTx writes the typed-table portion of a team upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -564,6 +580,9 @@ func (s *Store) upsertTeamTx(tx *sql.Tx, id string, obj map[string]any, data jso
 
 // UpsertTeam inserts or updates a team record with domain-specific columns.
 func (s *Store) UpsertTeam(data json.RawMessage) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return fmt.Errorf("unmarshaling team: %w", err)
@@ -589,6 +608,7 @@ func (s *Store) UpsertTeam(data json.RawMessage) error {
 
 	return tx.Commit()
 }
+
 // upsertCategoryTx writes the typed-table portion of a category upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -613,6 +633,9 @@ func (s *Store) upsertCategoryTx(tx *sql.Tx, id string, obj map[string]any, data
 
 // UpsertCategory inserts or updates a category record with domain-specific columns.
 func (s *Store) UpsertCategory(data json.RawMessage) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return fmt.Errorf("unmarshaling category: %w", err)
@@ -656,6 +679,10 @@ func (s *Store) UpsertCategory(data json.RawMessage) error {
 // only populate the generic resources table — typed tables (and indexed
 // columns like parent_id added by dependent-resource sync) would stay empty.
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, error) {
+	// PATCH: batch writes are the hot path hit by parallel sync workers.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return 0, fmt.Errorf("starting batch transaction: %w", err)
@@ -723,6 +750,9 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, ?, ?)
@@ -746,6 +776,9 @@ func (s *Store) GetSyncState(resourceType string) (cursor string, lastSynced tim
 
 // SaveSyncCursor stores the pagination cursor for a resource type.
 func (s *Store) SaveSyncCursor(resourceType, cursor string) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	_, err := s.db.Exec(
 		`INSERT INTO sync_state (resource_type, last_cursor, last_synced_at, total_count)
 		 VALUES (?, ?, CURRENT_TIMESTAMP, 0)
@@ -803,6 +836,9 @@ func (s *Store) GetLastSyncedAt(resourceType string) string {
 
 // ClearSyncCursors resets all sync state for a full resync.
 func (s *Store) ClearSyncCursors() error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	_, err := s.db.Exec("DELETE FROM sync_state")
 	return err
 }


### PR DESCRIPTION
## Summary

Fixes two local-store correctness problems in `postman-explore`:

1. Makes the SQLite DB path consistent across local commands, fallback reads, `doctor`, workflow commands, and MCP.
   - Adds a root persistent `--db` flag.
   - Adds `POSTMAN_EXPLORE_DB` as an env override for non-Cobra entry points such as MCP.
   - Routes local-store readers through one resolver instead of each command drifting to its own default path.
2. Serializes writes inside `store.Store` so the default parallel `sync` path no longer races SQLite writer locks.

## Why

The current generated CLI lets `sync/search/workflow` write/read one DB while novel read commands like `top`, `drift`, `velocity`, `publishers top`, and `category landscape` silently read the default DB. MCP also hard-codes the default path. That makes `--db` unreliable for agent/test workflows.

A deeper live smoke also found that the default parallel sync can fail with SQLite `SQLITE_BUSY` when multiple resources write concurrently.

Fresh HEAD repro before this patch:

```bash
/tmp/postman-explore-fresh sync --db /tmp/postman-fresh-default.sqlite \
  --resources category,collection,workspace,api,flow \
  --max-pages 1 --json --timeout 45s
```

Observed:

```text
{"event":"sync_error","resource":"api","error":"upserting api/40523: database is locked (5) (SQLITE_BUSY)"}
{"event":"sync_summary","total_records":312,"resources":5,"success":4,"warned":0,"errored":1,"duration_ms":1194}
Error: 1 resource(s) failed to sync
```

## Validation

From this branch:

```text
go test ./... = pass
```

Live smoke:

```text
/tmp/postman-explore-pr --db /tmp/postman-pr-db.sqlite sync --resources category,collection,workspace,api,flow --max-pages 1 --json --timeout 45s
{"event":"sync_summary","total_records":412,"resources":5,"success":5,"warned":0,"errored":0,"duration_ms":1158}

/tmp/postman-explore-pr top --db /tmp/postman-pr-db.sqlite --metric weekForkCount --type collection --limit 1 --json
# returned: WhatsApp Cloud API

POSTMAN_EXPLORE_DB=/tmp/postman-pr-env.sqlite /tmp/postman-explore-pr sync --resources category,collection --max-pages 1 --json --timeout 30s
POSTMAN_EXPLORE_DB=/tmp/postman-pr-env.sqlite /tmp/postman-explore-pr top --metric weekForkCount --type collection --limit 1 --json
# returned: WhatsApp Cloud API
```

## Notes

This is intentionally limited to the library copy of `postman-explore`. If the write-lock pattern is desired generator-wide, the same idea should probably move into the generated store template in `cli-printing-press` as a follow-up.
