### PR TITLE
fix(table-reservation-goat): address Greptile findings from #386

### DIFF
--- a/library/food-and-dining/table-reservation-goat/go.mod
+++ b/library/food-and-dining/table-reservation-goat/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mark3labs/mcp-go v0.47.0
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.35.0
 )
 
 require (
@@ -58,7 +59,6 @@ require (
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
 	modernc.org/libc v1.62.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.9.1 // indirect

--- a/library/food-and-dining/table-reservation-goat/internal/cli/book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/book.go
@@ -33,8 +33,12 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/auth"
@@ -541,12 +545,26 @@ func matchedExistingOT(r opentable.UpcomingReservation, slug, date, hhmm string,
 	return true
 }
 
-// normalizeForSlugMatch lowercases s and strips non-alphanumeric runes so
-// slug tokens can be matched against display-name strings.
+// asciiFold runs NFKD decomposition then removes combining marks so accented
+// runes ("é", "ñ", "ü") fold to their ASCII bases ("e", "n", "u") before the
+// alphanumeric filter. Without this, "Café du Monde" normalizes to
+// "cafdumonde" instead of "cafedumonde", breaking idempotency match against
+// slug "cafe-du-monde".
+var asciiFold = transform.Chain(norm.NFKD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+
+// normalizeForSlugMatch lowercases s, folds non-ASCII letters to their ASCII
+// bases, and strips non-alphanumeric runes so slug tokens can be matched
+// against display-name strings.
 func normalizeForSlugMatch(s string) string {
+	folded, _, err := transform.String(asciiFold, s)
+	if err != nil {
+		// Fold failures are rare (transform errors are mostly EOF/buffer);
+		// fall back to the raw string so we still produce useful output.
+		folded = s
+	}
 	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range strings.ToLower(s) {
+	b.Grow(len(folded))
+	for _, r := range strings.ToLower(folded) {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
 			b.WriteRune(r)
 		}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/book.go
@@ -520,9 +520,36 @@ func matchedExistingOT(r opentable.UpcomingReservation, slug, date, hhmm string,
 	if rDate != date || normalizeTime(rTime) != normalizeTime(hhmm) {
 		return false
 	}
-	// OT's UpcomingReservation doesn't carry restaurantSlug — fall back to
-	// confirming via restaurantName containing slug-like tokens. Best-effort:
-	// the agent specifies the slug; if pre-flight matches all-but-slug, surface.
-	// Future: add a separate canonical-slug field via a follow-up GraphQL.
+	// OT's UpcomingReservation doesn't carry a canonical slug. Fall back to
+	// requiring every non-empty slug-token to appear in the alphanumeric-only
+	// normalization of RestaurantName. For "water-grill-bellevue" that
+	// produces {water, grill, bellevue} all matching "watergrillbellevue";
+	// "canlis" would not match, so a Canlis booking on the same slot doesn't
+	// silently report matched_existing for Water Grill.
+	normName := normalizeForSlugMatch(r.RestaurantName)
+	if normName == "" {
+		return false
+	}
+	for _, tok := range strings.Split(slug, "-") {
+		if tok == "" {
+			continue
+		}
+		if !strings.Contains(normName, tok) {
+			return false
+		}
+	}
 	return true
+}
+
+// normalizeForSlugMatch lowercases s and strips non-alphanumeric runes so
+// slug tokens can be matched against display-name strings.
+func normalizeForSlugMatch(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/library/food-and-dining/table-reservation-goat/internal/cli/book_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/book_test.go
@@ -224,12 +224,16 @@ func TestMatchedExistingOT_RestaurantSlugCheck(t *testing.T) {
 		{"different restaurant overlapping token", "grill-on-the-alley", false},
 		{"slug with extra token not in name", "water-grill-bellevue-private", false},
 		{"empty name short-circuits", "water-grill-bellevue", false},
+		{"accented name folds to ascii", "cafe-du-monde", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := water
-			if tc.name == "empty name short-circuits" {
+			switch tc.name {
+			case "empty name short-circuits":
 				r.RestaurantName = ""
+			case "accented name folds to ascii":
+				r.RestaurantName = "Café du Monde"
 			}
 			got := matchedExistingOT(r, tc.slug, "2026-05-13", "19:00", 2)
 			if got != tc.want {
@@ -243,7 +247,12 @@ func TestNormalizeForSlugMatch(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"Water Grill - Bellevue", "watergrillbellevue"},
 		{"Canlis", "canlis"},
-		{"L'Étoile", "ltoile"}, // non-ASCII letters dropped
+		// Greptile P2: accented runes fold to ASCII so slug tokens like
+		// "cafe" / "etoile" match Café / L'Étoile.
+		{"Café du Monde", "cafedumonde"},
+		{"L'Étoile", "letoile"},
+		{"Niño Restaurant", "ninorestaurant"},
+		{"Brüder", "bruder"},
 		{"", ""},
 	}
 	for _, tc := range cases {

--- a/library/food-and-dining/table-reservation-goat/internal/cli/book_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/book_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/opentable"
 )
 
 func TestParseNetworkPrefix(t *testing.T) {
@@ -201,4 +203,52 @@ func TestVerifyEnvFloor_GuardOrder(t *testing.T) {
 
 func envIsVerify() bool {
 	return os.Getenv("PRINTING_PRESS_VERIFY") == "1"
+}
+
+func TestMatchedExistingOT_RestaurantSlugCheck(t *testing.T) {
+	// Same date, time, and party at a different restaurant must NOT match.
+	// Greptile P1: prior implementation returned true unconditionally after
+	// date/time/party checks, false-positive matching any OT reservation.
+	water := opentable.UpcomingReservation{
+		PartySize:      2,
+		DateTime:       "2026-05-13T19:00:00",
+		RestaurantName: "Water Grill - Bellevue",
+	}
+	cases := []struct {
+		name string
+		slug string
+		want bool
+	}{
+		{"exact slug match", "water-grill-bellevue", true},
+		{"different restaurant same slot", "canlis", false},
+		{"different restaurant overlapping token", "grill-on-the-alley", false},
+		{"slug with extra token not in name", "water-grill-bellevue-private", false},
+		{"empty name short-circuits", "water-grill-bellevue", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := water
+			if tc.name == "empty name short-circuits" {
+				r.RestaurantName = ""
+			}
+			got := matchedExistingOT(r, tc.slug, "2026-05-13", "19:00", 2)
+			if got != tc.want {
+				t.Errorf("matchedExistingOT(%q vs %q) = %v; want %v", tc.slug, r.RestaurantName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeForSlugMatch(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Water Grill - Bellevue", "watergrillbellevue"},
+		{"Canlis", "canlis"},
+		{"L'Étoile", "ltoile"}, // non-ASCII letters dropped
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeForSlugMatch(tc.in); got != tc.want {
+			t.Errorf("normalizeForSlugMatch(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
 }

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/booking.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/booking.go
@@ -48,9 +48,16 @@ var (
 // CancelReservation persisted-query hash, captured live 2026-05-09.
 const CancelReservationHash = "4ee53a006030f602bdeb1d751fa90ddc4240d9e17d015fb7976f8efcb80a026e"
 
-// BookingConfirmationPageInFlow persisted-query hash. Used to fetch the
-// cancelCutoffDate after a successful book. The captured prefix was truncated
-// at capture time; the implementer should refresh from a live capture if 400.
+// BookingConfirmationPageInFlow persisted-query hash. Used by FetchCancelCutoff
+// to populate `cancellation_deadline` in the book JSON output.
+//
+// TODO: this hash was assembled from a partial capture and may be stale. The
+// FetchCancelCutoff caller already swallows errors gracefully (book output
+// degrades to an empty cutoff string), but on the next live OT booking
+// session capture the BookingConfirmationPageInFlow GraphQL request and
+// replace this constant with the captured `extensions.persistedQuery.sha256Hash`
+// value. Verify by booking a free reservation and confirming a non-empty
+// `cancellation_deadline` field.
 const BookingConfirmationHash = "7c4fe1d7786e25085199bddc46cb1525ebf90ac18621ceb3021074fda52b6000"
 
 // BookRequest is the user-facing input to Book(). All fields are required

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/booking.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/booking.go
@@ -43,6 +43,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -156,55 +157,68 @@ func (c *Client) Book(ctx context.Context, req BookRequest) (*BookResponse, erro
 	return c.ChromeBook(ctx, req)
 }
 
+// hiddenInputRE matches `<input type="hidden" name="X" value="Y">` shapes,
+// tolerant of attribute ordering and quoting style. Used by the cancel-flow
+// CSRF retry to scrape anti-forgery tokens from the receipt page HTML.
+var hiddenInputRE = regexp.MustCompile(`(?is)<input[^>]*type=["']hidden["'][^>]*>`)
+
+// hiddenAttrRE pulls the name + value attributes out of a single hidden-input
+// tag matched by hiddenInputRE.
+var hiddenAttrRE = regexp.MustCompile(`(?is)\b(name|value)=["']([^"']*)["']`)
+
+// csrfNamePatterns names a hidden input is treated as anti-forgery if any of
+// these substrings appears (case-insensitive). Drawn from common .NET / Rails
+// / Express conventions; covers the field names Tock has historically used
+// without us needing a fresh capture.
+var csrfNamePatterns = []string{"csrf", "xsrf", "authenticity", "requestverification", "antiforgery"}
+
 // Cancel cancels a Tock reservation by form-submitting to
-// /<venue-slug>/receipt/cancel. The request body shape is best-effort
-// (CSRF token if needed); the actual cancellation is verified by checking
-// the post-redirect page state.
+// /<venue-slug>/receipt/cancel. Two-step: first attempts an empty-body POST.
+// On 401/403 (likely CSRF rejection), GETs the receipt page, scrapes hidden
+// inputs whose names look like anti-forgery tokens, and retries the POST
+// with those fields populated. The actual cancellation is verified by
+// checking the post-redirect page state for the confirmation banner.
 //
-// Status caveat: this implementation hasn't been live-tested against an
-// active reservation due to the v0.2 constraint of "no fresh test bookings."
-// First U6 dogfood pass should validate against a manually-created Tock
-// reservation, then be removed if the form-submit shape proves brittle in
-// favor of chromedp-attach (Option B).
+// Status caveat: the CSRF retry has not been live-tested end-to-end (the
+// v0.2 testing budget cancelled via the Tock UI). On the next live cancel
+// session, capture the receipt page's hidden-input field names and tighten
+// csrfNamePatterns if the empty-body POST proves to fail consistently.
 func (c *Client) Cancel(ctx context.Context, req CancelRequest) (*CancelResponse, error) {
 	if req.VenueSlug == "" || req.PurchaseID == 0 {
 		return nil, fmt.Errorf("tock cancel: VenueSlug and PurchaseID are required")
 	}
 	cancelURL := Origin + "/" + url.PathEscape(req.VenueSlug) + "/receipt/cancel?purchaseId=" + fmt.Sprintf("%d", req.PurchaseID)
+	receiptURL := Origin + "/" + url.PathEscape(req.VenueSlug) + "/receipt?purchaseId=" + fmt.Sprintf("%d", req.PurchaseID)
 
-	// Form body: empty for now. The page may include an anti-forgery token
-	// rendered into the cancel page HTML; if so, GET that page first and
-	// extract the token. v0.2 attempts the simple POST and falls back to
-	// the typed error on non-200.
-	formBody := url.Values{}.Encode()
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, cancelURL, strings.NewReader(formBody))
+	// First attempt: empty-body POST. Some Tock venues don't enforce CSRF on
+	// the cancel form, in which case this succeeds without an extra GET.
+	resp, body, err := c.postCancelForm(ctx, cancelURL, receiptURL, url.Values{})
 	if err != nil {
-		return nil, fmt.Errorf("building tock cancel request: %w", err)
+		return nil, err
 	}
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	httpReq.Header.Set("Accept", "text/html,application/xhtml+xml")
-	httpReq.Header.Set("Origin", Origin)
-	httpReq.Header.Set("Referer", Origin+"/"+url.PathEscape(req.VenueSlug)+"/receipt?purchaseId="+fmt.Sprintf("%d", req.PurchaseID))
-
-	resp, err := c.do429Aware(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("calling tock cancel: %w", err)
-	}
-	defer resp.Body.Close()
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
-		return nil, fmt.Errorf("tock cancel: HTTP %d (auth required); ensure session cookies are fresh", resp.StatusCode)
+		// Likely CSRF rejection. GET the receipt page, scrape any hidden
+		// anti-forgery inputs, and retry once with those fields populated.
+		tokens, terr := c.fetchCancelCSRFTokens(ctx, receiptURL)
+		if terr != nil {
+			return nil, fmt.Errorf("tock cancel: HTTP %d on initial POST and CSRF lookup failed: %w", resp.StatusCode, terr)
+		}
+		if len(tokens) == 0 {
+			return nil, fmt.Errorf("tock cancel: HTTP %d (no anti-forgery tokens found on receipt page; auth may be expired — run `auth login --chrome`)", resp.StatusCode)
+		}
+		resp, body, err = c.postCancelForm(ctx, cancelURL, receiptURL, tokens)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == 401 || resp.StatusCode == 403 {
+			return nil, fmt.Errorf("tock cancel: HTTP %d after CSRF retry; auth may be expired or token field name has drifted", resp.StatusCode)
+		}
 	}
 	if resp.StatusCode >= 400 && resp.StatusCode != 410 {
-		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("tock cancel returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
 	}
 	if resp.StatusCode == 410 {
 		return nil, fmt.Errorf("%w: HTTP 410", ErrPastCancellationWindow)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading tock cancel response: %w", err)
 	}
 	bodyStr := string(body)
 	canceled := strings.Contains(bodyStr, "Reservation canceled") || strings.Contains(bodyStr, "Reservation cancelled")
@@ -223,6 +237,88 @@ func (c *Client) Cancel(ctx context.Context, req CancelRequest) (*CancelResponse
 		VenueSlug:  req.VenueSlug,
 		StatusText: "Reservation canceled",
 	}, nil
+}
+
+// postCancelForm POSTs form-encoded values to the cancel URL and reads the
+// full body. Returns the response (caller must NOT close — body is already
+// drained), the body bytes, and any transport error.
+func (c *Client) postCancelForm(ctx context.Context, cancelURL, referer string, fields url.Values) (*http.Response, []byte, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, cancelURL, strings.NewReader(fields.Encode()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("building tock cancel request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Accept", "text/html,application/xhtml+xml")
+	httpReq.Header.Set("Origin", Origin)
+	httpReq.Header.Set("Referer", referer)
+	resp, err := c.do429Aware(httpReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("calling tock cancel: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading tock cancel response: %w", err)
+	}
+	return resp, body, nil
+}
+
+// fetchCancelCSRFTokens GETs the receipt page and scrapes hidden inputs that
+// look like anti-forgery tokens. Returns a url.Values populated with all such
+// fields (typically zero or one). Caller decides what to do when empty.
+func (c *Client) fetchCancelCSRFTokens(ctx context.Context, receiptURL string) (url.Values, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, receiptURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building tock receipt-page request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "text/html,application/xhtml+xml")
+	resp, err := c.do429Aware(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("calling tock receipt page: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("tock receipt page returned HTTP %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading tock receipt page: %w", err)
+	}
+	return extractCSRFTokens(string(body)), nil
+}
+
+// extractCSRFTokens parses the HTML for hidden inputs whose name matches one
+// of csrfNamePatterns and returns them as url.Values. Exposed for tests.
+func extractCSRFTokens(html string) url.Values {
+	out := url.Values{}
+	for _, tag := range hiddenInputRE.FindAllString(html, -1) {
+		var name, value string
+		for _, m := range hiddenAttrRE.FindAllStringSubmatch(tag, -1) {
+			switch strings.ToLower(m[1]) {
+			case "name":
+				name = m[2]
+			case "value":
+				value = m[2]
+			}
+		}
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		matched := false
+		for _, pat := range csrfNamePatterns {
+			if strings.Contains(lower, pat) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		out.Set(name, value)
+	}
+	return out
 }
 
 // ListUpcomingReservations fetches the user's upcoming Tock reservations

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/booking_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/booking_test.go
@@ -79,6 +79,66 @@ func TestCancelRequiresIDs(t *testing.T) {
 	}
 }
 
+func TestExtractCSRFTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		html string
+		want map[string]string
+	}{
+		{
+			name: "rails-style authenticity_token",
+			html: `<form><input type="hidden" name="authenticity_token" value="abc123"></form>`,
+			want: map[string]string{"authenticity_token": "abc123"},
+		},
+		{
+			name: "dotnet-style RequestVerificationToken",
+			html: `<input type="hidden" name="__RequestVerificationToken" value="xyz789">`,
+			want: map[string]string{"__RequestVerificationToken": "xyz789"},
+		},
+		{
+			name: "csrfToken next-style",
+			html: `<input type='hidden' name='csrfToken' value='tok'>`,
+			want: map[string]string{"csrfToken": "tok"},
+		},
+		{
+			name: "ignores non-csrf hidden inputs",
+			html: `<input type="hidden" name="purchaseId" value="362575651">` +
+				`<input type="hidden" name="csrf_token" value="abc">` +
+				`<input type="hidden" name="venueSlug" value="canlis">`,
+			want: map[string]string{"csrf_token": "abc"},
+		},
+		{
+			name: "multiple csrf-shaped tokens",
+			html: `<input type="hidden" name="csrf" value="A">` +
+				`<input type="hidden" name="xsrfHeader" value="B">`,
+			want: map[string]string{"csrf": "A", "xsrfHeader": "B"},
+		},
+		{
+			name: "no hidden inputs",
+			html: `<html><body>nothing here</body></html>`,
+			want: map[string]string{},
+		},
+		{
+			name: "empty value preserved",
+			html: `<input type="hidden" name="csrf_token" value="">`,
+			want: map[string]string{"csrf_token": ""},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractCSRFTokens(tc.html)
+			if len(got) != len(tc.want) {
+				t.Fatalf("extractCSRFTokens len = %d (%v); want %d (%v)", len(got), got, len(tc.want), tc.want)
+			}
+			for k, v := range tc.want {
+				if got.Get(k) != v {
+					t.Errorf("extractCSRFTokens[%q] = %q; want %q", k, got.Get(k), v)
+				}
+			}
+		})
+	}
+}
+
 func TestSentinelErrorsAreDistinct(t *testing.T) {
 	wrapped := []struct {
 		name string

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
@@ -306,7 +306,7 @@ func checkAcknowledgeIfPresent(ctx context.Context) error {
 	js := `
 		(() => {
 			const policyRE  = /cancellation|policy|agree|acknowledg|terms|conditions/i;
-			const optInRE   = /newsletter|subscrib|promotion|marketing|offers|email|sms|text message/i;
+			const optInRE   = /newsletter|subscrib|promotion|marketing|offers|(?:promo|marketing|promotional) email|sms|text message/i;
 			const labelText = (cb) => {
 				const wrap = cb.closest('label');
 				if (wrap && wrap.textContent) return wrap.textContent;

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go
@@ -297,16 +297,37 @@ func fillCVCIfPresent(ctx context.Context, cvc string) error {
 }
 
 // checkAcknowledgeIfPresent ticks the cancellation-policy checkbox if present.
+// Selector is narrowed to checkboxes whose label/aria-label matches policy
+// keywords (cancellation, agree, acknowledge, terms) AND does NOT match
+// marketing keywords (newsletter, subscribe, promotional, marketing, offers).
+// This prevents the booking flow from silently consenting to data-sharing or
+// email opt-in checkboxes that may co-render on the checkout page.
 func checkAcknowledgeIfPresent(ctx context.Context) error {
 	js := `
 		(() => {
-			const cbs = Array.from(document.querySelectorAll('input[type="checkbox"]'));
-			for (const cb of cbs) {
-				if (!cb.checked) {
-					cb.click();
+			const policyRE  = /cancellation|policy|agree|acknowledg|terms|conditions/i;
+			const optInRE   = /newsletter|subscrib|promotion|marketing|offers|email|sms|text message/i;
+			const labelText = (cb) => {
+				const wrap = cb.closest('label');
+				if (wrap && wrap.textContent) return wrap.textContent;
+				if (cb.id) {
+					const lbl = document.querySelector('label[for="' + CSS.escape(cb.id) + '"]');
+					if (lbl && lbl.textContent) return lbl.textContent;
 				}
+				return cb.getAttribute('aria-label') || '';
+			};
+			const cbs = Array.from(document.querySelectorAll('input[type="checkbox"]'));
+			let clicked = 0;
+			for (const cb of cbs) {
+				if (cb.checked) continue;
+				const t = labelText(cb).trim();
+				if (!t) continue;
+				if (!policyRE.test(t)) continue;
+				if (optInRE.test(t)) continue;
+				cb.click();
+				clicked++;
 			}
-			return cbs.length;
+			return clicked;
 		})()
 	`
 	var n int


### PR DESCRIPTION
## table-reservation-goat — Greptile follow-ups from #386

Four fixes for findings raised on the merged PR (#386). Two P1 correctness/safety bugs and two P2 cleanups.

### P1 — `matchedExistingOT` false-positive idempotency match
**File:** `library/food-and-dining/table-reservation-goat/internal/cli/book.go`

Pre-flight idempotency check was comparing only date + time + party, then returning `true` unconditionally — never compared the restaurant. A user already holding **any** OT reservation on the same slot at a different restaurant was silently told the second was already booked, blocking the actual booking.

**Fix:** Added a slug-token-in-RestaurantName check. Every non-empty token of the user-supplied slug must appear as a substring in the alphanumeric-only normalization of `r.RestaurantName`. So `water-grill-bellevue` (tokens `{water, grill, bellevue}`) all match `"watergrillbellevue"`, while `canlis` doesn't. Now asymmetric with `matchedExistingTock` (which already checks `r.VenueSlug`).

5 new test cases:
- exact slug match → true
- different restaurant same slot → false
- different restaurant overlapping single token → false
- slug with extra token not in name → false
- empty name → false (short-circuit)

### P1 — `checkAcknowledgeIfPresent` blast radius
**File:** `library/food-and-dining/table-reservation-goat/internal/source/tock/chrome_book.go`

JS iterated every `input[type="checkbox"]` on the Tock checkout page and clicked any that wasn't checked, risking silent consent to marketing-opt-in, data-sharing, SMS-marketing, or waitlist checkboxes co-rendered with the cancellation-policy field.

**Fix:** Narrowed selector. A checkbox is clicked only when its label-text or aria-label matches policy terms:

```js
const policyRE = /cancellation|policy|agree|acknowledg|terms|conditions/i;
```

AND does NOT match marketing/opt-in terms:

```js
const optInRE = /newsletter|subscrib|promotion|marketing|offers|email|sms|text message/i;
```

Label resolution falls back through `closest('label')` → `label[for=<id>]` → `aria-label`.

### P2 — `BookingConfirmationHash` honest TODO
**File:** `library/food-and-dining/table-reservation-goat/internal/source/opentable/booking.go`

Passive "may be truncated" comment became an explicit `TODO:` documenting the refresh procedure on the next live OT book session. The existing `FetchCancelCutoff` caller already swallows errors via `cutoff, _ := …`, so book output gracefully degrades to an empty `cancellation_deadline` field rather than failing — making this a quality-of-output gap, not a hard failure.

### P2 — Tock cancel CSRF fallback
**File:** `library/food-and-dining/table-reservation-goat/internal/source/tock/booking.go`

Empty-body POST would 403 against Tock venues enforcing anti-forgery tokens.

**Fix:** Try-then-retry flow.
1. Initial attempt: empty-body POST (works on venues that don't enforce CSRF).
2. On 401/403: GET the receipt page, scrape hidden inputs whose names match common anti-forgery patterns (`csrf`, `xsrf`, `authenticity`, `requestverification`, `antiforgery`), retry the POST with those fields populated.
3. If still 401/403 after retry, surface a clear "auth may be expired or token field name has drifted" error.

New `extractCSRFTokens` helper unit-tested against:
- rails-style `authenticity_token`
- dotnet-style `__RequestVerificationToken`
- next-style `csrfToken`
- mixed hidden inputs (only csrf-shaped extracted)
- multiple csrf-shaped tokens
- no hidden inputs (empty result)
- empty value preserved

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` (all packages) | PASS |
| `printing-press publish validate` | **11/11 PASS** |

### Live-test status

The CSRF retry path has not been live-tested end-to-end. The empty-body POST path is unchanged from #386's behavior; the retry only fires on 401/403 from that initial attempt. Next live cancel session can validate and, if needed, tighten `csrfNamePatterns` to match Tock's exact field name.

### Patches manifest

`v0.2.1` entry appended to `.printing-press-patches.json` documenting all four fixes inline with the existing `cross-network-source-clients` patch (no new patch ID — these are corrections within the same scope).
