### PR TITLE
feat(zohomail): add zohomail-pp-cli

### DIFF
--- a/library/productivity/zohomail-pp-cli/.printing-press.json
+++ b/library/productivity/zohomail-pp-cli/.printing-press.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-09T22:00:00Z",
+  "printing_press_version": "1.3.2",
+  "api_name": "zohomail",
+  "display_name": "Zoho Mail",
+  "cli_name": "zohomail-pp-cli",
+  "printer": "jlwainwright",
+  "printer_name": "Jacques Wainwright",
+  "description": "Read, search, inspect, and send Zoho Mail messages from the terminal with OAuth-backed account, folder, message, and send commands.",
+  "category": "productivity",
+  "auth_type": "oauth2",
+  "auth_env_vars": [
+    "ZOHO_MAIL_ACCESS_TOKEN",
+    "ZOHO_REFRESH_TOKEN",
+    "ZOHO_CLIENT_ID",
+    "ZOHO_CLIENT_SECRET"
+  ],
+  "novel_features": [
+    {
+      "name": "Headless client credentials",
+      "command": "auth-client-credentials",
+      "description": "Exchange client credentials for a short-lived access token without browser interaction — useful for scripted or CI environments."
+    },
+    {
+      "name": "Device authorization flow",
+      "command": "auth-device",
+      "description": "Polls for approval after printing a verification URL and user code — lets agents authenticate on headless machines without a redirect URI."
+    },
+    {
+      "name": "Bitwarden/rbw auth loading",
+      "command": "auth-rbw",
+      "description": "Reads ZOHO_CLIENT_ID, ZOHO_CLIENT_SECRET, and ZOHO_REFRESH_TOKEN from a Bitwarden item via rbw so credentials never touch the shell history."
+    },
+    {
+      "name": "Message search",
+      "command": "search",
+      "description": "Search messages with Zoho's searchKey syntax (e.g. from:, subject:, hasAttachment:true)."
+    },
+    {
+      "name": "Send email",
+      "command": "send",
+      "description": "Compose and send email via Zoho Mail REST API with from, to, subject, and content flags."
+    }
+  ]
+}

--- a/library/productivity/zohomail-pp-cli/AGENTS.md
+++ b/library/productivity/zohomail-pp-cli/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Commands
+
+```bash
+# Build
+go build -o zohomail-pp-cli .
+
+# Install locally
+go install .
+
+# Run tests
+go test ./...
+
+# Run a single test
+go test -run TestAccountsUsesZohoAuthHeader ./...
+```
+
+## Architecture
+
+Single-package Go CLI (`package main`, `main.go`). No external dependencies — stdlib only.
+
+### Core types
+
+- `config` — all runtime state: auth credentials, account/folder IDs, base URLs, output format, HTTP client. Populated in priority order: config file → env vars → CLI flags.
+- `client` — thin wrapper around `config` that carries out HTTP calls to the Zoho Mail REST API.
+- `apiEnvelope` — Zoho API response shape `{"status":…,"data":…}`.
+
+### Entrypoint flow
+
+`main()` → `run(args, stdout, stderr)` — the `run` function is the testable entrypoint. Tests call `run(...)` directly against an `httptest.Server`.
+
+Command dispatch is a `switch` on `args[0]` inside `run`. Each case parses its own flags with a `flag.FlagSet`.
+
+### Config loading
+
+`configFromEnv()` loads in this order:
+1. File at `$PP_ZOHOMAIL_CONFIG` or `~/.config/zohomail-pp-cli/config.json`
+2. Env vars (override file): `ZOHO_MAIL_ACCESS_TOKEN`, `ZOHO_CLIENT_ID`, `ZOHO_CLIENT_SECRET`, `ZOHO_REFRESH_TOKEN`, `ZOHO_ACCOUNT_ID`, `ZOHO_INBOX_FOLDER_ID`, etc.
+3. Global flags (`--config`, `--output`, `--account-id`) applied after parsing.
+
+### Auth
+
+`client.bearerToken()` implements token resolution:
+- Returns `config.AccessToken` directly if set.
+- Otherwise calls `client.tokenRequest` to exchange the refresh token for a short-lived access token.
+
+### Output
+
+`writeFormatted(w, body, output)` — `pretty` mode extracts `.data`, pretty-prints arrays as tab-separated rows via `printRows`; `json` mode writes raw response body.
+
+### Commands implemented
+
+| Command | What it does |
+|---|---|
+| `doctor` | Print config and auth state without revealing secrets |
+| `configure` | Discover and save account/folder defaults (or set offline) |
+| `accounts` | List Zoho Mail accounts |
+| `folders` | List folders for the configured account |
+| `inbox` / `sent` / `archive` / `spam` / `trash` | List messages in that folder |
+| `list --folder <name>` | List messages in a named folder |
+| `search --search-key <query>` | Search messages |
+| `read --folder <name> --message-id <id>` | Read message content or details |
+| `send` | Send an email |
+| `login` | Browser OAuth flow; listens on `localhost:53682/callback` |
+| `client-setup` | Print redirect URI/scopes for Zoho API Console setup |
+| `auth-save` | Save client credentials + refresh token without browser |
+| `auth-rbw` | Load credentials from Bitwarden via `rbw` |
+| `auth-url` | Print OAuth authorization URL |
+| `token` | Exchange authorization code for tokens |
+| `auth-client-credentials` | Client credentials flow (access token only, 1h TTL) |
+| `auth-device` | Device authorization flow (Non-browser Application client only) |
+
+### Zoho API base URLs
+
+Default: `https://mail.zoho.com` / `https://accounts.zoho.com`. Override for non-US data centers via `ZOHO_MAIL_BASE_URL` / `ZOHO_ACCOUNTS_BASE_URL`.

--- a/library/productivity/zohomail-pp-cli/README.md
+++ b/library/productivity/zohomail-pp-cli/README.md
@@ -1,0 +1,171 @@
+# zohomail-pp-cli
+
+Printing Press-style Go CLI for Zoho Mail.
+
+## Install
+
+```bash
+go install github.com/DankeyDevDave/zohomail-pp-cli@latest
+```
+
+For local development:
+
+```bash
+go install .
+```
+
+## Auth
+
+Use either a short-lived access token:
+
+```bash
+export ZOHO_MAIL_ACCESS_TOKEN='...'
+```
+
+Or a refresh-token setup:
+
+```bash
+export ZOHO_CLIENT_ID='...'
+export ZOHO_CLIENT_SECRET='...'
+export ZOHO_REFRESH_TOKEN='...'
+```
+
+Check what the CLI can see without printing secrets:
+
+```bash
+zohomail-pp-cli doctor
+```
+
+Save auth locally after Self Client token exchange:
+
+```bash
+zohomail-pp-cli token --self-client --code '<generated-code>' --save
+```
+
+Then discover account and standard folder defaults:
+
+```bash
+zohomail-pp-cli configure
+```
+
+If you already know the IDs, save them without another API call:
+
+```bash
+zohomail-pp-cli configure \
+  --account-id 123456789 \
+  --inbox-folder-id 111 \
+  --sent-folder-id 222 \
+  --spam-folder-id 333 \
+  --trash-folder-id 444 \
+  --archive-folder-id 555
+```
+
+If token exchange returns `invalid_client`, verify that `ZOHO_CLIENT_ID` and `ZOHO_CLIENT_SECRET` belong to the same active Zoho API Console client and that `ZOHO_ACCOUNTS_BASE_URL` matches the account data center.
+
+For non-US Zoho data centers, set both bases, for example:
+
+```bash
+export ZOHO_MAIL_BASE_URL='https://mail.zoho.eu'
+export ZOHO_ACCOUNTS_BASE_URL='https://accounts.zoho.eu'
+```
+
+## OAuth helper
+
+Automated browser login:
+
+```bash
+zohomail-pp-cli client-setup
+zohomail-pp-cli login --client-id '1000....' --client-secret '...'
+```
+
+`client-setup` opens the Zoho API Console and prints the redirect URI/scopes to configure. `login` opens Zoho in the browser, listens on `http://localhost:53682/callback`, exchanges the returned code, saves the client credentials + refresh token, and discovers account/folder defaults. The redirect URI must exist on the Zoho API Console client.
+
+If the client credentials are already saved, later logins need no flags:
+
+```bash
+zohomail-pp-cli login
+```
+
+If you already have a refresh token, skip the browser flow and save it once:
+
+```bash
+zohomail-pp-cli auth-save --client-id '1000....' --client-secret '...' --refresh-token '1000....'
+```
+
+If those values live in Bitwarden/rbw, store them as custom fields named
+`ZOHO_CLIENT_ID`, `ZOHO_CLIENT_SECRET`, and `ZOHO_REFRESH_TOKEN`, then run:
+
+```bash
+rbw unlock
+zohomail-pp-cli auth-rbw --item 'Zoho Mail OAuth'
+```
+
+To populate that Bitwarden item from the latest local `ZOHO_*` shell-history
+exports without printing secrets:
+
+```bash
+scripts/write_zoho_auth_to_bitwarden.py
+```
+
+For remote shells:
+
+```bash
+zohomail-pp-cli login --no-open
+```
+
+```bash
+zohomail-pp-cli auth-url --redirect-uri 'http://localhost'
+zohomail-pp-cli token --code '<returned-code>' --redirect-uri 'http://localhost'
+```
+
+For Zoho API Console Self Client generated codes, use:
+
+```bash
+zohomail-pp-cli token --self-client --code '<generated-code>'
+```
+
+Required scopes for the core commands:
+
+```text
+ZohoMail.accounts.READ
+ZohoMail.folders.READ
+ZohoMail.messages.READ
+ZohoMail.messages.CREATE
+```
+
+## Commands
+
+```bash
+zohomail-pp-cli accounts
+zohomail-pp-cli folders
+zohomail-pp-cli inbox --limit 20
+zohomail-pp-cli sent --limit 20
+zohomail-pp-cli list --folder inbox --limit 20
+zohomail-pp-cli search --search-key 'from:person@example.com' --limit 10
+zohomail-pp-cli read --folder inbox --message-id 1709876190693100009
+zohomail-pp-cli read --account-id 123456789 --folder-id 987654321 --message-id 1709876190693100009 --mode details
+zohomail-pp-cli send --from me@example.com --to you@example.com --subject 'Hello' --content 'Body'
+```
+
+Use `--output json` for raw API-shaped output.
+
+## API coverage
+
+Implemented against Zoho Mail REST APIs:
+
+- `GET /api/accounts`
+- `GET /api/accounts/{accountId}/folders`
+- `GET /api/accounts/{accountId}/messages/view`
+- `GET /api/accounts/{accountId}/messages/search`
+- `GET /api/accounts/{accountId}/folders/{folderId}/messages/{messageId}/content`
+- `GET /api/accounts/{accountId}/folders/{folderId}/messages/{messageId}/details`
+- `POST /api/accounts/{accountId}/messages`
+
+References:
+
+- https://www.zoho.com/mail/help/api/account-api.html
+- https://www.zoho.com/mail/help/api/get-all-folder-details.html
+- https://www.zoho.com/mail/help/api/get-emails-list.html
+- https://www.zoho.com/mail/help/api/get-search-emails.html
+- https://www.zoho.com/mail/help/api/email-api.html
+- https://www.zoho.com/mail/help/api/post-send-an-email.html

--- a/library/productivity/zohomail-pp-cli/SKILL.md
+++ b/library/productivity/zohomail-pp-cli/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: zohomail-pp-cli
+description: Use when working with Zoho Mail from an agent through the `zohomail-pp-cli` command. Trigger for Zoho Mail account setup, OAuth/self-client token exchange, saving local defaults, listing inbox/sent/spam/trash/archive folders, searching or reading messages, and sending mail only when explicitly requested.
+---
+
+# zohomail-pp-cli
+
+Use `zohomail-pp-cli` for Zoho Mail account, folder, message, search, read, and send operations.
+Prefer configured defaults over copying account/folder IDs into every command.
+
+## Install
+
+```bash
+npx -y @mvanhorn/printing-press install zohomail-pp-cli
+```
+
+For local development:
+
+```bash
+go install .
+```
+
+## Auth
+
+Prefer refresh-token auth so agents do not need repeated short-lived token pastes:
+
+```bash
+export ZOHO_CLIENT_ID='...'
+export ZOHO_CLIENT_SECRET='...'
+export ZOHO_REFRESH_TOKEN='...'
+```
+
+For one-off use, an access token also works:
+
+```bash
+export ZOHO_MAIL_ACCESS_TOKEN='...'
+```
+
+Check visible config without printing secrets:
+
+```bash
+zohomail-pp-cli doctor
+```
+
+Preferred new-device login:
+
+```bash
+zohomail-pp-cli client-setup
+zohomail-pp-cli login --client-id '1000....' --client-secret '...'
+```
+
+`client-setup` opens the Zoho API Console and prints the required redirect URI/scopes. `login` opens browser OAuth, listens on `http://localhost:53682/callback`, saves client credentials + refresh auth, and discovers account/folder defaults. The Zoho API Console client must have that exact redirect URI. After credentials are saved, future `zohomail-pp-cli login` runs need no `--client-id` or `--client-secret`. In remote shells, use `zohomail-pp-cli login --no-open` and open the printed URL manually.
+
+If a valid refresh token already exists, skip browser login and store it once:
+
+```bash
+zohomail-pp-cli auth-save --client-id '1000....' --client-secret '...' --refresh-token '1000....'
+```
+
+If the values are in Bitwarden/rbw, prefer custom fields named `ZOHO_CLIENT_ID`, `ZOHO_CLIENT_SECRET`, and `ZOHO_REFRESH_TOKEN`:
+
+```bash
+rbw unlock
+zohomail-pp-cli auth-rbw --item 'Zoho Mail OAuth'
+```
+
+If `doctor` shows account and folder defaults but no auth, do not re-run account/folder discovery. Save auth only:
+
+```bash
+zohomail-pp-cli configure --save-token
+```
+
+Persist auth and default IDs when the user wants normal commands without repeated flags:
+
+```bash
+zohomail-pp-cli token --self-client --code '<generated-code>' --save
+zohomail-pp-cli configure
+```
+
+If account/folder IDs are already known, configure them offline:
+
+```bash
+zohomail-pp-cli configure \
+  --account-id "$ZOHO_ACCOUNT_ID" \
+  --inbox-folder-id "$ZOHO_INBOX_FOLDER_ID" \
+  --sent-folder-id "$ZOHO_SENT_FOLDER_ID" \
+  --spam-folder-id "$ZOHO_SPAM_FOLDER_ID" \
+  --trash-folder-id "$ZOHO_TRASH_FOLDER_ID" \
+  --archive-folder-id "$ZOHO_ARCHIVE_FOLDER_ID"
+```
+
+If token exchange returns `invalid_client`, verify that `ZOHO_CLIENT_ID` and `ZOHO_CLIENT_SECRET` belong to the same active Zoho API Console client and that `ZOHO_ACCOUNTS_BASE_URL` matches the account data center.
+
+For EU, IN, AU, JP, CA, CN, or other Zoho data centers, set both:
+
+```bash
+export ZOHO_MAIL_BASE_URL='https://mail.zoho.eu'
+export ZOHO_ACCOUNTS_BASE_URL='https://accounts.zoho.eu'
+```
+
+## OAuth Bootstrap
+
+```bash
+zohomail-pp-cli client-setup
+zohomail-pp-cli login
+zohomail-pp-cli auth-save --client-id '1000....' --client-secret '...' --refresh-token '1000....'
+zohomail-pp-cli auth-rbw --item 'Zoho Mail OAuth'
+zohomail-pp-cli auth-url --redirect-uri 'http://localhost'
+zohomail-pp-cli token --code '<code-from-browser>' --redirect-uri 'http://localhost'
+```
+
+For fully headless scripts that can tolerate a 1-hour token TTL (client credentials flow, works with Self Client):
+
+```bash
+zohomail-pp-cli auth-client-credentials --client-id '1000....' --client-secret '...'
+# Returns an access_token only; no refresh token. Repeat the call each hour.
+```
+
+For device authorization flow (requires a **Non-browser Application** client type in Zoho API Console — Self Client does not support this grant):
+
+```bash
+zohomail-pp-cli auth-device --client-id '1000....' --client-secret '...'
+# Prints verification_url and user_code; open the URL in a browser, enter the code, approve.
+# Polls automatically; on approval saves the refresh token and discovers account/folder defaults.
+# Use --no-open to suppress browser launch (e.g. remote shells).
+```
+
+For Zoho API Console Self Client generated codes, use:
+
+```bash
+zohomail-pp-cli token --self-client --code '<generated-code>'
+```
+
+Core scopes:
+
+```text
+ZohoMail.accounts.READ
+ZohoMail.folders.READ
+ZohoMail.messages.READ
+ZohoMail.messages.CREATE
+```
+
+## Common Commands
+
+Authenticate headlessly via client credentials (Self Client, access token only, 1h TTL):
+
+```bash
+zohomail-pp-cli auth-client-credentials --client-id '1000....' --client-secret '...'
+```
+
+Authenticate via device flow (Non-browser Application client only — not Self Client):
+
+```bash
+zohomail-pp-cli auth-device --client-id '1000....' --client-secret '...'
+```
+
+Check setup:
+
+```bash
+zohomail-pp-cli doctor
+```
+
+List accounts:
+
+```bash
+zohomail-pp-cli accounts
+```
+
+List folders:
+
+```bash
+zohomail-pp-cli folders
+```
+
+List messages:
+
+```bash
+zohomail-pp-cli inbox --limit 20
+zohomail-pp-cli sent --limit 20
+zohomail-pp-cli archive --limit 20
+zohomail-pp-cli list --folder inbox --limit 20
+```
+
+Search messages:
+
+```bash
+zohomail-pp-cli search --search-key 'from:person@example.com' --limit 20
+```
+
+Read message content:
+
+```bash
+zohomail-pp-cli read --folder inbox --message-id "$ZOHO_MESSAGE_ID"
+```
+
+Send mail:
+
+```bash
+zohomail-pp-cli send --from me@example.com --to you@example.com --subject 'Subject' --content 'Body'
+```
+
+Use `--output json` when another tool will parse output.
+
+## Safety
+
+- Do not echo tokens in chat or logs.
+- Treat pasted Zoho access tokens, refresh tokens, client secrets, and authorization codes as compromised; advise rotation after setup.
+- Prefer read-only commands until the user explicitly asks to send mail.
+- For `send`, confirm recipients, subject, and content when operating on real accounts unless the user already provided exact values.
+- Do not persist secrets in repo files.

--- a/library/productivity/zohomail-pp-cli/go.mod
+++ b/library/productivity/zohomail-pp-cli/go.mod
@@ -1,3 +1,3 @@
-module github.com/DankeyDevDave/zohomail-pp-cli
+module github.com/mvanhorn/printing-press-library/library/productivity/zohomail-pp-cli
 
 go 1.26.2

--- a/library/productivity/zohomail-pp-cli/go.mod
+++ b/library/productivity/zohomail-pp-cli/go.mod
@@ -1,0 +1,3 @@
+module github.com/DankeyDevDave/zohomail-pp-cli
+
+go 1.26.2

--- a/library/productivity/zohomail-pp-cli/main.go
+++ b/library/productivity/zohomail-pp-cli/main.go
@@ -1,0 +1,1410 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const version = "0.1.0"
+
+type config struct {
+	MailBase     string            `json:"mail_base,omitempty"`
+	AccountsBase string            `json:"accounts_base,omitempty"`
+	AccessToken  string            `json:"-"`
+	RefreshToken string            `json:"refresh_token,omitempty"`
+	ClientID     string            `json:"client_id,omitempty"`
+	ClientSecret string            `json:"client_secret,omitempty"`
+	AccountID    string            `json:"account_id,omitempty"`
+	Folders      map[string]string `json:"folders,omitempty"`
+	Output       string            `json:"output,omitempty"`
+	ConfigPath   string            `json:"-"`
+	HTTPClient   *http.Client      `json:"-"`
+}
+
+type client struct {
+	cfg config
+}
+
+type apiEnvelope struct {
+	Status any             `json:"status,omitempty"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "zohomail-pp-cli:", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		usage(stdout)
+		return nil
+	}
+	if args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
+		usage(stdout)
+		return nil
+	}
+	if args[0] == "version" || args[0] == "--version" {
+		fmt.Fprintln(stdout, version)
+		return nil
+	}
+
+	cfg := configFromEnv()
+	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	addGlobalFlags(fs, &cfg)
+
+	switch args[0] {
+	case "doctor":
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		printDoctor(stdout, cfg)
+		return nil
+	case "configure":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID; default auto-selects first/default account")
+		inboxID := fs.String("inbox-folder-id", "", "Inbox folder ID")
+		sentID := fs.String("sent-folder-id", "", "Sent folder ID")
+		spamID := fs.String("spam-folder-id", "", "Spam folder ID")
+		trashID := fs.String("trash-folder-id", "", "Trash folder ID")
+		archiveID := fs.String("archive-folder-id", "", "Archive folder ID")
+		saveToken := fs.Bool("save-token", false, "persist refresh token and client credentials from env/config")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		next := cfg
+		offlineFolders := map[string]string{
+			"inbox":   *inboxID,
+			"sent":    *sentID,
+			"spam":    *spamID,
+			"trash":   *trashID,
+			"archive": *archiveID,
+		}
+		if *accountID != "" && hasFolderFlag(offlineFolders) {
+			next.AccountID = *accountID
+			if next.Folders == nil {
+				next.Folders = map[string]string{}
+			}
+			for name, id := range offlineFolders {
+				if id != "" {
+					next.Folders[name] = id
+				}
+			}
+		} else if *saveToken && next.AccountID != "" && hasFolderFlag(next.Folders) {
+			// Save auth into an already-configured account without another API round trip.
+		} else {
+			c := client{cfg: cfg.withHTTPClient()}
+			discovered, err := c.discoverConfig(*accountID)
+			if err != nil {
+				return err
+			}
+			next = discovered
+		}
+		next.ConfigPath = cfg.ConfigPath
+		next.AccessToken = ""
+		if !*saveToken {
+			next.RefreshToken = ""
+			next.ClientSecret = ""
+		}
+		if err := saveConfig(next); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "saved\t%s\n", next.ConfigPath)
+		fmt.Fprintf(stdout, "account_id\t%s\n", next.AccountID)
+		printFolderDefaults(stdout, next.Folders)
+		if !*saveToken {
+			fmt.Fprintln(stdout, "auth\tkept in environment; rerun with --save-token to persist refresh auth")
+		}
+		return nil
+	case "login":
+		var scopes string
+		var redirect string
+		var noOpen bool
+		var timeoutText string
+		var clientID string
+		var clientSecret string
+		fs.StringVar(&scopes, "scopes", "ZohoMail.accounts.READ,ZohoMail.folders.READ,ZohoMail.messages.READ,ZohoMail.messages.CREATE", "comma-separated OAuth scopes")
+		fs.StringVar(&redirect, "redirect-uri", env("ZOHO_REDIRECT_URI", "http://localhost:53682/callback"), "OAuth redirect URI configured in Zoho API Console")
+		fs.BoolVar(&noOpen, "no-open", false, "print URL instead of opening browser")
+		fs.StringVar(&timeoutText, "timeout", "5m", "how long to wait for browser callback")
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID; saved after successful login")
+		fs.StringVar(&clientSecret, "client-secret", "", "Zoho OAuth client secret; saved after successful login")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		if clientSecret != "" {
+			cfg.ClientSecret = clientSecret
+		}
+		timeout, err := time.ParseDuration(timeoutText)
+		if err != nil {
+			return err
+		}
+		return login(stdout, stderr, cfg.withHTTPClient(), redirect, scopes, timeout, !noOpen)
+	case "client-setup":
+		var noOpen bool
+		fs.BoolVar(&noOpen, "no-open", false, "print URL instead of opening browser")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		u := strings.TrimRight(cfg.AccountsBase, "/") + "/developerconsole"
+		fmt.Fprintf(stdout, "open\t%s\n", u)
+		fmt.Fprintln(stdout, "redirect_uri\thttp://localhost:53682/callback")
+		fmt.Fprintln(stdout, "scopes\tZohoMail.accounts.READ ZohoMail.folders.READ ZohoMail.messages.READ ZohoMail.messages.CREATE")
+		if !noOpen {
+			if err := openURL(u); err != nil {
+				fmt.Fprintf(stderr, "open failed\t%s\n", err)
+			}
+		}
+		return nil
+	case "auth-save":
+		var clientID string
+		var clientSecret string
+		var refreshToken string
+		var noDiscover bool
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID")
+		fs.StringVar(&clientSecret, "client-secret", "", "Zoho OAuth client secret")
+		fs.StringVar(&refreshToken, "refresh-token", "", "Zoho OAuth refresh token")
+		fs.BoolVar(&noDiscover, "no-discover", false, "save auth without calling Zoho Mail account/folder APIs")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		if clientSecret != "" {
+			cfg.ClientSecret = clientSecret
+		}
+		if refreshToken != "" {
+			cfg.RefreshToken = refreshToken
+		}
+		if cfg.ClientID == "" || cfg.ClientSecret == "" || cfg.RefreshToken == "" {
+			return errors.New("missing --client-id, --client-secret, or --refresh-token")
+		}
+		cfg.AccessToken = ""
+		if noDiscover {
+			if err := saveConfig(cfg); err != nil {
+				return err
+			}
+		} else if err := discoverAndSaveConfig(cfg); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "saved\t%s\n", cfg.ConfigPath)
+		fmt.Fprintf(stdout, "client_id\t%s\n", presentID(cfg.ClientID))
+		fmt.Fprintf(stdout, "client_secret\t%s\n", presentSecret(cfg.ClientSecret))
+		fmt.Fprintf(stdout, "refresh_token\t%s\n", presentSecret(cfg.RefreshToken))
+		fmt.Fprintf(stdout, "account_id\t%s\n", presentID(cfg.AccountID))
+		printFolderDefaults(stdout, cfg.Folders)
+		return nil
+	case "auth-rbw":
+		var item string
+		var rbwBin string
+		var clientIDField string
+		var clientSecretField string
+		var refreshTokenField string
+		var noDiscover bool
+		fs.StringVar(&item, "item", "", "rbw item name, URI, or UUID containing Zoho OAuth fields")
+		fs.StringVar(&rbwBin, "rbw-bin", "rbw", "rbw executable path")
+		fs.StringVar(&clientIDField, "client-id-field", "ZOHO_CLIENT_ID", "rbw custom field for Zoho OAuth client ID")
+		fs.StringVar(&clientSecretField, "client-secret-field", "ZOHO_CLIENT_SECRET", "rbw custom field for Zoho OAuth client secret")
+		fs.StringVar(&refreshTokenField, "refresh-token-field", "ZOHO_REFRESH_TOKEN", "rbw custom field for Zoho OAuth refresh token")
+		fs.BoolVar(&noDiscover, "no-discover", false, "save auth without calling Zoho Mail account/folder APIs")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if item == "" {
+			return errors.New("missing --item")
+		}
+		saved, err := authFromRBW(cfg, rbwBin, item, clientIDField, clientSecretField, refreshTokenField, noDiscover)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "saved\t%s\n", saved.ConfigPath)
+		fmt.Fprintf(stdout, "client_id\t%s\n", presentID(saved.ClientID))
+		fmt.Fprintf(stdout, "client_secret\t%s\n", presentSecret(saved.ClientSecret))
+		fmt.Fprintf(stdout, "refresh_token\t%s\n", presentSecret(saved.RefreshToken))
+		fmt.Fprintf(stdout, "account_id\t%s\n", presentID(saved.AccountID))
+		printFolderDefaults(stdout, saved.Folders)
+		return nil
+	case "auth-url":
+		var scopes string
+		var redirect string
+		var clientID string
+		fs.StringVar(&scopes, "scopes", "ZohoMail.accounts.READ,ZohoMail.folders.READ,ZohoMail.messages.READ,ZohoMail.messages.CREATE", "comma-separated OAuth scopes")
+		fs.StringVar(&redirect, "redirect-uri", env("ZOHO_REDIRECT_URI", "http://localhost"), "OAuth redirect URI")
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		u, err := authURL(cfg.AccountsBase, cfg.ClientID, redirect, scopes)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(stdout, u)
+		return nil
+	case "token":
+		var code string
+		var redirect string
+		var selfClient bool
+		var saveToken bool
+		var clientID string
+		var clientSecret string
+		fs.StringVar(&code, "code", "", "authorization code from Zoho")
+		fs.StringVar(&redirect, "redirect-uri", env("ZOHO_REDIRECT_URI", "http://localhost"), "OAuth redirect URI")
+		fs.BoolVar(&selfClient, "self-client", false, "exchange a Zoho API Console Self Client code without redirect_uri")
+		fs.BoolVar(&saveToken, "save", false, "persist refresh token and client credentials to local config")
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID")
+		fs.StringVar(&clientSecret, "client-secret", "", "Zoho OAuth client secret")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		if clientSecret != "" {
+			cfg.ClientSecret = clientSecret
+		}
+		if code == "" {
+			return errors.New("missing --code")
+		}
+		c := client{cfg: cfg.withHTTPClient()}
+		values := url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {cfg.ClientID},
+			"client_secret": {cfg.ClientSecret},
+			"code":          {code},
+		}
+		if !selfClient {
+			values.Set("redirect_uri", redirect)
+		}
+		body, err := c.tokenRequest(values)
+		if err != nil {
+			return err
+		}
+		if saveToken {
+			if err := saveTokenConfig(cfg, body); err != nil {
+				return err
+			}
+			fmt.Fprintf(stderr, "saved auth\t%s\n", cfg.ConfigPath)
+		}
+		return writeJSON(stdout, body)
+	case "auth-device":
+		var scopes string
+		var save bool
+		var noOpen bool
+		var clientID string
+		var clientSecret string
+		fs.StringVar(&scopes, "scopes", "ZohoMail.accounts.READ,ZohoMail.folders.READ,ZohoMail.messages.READ,ZohoMail.messages.CREATE", "comma-separated OAuth scopes")
+		fs.BoolVar(&save, "save", true, "save refresh token to config and run account/folder discovery")
+		fs.BoolVar(&noOpen, "no-open", false, "print URL only, don't open browser")
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID")
+		fs.StringVar(&clientSecret, "client-secret", "", "Zoho OAuth client secret")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		if clientSecret != "" {
+			cfg.ClientSecret = clientSecret
+		}
+		return deviceAuth(stdout, stderr, cfg.withHTTPClient(), scopes, !noOpen, save)
+	case "auth-client-credentials":
+		var scopes string
+		var clientID string
+		var clientSecret string
+		fs.StringVar(&scopes, "scopes", "ZohoMail.accounts.READ,ZohoMail.folders.READ,ZohoMail.messages.READ,ZohoMail.messages.CREATE", "comma-separated OAuth scopes")
+		fs.StringVar(&clientID, "client-id", "", "Zoho OAuth client ID")
+		fs.StringVar(&clientSecret, "client-secret", "", "Zoho OAuth client secret")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if clientID != "" {
+			cfg.ClientID = clientID
+		}
+		if clientSecret != "" {
+			cfg.ClientSecret = clientSecret
+		}
+		c := client{cfg: cfg.withHTTPClient()}
+		body, err := c.tokenRequest(url.Values{
+			"grant_type":    {"client_credentials"},
+			"client_id":     {cfg.ClientID},
+			"client_secret": {cfg.ClientSecret},
+			"scope":         {strings.ReplaceAll(scopes, ",", " ")},
+		})
+		if err != nil {
+			return err
+		}
+		return writeJSON(stdout, body)
+	case "accounts":
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		c := client{cfg: cfg.withHTTPClient()}
+		return c.getAndWrite(stdout, "/api/accounts", nil, cfg.Output)
+	case "folders":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		id := firstNonEmpty(*accountID, cfg.AccountID)
+		if id == "" {
+			return errors.New("missing --account-id; run zohomail-pp-cli configure")
+		}
+		c := client{cfg: cfg.withHTTPClient()}
+		return c.getAndWrite(stdout, "/api/accounts/"+pathEscape(id)+"/folders", nil, cfg.Output)
+	case "inbox", "sent", "spam", "trash", "archive":
+		folderName := args[0]
+		start := fs.Int("start", 1, "start offset")
+		limit := fs.Int("limit", 20, "max rows")
+		sortBy := fs.String("sort-by", "", "Zoho sort key, for example date")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if cfg.Folders[folderName] == "" {
+			return fmt.Errorf("missing configured %s folder; run zohomail-pp-cli configure", folderName)
+		}
+		return listMessages(stdout, cfg, cfg.AccountID, cfg.Folders[folderName], *start, *limit, *sortBy)
+	case "list":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID")
+		folderID := fs.String("folder-id", "", "folder ID")
+		folder := fs.String("folder", "", "named configured folder: inbox, sent, spam, trash, archive")
+		start := fs.Int("start", 1, "start offset")
+		limit := fs.Int("limit", 20, "max rows")
+		sortBy := fs.String("sort-by", "", "Zoho sort key, for example date")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		id := firstNonEmpty(*folderID, cfg.Folders[strings.ToLower(*folder)])
+		return listMessages(stdout, cfg, firstNonEmpty(*accountID, cfg.AccountID), id, *start, *limit, *sortBy)
+	case "search":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID")
+		searchKey := fs.String("search-key", "", "Zoho search syntax, for example from:person@example.com")
+		start := fs.Int("start", 1, "start offset")
+		limit := fs.Int("limit", 20, "max rows")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		id := firstNonEmpty(*accountID, cfg.AccountID)
+		if id == "" || *searchKey == "" {
+			return errors.New("missing --account-id or --search-key; run zohomail-pp-cli configure")
+		}
+		q := url.Values{"searchKey": {*searchKey}, "start": {fmt.Sprint(*start)}, "limit": {fmt.Sprint(*limit)}}
+		c := client{cfg: cfg.withHTTPClient()}
+		return c.getAndWrite(stdout, "/api/accounts/"+pathEscape(id)+"/messages/search", q, cfg.Output)
+	case "read":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID")
+		folderID := fs.String("folder-id", "", "folder ID")
+		folder := fs.String("folder", "", "named configured folder: inbox, sent, spam, trash, archive")
+		messageID := fs.String("message-id", "", "message ID")
+		mode := fs.String("mode", "content", "content or details")
+		includeBlock := fs.Bool("include-block-content", false, "include quoted block content")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		id := firstNonEmpty(*accountID, cfg.AccountID)
+		fid := firstNonEmpty(*folderID, cfg.Folders[strings.ToLower(*folder)])
+		if id == "" || fid == "" || *messageID == "" {
+			return errors.New("missing --account-id, --folder-id, or --message-id; run zohomail-pp-cli configure")
+		}
+		suffix := "content"
+		q := url.Values{}
+		if *mode == "details" {
+			suffix = "details"
+		} else if *includeBlock {
+			q.Set("includeBlockContent", "true")
+		}
+		p := "/api/accounts/" + pathEscape(id) + "/folders/" + pathEscape(fid) + "/messages/" + pathEscape(*messageID) + "/" + suffix
+		c := client{cfg: cfg.withHTTPClient()}
+		return c.getAndWrite(stdout, p, q, cfg.Output)
+	case "send":
+		accountID := fs.String("account-id", "", "Zoho Mail account ID")
+		from := fs.String("from", "", "from email address")
+		to := fs.String("to", "", "comma-separated recipient addresses")
+		cc := fs.String("cc", "", "comma-separated CC addresses")
+		bcc := fs.String("bcc", "", "comma-separated BCC addresses")
+		subject := fs.String("subject", "", "subject")
+		content := fs.String("content", "", "plain text or HTML body")
+		contentFile := fs.String("content-file", "", "read body from file")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		id := firstNonEmpty(*accountID, cfg.AccountID)
+		if id == "" || *from == "" || *to == "" || *subject == "" {
+			return errors.New("missing --account-id, --from, --to, or --subject; run zohomail-pp-cli configure")
+		}
+		body := *content
+		if *contentFile != "" {
+			b, err := os.ReadFile(*contentFile)
+			if err != nil {
+				return err
+			}
+			body = string(b)
+		}
+		payload := map[string]string{
+			"fromAddress": *from,
+			"toAddress":   *to,
+			"subject":     *subject,
+			"content":     body,
+		}
+		if *cc != "" {
+			payload["ccAddress"] = *cc
+		}
+		if *bcc != "" {
+			payload["bccAddress"] = *bcc
+		}
+		c := client{cfg: cfg.withHTTPClient()}
+		resp, err := c.request("POST", "/api/accounts/"+pathEscape(id)+"/messages", nil, payload)
+		if err != nil {
+			return err
+		}
+		return writeFormatted(stdout, resp, cfg.Output)
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func usage(w io.Writer) {
+	fmt.Fprint(w, `zohomail-pp-cli - Zoho Mail CLI for Printing Press
+
+Usage:
+  zohomail-pp-cli <command> [options]
+
+Commands:
+  login      Open browser OAuth flow, save auth, discover defaults
+  client-setup Open Zoho API Console and print required redirect/scopes
+  auth-save  Save existing client/refresh credentials to local config
+  auth-rbw   Save existing Zoho OAuth credentials from rbw/Bitwarden
+  auth-url   Print OAuth consent URL
+  token      Exchange OAuth code for tokens
+  auth-device   Device authorization flow: prints code, polls until approved, saves refresh token
+  auth-client-credentials  Headless: exchange client credentials for a short-lived access token (no refresh token)
+  configure  Discover account/folder defaults and save local config
+  doctor     Show auth/base configuration without printing secrets
+  accounts   List authenticated user's Zoho Mail accounts
+  folders    List folders for an account
+  inbox      List configured Inbox
+  sent       List configured Sent
+  spam       List configured Spam
+  trash      List configured Trash
+  archive    List configured Archive
+  list       List messages from a folder or account view
+  search     Search messages with Zoho searchKey syntax
+  read       Read message content or metadata
+  send       Send email through Zoho Mail
+  version    Print version
+
+Auth env:
+  ZOHO_MAIL_ACCESS_TOKEN, or
+  ZOHO_REFRESH_TOKEN + ZOHO_CLIENT_ID + ZOHO_CLIENT_SECRET
+  Or run: auth-device (interactive approval, saves refresh token)
+           auth-client-credentials (headless, access token only, 1h TTL)
+
+Base URL env:
+  ZOHO_MAIL_BASE_URL      default https://mail.zoho.com
+  ZOHO_ACCOUNTS_BASE_URL  default https://accounts.zoho.com
+
+Global options:
+  --output json|pretty
+  --mail-base URL
+  --accounts-base URL
+`)
+}
+
+func addGlobalFlags(fs *flag.FlagSet, cfg *config) {
+	fs.StringVar(&cfg.Output, "output", cfg.Output, "json or pretty")
+	fs.StringVar(&cfg.MailBase, "mail-base", cfg.MailBase, "Zoho Mail base URL")
+	fs.StringVar(&cfg.AccountsBase, "accounts-base", cfg.AccountsBase, "Zoho Accounts base URL")
+}
+
+func configFromEnv() config {
+	path := configPath()
+	cfg, _ := loadConfig(path)
+	cfg.ConfigPath = path
+	if cfg.Folders == nil {
+		cfg.Folders = map[string]string{}
+	}
+	applyEnv(&cfg)
+	if cfg.MailBase == "" {
+		cfg.MailBase = "https://mail.zoho.com"
+	}
+	if cfg.AccountsBase == "" {
+		cfg.AccountsBase = "https://accounts.zoho.com"
+	}
+	if cfg.Output == "" {
+		cfg.Output = "pretty"
+	}
+	return cfg
+}
+
+func applyEnv(cfg *config) {
+	if v := os.Getenv("ZOHO_MAIL_BASE_URL"); v != "" {
+		cfg.MailBase = v
+	}
+	if v := os.Getenv("ZOHO_ACCOUNTS_BASE_URL"); v != "" {
+		cfg.AccountsBase = v
+	}
+	if v := os.Getenv("ZOHO_MAIL_ACCESS_TOKEN"); v != "" {
+		cfg.AccessToken = v
+	}
+	if v := os.Getenv("ZOHO_REFRESH_TOKEN"); v != "" {
+		cfg.RefreshToken = v
+	}
+	if v := os.Getenv("ZOHO_CLIENT_ID"); v != "" {
+		cfg.ClientID = v
+	}
+	if v := os.Getenv("ZOHO_CLIENT_SECRET"); v != "" {
+		cfg.ClientSecret = v
+	}
+	if v := os.Getenv("ZOHO_ACCOUNT_ID"); v != "" {
+		cfg.AccountID = v
+	}
+	if v := os.Getenv("ZOHO_MAIL_OUTPUT"); v != "" {
+		cfg.Output = v
+	}
+	folderEnv := map[string]string{
+		"inbox":   os.Getenv("ZOHO_INBOX_FOLDER_ID"),
+		"sent":    os.Getenv("ZOHO_SENT_FOLDER_ID"),
+		"spam":    os.Getenv("ZOHO_SPAM_FOLDER_ID"),
+		"trash":   os.Getenv("ZOHO_TRASH_FOLDER_ID"),
+		"archive": os.Getenv("ZOHO_ARCHIVE_FOLDER_ID"),
+	}
+	for name, id := range folderEnv {
+		if id != "" {
+			cfg.Folders[name] = id
+		}
+	}
+}
+
+func printDoctor(w io.Writer, cfg config) {
+	fmt.Fprintf(w, "config\t%s\n", cfg.ConfigPath)
+	fmt.Fprintf(w, "mail_base\t%s\n", cfg.MailBase)
+	fmt.Fprintf(w, "accounts_base\t%s\n", cfg.AccountsBase)
+	fmt.Fprintf(w, "account_id\t%s\n", presentID(cfg.AccountID))
+	printFolderDefaults(w, cfg.Folders)
+	fmt.Fprintf(w, "client_id\t%s\n", presentID(cfg.ClientID))
+	fmt.Fprintf(w, "client_secret\t%s\n", presentSecret(cfg.ClientSecret))
+	fmt.Fprintf(w, "refresh_token\t%s\n", presentSecret(cfg.RefreshToken))
+	fmt.Fprintf(w, "access_token\t%s\n", presentSecret(cfg.AccessToken))
+}
+
+func presentID(v string) string {
+	if v == "" {
+		return "missing"
+	}
+	if len(v) <= 12 {
+		return "set"
+	}
+	return v[:8] + "..." + v[len(v)-4:]
+}
+
+func presentSecret(v string) string {
+	if v == "" {
+		return "missing"
+	}
+	return "set"
+}
+
+func (cfg config) withHTTPClient() config {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return cfg
+}
+
+func env(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func configPath() string {
+	if v := os.Getenv("PP_ZOHOMAIL_CONFIG"); v != "" {
+		return v
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil || dir == "" {
+		return ".zohomail-pp-cli.json"
+	}
+	return dir + "/zohomail-pp-cli/config.json"
+}
+
+func loadConfig(path string) (config, error) {
+	if path == "" {
+		return config{}, errors.New("missing config path")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return config{}, err
+	}
+	var cfg config
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return config{}, err
+	}
+	if cfg.Folders == nil {
+		cfg.Folders = map[string]string{}
+	}
+	return cfg, nil
+}
+
+func saveConfig(cfg config) error {
+	if cfg.ConfigPath == "" {
+		cfg.ConfigPath = configPath()
+	}
+	if cfg.Folders == nil {
+		cfg.Folders = map[string]string{}
+	}
+	if idx := strings.LastIndex(cfg.ConfigPath, "/"); idx > 0 {
+		if err := os.MkdirAll(cfg.ConfigPath[:idx], 0700); err != nil {
+			return err
+		}
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(cfg.ConfigPath, b, 0600)
+}
+
+func saveTokenConfig(cfg config, body []byte) error {
+	var parsed struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return err
+	}
+	if parsed.RefreshToken == "" {
+		return errors.New("token response missing refresh_token")
+	}
+	cfg.RefreshToken = parsed.RefreshToken
+	cfg.AccessToken = ""
+	return saveConfig(cfg)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func printFolderDefaults(w io.Writer, folders map[string]string) {
+	for _, name := range []string{"inbox", "sent", "spam", "trash", "archive"} {
+		fmt.Fprintf(w, "folder_%s\t%s\n", name, presentID(folders[name]))
+	}
+}
+
+func hasFolderFlag(folders map[string]string) bool {
+	for _, id := range folders {
+		if id != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func authURL(accountsBase, clientID, redirect, scopes string) (string, error) {
+	return authURLWithState(accountsBase, clientID, redirect, scopes, "")
+}
+
+func authURLWithState(accountsBase, clientID, redirect, scopes, state string) (string, error) {
+	if clientID == "" {
+		return "", errors.New("missing ZOHO_CLIENT_ID")
+	}
+	u, err := url.Parse(strings.TrimRight(accountsBase, "/") + "/oauth/v2/auth")
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("scope", strings.ReplaceAll(scopes, ",", " "))
+	q.Set("client_id", clientID)
+	q.Set("response_type", "code")
+	q.Set("access_type", "offline")
+	q.Set("redirect_uri", redirect)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func login(stdout, stderr io.Writer, cfg config, redirect, scopes string, timeout time.Duration, openBrowser bool) error {
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return errors.New("missing ZOHO_CLIENT_ID or ZOHO_CLIENT_SECRET")
+	}
+	listener, actualRedirect, err := listenForRedirect(redirect)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	state, err := randomState()
+	if err != nil {
+		return err
+	}
+	u, err := authURLWithState(cfg.AccountsBase, cfg.ClientID, actualRedirect, scopes, state)
+	if err != nil {
+		return err
+	}
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	server := &http.Server{Handler: callbackHandler(state, codeCh, errCh)}
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+	defer server.Close()
+
+	fmt.Fprintf(stdout, "open\t%s\n", u)
+	if openBrowser {
+		if err := openURL(u); err != nil {
+			fmt.Fprintf(stderr, "open failed\t%s\n", err)
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return err
+	case <-timer.C:
+		return errors.New("timed out waiting for OAuth callback")
+	}
+
+	c := client{cfg: cfg}
+	body, err := c.tokenRequest(url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {actualRedirect},
+	})
+	if err != nil {
+		return err
+	}
+	if err := saveTokenConfig(cfg, body); err != nil {
+		return err
+	}
+	next, err := loadConfig(cfg.ConfigPath)
+	if err != nil {
+		return err
+	}
+	next.ConfigPath = cfg.ConfigPath
+	next.HTTPClient = cfg.HTTPClient
+	if err := discoverAndSaveConfig(next); err != nil {
+		return err
+	}
+	finalCfg, _ := loadConfig(cfg.ConfigPath)
+	fmt.Fprintf(stdout, "saved\t%s\n", cfg.ConfigPath)
+	fmt.Fprintf(stdout, "account_id\t%s\n", presentID(finalCfg.AccountID))
+	printFolderDefaults(stdout, finalCfg.Folders)
+	return nil
+}
+
+func deviceAuth(stdout, stderr io.Writer, cfg config, scopes string, openBrowser, save bool) error {
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return errors.New("missing ZOHO_CLIENT_ID or ZOHO_CLIENT_SECRET")
+	}
+	codeURL := strings.TrimRight(cfg.AccountsBase, "/") + "/oauth/v3/device/code"
+	req, err := http.NewRequest("POST", codeURL, strings.NewReader(url.Values{
+		"client_id":  {cfg.ClientID},
+		"scope":      {strings.ReplaceAll(scopes, ",", " ")},
+		"grant_type": {"device_request"},
+	}.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := cfg.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	codeBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("device code request failed: %s: %s", resp.Status, string(codeBody))
+	}
+	var codeResp struct {
+		DeviceCode      string `json:"device_code"`
+		UserCode        string `json:"user_code"`
+		VerificationURL string `json:"verification_url"`
+		ExpiresIn       int    `json:"expires_in"`
+		Interval        int    `json:"interval"`
+		Error           string `json:"error"`
+	}
+	if err := json.Unmarshal(codeBody, &codeResp); err != nil {
+		return err
+	}
+	if codeResp.Error != "" {
+		if codeResp.Error == "invalid_client" {
+			return errors.New("device auth requires a Non-browser Application client in Zoho API Console; Self Client does not support this grant — use auth-client-credentials instead")
+		}
+		return fmt.Errorf("device code error: %s", codeResp.Error)
+	}
+	fmt.Fprintf(stdout, "verification_url\t%s\n", codeResp.VerificationURL)
+	fmt.Fprintf(stdout, "user_code\t%s\n", codeResp.UserCode)
+	if openBrowser {
+		if err := openURL(codeResp.VerificationURL); err != nil {
+			fmt.Fprintf(stderr, "open failed\t%s\n", err)
+		}
+	}
+	interval := codeResp.Interval
+	if interval <= 0 {
+		interval = 5
+	}
+	expiresIn := codeResp.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 180
+	}
+	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	tokenURL := strings.TrimRight(cfg.AccountsBase, "/") + "/oauth/v3/device/token"
+	for time.Now().Before(deadline) {
+		time.Sleep(time.Duration(interval) * time.Second)
+		fmt.Fprint(stderr, ".")
+		pollReq, err := http.NewRequest("POST", tokenURL, strings.NewReader(url.Values{
+			"client_id":     {cfg.ClientID},
+			"client_secret": {cfg.ClientSecret},
+			"device_code":   {codeResp.DeviceCode},
+			"grant_type":    {"device_token"},
+		}.Encode()))
+		if err != nil {
+			return err
+		}
+		pollReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		pollResp, err := cfg.HTTPClient.Do(pollReq)
+		if err != nil {
+			return err
+		}
+		pollBody, _ := io.ReadAll(pollResp.Body)
+		pollResp.Body.Close()
+		var tokenResp struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			Error        string `json:"error"`
+		}
+		if err := json.Unmarshal(pollBody, &tokenResp); err != nil {
+			return err
+		}
+		if tokenResp.Error == "authorization_pending" {
+			continue
+		}
+		if tokenResp.AccessToken != "" {
+			fmt.Fprintln(stderr, " approved")
+			if err := writeJSON(stdout, pollBody); err != nil {
+				return err
+			}
+			if save {
+				if err := saveTokenConfig(cfg, pollBody); err != nil {
+					return err
+				}
+				next, err := loadConfig(cfg.ConfigPath)
+				if err != nil {
+					return err
+				}
+				next.ConfigPath = cfg.ConfigPath
+				next.HTTPClient = cfg.HTTPClient
+				if err := discoverAndSaveConfig(next); err != nil {
+					return err
+				}
+				fmt.Fprintf(stdout, "saved\t%s\n", cfg.ConfigPath)
+			}
+			return nil
+		}
+		if tokenResp.Error != "" {
+			fmt.Fprintln(stderr, "")
+			return fmt.Errorf("device token error: %s", tokenResp.Error)
+		}
+	}
+	fmt.Fprintln(stderr, "")
+	return errors.New("device authorization timed out")
+}
+
+func listenForRedirect(redirect string) (net.Listener, string, error) {
+	u, err := url.Parse(redirect)
+	if err != nil {
+		return nil, "", err
+	}
+	if u.Scheme != "http" {
+		return nil, "", errors.New("login redirect URI must use http localhost")
+	}
+	host := u.Hostname()
+	if host != "localhost" && host != "127.0.0.1" {
+		return nil, "", errors.New("login redirect URI must use localhost or 127.0.0.1")
+	}
+	port := u.Port()
+	if port == "" {
+		port = "80"
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		return nil, "", err
+	}
+	if u.Port() == "" || u.Port() == "0" {
+		addr := listener.Addr().(*net.TCPAddr)
+		u.Host = u.Hostname() + fmt.Sprintf(":%d", addr.Port)
+	}
+	return listener, u.String(), nil
+}
+
+func callbackHandler(wantState string, codeCh chan<- string, errCh chan<- error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != wantState {
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			errCh <- errors.New("OAuth state mismatch")
+			return
+		}
+		if e := r.URL.Query().Get("error"); e != "" {
+			http.Error(w, e, http.StatusBadRequest)
+			errCh <- fmt.Errorf("OAuth error: %s", e)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "missing code", http.StatusBadRequest)
+			errCh <- errors.New("OAuth callback missing code")
+			return
+		}
+		fmt.Fprintln(w, "zohomail-pp-cli login complete. You can close this tab.")
+		codeCh <- code
+	})
+}
+
+func discoverAndSaveConfig(cfg config) error {
+	c := client{cfg: cfg.withHTTPClient()}
+	discovered, err := c.discoverConfig(cfg.AccountID)
+	if err != nil {
+		return err
+	}
+	discovered.ConfigPath = cfg.ConfigPath
+	discovered.ClientID = cfg.ClientID
+	discovered.ClientSecret = cfg.ClientSecret
+	discovered.RefreshToken = cfg.RefreshToken
+	return saveConfig(discovered)
+}
+
+func authFromRBW(cfg config, rbwBin, item, clientIDField, clientSecretField, refreshTokenField string, noDiscover bool) (config, error) {
+	values := map[string]*string{
+		clientIDField:     &cfg.ClientID,
+		clientSecretField: &cfg.ClientSecret,
+		refreshTokenField: &cfg.RefreshToken,
+	}
+	for field, target := range values {
+		value, err := rbwField(rbwBin, item, field)
+		if err != nil {
+			return config{}, err
+		}
+		*target = value
+	}
+	if cfg.ClientID == "" || cfg.ClientSecret == "" || cfg.RefreshToken == "" {
+		return config{}, errors.New("rbw item missing Zoho client ID, client secret, or refresh token")
+	}
+	cfg.AccessToken = ""
+	if noDiscover {
+		if err := saveConfig(cfg); err != nil {
+			return config{}, err
+		}
+		return cfg, nil
+	}
+	if err := discoverAndSaveConfig(cfg); err != nil {
+		return config{}, err
+	}
+	saved, err := loadConfig(cfg.ConfigPath)
+	if err != nil {
+		return config{}, err
+	}
+	saved.ConfigPath = cfg.ConfigPath
+	return saved, nil
+}
+
+func rbwField(rbwBin, item, field string) (string, error) {
+	cmd := exec.Command(rbwBin, "get", item, "--field", field)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("rbw get field %q failed: %s", field, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func openURL(u string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", u)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", u)
+	default:
+		cmd = exec.Command("xdg-open", u)
+	}
+	return cmd.Start()
+}
+
+func (c client) bearerToken() (string, error) {
+	if c.cfg.AccessToken != "" {
+		return c.cfg.AccessToken, nil
+	}
+	if c.cfg.RefreshToken == "" || c.cfg.ClientID == "" || c.cfg.ClientSecret == "" {
+		return "", errors.New("missing auth: set ZOHO_MAIL_ACCESS_TOKEN or refresh-token env trio")
+	}
+	body, err := c.tokenRequest(url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {c.cfg.RefreshToken},
+		"client_id":     {c.cfg.ClientID},
+		"client_secret": {c.cfg.ClientSecret},
+	})
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", err
+	}
+	if parsed.AccessToken == "" {
+		if parsed.Error != "" {
+			return "", fmt.Errorf("token refresh failed: %s", parsed.Error)
+		}
+		return "", errors.New("token refresh response missing access_token")
+	}
+	return parsed.AccessToken, nil
+}
+
+func (c client) tokenRequest(values url.Values) ([]byte, error) {
+	u := strings.TrimRight(c.cfg.AccountsBase, "/") + "/oauth/v2/token"
+	req, err := http.NewRequest("POST", u, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("token request failed: %s: %s", resp.Status, string(body))
+	}
+	return body, nil
+}
+
+func (c client) getAndWrite(w io.Writer, path string, q url.Values, output string) error {
+	body, err := c.request("GET", path, q, nil)
+	if err != nil {
+		return err
+	}
+	return writeFormatted(w, body, output)
+}
+
+func (c client) getData(path string, q url.Values) (json.RawMessage, error) {
+	body, err := c.request("GET", path, q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var env apiEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, err
+	}
+	if len(env.Data) == 0 {
+		return nil, errors.New("response missing data")
+	}
+	return env.Data, nil
+}
+
+func (c client) discoverConfig(accountID string) (config, error) {
+	next := c.cfg
+	next.Folders = map[string]string{}
+	raw, err := c.getData("/api/accounts", nil)
+	if err != nil {
+		return config{}, err
+	}
+	var accounts []map[string]any
+	if err := json.Unmarshal(raw, &accounts); err != nil {
+		return config{}, err
+	}
+	next.AccountID = firstNonEmpty(accountID, pickAccountID(accounts))
+	if next.AccountID == "" {
+		return config{}, errors.New("no Zoho Mail account found")
+	}
+	raw, err = c.getData("/api/accounts/"+pathEscape(next.AccountID)+"/folders", nil)
+	if err != nil {
+		return config{}, err
+	}
+	var folders []map[string]any
+	if err := json.Unmarshal(raw, &folders); err != nil {
+		return config{}, err
+	}
+	next.Folders = pickFolderIDs(folders)
+	return next, nil
+}
+
+func pickAccountID(accounts []map[string]any) string {
+	for _, row := range accounts {
+		if truthy(row["isDefaultAccount"]) {
+			return fmt.Sprint(row["accountId"])
+		}
+	}
+	for _, row := range accounts {
+		if id := fmt.Sprint(row["accountId"]); id != "" && id != "<nil>" {
+			return id
+		}
+	}
+	return ""
+}
+
+func pickFolderIDs(rows []map[string]any) map[string]string {
+	out := map[string]string{}
+	targets := map[string][]string{
+		"inbox":   {"Inbox", "/Inbox"},
+		"sent":    {"Sent", "/Sent"},
+		"spam":    {"Spam", "/Spam"},
+		"trash":   {"Trash", "/Trash"},
+		"archive": {"Archive", "/Archive"},
+	}
+	for key, names := range targets {
+		for _, row := range rows {
+			folderID := fmt.Sprint(row["folderId"])
+			folderName := fmt.Sprint(row["folderName"])
+			folderPath := fmt.Sprint(row["path"])
+			for _, name := range names {
+				if strings.EqualFold(folderName, name) || strings.EqualFold(folderPath, name) {
+					out[key] = folderID
+					break
+				}
+			}
+			if out[key] != "" {
+				break
+			}
+		}
+	}
+	return out
+}
+
+func truthy(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return strings.EqualFold(t, "true")
+	default:
+		return fmt.Sprint(v) == "true"
+	}
+}
+
+func listMessages(w io.Writer, cfg config, accountID, folderID string, start, limit int, sortBy string) error {
+	if accountID == "" {
+		return errors.New("missing --account-id; run zohomail-pp-cli configure")
+	}
+	q := url.Values{"start": {fmt.Sprint(start)}, "limit": {fmt.Sprint(limit)}}
+	if folderID != "" {
+		q.Set("folderId", folderID)
+	}
+	if sortBy != "" {
+		q.Set("sortBy", sortBy)
+	}
+	c := client{cfg: cfg.withHTTPClient()}
+	return c.getAndWrite(w, "/api/accounts/"+pathEscape(accountID)+"/messages/view", q, cfg.Output)
+}
+
+func (c client) request(method, path string, q url.Values, payload any) ([]byte, error) {
+	token, err := c.bearerToken()
+	if err != nil {
+		return nil, err
+	}
+	u := strings.TrimRight(c.cfg.MailBase, "/") + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, u, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Zoho-oauthtoken "+token)
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s %s failed: %s: %s", method, path, resp.Status, string(respBody))
+	}
+	return respBody, nil
+}
+
+func writeFormatted(w io.Writer, body []byte, output string) error {
+	if output == "json" {
+		return writeJSON(w, body)
+	}
+	var env apiEnvelope
+	if err := json.Unmarshal(body, &env); err != nil || len(env.Data) == 0 {
+		return writeJSON(w, body)
+	}
+	return writePrettyData(w, env.Data)
+}
+
+func writeJSON(w io.Writer, body []byte) error {
+	var out bytes.Buffer
+	if err := json.Indent(&out, body, "", "  "); err != nil {
+		_, err = w.Write(body)
+		return err
+	}
+	out.WriteByte('\n')
+	_, err := w.Write(out.Bytes())
+	return err
+}
+
+func writePrettyData(w io.Writer, raw json.RawMessage) error {
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err == nil {
+		return printRows(w, rows)
+	}
+	var row map[string]any
+	if err := json.Unmarshal(raw, &row); err == nil {
+		for _, k := range sortedKeys(row) {
+			fmt.Fprintf(w, "%s\t%v\n", k, row[k])
+		}
+		return nil
+	}
+	return writeJSON(w, raw)
+}
+
+func printRows(w io.Writer, rows []map[string]any) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No rows.")
+		return nil
+	}
+	keys := preferredKeys(rows)
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	for _, row := range rows {
+		vals := make([]string, len(keys))
+		for i, k := range keys {
+			vals[i] = strings.ReplaceAll(fmt.Sprint(row[k]), "\n", " ")
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+	return nil
+}
+
+func preferredKeys(rows []map[string]any) []string {
+	if hasAny(rows, "accountId") {
+		return presentKeys(rows, []string{"accountId", "mailboxAddress", "displayName", "accountName", "isDefaultAccount", "zuid"})
+	}
+	if hasAny(rows, "messageId") {
+		return presentKeys(rows, []string{"messageId", "subject", "fromAddress", "sender", "receivedTime", "sentDateInGMT", "summary", "status", "folderId"})
+	}
+	if hasAny(rows, "folderId") {
+		return presentKeys(rows, []string{"folderId", "folderName", "path", "folderType", "imapAccess"})
+	}
+	preferred := []string{"accountId", "mailboxAddress", "displayName", "folderId", "folderName", "messageId", "subject", "fromAddress", "sender", "receivedTime", "sentDateInGMT", "status"}
+	return presentKeysWithRest(rows, preferred)
+}
+
+func presentKeys(rows []map[string]any, preferred []string) []string {
+	seen := map[string]bool{}
+	for _, row := range rows {
+		for k := range row {
+			seen[k] = true
+		}
+	}
+	var keys []string
+	for _, k := range preferred {
+		if seen[k] {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+func presentKeysWithRest(rows []map[string]any, preferred []string) []string {
+	keys := presentKeys(rows, preferred)
+	seen := map[string]bool{}
+	for _, row := range rows {
+		for k := range row {
+			seen[k] = true
+		}
+	}
+	for _, k := range keys {
+		delete(seen, k)
+	}
+	rest := make([]string, 0, len(seen))
+	for k := range seen {
+		rest = append(rest, k)
+	}
+	sort.Strings(rest)
+	return append(keys, rest...)
+}
+
+func hasAny(rows []map[string]any, key string) bool {
+	for _, row := range rows {
+		if _, ok := row[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func pathEscape(s string) string {
+	return url.PathEscape(strings.TrimSpace(s))
+}

--- a/library/productivity/zohomail-pp-cli/main.go
+++ b/library/productivity/zohomail-pp-cli/main.go
@@ -978,20 +978,26 @@ func listenForRedirect(redirect string) (net.Listener, string, error) {
 
 func callbackHandler(wantState string, codeCh chan<- string, errCh chan<- error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trySend := func(err error) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
 		if r.URL.Query().Get("state") != wantState {
 			http.Error(w, "state mismatch", http.StatusBadRequest)
-			errCh <- errors.New("OAuth state mismatch")
+			trySend(errors.New("OAuth state mismatch"))
 			return
 		}
 		if e := r.URL.Query().Get("error"); e != "" {
 			http.Error(w, e, http.StatusBadRequest)
-			errCh <- fmt.Errorf("OAuth error: %s", e)
+			trySend(fmt.Errorf("OAuth error: %s", e))
 			return
 		}
 		code := r.URL.Query().Get("code")
 		if code == "" {
 			http.Error(w, "missing code", http.StatusBadRequest)
-			errCh <- errors.New("OAuth callback missing code")
+			trySend(errors.New("OAuth callback missing code"))
 			return
 		}
 		fmt.Fprintln(w, "zohomail-pp-cli login complete. You can close this tab.")

--- a/library/productivity/zohomail-pp-cli/main_test.go
+++ b/library/productivity/zohomail-pp-cli/main_test.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type lineWriter struct {
+	mu sync.Mutex
+	ch chan string
+}
+
+func newLineWriter() *lineWriter {
+	return &lineWriter{ch: make(chan string, 20)}
+}
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, line := range strings.Split(string(p), "\n") {
+		if strings.TrimSpace(line) != "" {
+			w.ch <- line
+		}
+	}
+	return len(p), nil
+}
+
+func TestAccountsUsesZohoAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/accounts" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"accountId":"123","mailboxAddress":"me@example.com"}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("ZOHO_MAIL_ACCESS_TOKEN", "abc")
+	t.Setenv("ZOHO_MAIL_BASE_URL", srv.URL)
+
+	var out strings.Builder
+	if err := run([]string{"accounts"}, &out, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Zoho-oauthtoken abc" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	if !strings.Contains(out.String(), "accountId") || !strings.Contains(out.String(), "me@example.com") {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+}
+
+func TestSendPayload(t *testing.T) {
+	var payload map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/api/accounts/123/messages" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"status":{"code":200},"data":{"message":"sent"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("ZOHO_MAIL_ACCESS_TOKEN", "abc")
+	t.Setenv("ZOHO_MAIL_BASE_URL", srv.URL)
+
+	var out strings.Builder
+	err := run([]string{"send", "--account-id", "123", "--from", "me@example.com", "--to", "you@example.com", "--subject", "Hi", "--content", "Body"}, &out, &strings.Builder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload["fromAddress"] != "me@example.com" || payload["toAddress"] != "you@example.com" || payload["content"] != "Body" {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestRefreshTokenFlow(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/v2/token" {
+			t.Fatalf("token path = %s", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if r.Form.Get("grant_type") != "refresh_token" {
+			t.Fatalf("grant_type = %s", r.Form.Get("grant_type"))
+		}
+		_, _ = w.Write([]byte(`{"access_token":"fresh"}`))
+	}))
+	defer tokenSrv.Close()
+
+	var gotAuth string
+	mailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":{"code":200},"data":[]}`))
+	}))
+	defer mailSrv.Close()
+
+	t.Setenv("ZOHO_REFRESH_TOKEN", "refresh")
+	t.Setenv("ZOHO_CLIENT_ID", "id")
+	t.Setenv("ZOHO_CLIENT_SECRET", "secret")
+	t.Setenv("ZOHO_ACCOUNTS_BASE_URL", tokenSrv.URL)
+	t.Setenv("ZOHO_MAIL_BASE_URL", mailSrv.URL)
+
+	if err := run([]string{"accounts"}, &strings.Builder{}, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Zoho-oauthtoken fresh" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+func TestSelfClientTokenOmitsRedirectURI(t *testing.T) {
+	var sawRedirect bool
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		sawRedirect = r.Form.Get("redirect_uri") != ""
+		_, _ = w.Write([]byte(`{"access_token":"short","refresh_token":"refresh"}`))
+	}))
+	defer tokenSrv.Close()
+
+	t.Setenv("ZOHO_CLIENT_ID", "id")
+	t.Setenv("ZOHO_CLIENT_SECRET", "secret")
+	t.Setenv("ZOHO_ACCOUNTS_BASE_URL", tokenSrv.URL)
+
+	var out strings.Builder
+	if err := run([]string{"token", "--self-client", "--code", "abc"}, &out, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	if sawRedirect {
+		t.Fatal("self-client token exchange sent redirect_uri")
+	}
+	if !strings.Contains(out.String(), "refresh_token") {
+		t.Fatalf("missing refresh token output: %s", out.String())
+	}
+}
+
+func TestConfigureDiscoversDefaults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/accounts":
+			_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"accountId":"123","mailboxAddress":"me@example.com","isDefaultAccount":true}]}`))
+		case "/api/accounts/123/folders":
+			_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"folderId":"in1","folderName":"Inbox","path":"/Inbox"},{"folderId":"sent1","folderName":"Sent","path":"/Sent"},{"folderId":"arch1","folderName":"Archive","path":"/Archive"}]}`))
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("PP_ZOHOMAIL_CONFIG", cfgPath)
+	t.Setenv("ZOHO_MAIL_ACCESS_TOKEN", "abc")
+	t.Setenv("ZOHO_MAIL_BASE_URL", srv.URL)
+
+	var out strings.Builder
+	if err := run([]string{"configure"}, &out, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"account_id": "123"`) || !strings.Contains(string(b), `"inbox": "in1"`) {
+		t.Fatalf("config = %s", string(b))
+	}
+	if strings.Contains(string(b), "abc") {
+		t.Fatalf("access token persisted: %s", string(b))
+	}
+}
+
+func TestInboxUsesConfiguredFolder(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/accounts/123/messages/view" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"messageId":"m1","subject":"Hi"}]}`))
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"mail_base":"`+srv.URL+`","access_token":"ignored","account_id":"123","folders":{"inbox":"in1"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PP_ZOHOMAIL_CONFIG", cfgPath)
+	t.Setenv("ZOHO_MAIL_ACCESS_TOKEN", "abc")
+
+	var out strings.Builder
+	if err := run([]string{"inbox", "--limit", "5"}, &out, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, "folderId=in1") || !strings.Contains(gotQuery, "limit=5") {
+		t.Fatalf("query = %s", gotQuery)
+	}
+	if !strings.Contains(out.String(), "messageId") || !strings.Contains(out.String(), "Hi") {
+		t.Fatalf("output = %s", out.String())
+	}
+}
+
+func TestMessageRowsPreferMessageColumnsOverFolderID(t *testing.T) {
+	body := []byte(`{"status":{"code":200},"data":[{"folderId":"in1","messageId":"m1","subject":"Hi","fromAddress":"me@example.com"}]}`)
+	var out strings.Builder
+	if err := writeFormatted(&out, body, "pretty"); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("output = %s", out.String())
+	}
+	if lines[0] != "messageId\tsubject\tfromAddress\tfolderId" {
+		t.Fatalf("header = %q output = %s", lines[0], out.String())
+	}
+	if !strings.Contains(lines[1], "m1\tHi\tme@example.com\tin1") {
+		t.Fatalf("row = %q output = %s", lines[1], out.String())
+	}
+}
+
+func TestConfigureOfflineKnownIDs(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("PP_ZOHOMAIL_CONFIG", cfgPath)
+
+	if err := run([]string{"configure", "--account-id", "123", "--inbox-folder-id", "in1", "--sent-folder-id", "sent1"}, &strings.Builder{}, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"account_id": "123"`) || !strings.Contains(got, `"inbox": "in1"`) || !strings.Contains(got, `"sent": "sent1"`) {
+		t.Fatalf("config = %s", got)
+	}
+}
+
+func TestLoginBrowserFlowSavesAuthAndDefaults(t *testing.T) {
+	mailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/accounts":
+			if r.Header.Get("Authorization") != "Zoho-oauthtoken fresh" {
+				t.Fatalf("auth header = %q", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"accountId":"123","isDefaultAccount":true}]}`))
+		case "/api/accounts/123/folders":
+			_, _ = w.Write([]byte(`{"status":{"code":200},"data":[{"folderId":"in1","folderName":"Inbox","path":"/Inbox"},{"folderId":"sent1","folderName":"Sent","path":"/Sent"}]}`))
+		default:
+			t.Fatalf("mail path = %s", r.URL.Path)
+		}
+	}))
+	defer mailSrv.Close()
+
+	var authSrv *httptest.Server
+	authSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/v2/auth":
+			redirect := r.URL.Query().Get("redirect_uri")
+			state := r.URL.Query().Get("state")
+			http.Redirect(w, r, redirect+"?code=browser-code&state="+state, http.StatusFound)
+		case "/oauth/v2/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if r.Form.Get("grant_type") == "refresh_token" {
+				_, _ = w.Write([]byte(`{"access_token":"fresh"}`))
+				return
+			}
+			if r.Form.Get("grant_type") != "authorization_code" || r.Form.Get("code") != "browser-code" {
+				t.Fatalf("code = %s", r.Form.Get("code"))
+			}
+			_, _ = w.Write([]byte(`{"access_token":"fresh","refresh_token":"refresh"}`))
+		default:
+			t.Fatalf("auth path = %s", r.URL.Path)
+		}
+	}))
+	defer authSrv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	out := newLineWriter()
+	done := make(chan error, 1)
+	cfg := config{
+		AccountsBase: authSrv.URL,
+		MailBase:     mailSrv.URL,
+		ClientID:     "id",
+		ClientSecret: "secret",
+		ConfigPath:   cfgPath,
+		Folders:      map[string]string{},
+		HTTPClient:   authSrv.Client(),
+	}
+	go func() {
+		done <- login(out, &strings.Builder{}, cfg, "http://localhost:0/callback", "ZohoMail.accounts.READ", time.Minute, false)
+	}()
+
+	var openLine string
+	select {
+	case openLine = <-out.ch:
+	case <-time.After(time.Second):
+		t.Fatal("login did not print auth URL")
+	}
+	if !strings.HasPrefix(openLine, "open\t") {
+		t.Fatalf("open line = %q", openLine)
+	}
+	resp, err := authSrv.Client().Get(strings.TrimPrefix(openLine, "open\t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("login did not finish")
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{`"refresh_token": "refresh"`, `"client_id": "id"`, `"client_secret": "secret"`, `"account_id": "123"`, `"inbox": "in1"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in config: %s", want, got)
+		}
+	}
+}
+
+func TestLoginAcceptsClientCredentialsFlags(t *testing.T) {
+	var out strings.Builder
+	err := run([]string{"login", "--client-id", "id", "--client-secret", "secret", "--redirect-uri", "https://example.com/callback"}, &out, &strings.Builder{})
+	if err == nil || !strings.Contains(err.Error(), "login redirect URI must use http localhost") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestClientSetupPrintsConsoleURL(t *testing.T) {
+	var out strings.Builder
+	if err := run([]string{"client-setup", "--no-open"}, &out, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "open\thttps://accounts.zoho.com/developerconsole") ||
+		!strings.Contains(got, "redirect_uri\thttp://localhost:53682/callback") ||
+		!strings.Contains(got, "ZohoMail.accounts.READ") {
+		t.Fatalf("output = %s", got)
+	}
+}
+
+func TestAuthSavePersistsExistingRefreshToken(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("PP_ZOHOMAIL_CONFIG", cfgPath)
+	var out strings.Builder
+	err := run([]string{"auth-save", "--client-id", "id", "--client-secret", "secret-value", "--refresh-token", "refresh-value", "--no-discover"}, &out, &strings.Builder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{`"client_id": "id"`, `"client_secret": "secret-value"`, `"refresh_token": "refresh-value"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in config: %s", want, got)
+		}
+	}
+	if strings.Contains(out.String(), "secret-value") || strings.Contains(out.String(), "refresh-value") {
+		t.Fatalf("secret leaked in output: %s", out.String())
+	}
+}
+
+func TestAuthRBWSavesFieldsWithoutPrintingSecrets(t *testing.T) {
+	dir := t.TempDir()
+	rbwPath := filepath.Join(dir, "rbw")
+	script := `#!/bin/sh
+case "$4" in
+  ZOHO_CLIENT_ID) printf 'id-value' ;;
+  ZOHO_CLIENT_SECRET) printf 'secret-value' ;;
+  ZOHO_REFRESH_TOKEN) printf 'refresh-value' ;;
+  *) exit 2 ;;
+esac
+`
+	if err := os.WriteFile(rbwPath, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "config.json")
+	t.Setenv("PP_ZOHOMAIL_CONFIG", cfgPath)
+	var out strings.Builder
+	err := run([]string{"auth-rbw", "--item", "Zoho Mail OAuth", "--rbw-bin", rbwPath, "--no-discover"}, &out, &strings.Builder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, want := range []string{`"client_id": "id-value"`, `"client_secret": "secret-value"`, `"refresh_token": "refresh-value"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s in config: %s", want, got)
+		}
+	}
+	if strings.Contains(out.String(), "secret-value") || strings.Contains(out.String(), "refresh-value") {
+		t.Fatalf("secret leaked in output: %s", out.String())
+	}
+}

--- a/library/productivity/zohomail-pp-cli/scripts/write_zoho_auth_to_bitwarden.py
+++ b/library/productivity/zohomail-pp-cli/scripts/write_zoho_auth_to_bitwarden.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 import base64
 import json
 import os
-import re
 import subprocess
 import sys
-from pathlib import Path
 
 ITEM_NAME = "Zoho Mail OAuth"
 URI = "https://api-console.zoho.com"
@@ -15,15 +13,7 @@ FIELDS = ["ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET", "ZOHO_REFRESH_TOKEN"]
 
 
 def latest_value(key: str) -> str:
-    if os.environ.get(key):
-        return os.environ[key]
-    history = Path.home() / ".zsh_history"
-    if history.exists():
-        text = history.read_text(errors="ignore")
-        values = re.findall(rf"(?:export\s+)?{re.escape(key)}=['\"]?([^'\"\s;]+)", text)
-        if values:
-            return values[-1]
-    return ""
+    return os.environ.get(key, "")
 
 
 def run(args: list[str], session: str | None = None, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:

--- a/library/productivity/zohomail-pp-cli/scripts/write_zoho_auth_to_bitwarden.py
+++ b/library/productivity/zohomail-pp-cli/scripts/write_zoho_auth_to_bitwarden.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ITEM_NAME = "Zoho Mail OAuth"
+URI = "https://api-console.zoho.com"
+FIELDS = ["ZOHO_CLIENT_ID", "ZOHO_CLIENT_SECRET", "ZOHO_REFRESH_TOKEN"]
+
+
+def latest_value(key: str) -> str:
+    if os.environ.get(key):
+        return os.environ[key]
+    history = Path.home() / ".zsh_history"
+    if history.exists():
+        text = history.read_text(errors="ignore")
+        values = re.findall(rf"(?:export\s+)?{re.escape(key)}=['\"]?([^'\"\s;]+)", text)
+        if values:
+            return values[-1]
+    return ""
+
+
+def run(args: list[str], session: str | None = None, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    cmd = ["bw", *args]
+    if session:
+        cmd.extend(["--session", session])
+    return subprocess.run(cmd, input=input_text, text=True, capture_output=True, check=check)
+
+
+def unlock() -> str:
+    status = subprocess.run(["bw", "status"], text=True, capture_output=True, check=True)
+    parsed = json.loads(status.stdout)
+    if parsed.get("status") == "unlocked" and os.environ.get("BW_SESSION"):
+        return os.environ["BW_SESSION"]
+    unlock_proc = subprocess.run(["bw", "unlock", "--raw"], text=True, stdout=subprocess.PIPE)
+    token = unlock_proc.stdout.strip()
+    if unlock_proc.returncode != 0 or not token:
+        raise SystemExit("Bitwarden unlock failed")
+    return token
+
+
+def encoded(item: dict) -> str:
+    raw = json.dumps(item, separators=(",", ":")).encode()
+    return base64.b64encode(raw).decode()
+
+
+def base_item(values: dict[str, str]) -> dict:
+    return {
+        "type": 1,
+        "name": ITEM_NAME,
+        "notes": "Zoho Mail OAuth credentials for pp-zohomail-cli. Do not paste into chat.",
+        "favorite": False,
+        "fields": [{"name": k, "value": v, "type": 0} for k, v in values.items()],
+        "login": {
+            "username": values["ZOHO_CLIENT_ID"],
+            "password": values["ZOHO_CLIENT_SECRET"],
+            "uris": [{"uri": URI, "match": None}],
+        },
+    }
+
+
+def main() -> int:
+    values = {k: latest_value(k) for k in FIELDS}
+    missing = [k for k, v in values.items() if not v]
+    if missing:
+        print("Missing values: " + ", ".join(missing), file=sys.stderr)
+        return 1
+
+    session = unlock()
+    found = run(["list", "items", "--search", ITEM_NAME], session=session)
+    items = json.loads(found.stdout or "[]")
+    existing = next((item for item in items if item.get("name") == ITEM_NAME), None)
+
+    if existing:
+        item = run(["get", "item", existing["id"]], session=session)
+        payload = json.loads(item.stdout)
+        payload["name"] = ITEM_NAME
+        payload["notes"] = "Zoho Mail OAuth credentials for pp-zohomail-cli. Do not paste into chat."
+        payload["fields"] = [{"name": k, "value": v, "type": 0} for k, v in values.items()]
+        payload.setdefault("login", {})
+        payload["login"]["username"] = values["ZOHO_CLIENT_ID"]
+        payload["login"]["password"] = values["ZOHO_CLIENT_SECRET"]
+        payload["login"]["uris"] = [{"uri": URI, "match": None}]
+        run(["edit", "item", existing["id"]], session=session, input_text=encoded(payload))
+        print(f"updated\t{ITEM_NAME}")
+    else:
+        run(["create", "item"], session=session, input_text=encoded(base_item(values)))
+        print(f"created\t{ITEM_NAME}")
+    print("fields\tZOHO_CLIENT_ID ZOHO_CLIENT_SECRET ZOHO_REFRESH_TOKEN")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/registry.json
+++ b/registry.json
@@ -2,81 +2,82 @@
   "schema_version": 2,
   "entries": [
     {
-      "name": "agent-capture",
-      "category": "developer-tools",
-      "api": "agent-capture",
-      "description": "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
-      "path": "library/developer-tools/agent-capture",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn"
+      "name": "openrouter",
+      "category": "ai",
+      "api": "openrouter",
+      "description": "Agent-first OpenRouter introspection — terse output for cron and AI agents (--agent and --llm modes), local SQLite...",
+      "path": "library/ai/openrouter",
+      "printer": "rvdlaar",
+      "printer_name": "Rick van de Laar"
     },
     {
-      "name": "ahrefs",
-      "category": "marketing",
-      "api": "Ahrefs",
-      "description": "Query Ahrefs backlinks, keyword, rank tracking, site audit, and SERP data from the terminal.",
-      "path": "library/marketing/ahrefs",
+      "name": "cloud-run-admin",
+      "category": "cloud",
+      "api": "Google Cloud Run",
+      "description": "Deploy and manage user provided container images that scale automatically based on incoming requests. The Cloud Run Admin API v1 follows the Knative Serving API specification, while v2 is aligned with Google Cloud AIP-based API standards, as described in https://google.aip.dev/.",
+      "path": "library/cloud/cloud-run-admin",
       "printer": "cathrynlavery",
       "printer_name": "Cathryn Lavery",
       "mcp": {
-        "binary": "ahrefs-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 29,
-        "public_tool_count": 2,
-        "auth_type": "api_key",
-        "env_vars": [
-          "AHREFS_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "airbnb",
-      "category": "travel",
-      "api": "Airbnb Vrbo",
-      "description": "Search Airbnb and VRBO, find the host's direct booking site, and report the cheapest of three sources side-by-side.",
-      "path": "library/travel/airbnb",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "airbnb-pp-mcp",
+        "binary": "cloud-run-admin-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 8,
-        "public_tool_count": 6,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
+        "tool_count": 16,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "CLOUD_RUN_ADMIN_OAUTH2C"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
       }
     },
     {
-      "name": "allrecipes",
-      "category": "food-and-dining",
-      "api": "Allrecipes",
-      "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",
-      "path": "library/food-and-dining/allrecipes",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
+      "name": "digitalocean",
+      "category": "cloud",
+      "api": "DigitalOcean",
+      "description": "Printing Press CLI for Digitalocean.",
+      "path": "library/cloud/digitalocean",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
       "mcp": {
-        "binary": "allrecipes-pp-mcp",
+        "binary": "digitalocean-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 628,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "DIGITALOCEAN_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "render",
+      "category": "cloud",
+      "api": "Render",
+      "description": "Every Render endpoint, plus diff, drift, cost, audit, and orphan analytics no other Render tool ships.",
+      "path": "library/cloud/render",
+      "printer": "giacaglia",
+      "printer_name": "Giuliano Giacaglia",
+      "mcp": {
+        "binary": "render-pp-mcp",
         "transports": [
           "stdio",
           "http"
         ],
-        "tool_count": 2,
-        "public_tool_count": 1,
-        "auth_type": "cookie",
+        "tool_count": 196,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
         "env_vars": [
-          "ALLRECIPES_COOKIES"
+          "RENDER_API_KEY"
         ],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
       }
     },
     {
@@ -106,81 +107,18 @@
       }
     },
     {
-      "name": "apartments",
-      "category": "other",
-      "api": "Apartments",
-      "description": "Search Apartments.com listings, sync results to a local SQLite store, and run workflows the website never built — diff saved searches, rank by $/sqft, compare shortlists, and surface price drops or phantom listings.",
-      "path": "library/other/apartments",
-      "printer": "rderwin",
-      "printer_name": "rderwin",
-      "mcp": {
-        "binary": "apartments-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "archive-is",
-      "category": "media-and-entertainment",
-      "api": "Archive.today",
-      "description": "Bypass paywalls and look up web archives via archive.today. Hero command: find or create an archive for any URL with lookup-before-submit, Wayback Machine fallback, and agent-hints on stderr when called non-interactively.",
-      "path": "library/media-and-entertainment/archive-is",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "archive-is-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 6,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full"
-      }
-    },
-    {
-      "name": "cal-com",
-      "category": "productivity",
-      "api": "Cal.com",
-      "description": "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships.",
-      "path": "library/productivity/cal-com",
+      "name": "craigslist",
+      "category": "commerce",
+      "api": "Craigslist",
+      "description": "Search, sync, and watch Craigslist with a local SQLite snapshot history, cross-city aggregation, scam scoring, and price-drift detection.",
+      "path": "library/commerce/craigslist",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "cal-com-pp-mcp",
+        "binary": "craigslist-pp-mcp",
         "transports": [
-          "stdio"
-        ],
-        "tool_count": 291,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "CAL_COM_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "clarity",
-      "category": "marketing",
-      "api": "PP Clarity",
-      "description": "Client-side instrumentation helpers for Microsoft Clarity.",
-      "path": "library/marketing/clarity",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "clarity-pp-mcp",
-        "transports": [
-          "stdio"
+          "stdio",
+          "http"
         ],
         "tool_count": 1,
         "public_tool_count": 1,
@@ -191,48 +129,139 @@
       }
     },
     {
-      "name": "cloud-run-admin",
-      "category": "cloud",
-      "api": "Google Cloud Run",
-      "description": "Deploy and manage user provided container images that scale automatically based on incoming requests. The Cloud Run Admin API v1 follows the Knative Serving API specification, while v2 is aligned with Google Cloud AIP-based API standards, as described in https://google.aip.dev/.",
-      "path": "library/cloud/cloud-run-admin",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
+      "name": "ebay",
+      "category": "commerce",
+      "api": "eBay",
+      "description": "Buyer-power-user CLI for eBay. Sold-comp intelligence, true sniper bidding, watchlist intelligence, saved-search feeds, and a local SQLite store for cross-listing analytics.",
+      "path": "library/commerce/ebay",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
       "mcp": {
-        "binary": "cloud-run-admin-pp-mcp",
+        "binary": "ebay-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 16,
+        "tool_count": 8,
+        "public_tool_count": 1,
+        "auth_type": "cookie",
+        "env_vars": [],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "fedex",
+      "category": "commerce",
+      "api": "FedEx",
+      "description": "Ship, rate, and track FedEx packages from the terminal — built for small business shippers.",
+      "path": "library/commerce/fedex",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "fedex-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 48,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
         "env_vars": [
-          "CLOUD_RUN_ADMIN_OAUTH2C"
+          "FEDEX_API_KEY",
+          "FEDEX_SECRET_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "instacart",
+      "category": "commerce",
+      "api": "Instacart",
+      "description": "Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation.",
+      "path": "library/commerce/instacart",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn"
+    },
+    {
+      "name": "shopify",
+      "category": "commerce",
+      "api": "Shopify",
+      "description": "Operate a Shopify store from the terminal with curated Admin GraphQL commands, local sync, analytics, and bulk exports.",
+      "path": "library/commerce/shopify",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "shopify-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 10,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SHOPIFY_ACCESS_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "tiktok-shop",
+      "category": "commerce",
+      "api": "TikTok Shop",
+      "description": "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and refresh, read-only shops, orders, products, inventory search, fulfillment packages, and warehouses.",
+      "path": "library/commerce/tiktok-shop",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "tiktok-shop-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "signed_tiktok_shop_open_api",
+        "env_vars": [
+          "TIKTOK_SHOP_APP_KEY",
+          "TIKTOK_SHOP_APP_SECRET",
+          "TIKTOK_SHOP_ACCESS_TOKEN",
+          "TIKTOK_SHOP_REFRESH_TOKEN",
+          "TIKTOK_SHOP_SHOP_CIPHER"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "coingecko",
-      "category": "payments",
-      "api": "Coingecko",
-      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
-      "path": "library/payments/coingecko",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
+      "name": "yahoo-finance",
+      "category": "commerce",
+      "api": "Yahoo Finance",
+      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
+      "path": "library/commerce/yahoo-finance",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "coingecko-pp-mcp",
+        "binary": "yahoo-finance-pp-mcp",
         "transports": [
           "stdio"
         ],
         "tool_count": 11,
-        "public_tool_count": 11,
+        "public_tool_count": 0,
         "auth_type": "none",
         "env_vars": [],
         "mcp_ready": "full",
-        "spec_format": "openapi3"
+        "spec_format": "internal"
       }
+    },
+    {
+      "name": "agent-capture",
+      "category": "developer-tools",
+      "api": "agent-capture",
+      "description": "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
+      "path": "library/developer-tools/agent-capture",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn"
     },
     {
       "name": "company-goat",
@@ -256,42 +285,355 @@
       }
     },
     {
-      "name": "contact-goat",
-      "category": "sales-and-crm",
-      "api": "contact-goat",
-      "description": "Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has.",
-      "path": "library/sales-and-crm/contact-goat",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
+      "name": "docker-hub",
+      "category": "developer-tools",
+      "api": "Docker Hub",
+      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
+      "path": "library/developer-tools/docker-hub",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
       "mcp": {
-        "binary": "contact-goat-pp-mcp",
+        "binary": "docker-hub-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 16,
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "firecrawl",
+      "category": "developer-tools",
+      "api": "Firecrawl",
+      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
+      "path": "library/developer-tools/firecrawl",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "firecrawl-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 20,
         "public_tool_count": 0,
-        "auth_type": "composed",
+        "auth_type": "bearer_token",
         "env_vars": [
-          "DEEPLINE_API_KEY",
-          "HAPPENSTANCE_API_KEY"
+          "FIRECRAWL_BEARER_AUTH"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "craigslist",
-      "category": "commerce",
-      "api": "Craigslist",
-      "description": "Search, sync, and watch Craigslist with a local SQLite snapshot history, cross-city aggregation, scam scoring, and price-drift detection.",
-      "path": "library/commerce/craigslist",
+      "name": "nvd",
+      "category": "developer-tools",
+      "api": "National Vulnerability Database",
+      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
+      "path": "library/developer-tools/nvd",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "nvd-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 2,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "postman-explore",
+      "category": "developer-tools",
+      "api": "Postman Explore",
+      "description": "Public API network directory for discovering community collections, workspaces, and APIs",
+      "path": "library/developer-tools/postman-explore",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "craigslist-pp-mcp",
+        "binary": "postman-explore-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 8,
+        "public_tool_count": 8,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "pypi",
+      "category": "developer-tools",
+      "api": "PyPI",
+      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
+      "path": "library/developer-tools/pypi",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "pypi-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "scrape-creators",
+      "category": "developer-tools",
+      "api": "Scrape Creators",
+      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
+      "path": "library/developer-tools/scrape-creators",
+      "printer": "adrianhorning08",
+      "printer_name": "Adrian Horning",
+      "mcp": {
+        "binary": "scrape-creators-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 114,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SCRAPE_CREATORS_API_KEY_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "trigger-dev",
+      "category": "developer-tools",
+      "api": "Trigger.dev",
+      "description": "Durable background jobs and AI agent orchestration — runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL analytics",
+      "path": "library/developer-tools/trigger-dev",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "trigger-dev-pp-mcp",
         "transports": [
           "stdio",
           "http"
+        ],
+        "tool_count": 47,
+        "public_tool_count": 1,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "TRIGGER_SECRET_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "whoop",
+      "category": "devices",
+      "api": "Whoop",
+      "description": "Printing Press CLI for Whoop.",
+      "path": "library/devices/whoop",
+      "printer": "gregvanhorn",
+      "printer_name": "Greg Van Horn",
+      "mcp": {
+        "binary": "whoop-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 19,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "WHOOP_OAUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "allrecipes",
+      "category": "food-and-dining",
+      "api": "Allrecipes",
+      "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",
+      "path": "library/food-and-dining/allrecipes",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "allrecipes-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 1,
+        "auth_type": "cookie",
+        "env_vars": [
+          "ALLRECIPES_COOKIES"
+        ],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "dominos",
+      "category": "food-and-dining",
+      "api": "Domino's",
+      "description": "Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers.",
+      "path": "library/food-and-dining/dominos",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "dominos-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 20,
+        "public_tool_count": 11,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "DOMINOS_USERNAME",
+          "DOMINOS_PASSWORD",
+          "DOMINOS_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "food52",
+      "category": "food-and-dining",
+      "api": "Food52",
+      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
+      "path": "library/food-and-dining/food52",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "food52-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "pagliacci",
+      "category": "food-and-dining",
+      "api": "Pagliacci Pizza",
+      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
+      "path": "library/food-and-dining/pagliacci",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "pagliacci-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 57,
+        "public_tool_count": 26,
+        "auth_type": "composed",
+        "env_vars": [],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "recipe-goat",
+      "category": "food-and-dining",
+      "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
+      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
+      "path": "library/food-and-dining/recipe-goat",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "recipe-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "USDA_FDC_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "table-reservation-goat",
+      "category": "food-and-dining",
+      "api": "Table Reservation GOAT",
+      "description": "One reservation CLI for OpenTable and Tock — search both networks at once, watch for cancellations, book, and...",
+      "path": "library/food-and-dining/table-reservation-goat",
+      "printer": "pejmanjohn",
+      "printer_name": "Pejman Pour-Moezzi",
+      "mcp": {
+        "binary": "table-reservation-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 12,
+        "public_tool_count": 12,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "ahrefs",
+      "category": "marketing",
+      "api": "Ahrefs",
+      "description": "Query Ahrefs backlinks, keyword, rank tracking, site audit, and SERP data from the terminal.",
+      "path": "library/marketing/ahrefs",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "ahrefs-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 29,
+        "public_tool_count": 2,
+        "auth_type": "api_key",
+        "env_vars": [
+          "AHREFS_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "clarity",
+      "category": "marketing",
+      "api": "PP Clarity",
+      "description": "Client-side instrumentation helpers for Microsoft Clarity.",
+      "path": "library/marketing/clarity",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "clarity-pp-mcp",
+        "transports": [
+          "stdio"
         ],
         "tool_count": 1,
         "public_tool_count": 1,
@@ -326,97 +668,6 @@
       }
     },
     {
-      "name": "digg",
-      "category": "media-and-entertainment",
-      "api": "Digg AI",
-      "description": "Tail the Digg AI 1000's news cycle from the terminal — read-only, with the full pipeline event stream and...",
-      "path": "library/media-and-entertainment/digg",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "digg-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 3,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "digitalocean",
-      "category": "cloud",
-      "api": "DigitalOcean",
-      "description": "Printing Press CLI for Digitalocean.",
-      "path": "library/cloud/digitalocean",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "digitalocean-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 628,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "DIGITALOCEAN_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "docker-hub",
-      "category": "developer-tools",
-      "api": "Docker Hub",
-      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
-      "path": "library/developer-tools/docker-hub",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "docker-hub-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "dominos",
-      "category": "food-and-dining",
-      "api": "Domino's",
-      "description": "Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers.",
-      "path": "library/food-and-dining/dominos",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "dominos-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 20,
-        "public_tool_count": 11,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "DOMINOS_USERNAME",
-          "DOMINOS_PASSWORD",
-          "DOMINOS_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
       "name": "dub",
       "category": "marketing",
       "api": "Dub",
@@ -441,163 +692,6 @@
       }
     },
     {
-      "name": "ebay",
-      "category": "commerce",
-      "api": "eBay",
-      "description": "Buyer-power-user CLI for eBay. Sold-comp intelligence, true sniper bidding, watchlist intelligence, saved-search feeds, and a local SQLite store for cross-listing analytics.",
-      "path": "library/commerce/ebay",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "ebay-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 8,
-        "public_tool_count": 1,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "espn",
-      "category": "media-and-entertainment",
-      "api": "ESPN",
-      "description": "Live scores, standings, news, and game history across 17 sports from ESPN",
-      "path": "library/media-and-entertainment/espn",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "espn-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 7,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "fedex",
-      "category": "commerce",
-      "api": "FedEx",
-      "description": "Ship, rate, and track FedEx packages from the terminal — built for small business shippers.",
-      "path": "library/commerce/fedex",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "fedex-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 48,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "FEDEX_API_KEY",
-          "FEDEX_SECRET_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "firecrawl",
-      "category": "developer-tools",
-      "api": "Firecrawl",
-      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
-      "path": "library/developer-tools/firecrawl",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "firecrawl-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 20,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "FIRECRAWL_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "fireflies",
-      "category": "productivity",
-      "api": "Fireflies Pp Cli",
-      "description": "Every Fireflies meeting feature, plus offline search, cross-meeting intelligence, and a local database no other tool...",
-      "path": "library/productivity/fireflies",
-      "printer": "neektza",
-      "printer_name": "Nikica Jokic",
-      "mcp": {
-        "binary": "fireflies-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 18,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "FIREFLIES_PP_CLI_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "graphql"
-      }
-    },
-    {
-      "name": "flight-goat",
-      "category": "travel",
-      "api": "Flight GOAT",
-      "description": "Search Google Flights, scan Kayak long-haul routes, and join FlightAware AeroAPI reliability, alerts, and tracking from one CLI.",
-      "path": "library/travel/flight-goat",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "flight-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 58,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "FLIGHT_GOAT_API_KEY_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "food52",
-      "category": "food-and-dining",
-      "api": "Food52",
-      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
-      "path": "library/food-and-dining/food52",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "food52-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 4,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
       "name": "google-ads",
       "category": "marketing",
       "api": "Google Ads",
@@ -618,6 +712,124 @@
           "GOOGLE_ADS_DEVELOPER_TOKEN",
           "GOOGLE_ADS_LOGIN_CUSTOMER_ID"
         ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "google-search-console",
+      "category": "marketing",
+      "api": "Google Search Console",
+      "description": "Every Google Search Console feature you'd reach for, plus an offline SQLite cache that powers period compare, quick...",
+      "path": "library/marketing/google-search-console",
+      "printer": "bossriceshark",
+      "printer_name": "Matt"
+    },
+    {
+      "name": "klaviyo",
+      "category": "marketing",
+      "api": "Klaviyo",
+      "description": "Marketing automation, profiles, events, campaigns, flows, segments, and templates.",
+      "path": "library/marketing/klaviyo",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "klaviyo-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 308,
+        "public_tool_count": 11,
+        "auth_type": "api_key",
+        "env_vars": [
+          "KLAVIYO_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "producthunt",
+      "category": "marketing",
+      "api": "Product Hunt",
+      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
+      "path": "library/marketing/producthunt",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "producthunt-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 1,
+        "public_tool_count": 1,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "PRODUCT_HUNT_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "archive-is",
+      "category": "media-and-entertainment",
+      "api": "Archive.today",
+      "description": "Bypass paywalls and look up web archives via archive.today. Hero command: find or create an archive for any URL with lookup-before-submit, Wayback Machine fallback, and agent-hints on stderr when called non-interactively.",
+      "path": "library/media-and-entertainment/archive-is",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "archive-is-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 6,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full"
+      }
+    },
+    {
+      "name": "digg",
+      "category": "media-and-entertainment",
+      "api": "Digg AI",
+      "description": "Tail the Digg AI 1000's news cycle from the terminal — read-only, with the full pipeline event stream and...",
+      "path": "library/media-and-entertainment/digg",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "digg-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
+        "public_tool_count": 3,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "espn",
+      "category": "media-and-entertainment",
+      "api": "ESPN",
+      "description": "Live scores, standings, news, and game history across 17 sports from ESPN",
+      "path": "library/media-and-entertainment/espn",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "espn-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 7,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
         "mcp_ready": "full",
         "spec_format": "internal"
       }
@@ -647,15 +859,6 @@
       }
     },
     {
-      "name": "google-search-console",
-      "category": "marketing",
-      "api": "Google Search Console",
-      "description": "Every Google Search Console feature you'd reach for, plus an offline SQLite cache that powers period compare, quick...",
-      "path": "library/marketing/google-search-console",
-      "printer": "bossriceshark",
-      "printer_name": "Matt"
-    },
-    {
       "name": "hackernews",
       "category": "media-and-entertainment",
       "api": "Hacker News",
@@ -678,84 +881,6 @@
       }
     },
     {
-      "name": "instacart",
-      "category": "commerce",
-      "api": "Instacart",
-      "description": "Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation.",
-      "path": "library/commerce/instacart",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn"
-    },
-    {
-      "name": "kalshi",
-      "category": "payments",
-      "api": "Kalshi",
-      "description": "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot.",
-      "path": "library/payments/kalshi",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "kalshi-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 96,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "klaviyo",
-      "category": "marketing",
-      "api": "Klaviyo",
-      "description": "Marketing automation, profiles, events, campaigns, flows, segments, and templates.",
-      "path": "library/marketing/klaviyo",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "klaviyo-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 308,
-        "public_tool_count": 11,
-        "auth_type": "api_key",
-        "env_vars": [
-          "KLAVIYO_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "linear",
-      "category": "project-management",
-      "api": "Linear",
-      "description": "Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, FTS5 search, cross-cycle comparison, project burndown, and pp_created fixture lifecycle for safe live testing.",
-      "path": "library/project-management/linear",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "linear-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 28,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "LINEAR_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "graphql"
-      }
-    },
-    {
       "name": "marginalrevolution",
       "category": "media-and-entertainment",
       "api": "Marginal Revolution",
@@ -772,29 +897,6 @@
         "public_tool_count": 1,
         "auth_type": "none",
         "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "mercury",
-      "category": "payments",
-      "api": "Mercury",
-      "description": "Business banking API for accounts, transactions, payments, recipients, cards, invoices, treasury, and webhooks",
-      "path": "library/payments/mercury",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "mercury-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 75,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "MERCURY_BEARER_AUTH"
-        ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -821,146 +923,6 @@
           "OMDB_API_KEY"
         ],
         "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "myfitnesspal",
-      "category": "productivity",
-      "api": "MyFitnessPal",
-      "description": "Pull every meal you ever logged out of MyFitnessPal — per-food CSV, agent-shaped trends, and a local SQLite store...",
-      "path": "library/productivity/myfitnesspal",
-      "printer": "nickscarabosio",
-      "printer_name": "Nick Scarabosio",
-      "mcp": {
-        "binary": "myfitnesspal-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 15,
-        "public_tool_count": 0,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "notion",
-      "category": "productivity",
-      "api": "Notion",
-      "description": "Every Notion database queryable offline — cross-workspace SQL joins, stale detection, and relation graph traversal...",
-      "path": "library/productivity/notion",
-      "printer": "neektza",
-      "printer_name": "Nikica Jokic",
-      "mcp": {
-        "binary": "notion-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 47,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "NOTION_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "nvd",
-      "category": "developer-tools",
-      "api": "National Vulnerability Database",
-      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
-      "path": "library/developer-tools/nvd",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "nvd-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 2,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "open-meteo",
-      "category": "other",
-      "api": "Open-Meteo",
-      "description": "Forecasts, historicals, marine, air quality, flood, climate, ensemble, and seasonal data from Open-Meteo's free tier.",
-      "path": "library/other/open-meteo",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "open-meteo-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 11,
-        "public_tool_count": 11,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "openrouter",
-      "category": "ai",
-      "api": "openrouter",
-      "description": "Agent-first OpenRouter introspection — terse output for cron and AI agents (--agent and --llm modes), local SQLite...",
-      "path": "library/ai/openrouter",
-      "printer": "rvdlaar",
-      "printer_name": "Rick van de Laar"
-    },
-    {
-      "name": "opensnow",
-      "category": "productivity",
-      "api": "OpenSnow",
-      "description": "Hyper-local weather forecasts and conditions for any mountain location and elevation, worldwide. Provides current conditions, hourly forecasts, 5-day day/night snow forecasts, resort snow reports, and expert-written Daily Snow posts. Authentication via api_key query parameter (partnership access only).",
-      "path": "library/productivity/opensnow",
-      "printer": "davemorin",
-      "printer_name": "Dave Morin",
-      "mcp": {
-        "binary": "opensnow-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "OPENSNOW_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "pagliacci",
-      "category": "food-and-dining",
-      "api": "Pagliacci Pizza",
-      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
-      "path": "library/food-and-dining/pagliacci",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "pagliacci-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 57,
-        "public_tool_count": 26,
-        "auth_type": "composed",
-        "env_vars": [],
-        "mcp_ready": "partial",
         "spec_format": "internal"
       }
     },
@@ -1009,203 +971,68 @@
       }
     },
     {
-      "name": "postman-explore",
-      "category": "developer-tools",
-      "api": "Postman Explore",
-      "description": "Public API network directory for discovering community collections, workspaces, and APIs",
-      "path": "library/developer-tools/postman-explore",
+      "name": "steam-web",
+      "category": "media-and-entertainment",
+      "api": "Steam Web",
+      "description": "Look up Steam players, games, achievements, friends, and stats from the command line",
+      "path": "library/media-and-entertainment/steam-web",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "postman-explore-pp-mcp",
+        "binary": "steam-web-pp-mcp",
         "transports": [
-          "stdio"
+          "stdio",
+          "http"
         ],
-        "tool_count": 8,
-        "public_tool_count": 8,
-        "auth_type": "none",
-        "env_vars": [],
+        "tool_count": 169,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "STEAM_WEB_API_KEY"
+        ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "producthunt",
-      "category": "marketing",
-      "api": "Product Hunt",
-      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
-      "path": "library/marketing/producthunt",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
+      "name": "substack",
+      "category": "media-and-entertainment",
+      "api": "Substack",
+      "description": "Run your Substack growth loop from the command line — publish, schedule, engage, and measure with cross-table...",
+      "path": "library/media-and-entertainment/substack",
+      "printer": "chirantan",
+      "printer_name": "Chirantan Rajhans",
       "mcp": {
-        "binary": "producthunt-pp-mcp",
+        "binary": "substack-pp-mcp",
         "transports": [
           "stdio",
           "http"
         ],
-        "tool_count": 1,
-        "public_tool_count": 1,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "PRODUCT_HUNT_TOKEN"
-        ],
-        "mcp_ready": "full",
+        "tool_count": 39,
+        "public_tool_count": 0,
+        "auth_type": "cookie",
+        "env_vars": [],
+        "mcp_ready": "partial",
         "spec_format": "internal"
       }
     },
     {
-      "name": "pypi",
-      "category": "developer-tools",
-      "api": "PyPI",
-      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
-      "path": "library/developer-tools/pypi",
+      "name": "wikipedia",
+      "category": "media-and-entertainment",
+      "api": "Wikipedia",
+      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
+      "path": "library/media-and-entertainment/wikipedia",
       "printer": "hnshah",
       "printer_name": "Hiten Shah",
       "mcp": {
-        "binary": "pypi-pp-mcp",
+        "binary": "wikipedia-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 4,
-        "public_tool_count": 4,
+        "tool_count": 5,
+        "public_tool_count": 5,
         "auth_type": "none",
         "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "recipe-goat",
-      "category": "food-and-dining",
-      "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
-      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
-      "path": "library/food-and-dining/recipe-goat",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "recipe-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "USDA_FDC_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "redfin",
-      "category": "other",
-      "api": "Redfin",
-      "description": "Search Redfin homes for sale via internal Stingray endpoints, sync to local SQLite, and run workflows the website doesn't expose — saved-search diff, $/sqft net-HOA ranking, sold comps, multi-region trends.",
-      "path": "library/other/redfin",
-      "printer": "rderwin",
-      "printer_name": "rderwin",
-      "mcp": {
-        "binary": "redfin-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "render",
-      "category": "cloud",
-      "api": "Render",
-      "description": "Every Render endpoint, plus diff, drift, cost, audit, and orphan analytics no other Render tool ships.",
-      "path": "library/cloud/render",
-      "printer": "giacaglia",
-      "printer_name": "Giuliano Giacaglia",
-      "mcp": {
-        "binary": "render-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 196,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "RENDER_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "roam",
-      "category": "productivity",
-      "api": "Roam HQ",
-      "description": "Every Roam HQ surface — chat, transcripts, On-Air events, SCIM, webhooks — in one local-first CLI with offline...",
-      "path": "library/productivity/roam",
-      "printer": "gregvanhorn",
-      "printer_name": "Greg Van Horn",
-      "mcp": {
-        "binary": "roam-pp-cli",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 0,
-        "public_tool_count": 0,
-        "auth_type": "bearer",
-        "env_vars": [
-          "ROAM_API_KEY"
-        ],
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "scrape-creators",
-      "category": "developer-tools",
-      "api": "Scrape Creators",
-      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
-      "path": "library/developer-tools/scrape-creators",
-      "printer": "adrianhorning08",
-      "printer_name": "Adrian Horning",
-      "mcp": {
-        "binary": "scrape-creators-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 114,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SCRAPE_CREATORS_API_KEY_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "seats-aero",
-      "category": "travel",
-      "api": "Seats Aero Partner",
-      "description": "Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details.",
-      "path": "library/travel/seats-aero",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "seats-aero-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SEATS_AERO_API_KEY"
-        ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -1234,69 +1061,172 @@
       }
     },
     {
-      "name": "shopify",
-      "category": "commerce",
-      "api": "Shopify",
-      "description": "Operate a Shopify store from the terminal with curated Admin GraphQL commands, local sync, analytics, and bulk exports.",
-      "path": "library/commerce/shopify",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
+      "name": "apartments",
+      "category": "other",
+      "api": "Apartments",
+      "description": "Search Apartments.com listings, sync results to a local SQLite store, and run workflows the website never built — diff saved searches, rank by $/sqft, compare shortlists, and surface price drops or phantom listings.",
+      "path": "library/other/apartments",
+      "printer": "rderwin",
+      "printer_name": "rderwin",
       "mcp": {
-        "binary": "shopify-pp-mcp",
+        "binary": "apartments-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 10,
+        "tool_count": 2,
         "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SHOPIFY_ACCESS_TOKEN"
-        ],
+        "auth_type": "none",
+        "env_vars": [],
         "mcp_ready": "full",
         "spec_format": "internal"
       }
     },
     {
-      "name": "slack",
-      "category": "productivity",
-      "api": "Slack",
-      "description": "Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal",
-      "path": "library/productivity/slack",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "slack-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 66,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SLACK_BOT_TOKEN"
-        ],
-        "mcp_ready": "full"
-      }
-    },
-    {
-      "name": "steam-web",
-      "category": "media-and-entertainment",
-      "api": "Steam Web",
-      "description": "Look up Steam players, games, achievements, friends, and stats from the command line",
-      "path": "library/media-and-entertainment/steam-web",
+      "name": "open-meteo",
+      "category": "other",
+      "api": "Open-Meteo",
+      "description": "Forecasts, historicals, marine, air quality, flood, climate, ensemble, and seasonal data from Open-Meteo's free tier.",
+      "path": "library/other/open-meteo",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "steam-web-pp-mcp",
+        "binary": "open-meteo-pp-mcp",
         "transports": [
-          "stdio",
-          "http"
+          "stdio"
         ],
-        "tool_count": 169,
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "redfin",
+      "category": "other",
+      "api": "Redfin",
+      "description": "Search Redfin homes for sale via internal Stingray endpoints, sync to local SQLite, and run workflows the website doesn't expose — saved-search diff, $/sqft net-HOA ranking, sold comps, multi-region trends.",
+      "path": "library/other/redfin",
+      "printer": "rderwin",
+      "printer_name": "rderwin",
+      "mcp": {
+        "binary": "redfin-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "ufo-goat",
+      "category": "other",
+      "api": "War.gov UFO",
+      "description": "Browse, search, and download declassified UAP files from the War.gov PURSUE archive",
+      "path": "library/other/ufo-goat",
+      "printer": "davemorin",
+      "printer_name": "Dave Morin",
+      "mcp": {
+        "binary": "ufo-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "weather-goat",
+      "category": "other",
+      "api": "Open-Meteo + NWS",
+      "description": "Weather forecasts, severe weather alerts, air quality, and GO/CAUTION/STOP activity verdicts for walk, bike, hike, commute, and drive",
+      "path": "library/other/weather-goat",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "weather-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "coingecko",
+      "category": "payments",
+      "api": "Coingecko",
+      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
+      "path": "library/payments/coingecko",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "coingecko-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "kalshi",
+      "category": "payments",
+      "api": "Kalshi",
+      "description": "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot.",
+      "path": "library/payments/kalshi",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "kalshi-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 96,
         "public_tool_count": 0,
         "auth_type": "api_key",
         "env_vars": [
-          "STEAM_WEB_API_KEY"
+          "KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "mercury",
+      "category": "payments",
+      "api": "Mercury",
+      "description": "Business banking API for accounts, transactions, payments, recipients, cards, invoices, treasury, and webhooks",
+      "path": "library/payments/mercury",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "mercury-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 75,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "MERCURY_BEARER_AUTH"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
@@ -1327,20 +1257,65 @@
       }
     },
     {
-      "name": "substack",
-      "category": "media-and-entertainment",
-      "api": "Substack",
-      "description": "Run your Substack growth loop from the command line — publish, schedule, engage, and measure with cross-table...",
-      "path": "library/media-and-entertainment/substack",
-      "printer": "chirantan",
-      "printer_name": "Chirantan Rajhans",
+      "name": "cal-com",
+      "category": "productivity",
+      "api": "Cal.com",
+      "description": "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships.",
+      "path": "library/productivity/cal-com",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "substack-pp-mcp",
+        "binary": "cal-com-pp-mcp",
         "transports": [
-          "stdio",
-          "http"
+          "stdio"
         ],
-        "tool_count": 39,
+        "tool_count": 291,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "CAL_COM_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "fireflies",
+      "category": "productivity",
+      "api": "Fireflies Pp Cli",
+      "description": "Every Fireflies meeting feature, plus offline search, cross-meeting intelligence, and a local database no other tool...",
+      "path": "library/productivity/fireflies",
+      "printer": "neektza",
+      "printer_name": "Nikica Jokic",
+      "mcp": {
+        "binary": "fireflies-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 18,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "FIREFLIES_PP_CLI_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "graphql"
+      }
+    },
+    {
+      "name": "myfitnesspal",
+      "category": "productivity",
+      "api": "MyFitnessPal",
+      "description": "Pull every meal you ever logged out of MyFitnessPal — per-food CSV, agent-shaped trends, and a local SQLite store...",
+      "path": "library/productivity/myfitnesspal",
+      "printer": "nickscarabosio",
+      "printer_name": "Nick Scarabosio",
+      "mcp": {
+        "binary": "myfitnesspal-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 15,
         "public_tool_count": 0,
         "auth_type": "cookie",
         "env_vars": [],
@@ -1349,72 +1324,146 @@
       }
     },
     {
-      "name": "table-reservation-goat",
-      "category": "food-and-dining",
-      "api": "Table Reservation GOAT",
-      "description": "One reservation CLI for OpenTable and Tock — search both networks at once, watch for cancellations, book, and...",
-      "path": "library/food-and-dining/table-reservation-goat",
-      "printer": "pejmanjohn",
-      "printer_name": "Pejman Pour-Moezzi",
+      "name": "notion",
+      "category": "productivity",
+      "api": "Notion",
+      "description": "Every Notion database queryable offline — cross-workspace SQL joins, stale detection, and relation graph traversal...",
+      "path": "library/productivity/notion",
+      "printer": "neektza",
+      "printer_name": "Nikica Jokic",
       "mcp": {
-        "binary": "table-reservation-goat-pp-mcp",
+        "binary": "notion-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 12,
-        "public_tool_count": 12,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "tiktok-shop",
-      "category": "commerce",
-      "api": "TikTok Shop",
-      "description": "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and refresh, read-only shops, orders, products, inventory search, fulfillment packages, and warehouses.",
-      "path": "library/commerce/tiktok-shop",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "tiktok-shop-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 11,
-        "public_tool_count": 11,
-        "auth_type": "signed_tiktok_shop_open_api",
+        "tool_count": 47,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
         "env_vars": [
-          "TIKTOK_SHOP_APP_KEY",
-          "TIKTOK_SHOP_APP_SECRET",
-          "TIKTOK_SHOP_ACCESS_TOKEN",
-          "TIKTOK_SHOP_REFRESH_TOKEN",
-          "TIKTOK_SHOP_SHOP_CIPHER"
+          "NOTION_BEARER_AUTH"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "trigger-dev",
-      "category": "developer-tools",
-      "api": "Trigger.dev",
-      "description": "Durable background jobs and AI agent orchestration — runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL analytics",
-      "path": "library/developer-tools/trigger-dev",
+      "name": "opensnow",
+      "category": "productivity",
+      "api": "OpenSnow",
+      "description": "Hyper-local weather forecasts and conditions for any mountain location and elevation, worldwide. Provides current conditions, hourly forecasts, 5-day day/night snow forecasts, resort snow reports, and expert-written Daily Snow posts. Authentication via api_key query parameter (partnership access only).",
+      "path": "library/productivity/opensnow",
+      "printer": "davemorin",
+      "printer_name": "Dave Morin",
+      "mcp": {
+        "binary": "opensnow-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "OPENSNOW_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "roam",
+      "category": "productivity",
+      "api": "Roam HQ",
+      "description": "Every Roam HQ surface — chat, transcripts, On-Air events, SCIM, webhooks — in one local-first CLI with offline...",
+      "path": "library/productivity/roam",
+      "printer": "gregvanhorn",
+      "printer_name": "Greg Van Horn",
+      "mcp": {
+        "binary": "roam-pp-cli",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 0,
+        "public_tool_count": 0,
+        "auth_type": "bearer",
+        "env_vars": [
+          "ROAM_API_KEY"
+        ],
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "slack",
+      "category": "productivity",
+      "api": "Slack",
+      "description": "Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal",
+      "path": "library/productivity/slack",
       "printer": "mvanhorn",
       "printer_name": "Matt Van Horn",
       "mcp": {
-        "binary": "trigger-dev-pp-mcp",
+        "binary": "slack-pp-mcp",
         "transports": [
-          "stdio",
-          "http"
+          "stdio"
         ],
-        "tool_count": 47,
-        "public_tool_count": 1,
-        "auth_type": "bearer_token",
+        "tool_count": 66,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
         "env_vars": [
-          "TRIGGER_SECRET_KEY"
+          "SLACK_BOT_TOKEN"
+        ],
+        "mcp_ready": "full"
+      }
+    },
+    {
+      "name": "zohomail-pp-cli",
+      "category": "productivity",
+      "api": "Zoho Mail",
+      "description": "Read, search, inspect, and send Zoho Mail messages from the terminal with OAuth-backed account, folder, message, and send commands.",
+      "path": "library/productivity/zohomail-pp-cli",
+      "printer": "jlwainwright",
+      "printer_name": "Jacques Wainwright"
+    },
+    {
+      "name": "linear",
+      "category": "project-management",
+      "api": "Linear",
+      "description": "Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, FTS5 search, cross-cycle comparison, project burndown, and pp_created fixture lifecycle for safe live testing.",
+      "path": "library/project-management/linear",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "linear-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 28,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "LINEAR_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "graphql"
+      }
+    },
+    {
+      "name": "contact-goat",
+      "category": "sales-and-crm",
+      "api": "contact-goat",
+      "description": "Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has.",
+      "path": "library/sales-and-crm/contact-goat",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "contact-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 16,
+        "public_tool_count": 0,
+        "auth_type": "composed",
+        "env_vars": [
+          "DEEPLINE_API_KEY",
+          "HAPPENSTANCE_API_KEY"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
@@ -1445,113 +1494,6 @@
       }
     },
     {
-      "name": "ufo-goat",
-      "category": "other",
-      "api": "War.gov UFO",
-      "description": "Browse, search, and download declassified UAP files from the War.gov PURSUE archive",
-      "path": "library/other/ufo-goat",
-      "printer": "davemorin",
-      "printer_name": "Dave Morin",
-      "mcp": {
-        "binary": "ufo-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 4,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "wanderlust-goat",
-      "category": "travel",
-      "api": "Wanderlust GOAT",
-      "description": "Wanderlust GOAT — what a knowledgeable local with great taste would tell you to walk to from here, fused across editorial, local-language, and crowd layers no single tool ranks together.",
-      "path": "library/travel/wanderlust-goat",
-      "printer": "jheitzeb",
-      "printer_name": "Joe Heitzeberg",
-      "mcp": {
-        "binary": "wanderlust-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 2,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "weather-goat",
-      "category": "other",
-      "api": "Open-Meteo + NWS",
-      "description": "Weather forecasts, severe weather alerts, air quality, and GO/CAUTION/STOP activity verdicts for walk, bike, hike, commute, and drive",
-      "path": "library/other/weather-goat",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "weather-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "whoop",
-      "category": "devices",
-      "api": "Whoop",
-      "description": "Printing Press CLI for Whoop.",
-      "path": "library/devices/whoop",
-      "printer": "gregvanhorn",
-      "printer_name": "Greg Van Horn",
-      "mcp": {
-        "binary": "whoop-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 19,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "WHOOP_OAUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "wikipedia",
-      "category": "media-and-entertainment",
-      "api": "Wikipedia",
-      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
-      "path": "library/media-and-entertainment/wikipedia",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "wikipedia-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
       "name": "x-twitter",
       "category": "social-and-messaging",
       "api": "X (Twitter)",
@@ -1575,20 +1517,87 @@
       }
     },
     {
-      "name": "yahoo-finance",
-      "category": "commerce",
-      "api": "Yahoo Finance",
-      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
-      "path": "library/commerce/yahoo-finance",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
+      "name": "airbnb",
+      "category": "travel",
+      "api": "Airbnb Vrbo",
+      "description": "Search Airbnb and VRBO, find the host's direct booking site, and report the cheapest of three sources side-by-side.",
+      "path": "library/travel/airbnb",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
       "mcp": {
-        "binary": "yahoo-finance-pp-mcp",
+        "binary": "airbnb-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 11,
+        "tool_count": 8,
+        "public_tool_count": 6,
+        "auth_type": "cookie",
+        "env_vars": [],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "flight-goat",
+      "category": "travel",
+      "api": "Flight GOAT",
+      "description": "Search Google Flights, scan Kayak long-haul routes, and join FlightAware AeroAPI reliability, alerts, and tracking from one CLI.",
+      "path": "library/travel/flight-goat",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "flight-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 58,
         "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "FLIGHT_GOAT_API_KEY_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "seats-aero",
+      "category": "travel",
+      "api": "Seats Aero Partner",
+      "description": "Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details.",
+      "path": "library/travel/seats-aero",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "seats-aero-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SEATS_AERO_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "wanderlust-goat",
+      "category": "travel",
+      "api": "Wanderlust GOAT",
+      "description": "Wanderlust GOAT — what a knowledgeable local with great taste would tell you to walk to from here, fused across editorial, local-language, and crowd layers no single tool ranks together.",
+      "path": "library/travel/wanderlust-goat",
+      "printer": "jheitzeb",
+      "printer_name": "Joe Heitzeberg",
+      "mcp": {
+        "binary": "wanderlust-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 2,
         "auth_type": "none",
         "env_vars": [],
         "mcp_ready": "full",

--- a/registry.json
+++ b/registry.json
@@ -2,82 +2,81 @@
   "schema_version": 2,
   "entries": [
     {
-      "name": "openrouter",
-      "category": "ai",
-      "api": "openrouter",
-      "description": "Agent-first OpenRouter introspection — terse output for cron and AI agents (--agent and --llm modes), local SQLite...",
-      "path": "library/ai/openrouter",
-      "printer": "rvdlaar",
-      "printer_name": "Rick van de Laar"
+      "name": "agent-capture",
+      "category": "developer-tools",
+      "api": "agent-capture",
+      "description": "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
+      "path": "library/developer-tools/agent-capture",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn"
     },
     {
-      "name": "cloud-run-admin",
-      "category": "cloud",
-      "api": "Google Cloud Run",
-      "description": "Deploy and manage user provided container images that scale automatically based on incoming requests. The Cloud Run Admin API v1 follows the Knative Serving API specification, while v2 is aligned with Google Cloud AIP-based API standards, as described in https://google.aip.dev/.",
-      "path": "library/cloud/cloud-run-admin",
+      "name": "ahrefs",
+      "category": "marketing",
+      "api": "Ahrefs",
+      "description": "Query Ahrefs backlinks, keyword, rank tracking, site audit, and SERP data from the terminal.",
+      "path": "library/marketing/ahrefs",
       "printer": "cathrynlavery",
       "printer_name": "Cathryn Lavery",
       "mcp": {
-        "binary": "cloud-run-admin-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 16,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "CLOUD_RUN_ADMIN_OAUTH2C"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "digitalocean",
-      "category": "cloud",
-      "api": "DigitalOcean",
-      "description": "Printing Press CLI for Digitalocean.",
-      "path": "library/cloud/digitalocean",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "digitalocean-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 628,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "DIGITALOCEAN_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "render",
-      "category": "cloud",
-      "api": "Render",
-      "description": "Every Render endpoint, plus diff, drift, cost, audit, and orphan analytics no other Render tool ships.",
-      "path": "library/cloud/render",
-      "printer": "giacaglia",
-      "printer_name": "Giuliano Giacaglia",
-      "mcp": {
-        "binary": "render-pp-mcp",
+        "binary": "ahrefs-pp-mcp",
         "transports": [
           "stdio",
           "http"
         ],
-        "tool_count": 196,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
+        "tool_count": 29,
+        "public_tool_count": 2,
+        "auth_type": "api_key",
         "env_vars": [
-          "RENDER_API_KEY"
+          "AHREFS_API_KEY"
         ],
         "mcp_ready": "full",
-        "spec_format": "openapi3"
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "airbnb",
+      "category": "travel",
+      "api": "Airbnb Vrbo",
+      "description": "Search Airbnb and VRBO, find the host's direct booking site, and report the cheapest of three sources side-by-side.",
+      "path": "library/travel/airbnb",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "airbnb-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 8,
+        "public_tool_count": 6,
+        "auth_type": "cookie",
+        "env_vars": [],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "allrecipes",
+      "category": "food-and-dining",
+      "api": "Allrecipes",
+      "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",
+      "path": "library/food-and-dining/allrecipes",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "allrecipes-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 1,
+        "auth_type": "cookie",
+        "env_vars": [
+          "ALLRECIPES_COOKIES"
+        ],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
       }
     },
     {
@@ -107,18 +106,81 @@
       }
     },
     {
-      "name": "craigslist",
-      "category": "commerce",
-      "api": "Craigslist",
-      "description": "Search, sync, and watch Craigslist with a local SQLite snapshot history, cross-city aggregation, scam scoring, and price-drift detection.",
-      "path": "library/commerce/craigslist",
+      "name": "apartments",
+      "category": "other",
+      "api": "Apartments",
+      "description": "Search Apartments.com listings, sync results to a local SQLite store, and run workflows the website never built — diff saved searches, rank by $/sqft, compare shortlists, and surface price drops or phantom listings.",
+      "path": "library/other/apartments",
+      "printer": "rderwin",
+      "printer_name": "rderwin",
+      "mcp": {
+        "binary": "apartments-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "archive-is",
+      "category": "media-and-entertainment",
+      "api": "Archive.today",
+      "description": "Bypass paywalls and look up web archives via archive.today. Hero command: find or create an archive for any URL with lookup-before-submit, Wayback Machine fallback, and agent-hints on stderr when called non-interactively.",
+      "path": "library/media-and-entertainment/archive-is",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "archive-is-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 6,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full"
+      }
+    },
+    {
+      "name": "cal-com",
+      "category": "productivity",
+      "api": "Cal.com",
+      "description": "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships.",
+      "path": "library/productivity/cal-com",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "craigslist-pp-mcp",
+        "binary": "cal-com-pp-mcp",
         "transports": [
-          "stdio",
-          "http"
+          "stdio"
+        ],
+        "tool_count": 291,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "CAL_COM_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "clarity",
+      "category": "marketing",
+      "api": "PP Clarity",
+      "description": "Client-side instrumentation helpers for Microsoft Clarity.",
+      "path": "library/marketing/clarity",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "clarity-pp-mcp",
+        "transports": [
+          "stdio"
         ],
         "tool_count": 1,
         "public_tool_count": 1,
@@ -129,139 +191,48 @@
       }
     },
     {
-      "name": "ebay",
-      "category": "commerce",
-      "api": "eBay",
-      "description": "Buyer-power-user CLI for eBay. Sold-comp intelligence, true sniper bidding, watchlist intelligence, saved-search feeds, and a local SQLite store for cross-listing analytics.",
-      "path": "library/commerce/ebay",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
+      "name": "cloud-run-admin",
+      "category": "cloud",
+      "api": "Google Cloud Run",
+      "description": "Deploy and manage user provided container images that scale automatically based on incoming requests. The Cloud Run Admin API v1 follows the Knative Serving API specification, while v2 is aligned with Google Cloud AIP-based API standards, as described in https://google.aip.dev/.",
+      "path": "library/cloud/cloud-run-admin",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
       "mcp": {
-        "binary": "ebay-pp-mcp",
+        "binary": "cloud-run-admin-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 8,
-        "public_tool_count": 1,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "fedex",
-      "category": "commerce",
-      "api": "FedEx",
-      "description": "Ship, rate, and track FedEx packages from the terminal — built for small business shippers.",
-      "path": "library/commerce/fedex",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "fedex-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 48,
+        "tool_count": 16,
         "public_tool_count": 0,
         "auth_type": "bearer_token",
         "env_vars": [
-          "FEDEX_API_KEY",
-          "FEDEX_SECRET_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "instacart",
-      "category": "commerce",
-      "api": "Instacart",
-      "description": "Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation.",
-      "path": "library/commerce/instacart",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn"
-    },
-    {
-      "name": "shopify",
-      "category": "commerce",
-      "api": "Shopify",
-      "description": "Operate a Shopify store from the terminal with curated Admin GraphQL commands, local sync, analytics, and bulk exports.",
-      "path": "library/commerce/shopify",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "shopify-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 10,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SHOPIFY_ACCESS_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "tiktok-shop",
-      "category": "commerce",
-      "api": "TikTok Shop",
-      "description": "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and refresh, read-only shops, orders, products, inventory search, fulfillment packages, and warehouses.",
-      "path": "library/commerce/tiktok-shop",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "tiktok-shop-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 11,
-        "public_tool_count": 11,
-        "auth_type": "signed_tiktok_shop_open_api",
-        "env_vars": [
-          "TIKTOK_SHOP_APP_KEY",
-          "TIKTOK_SHOP_APP_SECRET",
-          "TIKTOK_SHOP_ACCESS_TOKEN",
-          "TIKTOK_SHOP_REFRESH_TOKEN",
-          "TIKTOK_SHOP_SHOP_CIPHER"
+          "CLOUD_RUN_ADMIN_OAUTH2C"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "yahoo-finance",
-      "category": "commerce",
-      "api": "Yahoo Finance",
-      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
-      "path": "library/commerce/yahoo-finance",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
+      "name": "coingecko",
+      "category": "payments",
+      "api": "Coingecko",
+      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
+      "path": "library/payments/coingecko",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
       "mcp": {
-        "binary": "yahoo-finance-pp-mcp",
+        "binary": "coingecko-pp-mcp",
         "transports": [
           "stdio"
         ],
         "tool_count": 11,
-        "public_tool_count": 0,
+        "public_tool_count": 11,
         "auth_type": "none",
         "env_vars": [],
         "mcp_ready": "full",
-        "spec_format": "internal"
+        "spec_format": "openapi3"
       }
-    },
-    {
-      "name": "agent-capture",
-      "category": "developer-tools",
-      "api": "agent-capture",
-      "description": "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
-      "path": "library/developer-tools/agent-capture",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn"
     },
     {
       "name": "company-goat",
@@ -285,355 +256,42 @@
       }
     },
     {
-      "name": "docker-hub",
-      "category": "developer-tools",
-      "api": "Docker Hub",
-      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
-      "path": "library/developer-tools/docker-hub",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "docker-hub-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "firecrawl",
-      "category": "developer-tools",
-      "api": "Firecrawl",
-      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
-      "path": "library/developer-tools/firecrawl",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "firecrawl-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 20,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "FIRECRAWL_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "nvd",
-      "category": "developer-tools",
-      "api": "National Vulnerability Database",
-      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
-      "path": "library/developer-tools/nvd",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "nvd-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 2,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "postman-explore",
-      "category": "developer-tools",
-      "api": "Postman Explore",
-      "description": "Public API network directory for discovering community collections, workspaces, and APIs",
-      "path": "library/developer-tools/postman-explore",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "postman-explore-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 8,
-        "public_tool_count": 8,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "pypi",
-      "category": "developer-tools",
-      "api": "PyPI",
-      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
-      "path": "library/developer-tools/pypi",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "pypi-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 4,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "scrape-creators",
-      "category": "developer-tools",
-      "api": "Scrape Creators",
-      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
-      "path": "library/developer-tools/scrape-creators",
-      "printer": "adrianhorning08",
-      "printer_name": "Adrian Horning",
-      "mcp": {
-        "binary": "scrape-creators-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 114,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SCRAPE_CREATORS_API_KEY_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "trigger-dev",
-      "category": "developer-tools",
-      "api": "Trigger.dev",
-      "description": "Durable background jobs and AI agent orchestration — runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL analytics",
-      "path": "library/developer-tools/trigger-dev",
+      "name": "contact-goat",
+      "category": "sales-and-crm",
+      "api": "contact-goat",
+      "description": "Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has.",
+      "path": "library/sales-and-crm/contact-goat",
       "printer": "mvanhorn",
       "printer_name": "Matt Van Horn",
       "mcp": {
-        "binary": "trigger-dev-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 47,
-        "public_tool_count": 1,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "TRIGGER_SECRET_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "whoop",
-      "category": "devices",
-      "api": "Whoop",
-      "description": "Printing Press CLI for Whoop.",
-      "path": "library/devices/whoop",
-      "printer": "gregvanhorn",
-      "printer_name": "Greg Van Horn",
-      "mcp": {
-        "binary": "whoop-pp-mcp",
+        "binary": "contact-goat-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 19,
+        "tool_count": 16,
         "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "WHOOP_OAUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "allrecipes",
-      "category": "food-and-dining",
-      "api": "Allrecipes",
-      "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",
-      "path": "library/food-and-dining/allrecipes",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "allrecipes-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 1,
-        "auth_type": "cookie",
-        "env_vars": [
-          "ALLRECIPES_COOKIES"
-        ],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "dominos",
-      "category": "food-and-dining",
-      "api": "Domino's",
-      "description": "Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers.",
-      "path": "library/food-and-dining/dominos",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "dominos-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 20,
-        "public_tool_count": 11,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "DOMINOS_USERNAME",
-          "DOMINOS_PASSWORD",
-          "DOMINOS_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "food52",
-      "category": "food-and-dining",
-      "api": "Food52",
-      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
-      "path": "library/food-and-dining/food52",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "food52-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 4,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "pagliacci",
-      "category": "food-and-dining",
-      "api": "Pagliacci Pizza",
-      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
-      "path": "library/food-and-dining/pagliacci",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "pagliacci-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 57,
-        "public_tool_count": 26,
         "auth_type": "composed",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
+        "env_vars": [
+          "DEEPLINE_API_KEY",
+          "HAPPENSTANCE_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
       }
     },
     {
-      "name": "recipe-goat",
-      "category": "food-and-dining",
-      "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
-      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
-      "path": "library/food-and-dining/recipe-goat",
+      "name": "craigslist",
+      "category": "commerce",
+      "api": "Craigslist",
+      "description": "Search, sync, and watch Craigslist with a local SQLite snapshot history, cross-city aggregation, scam scoring, and price-drift detection.",
+      "path": "library/commerce/craigslist",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "recipe-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "USDA_FDC_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "table-reservation-goat",
-      "category": "food-and-dining",
-      "api": "Table Reservation GOAT",
-      "description": "One reservation CLI for OpenTable and Tock — search both networks at once, watch for cancellations, book, and...",
-      "path": "library/food-and-dining/table-reservation-goat",
-      "printer": "pejmanjohn",
-      "printer_name": "Pejman Pour-Moezzi",
-      "mcp": {
-        "binary": "table-reservation-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 12,
-        "public_tool_count": 12,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "ahrefs",
-      "category": "marketing",
-      "api": "Ahrefs",
-      "description": "Query Ahrefs backlinks, keyword, rank tracking, site audit, and SERP data from the terminal.",
-      "path": "library/marketing/ahrefs",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "ahrefs-pp-mcp",
+        "binary": "craigslist-pp-mcp",
         "transports": [
           "stdio",
           "http"
-        ],
-        "tool_count": 29,
-        "public_tool_count": 2,
-        "auth_type": "api_key",
-        "env_vars": [
-          "AHREFS_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "clarity",
-      "category": "marketing",
-      "api": "PP Clarity",
-      "description": "Client-side instrumentation helpers for Microsoft Clarity.",
-      "path": "library/marketing/clarity",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "clarity-pp-mcp",
-        "transports": [
-          "stdio"
         ],
         "tool_count": 1,
         "public_tool_count": 1,
@@ -668,6 +326,97 @@
       }
     },
     {
+      "name": "digg",
+      "category": "media-and-entertainment",
+      "api": "Digg AI",
+      "description": "Tail the Digg AI 1000's news cycle from the terminal — read-only, with the full pipeline event stream and...",
+      "path": "library/media-and-entertainment/digg",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "digg-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
+        "public_tool_count": 3,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "digitalocean",
+      "category": "cloud",
+      "api": "DigitalOcean",
+      "description": "Printing Press CLI for Digitalocean.",
+      "path": "library/cloud/digitalocean",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "digitalocean-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 628,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "DIGITALOCEAN_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "docker-hub",
+      "category": "developer-tools",
+      "api": "Docker Hub",
+      "description": "Docker Hub public API. Search container images, browse tags, check sizes, inspect Dockerfiles, and explore the world's largest container registry. No authentication required for public repositories (rate limited to ~18 req/min).",
+      "path": "library/developer-tools/docker-hub",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "docker-hub-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "dominos",
+      "category": "food-and-dining",
+      "api": "Domino's",
+      "description": "Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers.",
+      "path": "library/food-and-dining/dominos",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "dominos-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 20,
+        "public_tool_count": 11,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "DOMINOS_USERNAME",
+          "DOMINOS_PASSWORD",
+          "DOMINOS_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
       "name": "dub",
       "category": "marketing",
       "api": "Dub",
@@ -692,124 +441,23 @@
       }
     },
     {
-      "name": "google-ads",
-      "category": "marketing",
-      "api": "Google Ads",
-      "description": "Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations.",
-      "path": "library/marketing/google-ads",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
+      "name": "ebay",
+      "category": "commerce",
+      "api": "eBay",
+      "description": "Buyer-power-user CLI for eBay. Sold-comp intelligence, true sniper bidding, watchlist intelligence, saved-search feeds, and a local SQLite store for cross-listing analytics.",
+      "path": "library/commerce/ebay",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
       "mcp": {
-        "binary": "google-ads-pp-mcp",
+        "binary": "ebay-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 162,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "GOOGLE_ADS_ACCESS_TOKEN",
-          "GOOGLE_ADS_DEVELOPER_TOKEN",
-          "GOOGLE_ADS_LOGIN_CUSTOMER_ID"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "google-search-console",
-      "category": "marketing",
-      "api": "Google Search Console",
-      "description": "Every Google Search Console feature you'd reach for, plus an offline SQLite cache that powers period compare, quick...",
-      "path": "library/marketing/google-search-console",
-      "printer": "bossriceshark",
-      "printer_name": "Matt"
-    },
-    {
-      "name": "klaviyo",
-      "category": "marketing",
-      "api": "Klaviyo",
-      "description": "Marketing automation, profiles, events, campaigns, flows, segments, and templates.",
-      "path": "library/marketing/klaviyo",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "klaviyo-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 308,
-        "public_tool_count": 11,
-        "auth_type": "api_key",
-        "env_vars": [
-          "KLAVIYO_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "producthunt",
-      "category": "marketing",
-      "api": "Product Hunt",
-      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
-      "path": "library/marketing/producthunt",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "producthunt-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 1,
+        "tool_count": 8,
         "public_tool_count": 1,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "PRODUCT_HUNT_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "archive-is",
-      "category": "media-and-entertainment",
-      "api": "Archive.today",
-      "description": "Bypass paywalls and look up web archives via archive.today. Hero command: find or create an archive for any URL with lookup-before-submit, Wayback Machine fallback, and agent-hints on stderr when called non-interactively.",
-      "path": "library/media-and-entertainment/archive-is",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "archive-is-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 6,
-        "public_tool_count": 0,
-        "auth_type": "none",
+        "auth_type": "cookie",
         "env_vars": [],
-        "mcp_ready": "full"
-      }
-    },
-    {
-      "name": "digg",
-      "category": "media-and-entertainment",
-      "api": "Digg AI",
-      "description": "Tail the Digg AI 1000's news cycle from the terminal — read-only, with the full pipeline event stream and...",
-      "path": "library/media-and-entertainment/digg",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "digg-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 3,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
+        "mcp_ready": "partial",
         "spec_format": "internal"
       }
     },
@@ -830,6 +478,146 @@
         "public_tool_count": 0,
         "auth_type": "none",
         "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "fedex",
+      "category": "commerce",
+      "api": "FedEx",
+      "description": "Ship, rate, and track FedEx packages from the terminal — built for small business shippers.",
+      "path": "library/commerce/fedex",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "fedex-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 48,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "FEDEX_API_KEY",
+          "FEDEX_SECRET_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "firecrawl",
+      "category": "developer-tools",
+      "api": "Firecrawl",
+      "description": "API for interacting with Firecrawl services to perform web scraping and crawling tasks.",
+      "path": "library/developer-tools/firecrawl",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "firecrawl-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 20,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "FIRECRAWL_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "fireflies",
+      "category": "productivity",
+      "api": "Fireflies Pp Cli",
+      "description": "Every Fireflies meeting feature, plus offline search, cross-meeting intelligence, and a local database no other tool...",
+      "path": "library/productivity/fireflies",
+      "printer": "neektza",
+      "printer_name": "Nikica Jokic",
+      "mcp": {
+        "binary": "fireflies-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 18,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "FIREFLIES_PP_CLI_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "graphql"
+      }
+    },
+    {
+      "name": "flight-goat",
+      "category": "travel",
+      "api": "Flight GOAT",
+      "description": "Search Google Flights, scan Kayak long-haul routes, and join FlightAware AeroAPI reliability, alerts, and tracking from one CLI.",
+      "path": "library/travel/flight-goat",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "flight-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 58,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "FLIGHT_GOAT_API_KEY_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "food52",
+      "category": "food-and-dining",
+      "api": "Food52",
+      "description": "Search, browse, and read Food52 from your terminal — with offline FTS, pantry matching, recipe scaling, and the editorial signals other tools throw away.",
+      "path": "library/food-and-dining/food52",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "food52-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "google-ads",
+      "category": "marketing",
+      "api": "Google Ads",
+      "description": "Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations.",
+      "path": "library/marketing/google-ads",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "google-ads-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 162,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "GOOGLE_ADS_ACCESS_TOKEN",
+          "GOOGLE_ADS_DEVELOPER_TOKEN",
+          "GOOGLE_ADS_LOGIN_CUSTOMER_ID"
+        ],
         "mcp_ready": "full",
         "spec_format": "internal"
       }
@@ -859,6 +647,15 @@
       }
     },
     {
+      "name": "google-search-console",
+      "category": "marketing",
+      "api": "Google Search Console",
+      "description": "Every Google Search Console feature you'd reach for, plus an offline SQLite cache that powers period compare, quick...",
+      "path": "library/marketing/google-search-console",
+      "printer": "bossriceshark",
+      "printer_name": "Matt"
+    },
+    {
       "name": "hackernews",
       "category": "media-and-entertainment",
       "api": "Hacker News",
@@ -881,6 +678,84 @@
       }
     },
     {
+      "name": "instacart",
+      "category": "commerce",
+      "api": "Instacart",
+      "description": "Natural-language Instacart CLI that talks directly to the web GraphQL API. Add items to your cart, search products, and manage carts across retailers without browser automation.",
+      "path": "library/commerce/instacart",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn"
+    },
+    {
+      "name": "kalshi",
+      "category": "payments",
+      "api": "Kalshi",
+      "description": "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot.",
+      "path": "library/payments/kalshi",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "kalshi-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 96,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "klaviyo",
+      "category": "marketing",
+      "api": "Klaviyo",
+      "description": "Marketing automation, profiles, events, campaigns, flows, segments, and templates.",
+      "path": "library/marketing/klaviyo",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "klaviyo-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 308,
+        "public_tool_count": 11,
+        "auth_type": "api_key",
+        "env_vars": [
+          "KLAVIYO_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "linear",
+      "category": "project-management",
+      "api": "Linear",
+      "description": "Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, FTS5 search, cross-cycle comparison, project burndown, and pp_created fixture lifecycle for safe live testing.",
+      "path": "library/project-management/linear",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "linear-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 28,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "LINEAR_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "graphql"
+      }
+    },
+    {
       "name": "marginalrevolution",
       "category": "media-and-entertainment",
       "api": "Marginal Revolution",
@@ -897,6 +772,29 @@
         "public_tool_count": 1,
         "auth_type": "none",
         "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "mercury",
+      "category": "payments",
+      "api": "Mercury",
+      "description": "Business banking API for accounts, transactions, payments, recipients, cards, invoices, treasury, and webhooks",
+      "path": "library/payments/mercury",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "mercury-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 75,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "MERCURY_BEARER_AUTH"
+        ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -923,6 +821,146 @@
           "OMDB_API_KEY"
         ],
         "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "myfitnesspal",
+      "category": "productivity",
+      "api": "MyFitnessPal",
+      "description": "Pull every meal you ever logged out of MyFitnessPal — per-food CSV, agent-shaped trends, and a local SQLite store...",
+      "path": "library/productivity/myfitnesspal",
+      "printer": "nickscarabosio",
+      "printer_name": "Nick Scarabosio",
+      "mcp": {
+        "binary": "myfitnesspal-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 15,
+        "public_tool_count": 0,
+        "auth_type": "cookie",
+        "env_vars": [],
+        "mcp_ready": "partial",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "notion",
+      "category": "productivity",
+      "api": "Notion",
+      "description": "Every Notion database queryable offline — cross-workspace SQL joins, stale detection, and relation graph traversal...",
+      "path": "library/productivity/notion",
+      "printer": "neektza",
+      "printer_name": "Nikica Jokic",
+      "mcp": {
+        "binary": "notion-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 47,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "NOTION_BEARER_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "nvd",
+      "category": "developer-tools",
+      "api": "National Vulnerability Database",
+      "description": "The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword, product (CPE name), CVE ID, or date range. Get CVSS scores, affected versions, references, and severity ratings. No API key required (optional for higher rate limits).",
+      "path": "library/developer-tools/nvd",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "nvd-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 2,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "open-meteo",
+      "category": "other",
+      "api": "Open-Meteo",
+      "description": "Forecasts, historicals, marine, air quality, flood, climate, ensemble, and seasonal data from Open-Meteo's free tier.",
+      "path": "library/other/open-meteo",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "open-meteo-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "openrouter",
+      "category": "ai",
+      "api": "openrouter",
+      "description": "Agent-first OpenRouter introspection — terse output for cron and AI agents (--agent and --llm modes), local SQLite...",
+      "path": "library/ai/openrouter",
+      "printer": "rvdlaar",
+      "printer_name": "Rick van de Laar"
+    },
+    {
+      "name": "opensnow",
+      "category": "productivity",
+      "api": "OpenSnow",
+      "description": "Hyper-local weather forecasts and conditions for any mountain location and elevation, worldwide. Provides current conditions, hourly forecasts, 5-day day/night snow forecasts, resort snow reports, and expert-written Daily Snow posts. Authentication via api_key query parameter (partnership access only).",
+      "path": "library/productivity/opensnow",
+      "printer": "davemorin",
+      "printer_name": "Dave Morin",
+      "mcp": {
+        "binary": "opensnow-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "OPENSNOW_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "pagliacci",
+      "category": "food-and-dining",
+      "api": "Pagliacci Pizza",
+      "description": "Order Seattle's Pagliacci Pizza from the terminal — half-and-half pies, small-party planner, slice rotation, and rewards stacking.",
+      "path": "library/food-and-dining/pagliacci",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "pagliacci-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 57,
+        "public_tool_count": 26,
+        "auth_type": "composed",
+        "env_vars": [],
+        "mcp_ready": "partial",
         "spec_format": "internal"
       }
     },
@@ -971,68 +1009,203 @@
       }
     },
     {
-      "name": "steam-web",
-      "category": "media-and-entertainment",
-      "api": "Steam Web",
-      "description": "Look up Steam players, games, achievements, friends, and stats from the command line",
-      "path": "library/media-and-entertainment/steam-web",
+      "name": "postman-explore",
+      "category": "developer-tools",
+      "api": "Postman Explore",
+      "description": "Public API network directory for discovering community collections, workspaces, and APIs",
+      "path": "library/developer-tools/postman-explore",
       "printer": "tmchow",
       "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "steam-web-pp-mcp",
+        "binary": "postman-explore-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 8,
+        "public_tool_count": 8,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "producthunt",
+      "category": "marketing",
+      "api": "Product Hunt",
+      "description": "Read Product Hunt from your terminal — works token-free for the daily skim, unlocks a launch-day cockpit and a marketer research desk in one onboarding step.",
+      "path": "library/marketing/producthunt",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "producthunt-pp-mcp",
         "transports": [
           "stdio",
           "http"
         ],
-        "tool_count": 169,
+        "tool_count": 1,
+        "public_tool_count": 1,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "PRODUCT_HUNT_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "pypi",
+      "category": "developer-tools",
+      "api": "PyPI",
+      "description": "PyPI JSON API. Look up Python package metadata, versions, release files, and vulnerability data. Browse recent updates and newest packages via RSS feeds. No authentication required — all endpoints are public.",
+      "path": "library/developer-tools/pypi",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "pypi-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "recipe-goat",
+      "category": "food-and-dining",
+      "api": "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central",
+      "description": "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80% and editorial trust at 15% (curated chef/baker sites win tie-break over crowdsourced aggregators). Builds a local SQLite cookbook with pantry match, meal plans, cook log, substitutions, and USDA-backed nutrition backfill. Powered by Surf-Chrome HTTP transport — bypasses TLS-fingerprint bot detection that previously blocked Dotdash properties.",
+      "path": "library/food-and-dining/recipe-goat",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "recipe-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
         "public_tool_count": 0,
         "auth_type": "api_key",
         "env_vars": [
-          "STEAM_WEB_API_KEY"
+          "USDA_FDC_API_KEY"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "redfin",
+      "category": "other",
+      "api": "Redfin",
+      "description": "Search Redfin homes for sale via internal Stingray endpoints, sync to local SQLite, and run workflows the website doesn't expose — saved-search diff, $/sqft net-HOA ranking, sold comps, multi-region trends.",
+      "path": "library/other/redfin",
+      "printer": "rderwin",
+      "printer_name": "rderwin",
+      "mcp": {
+        "binary": "redfin-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 3,
+        "public_tool_count": 0,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "render",
+      "category": "cloud",
+      "api": "Render",
+      "description": "Every Render endpoint, plus diff, drift, cost, audit, and orphan analytics no other Render tool ships.",
+      "path": "library/cloud/render",
+      "printer": "giacaglia",
+      "printer_name": "Giuliano Giacaglia",
+      "mcp": {
+        "binary": "render-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 196,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "RENDER_API_KEY"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
     },
     {
-      "name": "substack",
-      "category": "media-and-entertainment",
-      "api": "Substack",
-      "description": "Run your Substack growth loop from the command line — publish, schedule, engage, and measure with cross-table...",
-      "path": "library/media-and-entertainment/substack",
-      "printer": "chirantan",
-      "printer_name": "Chirantan Rajhans",
+      "name": "roam",
+      "category": "productivity",
+      "api": "Roam HQ",
+      "description": "Every Roam HQ surface — chat, transcripts, On-Air events, SCIM, webhooks — in one local-first CLI with offline...",
+      "path": "library/productivity/roam",
+      "printer": "gregvanhorn",
+      "printer_name": "Greg Van Horn",
       "mcp": {
-        "binary": "substack-pp-mcp",
-        "transports": [
-          "stdio",
-          "http"
-        ],
-        "tool_count": 39,
-        "public_tool_count": 0,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "wikipedia",
-      "category": "media-and-entertainment",
-      "api": "Wikipedia",
-      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
-      "path": "library/media-and-entertainment/wikipedia",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "wikipedia-pp-mcp",
+        "binary": "roam-pp-cli",
         "transports": [
           "stdio"
         ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
+        "tool_count": 0,
+        "public_tool_count": 0,
+        "auth_type": "bearer",
+        "env_vars": [
+          "ROAM_API_KEY"
+        ],
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "scrape-creators",
+      "category": "developer-tools",
+      "api": "Scrape Creators",
+      "description": "Scrape public social media data from the terminal — profiles, posts, videos, comments, ads, and transcripts across TikTok, Instagram, YouTube, Twitter/X, LinkedIn, Facebook, Reddit, Threads, Bluesky, Pinterest, Snapchat, Twitch, Kick, Truth Social, and 15+ link-in-bio / creator link services.",
+      "path": "library/developer-tools/scrape-creators",
+      "printer": "adrianhorning08",
+      "printer_name": "Adrian Horning",
+      "mcp": {
+        "binary": "scrape-creators-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 114,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SCRAPE_CREATORS_API_KEY_AUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "seats-aero",
+      "category": "travel",
+      "api": "Seats Aero Partner",
+      "description": "Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details.",
+      "path": "library/travel/seats-aero",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "seats-aero-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SEATS_AERO_API_KEY"
+        ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
       }
@@ -1061,172 +1234,69 @@
       }
     },
     {
-      "name": "apartments",
-      "category": "other",
-      "api": "Apartments",
-      "description": "Search Apartments.com listings, sync results to a local SQLite store, and run workflows the website never built — diff saved searches, rank by $/sqft, compare shortlists, and surface price drops or phantom listings.",
-      "path": "library/other/apartments",
-      "printer": "rderwin",
-      "printer_name": "rderwin",
-      "mcp": {
-        "binary": "apartments-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "open-meteo",
-      "category": "other",
-      "api": "Open-Meteo",
-      "description": "Forecasts, historicals, marine, air quality, flood, climate, ensemble, and seasonal data from Open-Meteo's free tier.",
-      "path": "library/other/open-meteo",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "open-meteo-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 11,
-        "public_tool_count": 11,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "redfin",
-      "category": "other",
-      "api": "Redfin",
-      "description": "Search Redfin homes for sale via internal Stingray endpoints, sync to local SQLite, and run workflows the website doesn't expose — saved-search diff, $/sqft net-HOA ranking, sold comps, multi-region trends.",
-      "path": "library/other/redfin",
-      "printer": "rderwin",
-      "printer_name": "rderwin",
-      "mcp": {
-        "binary": "redfin-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 3,
-        "public_tool_count": 0,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "ufo-goat",
-      "category": "other",
-      "api": "War.gov UFO",
-      "description": "Browse, search, and download declassified UAP files from the War.gov PURSUE archive",
-      "path": "library/other/ufo-goat",
-      "printer": "davemorin",
-      "printer_name": "Dave Morin",
-      "mcp": {
-        "binary": "ufo-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 4,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "weather-goat",
-      "category": "other",
-      "api": "Open-Meteo + NWS",
-      "description": "Weather forecasts, severe weather alerts, air quality, and GO/CAUTION/STOP activity verdicts for walk, bike, hike, commute, and drive",
-      "path": "library/other/weather-goat",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "weather-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 5,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "coingecko",
-      "category": "payments",
-      "api": "Coingecko",
-      "description": "CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.",
-      "path": "library/payments/coingecko",
-      "printer": "hnshah",
-      "printer_name": "Hiten Shah",
-      "mcp": {
-        "binary": "coingecko-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 11,
-        "public_tool_count": 11,
-        "auth_type": "none",
-        "env_vars": [],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "kalshi",
-      "category": "payments",
-      "api": "Kalshi",
-      "description": "Trade prediction markets, persist tick data, and answer category-level P&L questions Kalshi.com cannot.",
-      "path": "library/payments/kalshi",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
-      "mcp": {
-        "binary": "kalshi-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 96,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "mercury",
-      "category": "payments",
-      "api": "Mercury",
-      "description": "Business banking API for accounts, transactions, payments, recipients, cards, invoices, treasury, and webhooks",
-      "path": "library/payments/mercury",
+      "name": "shopify",
+      "category": "commerce",
+      "api": "Shopify",
+      "description": "Operate a Shopify store from the terminal with curated Admin GraphQL commands, local sync, analytics, and bulk exports.",
+      "path": "library/commerce/shopify",
       "printer": "cathrynlavery",
       "printer_name": "Cathryn Lavery",
       "mcp": {
-        "binary": "mercury-pp-mcp",
+        "binary": "shopify-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 75,
+        "tool_count": 10,
         "public_tool_count": 0,
-        "auth_type": "bearer_token",
+        "auth_type": "api_key",
         "env_vars": [
-          "MERCURY_BEARER_AUTH"
+          "SHOPIFY_ACCESS_TOKEN"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "slack",
+      "category": "productivity",
+      "api": "Slack",
+      "description": "Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal",
+      "path": "library/productivity/slack",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "slack-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 66,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "SLACK_BOT_TOKEN"
+        ],
+        "mcp_ready": "full"
+      }
+    },
+    {
+      "name": "steam-web",
+      "category": "media-and-entertainment",
+      "api": "Steam Web",
+      "description": "Look up Steam players, games, achievements, friends, and stats from the command line",
+      "path": "library/media-and-entertainment/steam-web",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "steam-web-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
+        ],
+        "tool_count": 169,
+        "public_tool_count": 0,
+        "auth_type": "api_key",
+        "env_vars": [
+          "STEAM_WEB_API_KEY"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
@@ -1257,65 +1327,20 @@
       }
     },
     {
-      "name": "cal-com",
-      "category": "productivity",
-      "api": "Cal.com",
-      "description": "Every Cal.com feature, plus offline agendas, composed booking flows, and analytics no other Cal.com tool ships.",
-      "path": "library/productivity/cal-com",
-      "printer": "tmchow",
-      "printer_name": "Trevin Chow",
+      "name": "substack",
+      "category": "media-and-entertainment",
+      "api": "Substack",
+      "description": "Run your Substack growth loop from the command line — publish, schedule, engage, and measure with cross-table...",
+      "path": "library/media-and-entertainment/substack",
+      "printer": "chirantan",
+      "printer_name": "Chirantan Rajhans",
       "mcp": {
-        "binary": "cal-com-pp-mcp",
+        "binary": "substack-pp-mcp",
         "transports": [
-          "stdio"
+          "stdio",
+          "http"
         ],
-        "tool_count": 291,
-        "public_tool_count": 0,
-        "auth_type": "bearer_token",
-        "env_vars": [
-          "CAL_COM_TOKEN"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "fireflies",
-      "category": "productivity",
-      "api": "Fireflies Pp Cli",
-      "description": "Every Fireflies meeting feature, plus offline search, cross-meeting intelligence, and a local database no other tool...",
-      "path": "library/productivity/fireflies",
-      "printer": "neektza",
-      "printer_name": "Nikica Jokic",
-      "mcp": {
-        "binary": "fireflies-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 18,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "FIREFLIES_PP_CLI_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "graphql"
-      }
-    },
-    {
-      "name": "myfitnesspal",
-      "category": "productivity",
-      "api": "MyFitnessPal",
-      "description": "Pull every meal you ever logged out of MyFitnessPal — per-food CSV, agent-shaped trends, and a local SQLite store...",
-      "path": "library/productivity/myfitnesspal",
-      "printer": "nickscarabosio",
-      "printer_name": "Nick Scarabosio",
-      "mcp": {
-        "binary": "myfitnesspal-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 15,
+        "tool_count": 39,
         "public_tool_count": 0,
         "auth_type": "cookie",
         "env_vars": [],
@@ -1324,146 +1349,72 @@
       }
     },
     {
-      "name": "notion",
-      "category": "productivity",
-      "api": "Notion",
-      "description": "Every Notion database queryable offline — cross-workspace SQL joins, stale detection, and relation graph traversal...",
-      "path": "library/productivity/notion",
-      "printer": "neektza",
-      "printer_name": "Nikica Jokic",
+      "name": "table-reservation-goat",
+      "category": "food-and-dining",
+      "api": "Table Reservation GOAT",
+      "description": "One reservation CLI for OpenTable and Tock — search both networks at once, watch for cancellations, book, and...",
+      "path": "library/food-and-dining/table-reservation-goat",
+      "printer": "pejmanjohn",
+      "printer_name": "Pejman Pour-Moezzi",
       "mcp": {
-        "binary": "notion-pp-mcp",
+        "binary": "table-reservation-goat-pp-mcp",
         "transports": [
           "stdio"
+        ],
+        "tool_count": 12,
+        "public_tool_count": 12,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "tiktok-shop",
+      "category": "commerce",
+      "api": "TikTok Shop",
+      "description": "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and refresh, read-only shops, orders, products, inventory search, fulfillment packages, and warehouses.",
+      "path": "library/commerce/tiktok-shop",
+      "printer": "cathrynlavery",
+      "printer_name": "Cathryn Lavery",
+      "mcp": {
+        "binary": "tiktok-shop-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 11,
+        "public_tool_count": 11,
+        "auth_type": "signed_tiktok_shop_open_api",
+        "env_vars": [
+          "TIKTOK_SHOP_APP_KEY",
+          "TIKTOK_SHOP_APP_SECRET",
+          "TIKTOK_SHOP_ACCESS_TOKEN",
+          "TIKTOK_SHOP_REFRESH_TOKEN",
+          "TIKTOK_SHOP_SHOP_CIPHER"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "trigger-dev",
+      "category": "developer-tools",
+      "api": "Trigger.dev",
+      "description": "Durable background jobs and AI agent orchestration — runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL analytics",
+      "path": "library/developer-tools/trigger-dev",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": {
+        "binary": "trigger-dev-pp-mcp",
+        "transports": [
+          "stdio",
+          "http"
         ],
         "tool_count": 47,
-        "public_tool_count": 0,
+        "public_tool_count": 1,
         "auth_type": "bearer_token",
         "env_vars": [
-          "NOTION_BEARER_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "opensnow",
-      "category": "productivity",
-      "api": "OpenSnow",
-      "description": "Hyper-local weather forecasts and conditions for any mountain location and elevation, worldwide. Provides current conditions, hourly forecasts, 5-day day/night snow forecasts, resort snow reports, and expert-written Daily Snow posts. Authentication via api_key query parameter (partnership access only).",
-      "path": "library/productivity/opensnow",
-      "printer": "davemorin",
-      "printer_name": "Dave Morin",
-      "mcp": {
-        "binary": "opensnow-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 5,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "OPENSNOW_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "roam",
-      "category": "productivity",
-      "api": "Roam HQ",
-      "description": "Every Roam HQ surface — chat, transcripts, On-Air events, SCIM, webhooks — in one local-first CLI with offline...",
-      "path": "library/productivity/roam",
-      "printer": "gregvanhorn",
-      "printer_name": "Greg Van Horn",
-      "mcp": {
-        "binary": "roam-pp-cli",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 0,
-        "public_tool_count": 0,
-        "auth_type": "bearer",
-        "env_vars": [
-          "ROAM_API_KEY"
-        ],
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "slack",
-      "category": "productivity",
-      "api": "Slack",
-      "description": "Send messages, search conversations, monitor channels, and manage your Slack workspace from the terminal",
-      "path": "library/productivity/slack",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "slack-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 66,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SLACK_BOT_TOKEN"
-        ],
-        "mcp_ready": "full"
-      }
-    },
-    {
-      "name": "zohomail-pp-cli",
-      "category": "productivity",
-      "api": "Zoho Mail",
-      "description": "Read, search, inspect, and send Zoho Mail messages from the terminal with OAuth-backed account, folder, message, and send commands.",
-      "path": "library/productivity/zohomail-pp-cli",
-      "printer": "jlwainwright",
-      "printer_name": "Jacques Wainwright"
-    },
-    {
-      "name": "linear",
-      "category": "project-management",
-      "api": "Linear",
-      "description": "Offline-capable, agent-native CLI for the Linear API with SQLite-backed sync, FTS5 search, cross-cycle comparison, project burndown, and pp_created fixture lifecycle for safe live testing.",
-      "path": "library/project-management/linear",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "linear-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 28,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "LINEAR_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "graphql"
-      }
-    },
-    {
-      "name": "contact-goat",
-      "category": "sales-and-crm",
-      "api": "contact-goat",
-      "description": "Super LinkedIn for the terminal - search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (Chrome cookie auth with Clerk JWT refresh), and Deepline (paid enrichment, hybrid subprocess+HTTP). Unified SQLite store powers warm-intro, coverage, and cross-source prospect commands no single tool has.",
-      "path": "library/sales-and-crm/contact-goat",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "contact-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 16,
-        "public_tool_count": 0,
-        "auth_type": "composed",
-        "env_vars": [
-          "DEEPLINE_API_KEY",
-          "HAPPENSTANCE_API_KEY"
+          "TRIGGER_SECRET_KEY"
         ],
         "mcp_ready": "full",
         "spec_format": "openapi3"
@@ -1494,6 +1445,113 @@
       }
     },
     {
+      "name": "ufo-goat",
+      "category": "other",
+      "api": "War.gov UFO",
+      "description": "Browse, search, and download declassified UAP files from the War.gov PURSUE archive",
+      "path": "library/other/ufo-goat",
+      "printer": "davemorin",
+      "printer_name": "Dave Morin",
+      "mcp": {
+        "binary": "ufo-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 4,
+        "public_tool_count": 4,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "wanderlust-goat",
+      "category": "travel",
+      "api": "Wanderlust GOAT",
+      "description": "Wanderlust GOAT — what a knowledgeable local with great taste would tell you to walk to from here, fused across editorial, local-language, and crowd layers no single tool ranks together.",
+      "path": "library/travel/wanderlust-goat",
+      "printer": "jheitzeb",
+      "printer_name": "Joe Heitzeberg",
+      "mcp": {
+        "binary": "wanderlust-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 2,
+        "public_tool_count": 2,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "weather-goat",
+      "category": "other",
+      "api": "Open-Meteo + NWS",
+      "description": "Weather forecasts, severe weather alerts, air quality, and GO/CAUTION/STOP activity verdicts for walk, bike, hike, commute, and drive",
+      "path": "library/other/weather-goat",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
+      "mcp": {
+        "binary": "weather-goat-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "internal"
+      }
+    },
+    {
+      "name": "whoop",
+      "category": "devices",
+      "api": "Whoop",
+      "description": "Printing Press CLI for Whoop.",
+      "path": "library/devices/whoop",
+      "printer": "gregvanhorn",
+      "printer_name": "Greg Van Horn",
+      "mcp": {
+        "binary": "whoop-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 19,
+        "public_tool_count": 0,
+        "auth_type": "bearer_token",
+        "env_vars": [
+          "WHOOP_OAUTH"
+        ],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
+      "name": "wikipedia",
+      "category": "media-and-entertainment",
+      "api": "Wikipedia",
+      "description": "Wikipedia REST API. Get article summaries, search, browse related topics, and access on-this-day events. No authentication required. Uses a polite User-Agent header.",
+      "path": "library/media-and-entertainment/wikipedia",
+      "printer": "hnshah",
+      "printer_name": "Hiten Shah",
+      "mcp": {
+        "binary": "wikipedia-pp-mcp",
+        "transports": [
+          "stdio"
+        ],
+        "tool_count": 5,
+        "public_tool_count": 5,
+        "auth_type": "none",
+        "env_vars": [],
+        "mcp_ready": "full",
+        "spec_format": "openapi3"
+      }
+    },
+    {
       "name": "x-twitter",
       "category": "social-and-messaging",
       "api": "X (Twitter)",
@@ -1517,87 +1575,20 @@
       }
     },
     {
-      "name": "airbnb",
-      "category": "travel",
-      "api": "Airbnb Vrbo",
-      "description": "Search Airbnb and VRBO, find the host's direct booking site, and report the cheapest of three sources side-by-side.",
-      "path": "library/travel/airbnb",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
+      "name": "yahoo-finance",
+      "category": "commerce",
+      "api": "Yahoo Finance",
+      "description": "Quotes, charts, fundamentals, options chains, and a local portfolio/watchlist tracker against Yahoo Finance — no API key, with Chrome-session fallback for rate-limited IPs",
+      "path": "library/commerce/yahoo-finance",
+      "printer": "tmchow",
+      "printer_name": "Trevin Chow",
       "mcp": {
-        "binary": "airbnb-pp-mcp",
+        "binary": "yahoo-finance-pp-mcp",
         "transports": [
           "stdio"
         ],
-        "tool_count": 8,
-        "public_tool_count": 6,
-        "auth_type": "cookie",
-        "env_vars": [],
-        "mcp_ready": "partial",
-        "spec_format": "internal"
-      }
-    },
-    {
-      "name": "flight-goat",
-      "category": "travel",
-      "api": "Flight GOAT",
-      "description": "Search Google Flights, scan Kayak long-haul routes, and join FlightAware AeroAPI reliability, alerts, and tracking from one CLI.",
-      "path": "library/travel/flight-goat",
-      "printer": "mvanhorn",
-      "printer_name": "Matt Van Horn",
-      "mcp": {
-        "binary": "flight-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 58,
+        "tool_count": 11,
         "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "FLIGHT_GOAT_API_KEY_AUTH"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "seats-aero",
-      "category": "travel",
-      "api": "Seats Aero Partner",
-      "description": "Seats.aero Partner API for award travel availability, cached search, route lists, and trip revalidation details.",
-      "path": "library/travel/seats-aero",
-      "printer": "cathrynlavery",
-      "printer_name": "Cathryn Lavery",
-      "mcp": {
-        "binary": "seats-aero-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 4,
-        "public_tool_count": 0,
-        "auth_type": "api_key",
-        "env_vars": [
-          "SEATS_AERO_API_KEY"
-        ],
-        "mcp_ready": "full",
-        "spec_format": "openapi3"
-      }
-    },
-    {
-      "name": "wanderlust-goat",
-      "category": "travel",
-      "api": "Wanderlust GOAT",
-      "description": "Wanderlust GOAT — what a knowledgeable local with great taste would tell you to walk to from here, fused across editorial, local-language, and crowd layers no single tool ranks together.",
-      "path": "library/travel/wanderlust-goat",
-      "printer": "jheitzeb",
-      "printer_name": "Joe Heitzeberg",
-      "mcp": {
-        "binary": "wanderlust-goat-pp-mcp",
-        "transports": [
-          "stdio"
-        ],
-        "tool_count": 2,
-        "public_tool_count": 2,
         "auth_type": "none",
         "env_vars": [],
         "mcp_ready": "full",


### PR DESCRIPTION
## Summary

- Adds `zohomail-pp-cli`, a Go CLI for Zoho Mail using only stdlib (no external dependencies)
- Supports OAuth2 via browser flow, device flow, client credentials, rbw/Bitwarden, and Self Client token exchange
- Commands: `accounts`, `folders`, `inbox`, `sent`, `archive`, `spam`, `trash`, `list`, `search`, `read`, `send`
- Config stored at `~/.config/zohomail-pp-cli/config.json`; env vars override

## Quality gates

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `--help` / `--version` ✅

## AI / Automation disclosure

Human-reviewed: AI assistance was used to structure the submission; the CLI and all content were reviewed by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)