### PR TITLE
fix(podscan): populate resourceIDFieldOverrides so sync stores rows

### DIFF
--- a/library/media-and-entertainment/podscan/.printing-press-patches.json
+++ b/library/media-and-entertainment/podscan/.printing-press-patches.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-05-10",
+  "base_run_id": "20260509-110700",
+  "base_printing_press_version": "4.1.0",
+  "patches": [
+    {
+      "id": "id-field-overrides",
+      "summary": "Populate resourceIDFieldOverrides for every podscan resource so sync stores rows instead of skipping them.",
+      "reason": "PodScan uses {resource}_id naming (alert_id, category_id, episode_id, podcast_id) and has no plain `id` field. The generator's profiler emitted both override maps empty, so extractID and UpsertBatch fell through to the generic fallback list (id, ID, name, uuid, slug, key, code, uid), found nothing, and dropped every item. Reported externally in #383: `sync` for `categories` consumed 163 items and stored 0.",
+      "files": [
+        "internal/cli/sync.go",
+        "internal/store/store.go"
+      ],
+      "validated_outcome": "Both override maps now match the spec's response schemas (Alert.alert_id, Category.category_id, Episode.episode_id, Podcast.podcast_id; exports/* keyed off the shape they return). go build and go vet pass.",
+      "upstream_issue": "cli-printing-press: profiler should populate resourceIDFieldOverrides from response-schema {resource}_id fields when the spec lacks x-resource-id annotations"
+    }
+  ]
+}

--- a/library/media-and-entertainment/podscan/internal/cli/sync.go
+++ b/library/media-and-entertainment/podscan/internal/cli/sync.go
@@ -1070,7 +1070,19 @@ func syncDependentResource(c interface {
 // Includes both flat resources and dependent (parent-child) resources so
 // annotations on a child path-item are honored at runtime, not just on
 // flat paths.
+//
+// PATCH: PodScan uses {resource}_id naming (no plain "id" field anywhere),
+// so without these overrides every flat resource hits the generic fallback
+// list, fails ID extraction, and stores 0 rows. The generator's profiler
+// shipped this map empty for podscan; populate it from the spec schemas.
 var resourceIDFieldOverrides = map[string]string{
+	"alerts":           "alert_id",
+	"categories":       "category_id",
+	"episodes":         "episode_id",
+	"podcasts":         "podcast_id",
+	"exports":          "episode_id",
+	"exports-podcasts": "podcast_id",
+	"mentions":         "episode_id",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did

--- a/library/media-and-entertainment/podscan/internal/store/store.go
+++ b/library/media-and-entertainment/podscan/internal/store/store.go
@@ -946,7 +946,18 @@ func (s *Store) UpsertPodcastsEpisodes(data json.RawMessage) error {
 // Includes both flat resources and dependent (parent-child) resources so a
 // child path-item annotated with x-resource-id resolves the same as a flat
 // path-item.
+//
+// PATCH: mirrors the same map in internal/cli/sync.go — see that file for
+// rationale. Both must stay in sync; UpsertBatch and extractID resolve
+// fields the same way.
 var resourceIDFieldOverrides = map[string]string{
+	"alerts":           "alert_id",
+	"categories":       "category_id",
+	"episodes":         "episode_id",
+	"podcasts":         "podcast_id",
+	"exports":          "episode_id",
+	"exports-podcasts": "podcast_id",
+	"mentions":         "episode_id",
 }
 
 // genericIDFieldFallbacks is the runtime safety net for resources that did


### PR DESCRIPTION
## Summary

Fixes #383. Thanks @jaredirish for the detailed repro.

`podscan-pp-cli sync` was consuming items over the wire but storing 0 rows for any resource without a plain `id` field. The generator's profiler shipped both `resourceIDFieldOverrides` maps empty (one in `internal/cli/sync.go`, one in `internal/store/store.go`), so `extractID` and `UpsertBatch` fell through to the generic fallback list — `id, ID, name, uuid, slug, key, code, uid` — none of which match PodScan's `{resource}_id` naming.

Visible failure: `categories` consumed 163, stored 0. The same shape was latent on `alerts`, `exports`, and `exports-podcasts`.

## Fix

Populate both override maps from the spec's response schemas:

| resource | id field | source |
|---|---|---|
| alerts | `alert_id` | `Alert.alert_id` |
| categories | `category_id` | `Category.category_id` |
| episodes | `episode_id` | `Episode.episode_id` |
| podcasts | `podcast_id` | `Podcast.podcast_id` |
| exports | `episode_id` | `/exports/episodes` returns Episode shape |
| exports-podcasts | `podcast_id` | `/exports/podcasts` returns Podcast shape |
| mentions | `episode_id` | `Mention` natural-keys on episode_id |

Both maps are kept in sync (UpsertBatch and extractID must resolve fields the same way).

## Why both files

`internal/cli/sync.go::extractID` and `internal/store/store.go::UpsertBatch` each maintain their own copy of the override map. A divergence between them produces silent drops on heterogeneous payloads — see the comment block at `store.go:629`.

## Upstream follow-up

The real fix belongs in `cli-printing-press`: the profiler should populate `resourceIDFieldOverrides` from response-schema `{resource}_id` fields when the spec lacks an `x-resource-id` annotation. Will file a separate issue against the generator. This PR is the library-side patch so users on v1.0.0 get a working sync today; recorded in `.printing-press-patches.json` so the next regen preserves the customization.

## Validation

- `go build ./...` ✓
- `go vet ./...` ✓
- `printing-press publish validate` ✓ (all 11 checks pass)

## Test plan

- [ ] `npx -y @mvanhorn/printing-press install podscan` (re-install)
- [ ] `podscan-pp-cli auth set-token <token>`
- [ ] `podscan-pp-cli sync` → categories should show `stored: 163` (not `stored: 0`)
- [ ] `podscan-pp-cli sync` → alerts/exports/exports-podcasts also store > 0 if account has them