### PR TITLE
fix(whoop): request `offline` as a scope value so refresh tokens work

### DIFF
--- a/library/devices/whoop/.printing-press-patches.json
+++ b/library/devices/whoop/.printing-press-patches.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-05-10",
+  "base_run_id": "20260509-091026",
+  "base_printing_press_version": "4.1.0",
+  "patches": [
+    {
+      "id": "oauth-offline-scope",
+      "summary": "Append `offline` to the OAuth scope list and drop the misleading Google-style `access_type=offline` query param so WHOOP issues refresh tokens.",
+      "reason": "WHOOP requires the literal `offline` scope value to return a refresh_token from the token endpoint. The generator's OAuth template assumed Google semantics (access_type=offline query param), which WHOOP ignores. Without the scope value, refresh_token in the saved config is empty, the transparent refresh path in internal/client/client.go has nothing to use, and every call after the 1h access-token expiry returns HTTP 401 with no recovery short of an interactive `auth login` re-run. Reported externally in #391.",
+      "files": [
+        "internal/cli/auth.go"
+      ],
+      "validated_outcome": "go build and go vet pass. Auth URL now includes `offline` as the last scope value (matches what WHOOP's developer docs and existing community CLIs use); access_type=offline query param removed.",
+      "upstream_issue": "cli-printing-press: OAuth template currently emits Google-specific access_type=offline query param across all CLIs and never sets `offline` as a scope value; generator should emit provider-correct refresh-token semantics (or expose the convention as a spec annotation)."
+    }
+  ]
+}

--- a/library/devices/whoop/internal/cli/auth.go
+++ b/library/devices/whoop/internal/cli/auth.go
@@ -68,15 +68,22 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 			redirectURI := fmt.Sprintf("http://localhost:%d/callback", listener.Addr().(*net.TCPAddr).Port)
 
 			authURL := "https://api.prod.whoop.com/oauth/oauth2/auth"
+			// PATCH: WHOOP requires the literal `offline` scope value to issue a
+			// refresh token (https://developer.whoop.com/docs/developing/oauth/).
+			// The generator's OAuth template assumed Google semantics
+			// (access_type=offline query param), which WHOOP ignores. Without
+			// the scope value, the token endpoint returns no refresh_token,
+			// the transparent refresh path in internal/client/client.go has
+			// nothing to use, and every call after the 1h expiry 401s with
+			// no recovery short of an interactive `auth login` re-run.
 			params := url.Values{
 				"client_id":     {clientID},
 				"redirect_uri":  {redirectURI},
 				"response_type": {"code"},
 				"state":         {state},
-				"access_type":   {"offline"},
 				"prompt":        {"consent"},
 			}
-			scopes := []string{"read:body_measurement", "read:cycles", "read:profile", "read:recovery", "read:sleep", "read:workout",  }
+			scopes := []string{"read:body_measurement", "read:cycles", "read:profile", "read:recovery", "read:sleep", "read:workout", "offline"}
 			if len(scopes) > 0 {
 				params.Set("scope", strings.Join(scopes, " "))
 			}


### PR DESCRIPTION
## Summary

Fixes #391. Thanks @einargudnig for the detailed repro and the comparison against `siddhantjain/whoop-cli`.

The CLI was constructing the OAuth authorization URL with Google-style semantics: `access_type=offline` as a query param (which WHOOP ignores) but no `offline` in the scope list (which is what WHOOP actually requires to issue a refresh token). Result: `refresh_token` in `~/.config/whoop-pp-cli/config.toml` was always empty, the transparent refresh path that already exists in `internal/client/client.go:338` had nothing to use, and every call after the 1h access-token expiry returned `HTTP 401: Authorization was not valid` with no recovery short of an interactive `auth login` re-run.

## Fix

In `library/devices/whoop/internal/cli/auth.go`:

- Append `offline` to the scope list (matches what WHOOP's developer docs and `siddhantjain/whoop-cli` use).
- Drop the misleading `access_type=offline` query param.

The transparent refresh path in `internal/client/client.go` then takes over automatically once a `refresh_token` exists. No new `auth refresh` subcommand strictly needed (could add one later for explicit control).

## Audit of related CLIs

The same OAuth template shape (`access_type=offline`) appears in five library CLIs. Verified each:

| CLI | Status |
|---|---|
| **whoop** | **broken (this fix)** — non-Google provider, missing `offline` scope value |
| x-twitter | harmless — `offline.access` already in scope list, refresh tokens work |
| cloud-run-admin | correct — Google APIs do use `access_type=offline` |
| google-ads | correct — Google |
| google-photos | correct — Google |

So the bug is whoop-only on the published-library side.

## Upstream follow-up

Will file a separate issue against `cli-printing-press` — the OAuth template currently emits Google-specific `access_type=offline` across all CLIs and never sets `offline` as a scope value. The generator should emit provider-correct refresh-token semantics (likely via a spec-annotation convention so each CLI declares whichever its provider expects).

## Validation

- `go build ./...` ✓
- `go vet ./...` ✓

## Test plan

- [ ] `npx -y @mvanhorn/printing-press install whoop` (re-install)
- [ ] `whoop-pp-cli auth login --client-id <id> --client-secret <secret>`
- [ ] Inspect the printed auth URL — `scope=` should end with `offline`; no `access_type` query param
- [ ] Inspect `~/.config/whoop-pp-cli/config.toml` — `refresh_token` should be populated
- [ ] Wait > 1h, then `whoop-pp-cli sync` → should silently auto-refresh and succeed (no 401)