### PR TITLE
fix(table-reservation-goat): walk Chrome dirs directly in cookie discovery

### DIFF
--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
@@ -9,12 +9,196 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/chrome"
+	chromebrowser "github.com/browserutils/kooky/browser/chrome"
 )
+
+// chromeRoots returns the per-platform candidate Chrome (and Chrome-derivative)
+// user-data directories. Used by the supplementary filesystem walk below to
+// supplement kooky's info_cache-driven discovery — kooky only iterates profiles
+// listed in <root>/Local State's profile.info_cache, so a profile dir present
+// on disk but missing from info_cache (corrupted, stale, fresh-install edge
+// cases) gets silently skipped along with its <profile>/Cookies file.
+func chromeRoots() []string {
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(cfgDir, "Google", "Chrome"),
+			filepath.Join(cfgDir, "Google", "Chrome Beta"),
+			filepath.Join(cfgDir, "Google", "Chrome Canary"),
+			filepath.Join(cfgDir, "Google", "Chrome Dev"),
+			filepath.Join(cfgDir, "Chromium"),
+			filepath.Join(cfgDir, "BraveSoftware", "Brave-Browser"),
+			filepath.Join(cfgDir, "Arc", "User Data"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(cfgDir, "google-chrome"),
+			filepath.Join(cfgDir, "google-chrome-beta"),
+			filepath.Join(cfgDir, "google-chrome-unstable"),
+			filepath.Join(cfgDir, "chromium"),
+			filepath.Join(cfgDir, "BraveSoftware", "Brave-Browser"),
+		}
+	default:
+		// Windows + others fall back to kooky's own discovery only;
+		// we don't have a reliable cross-version path map here.
+		return nil
+	}
+}
+
+// nonProfileDirs are subdirectories under a Chrome user-data root that are
+// not user profiles and never contain Cookies databases.
+var nonProfileDirs = map[string]bool{
+	"System Profile":                  true,
+	"Crashpad":                        true,
+	"GrShaderCache":                   true,
+	"GraphiteDawnCache":               true,
+	"ShaderCache":                     true,
+	"Subresource Filter":              true,
+	"OnDeviceHeadSuggestModel":        true,
+	"FirstPartySetsPreloaded":         true,
+	"hyphen-data":                     true,
+	"OptimizationHints":               true,
+	"OriginTrials":                    true,
+	"PnaclTranslationCache":           true,
+	"Safe Browsing":                   true,
+	"SSLErrorAssistant":               true,
+	"CertificateRevocation":           true,
+	"WidevineCdm":                     true,
+	"ZxcvbnData":                      true,
+	"AutofillStates":                  true,
+	"FileTypePolicies":                true,
+	"CertificateAuthorityNetworkPath": true,
+	"GCM Store":                       true,
+	"BrowserMetrics":                  true,
+	"CrashReports":                    true,
+	"Local Traces":                    true,
+	"PKIMetadata":                     true,
+	"hyphen-data-en":                  true,
+	"FirstPartySetsPreloaded.tmp":     true,
+	"DefaultRecord":                   true,
+	"AutofillRegexes":                 true,
+	"recovery_test":                   true,
+	"recovery":                        true,
+	"Last Browser":                    true,
+	"Last Version":                    true,
+	"Local State":                     true,
+}
+
+// chromeCookieCandidatePaths returns the absolute paths of every plausible
+// Chrome cookie database on this machine, walking the actual filesystem
+// rather than trusting <root>/Local State's profile.info_cache.
+func chromeCookieCandidatePaths() []string {
+	return chromeCookieCandidatePathsIn(chromeRoots())
+}
+
+// chromeCookieCandidatePathsIn is the testable variant of
+// chromeCookieCandidatePaths. For each profile-shaped subdirectory under
+// each given root, both Chrome 96+ (<profile>/Network/Cookies) and pre-96
+// (<profile>/Cookies) layouts are tried; non-existent paths are silently
+// skipped.
+func chromeCookieCandidatePathsIn(roots []string) []string {
+	var out []string
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if nonProfileDirs[name] {
+				continue
+			}
+			for _, sub := range []string{
+				filepath.Join(root, name, "Network", "Cookies"),
+				filepath.Join(root, name, "Cookies"),
+			} {
+				if info, err := os.Stat(sub); err == nil && !info.IsDir() {
+					out = append(out, sub)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// supplementaryChromeCookies reads cookies matching domainSuffix directly
+// from every Chrome cookie file found by chromeCookieCandidatePaths().
+// This supplements kooky's info_cache-driven discovery, which silently skips
+// profile directories not listed in <root>/Local State's profile.info_cache.
+// Per-file errors are returned as notes (non-fatal); reads from missing
+// keychain entries or corrupt files yield zero cookies for that file but
+// don't abort the rest of the walk.
+func supplementaryChromeCookies(ctx context.Context, domainSuffix string) ([]*kooky.Cookie, []string) {
+	paths := chromeCookieCandidatePaths()
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	var (
+		cookies []*kooky.Cookie
+		notes   []string
+	)
+	for _, path := range paths {
+		got, err := chromebrowser.ReadCookies(ctx, path, kooky.DomainHasSuffix(domainSuffix))
+		if err != nil {
+			// Truncate the error so a per-file note doesn't dominate the
+			// output. Most failures here are "no such file" (race against
+			// Chrome rotating Network/Cookies) or "decryption failed"
+			// (keychain access denied for an old profile).
+			notes = append(notes, fmt.Sprintf("%s: %s", filepath.Base(filepath.Dir(path))+"/"+filepath.Base(path), shortErr(err)))
+			continue
+		}
+		cookies = append(cookies, got...)
+	}
+	return cookies, notes
+}
+
+// dedupeCookies removes duplicate (Domain, Name, Path) entries across all
+// input slices. When the same key appears multiple times, the LAST one wins
+// — both kooky's auto-discovery and our supplementary walk return cookies
+// in disk-order, so the latest-written entry is the freshest. Entries with
+// later Expires are preferred; on ties, the later-encountered one wins.
+func dedupeCookies(slices ...[]*kooky.Cookie) []*kooky.Cookie {
+	type key struct {
+		domain string
+		name   string
+		path   string
+	}
+	seen := make(map[key]*kooky.Cookie)
+	for _, slc := range slices {
+		for _, c := range slc {
+			if c == nil {
+				continue
+			}
+			k := key{c.Domain, c.Name, c.Path}
+			if existing, ok := seen[k]; ok {
+				// Prefer the entry with the later Expires; breaks tie in
+				// favor of later-encountered (assumed freshest snapshot).
+				if !existing.Expires.IsZero() && !c.Expires.IsZero() && existing.Expires.After(c.Expires) {
+					continue
+				}
+			}
+			seen[k] = c
+		}
+	}
+	out := make([]*kooky.Cookie, 0, len(seen))
+	for _, c := range seen {
+		out = append(out, c)
+	}
+	return out
+}
 
 // shortErr trims a kooky multi-error to its first line to keep notes scannable.
 func shortErr(err error) string {
@@ -51,6 +235,18 @@ func ImportFromChrome(ctx context.Context) (otCookies, tockCookies []Cookie, res
 	// the error text as a note.
 	otRaw, otErr := kooky.ReadCookies(ctx, kooky.DomainHasSuffix("opentable.com"))
 	tockRaw, tockErr := kooky.ReadCookies(ctx, kooky.DomainHasSuffix("exploretock.com"))
+	// Supplement kooky's info_cache-driven discovery with a direct filesystem
+	// walk: kooky silently skips profile directories that aren't listed in
+	// <root>/Local State's profile.info_cache, even when their <profile>/Cookies
+	// file is present and readable. Symptom: doctor and `auth login --chrome`
+	// report 0 cookies (or incomplete cookies) on machines whose info_cache is
+	// missing entries that exist on disk — recovery the user reported is to
+	// symlink <profile>/Network/Cookies -> ../Cookies, but a direct walk is
+	// the right fix.
+	otSupp, otSuppNotes := supplementaryChromeCookies(ctx, "opentable.com")
+	tockSupp, tockSuppNotes := supplementaryChromeCookies(ctx, "exploretock.com")
+	otRaw = dedupeCookies(otRaw, otSupp)
+	tockRaw = dedupeCookies(tockRaw, tockSupp)
 	if otErr != nil && len(otRaw) == 0 && tockErr != nil && len(tockRaw) == 0 {
 		return nil, nil, result, fmt.Errorf("reading chrome cookies (ot=%v, tock=%v); is Chrome installed and have you signed in to opentable.com / exploretock.com?", otErr, tockErr)
 	}
@@ -63,6 +259,15 @@ func ImportFromChrome(ctx context.Context) (otCookies, tockCookies []Cookie, res
 		result.Notes = append(result.Notes, fmt.Sprintf("Tock: read %d cookies; some stores failed (non-fatal): %s", len(tockRaw), shortErr(tockErr)))
 	} else if tockErr != nil {
 		result.Notes = append(result.Notes, "Tock cookie read failed: "+shortErr(tockErr))
+	}
+	// Surface any supplementary-walk per-file failures only when they didn't
+	// also yield useful cookies; full failures are noteworthy, partial successes
+	// are signal-noise.
+	if len(otSupp) == 0 && len(otSuppNotes) > 0 {
+		result.Notes = append(result.Notes, "OpenTable supplementary walk: "+strings.Join(otSuppNotes, "; "))
+	}
+	if len(tockSupp) == 0 && len(tockSuppNotes) > 0 {
+		result.Notes = append(result.Notes, "Tock supplementary walk: "+strings.Join(tockSuppNotes, "; "))
 	}
 	now := time.Now()
 	convert := func(in kooky.Cookies, network string) []Cookie {
@@ -254,6 +459,11 @@ func RefreshAkamaiCookies(ctx context.Context, domainSuffix string) []Cookie {
 	ch := make(chan []Cookie, 1)
 	go func() {
 		raw, _ := kooky.ReadCookies(rctx, kooky.DomainHasSuffix(domainSuffix))
+		// Same supplementary walk as ImportFromChrome — kooky's info_cache
+		// driven discovery silently skips profile directories whose Local
+		// State entry is missing or stale.
+		supp, _ := supplementaryChromeCookies(rctx, domainSuffix)
+		raw = dedupeCookies(raw, supp)
 		out := make([]Cookie, 0, len(raw))
 		now := time.Now()
 		for _, c := range raw {

--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -55,44 +56,14 @@ func chromeRoots() []string {
 	}
 }
 
-// nonProfileDirs are subdirectories under a Chrome user-data root that are
-// not user profiles and never contain Cookies databases.
-var nonProfileDirs = map[string]bool{
-	"System Profile":                  true,
-	"Crashpad":                        true,
-	"GrShaderCache":                   true,
-	"GraphiteDawnCache":               true,
-	"ShaderCache":                     true,
-	"Subresource Filter":              true,
-	"OnDeviceHeadSuggestModel":        true,
-	"FirstPartySetsPreloaded":         true,
-	"hyphen-data":                     true,
-	"OptimizationHints":               true,
-	"OriginTrials":                    true,
-	"PnaclTranslationCache":           true,
-	"Safe Browsing":                   true,
-	"SSLErrorAssistant":               true,
-	"CertificateRevocation":           true,
-	"WidevineCdm":                     true,
-	"ZxcvbnData":                      true,
-	"AutofillStates":                  true,
-	"FileTypePolicies":                true,
-	"CertificateAuthorityNetworkPath": true,
-	"GCM Store":                       true,
-	"BrowserMetrics":                  true,
-	"CrashReports":                    true,
-	"Local Traces":                    true,
-	"PKIMetadata":                     true,
-	"hyphen-data-en":                  true,
-	"FirstPartySetsPreloaded.tmp":     true,
-	"DefaultRecord":                   true,
-	"AutofillRegexes":                 true,
-	"recovery_test":                   true,
-	"recovery":                        true,
-	"Last Browser":                    true,
-	"Last Version":                    true,
-	"Local State":                     true,
-}
+// profileDirRE matches Chrome's actual profile-directory naming scheme:
+// the literal "Default", numbered "Profile N", and "Guest Profile". Using
+// an allowlist (instead of a denylist of every browser-internal sibling
+// dir like Crashpad / GraphiteDawnCache / SegmentationPlatform / etc.) is
+// the right shape: the denylist was guaranteed to go stale on every Chrome
+// release, while real profile dirs follow this stable convention across
+// Chrome / Brave / Chromium / Arc derivatives.
+var profileDirRE = regexp.MustCompile(`^(Default|Profile \d+|Guest Profile)$`)
 
 // chromeCookieCandidatePaths returns the absolute paths of every plausible
 // Chrome cookie database on this machine, walking the actual filesystem
@@ -118,7 +89,7 @@ func chromeCookieCandidatePathsIn(roots []string) []string {
 				continue
 			}
 			name := entry.Name()
-			if nonProfileDirs[name] {
+			if !profileDirRE.MatchString(name) {
 				continue
 			}
 			for _, sub := range []string{
@@ -186,7 +157,11 @@ func dedupeCookies(slices ...[]*kooky.Cookie) []*kooky.Cookie {
 			if existing, ok := seen[k]; ok {
 				// Prefer the entry with the later Expires; breaks tie in
 				// favor of later-encountered (assumed freshest snapshot).
-				if !existing.Expires.IsZero() && !c.Expires.IsZero() && existing.Expires.After(c.Expires) {
+				// Also keep the existing entry when it has a concrete expiry
+				// and the challenger is a session cookie (zero Expires) —
+				// otherwise a session-only re-encounter from a stale profile
+				// would replace a persistent cookie from a fresh profile.
+				if !existing.Expires.IsZero() && (c.Expires.IsZero() || existing.Expires.After(c.Expires)) {
 					continue
 				}
 			}

--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/browserutils/kooky"
+)
+
+// TestChromeCookieCandidatePathsIn verifies the filesystem walk finds both
+// Chrome 96+ (<profile>/Network/Cookies) and pre-96 (<profile>/Cookies)
+// layouts even when <root>/Local State doesn't list the profile in
+// info_cache. This is the bug surfaced by a user whose macOS Chrome had
+// `Default/Cookies` and `Profile 1/Cookies` on disk but kooky returned
+// 0 Tock cookies — symptom of info_cache not listing those profiles.
+func TestChromeCookieCandidatePathsIn(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Layout: a Chrome-like root with both layouts present in different profiles,
+	// plus a non-profile sibling directory that must be skipped.
+	mustWriteFile := func(p string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	root := filepath.Join(tmp, "Chrome")
+	// Default profile: only OLD layout (the failing case from the bug report)
+	defaultCookies := filepath.Join(root, "Default", "Cookies")
+	mustWriteFile(defaultCookies)
+	// Profile 1: only NEW layout
+	profile1Network := filepath.Join(root, "Profile 1", "Network", "Cookies")
+	mustWriteFile(profile1Network)
+	// Profile 2: BOTH layouts (e.g., a recently migrated profile)
+	profile2Network := filepath.Join(root, "Profile 2", "Network", "Cookies")
+	profile2Old := filepath.Join(root, "Profile 2", "Cookies")
+	mustWriteFile(profile2Network)
+	mustWriteFile(profile2Old)
+	// Non-profile sibling: must NOT be enumerated as a profile.
+	mustWriteFile(filepath.Join(root, "Crashpad", "Cookies"))
+	mustWriteFile(filepath.Join(root, "GrShaderCache", "Cookies"))
+	// A file (not a directory) at root level: must not crash the walk.
+	mustWriteFile(filepath.Join(root, "Local State"))
+
+	got := chromeCookieCandidatePathsIn([]string{root})
+
+	want := []string{
+		defaultCookies,
+		profile1Network,
+		profile2Network,
+		profile2Old,
+	}
+	slices.Sort(got)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("chromeCookieCandidatePathsIn:\n got:  %v\n want: %v", got, want)
+	}
+
+	// Excluded sibling must NOT appear.
+	for _, g := range got {
+		if strings.Contains(g, "Crashpad") || strings.Contains(g, "GrShaderCache") {
+			t.Errorf("non-profile dir leaked into candidates: %q", g)
+		}
+	}
+}
+
+// TestChromeCookieCandidatePathsIn_MissingRoot verifies a non-existent root
+// is silently skipped rather than failing the walk — Chrome Beta / Canary
+// / Brave on machines that don't have them installed must be tolerated.
+func TestChromeCookieCandidatePathsIn_MissingRoot(t *testing.T) {
+	got := chromeCookieCandidatePathsIn([]string{"/nonexistent-path-aaa", "/nonexistent-path-bbb"})
+	if len(got) != 0 {
+		t.Errorf("expected zero candidates for non-existent roots; got %v", got)
+	}
+}
+
+// TestDedupeCookies_KeysOnDomainNamePath verifies the dedupe collapses
+// duplicate (Domain, Name, Path) entries and prefers the entry with the
+// later Expires.
+func TestDedupeCookies_KeysOnDomainNamePath(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(1 * time.Hour)
+	later := now.Add(24 * time.Hour)
+
+	a := []*kooky.Cookie{
+		{Cookie: http.Cookie{Name: "session", Domain: ".opentable.com", Path: "/", Value: "old", Expires: earlier}},
+		{Cookie: http.Cookie{Name: "csrf", Domain: ".opentable.com", Path: "/", Value: "x", Expires: later}},
+	}
+	b := []*kooky.Cookie{
+		// Same key as a's "session" cookie but with a LATER expiry — should win.
+		{Cookie: http.Cookie{Name: "session", Domain: ".opentable.com", Path: "/", Value: "new", Expires: later}},
+		// Distinct (different Path)
+		{Cookie: http.Cookie{Name: "session", Domain: ".opentable.com", Path: "/admin", Value: "admin-only", Expires: later}},
+	}
+
+	got := dedupeCookies(a, b)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 deduped cookies; got %d (%+v)", len(got), got)
+	}
+	for _, c := range got {
+		if c.Name == "session" && c.Path == "/" && c.Value != "new" {
+			t.Errorf("dedupeCookies kept the older session cookie value=%q; expected the later-expiring 'new' value", c.Value)
+		}
+	}
+}
+
+// TestDedupeCookies_NilEntriesIgnored confirms nil entries (which kooky may
+// occasionally emit) don't panic and don't pollute the output.
+func TestDedupeCookies_NilEntriesIgnored(t *testing.T) {
+	a := []*kooky.Cookie{
+		nil,
+		{Cookie: http.Cookie{Name: "x", Domain: "y", Path: "/"}},
+		nil,
+	}
+	got := dedupeCookies(a)
+	if len(got) != 1 {
+		t.Errorf("expected nil entries to be skipped; got %d cookies", len(got))
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/auth/chrome_test.go
@@ -45,9 +45,17 @@ func TestChromeCookieCandidatePathsIn(t *testing.T) {
 	profile2Old := filepath.Join(root, "Profile 2", "Cookies")
 	mustWriteFile(profile2Network)
 	mustWriteFile(profile2Old)
-	// Non-profile sibling: must NOT be enumerated as a profile.
+	// Guest Profile: covered by the allowlist
+	guestCookies := filepath.Join(root, "Guest Profile", "Cookies")
+	mustWriteFile(guestCookies)
+	// Non-profile siblings: every browser-internal directory must be ignored
+	// without us having to enumerate them by name. These three include both
+	// stable Chrome internals and a future Chrome dir we don't yet know about
+	// — the allowlist must reject them all.
 	mustWriteFile(filepath.Join(root, "Crashpad", "Cookies"))
 	mustWriteFile(filepath.Join(root, "GrShaderCache", "Cookies"))
+	mustWriteFile(filepath.Join(root, "SegmentationPlatform", "Cookies"))
+	mustWriteFile(filepath.Join(root, "System Profile", "Cookies"))
 	// A file (not a directory) at root level: must not crash the walk.
 	mustWriteFile(filepath.Join(root, "Local State"))
 
@@ -58,6 +66,7 @@ func TestChromeCookieCandidatePathsIn(t *testing.T) {
 		profile1Network,
 		profile2Network,
 		profile2Old,
+		guestCookies,
 	}
 	slices.Sort(got)
 	slices.Sort(want)
@@ -67,8 +76,10 @@ func TestChromeCookieCandidatePathsIn(t *testing.T) {
 
 	// Excluded sibling must NOT appear.
 	for _, g := range got {
-		if strings.Contains(g, "Crashpad") || strings.Contains(g, "GrShaderCache") {
-			t.Errorf("non-profile dir leaked into candidates: %q", g)
+		for _, banned := range []string{"Crashpad", "GrShaderCache", "SegmentationPlatform", "System Profile"} {
+			if strings.Contains(g, banned) {
+				t.Errorf("non-profile dir %q leaked into candidates: %q", banned, g)
+			}
 		}
 	}
 }
@@ -110,6 +121,38 @@ func TestDedupeCookies_KeysOnDomainNamePath(t *testing.T) {
 		if c.Name == "session" && c.Path == "/" && c.Value != "new" {
 			t.Errorf("dedupeCookies kept the older session cookie value=%q; expected the later-expiring 'new' value", c.Value)
 		}
+	}
+}
+
+// TestDedupeCookies_PersistentBeatsSession verifies that a persistent cookie
+// (concrete Expires) is preferred over a session-only cookie (zero Expires)
+// for the same (Domain, Name, Path) — even when the session cookie is
+// encountered later. Greptile P-finding from PR #399: prior logic short-
+// circuited the Expires comparison whenever either side had a zero Expires,
+// causing a stale-profile session cookie to silently overwrite a fresh
+// persistent cookie from kooky's auto-discovery.
+func TestDedupeCookies_PersistentBeatsSession(t *testing.T) {
+	now := time.Now()
+	persistent := &kooky.Cookie{Cookie: http.Cookie{
+		Name: "session", Domain: ".opentable.com", Path: "/", Value: "fresh-persistent",
+		Expires: now.Add(48 * time.Hour),
+	}}
+	sessionOnly := &kooky.Cookie{Cookie: http.Cookie{
+		Name: "session", Domain: ".opentable.com", Path: "/", Value: "stale-session-only",
+		// Expires zero → session cookie
+	}}
+
+	// Persistent encountered first, session-only later.
+	got := dedupeCookies([]*kooky.Cookie{persistent}, []*kooky.Cookie{sessionOnly})
+	if len(got) != 1 || got[0].Value != "fresh-persistent" {
+		t.Errorf("session cookie replaced persistent one; got %+v", got)
+	}
+
+	// Reverse order: session-only first, persistent later. The persistent
+	// one should win regardless of order.
+	got = dedupeCookies([]*kooky.Cookie{sessionOnly}, []*kooky.Cookie{persistent})
+	if len(got) != 1 || got[0].Value != "fresh-persistent" {
+		t.Errorf("dedupe order-dependent; expected persistent to win, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## table-reservation-goat — Chrome cookie discovery fallback

### Bug (user report)

`table-reservation-goat-pp-cli auth login --chrome` returned 0 or partial cookies on a machine where Chrome was signed in to both networks:

```json
{
  "notes": [
    "Tock cookie read failed: open /…/Profile 1/Network/Cookies: no such file or directory (and others)"
  ],
  "opentable_imported": 14,
  "opentable_logged_in": false,
  "tock_imported": 0,
  "tock_logged_in": false
}
```

Filesystem inspection showed:

```
~/Library/Application Support/Google/Chrome/Default/Cookies
~/Library/Application Support/Google/Chrome/Profile 1/Cookies
~/Library/Application Support/Google/Chrome/Local State
```

— old-layout `<profile>/Cookies`, no `Network/Cookies`. Manual workaround with symlinks `Default/Network/Cookies → ../Cookies` and `Profile 1/Network/Cookies → ../Cookies` recovered:

```json
{ "opentable_imported": 52, "opentable_logged_in": true, "tock_imported": 38, "tock_logged_in": true }
```

### Root cause

kooky v0.2.9's Chrome cookie discovery (`internal/chrome/find/find.go`) iterates only profiles listed in `<root>/Local State`'s `profile.info_cache` map. For each listed profile it tries both Chrome 96+ (`<profile>/Network/Cookies`) and pre-96 (`<profile>/Cookies`) layouts, so the layout fallback exists in theory. But a profile directory present on disk that's missing from `info_cache` is silently skipped — along with both layouts. The user's `info_cache` happened to omit at least one profile where the Tock cookies lived. Their symlinks happened to satisfy a `Network/Cookies` path kooky was already trying for some other (listed) profile.

### Fix

Supplement kooky's auto-discovery with a direct filesystem walk of every Chrome user-data root we know about. For each subdirectory that isn't a known non-profile sibling (`Crashpad`, `GrShaderCache`, `Subresource Filter`, etc.), try both cookie layouts via `kooky/browser/chrome.ReadCookies(path, ...)`. Merge with kooky's auto-discovery results, dedupe by `(Domain, Name, Path)`, prefer the entry with the later `Expires`.

Per-platform Chrome roots covered:
- **darwin**: `Google/Chrome`, `Google/Chrome Beta`, `Google/Chrome Canary`, `Google/Chrome Dev`, `Chromium`, `BraveSoftware/Brave-Browser`, `Arc/User Data`
- **linux**: `google-chrome`, `google-chrome-beta`, `google-chrome-unstable`, `chromium`, `BraveSoftware/Brave-Browser`
- **windows**: kooky-only (no reliable cross-version path map here)

Same supplementary walk applied to `RefreshAkamaiCookies` (the per-call freshness re-read), so cross-network commands benefit too.

### Tests

- `TestChromeCookieCandidatePathsIn` — temp-dir Chrome-like layout with mixed Default-only-old, Profile-1-only-new, Profile-2-both-layouts, plus `Crashpad`/`GrShaderCache` siblings that must be excluded
- `TestChromeCookieCandidatePathsIn_MissingRoot` — non-existent roots silently tolerated
- `TestDedupeCookies_KeysOnDomainNamePath` — same `(Domain, Name, Path)` collapsed; later-`Expires` wins
- `TestDedupeCookies_NilEntriesIgnored` — kooky's occasional nil entries don't panic

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS (4 new tests, all packages green) |
| `printing-press publish validate` | **11/11 PASS** |

### Out of scope

- Updating `.printing-press-patches.json`'s `validated_outcome` ledger — deferred to avoid a recurring conflict with PR #387 (still open). The patches manifest can be brought up to date in a follow-up commit once the open PRs settle.
