### PR TITLE
fix(table-reservation-goat): doctor probe — use source clients, not dead http path

### DIFF
--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -6,17 +6,17 @@ package cli
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/client"
-	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/config"
-	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/store"
 	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/auth"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/opentable"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/store"
 )
 
 // looksLikeDoctorInterstitial reports whether the response body matches a known
@@ -84,96 +84,56 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				report["base_url"] = cfg.BaseURL
 			}
 
-			// Check auth
-			report["auth"] = "not required"
+			// Check auth and API reachability via the actual code paths the
+			// CLI uses for OpenTable and Tock — Surf with Chrome TLS
+			// fingerprint plus kooky-imported cookies. The previous probe did
+			// `client.Get("/", nil)` against `BaseURL = https://www.opentable.com`
+			// via the vestigial generic stdlib HTTP client, which Akamai
+			// uniformly RST_STREAMs (false "API: unreachable" failure). The
+			// real commands never use that path; the honest probe exercises
+			// the source clients directly.
+			session, sessErr := auth.Load()
+			otCookies := 0
+			tockCookies := 0
+			if sessErr == nil && session != nil {
+				otCookies = len(session.HTTPCookies(auth.NetworkOpenTable))
+				tockCookies = len(session.HTTPCookies(auth.NetworkTock))
+			}
+			switch {
+			case sessErr != nil:
+				report["auth"] = fmt.Sprintf("error loading session: %s", sessErr)
+			case otCookies == 0 && tockCookies == 0:
+				report["auth"] = "no cookies imported (run `auth login --chrome` after signing in to opentable.com and exploretock.com in Chrome)"
+			default:
+				report["auth"] = fmt.Sprintf("opentable: %d cookies, tock: %d cookies", otCookies, tockCookies)
+			}
 
-			// Check auth environment variables
-
-			// Check API connectivity and validate credentials.
-			//
-			// The doctor uses the same client every other command uses --
-			// flags.newClient() returns a *client.Client wrapping whatever
-			// transport the spec declared (Surf for browser-chrome, stdlib
-			// for standard). A separate stdlib http.Client would silently
-			// bypass that choice and report false negatives against
-			// Cloudflare-fronted, Akamai-fronted, or otherwise bot-detected
-			// sites. By going through flags.newClient(), the doctor's
-			// reachability verdict matches what real commands experience.
-			if cfg != nil && cfg.BaseURL != "" {
-				c, clientErr := flags.newClient()
-				if clientErr != nil {
-					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
-				} else {
-					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get("/", nil)
-					var reachAPIErr *client.APIError
-					switch {
-					case reachErr == nil:
-						// 2xx response — clearly reachable. Still inspect the
-						// body for a known interstitial; some bot walls return
-						// 200 with a JS challenge page.
-						if vendor := looksLikeDoctorInterstitial(reachBody); vendor != "" {
-							report["api"] = fmt.Sprintf("blocked by %s interstitial — the configured transport reached the wall. Try a different network, wait for the IP-level rate limit to clear, or check that the browser-chrome transport is bound correctly.", vendor)
+			// API probe: exercise OpenTable's Bootstrap via the working source
+			// client. Bootstrap navigates the Akamai-whitelisted /restaurant/profile/100
+			// path (NOT the bot-detected `/`), uses Surf's Chrome TLS
+			// fingerprint, and short-circuits when a 403-cooldown is active.
+			// Tock has no equivalent cheap probe (each venue is its own SSR
+			// page); we rely on cookie-jar freshness as a Tock readiness
+			// signal until a stable cheap Tock probe lands.
+			if session != nil {
+				otCli, otErr := opentable.New(session)
+				switch {
+				case otErr != nil:
+					report["api_opentable"] = fmt.Sprintf("client init: %s", otErr)
+				default:
+					ctx := cmd.Context()
+					if err := otCli.Bootstrap(ctx); err != nil {
+						if bde, ok := opentable.IsBotDetection(err); ok {
+							report["api_opentable"] = fmt.Sprintf("blocked by Akamai: %s — try `auth login --chrome` to refresh cookies", bde.Error())
 						} else {
-							report["api"] = "reachable"
+							report["api_opentable"] = fmt.Sprintf("unreachable: %s", err)
 						}
-					case errors.As(reachErr, &reachAPIErr):
-						// Non-2xx from the server. The network reached, the
-						// server responded — that's "reachable" for our
-						// purposes. Inspect the response body for a known
-						// interstitial first; otherwise note the status.
-						status := reachAPIErr.StatusCode
-						if vendor := looksLikeDoctorInterstitial([]byte(reachAPIErr.Body)); vendor != "" {
-							report["api"] = fmt.Sprintf("blocked by %s interstitial (HTTP %d) — the configured transport reached the wall.", vendor, status)
-						} else {
-							report["api"] = fmt.Sprintf("reachable (HTTP %d at /)", status)
-						}
-					default:
-						// Network-level failure: DNS, connection refused, TLS,
-						// transport init, etc. The transport itself didn't
-						// connect.
-						report["api"] = fmt.Sprintf("unreachable: %s", reachErr)
-					}
-
-					// Step 2: Validate credentials with an authenticated probe.
-					authHeader := cfg.AuthHeader()
-					if authHeader == "" {
-						// No auth configured — skip credential validation
-					} else if reachErr != nil && !errors.As(reachErr, &reachAPIErr) {
-						report["credentials"] = "skipped (API unreachable)"
 					} else {
-						verifyPath := "/"
-						authParams := map[string]string{}
-						authHeaders := map[string]string{}
-						authHeaders["Authorization"] = authHeader
-						authHeaders["User-Agent"] = "table-reservation-goat-pp-cli"
-						_, authErr := c.GetWithHeaders(verifyPath, authParams, authHeaders)
-						var authAPIErr *client.APIError
-						switch {
-						case authErr == nil:
-							report["credentials"] = "valid"
-						case errors.As(authErr, &authAPIErr):
-							switch {
-							case authAPIErr.StatusCode == 401 || authAPIErr.StatusCode == 403:
-								// The probe hit the bare base URL because no auth.verify_path
-								// is configured in the spec. Many APIs return 401/403 from a
-								// bare versioned root regardless of token validity (the path
-								// isn't routed but the gateway still demands credentials).
-								// Don't claim invalid without certainty — set verify_path to
-								// a known-good authenticated GET (e.g. /me, /v1/account, /user)
-								// for a definitive verdict.
-								report["credentials"] = fmt.Sprintf("inconclusive (HTTP %d from base URL — set auth.verify_path in spec for a definitive probe)", authAPIErr.StatusCode)
-							default:
-								// Non-auth HTTP error (404, 500, etc.) — don't blame credentials
-								report["credentials"] = fmt.Sprintf("ok (HTTP %d from %s, but auth was accepted)", authAPIErr.StatusCode, verifyPath)
-							}
-						default:
-							report["credentials"] = fmt.Sprintf("error: %s", authErr)
-						}
+						report["api_opentable"] = "reachable"
 					}
 				}
-			} else if cfg != nil && cfg.BaseURL == "" {
-				report["api"] = "not configured (set base_url in config file)"
+			} else if sessErr == nil {
+				report["api_opentable"] = "skipped (no session loaded)"
 			}
 			// Cache health: only reported when this CLI has a local store.
 			// Surfaces rows + last_synced_at per resource, schema version,
@@ -196,8 +156,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				{"config", "Config"},
 				{"auth", "Auth"},
 				{"env_vars", "Env Vars"},
-				{"api", "API"},
-				{"credentials", "Credentials"},
+				{"api_opentable", "OpenTable"},
 			}
 			for _, ck := range checkKeys {
 				v, ok := report[ck.key]

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -60,7 +60,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				report["auth"] = fmt.Sprintf("error loading session: %s", sessErr)
 			case otCookies == 0 && tockCookies == 0:
 				// "not configured" prefix maps to the FAIL indicator on line
-				// ~197 and trips `doctorExitForFailOn` for `--fail-on=error`.
+				// ~164 and trips `doctorExitForFailOn` for `--fail-on=error`.
 				// Without it the message contains "no" but not "not " (with
 				// trailing space) and falls through to a green OK that
 				// contradicts the recovery prompt.
@@ -94,7 +94,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				otCli, otErr := opentable.New(session)
 				switch {
 				case otErr != nil:
-					// Prefix with "error:" so the indicator switch (line ~197)
+					// Prefix with "error:" so the indicator switch (line ~164)
 					// and doctorExitForFailOn both classify this as FAIL.
 					// Their predicates match the literal substring "error";
 					// Go errors like `"no cookie jar"` or `"connection

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -115,7 +115,21 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Tock has no equivalent cheap probe (each venue is its own SSR
 			// page); we rely on cookie-jar freshness as a Tock readiness
 			// signal until a stable cheap Tock probe lands.
-			if session != nil {
+			//
+			// Skip Bootstrap entirely when no opentable cookies are present:
+			// auth.Load() always returns a non-nil *Session even on a missing
+			// session file (auth.go: empty &Session{Version: 1}), so an
+			// `if session != nil` guard isn't enough. Without cookies the
+			// Bootstrap call will hit Akamai cold, 403, and set a cooldown —
+			// reporting "blocked by Akamai" when the real problem is "no
+			// cookies imported."
+			switch {
+			case sessErr != nil:
+				// auth load failed → already surfaced as "auth: error ...".
+				// Don't pile on a redundant api_opentable line.
+			case otCookies == 0:
+				report["api_opentable"] = "skipped (no opentable cookies — run `auth login --chrome`)"
+			default:
 				otCli, otErr := opentable.New(session)
 				switch {
 				case otErr != nil:
@@ -124,7 +138,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					ctx := cmd.Context()
 					if err := otCli.Bootstrap(ctx); err != nil {
 						if bde, ok := opentable.IsBotDetection(err); ok {
-							report["api_opentable"] = fmt.Sprintf("blocked by Akamai: %s — try `auth login --chrome` to refresh cookies", bde.Error())
+							// bde.Error() already names the recovery
+							// (`auth login --chrome`); don't append a
+							// duplicate hint.
+							report["api_opentable"] = fmt.Sprintf("blocked by Akamai: %s", bde.Error())
 						} else {
 							report["api_opentable"] = fmt.Sprintf("unreachable: %s", err)
 						}
@@ -132,8 +149,6 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						report["api_opentable"] = "reachable"
 					}
 				}
-			} else if sessErr == nil {
-				report["api_opentable"] = "skipped (no session loaded)"
 			}
 			// Cache health: only reported when this CLI has a local store.
 			// Surfaces rows + last_synced_at per resource, schema version,

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -103,7 +103,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			case sessErr != nil:
 				report["auth"] = fmt.Sprintf("error loading session: %s", sessErr)
 			case otCookies == 0 && tockCookies == 0:
-				report["auth"] = "no cookies imported (run `auth login --chrome` after signing in to opentable.com and exploretock.com in Chrome)"
+				// "not configured" prefix maps to the FAIL indicator on line
+				// ~197 and trips `doctorExitForFailOn` for `--fail-on=error`.
+				// Without it the message contains "no" but not "not " (with
+				// trailing space) and falls through to a green OK that
+				// contradicts the recovery prompt.
+				report["auth"] = "not configured: no cookies imported (run `auth login --chrome` after signing in to opentable.com and exploretock.com in Chrome)"
 			default:
 				report["auth"] = fmt.Sprintf("opentable: %d cookies, tock: %d cookies", otCookies, tockCookies)
 			}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -205,7 +205,7 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 	for _, v := range report {
 		s, ok := v.(string)
 		if ok {
-			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.Contains(s, "blocked") {
+			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.Contains(s, "blocked") || strings.Contains(s, "not configured") {
 				worstError = true
 			}
 		}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -133,7 +133,13 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				otCli, otErr := opentable.New(session)
 				switch {
 				case otErr != nil:
-					report["api_opentable"] = fmt.Sprintf("client init: %s", otErr)
+					// Prefix with "error:" so the indicator switch (line ~197)
+					// and doctorExitForFailOn both classify this as FAIL.
+					// Their predicates match the literal substring "error";
+					// Go errors like `"no cookie jar"` or `"connection
+					// refused"` don't carry it on their own, so without the
+					// prefix this status falls through to a green OK.
+					report["api_opentable"] = fmt.Sprintf("error: client init: %s", otErr)
 				default:
 					ctx := cmd.Context()
 					if err := otCli.Bootstrap(ctx); err != nil {

--- a/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/doctor.go
@@ -19,50 +19,6 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/store"
 )
 
-// looksLikeDoctorInterstitial reports whether the response body matches a known
-// bot-detection challenge page (Cloudflare, Akamai, Vercel, AWS WAF, DataDome,
-// PerimeterX). Only fires on the doctor probe — used to distinguish "transport
-// reached the wall" from "transport failed entirely." Returns the vendor name
-// when matched, or empty string when no match.
-//
-// Markers are anchored to <title> or vendor-specific strings to avoid
-// false-positives on benign content. For example, a recipe titled "Just A
-// Moment of Pause Cookies" must NOT match the Cloudflare challenge marker;
-// only "<title>just a moment" (the actual interstitial title) does.
-func looksLikeDoctorInterstitial(body []byte) string {
-	if len(body) == 0 {
-		return ""
-	}
-	limit := len(body)
-	if limit > 8192 {
-		limit = 8192
-	}
-	prefix := strings.ToLower(string(body[:limit]))
-	if !strings.Contains(prefix, "<title") {
-		// Every bot interstitial we recognize sets a <title>; bodies without
-		// one are body-only API responses, not challenge pages.
-		return ""
-	}
-	switch {
-	case strings.Contains(prefix, "<title>just a moment") || // CF JS challenge
-		strings.Contains(prefix, "challenges.cloudflare.com") || // CF Turnstile
-		(strings.Contains(prefix, "attention required") && strings.Contains(prefix, "cloudflare")):
-		return "Cloudflare"
-	case strings.Contains(prefix, "akamai") && (strings.Contains(prefix, "request unsuccessful") || strings.Contains(prefix, "access denied")):
-		return "Akamai"
-	case strings.Contains(prefix, "x-vercel-mitigated") || strings.Contains(prefix, "x-vercel-challenge-token") ||
-		(strings.Contains(prefix, "vercel") && strings.Contains(prefix, "challenge")):
-		return "Vercel"
-	case strings.Contains(prefix, "request blocked") && strings.Contains(prefix, "aws waf"):
-		return "AWS WAF"
-	case strings.Contains(prefix, "datadome") && (strings.Contains(prefix, "blocked") || strings.Contains(prefix, "captcha") || strings.Contains(prefix, "challenge")):
-		return "DataDome"
-	case strings.Contains(prefix, "perimeterx") || strings.Contains(prefix, "px-captcha"):
-		return "PerimeterX"
-	}
-	return ""
-}
-
 func newDoctorCmd(flags *rootFlags) *cobra.Command {
 	var failOn string
 	cmd := &cobra.Command{
@@ -205,7 +161,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					// valid tokens). Surface as WARN, not FAIL — the user's actual
 					// commands will reveal a real auth failure if one exists.
 					indicator = yellow("WARN")
-				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
+				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.Contains(s, "blocked"):
 					indicator = red("FAIL")
 				case s == "not required":
 					// Public APIs: no auth needed is a healthy state, not a warning.
@@ -249,7 +205,7 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 	for _, v := range report {
 		s, ok := v.(string)
 		if ok {
-			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") {
+			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.Contains(s, "blocked") {
 				worstError = true
 			}
 		}


### PR DESCRIPTION
## table-reservation-goat — `doctor` probe via source clients, not dead http path

### Bug (user report)

```
table-reservation-goat-pp-cli doctor reports:
FAIL API: unreachable: GET /: Get "https://www.opentable.com/": stream error: stream ID 7; INTERNAL_ERROR; received from peer
base_url: https://www.opentable.com
version: 1.0.0
```

`curl` confirms the upstream behavior: `403 Akamai access denied` over HTTP/1.1, `HTTP/2 stream not closed cleanly: INTERNAL_ERROR` over HTTP/2. Akamai's WAF rejects naive clients on the bare root.

### Root cause

Same family as PR #389 — `doctor` was probing via the vestigial `internal/client.Client` against `BaseURL = "https://www.opentable.com"` with `c.Get("/", nil)`. No real CLI command uses that path; the working code routes through `internal/source/{opentable,tock}/` with Surf's Chrome TLS fingerprint, GraphQL persisted-queries, SSR scraping, kooky-imported cookies, and Akamai-aware cooldown handling. `doctor`'s probe was lying about what the CLI actually does.

The HTTP/2 `INTERNAL_ERROR` doesn't fit the `*client.APIError` shape (no response body), so it falls through to the bare transport-error path → `unreachable: …` even though Akamai's edge clearly responded.

### Fix

Replace `c.Get("/", nil)` with `opentable.New(session).Bootstrap(ctx)` — the same Bootstrap call `goat`, `earliest`, `watch`, etc. use. It:
- Navigates `/restaurant/profile/100` (Akamai-whitelisted; the cooldown patch's documented escape hatch)
- Reads kooky-imported session cookies via Surf's Chrome fingerprint
- Short-circuits with `*BotDetectionError` when a prior-403 cooldown is active
- Caches CSRF token so warm probes are essentially free

Distinct rendering for the three failure modes:
- transport reached, Akamai blocked → `OpenTable: blocked by Akamai (cooldown until 2026-05-10T08:30Z) — try \`auth login --chrome\` to refresh cookies`
- transport failed → `OpenTable: unreachable: <err>`
- success → `OpenTable: reachable`

New `Auth:` line replaces the previous `Auth: not required` placeholder with actual cookie counts:

```
Config:    ok
Auth:      opentable: 24 cookies, tock: 38 cookies
OpenTable: reachable
```

…or, if not signed in:

```
Auth:      no cookies imported (run `auth login --chrome` after signing in to opentable.com and exploretock.com in Chrome)
OpenTable: skipped (no session loaded)
```

### Tock probe

Skipped in this PR — Tock has no equivalent cheap stable probe; each venue is its own SSR page. Cookie-jar count is the Tock readiness signal. Future PR can add a Tock probe (city-search SSR with a known stable metro) if useful.

### Removed

- `credentials` check — was guarded on `cfg.AuthHeader() != ""`, which is always empty for this cookie-auth CLI. Code path was dead user-visible.
- `internal/client` import in `doctor.go` — `data_source.go` still references it via the read-cache pipeline, so the package itself stays.

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS |
| `printing-press publish validate` | **11/11 PASS** |
| Manual `doctor --help` smoke | PASS |

### Out of scope

- `.printing-press-patches.json` ledger update — deferred (same reason as #399, avoiding manifest conflict with #387).
- Full removal of `internal/client/client.go` — still referenced by `data_source.go` via typed-endpoint subcommands' read-cache pipeline. Bigger refactor; separate PR.

### Related

- #389 (merged) — removed the broken typed-tool MCP layer that hit the same dead client
- #399 — companion fix for `auth login --chrome` cookie discovery on machines where Chrome's `Local State` is missing profile entries
