### PR TITLE
chore(publish-flow): harden new-CLI submission guard rails

### DIFF
--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -211,6 +211,14 @@ def validate_manifest_identity(cli_dir: Path, manifest: dict | None, strict: boo
         )
 
     if strict:
+        if slug.endswith("-pp-cli") or slug.endswith("-pp-mcp"):
+            problems.append(
+                Problem(
+                    manifest_path,
+                    f"new library CLI directory {slug!r} uses the -pp-cli/-pp-mcp binary suffix in its directory name. The slug-only convention is library/<category>/<slug>/; the -pp-cli infix belongs to cmd/<slug>-pp-cli/, not the parent directory. Re-run the publish package step or rename the directory to drop the suffix.",
+                )
+            )
+
         run_id = manifest.get("run_id")
         if not run_id:
             problems.append(

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -126,6 +126,56 @@ class PublishPackageVerifierTest(unittest.TestCase):
         self.assertIn("### Publication Path", suggestions[0])
         self.assertIn("| `search` | Example search | Searches example data. |", suggestions[0])
 
+    def test_new_cli_directory_with_pp_cli_suffix_fails(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "example-pp-cli"
+        manifest = {
+            "schema_version": 1,
+            "api_name": "example-pp-cli",
+            "category": "cloud",
+            "cli_name": "example-pp-cli",
+            "printer": "tmchow",
+            "printing_press_version": "4.0.1",
+            "run_id": "20260509T010203Z-test",
+            "novel_features": [{"name": "n", "command": "search", "description": "d"}],
+        }
+        files = {
+            ".printing-press.json": json.dumps(manifest),
+            ".printing-press-patches.json": json.dumps({"schema_version": 1, "applied_at": "2026-05-09", "patches": []}),
+            "AGENTS.md": "# Agents\n",
+            "README.md": "# Example\n",
+            "SKILL.md": "---\nname: pp-example\n---\n",
+            "go.mod": "module github.com/mvanhorn/printing-press-library/library/cloud/example-pp-cli\n",
+            ".goreleaser.yaml": "version: 2\n",
+            "LICENSE": "MIT\n",
+            "NOTICE": "Example\n",
+            "cmd/example-pp-cli/main.go": "package main\n",
+            ".manuscripts/20260509T010203Z-test/research/research.json": "{}\n",
+            ".manuscripts/20260509T010203Z-test/proofs/shipcheck.json": "{}\n",
+        }
+        for name, content in files.items():
+            self.write(f"library/cloud/example-pp-cli/{name}", content)
+
+        problems = verifier.validate_cli_dir(cli_dir, strict=True)
+        messages = [p.message for p in problems]
+
+        self.assertTrue(any("-pp-cli/-pp-mcp binary suffix" in msg for msg in messages))
+
+    def test_existing_cli_with_pp_cli_suffix_does_not_fail_when_non_strict(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "legacy-pp-cli"
+        manifest = {
+            "schema_version": 1,
+            "api_name": "legacy-pp-cli",
+            "category": "cloud",
+            "cli_name": "legacy-pp-cli",
+        }
+        self.write("library/cloud/legacy-pp-cli/.printing-press.json", json.dumps(manifest))
+        self.write("library/cloud/legacy-pp-cli/cmd/legacy-pp-cli/main.go", "package main\n")
+
+        problems = verifier.validate_cli_dir(cli_dir, strict=False)
+        messages = [p.message for p in problems]
+
+        self.assertFalse(any("-pp-cli/-pp-mcp binary suffix" in msg for msg in messages))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,80 @@ The normal flow is:
 
 Use this distinction in your own language: **generator repo** or **Printing Press** for `cli-printing-press`; **published library** or **catalog repo** for this repo; **local library** for the generated working-copy library, commonly `~/printing-press/library`.
 
+## Adding a new CLI or reprinting an existing one — use the Printing Press, not a hand-built PR
+
+**New CLI additions and reprints do not start in this repo.** They are produced by `cli-printing-press` and shipped here through the publish phase of `/printing-press` (which invokes the `/printing-press-publish` skill at the end of a run). Hand-constructed PRs that try to assemble the canonical CLI shape from scratch in this repo systematically miss things: wrong directory layout (`<slug>-pp-cli/` instead of `<slug>/`), missing `.manuscripts/<run-id>/{research,proofs}/`, missing `dogfood-results.json`, hand-authored `cli-skills/pp-<slug>/SKILL.md` (which is a generated mirror), wrong PR title scope (`feat(library)` instead of `feat(<slug>)`), wrong branch name (`add-<slug>` instead of `feat/<slug>`), and PR descriptions that are free-form prose instead of the validation-table-bearing template the publish skill produces. We get those PRs every week and they are not mergeable as-is.
+
+This rule applies to **any agent working in this repo** that has been asked to "add the X CLI", "publish the X CLI", "reprint X under the new template", or anything that produces a fresh `library/<category>/<slug>/` tree. Stop before you start writing `main.go`.
+
+### When this rule applies
+
+Treat the change as a **new CLI / reprint** (subject to this rule) if any of these are true:
+
+- A brand-new directory `library/<category>/<slug>/` is being created.
+- `library/<category>/<slug>/.printing-press.json` is being added, or the existing one is being replaced wholesale (not a small `printing_press_version` bump or single-field tweak).
+- You are about to write more than two of the canonical foundational files for a slug that did not exist on `main`: `cmd/<slug>-pp-cli/main.go`, `internal/cli/root.go`, `internal/client/client.go`, `SKILL.md`, `README.md`, `AGENTS.md`, `Makefile`, `LICENSE`, `NOTICE`, `.goreleaser.yaml`, `.golangci.yml`, `go.mod`, `go.sum`.
+
+The following are **not** new CLI / reprint changes and are fine to land via a normal hand-authored PR from this repo:
+
+- Bug fixes or behavior tweaks in an already-published CLI's `internal/cli/*.go`, `internal/client/*.go`, etc. Record any code-level customization in `.printing-press-patches.json` per the convention below.
+- README/SKILL.md polish on an already-published CLI (edit `library/<cat>/<slug>/SKILL.md`, never the `cli-skills/` mirror).
+- AST-level patches via `printing-press patch` from the generator repo.
+- `tools/sweep-canonical/` runs that retrofit canonical shape across all entries.
+- CI changes under `.github/workflows/`, repo-root docs, or installer changes under `npm/`.
+- Manual edits to the generator-output files (`registry.json`, `cli-skills/pp-*/SKILL.md`) — don't; those are bot-regenerated post-merge.
+
+### What to do instead, when the change *is* a new CLI / reprint
+
+1. **Stop editing files in this repo** and tell the user: "This is a new CLI / reprint. The canonical path is `/printing-press <api>` (or `/printing-press-reprint <api>` for a regen) in a workspace that has the `cli-printing-press` generator available. That flow runs research → generate → dogfood → verify → archive → publish end-to-end, and Phase 6 opens a properly-shaped PR back into this repo by invoking `/printing-press-publish` for you. You almost never invoke the publish skill directly."
+2. If the CLI is already generated and archived under `~/printing-press/library/<slug>/` and only the publish step remains, run `/printing-press-publish <slug>` directly — that skill handles category resolution, validation, branch naming, registry update, manuscript inclusion, and PR description shape end-to-end. Don't replicate any of those steps by hand.
+3. If the user does not have the generator and is committed to a hand-built submission anyway, you must reproduce the canonical shape exactly. The publish-skill PR template is the contract; deviations get bounced. See the next section.
+
+### Canonical PR shape (the publish-skill contract)
+
+If you are constructing a new-CLI PR by any path, it must match this shape:
+
+- **Branch:** `feat/<slug>` exactly. Not `add-<slug>`, not `feat/<slug>-pp-cli`, not `feature/<slug>`.
+- **Title:** `feat(<slug>): add <slug>` exactly. No trailing dash-suffix description (`— Korean startup database`), no `feat(library)` scope, no Co-Authored-By or "Claude Code" trailers.
+- **Directory:** `library/<category>/<slug>/`. Slug only — never `library/<category>/<slug>-pp-cli/`. The `-pp-cli` infix lives in binary names, not directory names.
+- **Files present at minimum:** `.printing-press.json` (full manifest with `api_name`, `cli_name`, `spec_format`, `spec_checksum`, `spec_source`, `printing_press_version`, plus MCP fields if applicable), `cmd/<slug>-pp-cli/main.go`, `internal/cli/root.go` and the per-resource files, `internal/client/client.go`, `SKILL.md`, `README.md`, `AGENTS.md`, `LICENSE`, `NOTICE`, `Makefile`, `.goreleaser.yaml`, `.golangci.yml`, `go.mod`, `go.sum`, `dogfood-results.json`, and a populated `.manuscripts/<run-id>/research/` plus `.manuscripts/<run-id>/proofs/`. A reprint that drops the manuscripts is not a publishable reprint.
+- **Files NOT in the PR:** `cli-skills/pp-<slug>/SKILL.md` (auto-regenerated post-merge from `library/<cat>/<slug>/SKILL.md` by `tools/generate-skills/`); committed binaries; `.env`, `session-state.json`, or other files with real credentials.
+- **Registry update:** `registry.json` gets the new entry inserted in alphabetical order by `name`, with the full MCP block populated when the manifest declares one.
+- **PR body:** matches the publish-skill template — `## <slug>` heading, description paragraph, `**API:** … | **Category:** … | **Press version:** …` line, `**Spec:** …` line, then `### CLI Shape` (with the verbatim `--help` output in a fenced code block), `### What This CLI Does`, `### Manuscripts` (links to the in-PR `.manuscripts/<run-id>/research/` and `.manuscripts/<run-id>/proofs/` paths), `### Validation Results` (a table with PASS/FAIL for Manifest, Phase 5, `go mod tidy`, `go vet`, `go build`, `--help`, `--version`, `verify-skill`, `govulncheck`, Manuscripts), and an optional `### Gaps` section. **No** `## Summary` / `## Why This Matters` / `## What It Does` / `## Endpoints` / `## Test plan` / generic-template prose; that shape signals a hand-built submission and a likely missing-files PR.
+
+### Signs you've drifted off the canonical path
+
+If you're constructing a new-CLI PR and you notice any of these, stop and route through `/printing-press publish` instead:
+
+- You're writing the PR description from scratch in prose rather than filling in the publish-skill template.
+- You're using `## Summary`, `## Why This Matters`, `## Endpoints`, `## Test plan`, or appending `🤖 Generated with Claude Code` — those are universal-PR-template tells, not publish-skill output.
+- Your validation evidence is a `## Testing` code block with `go build ./...` and a smoke command, instead of the structured `### Validation Results` table.
+- You can't link to manuscripts because there are no `.manuscripts/<run-id>/research/` or `.manuscripts/<run-id>/proofs/` files in the diff.
+- You're hand-editing `cli-skills/pp-<slug>/SKILL.md` or `registry.json`. Both are bot-regenerated; hand-edits get overwritten and create merge conflicts.
+- The PR diff has fewer than ~30 files for a new CLI — the canonical layout always lands dozens of files (`internal/cli/*.go` per endpoint plus `internal/cliutil/`, `internal/client/`, optional `internal/mcp/`, `cmd/<slug>-pp-cli/`, plus the docs/build files). A new-CLI PR with a single `main.go` and a registry edit is missing nearly all of it.
+
+When any of these fire, **the right move is not to fix the PR by adding more sections**. The right move is to drop the hand-built branch, re-enter `/printing-press <api>` (or `/printing-press-publish <slug>` if the CLI is already generated and only the publish step remains), and let the skill open the PR.
+
+### CI gates for new-CLI / reprint shape
+
+The `verify-library-conventions.yml` workflow runs `verify_publish_package.py` on every PR that touches `library/**`. For PRs that **add** a `library/<cat>/<slug>/.printing-press.json` (the classifier for new-CLI submissions), it hard-fails on missing publish artifacts (`.printing-press-patches.json`, `AGENTS.md`, `README.md`, `SKILL.md`, `go.mod`, `.goreleaser.yaml`, `LICENSE`, `NOTICE`, `cmd/<cli_name>/main.go`), missing `.manuscripts/<run-id>/{research,proofs}/`, missing `run_id` / `printer` / `printing_press_version` in the manifest, missing `novel_features`, and missing MCP artifacts (`manifest.json`, `tools-manifest.json`) when MCP is advertised. It also emits advisory notices when the PR body lacks `### Publication Path` or `### Novel Commands`. Don't try to placate the verifier file by file — if it fires, you've drifted off the publish flow; re-run the publish skill.
+
+## Automated code review with Greptile
+
+Every PR against this repo gets an automated review from **Greptile** alongside the verify-* workflows. Greptile posts a top-level summary comment with a **confidence score on a 0-5 scale** (5 = "Production ready", 4 = "Minor polish needed", 3 = "Implementation issues", 2 = "Significant bugs", 0-1 = "Critical problems"), plus inline comments tagged with **P0 / P1 / P2** severity (P0 = must fix before merge, P1 = should fix, P2 = consider fixing) and categorized as Logic / Syntax / Style. Status is shown via 👀 (analyzing) → 👍 (done) or 😕 (failed); Greptile does NOT use GitHub's approve / request-changes flow.
+
+**The bar is 5/5 with zero unresolved comments before merge.** A 4/5 with open P1s is not ready. The score is a triage signal — a high score doesn't mean "merge blindly", it means "no obvious problems found, focus human review where it matters." Treat every P0 and P1 as blocking; P2s require either a fix or a concrete reply explaining why we're deferring.
+
+If you (an agent) opened the PR, you own driving it to 5/5:
+
+1. **Watch for the review.** Greptile posts within a few minutes of PR open or push. Read findings with `gh pr view <PR> --comments`; check the summary comment for the score and the inline threads for P0/P1/P2 tags.
+2. **Address every finding in code or in a reply.** Push fixes when a finding is valid. When you genuinely believe a finding is wrong or out of scope, reply with a concrete reason (not "won't fix" — explain *why* the code is right as written, or *why* the deferral is justified) and ask the thread to be resolved.
+3. **Re-trigger after pushes.** Greptile re-reviews automatically on push. A stuck review can be re-run via the "Re-trigger Greptile" button in the summary comment footer.
+4. **Don't merge with unresolved Greptile threads or a sub-5 score.** If a finding looks like a genuine false positive that won't drop, escalate to a human reviewer on the thread before merging.
+5. **Greptile is configured by `greptile.json` at the repo root.** That config encodes repo-specific rules — manuscript-content judgment for new CLIs, reprint classification, PR title / branch / body shape. Don't disable rules to silence a finding; the rule exists because something burned us. If you believe a rule is mis-firing across the board, file a separate PR amending `greptile.json` with reasoning.
+
+The same expectation applies to non-CLI PRs (CI fixes, bug fixes, doc edits, sweep-canonical runs): drive to 5/5 with no open comments before merge. The strictness is uniform; the rule-set Greptile applies varies with what you touched.
+
 ## Repository layout
 
 ```

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,42 @@
+{
+  "customContext": {
+    "files": [
+      {
+        "scope": ["library/**/.printing-press.json", "library/**", "registry.json", "cli-skills/**"],
+        "path": "AGENTS.md"
+      }
+    ],
+    "rules": [
+      {
+        "scope": ["library/**/.printing-press.json"],
+        "rule": "When this manifest is added, the directory containing it must be named with the slug only — e.g. library/<cat>/<slug>/, never library/<cat>/<slug>-pp-cli/ or library/<cat>/<slug>-pp-mcp/. The -pp-cli / -pp-mcp infix belongs to binary names, not directory names. Flag any directory whose name ends in -pp-cli or -pp-mcp."
+      },
+      {
+        "scope": ["library/**/.printing-press.json"],
+        "rule": "When this manifest is added, it must declare api_name matching the directory slug, cli_name matching cmd/<cli_name>/main.go, a non-empty run_id with a matching .manuscripts/<run_id>/ directory, a printer that is not USER/unknown/changeme, a non-empty printing_press_version, and a non-empty novel_features array. Flag any of these missing on a new submission."
+      },
+      {
+        "scope": ["cli-skills/pp-*/SKILL.md", "registry.json"],
+        "rule": "These files are auto-regenerated post-merge by tools/generate-skills/ and tools/generate-registry/. A PR that hand-edits them in the same change as adding library/<cat>/<slug>/.printing-press.json indicates the author is bypassing the printing-press publish flow. Flag and recommend re-running /printing-press."
+      },
+      {
+        "scope": ["library/**/.printing-press.json"],
+        "rule": "For PRs adding this manifest, the branch name must be exactly feat/<slug> and the PR title must be exactly feat(<slug>): add <slug>. Flag titles like feat(library): add <slug>, feat(<slug>): add <slug> — <description>, branches like add-<slug>, and Co-Authored-By or 🤖 Generated with Claude Code trailers."
+      },
+      {
+        "scope": ["library/**/.printing-press.json"],
+        "rule": "For PRs adding this manifest, the PR body must follow the publish-skill template: ## <slug> heading, **API:** … | **Category:** … | **Press version:** … line, **Spec:** line, ### CLI Shape with --help output, ### What This CLI Does, ### Manuscripts, ### Validation Results table, optionally ### Publication Path / ### Novel Commands / ### Gaps. Flag bodies that use generic ## Summary / ## Why This Matters / ## What It Does / ## Endpoints / ## Test plan templates instead."
+      }
+    ],
+    "other": [
+      {
+        "scope": ["library/**/.manuscripts/**"],
+        "rule": "When a PR adds .manuscripts/<run-id>/research/ and .manuscripts/<run-id>/proofs/ files for a new library/<cat>/<slug>/ directory, judge whether the files contain real research output (API endpoints discussed, generation decisions documented, dogfood/shipcheck evidence with concrete numbers and command output) or whether they are stubs / placeholders / single-paragraph summaries. Stub manuscripts strongly suggest the author hand-built the tree without running the printing-press generator and dropped a sketch into .manuscripts/ to satisfy CI's file-existence check. Flag and recommend re-running /printing-press end-to-end."
+      },
+      {
+        "scope": ["library/**/.printing-press.json"],
+        "rule": "When this manifest is modified (not added) and printing_press_version changed, judge whether the surrounding diff looks like a full reprint (most files in the same library/<cat>/<slug>/ regenerated, fresh .manuscripts/<run-id>/ directory, dogfood-results.json updated) or just a metadata fix (one or two field tweaks only). If the diff looks like a reprint, apply the same expectations as a new-CLI PR: feat/<slug> branch, feat(<slug>): add <slug> title, validation-table-bearing PR body, populated manuscripts. Flag reprints that drop any of these. Do not flag genuine metadata-only fixes."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Tighten the guard rails around new-CLI / reprint PRs so hand-built submissions that bypass the printing-press publish skill are caught before merge.

Recent failures (e.g. PRs #368, #372, #379, #405) arrived with wrong directory layout, missing `.manuscripts/<run-id>/`, free-form bodies in the universal-PR-template shape (`## Summary` / `## Why This Matters` / `## Test plan`), and other deviations from the canonical publish-skill output. Each of these requires a round-trip with the contributor or an outright bounce. This PR adds three layers of defense.

## What Changed

**`AGENTS.md` (+74 lines):** Two new sections.

- *Adding a new CLI or reprinting an existing one — use the Printing Press, not a hand-built PR.* Spells out when the rule applies (new directory, added/replaced `.printing-press.json`, writing canonical foundational files), what to do instead (`/printing-press <api>` for full flow; `/printing-press-publish <slug>` for already-archived CLIs), the canonical PR shape contract (branch / title / directory / files / body sections), drift signals agents can use to self-correct, and a cross-reference to the existing CI gates in `verify_publish_package.py`.
- *Automated code review with Greptile.* Documents Greptile's 0-5 confidence score (5 = "Production ready"), P0/P1/P2 severity tags, Logic/Syntax/Style categorization, 👀/👍/😕 status indicators, and the 5/5-with-zero-comments review bar agents must drive PRs to before merge. Terminology pulled from [Greptile's own docs](https://www.greptile.com/docs/code-review/first-pr-review).

**`greptile.json` (new file at repo root):** Repo-specific Greptile review rules.

- 5 `customContext.rules` entries (deterministic checks): directory-suffix `-pp-cli`/`-pp-mcp` ban, manifest identity invariants, generated-mirror hand-edit detection, PR branch/title shape, PR body shape. All scoped to `library/**/.printing-press.json` so they only fire on new-CLI submissions, not bug-fix PRs.
- 2 `customContext.other` entries (judgment): manuscript-content reality-check (real research output vs stubs/placeholders) and reprint classification (full reprint vs metadata-only fix).
- 1 `customContext.files` reference pointing Greptile at `AGENTS.md` so the convention doc is part of its context.

**`.github/scripts/verify-publish-package/verify_publish_package.py` (+8 lines):** New strict-mode check rejecting directory names ending in `-pp-cli` or `-pp-mcp`. This was the failure mode from PR #368 (`library/government/govprocure-pp-cli/`) and the existing identity check would not have caught it. Two new tests in `verify_publish_package_test.py` cover positive (suffix → fail) and legacy (non-strict → no fail) cases.

## Why This Matters

This is preventive guidance + mechanical CI guard + AI-reviewer rules, layered to match each rule to the right enforcement surface:

- **AGENTS.md** prevents misuse before the PR exists. Zero false-positive cost.
- **`verify_publish_package.py`** is the deterministic CI gate. Triggers only on `library/**/.printing-press.json` ADDED, which is a near-zero-FP classifier (bug fixes don't add manifests; sweep-canonical and `printing-press patch` don't touch them).
- **`greptile.json`** handles the things CI can't reduce to rules: judging whether manuscripts contain real research vs stubs, classifying reprints, and PR-shape critique.

The split keeps each layer doing what it's good at and avoids false-firing on legitimate bug-fix PRs.

## Validation

- [x] `python3 -m unittest verify_publish_package_test` — all 5 tests pass (3 existing + 2 new).
- [x] `python3 -c "import json; json.load(open('greptile.json'))"` — JSON valid.
- [x] Confirmed all 73 existing library directories pass the new `-pp-cli`/`-pp-mcp` suffix check (none currently use those suffixes).

## Gaps / Follow-Up

- Greptile rule effectiveness for the longer judgment-style `other` entries is empirical — Greptile's own docs only show 1-sentence rule examples, so the 2-3-sentence rules here may dilute. Worth watching the first few PRs after merge and tightening if rules misfire or get ignored.
- The reprint classification rule asks Greptile to distinguish "manifest added vs modified" from diff context. Untested — Greptile may or may not have first-class git-diff status access. May silently no-op on reprint PRs; will revisit if so.
- "Canonical PR shape" file list in AGENTS.md and `ROOT_ARTIFACTS` in `verify_publish_package.py` are now two slightly different lists for "what files must be present." A future PR could collapse them to a single source of truth.