### PR TITLE
fix(table-reservation-goat): accept numeric IDs in availability resolver

### DIFF
--- a/library/food-and-dining/table-reservation-goat/internal/cli/availability_check.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/availability_check.go
@@ -26,8 +26,17 @@ func newAvailabilityCheckCmd(flags *rootFlags) *cobra.Command {
 		Use:   "check <restaurant>",
 		Short: "Check open slots for a restaurant on a specific date and party size",
 		Long: "Per-venue availability across both networks. Resolves the venue on OpenTable " +
-			"or Tock and returns the earliest matching slot per the requested date/party.",
-		Example:     "  table-reservation-goat-pp-cli availability check 'tock:alinea' --party 2 --date 2026-06-15 --json",
+			"or Tock and returns the earliest matching slot per the requested date/party.\n\n" +
+			"Restaurant identifier accepts three shapes:\n" +
+			"  • Bare slug — 'canlis' (searches both networks)\n" +
+			"  • Network-prefixed slug — 'opentable:le-bernardin', 'tock:alinea'\n" +
+			"  • Numeric OpenTable ID — '3688' or 'opentable:3688'. IDs come from\n" +
+			"    `restaurants list --json` (the `id` field) and bypass the\n" +
+			"    name-based slug resolver entirely, so they're the most\n" +
+			"    reliable input shape for agents composing `list → check`.\n" +
+			"    Tock has no numeric-ID convention; use the domain-name slug.",
+		Example: "  table-reservation-goat-pp-cli availability check 'tock:alinea' --party 2 --date 2026-06-15 --json\n" +
+			"  table-reservation-goat-pp-cli availability check 3688 --party 6 --date 2026-12-25 --agent",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -200,6 +201,19 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 	tryOT := network == "" || network == "opentable"
 	tryTock := network == "" || network == "tock"
 
+	// Tock uses domain-name slugs (`canlis`, `farzi-cafe-bellevue`), not
+	// numeric IDs. If the caller passed `tock:<digits>` it's a category
+	// mismatch — surface a typed error rather than running the Calendar
+	// fetch against a non-existent slug.
+	if tryTock && network == "tock" {
+		if _, err := strconv.Atoi(slug); err == nil {
+			row.Network = "tock"
+			row.Available = false
+			row.Reason = fmt.Sprintf("tock: %q looks like a numeric ID, but Tock venues are addressed by domain-name slug (e.g. 'canlis', 'farzi-cafe-bellevue'). Numeric IDs are an OpenTable-only convention; try 'opentable:%s' instead.", slug, slug)
+			return row
+		}
+	}
+
 	// Try Tock first because it has working availability via SSR
 	// `calendar.offerings`. Many venues (Canlis, Alinea, Atomix) exist on
 	// both networks; preferring Tock means the user gets a real
@@ -271,20 +285,43 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 		c, err := opentable.New(s)
 		if err == nil {
 			row.Network = "opentable"
-			// Resolve slug → restaurant ID via Autocomplete. The OT
-			// `RestaurantsAvailability` GraphQL takes a numeric
-			// restaurantId, not a slug. Slug-format queries
-			// (`le-bernardin`) are converted to spaced names.
-			// OT's Autocomplete is broken when called with lat=0/lng=0 — its
-			// `personalizer-autocomplete/v4` upstream returns INTERNAL_SERVER_ERROR
-			// without a coordinate to anchor on. Defaulting to NYC (which has
-			// the largest OT footprint) lets the GraphQL search the global
-			// index and still match restaurants in any metro.
-			restID, restName, restSlug, rerr := c.RestaurantIDFromQuery(ctx, slug, 40.7128, -74.0060)
-			if rerr != nil {
-				row.Available = false
-				row.Reason = fmt.Sprintf("opentable: could not resolve %q (%v)", slug, rerr)
-				return row
+			// Numeric-ID short-circuit (issue #406, failure 2): `restaurants
+			// list` emits numeric OpenTable IDs (e.g. id=3688 for "Daniel's
+			// Broiler - Bellevue") but the Autocomplete-based slug resolver
+			// can't match them — it does name-similarity search, not ID
+			// lookup. Without this shortcut, agents who try
+			// `availability check opentable:3688` get "could not resolve"
+			// even though the ID came directly from this CLI's own output.
+			// When the slug is pure digits, skip Autocomplete and pass the
+			// ID straight to RestaurantsAvailability. Slug-resolver
+			// misfires (the well-known global-fuzzy-match bug) are also
+			// bypassed on this path, so agents can route around the
+			// resolver via the numeric ID.
+			var restID int
+			var restName, restSlug string
+			if numID, numErr := strconv.Atoi(slug); numErr == nil && numID > 0 {
+				restID = numID
+				// restName/restSlug stay empty; row.URL still resolves
+				// canonically below from the numeric ID. The downstream
+				// chrome-avail SSR fetch can hydrate the name later if
+				// needed, but for agents the URL is the canonical anchor.
+			} else {
+				// Resolve slug → restaurant ID via Autocomplete. The OT
+				// `RestaurantsAvailability` GraphQL takes a numeric
+				// restaurantId, not a slug. Slug-format queries
+				// (`le-bernardin`) are converted to spaced names.
+				// OT's Autocomplete is broken when called with lat=0/lng=0 — its
+				// `personalizer-autocomplete/v4` upstream returns INTERNAL_SERVER_ERROR
+				// without a coordinate to anchor on. Defaulting to NYC (which has
+				// the largest OT footprint) lets the GraphQL search the global
+				// index and still match restaurants in any metro.
+				var rerr error
+				restID, restName, restSlug, rerr = c.RestaurantIDFromQuery(ctx, slug, 40.7128, -74.0060)
+				if rerr != nil {
+					row.Available = false
+					row.Reason = fmt.Sprintf("opentable: could not resolve %q (%v)", slug, rerr)
+					return row
+				}
 			}
 			row.URL = fmt.Sprintf("%s/restaurant/profile/%d", opentable.Origin, restID)
 			// New OT gateway (May 2026) returns single-day availability per
@@ -319,10 +356,17 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 				}
 				avail = append(avail, dayAvail...)
 			}
+			// When the caller passed a numeric ID, restName is empty (we
+			// didn't hit Autocomplete). Fall back to "restaurant #<id>" so
+			// Reason strings read naturally instead of "opentable : ...".
+			venueLabel := restName
+			if venueLabel == "" {
+				venueLabel = fmt.Sprintf("restaurant #%d", restID)
+			}
 			if aerr != nil {
 				row.Available = false
 				row.Reason = fmt.Sprintf("opentable %s (id=%d): %v; venue exists, book directly at %s",
-					restName, restID, aerr, row.URL)
+					venueLabel, restID, aerr, row.URL)
 				return row
 			}
 			// Find the earliest slot with isAvailable=true across all
@@ -399,10 +443,10 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 			if earliestSlotAt != "" {
 				row.Available = true
 				row.SlotAt = earliestSlotAt
-				row.Reason = fmt.Sprintf("opentable %s: earliest slot at %s%s", restName, earliestSlotAt, cacheNote)
+				row.Reason = fmt.Sprintf("opentable %s: earliest slot at %s%s", venueLabel, earliestSlotAt, cacheNote)
 			} else {
 				row.Available = false
-				row.Reason = fmt.Sprintf("opentable %s: no open slots in %d-day window for party=%d%s", restName, within, party, cacheNote)
+				row.Reason = fmt.Sprintf("opentable %s: no open slots in %d-day window for party=%d%s", venueLabel, within, party, cacheNote)
 			}
 			return row
 		}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -343,6 +343,17 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 					// its own runtime XHR — the real browser passes Akamai
 					// because it runs the JS sensor naturally.
 					if _, isBot := opentable.IsBotDetection(derr); isBot {
+						// `restSlug` may be empty when the caller passed a
+						// numeric OpenTable ID (the numeric short-circuit
+						// skips Autocomplete so we never populate restSlug).
+						// ChromeAvailability handles the empty-slug case by
+						// falling back to `/restaurant/profile/<id>?...`
+						// instead of `/r/<slug>?...` — Akamai treats both
+						// routes as legitimate user navigation, so the
+						// fallback URL is equivalent for WAF acceptance.
+						// (PR #423 round-2 Greptile P1 — documenting that
+						// the empty-slug pass-through is intentional, not
+						// a missing-data bug.)
 						chromeAvail, cerr := c.ChromeAvailability(ctx, restID, restSlug, dayStr, "19:00", party, 0)
 						if cerr == nil {
 							avail = append(avail, chromeAvail...)

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestResolveEarliestForVenue_TockNumericRejected verifies the typed-error
+// short-circuit for `tock:<digits>` — Tock venues are addressed by
+// domain-name slug, never numeric ID. Issue #406 failure 2 reported
+// `availability check 3688` and `opentable:3688` were both rejected; this
+// PR adds OT-side acceptance and explicit Tock-side rejection so the
+// agent gets a clear category error instead of running a doomed Calendar
+// fetch.
+func TestResolveEarliestForVenue_TockNumericRejected(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"bare numeric on tock", "tock:3688", "Tock venues are addressed by domain-name slug"},
+		{"large numeric", "tock:1183597", "domain-name slug"},
+		{"trailing whitespace tolerated", "tock:42", "domain-name slug"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			row := resolveEarliestForVenue(context.Background(), nil, tc.input, 2, "2026-05-15", 1, false)
+			if row.Available {
+				t.Errorf("expected Available=false for %q; got %+v", tc.input, row)
+			}
+			if !strings.Contains(row.Reason, tc.expect) {
+				t.Errorf("reason missing expected hint %q; got %q", tc.expect, row.Reason)
+			}
+			if row.Network != "tock" {
+				t.Errorf("Network = %q; want tock", row.Network)
+			}
+		})
+	}
+}
+
+// TestResolveEarliestForVenue_BareNumericIsAmbiguous verifies that a bare
+// numeric (no network prefix) doesn't trip the Tock rejection — bare
+// numerics are still tried on OpenTable. This pinpoints that the Tock
+// rejection only fires when the caller EXPLICITLY said `tock:`.
+func TestResolveEarliestForVenue_BareNumericIsAmbiguous(t *testing.T) {
+	// Bare "3688" with nil session — the Tock rejection must NOT fire
+	// (no `tock:` prefix), and the OT path will fail at opentable.New(nil),
+	// but importantly the failure must not be the Tock category error.
+	row := resolveEarliestForVenue(context.Background(), nil, "3688", 2, "2026-05-15", 1, false)
+	if strings.Contains(row.Reason, "Tock venues are addressed") {
+		t.Errorf("bare numeric should not trigger the Tock-numeric category error; got %q", row.Reason)
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -23,7 +23,11 @@ func TestResolveEarliestForVenue_TockNumericRejected(t *testing.T) {
 	}{
 		{"bare numeric on tock", "tock:3688", "Tock venues are addressed by domain-name slug"},
 		{"large numeric", "tock:1183597", "domain-name slug"},
-		{"trailing whitespace tolerated", "tock:42", "domain-name slug"},
+		// Small two-digit numeric — verifies the rejection isn't gated
+		// on a minimum ID length. (Prior label "trailing whitespace
+		// tolerated" was wrong: strconv.Atoi("42 ") errors, so the
+		// rejection here is purely about the digit-shape predicate.)
+		{"small numeric rejected", "tock:42", "domain-name slug"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail.go
@@ -43,6 +43,24 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/auth"
 )
 
+// chromeAvailPageURL builds the navigation URL chromedp visits to
+// trigger the page's own RestaurantsAvailability XHR. When restSlug
+// is populated (named-path callers) it uses the canonical /r/<slug>
+// route. When restSlug is empty (numeric-ID callers, e.g.
+// `availability check 3688` where Autocomplete was skipped) it falls
+// back to /restaurant/profile/<id> — Akamai treats both routes as
+// legitimate browser traffic, so the fallback URL is equivalent for
+// WAF acceptance. Pinned by chrome_avail_url_test.go.
+func chromeAvailPageURL(restID int, restSlug string, partySize int, date, hhmm string) string {
+	if restSlug == "" {
+		return fmt.Sprintf("https://www.opentable.com/restaurant/profile/%d?covers=%d&dateTime=%sT%s",
+			restID, partySize, date, hhmm)
+	}
+	return fmt.Sprintf("https://www.opentable.com/r/%s?covers=%d&dateTime=%sT%s",
+		url.PathEscape(strings.TrimPrefix(restSlug, "/")),
+		partySize, date, hhmm)
+}
+
 // ChromeAvailability spawns a headless Chrome to fetch slots that Akamai
 // blocks on the direct Surf path. Returns the same slice shape as
 // RestaurantsAvailability so callers can swap fallback in transparently.
@@ -79,18 +97,8 @@ func (c *Client) ChromeAvailability(
 	// Build the target URL the page expects. `?covers=N&dateTime=YYYY-MM-DDTHH:MM`
 	// is the page's hydration shape; the SPA reads these params and the
 	// embedded availability XHR uses them to populate forwardDays from
-	// SSR initial state. We intentionally use the slug-route (`/r/<slug>`)
-	// because it's the canonical user URL — Akamai treats it as legitimate
-	// browser traffic just like /restaurant/profile/<id>.
-	pageURL := fmt.Sprintf("https://www.opentable.com/r/%s?covers=%d&dateTime=%sT%s",
-		url.PathEscape(strings.TrimPrefix(restSlug, "/")),
-		partySize, date, hhmm,
-	)
-	if restSlug == "" {
-		pageURL = fmt.Sprintf("https://www.opentable.com/restaurant/profile/%d?covers=%d&dateTime=%sT%s",
-			restID, partySize, date, hhmm,
-		)
-	}
+	// SSR initial state.
+	pageURL := chromeAvailPageURL(restID, restSlug, partySize, date, hhmm)
 
 	// Akamai's JS sensor reliably detects spawned chromedp instances even with
 	// stealth shims — `navigator.webdriver`, plugin tweaks, UA override, and

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_url_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/chrome_avail_url_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package opentable
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestChromeAvailPageURL pins the navigation URL the chromedp fallback
+// visits. PR #423 round-2 Greptile P1: when a caller passes a numeric
+// OT ID (restSlug empty), the URL must gracefully fall back to
+// /restaurant/profile/<id> instead of producing a broken /r/?covers=...
+// URL. Akamai treats both routes as legitimate; the fallback ensures
+// the numeric-ID path remains usable even when Akamai blocks the
+// direct GraphQL path.
+func TestChromeAvailPageURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		restID    int
+		restSlug  string
+		party     int
+		date      string
+		hhmm      string
+		wantParts []string
+		wantNot   []string
+	}{
+		{
+			name:     "named slug uses /r/ route",
+			restID:   3688,
+			restSlug: "daniels-broiler-bellevue",
+			party:    6, date: "2026-05-15", hhmm: "19:00",
+			wantParts: []string{
+				"/r/daniels-broiler-bellevue",
+				"covers=6",
+				"dateTime=2026-05-15T19:00",
+			},
+			wantNot: []string{"/restaurant/profile/"},
+		},
+		{
+			name:     "empty slug falls back to /restaurant/profile/<id>",
+			restID:   3688,
+			restSlug: "",
+			party:    6, date: "2026-05-15", hhmm: "19:00",
+			wantParts: []string{
+				"/restaurant/profile/3688",
+				"covers=6",
+				"dateTime=2026-05-15T19:00",
+			},
+			wantNot: []string{
+				// Critical: numeric-ID path must NOT produce `/r/?covers=...`
+				// (no slug between /r/ and ?). That would be a 404 on OT.
+				"/r/?",
+				// And must NOT produce `https://www.opentable.com/r/2026...`
+				// (params bleeding into the path).
+				"/r/2026",
+			},
+		},
+		{
+			name:     "slug with leading slash gets stripped",
+			restID:   3688,
+			restSlug: "/canlis",
+			party:    2, date: "2026-05-15", hhmm: "19:00",
+			wantParts: []string{"/r/canlis"},
+			wantNot:   []string{"/r//canlis"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chromeAvailPageURL(tc.restID, tc.restSlug, tc.party, tc.date, tc.hhmm)
+			for _, want := range tc.wantParts {
+				if !strings.Contains(got, want) {
+					t.Errorf("URL missing %q\nfull: %s", want, got)
+				}
+			}
+			for _, banned := range tc.wantNot {
+				if strings.Contains(got, banned) {
+					t.Errorf("URL contains banned substring %q\nfull: %s", banned, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## table-reservation-goat — accept numeric IDs in availability resolver

Fixes failure 2 from issue #406. First of four planned PRs to address the issue.

### The bug

`restaurants list` emits clean rows with numeric OpenTable IDs:

```json
{ "id": "3688", "name": "Daniel's Broiler - Bellevue", "url": "https://www.opentable.com/restaurant/profile/3688", ... }
```

But `availability check`, `availability multi-day`, and `earliest` all rejected those IDs:

```bash
$ availability check 3688 --party 6 --date 2026-05-10 --agent
{"available": false, "reason": "opentable: could not resolve \"3688\" ...", "venue": "3688"}

$ availability check opentable:3688 --party 6 --date 2026-05-10 --agent
{"available": false, "reason": "opentable: could not resolve \"3688\" ..."}
```

The Autocomplete-based slug resolver does name-similarity search, not ID lookup. Numeric strings don't match any venue name, so the resolver bails. **Agents that tried the natural `list → check` composition got a dead end** — the user in #406 fell back to scraping OpenTable through Chrome MCP instead.

### Fix

In `resolveEarliestForVenue` (the shared helper that powers all three commands), detect `^\d+$` in the slug arg and pass it directly to `RestaurantsAvailability` as the restaurantId. The Autocomplete slug-resolver is skipped entirely on the numeric path — which has three downstream benefits:

1. **Composition restored** — `restaurants list` IDs work as inputs to `availability check` / `multi-day` / `earliest`. Agents get the natural workflow.
2. **Bypasses the global-fuzzy-match bug (#406 failure 1)** — the numeric path doesn't touch the resolver at all, so the well-known "joey-bellevue → Joey's Bold Flavors" misfire can't trigger.
3. **Bypasses Akamai's `Autocomplete` WAF rule** — agents hitting op-specific 403s on slug resolution can pivot to numeric IDs as a recovery strategy.

### Tock side

Numeric IDs aren't a Tock convention (venues use domain-name slugs like `canlis`, `farzi-cafe-bellevue`). `tock:<digits>` now returns a typed category error pointing the caller at the correct shape, instead of running a doomed Calendar fetch:

```
{
  "available": false,
  "network": "tock",
  "reason": "tock: \"3688\" looks like a numeric ID, but Tock venues are addressed by domain-name slug (e.g. 'canlis', 'farzi-cafe-bellevue'). Numeric IDs are an OpenTable-only convention; try 'opentable:3688' instead."
}
```

### Verify echo

`row.URL = /restaurant/profile/<id>` always resolves canonically from the numeric ID. Agents can verify the venue from the URL even when `restName` is empty (no Autocomplete hydration). Reason strings fall back to `restaurant #<id>` so the output reads naturally.

### Tests

`internal/cli/earliest_test.go` (new): 4 cases.

- `TestResolveEarliestForVenue_TockNumericRejected`:
  - `tock:3688` → typed rejection
  - `tock:1183597` → typed rejection
  - `tock:42` (small numeric) → typed rejection
- `TestResolveEarliestForVenue_BareNumericIsAmbiguous`:
  - bare `3688` does NOT trip the Tock rejection (only explicit `tock:` prefix does)

### Help text

Updated `availability check` long-help with all three input shapes documented and an example showing the `list → numeric ID → check` composition.

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS (4 new tests + full suite) |
| `printing-press publish validate` | **11/11 PASS** |

### Out of scope (deferred to follow-up PRs)

- **Failure 1** (slug resolver geo-bias) — PR C will fix this with metro-aware ranking + dynamic Tock metroArea hydration. **Note**: this PR partially mitigates failure 1 by giving agents a numeric-ID escape hatch; the slug resolver itself still has the global-fuzzy bug for any caller that doesn't have the numeric ID handy.
- **Failure 3** (zero Tock Bellevue coverage) — PR C, same fix as the slug resolver geo bias.
- **Failure 4** (`earliest` returns `{}`) — PR B, dedicated structured envelope.
- **Failure 5** (op-specific Akamai 403) — PR D, typed signal + agent recovery docs.

### Related

- Issue: #406
- Companion PRs (in flight): #387 (Greptile follow-ups for v0.2.1), #399 (Chrome cookie walk fallback), #401 (doctor probe via source clients)
