### PR TITLE
fix(table-reservation-goat): earliest — structured envelope vs `{}`

### DIFF
--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -376,7 +376,15 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 	if tryOT {
 		c, err := opentable.New(s)
 		if err == nil {
-			row.Network = "opentable"
+			// NOTE: `row.Network = "opentable"` is deliberately NOT set
+			// here. PR #424 round-3 Greptile finding: setting Network
+			// before slug resolution caused slug-resolve failures to be
+			// miscounted as `meta.resolved` (Network was already
+			// "opentable" when summarizeEarliest's partition ran). The
+			// assignment moves AFTER we have a confirmed valid restID
+			// so the partition correctly categorizes failures as
+			// `meta.unresolved`.
+
 			// Numeric-ID short-circuit (issue #406, failure 2): `restaurants
 			// list` emits numeric OpenTable IDs (e.g. id=3688 for "Daniel's
 			// Broiler - Bellevue") but the Autocomplete-based slug resolver
@@ -410,11 +418,19 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 				var rerr error
 				restID, restName, restSlug, rerr = c.RestaurantIDFromQuery(ctx, slug, 40.7128, -74.0060)
 				if rerr != nil {
+					// Slug-resolve failed. row.Network stays empty so
+					// summarizeEarliest partitions this row into
+					// `unresolved[]` (PR #424 round-3 fix).
 					row.Available = false
 					row.Reason = fmt.Sprintf("opentable: could not resolve %q (%v)", slug, rerr)
 					return row
 				}
 			}
+			// Slug resolution succeeded (numeric path or named path).
+			// Claim the row for OpenTable so downstream partitioning
+			// counts this venue as resolved, even if the subsequent
+			// availability fetch is blocked by Akamai.
+			row.Network = "opentable"
 			row.URL = fmt.Sprintf("%s/restaurant/profile/%d", opentable.Origin, restID)
 			// New OT gateway (May 2026) returns single-day availability per
 			// call (forwardDays=0); scan multi-day windows by looping the

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -48,12 +48,64 @@ type earliestRow struct {
 	Source   string `json:"source,omitempty"`
 }
 
+type earliestMeta struct {
+	// VenuesRequested is the count of input slugs (including duplicates).
+	VenuesRequested int `json:"venues_requested"`
+	// Resolved is the count of slugs that the source-client successfully
+	// mapped to a real network (OpenTable or Tock). Resolved-but-blocked
+	// counts here too — they got past slug→ID resolution, just couldn't
+	// fetch slots.
+	Resolved int `json:"resolved"`
+	// Unresolved is VenuesRequested - Resolved. Issue #406 failure 4:
+	// without this field, a request that resolved zero slugs returned
+	// `{}` (under `--select results.X` with no rows), indistinguishable
+	// from "resolved fine, just no slots open." Surfacing the count
+	// always lets agents branch on the case.
+	Unresolved int `json:"unresolved"`
+	// Available is the count of resolved venues with at least one bookable
+	// slot in the window.
+	Available int `json:"available"`
+}
+
+type unresolvedRow struct {
+	Venue  string `json:"venue"`
+	Reason string `json:"reason,omitempty"`
+}
+
 type earliestResponse struct {
-	Venues    []string      `json:"venues"`
-	Party     int           `json:"party"`
-	Within    int           `json:"within_days"`
-	Results   []earliestRow `json:"results"`
-	QueriedAt string        `json:"queried_at"`
+	Venues     []string        `json:"venues"`
+	Party      int             `json:"party"`
+	Within     int             `json:"within_days"`
+	Meta       earliestMeta    `json:"meta"`
+	Results    []earliestRow   `json:"results"`
+	Unresolved []unresolvedRow `json:"unresolved,omitempty"`
+	QueriedAt  string          `json:"queried_at"`
+}
+
+// summarizeEarliest computes meta + unresolved from the resolved row set.
+// A row is considered "unresolved" when its Network is empty or "unknown" —
+// the resolver short-circuited before assigning a network. Resolved-but-
+// blocked rows (Network set, Available=false, Reason mentions Akamai etc.)
+// stay in Results but don't count toward Available.
+func summarizeEarliest(venues []string, rows []earliestRow) (earliestMeta, []unresolvedRow) {
+	var unresolved []unresolvedRow
+	var resolved, available int
+	for _, r := range rows {
+		if r.Network == "" || r.Network == "unknown" {
+			unresolved = append(unresolved, unresolvedRow{Venue: r.Venue, Reason: r.Reason})
+			continue
+		}
+		resolved++
+		if r.Available {
+			available++
+		}
+	}
+	return earliestMeta{
+		VenuesRequested: len(venues),
+		Resolved:        resolved,
+		Unresolved:      len(unresolved),
+		Available:       available,
+	}, unresolved
 }
 
 // newEarliestCmd computes "soonest open slot per venue across both networks"
@@ -75,8 +127,20 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 		Long: "Across a comma-separated list of restaurant slugs, return the " +
 			"earliest open slot per venue within `--within N days`. Slugs may be " +
 			"network-prefixed (`opentable:le-bernardin`, `tock:alinea`) for " +
-			"explicit routing, otherwise both networks are tried. Use `--tonight` " +
-			"as shorthand for `--date <today> --within 1d`.\n\n" +
+			"explicit routing, otherwise both networks are tried. Numeric IDs " +
+			"from `restaurants list --json` (the `id` field) work as inputs too. " +
+			"Use `--tonight` as shorthand for `--date <today> --within 1d`.\n\n" +
+			"Response shape:\n" +
+			"  • `meta.venues_requested`, `meta.resolved`, `meta.unresolved`, " +
+			"`meta.available` — summary counts always present, regardless of\n" +
+			"    `--select` path, so agents can distinguish \"checked, no\n" +
+			"    slots\" from \"couldn't resolve any input.\"\n" +
+			"  • `results[]` — one row per resolved venue with slot data.\n" +
+			"  • `unresolved[]` — venues that didn't resolve, with reason\n" +
+			"    strings. Empty when all resolve.\n\n" +
+			"Common `--select` paths: `results.venue`, `results.network`,\n" +
+			"`results.slot_at`, `results.bookable_times`, `meta.resolved`,\n" +
+			"`meta.available`, `unresolved.venue`, `unresolved.reason`.\n\n" +
 			"OpenTable availability is cached on disk for 3 minutes by default; " +
 			"pass `--no-cache` (or set `TRG_OT_NO_CACHE=1`) to force a fresh fetch. " +
 			"To route OT traffic through a personal proxy or Tor SOCKS5, set " +
@@ -111,8 +175,10 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 				for _, v := range venues {
 					rows = append(rows, earliestRow{Venue: v, Network: "opentable", Available: false, Reason: "dry-run"})
 				}
+				meta, unresolved := summarizeEarliest(venues, rows)
 				return printJSONFiltered(cmd.OutOrStdout(), earliestResponse{
-					Venues: venues, Party: party, Within: withinDays, Results: rows,
+					Venues: venues, Party: party, Within: withinDays,
+					Meta: meta, Results: rows, Unresolved: unresolved,
 					QueriedAt: time.Now().UTC().Format(time.RFC3339),
 				}, flags)
 			}
@@ -140,8 +206,10 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 				}
 				return rows[i].Venue < rows[j].Venue
 			})
+			meta, unresolved := summarizeEarliest(venues, rows)
 			return printJSONFiltered(cmd.OutOrStdout(), earliestResponse{
-				Venues: venues, Party: party, Within: withinDays, Results: rows,
+				Venues: venues, Party: party, Within: withinDays,
+				Meta: meta, Results: rows, Unresolved: unresolved,
 				QueriedAt: time.Now().UTC().Format(time.RFC3339),
 			}, flags)
 		},

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -73,12 +73,17 @@ type unresolvedRow struct {
 }
 
 type earliestResponse struct {
-	Venues     []string        `json:"venues"`
-	Party      int             `json:"party"`
-	Within     int             `json:"within_days"`
-	Meta       earliestMeta    `json:"meta"`
-	Results    []earliestRow   `json:"results"`
-	Unresolved []unresolvedRow `json:"unresolved,omitempty"`
+	Venues  []string      `json:"venues"`
+	Party   int           `json:"party"`
+	Within  int           `json:"within_days"`
+	Meta    earliestMeta  `json:"meta"`
+	Results []earliestRow `json:"results"`
+	// Unresolved is emitted as `[]` (not omitted) when empty, mirroring
+	// `Results`. Agents checking `"unresolved" in response` would
+	// otherwise see a false negative when ALL venues resolved (key
+	// absent) vs SOME unresolved (key present). Symmetry with Results
+	// keeps the response shape predictable.
+	Unresolved []unresolvedRow `json:"unresolved"`
 	QueriedAt  string          `json:"queried_at"`
 }
 
@@ -87,8 +92,19 @@ type earliestResponse struct {
 // the resolver short-circuited before assigning a network. Resolved-but-
 // blocked rows (Network set, Available=false, Reason mentions Akamai etc.)
 // stay in Results but don't count toward Available.
+//
+// PRECONDITION: callers must pass `rows` produced from `venues` so that
+// `len(rows) == len(venues)` and entries correspond positionally. The
+// invariant `Resolved + Unresolved == VenuesRequested` only holds under
+// this condition; mismatched slices silently produce diverging counts.
+// All current callers (newEarliestCmd's dry-run and live paths) satisfy
+// this by appending one row per input venue in order.
 func summarizeEarliest(venues []string, rows []earliestRow) (earliestMeta, []unresolvedRow) {
-	var unresolved []unresolvedRow
+	// Initialize as empty slice (not nil) so JSON serialization emits
+	// `[]` rather than `null`. Symmetry with Results matters for the
+	// PR #424 Greptile finding — agents checking `"unresolved" in
+	// response` should always see a present key.
+	unresolved := []unresolvedRow{}
 	var resolved, available int
 	for _, r := range rows {
 		if r.Network == "" || r.Network == "unknown" {

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -87,11 +87,18 @@ type earliestResponse struct {
 	QueriedAt  string          `json:"queried_at"`
 }
 
-// summarizeEarliest computes meta + unresolved from the resolved row set.
+// summarizeEarliest partitions the row set into resolved-only Results
+// and unresolved companions, and computes the meta summary alongside.
+//
 // A row is considered "unresolved" when its Network is empty or "unknown" —
 // the resolver short-circuited before assigning a network. Resolved-but-
 // blocked rows (Network set, Available=false, Reason mentions Akamai etc.)
 // stay in Results but don't count toward Available.
+//
+// Partitioning here (rather than passing the raw `rows` to Results)
+// closes the duplication bug Greptile flagged on PR #424 round-2:
+// previously unresolved venues appeared in BOTH the results[] and
+// unresolved[] arrays simultaneously.
 //
 // PRECONDITION: callers must pass `rows` produced from `venues` so that
 // `len(rows) == len(venues)` and entries correspond positionally. The
@@ -99,29 +106,30 @@ type earliestResponse struct {
 // this condition; mismatched slices silently produce diverging counts.
 // All current callers (newEarliestCmd's dry-run and live paths) satisfy
 // this by appending one row per input venue in order.
-func summarizeEarliest(venues []string, rows []earliestRow) (earliestMeta, []unresolvedRow) {
-	// Initialize as empty slice (not nil) so JSON serialization emits
-	// `[]` rather than `null`. Symmetry with Results matters for the
-	// PR #424 Greptile finding — agents checking `"unresolved" in
-	// response` should always see a present key.
+func summarizeEarliest(venues []string, rows []earliestRow) (earliestMeta, []earliestRow, []unresolvedRow) {
+	// Initialize as empty slices (not nil) so JSON serialization emits
+	// `[]` rather than `null`. Symmetry across results + unresolved
+	// matters for the agent contract — both keys should always be
+	// present so consumers can iterate without nil-checks.
+	results := []earliestRow{}
 	unresolved := []unresolvedRow{}
-	var resolved, available int
+	var available int
 	for _, r := range rows {
 		if r.Network == "" || r.Network == "unknown" {
 			unresolved = append(unresolved, unresolvedRow{Venue: r.Venue, Reason: r.Reason})
 			continue
 		}
-		resolved++
+		results = append(results, r)
 		if r.Available {
 			available++
 		}
 	}
 	return earliestMeta{
 		VenuesRequested: len(venues),
-		Resolved:        resolved,
+		Resolved:        len(results),
 		Unresolved:      len(unresolved),
 		Available:       available,
-	}, unresolved
+	}, results, unresolved
 }
 
 // newEarliestCmd computes "soonest open slot per venue across both networks"
@@ -191,10 +199,10 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 				for _, v := range venues {
 					rows = append(rows, earliestRow{Venue: v, Network: "opentable", Available: false, Reason: "dry-run"})
 				}
-				meta, unresolved := summarizeEarliest(venues, rows)
+				meta, results, unresolved := summarizeEarliest(venues, rows)
 				return printJSONFiltered(cmd.OutOrStdout(), earliestResponse{
 					Venues: venues, Party: party, Within: withinDays,
-					Meta: meta, Results: rows, Unresolved: unresolved,
+					Meta: meta, Results: results, Unresolved: unresolved,
 					QueriedAt: time.Now().UTC().Format(time.RFC3339),
 				}, flags)
 			}
@@ -222,10 +230,10 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 				}
 				return rows[i].Venue < rows[j].Venue
 			})
-			meta, unresolved := summarizeEarliest(venues, rows)
+			meta, results, unresolved := summarizeEarliest(venues, rows)
 			return printJSONFiltered(cmd.OutOrStdout(), earliestResponse{
 				Venues: venues, Party: party, Within: withinDays,
-				Meta: meta, Results: rows, Unresolved: unresolved,
+				Meta: meta, Results: results, Unresolved: unresolved,
 				QueriedAt: time.Now().UTC().Format(time.RFC3339),
 			}, flags)
 		},

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -123,7 +123,7 @@ func TestSummarizeEarliest(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			meta, unresolved := summarizeEarliest(tc.venues, tc.rows)
+			meta, results, unresolved := summarizeEarliest(tc.venues, tc.rows)
 			if meta.VenuesRequested != tc.wantRequested {
 				t.Errorf("VenuesRequested = %d; want %d", meta.VenuesRequested, tc.wantRequested)
 			}
@@ -145,6 +145,26 @@ func TestSummarizeEarliest(t *testing.T) {
 				}
 				if unresolved[i].Venue != name {
 					t.Errorf("unresolved[%d].Venue = %q; want %q", i, unresolved[i].Venue, name)
+				}
+			}
+			// PR #424 round-2 Greptile finding: unresolved venues must
+			// NOT appear in both results[] and unresolved[]. Verify the
+			// partition is disjoint.
+			if len(results) != tc.wantResolved {
+				t.Errorf("results len = %d; want %d (must equal Resolved count)", len(results), tc.wantResolved)
+			}
+			for _, r := range results {
+				if r.Network == "" || r.Network == "unknown" {
+					t.Errorf("results[] leaked unresolved venue %q (Network=%q) — partition broken", r.Venue, r.Network)
+				}
+			}
+			unresolvedSet := map[string]bool{}
+			for _, u := range unresolved {
+				unresolvedSet[u.Venue] = true
+			}
+			for _, r := range results {
+				if unresolvedSet[r.Venue] {
+					t.Errorf("venue %q appears in BOTH results[] and unresolved[] — duplication bug", r.Venue)
 				}
 			}
 		})

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -180,3 +180,36 @@ func TestEarliestResponse_JSONShapeContractsMeta(t *testing.T) {
 		}
 	}
 }
+
+// TestEarliestResponse_UnresolvedEmittedWhenEmpty pins the symmetry
+// promise from PR #424's Greptile finding: when all venues resolve,
+// `unresolved` must still emit as `[]` (not absent), matching `results`.
+// Agents using `"unresolved" in response` checks should never see a
+// false-negative due to omitempty.
+func TestEarliestResponse_UnresolvedEmittedWhenEmpty(t *testing.T) {
+	resp := earliestResponse{
+		Venues:     []string{"canlis"},
+		Party:      2,
+		Within:     1,
+		Meta:       earliestMeta{VenuesRequested: 1, Resolved: 1, Available: 1},
+		Results:    []earliestRow{{Venue: "canlis", Network: "tock", Available: true}},
+		Unresolved: nil, // explicitly nil — must still serialize as []
+		QueriedAt:  "2026-05-10T12:00:00Z",
+	}
+	raw, _ := json.Marshal(resp)
+	body := string(raw)
+	if !strings.Contains(body, `"unresolved":null`) && !strings.Contains(body, `"unresolved":[]`) {
+		t.Errorf("unresolved key must always emit when empty; got %s", body)
+	}
+	// More strictly: ensure it's `[]` not `null` so JSON consumers can
+	// iterate without nil-checks. Go marshals a nil slice as `null` by
+	// default, so the calling site (newEarliestCmd) must initialize the
+	// slice to []. Check that contract here by serializing an empty
+	// slice explicitly.
+	resp.Unresolved = []unresolvedRow{}
+	raw, _ = json.Marshal(resp)
+	body = string(raw)
+	if !strings.Contains(body, `"unresolved":[]`) {
+		t.Errorf("empty-slice unresolved should serialize as []; got %s", body)
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -56,5 +57,126 @@ func TestResolveEarliestForVenue_BareNumericIsAmbiguous(t *testing.T) {
 	row := resolveEarliestForVenue(context.Background(), nil, "3688", 2, "2026-05-15", 1, false)
 	if strings.Contains(row.Reason, "Tock venues are addressed") {
 		t.Errorf("bare numeric should not trigger the Tock-numeric category error; got %q", row.Reason)
+	}
+}
+
+// TestSummarizeEarliest covers issue #406 failure 4: zero-resolution
+// requests previously rendered as `{}` (via the --select path), making
+// "couldn't resolve any input" look identical to "checked, no slots."
+// The new meta envelope and unresolved[] always carry the distinction.
+func TestSummarizeEarliest(t *testing.T) {
+	cases := []struct {
+		name                string
+		venues              []string
+		rows                []earliestRow
+		wantRequested       int
+		wantResolved        int
+		wantUnresolved      int
+		wantAvailable       int
+		wantUnresolvedNames []string
+	}{
+		{
+			name:   "all resolved, none available",
+			venues: []string{"canlis", "spinasse"},
+			rows: []earliestRow{
+				{Venue: "canlis", Network: "tock", Available: false, Reason: "tock canlis: no open slots for party=2"},
+				{Venue: "spinasse", Network: "opentable", Available: false, Reason: "opentable spinasse: no open slots in 14-day window for party=2"},
+			},
+			wantRequested: 2, wantResolved: 2, wantUnresolved: 0, wantAvailable: 0,
+		},
+		{
+			name:   "all resolved, all available",
+			venues: []string{"canlis", "alinea"},
+			rows: []earliestRow{
+				{Venue: "canlis", Network: "tock", Available: true, SlotAt: "2026-05-15T17:00"},
+				{Venue: "alinea", Network: "tock", Available: true, SlotAt: "2026-05-15T19:00"},
+			},
+			wantRequested: 2, wantResolved: 2, wantUnresolved: 0, wantAvailable: 2,
+		},
+		{
+			name:   "all unresolved",
+			venues: []string{"daniels-broiler-bellevue", "joey-bellevue"},
+			rows: []earliestRow{
+				{Venue: "daniels-broiler-bellevue", Network: "unknown", Available: false, Reason: "could not resolve venue on OpenTable or Tock"},
+				{Venue: "joey-bellevue", Network: "", Available: false, Reason: "auth error"},
+			},
+			wantRequested: 2, wantResolved: 0, wantUnresolved: 2, wantAvailable: 0,
+			wantUnresolvedNames: []string{"daniels-broiler-bellevue", "joey-bellevue"},
+		},
+		{
+			name:   "mixed: some resolve, some don't, one has slots",
+			venues: []string{"canlis", "fake-venue", "spinasse"},
+			rows: []earliestRow{
+				{Venue: "canlis", Network: "tock", Available: true, SlotAt: "..."},
+				{Venue: "fake-venue", Network: "unknown", Reason: "could not resolve"},
+				{Venue: "spinasse", Network: "opentable", Available: false, Reason: "no slots"},
+			},
+			wantRequested: 3, wantResolved: 2, wantUnresolved: 1, wantAvailable: 1,
+			wantUnresolvedNames: []string{"fake-venue"},
+		},
+		{
+			name:          "empty input",
+			venues:        []string{},
+			rows:          []earliestRow{},
+			wantRequested: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta, unresolved := summarizeEarliest(tc.venues, tc.rows)
+			if meta.VenuesRequested != tc.wantRequested {
+				t.Errorf("VenuesRequested = %d; want %d", meta.VenuesRequested, tc.wantRequested)
+			}
+			if meta.Resolved != tc.wantResolved {
+				t.Errorf("Resolved = %d; want %d", meta.Resolved, tc.wantResolved)
+			}
+			if meta.Unresolved != tc.wantUnresolved {
+				t.Errorf("Unresolved = %d; want %d", meta.Unresolved, tc.wantUnresolved)
+			}
+			if meta.Available != tc.wantAvailable {
+				t.Errorf("Available = %d; want %d", meta.Available, tc.wantAvailable)
+			}
+			if len(unresolved) != len(tc.wantUnresolvedNames) {
+				t.Errorf("unresolved len = %d (%v); want %d (%v)", len(unresolved), unresolved, len(tc.wantUnresolvedNames), tc.wantUnresolvedNames)
+			}
+			for i, name := range tc.wantUnresolvedNames {
+				if i >= len(unresolved) {
+					break
+				}
+				if unresolved[i].Venue != name {
+					t.Errorf("unresolved[%d].Venue = %q; want %q", i, unresolved[i].Venue, name)
+				}
+			}
+		})
+	}
+}
+
+// TestEarliestResponse_JSONShapeContractsMeta verifies that the meta
+// envelope is ALWAYS present in JSON output, even when results is empty.
+// The user's original symptom was `--select results.X` returning `{}` on
+// zero-resolution — the new shape makes meta.* available at the top level
+// so agents can branch on it even when results is filtered out.
+func TestEarliestResponse_JSONShapeContractsMeta(t *testing.T) {
+	resp := earliestResponse{
+		Venues:     []string{"x"},
+		Party:      2,
+		Within:     1,
+		Meta:       earliestMeta{VenuesRequested: 1, Resolved: 0, Unresolved: 1, Available: 0},
+		Results:    []earliestRow{},
+		Unresolved: []unresolvedRow{{Venue: "x", Reason: "could not resolve"}},
+		QueriedAt:  "2026-05-10T12:00:00Z",
+	}
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"meta":`, `"venues_requested":1`, `"resolved":0`, `"unresolved":1`, `"available":0`,
+		`"results":[]`, `"unresolved":[`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("JSON missing %q; got %s", want, body)
+		}
 	}
 }

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest_test.go
@@ -201,35 +201,62 @@ func TestEarliestResponse_JSONShapeContractsMeta(t *testing.T) {
 	}
 }
 
-// TestEarliestResponse_UnresolvedEmittedWhenEmpty pins the symmetry
-// promise from PR #424's Greptile finding: when all venues resolve,
-// `unresolved` must still emit as `[]` (not absent), matching `results`.
-// Agents using `"unresolved" in response` checks should never see a
-// false-negative due to omitempty.
+// TestEarliestResponse_UnresolvedEmittedWhenEmpty pins TWO contracts
+// the meta envelope's promise to agents relies on:
+//
+//  1. JSON marshaling of a nil slice produces `"unresolved":null` (Go
+//     semantics, baseline we explicitly DON'T want).
+//  2. The package contract is: `summarizeEarliest` initializes the
+//     slice to `[]unresolvedRow{}` so the JSON contains
+//     `"unresolved":[]`. Agents calling iterate-without-nil-checks
+//     depend on this contract.
+//
+// Greptile P2 round-2 (PR #424): the prior shape of this test had a
+// misleading comment ("explicitly nil — must still serialize as `[]`")
+// alongside a weak `null || []` assertion. The reality is that a bare
+// nil slice marshals to `null`, NOT `[]` — so the assertion was
+// vacuously true and the comment claimed a guarantee the test didn't
+// enforce.
+//
+// The fix: assert each contract separately, with the right expectation.
 func TestEarliestResponse_UnresolvedEmittedWhenEmpty(t *testing.T) {
-	resp := earliestResponse{
+	// Case 1: a nil slice marshals to "null". This is Go's default
+	// behavior; we explicitly DOCUMENT that we don't rely on it.
+	respNil := earliestResponse{
 		Venues:     []string{"canlis"},
 		Party:      2,
 		Within:     1,
 		Meta:       earliestMeta{VenuesRequested: 1, Resolved: 1, Available: 1},
 		Results:    []earliestRow{{Venue: "canlis", Network: "tock", Available: true}},
-		Unresolved: nil, // explicitly nil — must still serialize as []
+		Unresolved: nil,
 		QueriedAt:  "2026-05-10T12:00:00Z",
 	}
-	raw, _ := json.Marshal(resp)
-	body := string(raw)
-	if !strings.Contains(body, `"unresolved":null`) && !strings.Contains(body, `"unresolved":[]`) {
-		t.Errorf("unresolved key must always emit when empty; got %s", body)
+	rawNil, _ := json.Marshal(respNil)
+	if !strings.Contains(string(rawNil), `"unresolved":null`) {
+		t.Errorf("baseline: nil slice should marshal to null; got %s", string(rawNil))
 	}
-	// More strictly: ensure it's `[]` not `null` so JSON consumers can
-	// iterate without nil-checks. Go marshals a nil slice as `null` by
-	// default, so the calling site (newEarliestCmd) must initialize the
-	// slice to []. Check that contract here by serializing an empty
-	// slice explicitly.
-	resp.Unresolved = []unresolvedRow{}
-	raw, _ = json.Marshal(resp)
-	body = string(raw)
-	if !strings.Contains(body, `"unresolved":[]`) {
-		t.Errorf("empty-slice unresolved should serialize as []; got %s", body)
+
+	// Case 2: an explicit empty slice marshals to `[]`. This is the
+	// contract `summarizeEarliest` enforces — it ALWAYS returns
+	// `[]unresolvedRow{}` (never nil) so JSON consumers iterate
+	// without nil-checks.
+	respEmpty := respNil
+	respEmpty.Unresolved = []unresolvedRow{}
+	rawEmpty, _ := json.Marshal(respEmpty)
+	if !strings.Contains(string(rawEmpty), `"unresolved":[]`) {
+		t.Errorf("contract: empty-slice unresolved must marshal to []; got %s", string(rawEmpty))
+	}
+	if strings.Contains(string(rawEmpty), `"unresolved":null`) {
+		t.Errorf("contract: empty-slice unresolved must NOT marshal as null; got %s", string(rawEmpty))
+	}
+
+	// Case 3: verify summarizeEarliest itself produces the `[]` shape,
+	// not nil. This pins the contract end-to-end at the call site
+	// agents actually depend on.
+	_, _, unresolved := summarizeEarliest([]string{"x"}, []earliestRow{
+		{Venue: "x", Network: "tock", Available: true},
+	})
+	if unresolved == nil {
+		t.Error("summarizeEarliest must return a non-nil unresolved slice (empty []), not nil — agents iterate without nil-checks")
 	}
 }


### PR DESCRIPTION
## table-reservation-goat — `earliest` structured envelope vs `{}`

Fixes failure 4 from issue #406. Second of four planned PRs.

### The bug

```bash
$ earliest 'daniels-broiler-bellevue,joey-bellevue,fogo-de-chao-bellevue,...' \
    --party 6 --within 1d --agent --select earliest.venue,earliest.network,earliest.slot_at
{}
```

`{}` with no envelope, no error. Indistinguishable from "checked, no slots." The reporter couldn't tell whether their 8 slugs failed to resolve, the API was down, or there were genuinely zero slots.

### Two compounding causes

1. **Wrong `--select` path** — the response had `results[]`, not `earliest`. `--select earliest.X` matched nothing and the filter stripped to `{}`. Help text didn't document the response shape.
2. **No structural distinction between "zero resolved" and "resolved but no slots"** — even with the right selector, both rendered as `results: []` (with a `--select` that didn't pull meta out, indistinguishable).

### Fix

Added a `meta` envelope at the top level of `earliestResponse` that always carries summary counts, plus an `unresolved[]` companion to `results[]`:

```json
{
  "venues":     ["daniels-broiler-bellevue", "joey-bellevue", ...],
  "party":      6,
  "within_days": 1,
  "meta": {
    "venues_requested": 8,
    "resolved":         3,
    "unresolved":       5,
    "available":        1
  },
  "results":    [{"venue": "daniels-broiler-bellevue", ...}, ...],
  "unresolved": [{"venue": "joey-bellevue", "reason": "..."}, ...],
  "queried_at": "..."
}
```

A row counts as **unresolved** when its `Network` is empty or `"unknown"` — the slug→ID resolver short-circuited before any source call. Resolved-but-blocked rows (Network set, Available=false, Reason mentions Akamai or no-slots) stay in `results` and count toward `resolved` but not `available`.

Agents can now branch on `meta.resolved == 0` to detect "nothing resolved, try different inputs" distinctly from `meta.available == 0` meaning "checked, no slots."

### Help text

`earliest --help` now enumerates the actual response shape and lists common `--select` paths:

> **Common `--select` paths:** `results.venue`, `results.network`, `results.slot_at`, `results.bookable_times`, `meta.resolved`, `meta.available`, `unresolved.venue`, `unresolved.reason`.

So the next agent that reaches for `--select earliest.X` will check the help and see the right path.

### Tests

`internal/cli/earliest_test.go` grows by 2 new test functions:

- `TestSummarizeEarliest` — 5 sub-cases covering:
  - All resolved, none available
  - All resolved, all available
  - All unresolved
  - Mixed (some resolve, some don't, some available)
  - Empty input
- `TestEarliestResponse_JSONShapeContractsMeta` — pins the JSON-shape invariants the meta envelope is supposed to guarantee (meta always present, venues_requested/resolved/unresolved/available all serialized, results+unresolved arrays present).

### Smoke verify

```bash
$ ./table-reservation-goat-pp-cli earliest 'foo,bar' --party 2 --within 1d --dry-run --agent \
    --select 'results.venue,results.network,meta.resolved,meta.unresolved'
{
  "meta": {"resolved": 2, "unresolved": 0},
  "results": [{"network": "opentable", "venue": "foo"}, {"network": "opentable", "venue": "bar"}]
}
```

The `--select earliest.X` case still produces `{}` (selector engine has no match for `earliest`), but agents reading the help will use the right path.

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS (2 new test functions, 6 new sub-cases; full suite green) |
| `printing-press publish validate` | **11/11 PASS** |
| Live JSON-shape smoke (dry-run) | PASS |

### PR stacking

This PR is **stacked on top of #423** (numeric-ID acceptance). `internal/cli/earliest_test.go` includes both PR A's `TockNumericRejected` / `BareNumericIsAmbiguous` tests and PR B's `SummarizeEarliest` / `JSONShape` tests because the test file as a unit moves together. If #423 lands first, this PR rebases cleanly to a 2-file diff.

If you'd prefer to review them in either order, the changes are conceptually independent — both touch `earliest.go` but in disjoint regions (PR A in the resolver, PR B in the response shape).

### Related

- Issue: #406
- PR A (stacked under this): #423 — numeric IDs in availability resolver
- PR C (planned, stacks above this): dynamic Tock metroArea + slug-resolver geo bias
- PR D (planned): op-specific WAF typed signal + agent recovery docs
