### PR TITLE
fix(table-reservation-goat): geo-aware slug resolution + dynamic Tock metro list

### DIFF
--- a/cli-skills/pp-table-reservation-goat/SKILL.md
+++ b/cli-skills/pp-table-reservation-goat/SKILL.md
@@ -101,6 +101,67 @@ table-reservation-goat-pp-cli which "<capability in your own words>"
 
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
+## Geographic Lookups (Agent Playbook)
+
+The reservation networks index restaurants by metro. `--metro <slug>` is the
+fastest way to constrain a search. Two things to know before composing a query:
+
+**1. Discover the available metros first.** The CLI hydrates the live Tock
+metro list (~248 metros worldwide) and merges it with a US-focused static
+fallback. To see everything available:
+
+```bash
+table-reservation-goat-pp-cli goat --list-metros --agent
+```
+
+Returns `{metros: [{slug, name, lat, lng}], city_hints: {...}, total: N}`. The
+`city_hints` field maps secondary cities (Bellevue, Oakland, Cambridge,
+Brooklyn, etc.) onto the parent metro they're indexed under — useful when a
+user asks about a city that isn't a standalone metro.
+
+**2. Use the city-hint when the user names a secondary city.** Example flow
+for "find me a Bellevue WA reservation":
+
+```bash
+# Bellevue isn't its own metro on either network — it's lumped into Seattle.
+table-reservation-goat-pp-cli goat 'steakhouse' --metro seattle --metro-radius-km 20 --party 6 --agent
+```
+
+`--metro-radius-km 20` (vs the 50km default) constrains the Autocomplete-result
+filter to Bellevue-area venues only, dropping Seattle proper. The CLI will
+return per-row `metro_centroid_distance_km` so you can verify each result is
+actually in the requested geo.
+
+If `--metro <slug>` is rejected as unknown, the error message names the parent
+metro and suggests the right radius:
+
+```
+unknown metro "bellevue" — neither OpenTable nor Tock breaks this out as its
+own metro. Bellevue is lumped under metro "seattle" (centroid 47.6062,
+-122.3321). Try `--metro seattle --metro-radius-km 20` to constrain results
+to Bellevue-area venues, or pass `--latitude 47.6062 --longitude -122.3321`
+directly with a tight `--metro-radius-km`.
+```
+
+**3. Slug suffixes work too.** If you compose a venue slug with a city suffix
+(`joey-bellevue`, `13-coins-bellevue`), the CLI peels the suffix as a metro
+hint and anchors the Autocomplete search at the metro centroid. Wrong-city
+matches (the issue #406 "Joey's Bold Flavors" / Tampa class of failures) are
+geo-filtered out before they reach the response.
+
+**4. When you have a known numeric ID, use it.** `restaurants list` returns
+OpenTable numeric IDs (`id: "3688"` for Daniel's Broiler - Bellevue). Pass
+those directly to `availability check` / `availability multi-day` / `earliest`
+to bypass the slug resolver entirely:
+
+```bash
+table-reservation-goat-pp-cli availability check 3688 --party 6 --date 2026-12-25 --agent
+```
+
+Numeric IDs route through a separate code path that doesn't touch the
+Autocomplete-based resolver, so they're the most reliable input shape when
+the agent already has the ID in hand.
+
 ## Recipes
 
 

--- a/library/food-and-dining/table-reservation-goat/SKILL.md
+++ b/library/food-and-dining/table-reservation-goat/SKILL.md
@@ -101,6 +101,67 @@ table-reservation-goat-pp-cli which "<capability in your own words>"
 
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
+## Geographic Lookups (Agent Playbook)
+
+The reservation networks index restaurants by metro. `--metro <slug>` is the
+fastest way to constrain a search. Two things to know before composing a query:
+
+**1. Discover the available metros first.** The CLI hydrates the live Tock
+metro list (~248 metros worldwide) and merges it with a US-focused static
+fallback. To see everything available:
+
+```bash
+table-reservation-goat-pp-cli goat --list-metros --agent
+```
+
+Returns `{metros: [{slug, name, lat, lng}], city_hints: {...}, total: N}`. The
+`city_hints` field maps secondary cities (Bellevue, Oakland, Cambridge,
+Brooklyn, etc.) onto the parent metro they're indexed under — useful when a
+user asks about a city that isn't a standalone metro.
+
+**2. Use the city-hint when the user names a secondary city.** Example flow
+for "find me a Bellevue WA reservation":
+
+```bash
+# Bellevue isn't its own metro on either network — it's lumped into Seattle.
+table-reservation-goat-pp-cli goat 'steakhouse' --metro seattle --metro-radius-km 20 --party 6 --agent
+```
+
+`--metro-radius-km 20` (vs the 50km default) constrains the Autocomplete-result
+filter to Bellevue-area venues only, dropping Seattle proper. The CLI will
+return per-row `metro_centroid_distance_km` so you can verify each result is
+actually in the requested geo.
+
+If `--metro <slug>` is rejected as unknown, the error message names the parent
+metro and suggests the right radius:
+
+```
+unknown metro "bellevue" — neither OpenTable nor Tock breaks this out as its
+own metro. Bellevue is lumped under metro "seattle" (centroid 47.6062,
+-122.3321). Try `--metro seattle --metro-radius-km 20` to constrain results
+to Bellevue-area venues, or pass `--latitude 47.6062 --longitude -122.3321`
+directly with a tight `--metro-radius-km`.
+```
+
+**3. Slug suffixes work too.** If you compose a venue slug with a city suffix
+(`joey-bellevue`, `13-coins-bellevue`), the CLI peels the suffix as a metro
+hint and anchors the Autocomplete search at the metro centroid. Wrong-city
+matches (the issue #406 "Joey's Bold Flavors" / Tampa class of failures) are
+geo-filtered out before they reach the response.
+
+**4. When you have a known numeric ID, use it.** `restaurants list` returns
+OpenTable numeric IDs (`id: "3688"` for Daniel's Broiler - Bellevue). Pass
+those directly to `availability check` / `availability multi-day` / `earliest`
+to bypass the slug resolver entirely:
+
+```bash
+table-reservation-goat-pp-cli availability check 3688 --party 6 --date 2026-12-25 --agent
+```
+
+Numeric IDs route through a separate code path that doesn't touch the
+Autocomplete-based resolver, so they're the most reliable input shape when
+the agent already has the ID in hand.
+
 ## Recipes
 
 

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -215,6 +215,18 @@ func newEarliestCmd(flags *rootFlags) *cobra.Command {
 				startDate = time.Now().Format("2006-01-02")
 			}
 			ctx := cmd.Context()
+
+			// Hydrate the metro registry from Tock's metroArea SSR so
+			// slug-suffix inference inside resolveOTSlugGeoAware can
+			// resolve the full 248-metro dynamic list (vs the 20-entry
+			// static fallback). Cached 24h on disk; first call ~200ms,
+			// subsequent calls <1ms. Silent on failure — falls back to
+			// static. (PR #425 round-2 Greptile finding: this call
+			// existed on the goat path but was missing here, so
+			// `earliest 'joey-bellevue'` couldn't infer the bellevue
+			// suffix on a fresh install.)
+			hydrateMetrosFromTock(ctx, session)
+
 			rows := make([]earliestRow, 0, len(venues))
 			for _, v := range venues {
 				row := resolveEarliestForVenue(ctx, session, v, party, startDate, withinDays, noCache)

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -406,17 +406,23 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 				// chrome-avail SSR fetch can hydrate the name later if
 				// needed, but for agents the URL is the canonical anchor.
 			} else {
-				// Resolve slug → restaurant ID via Autocomplete. The OT
-				// `RestaurantsAvailability` GraphQL takes a numeric
-				// restaurantId, not a slug. Slug-format queries
-				// (`le-bernardin`) are converted to spaced names.
-				// OT's Autocomplete is broken when called with lat=0/lng=0 — its
-				// `personalizer-autocomplete/v4` upstream returns INTERNAL_SERVER_ERROR
-				// without a coordinate to anchor on. Defaulting to NYC (which has
-				// the largest OT footprint) lets the GraphQL search the global
-				// index and still match restaurants in any metro.
-				var rerr error
-				restID, restName, restSlug, rerr = c.RestaurantIDFromQuery(ctx, slug, 40.7128, -74.0060)
+				// Resolve slug → restaurant ID. Issue #406 failure 1: the
+				// previous resolver called RestaurantIDFromQuery directly,
+				// which picks the first Autocomplete hit by name — so
+				// `joey-bellevue` resolved to "Joey's Bold Flavors"
+				// (Tampa, FL) because the `-bellevue` suffix was dropped
+				// on the floor. resolveOTSlugGeoAware detects the city
+				// suffix, anchors Autocomplete on the inferred metro's
+				// centroid, and picks the geo-closest in-radius match.
+				// When no city suffix is detected, falls through to the
+				// existing RestaurantIDFromQuery behavior (NYC anchor).
+				var (
+					rerr      error
+					metroUsed Metro
+				)
+				restID, restName, restSlug, metroUsed, rerr = resolveOTSlugGeoAware(
+					ctx, c, slug, 40.7128, -74.0060, defaultMetroRadiusKm,
+				)
 				if rerr != nil {
 					// Slug-resolve failed. row.Network stays empty so
 					// summarizeEarliest partitions this row into
@@ -425,6 +431,7 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 					row.Reason = fmt.Sprintf("opentable: could not resolve %q (%v)", slug, rerr)
 					return row
 				}
+				_ = metroUsed // hooks into future per-row geo annotation
 			}
 			// Slug resolution succeeded (numeric path or named path).
 			// Claim the row for OpenTable so downstream partitioning

--- a/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter.go
@@ -219,12 +219,16 @@ func resolveOTSlugGeoAware(
 	}
 
 	// Pick the closest. Stable: name tiebreak.
+	// PR #425 round-2 Greptile P2: rename loop variable from `c` to
+	// `cand` so it doesn't shadow the outer `c *opentable.Client`
+	// parameter. The shadow was non-functional (different types) but
+	// reading the code is easier with distinct names.
 	best := inRadius[0]
-	for _, c := range inRadius[1:] {
-		if c.distKm < best.distKm {
-			best = c
-		} else if c.distKm == best.distKm && c.name < best.name {
-			best = c
+	for _, cand := range inRadius[1:] {
+		if cand.distKm < best.distKm {
+			best = cand
+		} else if cand.distKm == best.distKm && cand.name < best.name {
+			best = cand
 		}
 	}
 	return best.id, best.name, best.slug, metro, nil

--- a/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter.go
@@ -1,0 +1,272 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+// PATCH: scaffold-endpoint-redirects — issue #406 failure 1.
+//
+// Geo-aware ranking for cross-network search results.
+//
+// Background: OpenTable's Autocomplete returns the closest fuzzy match
+// to a query term anywhere in the world, scored by name similarity
+// only. When an agent passes a city-suffixed slug like `joey-bellevue`,
+// Autocomplete returns "Joey's Bold Flavors" (Tampa, FL) because the
+// first-token match scores well — and our CLI surfaced that as if it
+// were the Bellevue venue. Result: agents got "available" for the
+// wrong venue, with no way to know.
+//
+// Fix shape: when a metro centroid is set (either via explicit `--metro`
+// or inferred from a slug suffix), compute haversine distance per
+// result. Drop or demote results beyond a radius threshold based on
+// whether the metro was explicit (hard reject) or inferred (soft
+// demote — caller can see the low score and decide).
+//
+// This file holds the pure-function pieces (haversine math, slug-suffix
+// inference, score adjustment). The wiring into goat/earliest lives in
+// those command files so each can tune the policy independently.
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/opentable"
+)
+
+// defaultMetroRadiusKm is the cutoff for "this venue is in the metro."
+// 50km covers most metro areas including their suburbs (e.g., a
+// Bellevue, WA venue is ~13km from Seattle's centroid; LA spans ~50km
+// on its longest axis). Tunable per-invocation via --metro-radius-km.
+const defaultMetroRadiusKm = 50.0
+
+// metroFilterMode controls how the filter handles results outside the
+// radius. Issue #406 brainstorm conclusion: hard-reject when the user
+// EXPLICITLY set `--metro`, soft-demote when we INFERRED it from a
+// slug suffix. Hard-reject is honest about confident intent; soft-
+// demote preserves "show me everything" when the geo hint was a
+// best-effort inference we might have gotten wrong.
+type metroFilterMode int
+
+const (
+	// metroFilterOff disables geo filtering. Used when no centroid is
+	// set (no --metro, no slug suffix, no lat/lng).
+	metroFilterOff metroFilterMode = iota
+
+	// metroFilterHardReject drops results outside the radius. Used when
+	// the user explicitly passed `--metro <slug>`.
+	metroFilterHardReject
+
+	// metroFilterSoftDemote keeps results but multiplies their match
+	// score by a small constant so they sort to the bottom. Used when
+	// the metro was inferred from a slug suffix.
+	metroFilterSoftDemote
+)
+
+// softDemoteFactor is multiplied into match_score for results outside
+// the radius under soft-demote mode. 0.1 means a baseline 0.95-match
+// venue ends up at 0.095 — clearly below any in-radius venue's score,
+// but still visible to the agent.
+const softDemoteFactor = 0.1
+
+// haversineKm returns the great-circle distance in kilometers between
+// two lat/lng points using the standard haversine formula. Radius
+// 6371 km is mean Earth radius — accurate to ~0.5% which is plenty
+// for metro filtering (a 50km threshold tolerates ~250m of slop).
+func haversineKm(lat1, lng1, lat2, lng2 float64) float64 {
+	const earthRadiusKm = 6371.0
+	rad := math.Pi / 180.0
+	dLat := (lat2 - lat1) * rad
+	dLng := (lng2 - lng1) * rad
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(lat1*rad)*math.Cos(lat2*rad)*
+			math.Sin(dLng/2)*math.Sin(dLng/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return earthRadiusKm * c
+}
+
+// inferMetroFromSlug tries to detect a city-suffix in a user-supplied
+// slug. Issue #406 failure 1: agents compose slugs like `joey-bellevue`,
+// `13-coins-bellevue` to disambiguate by city — without this inference
+// the suffix is dropped on the floor and the resolver returns wrong-
+// city matches.
+//
+// Strategy: walk the slug from end to start, peeling off hyphen-
+// separated tokens. For each suffix of 1-3 tokens, try the registry.
+// Returns the matched Metro + the prefix (slug-minus-suffix) so
+// callers can use the prefix as the actual search term. Returns
+// ok=false when no suffix maps to a known metro.
+func inferMetroFromSlug(slug string, reg MetroRegistry) (m Metro, prefix string, ok bool) {
+	tokens := strings.Split(slug, "-")
+	// Try longer suffixes first so "new-york-city" wins over the
+	// substring "city" / "york".
+	for suffixLen := 3; suffixLen >= 1; suffixLen-- {
+		if suffixLen > len(tokens) {
+			continue
+		}
+		suffix := strings.Join(tokens[len(tokens)-suffixLen:], "-")
+		if metro, found := reg.Lookup(suffix); found {
+			prefixTokens := tokens[:len(tokens)-suffixLen]
+			return metro, strings.Join(prefixTokens, "-"), true
+		}
+	}
+	return Metro{}, slug, false
+}
+
+// resolveOTSlugGeoAware is the geo-aware replacement for the bare
+// opentable.Client.RestaurantIDFromQuery call site in
+// resolveEarliestForVenue. Issue #406 failure 1 root cause:
+// RestaurantIDFromQuery picks the FIRST Autocomplete result whose name
+// matches the query — so `joey-bellevue` resolves to "Joey's Bold
+// Flavors" (Tampa) because it scores well on first-token match. The
+// `-bellevue` city suffix is dropped on the floor.
+//
+// This function:
+//  1. Detects a city suffix in the slug. If present, peels it off and
+//     uses the metro's centroid as the Autocomplete coordinate hint.
+//  2. Calls Autocomplete directly (bypassing RestaurantIDFromQuery's
+//     first-match-wins logic).
+//  3. Among candidates whose name actually matches the prefix, picks
+//     the one CLOSEST to the metro centroid — not the highest-scoring
+//     by name alone.
+//  4. Hard-rejects candidates beyond the radius.
+//
+// When no city suffix is detected, falls back to the existing
+// RestaurantIDFromQuery behavior via opentable.Client.
+func resolveOTSlugGeoAware(
+	ctx context.Context,
+	c *opentable.Client,
+	slug string,
+	defaultLat, defaultLng float64,
+	radiusKm float64,
+) (restID int, restName, restSlug string, metroUsed Metro, err error) {
+	if radiusKm <= 0 {
+		radiusKm = defaultMetroRadiusKm
+	}
+	reg := getRegistry()
+	metro, prefix, found := inferMetroFromSlug(slug, reg)
+	if !found {
+		// No city suffix — fall back to the existing resolver path.
+		id, name, urlSlug, fallbackErr := c.RestaurantIDFromQuery(ctx, slug, defaultLat, defaultLng)
+		return id, name, urlSlug, Metro{}, fallbackErr
+	}
+
+	// City suffix detected. Use the metro centroid as the Autocomplete
+	// coordinate hint and search by the prefix.
+	q := strings.ReplaceAll(strings.ToLower(prefix), "-", " ")
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return 0, "", "", metro,
+			fmt.Errorf("slug %q is just a city suffix with no venue prefix", slug)
+	}
+
+	results, autoErr := c.Autocomplete(ctx, q, metro.Lat, metro.Lng)
+	if autoErr != nil {
+		return 0, "", "", metro, autoErr
+	}
+
+	// Walk candidates. Keep only Restaurant entries whose name matches
+	// the prefix on full-substring OR first-token. Among those, pick
+	// the one closest to the metro centroid. Hard-reject everything
+	// beyond radius.
+	type candidate struct {
+		id     int
+		name   string
+		slug   string
+		distKm float64
+	}
+	var inRadius []candidate
+	for _, r := range results {
+		if r.Type != "Restaurant" {
+			continue
+		}
+		nameLower := strings.ToLower(r.Name)
+		match := strings.Contains(nameLower, q) || strings.Contains(q, nameLower)
+		if !match {
+			tokens := strings.Fields(q)
+			if len(tokens) == 0 || !strings.Contains(nameLower, tokens[0]) {
+				continue
+			}
+		}
+		var idInt int
+		fmt.Sscanf(r.ID, "%d", &idInt)
+		if idInt == 0 {
+			continue
+		}
+		// If venue lat/lng is missing, skip — we can't make a geo
+		// judgement, and including it risks the wrong-city symptom.
+		if r.Latitude == 0 && r.Longitude == 0 {
+			continue
+		}
+		dist := haversineKm(metro.Lat, metro.Lng, r.Latitude, r.Longitude)
+		if dist > radiusKm {
+			continue
+		}
+		inRadius = append(inRadius, candidate{
+			id:     idInt,
+			name:   r.Name,
+			slug:   r.URLSlug,
+			distKm: dist,
+		})
+	}
+
+	if len(inRadius) == 0 {
+		return 0, "", "", metro, fmt.Errorf(
+			"no %q venue found in metro %q within %.0fkm of (%.4f, %.4f) — "+
+				"the slug suffix appears to be a city hint, but no matching "+
+				"restaurant resolved there; try `restaurants list --query %q --metro %s` "+
+				"to discover the correct slug or numeric ID",
+			q, metro.Slug, radiusKm, metro.Lat, metro.Lng, q, metro.Slug)
+	}
+
+	// Pick the closest. Stable: name tiebreak.
+	best := inRadius[0]
+	for _, c := range inRadius[1:] {
+		if c.distKm < best.distKm {
+			best = c
+		} else if c.distKm == best.distKm && c.name < best.name {
+			best = c
+		}
+	}
+	return best.id, best.name, best.slug, metro, nil
+}
+
+// applyGeoFilter mutates a slice of goatResult according to the
+// configured mode + centroid. Returns the post-filter slice (which
+// may be shorter under hard-reject, same length under soft-demote).
+// Also annotates each row with the computed distance in km so agents
+// can see why a row was kept/dropped.
+func applyGeoFilter(results []goatResult, centroid Metro, radiusKm float64, mode metroFilterMode) []goatResult {
+	if mode == metroFilterOff || (centroid.Lat == 0 && centroid.Lng == 0) {
+		return results
+	}
+	if radiusKm <= 0 {
+		radiusKm = defaultMetroRadiusKm
+	}
+	out := results[:0]
+	for _, r := range results {
+		// Results with no lat/lng (Tock SSR sometimes omits Location
+		// for newly-listed venues) bypass the filter — we can't make a
+		// geo judgement on missing data.
+		if r.Latitude == 0 && r.Longitude == 0 {
+			out = append(out, r)
+			continue
+		}
+		dist := haversineKm(centroid.Lat, centroid.Lng, r.Latitude, r.Longitude)
+		r.MetroCentroidDistanceKm = dist
+		if dist <= radiusKm {
+			out = append(out, r)
+			continue
+		}
+		switch mode {
+		case metroFilterHardReject:
+			// Drop entirely.
+			continue
+		case metroFilterSoftDemote:
+			r.MatchScore *= softDemoteFactor
+			out = append(out, r)
+		default:
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/geo_filter_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"math"
+	"testing"
+)
+
+// TestHaversineKm pins the math against well-known distance pairs.
+// Allows ~1% tolerance because the haversine formula assumes a
+// spherical Earth (the real shape is an oblate spheroid).
+func TestHaversineKm(t *testing.T) {
+	cases := []struct {
+		name         string
+		lat1, lng1   float64
+		lat2, lng2   float64
+		wantKm       float64
+		tolerancePct float64
+	}{
+		// Seattle ↔ Bellevue WA — the exact failure case from #406.
+		// Reference: 13 km via straight-line distance.
+		{"seattle ↔ bellevue WA", 47.6062, -122.3321, 47.6101, -122.2015, 9.8, 5.0},
+		// Seattle ↔ NYC — 3850 km. Verifies sign handling and long-range
+		// accuracy.
+		{"seattle ↔ nyc", 47.6062, -122.3321, 40.7589, -73.9851, 3850, 1.0},
+		// SF ↔ LA — 558 km.
+		{"sf ↔ la", 37.7749, -122.4194, 34.0522, -118.2437, 558, 1.0},
+		// Same point — 0 km.
+		{"identity", 47.6062, -122.3321, 47.6062, -122.3321, 0, 0.1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := haversineKm(tc.lat1, tc.lng1, tc.lat2, tc.lng2)
+			if tc.tolerancePct == 0 {
+				if got != tc.wantKm {
+					t.Errorf("got %.3f km; want exactly %.3f km", got, tc.wantKm)
+				}
+				return
+			}
+			tol := tc.wantKm * tc.tolerancePct / 100.0
+			if tc.wantKm == 0 {
+				tol = 0.001
+			}
+			if math.Abs(got-tc.wantKm) > tol {
+				t.Errorf("got %.3f km; want %.3f km ±%.2f%%", got, tc.wantKm, tc.tolerancePct)
+			}
+		})
+	}
+}
+
+// TestInferMetroFromSlug_ExactMatch covers the typical case from #406:
+// agent composes `joey-bellevue` and we need to peel the `bellevue`
+// suffix as the metro hint.
+func TestInferMetroFromSlug_ExactMatch(t *testing.T) {
+	// Seed registry with bellevue dynamically (not in static fallback).
+	defer setDynamicMetros(nil, 0)
+	setDynamicMetros([]Metro{
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6101, Lng: -122.2015},
+	}, 100)
+
+	reg := getRegistry()
+	cases := []struct {
+		input      string
+		wantMetro  string
+		wantPrefix string
+	}{
+		{"joey-bellevue", "bellevue", "joey"},
+		{"13-coins-bellevue", "bellevue", "13-coins"},
+		{"daniels-broiler-bellevue", "bellevue", "daniels-broiler"},
+		// Multi-token suffixes: "new-york-city" must beat "city" or "york".
+		{"katz-new-york-city", "new-york-city", "katz"},
+		// Alias (sf) as suffix → resolves via alias chain.
+		{"tartine-sf", "san-francisco", "tartine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			m, prefix, ok := inferMetroFromSlug(tc.input, reg)
+			if !ok {
+				t.Fatalf("expected match for %q; got !ok", tc.input)
+			}
+			if m.Slug != tc.wantMetro {
+				t.Errorf("metro slug = %q; want %q", m.Slug, tc.wantMetro)
+			}
+			if prefix != tc.wantPrefix {
+				t.Errorf("prefix = %q; want %q", prefix, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestInferMetroFromSlug_NoMatch verifies we don't false-positive on
+// slugs that happen to end in a token resembling a city. Agents using
+// `wild-ginger` (no city suffix) should NOT trigger inference.
+func TestInferMetroFromSlug_NoMatch(t *testing.T) {
+	reg := getRegistry()
+	cases := []string{
+		"wild-ginger", // bare venue name, no city suffix
+		"canlis",      // single-token slug
+		"foo-bar-baz", // no token matches any metro
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, prefix, ok := inferMetroFromSlug(in, reg)
+			if ok {
+				t.Errorf("inferMetroFromSlug(%q) returned ok=true unexpectedly", in)
+			}
+			if prefix != in {
+				t.Errorf("prefix on no-match should be input %q; got %q", in, prefix)
+			}
+		})
+	}
+}
+
+// TestApplyGeoFilter_HardReject verifies hard-reject mode drops
+// results beyond the radius. The user's `joey-bellevue` case from
+// #406 maps to: query for Bellevue venues, get a Tampa result back,
+// drop it.
+func TestApplyGeoFilter_HardReject(t *testing.T) {
+	bellevue := Metro{Slug: "bellevue", Name: "Bellevue", Lat: 47.6101, Lng: -122.2015}
+	results := []goatResult{
+		// Real Bellevue venue
+		{Name: "Daniel's Broiler - Bellevue", Latitude: 47.6181, Longitude: -122.2007, MatchScore: 0.95},
+		// JOEY Bellevue (real Bellevue, slightly outside city center)
+		{Name: "JOEY Bellevue", Latitude: 47.6149, Longitude: -122.1959, MatchScore: 0.95},
+		// Tampa, FL — the #406 wrong-city match
+		{Name: "Joey's Bold Flavors", Latitude: 27.9506, Longitude: -82.4572, MatchScore: 0.65},
+		// NYC — another wrong-city
+		{Name: "Wildair", Latitude: 40.7128, Longitude: -74.0060, MatchScore: 0.65},
+	}
+	got := applyGeoFilter(results, bellevue, 50.0, metroFilterHardReject)
+	if len(got) != 2 {
+		t.Fatalf("got %d in-radius results; want 2", len(got))
+	}
+	names := []string{got[0].Name, got[1].Name}
+	for _, want := range []string{"Daniel's Broiler - Bellevue", "JOEY Bellevue"} {
+		found := false
+		for _, n := range names {
+			if n == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("real Bellevue venue %q dropped; results: %v", want, names)
+		}
+	}
+	// Verify distance is annotated on kept rows.
+	if got[0].MetroCentroidDistanceKm <= 0 {
+		t.Errorf("MetroCentroidDistanceKm should be set on kept rows; got %v", got[0].MetroCentroidDistanceKm)
+	}
+}
+
+// TestApplyGeoFilter_SoftDemote verifies soft-demote mode keeps far
+// results but slashes their match_score so they sort to the bottom.
+// Issue #406 brainstorm: this is the inferred-metro path — we don't
+// know for sure the user meant Bellevue, so we keep the results
+// visible but make the geo mismatch loud in the score.
+func TestApplyGeoFilter_SoftDemote(t *testing.T) {
+	bellevue := Metro{Slug: "bellevue", Name: "Bellevue", Lat: 47.6101, Lng: -122.2015}
+	results := []goatResult{
+		{Name: "JOEY Bellevue", Latitude: 47.6149, Longitude: -122.1959, MatchScore: 0.95},
+		{Name: "Joey's Bold Flavors (Tampa)", Latitude: 27.9506, Longitude: -82.4572, MatchScore: 0.65},
+	}
+	got := applyGeoFilter(results, bellevue, 50.0, metroFilterSoftDemote)
+	if len(got) != 2 {
+		t.Fatalf("got %d results; want 2 (no drops in soft-demote)", len(got))
+	}
+	if got[1].MatchScore >= 0.5 {
+		t.Errorf("far result score = %.3f; want demoted (well below 0.5)", got[1].MatchScore)
+	}
+	if got[0].MatchScore != 0.95 {
+		t.Errorf("near result score should be untouched; got %.3f", got[0].MatchScore)
+	}
+}
+
+// TestApplyGeoFilter_PreservesNoLatLngRows verifies results missing
+// lat/lng aren't dropped — we can't make a geo judgement on missing
+// data. Common for newly-listed Tock venues.
+func TestApplyGeoFilter_PreservesNoLatLngRows(t *testing.T) {
+	bellevue := Metro{Slug: "bellevue", Name: "Bellevue", Lat: 47.6101, Lng: -122.2015}
+	results := []goatResult{
+		{Name: "Venue with no geo", Latitude: 0, Longitude: 0, MatchScore: 0.95},
+	}
+	got := applyGeoFilter(results, bellevue, 50.0, metroFilterHardReject)
+	if len(got) != 1 {
+		t.Errorf("no-geo row dropped; got %d rows", len(got))
+	}
+}
+
+// TestApplyGeoFilter_OffMode verifies metroFilterOff is a true pass-
+// through — no row mutation, no drops.
+func TestApplyGeoFilter_OffMode(t *testing.T) {
+	results := []goatResult{
+		{Name: "X", Latitude: 1, Longitude: 1, MatchScore: 0.95},
+		{Name: "Y", Latitude: 50, Longitude: 50, MatchScore: 0.4},
+	}
+	got := applyGeoFilter(results, Metro{}, 50.0, metroFilterOff)
+	if len(got) != 2 {
+		t.Errorf("off mode should preserve all rows; got %d", len(got))
+	}
+	if got[0].MetroCentroidDistanceKm != 0 || got[1].MetroCentroidDistanceKm != 0 {
+		t.Error("off mode should NOT annotate distance")
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/goat.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/goat.go
@@ -36,6 +36,11 @@ type goatResult struct {
 	Longitude    float64 `json:"longitude,omitempty"`
 	URL          string  `json:"url,omitempty"`
 	MatchScore   float64 `json:"match_score"`
+	// MetroCentroidDistanceKm is populated by applyGeoFilter when a metro
+	// centroid is set. Agents can use this to verify a result is actually
+	// in the expected metro (issue #406 failure 1: wrong-city venues
+	// previously surfaced as "available" with no geo context).
+	MetroCentroidDistanceKm float64 `json:"metro_centroid_distance_km,omitempty"`
 }
 
 type goatResponse struct {
@@ -52,13 +57,15 @@ type goatResponse struct {
 // single command an agent should reach for when asked to find a table.
 func newGoatCmd(flags *rootFlags) *cobra.Command {
 	var (
-		latitude  float64
-		longitude float64
-		metro     string
-		network   string
-		limit     int
-		party     int
-		when      string
+		latitude      float64
+		longitude     float64
+		metro         string
+		network       string
+		limit         int
+		party         int
+		when          string
+		metroRadiusKm float64
+		listMetros    bool
 	)
 	cmd := &cobra.Command{
 		Use:     "goat <query>",
@@ -70,21 +77,63 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 		},
 		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Hydrate the metro registry from Tock's metroArea SSR
+			// before resolving --metro. Cached for 24h on disk so this
+			// is free after the first call. Silent on failure — falls
+			// back to the 20-entry static registry. (issue #406 failure 3)
+			//
+			// Loaded here (not in init) so it benefits from the active
+			// auth.Session and respects ctx cancellation. Runs ahead of
+			// --list-metros / args check so the dumped registry includes
+			// the dynamic 250-metro list when available.
+			if loadedSession, sessErr := auth.Load(); sessErr == nil {
+				hydrateMetrosFromTock(ctx, loadedSession)
+			}
+
+			// --list-metros: dump the full hydrated registry as JSON
+			// and exit. Agents can enumerate available --metro values
+			// without parsing the on-disk cache file. Issue #406:
+			// agents need a programmatic way to discover whether a
+			// target city (like Bellevue WA) is a standalone metro or
+			// rolled into a parent.
+			if listMetros {
+				return printJSONFiltered(cmd.OutOrStdout(), metroListResponse{
+					Metros:    getRegistry().All(),
+					Total:     len(getRegistry().All()),
+					CityHints: cityHints,
+					QueriedAt: time.Now().UTC().Format(time.RFC3339),
+				}, flags)
+			}
+
 			if len(args) == 0 {
 				return cmd.Help()
 			}
 			query := strings.Join(args, " ")
+
 			// `--metro <slug>` resolves to lat/lng for autocomplete unless
 			// explicit lat/lng is provided. Without this, queries without
 			// geo defaulted to NYC midtown (40.7589, -73.9851) — so
 			// `goat 'tasting menu' --metro seattle` previously returned
 			// New York results.
-			if metro != "" && latitude == 0 && longitude == 0 {
-				if lat, lng, ok := metroLatLng(metro); ok {
-					latitude, longitude = lat, lng
-				} else {
-					return fmt.Errorf("unknown metro %q (known: %s)", metro, strings.Join(knownMetros(), ", "))
+			var metroCentroid Metro
+			filterMode := metroFilterOff
+			if metro != "" {
+				m, ok := getRegistry().Lookup(metro)
+				if !ok {
+					return fmt.Errorf("%s", formatUnknownMetroError(metro))
 				}
+				if latitude == 0 && longitude == 0 {
+					latitude, longitude = m.Lat, m.Lng
+				}
+				metroCentroid = m
+				filterMode = metroFilterHardReject
+			} else if latitude != 0 || longitude != 0 {
+				// Explicit lat/lng without --metro: hard-reject mode using
+				// the provided centroid as the anchor.
+				metroCentroid = Metro{Lat: latitude, Lng: longitude}
+				filterMode = metroFilterHardReject
 			}
 			if dryRunOK(flags) {
 				return printJSONFiltered(cmd.OutOrStdout(), goatResponse{
@@ -96,7 +145,6 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 					QueriedAt: time.Now().UTC().Format(time.RFC3339),
 				}, flags)
 			}
-			ctx := cmd.Context()
 			session, err := auth.Load()
 			if err != nil {
 				return fmt.Errorf("loading session: %w", err)
@@ -130,6 +178,10 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 					results = append(results, tockRes...)
 				}
 			}
+			// Geo filter: drop or demote results outside the metro
+			// centroid based on filterMode (#406 failure 1).
+			results = applyGeoFilter(results, metroCentroid, metroRadiusKm, filterMode)
+
 			// Rank: match score descending. Ties broken by name for determinism.
 			sort.SliceStable(results, func(i, j int) bool {
 				if results[i].MatchScore != results[j].MatchScore {
@@ -157,120 +209,30 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max merged results to return")
 	cmd.Flags().IntVar(&party, "party", 2, "Party size (informational; OT autocomplete does not filter on this)")
 	cmd.Flags().StringVar(&when, "when", "", "Time hint for search (e.g., 'fri 7-9pm', 'tonight', 'this weekend'); informational in v1")
+	cmd.Flags().Float64Var(&metroRadiusKm, "metro-radius-km", defaultMetroRadiusKm,
+		"When --metro is set, drop results more than this many km from the metro centroid. Default 50km covers most metros including suburbs.")
+	cmd.Flags().BoolVar(&listMetros, "list-metros", false,
+		"Print the full hydrated metro registry as JSON (every Tock metro + static fallbacks + city-hint mappings) and exit. Useful for agents discovering valid --metro values programmatically.")
 	_ = when
 	return cmd
 }
 
-// metroLatLng resolves a known metro slug to a representative lat/lng for
-// the OpenTable Autocomplete geo-narrowing. Returns ok=false on unknown
-// slugs so the caller can return a clear error.
-func metroLatLng(slug string) (lat, lng float64, ok bool) {
-	switch strings.ToLower(strings.TrimSpace(slug)) {
-	case "seattle":
-		return 47.6062, -122.3321, true
-	case "chicago":
-		return 41.8781, -87.6298, true
-	case "new-york", "new-york-city", "nyc", "manhattan":
-		return 40.7589, -73.9851, true
-	case "san-francisco", "sf":
-		return 37.7749, -122.4194, true
-	case "los-angeles", "la":
-		return 34.0522, -118.2437, true
-	case "miami":
-		return 25.7617, -80.1918, true
-	case "boston":
-		return 42.3601, -71.0589, true
-	case "washington-dc", "dc", "washington":
-		return 38.9072, -77.0369, true
-	case "austin":
-		return 30.2672, -97.7431, true
-	case "portland":
-		return 45.5152, -122.6784, true
-	case "denver":
-		return 39.7392, -104.9903, true
-	case "philadelphia", "philly":
-		return 39.9526, -75.1652, true
-	case "atlanta":
-		return 33.7490, -84.3880, true
-	case "houston":
-		return 29.7604, -95.3698, true
-	case "dallas":
-		return 32.7767, -96.7970, true
-	case "san-diego":
-		return 32.7157, -117.1611, true
-	case "minneapolis":
-		return 44.9778, -93.2650, true
-	case "nashville":
-		return 36.1627, -86.7816, true
-	case "new-orleans", "nola":
-		return 29.9511, -90.0715, true
-	case "las-vegas", "vegas":
-		return 36.1699, -115.1398, true
-	}
-	return 0, 0, false
+// metroListResponse is the JSON shape emitted by `goat --list-metros`.
+// Includes the hydrated registry, the static city-hint mappings (so
+// agents know which secondary cities roll up under which metro), and
+// a queried_at timestamp for cache-age inference.
+type metroListResponse struct {
+	Metros    []Metro           `json:"metros"`
+	Total     int               `json:"total"`
+	CityHints map[string]string `json:"city_hints"`
+	QueriedAt string            `json:"queried_at"`
 }
 
-// metroCityName resolves a metro slug to its display name. Tock's city-search
-// URL accepts both: the slug appears as the path segment (`/city/seattle/`)
-// while the display name appears as the `?city=` query param (`?city=Seattle`).
-// Returns "" on unknown slug so callers can fall back.
-func metroCityName(slug string) string {
-	switch strings.ToLower(strings.TrimSpace(slug)) {
-	case "seattle":
-		return "Seattle"
-	case "chicago":
-		return "Chicago"
-	case "new-york", "new-york-city", "nyc", "manhattan":
-		// Tock's canonical slug is `new-york-city`; the display name `New York City`
-		// produces that slug via citySlugFromName, which matches the URL the
-		// /city/new-york-city/search SSR responds at.
-		return "New York City"
-	case "san-francisco", "sf":
-		return "San Francisco"
-	case "los-angeles", "la":
-		return "Los Angeles"
-	case "miami":
-		return "Miami"
-	case "boston":
-		return "Boston"
-	case "washington-dc", "dc", "washington":
-		return "Washington DC"
-	case "austin":
-		return "Austin"
-	case "portland":
-		return "Portland"
-	case "denver":
-		return "Denver"
-	case "philadelphia", "philly":
-		return "Philadelphia"
-	case "atlanta":
-		return "Atlanta"
-	case "houston":
-		return "Houston"
-	case "dallas":
-		return "Dallas"
-	case "san-diego":
-		return "San Diego"
-	case "minneapolis":
-		return "Minneapolis"
-	case "nashville":
-		return "Nashville"
-	case "new-orleans", "nola":
-		return "New Orleans"
-	case "las-vegas", "vegas":
-		return "Las Vegas"
-	}
-	return ""
-}
-
-func knownMetros() []string {
-	return []string{
-		"seattle", "chicago", "new-york", "san-francisco", "los-angeles",
-		"miami", "boston", "washington-dc", "austin", "portland", "denver",
-		"philadelphia", "atlanta", "houston", "dallas", "san-diego",
-		"minneapolis", "nashville", "new-orleans", "las-vegas",
-	}
-}
+// metroLatLng, metroCityName, knownMetros all moved to metro_registry.go
+// (issue #406): a single declarative registry replaces the 90-line
+// triplicate-switch pattern and grows to cover Tock's full 253-metro
+// metroArea hydration. Lookups still go through the same functions for
+// backward compatibility with existing callers.
 
 func goatQueryOpenTable(ctx context.Context, s *auth.Session, query string, lat, lng float64) ([]goatResult, error) {
 	c, err := opentable.New(s)

--- a/library/food-and-dining/table-reservation-goat/internal/cli/goat.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/goat.go
@@ -99,9 +99,14 @@ func newGoatCmd(flags *rootFlags) *cobra.Command {
 			// target city (like Bellevue WA) is a standalone metro or
 			// rolled into a parent.
 			if listMetros {
+				// Single registry snapshot so Total and Metros agree even
+				// if a concurrent hydration upgrade fires between calls
+				// (PR #425 round-2 Greptile P2: prior shape called
+				// getRegistry().All() twice and could TOCTOU-race).
+				allMetros := getRegistry().All()
 				return printJSONFiltered(cmd.OutOrStdout(), metroListResponse{
-					Metros:    getRegistry().All(),
-					Total:     len(getRegistry().All()),
+					Metros:    allMetros,
+					Total:     len(allMetros),
 					CityHints: cityHints,
 					QueriedAt: time.Now().UTC().Format(time.RFC3339),
 				}, flags)

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration.go
@@ -1,0 +1,164 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+// PATCH: scaffold-endpoint-redirects — issue #406 failures 1 + 3.
+//
+// Tock metroArea hydration with disk cache.
+//
+// Tock's $REDUX_STATE hydrates `state.app.config.metroArea` with the
+// full 253-metro registry on every city-search SSR. This file fetches
+// that array once per CLI invocation (cheap) and caches the result for
+// 24h on disk (`<UserCacheDir>/table-reservation-goat-pp-cli/
+// tock-metros.json`) so subsequent invocations skip the fetch entirely.
+//
+// Failure semantics: every step is best-effort. Cache read failures,
+// HTTP failures, parse failures all silently fall back to the static
+// 20-entry registry — the CLI never regresses below pre-#406 behavior
+// because of a hydration miss.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/auth"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/tock"
+)
+
+// metroHydrationTTL bounds how long a cached Tock metro registry is
+// reused. Tock's metroArea is config-tier and changes maybe once a
+// quarter; 24h is well within the staleness budget.
+const metroHydrationTTL = 24 * time.Hour
+
+// metroCacheFile is the on-disk JSON shape. Pinned to a tiny stable
+// surface so future schema changes can detect-and-rebuild via
+// SchemaVersion.
+type metroCacheFile struct {
+	SchemaVersion int       `json:"schema_version"`
+	FetchedAt     time.Time `json:"fetched_at"`
+	Metros        []Metro   `json:"metros"`
+}
+
+const metroCacheSchemaVersion = 1
+
+// metroCachePath returns the on-disk cache location, creating the
+// parent directory on demand. Returns ok=false (instead of an error)
+// because every cache miss is non-fatal.
+func metroCachePath() (string, bool) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(dir, "table-reservation-goat-pp-cli", "tock-metros.json"), true
+}
+
+// loadMetroCache returns the cache contents if present and within TTL.
+// Returns nil on any failure — the caller proceeds to fetch.
+func loadMetroCache() []Metro {
+	path, ok := metroCachePath()
+	if !ok {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var cf metroCacheFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		return nil
+	}
+	if cf.SchemaVersion != metroCacheSchemaVersion {
+		return nil
+	}
+	if time.Since(cf.FetchedAt) > metroHydrationTTL {
+		return nil
+	}
+	if len(cf.Metros) == 0 {
+		return nil
+	}
+	return cf.Metros
+}
+
+// saveMetroCache writes the cache atomically (temp + rename) at mode
+// 0600. Silent on failure — cache rebuild on next invocation.
+func saveMetroCache(metros []Metro) {
+	if len(metros) == 0 {
+		return
+	}
+	path, ok := metroCachePath()
+	if !ok {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	cf := metroCacheFile{
+		SchemaVersion: metroCacheSchemaVersion,
+		FetchedAt:     time.Now(),
+		Metros:        metros,
+	}
+	data, err := json.Marshal(cf)
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+// projectTockMetros converts the source-layer Tock shape into the
+// CLI's leaner Metro registry shape. Drops aliases since Tock has no
+// alias concept — agents typing `--metro nyc` get matched via the
+// static fallback's alias chain, and the dynamic `new-york-city`
+// entry (or whatever Tock canonicalizes to) takes over the centroid.
+func projectTockMetros(in []tock.MetroArea) []Metro {
+	out := make([]Metro, 0, len(in))
+	for _, m := range in {
+		out = append(out, Metro{
+			Slug: m.Slug,
+			Name: m.Name,
+			Lat:  m.Lat,
+			Lng:  m.Lng,
+		})
+	}
+	return out
+}
+
+// hydrateMetrosFromTock is the high-level entry point: cache first,
+// then HTTP, then silent. Designed to be called once per CLI
+// invocation before the first metro lookup.
+func hydrateMetrosFromTock(ctx context.Context, session *auth.Session) {
+	// Cache fast-path.
+	if cached := loadMetroCache(); len(cached) > 0 {
+		setDynamicMetros(cached, time.Now().Unix())
+		return
+	}
+	// Cache miss — fetch from Tock SSR.
+	if session == nil {
+		return
+	}
+	c, err := tock.New(session)
+	if err != nil {
+		return
+	}
+	areas, err := c.FetchMetroAreas(ctx)
+	if err != nil || len(areas) == 0 {
+		return
+	}
+	metros := projectTockMetros(areas)
+	setDynamicMetros(metros, time.Now().Unix())
+	saveMetroCache(metros)
+}
+
+// invalidateMetroCache wipes the on-disk metro cache. Called by
+// `auth login --chrome` (future) and exposed for tests.
+func invalidateMetroCache() {
+	if path, ok := metroCachePath(); ok {
+		_ = os.Remove(path)
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration_test.go
@@ -70,7 +70,7 @@ func TestSaveLoadMetroCache_RoundTrip(t *testing.T) {
 // stale cache entries. Past-TTL files are silently dropped — caller
 // falls back to fetch.
 func TestLoadMetroCache_RejectsStale(t *testing.T) {
-	tmp := withTempCacheDir(t)
+	withTempCacheDir(t)
 
 	cf := metroCacheFile{
 		SchemaVersion: metroCacheSchemaVersion,
@@ -78,11 +78,17 @@ func TestLoadMetroCache_RejectsStale(t *testing.T) {
 		Metros:        []Metro{{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3}},
 	}
 	data, _ := json.Marshal(cf)
-	dir := filepath.Join(tmp, "Library", "Caches", "table-reservation-goat-pp-cli")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	// PR #425 round-2 Greptile finding: don't hardcode `Library/Caches`
+	// (macOS-only). Ask metroCachePath() for the canonical location so
+	// the test passes on Linux too (where os.UserCacheDir returns
+	// $XDG_CACHE_HOME directly, no Library/Caches prefix).
+	path, ok := metroCachePath()
+	if !ok {
+		t.Fatal("metroCachePath() returned !ok in test fixture")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(dir, "tock-metros.json")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +102,7 @@ func TestLoadMetroCache_RejectsStale(t *testing.T) {
 // invalidation — bumping metroCacheSchemaVersion silently invalidates
 // pre-existing caches without users having to wipe them manually.
 func TestLoadMetroCache_RejectsSchemaMismatch(t *testing.T) {
-	tmp := withTempCacheDir(t)
+	withTempCacheDir(t)
 
 	cf := metroCacheFile{
 		SchemaVersion: 9999, // future schema
@@ -104,9 +110,13 @@ func TestLoadMetroCache_RejectsSchemaMismatch(t *testing.T) {
 		Metros:        []Metro{{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3}},
 	}
 	data, _ := json.Marshal(cf)
-	dir := filepath.Join(tmp, "Library", "Caches", "table-reservation-goat-pp-cli")
-	_ = os.MkdirAll(dir, 0o700)
-	_ = os.WriteFile(filepath.Join(dir, "tock-metros.json"), data, 0o600)
+	// Same as above: ask metroCachePath() for the cross-platform path.
+	path, ok := metroCachePath()
+	if !ok {
+		t.Fatal("metroCachePath() returned !ok in test fixture")
+	}
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
+	_ = os.WriteFile(path, data, 0o600)
 
 	if got := loadMetroCache(); got != nil {
 		t.Errorf("schema-mismatched cache should return nil; got %v", got)

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_hydration_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/internal/source/tock"
+)
+
+// withTempCacheDir redirects os.UserCacheDir() to a per-test temp dir
+// for the duration of t. Avoids interleaving with real user cache and
+// makes cleanup automatic.
+func withTempCacheDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	// On macOS, os.UserCacheDir uses $HOME/Library/Caches, not XDG.
+	// HOME override gets it.
+	t.Setenv("HOME", tmp)
+	return tmp
+}
+
+// TestProjectTockMetros verifies the source→registry projection
+// preserves the four fields the geo filter actually uses (slug, name,
+// lat, lng) and drops the businessCount we don't need.
+func TestProjectTockMetros(t *testing.T) {
+	in := []tock.MetroArea{
+		{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3, BusinessCount: 120},
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6, Lng: -122.2, BusinessCount: 38},
+	}
+	got := projectTockMetros(in)
+	if len(got) != 2 {
+		t.Fatalf("got %d; want 2", len(got))
+	}
+	if got[0].Slug != "seattle" || got[0].Name != "Seattle" {
+		t.Errorf("slug/name not preserved: %+v", got[0])
+	}
+	if got[0].Lat != 47.6 || got[0].Lng != -122.3 {
+		t.Errorf("centroid not preserved: %+v", got[0])
+	}
+}
+
+// TestSaveLoadMetroCache_RoundTrip writes and reads a cache file via
+// the public helpers. Verifies the file format is stable across calls.
+func TestSaveLoadMetroCache_RoundTrip(t *testing.T) {
+	withTempCacheDir(t)
+
+	metros := []Metro{
+		{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3},
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6, Lng: -122.2},
+	}
+	saveMetroCache(metros)
+
+	got := loadMetroCache()
+	if len(got) != 2 {
+		t.Fatalf("got %d; want 2 from round-trip", len(got))
+	}
+	if got[1].Slug != "bellevue" {
+		t.Errorf("entry order not preserved: %+v", got)
+	}
+}
+
+// TestLoadMetroCache_RejectsStale verifies the TTL guard kicks in on
+// stale cache entries. Past-TTL files are silently dropped — caller
+// falls back to fetch.
+func TestLoadMetroCache_RejectsStale(t *testing.T) {
+	tmp := withTempCacheDir(t)
+
+	cf := metroCacheFile{
+		SchemaVersion: metroCacheSchemaVersion,
+		FetchedAt:     time.Now().Add(-2 * metroHydrationTTL), // way past TTL
+		Metros:        []Metro{{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3}},
+	}
+	data, _ := json.Marshal(cf)
+	dir := filepath.Join(tmp, "Library", "Caches", "table-reservation-goat-pp-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "tock-metros.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := loadMetroCache(); got != nil {
+		t.Errorf("stale cache should return nil; got %v", got)
+	}
+}
+
+// TestLoadMetroCache_RejectsSchemaMismatch verifies schema-versioned
+// invalidation — bumping metroCacheSchemaVersion silently invalidates
+// pre-existing caches without users having to wipe them manually.
+func TestLoadMetroCache_RejectsSchemaMismatch(t *testing.T) {
+	tmp := withTempCacheDir(t)
+
+	cf := metroCacheFile{
+		SchemaVersion: 9999, // future schema
+		FetchedAt:     time.Now(),
+		Metros:        []Metro{{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3}},
+	}
+	data, _ := json.Marshal(cf)
+	dir := filepath.Join(tmp, "Library", "Caches", "table-reservation-goat-pp-cli")
+	_ = os.MkdirAll(dir, 0o700)
+	_ = os.WriteFile(filepath.Join(dir, "tock-metros.json"), data, 0o600)
+
+	if got := loadMetroCache(); got != nil {
+		t.Errorf("schema-mismatched cache should return nil; got %v", got)
+	}
+}
+
+// TestInvalidateMetroCache verifies the deletion path works even when
+// the cache doesn't exist (no error to surface; silent best-effort).
+func TestInvalidateMetroCache(t *testing.T) {
+	withTempCacheDir(t)
+
+	saveMetroCache([]Metro{{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3}})
+	if loadMetroCache() == nil {
+		t.Fatal("setup: cache should exist after save")
+	}
+	invalidateMetroCache()
+	if loadMetroCache() != nil {
+		t.Error("post-invalidate cache should be empty")
+	}
+	// Second invalidate on already-empty cache must not panic.
+	invalidateMetroCache()
+}
+
+// TestHydrateMetrosFromTock_UsesCache verifies the cache fast-path:
+// when a fresh cache exists, the function loads it without touching
+// the network at all. Done by pre-seeding the cache and passing nil
+// session — if the function ignored the cache and fell through to the
+// fetch, it would no-op (session is nil).
+func TestHydrateMetrosFromTock_UsesCache(t *testing.T) {
+	withTempCacheDir(t)
+	defer setDynamicMetros(nil, 0)
+
+	preseeded := []Metro{
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6, Lng: -122.2},
+		{Slug: "seattle", Name: "Seattle", Lat: 47.6, Lng: -122.3},
+	}
+	saveMetroCache(preseeded)
+
+	hydrateMetrosFromTock(context.Background(), nil) // nil session must not matter when cache is fresh
+
+	if _, ok := getRegistry().Lookup("bellevue"); !ok {
+		t.Fatal("bellevue should be available from cache-hydrated registry")
+	}
+}
+
+// TestHydrateMetrosFromTock_NilSessionOnCacheMiss verifies that when
+// the cache is absent AND session is nil, we silently no-op rather
+// than panicking. This is the path agents hit when `auth login` hasn't
+// been run yet.
+func TestHydrateMetrosFromTock_NilSessionOnCacheMiss(t *testing.T) {
+	withTempCacheDir(t)
+	defer setDynamicMetros(nil, 0)
+
+	hydrateMetrosFromTock(context.Background(), nil)
+
+	// Registry should still respond from the static fallback.
+	if _, ok := getRegistry().Lookup("seattle"); !ok {
+		t.Error("static fallback should still cover seattle even when hydration no-ops")
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry.go
@@ -31,8 +31,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
+	"unicode"
 )
 
 // Metro is a single metro-area entry: canonical slug, display name, and
@@ -217,14 +219,29 @@ func metroCityName(slug string) string {
 }
 
 // knownMetros returns the set of canonical slugs the registry currently
-// covers, sorted for stable error-message output.
+// covers, sorted alphabetically for stable error-message output.
 func knownMetros() []string {
 	all := getRegistry().All()
 	slugs := make([]string, 0, len(all))
 	for _, m := range all {
 		slugs = append(slugs, m.Slug)
 	}
+	sort.Strings(slugs)
 	return slugs
+}
+
+// titleCase uppercases the first rune of s. Replaces strings.Title
+// (deprecated in Go 1.18) for the city-hint UX where we want
+// "bellevue" → "Bellevue" in error messages. Doesn't try to handle
+// hyphens or multi-word names — those aren't in the cityHints map
+// keys today and city display names come from the registry directly.
+func titleCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }
 
 // suggestMetros returns up to maxN slugs that share a token with `query`
@@ -355,12 +372,13 @@ func cityHintFor(slug string) string {
 func formatUnknownMetroError(input string) string {
 	if parent := cityHintFor(input); parent != "" {
 		if m, ok := getRegistry().Lookup(parent); ok {
+			cityName := titleCase(input)
 			return fmt.Sprintf(
 				"unknown metro %q — neither OpenTable nor Tock breaks this out as its own metro. "+
 					"%s is lumped under metro %q (centroid %.4f, %.4f). "+
 					"Try `--metro %s --metro-radius-km 20` to constrain results to %s-area venues, "+
 					"or pass `--latitude %.4f --longitude %.4f` directly with a tight `--metro-radius-km`.",
-				input, strings.Title(input), m.Slug, m.Lat, m.Lng, m.Slug, strings.Title(input), m.Lat, m.Lng,
+				input, cityName, m.Slug, m.Lat, m.Lng, m.Slug, cityName, m.Lat, m.Lng,
 			)
 		}
 	}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry.go
@@ -1,0 +1,395 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+// PATCH: scaffold-endpoint-redirects — issue #406 failures 1 + 3.
+//
+// Metro registry — single source of truth for `--metro <slug>` lookups
+// across `goat`, `earliest`, `availability check`, and `restaurants list`.
+//
+// Background: prior versions hardcoded a 20-entry switch statement (Seattle,
+// Chicago, NYC, …). That static table missed every secondary metro Tock
+// hydrates in `state.app.config.metroArea` (253 cities), so users asking
+// for `--metro bellevue` (Bellevue WA — a real Tock metro) got `unknown
+// metro` even though the data was right there in the Tock SSR they'd
+// already fetched.
+//
+// Shape: a Metro carries a canonical slug, a display Name (Tock's
+// `?city=` query param shape — preserves spaces + casing), a centroid
+// (Lat/Lng for OpenTable Autocomplete + geo-filter math), and a slice
+// of Aliases for human shorthand (`sf`, `nyc`, `dc`).
+//
+// Lookups:
+//   - Lookup(slug) — exact match on canonical slug or any alias
+//   - KnownSlugs() — for error-message "did you mean …" UX
+//
+// The registry chains a dynamic source (loaded from Tock's metroArea
+// SSR, disk-cached 24h) over the static fallback. If hydration fails or
+// hasn't run yet, the static fallback covers the 20 most common US
+// metros so the CLI never regresses below the prior baseline.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Metro is a single metro-area entry: canonical slug, display name, and
+// centroid coordinates. Aliases let a single canonical entry answer to
+// multiple human shorthands ("sf", "san-francisco") without proliferating
+// rows in the registry.
+type Metro struct {
+	Slug    string   `json:"slug"`              // canonical lookup key (e.g. "san-francisco")
+	Name    string   `json:"name"`              // Tock `?city=` display shape (e.g. "San Francisco")
+	Lat     float64  `json:"lat"`               // metro centroid latitude
+	Lng     float64  `json:"lng"`               // metro centroid longitude
+	Aliases []string `json:"aliases,omitempty"` // additional accepted lookup keys (e.g. ["sf"])
+}
+
+// MetroRegistry is the lookup surface every consumer uses. Concrete
+// implementations: staticMetroRegistry (compile-time fallback) and
+// chainedMetroRegistry (dynamic-over-static at runtime).
+type MetroRegistry interface {
+	// Lookup returns the canonical Metro matching the slug or any alias.
+	// Normalizes input (lowercases, trims) before matching.
+	Lookup(slug string) (Metro, bool)
+
+	// All returns the full registry contents — used by `--help` error
+	// messages and the "did you mean" UX.
+	All() []Metro
+}
+
+// staticMetros is the 20-entry US-centric fallback registry. Replaces
+// the prior metroLatLng + metroCityName switch pair with a single
+// declarative table.
+var staticMetros = []Metro{
+	{Slug: "seattle", Name: "Seattle", Lat: 47.6062, Lng: -122.3321},
+	{Slug: "chicago", Name: "Chicago", Lat: 41.8781, Lng: -87.6298},
+	{Slug: "new-york-city", Name: "New York City", Lat: 40.7589, Lng: -73.9851,
+		Aliases: []string{"new-york", "nyc", "manhattan"}},
+	{Slug: "san-francisco", Name: "San Francisco", Lat: 37.7749, Lng: -122.4194,
+		Aliases: []string{"sf"}},
+	{Slug: "los-angeles", Name: "Los Angeles", Lat: 34.0522, Lng: -118.2437,
+		Aliases: []string{"la"}},
+	{Slug: "miami", Name: "Miami", Lat: 25.7617, Lng: -80.1918},
+	{Slug: "boston", Name: "Boston", Lat: 42.3601, Lng: -71.0589},
+	{Slug: "washington-dc", Name: "Washington DC", Lat: 38.9072, Lng: -77.0369,
+		Aliases: []string{"dc", "washington"}},
+	{Slug: "austin", Name: "Austin", Lat: 30.2672, Lng: -97.7431},
+	{Slug: "portland", Name: "Portland", Lat: 45.5152, Lng: -122.6784},
+	{Slug: "denver", Name: "Denver", Lat: 39.7392, Lng: -104.9903},
+	{Slug: "philadelphia", Name: "Philadelphia", Lat: 39.9526, Lng: -75.1652,
+		Aliases: []string{"philly"}},
+	{Slug: "atlanta", Name: "Atlanta", Lat: 33.7490, Lng: -84.3880},
+	{Slug: "houston", Name: "Houston", Lat: 29.7604, Lng: -95.3698},
+	{Slug: "dallas", Name: "Dallas", Lat: 32.7767, Lng: -96.7970},
+	{Slug: "san-diego", Name: "San Diego", Lat: 32.7157, Lng: -117.1611},
+	{Slug: "minneapolis", Name: "Minneapolis", Lat: 44.9778, Lng: -93.2650},
+	{Slug: "nashville", Name: "Nashville", Lat: 36.1627, Lng: -86.7816},
+	{Slug: "new-orleans", Name: "New Orleans", Lat: 29.9511, Lng: -90.0715,
+		Aliases: []string{"nola"}},
+	{Slug: "las-vegas", Name: "Las Vegas", Lat: 36.1699, Lng: -115.1398,
+		Aliases: []string{"vegas"}},
+}
+
+// staticMetroRegistry is the compile-time fallback. Always non-nil so
+// even when dynamic hydration fails the CLI behaves identically to
+// pre-issue-#406 versions for the 20 covered metros.
+type staticMetroRegistry struct{}
+
+func (staticMetroRegistry) All() []Metro { return staticMetros }
+
+func (s staticMetroRegistry) Lookup(slug string) (Metro, bool) {
+	return lookupIn(staticMetros, slug)
+}
+
+// lookupIn searches metros for a canonical-slug match or alias match,
+// case-insensitive after trimming whitespace. Shared by static and
+// chained registries.
+func lookupIn(metros []Metro, slug string) (Metro, bool) {
+	key := strings.ToLower(strings.TrimSpace(slug))
+	if key == "" {
+		return Metro{}, false
+	}
+	for _, m := range metros {
+		if m.Slug == key {
+			return m, true
+		}
+		for _, a := range m.Aliases {
+			if a == key {
+				return m, true
+			}
+		}
+	}
+	return Metro{}, false
+}
+
+// chainedMetroRegistry composes a dynamic source over the static
+// fallback: Lookup tries dynamic first, returns the static match if
+// dynamic doesn't have it. All() returns the union (dynamic first,
+// then static entries the dynamic source didn't already cover).
+type chainedMetroRegistry struct {
+	dynamic []Metro // hydrated from Tock metroArea (may be empty)
+}
+
+func (c chainedMetroRegistry) Lookup(slug string) (Metro, bool) {
+	if m, ok := lookupIn(c.dynamic, slug); ok {
+		return m, true
+	}
+	return lookupIn(staticMetros, slug)
+}
+
+func (c chainedMetroRegistry) All() []Metro {
+	if len(c.dynamic) == 0 {
+		return staticMetros
+	}
+	// Dynamic-first union: static entries are appended only when their
+	// canonical slug isn't already represented in the dynamic source.
+	seen := make(map[string]struct{}, len(c.dynamic))
+	out := make([]Metro, 0, len(c.dynamic)+len(staticMetros))
+	for _, m := range c.dynamic {
+		seen[m.Slug] = struct{}{}
+		out = append(out, m)
+	}
+	for _, m := range staticMetros {
+		if _, ok := seen[m.Slug]; ok {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// defaultRegistry is the package-wide registry singleton. It starts as
+// the static-only fallback and gets upgraded to chained once dynamic
+// metros are loaded. Access is guarded by registryMu — concurrent
+// `goat` invocations may race to upgrade.
+var (
+	registryMu      sync.RWMutex
+	defaultReg      MetroRegistry = staticMetroRegistry{}
+	dynamicLoadedAt int64         // unix seconds; 0 until first successful load
+)
+
+// getRegistry returns the current registry (caller may hold the read
+// lock for the duration of a single lookup). Always non-nil.
+func getRegistry() MetroRegistry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return defaultReg
+}
+
+// setDynamicMetros upgrades the default registry to a chained registry
+// with the supplied dynamic entries. Safe to call concurrently — last
+// writer wins. Pass nil/empty to revert to the static-only fallback.
+func setDynamicMetros(metros []Metro, loadedAtUnix int64) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if len(metros) == 0 {
+		defaultReg = staticMetroRegistry{}
+		dynamicLoadedAt = 0
+		return
+	}
+	defaultReg = chainedMetroRegistry{dynamic: metros}
+	dynamicLoadedAt = loadedAtUnix
+}
+
+// metroLatLng is the legacy-shape wrapper for code that still calls the
+// pre-#406 lookup signature. New code should use getRegistry().Lookup
+// directly so the canonical Metro (with display name + aliases) is
+// available to format error messages and inform the geo filter.
+func metroLatLng(slug string) (lat, lng float64, ok bool) {
+	m, found := getRegistry().Lookup(slug)
+	if !found {
+		return 0, 0, false
+	}
+	return m.Lat, m.Lng, true
+}
+
+// metroCityName mirrors the legacy display-name lookup. Returns "" on
+// unknown slug so existing callers' empty-string fallbacks still work.
+func metroCityName(slug string) string {
+	m, ok := getRegistry().Lookup(slug)
+	if !ok {
+		return ""
+	}
+	return m.Name
+}
+
+// knownMetros returns the set of canonical slugs the registry currently
+// covers, sorted for stable error-message output.
+func knownMetros() []string {
+	all := getRegistry().All()
+	slugs := make([]string, 0, len(all))
+	for _, m := range all {
+		slugs = append(slugs, m.Slug)
+	}
+	return slugs
+}
+
+// suggestMetros returns up to maxN slugs that share a token with `query`
+// (best-effort "did you mean"). Used to keep the unknown-metro error
+// message readable when the registry has 200+ entries — dumping the
+// full list overwhelms terminals.
+func suggestMetros(query string, maxN int) []string {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return nil
+	}
+	type scored struct {
+		slug  string
+		score int
+	}
+	var hits []scored
+	for _, m := range getRegistry().All() {
+		score := 0
+		ms := strings.ToLower(m.Slug)
+		// Full-substring of query in slug → strong signal.
+		if strings.Contains(ms, q) {
+			score += 10
+		}
+		// Any shared token from query split on hyphen → weaker signal.
+		for _, tok := range strings.Split(q, "-") {
+			if tok == "" {
+				continue
+			}
+			if strings.Contains(ms, tok) {
+				score++
+			}
+		}
+		// Check aliases too.
+		for _, a := range m.Aliases {
+			al := strings.ToLower(a)
+			if al == q || strings.Contains(al, q) {
+				score += 5
+			}
+		}
+		if score > 0 {
+			hits = append(hits, scored{slug: m.Slug, score: score})
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	// Sort by score desc, slug asc (stable).
+	for i := 1; i < len(hits); i++ {
+		for j := i; j > 0 && (hits[j].score > hits[j-1].score ||
+			(hits[j].score == hits[j-1].score && hits[j].slug < hits[j-1].slug)); j-- {
+			hits[j], hits[j-1] = hits[j-1], hits[j]
+		}
+	}
+	out := make([]string, 0, maxN)
+	for i := 0; i < len(hits) && i < maxN; i++ {
+		out = append(out, hits[i].slug)
+	}
+	return out
+}
+
+// cityHints maps cities that aren't standalone Tock/registry metros
+// onto the metro they're handled under. Issue #406's Bellevue WA case:
+// Tock's `metroArea` config lumps Eastside venues into `seattle`, so
+// agents typing `--metro bellevue` need to be routed to "use seattle
+// with a tight radius."
+//
+// These are static facts about how reservation networks group
+// neighborhoods — they won't change with Tock's metroArea hydration.
+// Kept small and US-focused (the metros most likely to surface in
+// agent prompts).
+var cityHints = map[string]string{
+	// Seattle / Eastern WA
+	"bellevue":  "seattle",
+	"redmond":   "seattle",
+	"kirkland":  "seattle",
+	"issaquah":  "seattle",
+	"renton":    "seattle",
+	"sammamish": "seattle",
+	// Bay Area
+	"oakland":   "san-francisco",
+	"berkeley":  "san-francisco",
+	"alameda":   "san-francisco",
+	"san-mateo": "san-francisco",
+	"daly-city": "san-francisco",
+	// NYC outer boroughs / NJ commuter
+	"brooklyn":         "new-york-city",
+	"queens":           "new-york-city",
+	"bronx":            "new-york-city",
+	"staten-island":    "new-york-city",
+	"long-island-city": "new-york-city",
+	"hoboken":          "new-york-city",
+	"jersey-city":      "new-york-city",
+	// LA area
+	"santa-monica":  "los-angeles",
+	"pasadena":      "los-angeles",
+	"beverly-hills": "los-angeles",
+	"venice":        "los-angeles",
+	"culver-city":   "los-angeles",
+	// Boston area
+	"cambridge":  "boston",
+	"somerville": "boston",
+	"newton":     "boston",
+	"brookline":  "boston",
+	// DC area
+	"arlington":     "washington-dc",
+	"alexandria":    "washington-dc",
+	"bethesda":      "washington-dc",
+	"silver-spring": "washington-dc",
+	// Chicago area
+	"evanston": "chicago",
+	"oak-park": "chicago",
+}
+
+// cityHintFor returns the metro slug a city is lumped under, or "" if
+// the city has no hint mapping. Case-insensitive after trim.
+func cityHintFor(slug string) string {
+	return cityHints[strings.ToLower(strings.TrimSpace(slug))]
+}
+
+// formatUnknownMetroError builds a readable error for `--metro <slug>`
+// when the lookup misses. Three layers of helpfulness:
+//  1. If the slug is a known secondary city (Bellevue, Oakland, etc.),
+//     point at the parent metro with a radius hint — this is the
+//     "best advice" for issue #406's Bellevue WA case.
+//  2. Else if there are name-similar entries in the registry, show
+//     them as "did you mean: ...".
+//  3. Else fall back to the count + sample.
+func formatUnknownMetroError(input string) string {
+	if parent := cityHintFor(input); parent != "" {
+		if m, ok := getRegistry().Lookup(parent); ok {
+			return fmt.Sprintf(
+				"unknown metro %q — neither OpenTable nor Tock breaks this out as its own metro. "+
+					"%s is lumped under metro %q (centroid %.4f, %.4f). "+
+					"Try `--metro %s --metro-radius-km 20` to constrain results to %s-area venues, "+
+					"or pass `--latitude %.4f --longitude %.4f` directly with a tight `--metro-radius-km`.",
+				input, strings.Title(input), m.Slug, m.Lat, m.Lng, m.Slug, strings.Title(input), m.Lat, m.Lng,
+			)
+		}
+	}
+	suggestions := suggestMetros(input, 5)
+	if len(suggestions) > 0 {
+		return fmt.Sprintf("unknown metro %q (did you mean: %s? — %d metros known total; pass `--list-metros` to see them all)",
+			input, strings.Join(suggestions, ", "), len(getRegistry().All()))
+	}
+	all := getRegistry().All()
+	sample := make([]string, 0, 10)
+	for i := 0; i < len(all) && i < 10; i++ {
+		sample = append(sample, all[i].Slug)
+	}
+	return fmt.Sprintf("unknown metro %q (no similar entries in registry; %d metros known — pass `--list-metros` to see them all, sample: %s, ...)",
+		input, len(all), strings.Join(sample, ", "))
+}
+
+// hydrateMetroRegistry attempts a best-effort dynamic load. Designed to
+// be called once per CLI invocation (before the first metro lookup) so
+// the registry has the 253-metro Tock list available when present. On
+// any failure (no Tock cookies, Akamai blocks the SSR fetch, JSON parse
+// error) the static fallback stays in place — no hard error.
+func hydrateMetroRegistry(ctx context.Context, load func(ctx context.Context) ([]Metro, int64, error)) {
+	if load == nil {
+		return
+	}
+	metros, loadedAt, err := load(ctx)
+	if err != nil || len(metros) == 0 {
+		return
+	}
+	setDynamicMetros(metros, loadedAt)
+}

--- a/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/metro_registry_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestStaticRegistry_Lookup covers the legacy 20-entry baseline plus
+// alias resolution. The aliases were previously OR'd into single switch
+// cases; the registry surfaces them as a property so we test each shape
+// once and trust them everywhere.
+func TestStaticRegistry_Lookup(t *testing.T) {
+	r := staticMetroRegistry{}
+	cases := []struct {
+		input    string
+		wantSlug string
+	}{
+		{"seattle", "seattle"},
+		{"Seattle", "seattle"},        // case insensitive
+		{"  seattle  ", "seattle"},    // whitespace tolerated
+		{"sf", "san-francisco"},       // alias
+		{"SF", "san-francisco"},       // alias case insensitive
+		{"nyc", "new-york-city"},      // alias
+		{"new-york", "new-york-city"}, // alias
+		{"manhattan", "new-york-city"},
+		{"nola", "new-orleans"},
+		{"vegas", "las-vegas"},
+		{"dc", "washington-dc"},
+		{"philly", "philadelphia"},
+		{"la", "los-angeles"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			m, ok := r.Lookup(tc.input)
+			if !ok {
+				t.Fatalf("Lookup(%q) returned !ok; expected slug %q", tc.input, tc.wantSlug)
+			}
+			if m.Slug != tc.wantSlug {
+				t.Errorf("Lookup(%q).Slug = %q; want %q", tc.input, m.Slug, tc.wantSlug)
+			}
+			if m.Lat == 0 && m.Lng == 0 {
+				t.Errorf("Lookup(%q).Lat/Lng = 0/0; centroid must be populated", tc.input)
+			}
+			if m.Name == "" {
+				t.Errorf("Lookup(%q).Name is empty; display name required for Tock ?city= param", tc.input)
+			}
+		})
+	}
+}
+
+// TestStaticRegistry_UnknownSlug verifies the unknown case returns
+// ok=false rather than a zero-valued Metro pretending to be a real
+// entry. Issue #406's "unknown metro %q (known: %s)" error UX depends
+// on this signal.
+func TestStaticRegistry_UnknownSlug(t *testing.T) {
+	r := staticMetroRegistry{}
+	for _, in := range []string{"", "  ", "bellevue", "shanghai", "made-up-metro"} {
+		if _, ok := r.Lookup(in); ok {
+			t.Errorf("Lookup(%q) returned ok=true unexpectedly", in)
+		}
+	}
+}
+
+// TestChainedRegistry_DynamicOverridesStatic verifies the core promise
+// of the dynamic-over-static chain: when Tock metroArea hydrates a
+// metro that the static fallback ALSO covers, the dynamic centroid
+// wins. Concrete case: Tock's seattle entry has slightly different
+// coords than the static placeholder, and the chain must surface the
+// dynamic ones because they're closer to whatever Tock's search uses
+// internally.
+func TestChainedRegistry_DynamicOverridesStatic(t *testing.T) {
+	dynamicSeattle := Metro{Slug: "seattle", Name: "Seattle (dyn)", Lat: 47.7, Lng: -122.4}
+	chain := chainedMetroRegistry{dynamic: []Metro{dynamicSeattle}}
+	m, ok := chain.Lookup("seattle")
+	if !ok {
+		t.Fatal("expected seattle lookup to succeed")
+	}
+	if m.Name != "Seattle (dyn)" {
+		t.Errorf("Name = %q; want dynamic %q (chain must prefer dynamic over static)", m.Name, "Seattle (dyn)")
+	}
+	if m.Lat != 47.7 || m.Lng != -122.4 {
+		t.Errorf("centroid = %v,%v; want dynamic 47.7,-122.4", m.Lat, m.Lng)
+	}
+}
+
+// TestChainedRegistry_StaticFallback verifies entries the dynamic
+// source DOESN'T cover still resolve via the static fallback.
+func TestChainedRegistry_StaticFallback(t *testing.T) {
+	chain := chainedMetroRegistry{dynamic: []Metro{
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6101, Lng: -122.2015},
+	}}
+	if m, ok := chain.Lookup("chicago"); !ok || m.Slug != "chicago" {
+		t.Errorf("chicago should fall through to static; got (%+v, %v)", m, ok)
+	}
+	if m, ok := chain.Lookup("bellevue"); !ok || m.Slug != "bellevue" {
+		t.Errorf("bellevue should resolve from dynamic; got (%+v, %v)", m, ok)
+	}
+}
+
+// TestChainedRegistry_All verifies the union semantics: dynamic
+// entries come first, then static entries the dynamic source didn't
+// already cover. Order matters for the "known metros" error UX, which
+// surfaces the most relevant entries first.
+func TestChainedRegistry_All(t *testing.T) {
+	chain := chainedMetroRegistry{dynamic: []Metro{
+		{Slug: "bellevue", Name: "Bellevue", Lat: 47.6, Lng: -122.2},
+		{Slug: "seattle", Name: "Seattle (dyn)", Lat: 47.6, Lng: -122.3},
+	}}
+	all := chain.All()
+	if all[0].Slug != "bellevue" || all[1].Slug != "seattle" {
+		t.Errorf("dynamic entries should appear first; got %v + %v", all[0].Slug, all[1].Slug)
+	}
+	for i, m := range all {
+		if m.Slug == "seattle" && m.Name == "Seattle" && i > 1 {
+			t.Errorf("static seattle leaked into All() at idx %d; dedupe failed", i)
+		}
+	}
+	hasBellevue := slices.ContainsFunc(all, func(m Metro) bool { return m.Slug == "bellevue" })
+	if !hasBellevue {
+		t.Error("bellevue (dynamic-only) missing from All()")
+	}
+	hasAustin := slices.ContainsFunc(all, func(m Metro) bool { return m.Slug == "austin" })
+	if !hasAustin {
+		t.Error("austin (static-only) missing from All() — fallback merging is broken")
+	}
+}
+
+// TestSetDynamicMetros_Concurrency verifies the registry singleton can
+// be upgraded concurrently without panicking. Two goroutines racing to
+// set the dynamic source should both succeed; last writer wins.
+func TestSetDynamicMetros_Concurrency(t *testing.T) {
+	defer setDynamicMetros(nil, 0)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			setDynamicMetros([]Metro{
+				{Slug: "test-metro", Name: "Test", Lat: float64(i), Lng: float64(i)},
+			}, int64(i))
+		}(i)
+	}
+	wg.Wait()
+
+	if _, ok := getRegistry().Lookup("test-metro"); !ok {
+		t.Error("post-race lookup failed; race may have corrupted the registry")
+	}
+}
+
+// TestMetroLatLng_LegacyShape verifies the legacy wrapper still
+// surfaces the same (lat, lng, ok) signature pre-#406 callers rely on.
+func TestMetroLatLng_LegacyShape(t *testing.T) {
+	lat, lng, ok := metroLatLng("seattle")
+	if !ok || lat == 0 || lng == 0 {
+		t.Errorf("legacy wrapper broken: (%v, %v, %v)", lat, lng, ok)
+	}
+	_, _, ok = metroLatLng("nonexistent-metro")
+	if ok {
+		t.Error("legacy wrapper should report ok=false on unknown slug")
+	}
+}
+
+// TestKnownMetros_SnapshotIncludesMajors is a sanity-check that the
+// `--metro` UX error message ("unknown metro %q (known: %s)") includes
+// at least the major US slugs. Catches accidentally dropping rows from
+// staticMetros.
+func TestKnownMetros_SnapshotIncludesMajors(t *testing.T) {
+	all := knownMetros()
+	want := []string{"seattle", "new-york-city", "san-francisco", "chicago", "los-angeles"}
+	for _, w := range want {
+		if !slices.Contains(all, w) {
+			t.Errorf("known metros missing %q: %v", w, strings.Join(all, ","))
+		}
+	}
+}
+
+// TestHydrateMetroRegistry_NoOpOnFailure verifies a failing or empty
+// load function doesn't downgrade the registry. The static fallback
+// stays in place.
+func TestHydrateMetroRegistry_NoOpOnFailure(t *testing.T) {
+	defer setDynamicMetros(nil, 0)
+
+	setDynamicMetros([]Metro{{Slug: "preexisting", Name: "Pre", Lat: 1, Lng: 1}}, 100)
+	if _, ok := getRegistry().Lookup("preexisting"); !ok {
+		t.Fatal("setup: dynamic metro not loaded")
+	}
+
+	hydrateMetroRegistry(context.Background(), func(context.Context) ([]Metro, int64, error) {
+		return nil, 0, errSentinel{}
+	})
+	if _, ok := getRegistry().Lookup("preexisting"); !ok {
+		t.Error("error-returning hydrate wiped the dynamic registry")
+	}
+
+	hydrateMetroRegistry(context.Background(), func(context.Context) ([]Metro, int64, error) {
+		return []Metro{}, 0, nil
+	})
+	if _, ok := getRegistry().Lookup("preexisting"); !ok {
+		t.Error("empty-return hydrate wiped the dynamic registry")
+	}
+}
+
+type errSentinel struct{}
+
+func (errSentinel) Error() string { return "sentinel test error" }
+
+// TestCityHintFor covers the secondary-city → parent-metro map.
+// Issue #406's Bellevue WA case: agents need to know that "bellevue"
+// isn't its own metro but rolls into "seattle". Same pattern for
+// Oakland, Cambridge, Brooklyn, etc.
+func TestCityHintFor(t *testing.T) {
+	cases := []struct {
+		input    string
+		wantHint string
+	}{
+		{"bellevue", "seattle"},
+		{"BELLEVUE", "seattle"}, // case insensitive
+		{"  bellevue  ", "seattle"},
+		{"oakland", "san-francisco"},
+		{"brooklyn", "new-york-city"},
+		{"hoboken", "new-york-city"},
+		{"cambridge", "boston"},
+		{"arlington", "washington-dc"},
+		{"unknown-city", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := cityHintFor(tc.input); got != tc.wantHint {
+				t.Errorf("cityHintFor(%q) = %q; want %q", tc.input, got, tc.wantHint)
+			}
+		})
+	}
+}
+
+// TestFormatUnknownMetroError_BellevueHint verifies the three-layer
+// helpful-error UX. Bellevue should produce the "lumped under seattle"
+// suggestion (highest-quality signal), NOT just "did you mean".
+func TestFormatUnknownMetroError_BellevueHint(t *testing.T) {
+	got := formatUnknownMetroError("bellevue")
+	for _, want := range []string{
+		`unknown metro "bellevue"`,
+		`lumped under metro "seattle"`,
+		`--metro seattle --metro-radius-km 20`,
+		`--latitude 47.6062 --longitude -122.3321`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error missing expected substring %q\nfull error: %s", want, got)
+		}
+	}
+}
+
+// TestFormatUnknownMetroError_GibberishFallsBack verifies a totally
+// unknown city (no hint, no name match) gets the count + sample
+// fallback message instead of an empty/silent response.
+func TestFormatUnknownMetroError_GibberishFallsBack(t *testing.T) {
+	got := formatUnknownMetroError("xyz12345-not-a-place")
+	if !strings.Contains(got, "unknown metro") {
+		t.Errorf("missing 'unknown metro' prefix: %s", got)
+	}
+	if !strings.Contains(got, "metros known") {
+		t.Errorf("missing count signal: %s", got)
+	}
+}
+
+// TestFormatUnknownMetroError_DidYouMean verifies the middle-layer
+// suggester fires when the input shares tokens with real metros but
+// doesn't have a hint mapping. For "san-fransisco" (typo), it should
+// suggest "san-francisco" via the alias chain or token match.
+func TestFormatUnknownMetroError_DidYouMean(t *testing.T) {
+	// Construct an input that won't match a hint but shares tokens
+	// with a real metro slug. "san" appears in "san-francisco",
+	// "san-diego", etc.
+	got := formatUnknownMetroError("san-nowhere")
+	if !strings.Contains(got, "did you mean") && !strings.Contains(got, "lumped under") {
+		t.Errorf("expected 'did you mean' or 'lumped under' branch; got: %s", got)
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/search.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/search.go
@@ -188,6 +188,88 @@ func entryToBusiness(e offeringAvailEntry) TockBusiness {
 	}
 }
 
+// MetroArea is one Tock metro entry from state.app.config.metroArea[].
+// Roughly 253 metros worldwide as of 2026-05; covers far more than the
+// 20-entry static fallback in the CLI's metro registry. Slug is Tock's
+// path segment (`bellevue`, `new-york-city`); Name is the display
+// shape used in `?city=` query params.
+type MetroArea struct {
+	Slug          string  `json:"slug"`
+	Name          string  `json:"name"`
+	Lat           float64 `json:"lat"`
+	Lng           float64 `json:"lng"`
+	BusinessCount int     `json:"businessCount,omitempty"`
+}
+
+// FetchMetroAreas pulls Tock's full metro registry from any city-search
+// SSR (the metroArea config is identical across all city-search pages,
+// since it's a config-tier value not derived from the path). Issue
+// #406 deferred-TODO: replaces the static 20-entry CLI fallback with
+// the 253-metro live list.
+//
+// Strategy: seed the SSR with a known-stable metro (Seattle) so a
+// fresh install — with no prior queries — can still hydrate. The
+// returned slice carries the full Tock-canonical shape; callers may
+// project into a leaner Metro form for their own use.
+//
+// On HTML-fetch or extractor failure, returns the error so callers can
+// retain their pre-#406 static fallback rather than masking the
+// regression.
+func (c *Client) FetchMetroAreas(ctx context.Context) ([]MetroArea, error) {
+	// Pick the smallest plausible payload — `/city/<slug>/search` with
+	// minimal query params. The metroArea config rides in the same
+	// $REDUX_STATE regardless of city/date/time, so any city works.
+	seed := SearchParams{
+		City: "Seattle", Date: "2099-01-01", Time: "19:00",
+		PartySize: 2, Lat: 47.6062, Lng: -122.3321,
+	}
+	path := buildSearchPath(seed)
+	state, err := c.FetchReduxState(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("tock metroArea: fetch %s: %w", path, err)
+	}
+	return extractMetroAreas(state)
+}
+
+// extractMetroAreas pulls the metroArea array out of a parsed
+// $REDUX_STATE tree. Separated from the HTTP fetch so tests can pin
+// behavior with a fixture map.
+func extractMetroAreas(state map[string]any) ([]MetroArea, error) {
+	app, ok := state["app"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("tock metroArea: state.app missing or wrong type — Tock SPA may have refactored")
+	}
+	cfg, ok := app["config"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("tock metroArea: state.app.config missing or wrong type")
+	}
+	raw, ok := cfg["metroArea"]
+	if !ok || raw == nil {
+		return nil, fmt.Errorf("tock metroArea: state.app.config.metroArea absent")
+	}
+	rawJSON, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("tock metroArea: re-marshal: %w", err)
+	}
+	var metros []MetroArea
+	if err := json.Unmarshal(rawJSON, &metros); err != nil {
+		return nil, fmt.Errorf("tock metroArea: decoding: %w", err)
+	}
+	// Filter out malformed/empty entries — a metro with zero centroid is
+	// useless for geo math and probably a Tock-side data hiccup.
+	out := metros[:0]
+	for _, m := range metros {
+		if m.Slug == "" || m.Name == "" {
+			continue
+		}
+		if m.Lat == 0 && m.Lng == 0 {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
 // decodeCuisines accepts either a JSON string ("Indian") or a JSON array
 // (["Indian","Vegetarian"]) and returns a flat string. Empty/null returns "".
 func decodeCuisines(raw json.RawMessage) string {

--- a/library/food-and-dining/table-reservation-goat/internal/source/tock/search_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/tock/search_test.go
@@ -329,3 +329,83 @@ func TestSearchCity_HTTPError(t *testing.T) {
 		t.Fatal("expected error on HTTP 500; got nil")
 	}
 }
+
+// TestExtractMetroAreas_HappyPath verifies the parser pulls the
+// metroArea array out of a state map matching Tock's actual SSR shape.
+// Issue #406 deferred TODO: replaces the CLI's 20-entry static fallback
+// with the 253-metro live list.
+func TestExtractMetroAreas_HappyPath(t *testing.T) {
+	state := map[string]any{
+		"app": map[string]any{
+			"config": map[string]any{
+				"metroArea": []map[string]any{
+					{"slug": "seattle", "name": "Seattle", "lat": 47.6062, "lng": -122.3321, "businessCount": 120},
+					{"slug": "bellevue", "name": "Bellevue", "lat": 47.6101, "lng": -122.2015, "businessCount": 38},
+					{"slug": "new-york-city", "name": "New York City", "lat": 40.7589, "lng": -73.9851, "businessCount": 412},
+				},
+			},
+		},
+	}
+	got, err := extractMetroAreas(state)
+	if err != nil {
+		t.Fatalf("extractMetroAreas: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d metros; want 3", len(got))
+	}
+	if got[1].Slug != "bellevue" || got[1].Name != "Bellevue" || got[1].BusinessCount != 38 {
+		t.Errorf("bellevue entry off: %+v", got[1])
+	}
+	if got[1].Lat != 47.6101 || got[1].Lng != -122.2015 {
+		t.Errorf("bellevue centroid wrong: %v,%v", got[1].Lat, got[1].Lng)
+	}
+}
+
+// TestExtractMetroAreas_FiltersInvalidEntries verifies entries with
+// empty slug/name or zero centroid are dropped — they'd be useless for
+// geo math even if Tock emits them.
+func TestExtractMetroAreas_FiltersInvalidEntries(t *testing.T) {
+	state := map[string]any{
+		"app": map[string]any{
+			"config": map[string]any{
+				"metroArea": []map[string]any{
+					{"slug": "seattle", "name": "Seattle", "lat": 47.6, "lng": -122.3},
+					{"slug": "", "name": "No slug", "lat": 1.0, "lng": 2.0},       // dropped
+					{"slug": "no-name", "name": "", "lat": 3.0, "lng": 4.0},       // dropped
+					{"slug": "zero-centroid", "name": "Zero", "lat": 0, "lng": 0}, // dropped
+					{"slug": "bellevue", "name": "Bellevue", "lat": 47.6, "lng": -122.2},
+				},
+			},
+		},
+	}
+	got, _ := extractMetroAreas(state)
+	if len(got) != 2 {
+		t.Fatalf("got %d valid metros; want 2 (seattle + bellevue), filter not aggressive enough", len(got))
+	}
+}
+
+// TestExtractMetroAreas_ShapeErrors covers the typed errors emitted
+// when Tock's SPA refactors the config tree. Each layer of the path
+// has its own sentinel so debug output points at the right level.
+func TestExtractMetroAreas_ShapeErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		state map[string]any
+		want  string
+	}{
+		{"missing app", map[string]any{}, "state.app missing"},
+		{"missing app.config", map[string]any{"app": map[string]any{}}, "state.app.config missing"},
+		{"missing metroArea key", map[string]any{"app": map[string]any{"config": map[string]any{}}}, "state.app.config.metroArea absent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := extractMetroAreas(tc.state)
+			if err == nil {
+				t.Fatalf("expected error for %q; got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## table-reservation-goat — geo-aware slug resolution + dynamic Tock metro list

Fixes failures 1 + 3 from issue #406. Third of four planned PRs, the structural one.

### Two compounding bugs

**Failure 1**: slug resolver matched globally. Agents composing slugs like `joey-bellevue` got "Joey's Bold Flavors" (Tampa, FL) because Autocomplete's first-token match scored well, the `-bellevue` suffix was dropped on the floor, and we picked the first hit. **8 wrong-city resolutions** in the user's report (`joey-bellevue → Joey's Bold Flavors`, `13-coins-bellevue → Via 13`, `carmines-bellevue → Carmines Ybor City` in Tampa, etc.).

**Failure 3**: Tock metroArea registry was a hardcoded 20-metro switch. The SSR config carries 248 worldwide metros at `state.app.config.metroArea` — but we never hydrated it. `--metro bellevue` couldn't even be tried.

### What landed

#### 1. Metro registry (`metro_registry.go`)

Replaces the triplicate-switch (`metroLatLng`/`metroCityName`/`knownMetros`) with a declarative table carrying canonical slug, display name, centroid, and aliases. Chains a dynamic source (Tock metroArea) over a 20-entry static fallback so hydration failures never regress below pre-#406 behavior.

#### 2. Tock metroArea hydration (`tock/search.go` + `metro_hydration.go`)

`tock.Client.FetchMetroAreas(ctx)` pulls all 248 metros from any city-search SSR. Disk-cached 24h, schema-versioned, atomic write+rename. Failure modes (no session, Akamai block, parse error) silently fall back to static.

#### 3. Geo filter (`geo_filter.go`)

Haversine distance from metro centroid. Two modes per the brainstorm:
- **`metroFilterHardReject`** when `--metro` is explicit → Tampa result for Bellevue gets dropped.
- **`metroFilterSoftDemote`** when metro is INFERRED from a slug suffix → match_score × 0.1, row sorts to bottom but stays visible.

Default radius 50km, `--metro-radius-km` to tune. Rows with no lat/lng pass through (can't judge missing data).

#### 4. Slug-suffix inference

`inferMetroFromSlug` peels 1-3 hyphen-separated tokens from the slug end and tries the registry. Longer suffixes win (`new-york-city` beats `city`/`york`).

Wires into a new `resolveOTSlugGeoAware` that replaces the bare `RestaurantIDFromQuery` callsite in `resolveEarliestForVenue`:

```bash
# Before:  availability check opentable:joey-bellevue → "Joey's Bold Flavors" (Tampa) ❌
# After:   anchors Autocomplete on Bellevue centroid → picks geo-closest match ✓
```

#### 5. `--list-metros` flag (user-requested addition)

```bash
$ goat --list-metros --agent | jq '{total, sample: .metros[0:3]}'
{
  "total": 248,
  "sample": [
    {"slug": "abbotsford", "name": "Abbotsford", "lat": 49.0504, "lng": -122.3044},
    {"slug": "adelaide", "name": "Adelaide", "lat": -34.9285, "lng": 138.6007},
    ...
  ]
}
```

Includes `city_hints` map (`{"bellevue": "seattle", "oakland": "san-francisco", ...}`) so agents can resolve secondary cities programmatically.

#### 6. Helpful unknown-metro errors

Three-layer fallback in `formatUnknownMetroError`:

a. **City-hint suggestion** (highest signal):
```
unknown metro "bellevue" — neither OpenTable nor Tock breaks this out as its
own metro. Bellevue is lumped under metro "seattle" (centroid 47.6062,
-122.3321). Try `--metro seattle --metro-radius-km 20` to constrain results
to Bellevue-area venues, or pass `--latitude 47.6062 --longitude -122.3321`
directly with a tight `--metro-radius-km`.
```

b. **"Did you mean"** for token-similar metros.

c. **Count + sample** fallback when nothing matches.

Replaces the prior wall-of-248-metros error message.

#### 7. SKILL.md "Geographic Lookups" section

New playbook section teaching agents:
- Discover via `--list-metros`
- Use `city_hints` for secondary cities
- Tighten `--metro-radius-km` for sub-metro neighborhoods
- Fall back to numeric IDs from `restaurants list` when slug resolution is uncertain

### Tests

**40+ cases across 4 new test files**:
- `metro_registry_test.go` — lookup (exact/alias/case/whitespace), chained dynamic-over-static + union, concurrent `setDynamicMetros`, city-hint mapping (10 cases), `formatUnknownMetroError` branches (Bellevue/did-you-mean/fallback)
- `metro_hydration_test.go` — cache round-trip, TTL invalidation, schema-version invalidation, nil-session no-op, `projectTockMetros`
- `geo_filter_test.go` — haversine math (Seattle↔Bellevue/Seattle↔NYC/SF↔LA/identity), slug-suffix inference (single/multi/alias/no-match), filter modes (hard/soft/off/no-latlng)
- `search_test.go` additions — `extractMetroAreas` happy-path / filter-invalid / shape-error sentinels

### Live smoke verification

```bash
$ ./table-reservation-goat-pp-cli goat --list-metros --agent | jq '.total'
248

$ ./table-reservation-goat-pp-cli goat 'test' --metro bellevue --dry-run --agent
Error: unknown metro "bellevue" — neither OpenTable nor Tock breaks this out
as its own metro. Bellevue is lumped under metro "seattle" (centroid 47.6062,
-122.3321). Try `--metro seattle --metro-radius-km 20`...
```

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS (40+ new tests, full suite green) |
| `printing-press publish validate` | **11/11 PASS** |
| Live `--list-metros` smoke | PASS (248 metros enumerated) |
| Live unknown-metro UX smoke | PASS (Bellevue → seattle hint with coords) |

### Out of scope

- **`looksLikeDoctorInterstitial`-style typed signal for op-specific WAF 403** — PR D.
- **Geocoding free-text city input** — agents can use the `city_hints` map + `--latitude/--longitude` for now.

### PR stacking

This PR is **stacked on #424** which stacks on **#423**. Each lands cleanly on top of the prior. If you'd like to review in isolation, the `internal/cli/metro_*.go` + `internal/cli/geo_filter*.go` + `internal/source/tock/search.go` metroArea additions are conceptually independent from the PR A/B changes.

### Related

- Issue: #406
- PR A: #423 — numeric IDs in availability resolver
- PR B: #424 — earliest no-resolution envelope
- PR D (planned): op-specific WAF typed signal + agent recovery docs
