### PR TITLE
fix(table-reservation-goat): WAF block kind discrimination + agent recovery docs

### DIFF
--- a/cli-skills/pp-table-reservation-goat/SKILL.md
+++ b/cli-skills/pp-table-reservation-goat/SKILL.md
@@ -162,6 +162,64 @@ Numeric IDs route through a separate code path that doesn't touch the
 Autocomplete-based resolver, so they're the most reliable input shape when
 the agent already has the ID in hand.
 
+## Error Recovery for Agents
+
+The CLI surfaces a typed `error_kind` field on availability rows so agents
+can branch on the recovery strategy without parsing free-text `reason`
+strings. Three cases the agent should handle distinctly:
+
+### `error_kind: "session_blocked"`
+
+The entire OpenTable session is shadow-banned (Akamai sees the cookies as
+expired/invalid). **All** OT operations will fail until cookies are refreshed.
+
+**Recovery:** ask the user to run `auth login --chrome` (interactive). The
+CLI's in-memory cooldown will clear once the new cookies pass through
+Bootstrap. The disk-persisted cooldown auto-expires (5min → 60min exponential
+backoff per consecutive 403).
+
+### `error_kind: "operation_blocked"`
+
+A specific GraphQL opname (typically `RestaurantsAvailability` or
+`Autocomplete`) is on a WAF blocklist. **Sibling operations on the same
+session still work.**
+
+**Recovery paths, in order of preference:**
+
+1. **Pivot to a numeric OpenTable ID.** `restaurants list` returns ids like
+   `3688`. Passing `availability check 3688` bypasses the Autocomplete-based
+   resolver entirely, so an `Autocomplete`-specific WAF rule doesn't apply:
+
+   ```bash
+   table-reservation-goat-pp-cli availability check 3688 --party 6 --agent
+   ```
+
+2. **Use the chromedp escape hatch.** When Chrome is running with remote-
+   debugging enabled, the CLI routes blocked requests through the real
+   browser's TLS stack:
+
+   ```bash
+   # Launch Chrome with debugging once per session
+   open -a "Google Chrome" --args --remote-debugging-port=9222
+   # Or point at a custom port via env var
+   export TABLE_RESERVATION_GOAT_OT_CHROME_DEBUG_URL=http://localhost:9222
+   ```
+
+   The CLI auto-falls-back to chromedp on `BotDetectionError`s in the
+   availability path.
+
+3. **Surface the venue URL to the user.** Every row carries `url` (e.g.,
+   `https://www.opentable.com/restaurant/profile/3688`). When both code
+   paths are blocked, the agent should hand the user the URL so they can
+   click through to OpenTable directly.
+
+### No `error_kind` field (Tock errors, non-WAF errors)
+
+Tock doesn't have a Kind discriminator yet — its errors arrive as plain
+text in `reason`. The reason strings name the upstream condition
+(`venue not found`, `calendar empty`, etc.); agents should surface them
+to the user without retry.
+
 ## Recipes
 
 

--- a/library/food-and-dining/table-reservation-goat/SKILL.md
+++ b/library/food-and-dining/table-reservation-goat/SKILL.md
@@ -162,6 +162,64 @@ Numeric IDs route through a separate code path that doesn't touch the
 Autocomplete-based resolver, so they're the most reliable input shape when
 the agent already has the ID in hand.
 
+## Error Recovery for Agents
+
+The CLI surfaces a typed `error_kind` field on availability rows so agents
+can branch on the recovery strategy without parsing free-text `reason`
+strings. Three cases the agent should handle distinctly:
+
+### `error_kind: "session_blocked"`
+
+The entire OpenTable session is shadow-banned (Akamai sees the cookies as
+expired/invalid). **All** OT operations will fail until cookies are refreshed.
+
+**Recovery:** ask the user to run `auth login --chrome` (interactive). The
+CLI's in-memory cooldown will clear once the new cookies pass through
+Bootstrap. The disk-persisted cooldown auto-expires (5min → 60min exponential
+backoff per consecutive 403).
+
+### `error_kind: "operation_blocked"`
+
+A specific GraphQL opname (typically `RestaurantsAvailability` or
+`Autocomplete`) is on a WAF blocklist. **Sibling operations on the same
+session still work.**
+
+**Recovery paths, in order of preference:**
+
+1. **Pivot to a numeric OpenTable ID.** `restaurants list` returns ids like
+   `3688`. Passing `availability check 3688` bypasses the Autocomplete-based
+   resolver entirely, so an `Autocomplete`-specific WAF rule doesn't apply:
+
+   ```bash
+   table-reservation-goat-pp-cli availability check 3688 --party 6 --agent
+   ```
+
+2. **Use the chromedp escape hatch.** When Chrome is running with remote-
+   debugging enabled, the CLI routes blocked requests through the real
+   browser's TLS stack:
+
+   ```bash
+   # Launch Chrome with debugging once per session
+   open -a "Google Chrome" --args --remote-debugging-port=9222
+   # Or point at a custom port via env var
+   export TABLE_RESERVATION_GOAT_OT_CHROME_DEBUG_URL=http://localhost:9222
+   ```
+
+   The CLI auto-falls-back to chromedp on `BotDetectionError`s in the
+   availability path.
+
+3. **Surface the venue URL to the user.** Every row carries `url` (e.g.,
+   `https://www.opentable.com/restaurant/profile/3688`). When both code
+   paths are blocked, the agent should hand the user the URL so they can
+   click through to OpenTable directly.
+
+### No `error_kind` field (Tock errors, non-WAF errors)
+
+Tock doesn't have a Kind discriminator yet — its errors arrive as plain
+text in `reason`. The reason strings name the upstream condition
+(`venue not found`, `calendar empty`, etc.); agents should surface them
+to the user without retry.
+
 ## Recipes
 
 

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -500,7 +500,11 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 							avail = append(avail, chromeAvail...)
 							continue
 						}
-						aerr = fmt.Errorf("direct path blocked by Akamai (%v); chrome fallback also failed: %v", derr, cerr)
+						// Use %w (not %v) on derr so the wrapped *BotDetectionError
+						// remains unwrappable by errors.As — downstream
+						// IsBotDetection(aerr) needs to surface row.ErrorKind even
+						// in the dual-failure case. (PR #426 round-2 Greptile P1.)
+						aerr = fmt.Errorf("direct path blocked by Akamai (%w); chrome fallback also failed: %v", derr, cerr)
 						break
 					}
 					aerr = derr

--- a/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
+++ b/library/food-and-dining/table-reservation-goat/internal/cli/earliest.go
@@ -24,11 +24,18 @@ import (
 )
 
 type earliestRow struct {
-	Venue     string  `json:"venue"`
-	Network   string  `json:"network"`
-	SlotAt    string  `json:"slot_at,omitempty"`
-	Available bool    `json:"available"`
-	Reason    string  `json:"reason,omitempty"`
+	Venue     string `json:"venue"`
+	Network   string `json:"network"`
+	SlotAt    string `json:"slot_at,omitempty"`
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+	// ErrorKind discriminates anti-bot block types so agents can branch
+	// on the recovery strategy without parsing Reason. Issue #406
+	// failure 5. Values: "session_blocked" → run `auth login --chrome`;
+	// "operation_blocked" → pivot to a numeric OT ID via
+	// `restaurants list` to bypass the blocked GraphQL op. Empty for
+	// non-bot errors.
+	ErrorKind string  `json:"error_kind,omitempty"`
 	URL       string  `json:"url,omitempty"`
 	Latitude  float64 `json:"latitude,omitempty"`
 	Longitude float64 `json:"longitude,omitempty"`
@@ -441,6 +448,13 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 					// `unresolved[]` (PR #424 round-3 fix).
 					row.Available = false
 					row.Reason = fmt.Sprintf("opentable: could not resolve %q (%v)", slug, rerr)
+					// If the slug-resolve itself failed because Autocomplete
+					// is WAF-blocked, surface the typed kind so the agent knows
+					// to pivot to a numeric ID (which bypasses Autocomplete
+					// entirely) — issue #406 failure 5.
+					if bde, isBot := opentable.IsBotDetection(rerr); isBot {
+						row.ErrorKind = string(bde.Kind)
+					}
 					return row
 				}
 				_ = metroUsed // hooks into future per-row geo annotation
@@ -505,6 +519,12 @@ func resolveEarliestForVenue(ctx context.Context, s *auth.Session, venue string,
 				row.Available = false
 				row.Reason = fmt.Sprintf("opentable %s (id=%d): %v; venue exists, book directly at %s",
 					venueLabel, restID, aerr, row.URL)
+				// Surface typed kind so the agent can branch — operation_blocked
+				// means "try a different op/numeric ID"; session_blocked means
+				// "run auth login --chrome". Issue #406 failure 5.
+				if bde, isBot := opentable.IsBotDetection(aerr); isBot {
+					row.ErrorKind = string(bde.Kind)
+				}
 				return row
 			}
 			// Find the earliest slot with isAvailable=true across all

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/bot_detection_kind_test.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/bot_detection_kind_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 pejman-pour-moezzi. Licensed under Apache-2.0. See LICENSE.
+
+package opentable
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBotDetectionError_KindDiscriminatesRecoveryMessage verifies that
+// Kind drives distinct human-readable recovery hints. Issue #406
+// failure 5: agents that swallow the error string need to be told
+// what to try next — and "operation_blocked" vs "session_blocked"
+// produces very different next actions.
+func TestBotDetectionError_KindDiscriminatesRecoveryMessage(t *testing.T) {
+	op := &BotDetectionError{
+		Kind:   BotKindOperationBlocked,
+		Status: 403,
+		Reason: "Akamai blocks opname=RestaurantsAvailability",
+	}
+	msg := op.Error()
+	for _, want := range []string{
+		"operation blocked by Akamai WAF",
+		"sibling ops still work",
+		"numeric restaurant ID",
+		"restaurants list",
+		"chromedp escape hatch",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("operation_blocked error missing %q\nfull: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "session_blocked") {
+		t.Errorf("operation_blocked error must not advertise session_blocked recovery\nfull: %s", msg)
+	}
+
+	sess := &BotDetectionError{
+		Kind:   BotKindSessionBlocked,
+		Status: 403,
+		Until:  time.Now().Add(10 * time.Minute),
+		Streak: 2,
+		Reason: "bootstrap 403",
+	}
+	msg = sess.Error()
+	for _, want := range []string{
+		"anti-bot cooldown",
+		"kind=session_blocked",
+		"auth login --chrome",
+		"refresh Akamai cookies",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("session_blocked error missing %q\nfull: %s", want, msg)
+		}
+	}
+}
+
+// TestBotDetectionError_EmptyKindDefaultsToSession covers backward
+// compat: errors constructed without setting Kind (e.g. from older
+// code paths or third-party error wrapping) should default to the
+// session-blocked recovery message, since that's the more cautious
+// recovery — telling the user to refresh cookies never hurts, while
+// telling them to "use a numeric ID" is wrong advice for a real
+// session block.
+func TestBotDetectionError_EmptyKindDefaultsToSession(t *testing.T) {
+	e := &BotDetectionError{
+		Status: 403,
+		Until:  time.Now().Add(5 * time.Minute),
+		Reason: "some 403",
+	}
+	msg := e.Error()
+	if !strings.Contains(msg, "auth login --chrome") {
+		t.Errorf("default Kind should produce session-blocked recovery message; got: %s", msg)
+	}
+}
+
+// TestIsBotDetection_RoundTripsKind verifies that callers using
+// IsBotDetection() (the type-assertion helper) can read Kind off the
+// returned pointer. This is the agent's path to typed recovery
+// branching.
+func TestIsBotDetection_RoundTripsKind(t *testing.T) {
+	original := &BotDetectionError{Kind: BotKindOperationBlocked, Status: 403}
+	wrapped := error(original)
+	bde, ok := IsBotDetection(wrapped)
+	if !ok {
+		t.Fatal("IsBotDetection should report true for *BotDetectionError")
+	}
+	if bde.Kind != BotKindOperationBlocked {
+		t.Errorf("Kind round-trip failed: got %q, want %q", bde.Kind, BotKindOperationBlocked)
+	}
+}
+
+// TestIsBotDetection_NotBotError pins the negative case so callers
+// can rely on the boolean signal.
+func TestIsBotDetection_NotBotError(t *testing.T) {
+	other := errors.New("some unrelated error")
+	if _, ok := IsBotDetection(other); ok {
+		t.Error("IsBotDetection should report false for non-BotDetectionError")
+	}
+	if _, ok := IsBotDetection(nil); ok {
+		t.Error("IsBotDetection should report false for nil")
+	}
+}

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/client.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/client.go
@@ -209,11 +209,8 @@ func (c *Client) do429Aware(req *http.Request) (*http.Response, error) {
 				Reason: fmt.Sprintf("403 from %s; cooldown not persisted: %v", req.URL.Path, sErr),
 			}
 		}
-		// setCooldown returns a session-wide cooldown error; ensure Kind is set
-		// even if the cooldown layer doesn't have the constant available.
-		if bde != nil && bde.Kind == "" {
-			bde.Kind = BotKindSessionBlocked
-		}
+		// setCooldown sets Kind = BotKindSessionBlocked unconditionally;
+		// no patch needed here.
 		return nil, bde
 	}
 	if resp.StatusCode != http.StatusTooManyRequests {

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/client.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/client.go
@@ -192,6 +192,7 @@ func (c *Client) do429Aware(req *http.Request) (*http.Response, error) {
 				}
 			}
 			return nil, &BotDetectionError{
+				Kind:   BotKindOperationBlocked,
 				URL:    req.URL.String(),
 				Status: 403,
 				Streak: 1,
@@ -202,10 +203,16 @@ func (c *Client) do429Aware(req *http.Request) (*http.Response, error) {
 		bde, sErr := setCooldown(fmt.Sprintf("403 from %s (Akamai anti-bot)", req.URL.Path))
 		if sErr != nil {
 			return nil, &BotDetectionError{
-				URL: req.URL.String(), Status: 403, Streak: 1,
+				Kind: BotKindSessionBlocked,
+				URL:  req.URL.String(), Status: 403, Streak: 1,
 				Until:  time.Now().Add(5 * time.Minute),
 				Reason: fmt.Sprintf("403 from %s; cooldown not persisted: %v", req.URL.Path, sErr),
 			}
+		}
+		// setCooldown returns a session-wide cooldown error; ensure Kind is set
+		// even if the cooldown layer doesn't have the constant available.
+		if bde != nil && bde.Kind == "" {
+			bde.Kind = BotKindSessionBlocked
 		}
 		return nil, bde
 	}
@@ -318,7 +325,8 @@ func (c *Client) Bootstrap(ctx context.Context) error {
 				// transient bot-detection error so the user sees the
 				// right error class.
 				return nil, &BotDetectionError{
-					URL: Origin + bootstrapPath, Status: 403, Streak: 1,
+					Kind: BotKindSessionBlocked,
+					URL:  Origin + bootstrapPath, Status: 403, Streak: 1,
 					Until:  time.Now().Add(5 * time.Minute),
 					Reason: "bootstrap returned 403 from " + bootstrapPath + " (Akamai anti-bot); cooldown not persisted: " + sErr.Error(),
 				}
@@ -761,7 +769,11 @@ func (c *Client) gqlCall(ctx context.Context, opname string, body any) ([]byte, 
 	// `do429Aware` were to surface a raw 403 here, surface it as
 	// BotDetectionError so callers' downstream handling stays correct.
 	if resp.StatusCode == 403 {
+		// This is the defense-in-depth path — a single GraphQL op being
+		// blocked is operation-specific, not session-wide. Setting Kind
+		// correctly lets the CLI suggest the numeric-ID bypass.
 		return nil, &BotDetectionError{
+			Kind:   BotKindOperationBlocked,
 			URL:    u,
 			Status: 403,
 			Streak: 1,

--- a/library/food-and-dining/table-reservation-goat/internal/source/opentable/cooldown.go
+++ b/library/food-and-dining/table-reservation-goat/internal/source/opentable/cooldown.go
@@ -33,12 +33,48 @@ import (
 	"time"
 )
 
+// BotDetectionKind enumerates the recovery shapes for an anti-bot
+// block. The CLI-layer JSON encoder surfaces this verbatim so agents
+// can branch on it without parsing free-text Reason strings (issue
+// #406 failure 5).
+//
+//	BotKindSessionBlocked — session-wide block (Bootstrap 403, all
+//	  downstream ops will fail). Recovery: `auth login --chrome` to
+//	  refresh Akamai cookies. The CLI sets a disk-persisted cooldown
+//	  so subsequent invocations fast-fail rather than re-hitting the
+//	  wall.
+//
+//	BotKindOperationBlocked — single-opname WAF rule (e.g. Akamai
+//	  specifically blocks `opname=RestaurantsAvailability`). Sibling
+//	  ops on the same session still work. Recovery: pass a numeric
+//	  OpenTable ID instead (bypasses Autocomplete entirely), use the
+//	  chromedp escape hatch, or surface the venue URL so the user
+//	  can click through.
+type BotDetectionKind string
+
+const (
+	// BotKindSessionBlocked: the entire OT session is shadow-banned.
+	// All ops will fail until cookies are refreshed.
+	BotKindSessionBlocked BotDetectionKind = "session_blocked"
+
+	// BotKindOperationBlocked: a single GraphQL opname is blocked at
+	// the WAF tier. Other ops on the same session work fine.
+	BotKindOperationBlocked BotDetectionKind = "operation_blocked"
+)
+
 // BotDetectionError signals a persistent anti-bot block (403 from the home
 // page or another well-known endpoint). Distinct from `cliutil.RateLimitError`
 // because the remediation is different: rate-limit recovery is "back off
 // briefly," bot-detection recovery is "wait minutes-to-hours and possibly
 // rotate the fingerprint."
+//
+// The Kind field discriminates between session-wide and operation-
+// specific blocks so agents can branch on the recovery strategy
+// without parsing Reason. Issue #406 failure 5: prior versions buried
+// this distinction in Reason text only — agents that didn't parse it
+// couldn't tell whether to refresh cookies or pivot to a different op.
 type BotDetectionError struct {
+	Kind   BotDetectionKind
 	URL    string
 	Status int
 	Until  time.Time // when the cached cooldown expires; zero means "now"
@@ -51,8 +87,15 @@ func (e *BotDetectionError) Error() string {
 	if wait < 0 {
 		wait = 0
 	}
-	return fmt.Sprintf("opentable: anti-bot cooldown (status=%d, streak=%d) — retry after %s (%s); reason: %s; recovery: close Chrome briefly and run `auth login --chrome` to refresh Akamai cookies",
-		e.Status, e.Streak, wait, e.Until.Format(time.RFC3339), e.Reason)
+	switch e.Kind {
+	case BotKindOperationBlocked:
+		return fmt.Sprintf("opentable: operation blocked by Akamai WAF (status=%d) — the specific GraphQL opname is on a blocklist, but sibling ops still work; reason: %s; recovery: use a numeric restaurant ID via `restaurants list` to bypass Autocomplete, or use the chromedp escape hatch (set TABLE_RESERVATION_GOAT_OT_CHROME_DEBUG_URL)",
+			e.Status, e.Reason)
+	default:
+		// Default and BotKindSessionBlocked: full session cooldown.
+		return fmt.Sprintf("opentable: anti-bot cooldown (kind=session_blocked, status=%d, streak=%d) — retry after %s (%s); reason: %s; recovery: close Chrome briefly and run `auth login --chrome` to refresh Akamai cookies",
+			e.Status, e.Streak, wait, e.Until.Format(time.RFC3339), e.Reason)
+	}
 }
 
 // cooldownState is the on-disk shape. Persisted to a per-user cache file so
@@ -102,6 +145,7 @@ func loadActiveCooldown() *BotDetectionError {
 		return nil
 	}
 	return &BotDetectionError{
+		Kind:   BotKindSessionBlocked,
 		URL:    Origin + "/",
 		Status: 403,
 		Until:  s.Until,
@@ -153,6 +197,7 @@ func setCooldown(reason string) (*BotDetectionError, error) {
 		return nil, fmt.Errorf("renaming cooldown file: %w", err)
 	}
 	return &BotDetectionError{
+		Kind:   BotKindSessionBlocked,
 		URL:    Origin + "/",
 		Status: 403,
 		Until:  until,


### PR DESCRIPTION
## table-reservation-goat — WAF block kind discrimination + agent recovery docs

Fixes failure 5 from issue #406. **Closes the four-PR series for #406.**

### The problem

When OpenTable's Akamai WAF blocks the CLI, agents got back a free-text `reason` string mixing two very different conditions:

- **Session-wide block** — all OT operations fail; recovery is `auth login --chrome` to refresh cookies
- **Operation-specific block** — one GraphQL opname (e.g. `Autocomplete` or `RestaurantsAvailability`) is on a WAF blocklist; sibling ops on the same session still work; recovery is "pivot to a different op"

The distinction lived only in the `reason` text. Agents that didn't parse the string couldn't tell which recovery to attempt — they either spammed `auth login --chrome` for ops that didn't need it, or skipped the recovery entirely.

### Fix

#### 1. Typed `BotDetectionKind` enum

```go
type BotDetectionKind string

const (
	BotKindSessionBlocked    BotDetectionKind = "session_blocked"
	BotKindOperationBlocked  BotDetectionKind = "operation_blocked"
)
```

Set at every `BotDetectionError` construction site:

| Site | Kind |
|---|---|
| `client.go` do429Aware retry-403 | `operation_blocked` |
| `client.go` session-wide cooldown setter | `session_blocked` |
| `client.go` gqlCall 403 defense-in-depth | `operation_blocked` |
| `client.go` Bootstrap 403 | `session_blocked` |
| `cooldown.go` `loadActiveCooldown` (disk replay) | `session_blocked` |
| `cooldown.go` `setCooldown` (fresh session block) | `session_blocked` |

#### 2. Kind-aware `BotDetectionError.Error()`

`operation_blocked`:
> *opentable: operation blocked by Akamai WAF (status=403) — the specific GraphQL opname is on a blocklist, but sibling ops still work; reason: ...; recovery: **use a numeric restaurant ID via `restaurants list` to bypass Autocomplete**, or use the chromedp escape hatch (set `TABLE_RESERVATION_GOAT_OT_CHROME_DEBUG_URL`)*

`session_blocked` (default):
> *opentable: anti-bot cooldown (kind=session_blocked, status=403, streak=2) — retry after Xm (...); reason: ...; recovery: **close Chrome briefly and run `auth login --chrome`** to refresh Akamai cookies*

#### 3. `earliestRow.ErrorKind` JSON field

```json
{
  "venue": "joey-bellevue",
  "available": false,
  "reason": "opentable: ...",
  "error_kind": "operation_blocked",
  "url": "https://www.opentable.com/restaurant/profile/..."
}
```

Surfaces the typed kind to agents at both error sites in `resolveEarliestForVenue` (slug-resolve fail AND availability-fetch fail). Empty for non-bot errors.

#### 4. SKILL.md "Error Recovery for Agents" section

Walks agents through the three cases with exact commands to run:

- `error_kind: "session_blocked"` → `auth login --chrome`
- `error_kind: "operation_blocked"` → (1) numeric ID pivot via `restaurants list`, (2) chromedp escape hatch with `--remote-debugging-port=9222`, (3) surface venue URL
- No `error_kind` → surface `reason` to user, no retry

This is the playbook the #406 reporter needed but didn't have.

### Tests

5 new cases in `internal/source/opentable/bot_detection_kind_test.go`:

- `TestBotDetectionError_KindDiscriminatesRecoveryMessage` — `operation_blocked` surfaces "numeric restaurant ID" + "chromedp escape hatch" but NOT "session_blocked"; `session_blocked` surfaces "auth login --chrome" + "Akamai cookies"
- `TestBotDetectionError_EmptyKindDefaultsToSession` — backward-compat: errors without Kind default to session-blocked recovery
- `TestIsBotDetection_RoundTripsKind` — agents using `IsBotDetection()` read Kind off the returned pointer
- `TestIsBotDetection_NotBotError` — negative case (non-bot errors, nil)

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go test ./...` | PASS (5 new tests, full suite green) |
| `printing-press publish validate` | **11/11 PASS** |

### PR series summary (issue #406)

This PR closes the four-PR series. Stacking order:

1. **#423** — accept numeric IDs in availability resolver (fixes failure 2 — `restaurants list → availability check` composition)
2. **#424** — `earliest` structured envelope vs `{}` (fixes failure 4)
3. **#425** — geo-aware slug resolution + dynamic Tock metro list (fixes failures 1 + 3)
4. **#XXX (this PR)** — WAF block kind discrimination + agent recovery docs (fixes failure 5)

Together they address every primary and secondary failure from #406 except failure 6 (auth-login Network/Cookies warning) which is already addressed by the in-flight #399.

### Related

- Issue: #406
- PR A: #423 — numeric IDs in availability resolver
- PR B: #424 — earliest no-resolution envelope
- PR C: #425 — geo-aware slug resolution + dynamic Tock metro list
- Related (issue #399): Chrome cookie discovery walk (independent fix surfaced in the same auth path)
