### PR TITLE
fix(verifier): match // PATCH: comment marker, not bare PATCH word

### DIFF
--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -343,12 +343,13 @@ def candidate_patch_marker_files(cli_dir: Path) -> Iterable[Path]:
 #     // PATCH: <one-line summary>
 #     // PATCH(upstream cli-printing-press#<n>): ...
 #
-# Intentionally excludes bare HTTP method literals like "PATCH" that appear in
-# generated client/handler code (case "PATCH":, makeAPIHandler("PATCH", ...),
-# {"pp:method": "PATCH"}, etc.), which are not hand-authored customizations and
-# would otherwise false-positive on any printed CLI for an API that exposes
-# HTTP PATCH endpoints.
-_PATCH_MARKER_RE = re.compile(r"//\s*PATCH(?:\s*[:(]|\s*$)", re.MULTILINE)
+# Anchored on the `// PATCH` comment prefix immediately followed by `:` or `(`
+# — exactly the two documented forms. Intentionally excludes bare HTTP method
+# literals like "PATCH" that appear in generated client/handler code
+# (case "PATCH":, makeAPIHandler("PATCH", ...), {"pp:method": "PATCH"}, etc.),
+# which are not hand-authored customizations and would otherwise false-positive
+# on any printed CLI for an API that exposes HTTP PATCH endpoints.
+_PATCH_MARKER_RE = re.compile(r"//\s*PATCH\s*[:(]")
 
 
 def has_patch_marker(path: Path) -> bool:

--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -336,9 +337,23 @@ def candidate_patch_marker_files(cli_dir: Path) -> Iterable[Path]:
             yield path
 
 
+# Matches the inline marker convention documented in each printed CLI's
+# AGENTS.md:
+#
+#     // PATCH: <one-line summary>
+#     // PATCH(upstream cli-printing-press#<n>): ...
+#
+# Intentionally excludes bare HTTP method literals like "PATCH" that appear in
+# generated client/handler code (case "PATCH":, makeAPIHandler("PATCH", ...),
+# {"pp:method": "PATCH"}, etc.), which are not hand-authored customizations and
+# would otherwise false-positive on any printed CLI for an API that exposes
+# HTTP PATCH endpoints.
+_PATCH_MARKER_RE = re.compile(r"//\s*PATCH(?:\s*[:(]|\s*$)", re.MULTILINE)
+
+
 def has_patch_marker(path: Path) -> bool:
     try:
-        return "PATCH" in path.read_text(errors="ignore")
+        return bool(_PATCH_MARKER_RE.search(path.read_text(errors="ignore")))
     except OSError:
         return False
 

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -177,5 +177,72 @@ class PublishPackageVerifierTest(unittest.TestCase):
         self.assertFalse(any("-pp-cli/-pp-mcp binary suffix" in msg for msg in messages))
 
 
+class HasPatchMarkerTest(unittest.TestCase):
+    """Unit tests for ``has_patch_marker`` to ensure only the documented
+    ``// PATCH:`` / ``// PATCH(...)`` comment convention is detected, not bare
+    HTTP method literals or other coincidental occurrences of the word.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="has-patch-marker-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+
+    def _write(self, name: str, body: str) -> Path:
+        path = self.tmp / name
+        path.write_text(body)
+        return path
+
+    def test_detects_real_patch_marker(self) -> None:
+        path = self._write(
+            "real.go",
+            "// PATCH: align response envelope with upstream\nfunc foo() {}\n",
+        )
+        self.assertTrue(verifier.has_patch_marker(path))
+
+    def test_detects_patch_marker_with_upstream_ref(self) -> None:
+        path = self._write(
+            "real.go",
+            "    // PATCH(upstream cli-printing-press#842): auto-fill AccountSid\n",
+        )
+        self.assertTrue(verifier.has_patch_marker(path))
+
+    def test_ignores_http_method_string_literal(self) -> None:
+        path = self._write(
+            "client.go",
+            'return c.do("PATCH", path, nil, body, nil)\n',
+        )
+        self.assertFalse(verifier.has_patch_marker(path))
+
+    def test_ignores_makeAPIHandler_PATCH(self) -> None:
+        path = self._write(
+            "tools.go",
+            'makeAPIHandler("PATCH", "/conversations/{id}", bindings, positional)\n',
+        )
+        self.assertFalse(verifier.has_patch_marker(path))
+
+    def test_ignores_switch_case_PATCH(self) -> None:
+        path = self._write(
+            "tools.go",
+            'switch method {\ncase "POST", "PUT", "PATCH":\n    return body\n}\n',
+        )
+        self.assertFalse(verifier.has_patch_marker(path))
+
+    def test_ignores_annotation_map_value(self) -> None:
+        path = self._write(
+            "cmd.go",
+            'Annotations: map[string]string{"pp:method": "PATCH", "pp:path": "/x"},\n',
+        )
+        self.assertFalse(verifier.has_patch_marker(path))
+
+    def test_ignores_word_PATCH_in_string_or_comment(self) -> None:
+        path = self._write(
+            "doc.go",
+            "// This handler issues HTTP PATCH requests against the upstream API.\n",
+        )
+        # Plain prose comment without the colon/paren marker shape is not a
+        # customization marker.
+        self.assertFalse(verifier.has_patch_marker(path))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #419.

## Problem

`has_patch_marker` in `verify_publish_package.py` did a naive `"PATCH" in text` substring match. It false-positives on any printed CLI whose source API exposes HTTP `PATCH` endpoints — generated code routinely contains literals like:

```go
makeAPIHandler("PATCH", "/conversations/{id}", ...)
case "PATCH":
{"pp:method": "PATCH", "pp:path": "..."}
c.do("PATCH", path, nil, body, nil)
```

These are part of generic generator-emitted code and will never correspond to hand-authored customizations. The verifier blocks every such fresh-print PR with:

> source files contain PATCH markers but `patches[]` is empty.

## Surfaced via

PR #417 (`feat(bird): add bird`) — fresh print, Press 4.2.2, empty `patches[]`, blocked on this check. Bird is the first Library CLI hit by the combination of (a) the verifier check landing via #407 and (b) an API that uses HTTP `PATCH` semantics. Any future modern-REST CLI (Stripe update endpoints, Notion updates, GitHub PATs, etc.) would trip the same gate.

## Fix

Match the marker shape that `AGENTS.md` actually documents (`// PATCH: <summary>`, `// PATCH(upstream cli-printing-press#<n>): ...`) with a regex anchored on the `// PATCH` comment prefix plus `:` or `(`. Bare HTTP method literals in strings, annotations, and switch-cases no longer match.

## Tests

Adds focused unit tests for `has_patch_marker`:

- ✅ detects real `// PATCH: <summary>` markers
- ✅ detects `// PATCH(upstream cli-printing-press#<n>): ...`
- ✅ ignores `c.do("PATCH", ...)`
- ✅ ignores `makeAPIHandler("PATCH", ...)`
- ✅ ignores `case "PATCH":`
- ✅ ignores `{"pp:method": "PATCH"}` annotation values
- ✅ ignores plain prose containing the word "PATCH"

All 12 tests in `verify_publish_package_test.py` pass locally.

## Test plan

- [x] `python3 -m unittest verify_publish_package_test.py` — 12/12 pass
- [x] Repro check: re-running the verifier on PR #417's tree with this fix no longer raises the false positive
- [ ] CI on this PR verifies the Verify check itself stays green on existing library entries