### PR TITLE
fix(ci): drop printer==owner heuristic from attribution guard

### DIFF
--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -233,7 +233,6 @@ def validate_new_cli(head: str, change: CLIChange) -> list[str]:
     problems: list[str] = []
     printer = str(manifest.get("printer") or "")
     printer_name = str(manifest.get("printer_name") or "")
-    owner = str(manifest.get("owner") or "")
     api_name = str(manifest.get("api_name") or change.api_name)
 
     if printer in PLACEHOLDER_PRINTERS:
@@ -243,10 +242,6 @@ def validate_new_cli(head: str, change: CLIChange) -> list[str]:
     if printer_name in PLACEHOLDER_PRINTERS:
         problems.append(
             f"::error file={manifest_path}::new CLI {api_name} must set .printing-press.json printer_name to the printer display name"
-        )
-    if printer and owner and printer == owner:
-        problems.append(
-            f"::error file={manifest_path}::new CLI {api_name} has printer equal to owner ({printer}); this usually means the generator fallback claimed no real printer"
         )
     if printer and printer == api_name:
         problems.append(

--- a/.github/scripts/verify-attribution/verify_attribution_test.py
+++ b/.github/scripts/verify-attribution/verify_attribution_test.py
@@ -74,6 +74,25 @@ class AttributionVerifierTest(unittest.TestCase):
 
         self.assertEqual(1, verifier.run(base, "HEAD"))
 
+    def test_new_cli_allows_printer_equal_to_owner(self) -> None:
+        self.write("README.md", "# repo\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "base")
+        base = self.git("rev-parse", "HEAD").stdout.strip()
+
+        self.git("switch", "-c", "feature")
+        self.write_manifest(
+            "library/other/openalex",
+            owner="hiten-shah",
+            printer="hiten-shah",
+            printer_name="Hiten Shah",
+        )
+        self.write("library/other/openalex/README.md", "# OpenAlex\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add openalex")
+
+        self.assertEqual(0, verifier.run(base, "HEAD"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The attribution guard's `printer == owner` check is a heuristic that fires false-positives on the legitimate case of a printer publishing a CLI for an API they also own. It blocked [PR #441 (openalex)](https://github.com/mvanhorn/printing-press-library/pull/441) and [PR #442 (arxiv)](https://github.com/mvanhorn/printing-press-library/pull/442), both from @hnshah, where the printer is correctly recorded as `hiten-shah` and the owner happens to be the same handle.

The check's own error message hedges — "this *usually* means the generator fallback claimed no real printer" — but it has no way to distinguish a real fallback from a real self-print. The actual "no real printer" signal is the placeholder check on the previous line (`printer in {"", "USER", "user"}`), which remains in place.

## Evidence this is the right call

Two CLIs already merged on `main` sit in this exact state and would fail the guard if it were re-run on their original PR:

- [library/devices/whoop/.printing-press.json](library/devices/whoop/.printing-press.json) — `owner: gregvanhorn`, `printer: gregvanhorn`
- [library/marketing/google-search-console/.printing-press.json](library/marketing/google-search-console/.printing-press.json) — `owner: bossriceshark`, `printer: bossriceshark`

The guard is PR-scoped (only checks newly-added CLIs), which is why those slipped through and why the rule is internally inconsistent with the published baseline.

## Changes

- Remove the `printer == owner` block from `validate_new_cli` in `.github/scripts/verify-attribution/verify_attribution.py`.
- Add a regression test pinning that a new CLI with `printer == owner` passes the guard.

## Test plan

- [x] `python3 .github/scripts/verify-attribution/verify_attribution_test.py` — all 3 tests pass, including the new `test_new_cli_allows_printer_equal_to_owner`.
- [x] Existing tests (`test_non_library_pr_ignores_unrelated_baseline_attribution_gaps`, `test_touched_existing_cli_still_requires_attribution`) still pass — placeholder and existing-CLI attribution-preservation paths are unchanged.
- [ ] After merge, re-run CI on PRs #441 and #442 to confirm the Verify / Guard CLI attribution job goes green.