### PR TITLE
fix(shopify): declare $id as ID! in root *Get queries

### DIFF
--- a/library/commerce/shopify/internal/client/queries.go
+++ b/library/commerce/shopify/internal/client/queries.go
@@ -5,7 +5,7 @@ package client
 
 // GraphQL query constants generated from the API spec.
 
-const CustomersGetQuery = `query($id: String!) {
+const CustomersGetQuery = `query($id: ID!) {
   customer(id: $id) {
     id
     email
@@ -34,7 +34,7 @@ const CustomersListQuery = `query($first: Int!, $after: String) {
   }
 }`
 
-const FulfillmentOrdersGetQuery = `query($id: String!) {
+const FulfillmentOrdersGetQuery = `query($id: ID!) {
   fulfillmentOrder(id: $id) {
     id
     status
@@ -63,7 +63,7 @@ const FulfillmentOrdersListQuery = `query($first: Int!, $after: String) {
   }
 }`
 
-const InventoryItemsGetQuery = `query($id: String!) {
+const InventoryItemsGetQuery = `query($id: ID!) {
   inventoryItem(id: $id) {
     id
     sku
@@ -86,7 +86,7 @@ const InventoryItemsListQuery = `query($first: Int!, $after: String) {
   }
 }`
 
-const OrdersGetQuery = `query($id: String!) {
+const OrdersGetQuery = `query($id: ID!) {
   order(id: $id) {
     id
     name
@@ -119,7 +119,7 @@ const OrdersListQuery = `query($first: Int!, $after: String, $query: String, $so
   }
 }`
 
-const ProductsGetQuery = `query($id: String!) {
+const ProductsGetQuery = `query($id: ID!) {
   product(id: $id) {
     id
     title

--- a/library/commerce/shopify/internal/client/queries_test.go
+++ b/library/commerce/shopify/internal/client/queries_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 user. Licensed under Apache-2.0. See LICENSE.
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGetQueriesDeclareIDType is a regression test for a GraphQL type mismatch
+// where root *Get queries declared `$id: String!` but Shopify's product(id:),
+// customer(id:), order(id:), fulfillmentOrder(id:), and inventoryItem(id:)
+// root query arguments expect `ID!`. The previous typing caused the API to
+// reject calls with: `Type mismatch on variable $id and argument id
+// (String! / ID!)`.
+func TestGetQueriesDeclareIDType(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"CustomersGetQuery", CustomersGetQuery},
+		{"FulfillmentOrdersGetQuery", FulfillmentOrdersGetQuery},
+		{"InventoryItemsGetQuery", InventoryItemsGetQuery},
+		{"OrdersGetQuery", OrdersGetQuery},
+		{"ProductsGetQuery", ProductsGetQuery},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.query, "$id: ID!") {
+				t.Errorf("%s must declare $id as ID! to match Shopify's root query argument type; got: %s", tc.name, tc.query)
+			}
+			if strings.Contains(tc.query, "$id: String!") {
+				t.Errorf("%s must not declare $id as String! (Shopify expects ID!); got: %s", tc.name, tc.query)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a GraphQL type-mismatch that breaks every `shopify-pp-cli <resource> get <gid>` invocation against current Shopify Admin API versions.

The generated query constants in `library/commerce/shopify/internal/client/queries.go` declared the id variable as `String!`, but Shopify's root query arguments `product(id:)`, `customer(id:)`, `order(id:)`, `fulfillmentOrder(id:)`, and `inventoryItem(id:)` all expect `ID!`. With API version `2026-04` (and any version where the server enforces strict variable/argument type matching), the API returns:

```
Error: graphql: Type mismatch on variable $id and argument id (String! / ID!)
```

## Changes

- `library/commerce/shopify/internal/client/queries.go`: change `$id: String!` to `$id: ID!` in `CustomersGetQuery`, `FulfillmentOrdersGetQuery`, `InventoryItemsGetQuery`, `OrdersGetQuery`, and `ProductsGetQuery`.
- `library/commerce/shopify/internal/client/queries_test.go`: new regression test asserting all five *Get query constants declare `$id` as `ID!` and not `String!`.

Other `String!` usages in the package are correct and untouched:
- `bulkOperationRunQueryMutation`'s `$query: String!` carries a GraphQL query body (not an ID).
- List queries' `$after: String` and `$query: String` map to GraphQL `String`, which is correct for those fields.

Note: `queries.go` is generated (`DO NOT EDIT` header). The fix is applied to the generated output so the shipped behavior is correct now. The upstream generator/spec mapping (`spec.yaml` describes the `id` param as `type: string`) may want a follow-up to emit `ID!` for fields whose GraphQL argument is `ID!`, but that's out of scope for this targeted bug fix.

## Reproduction (before fix)

```bash
export SHOPIFY_API_VERSION="2026-04"
shopify-pp-cli products get "gid://shopify/Product/8912800907568" --agent
# Error: graphql: Type mismatch on variable $id and argument id (String! / ID!)
```

## Verification (after fix)

```bash
cd library/commerce/shopify
go build ./...                            # passes
go test ./...                             # passes, incl. new regression test
go install ./cmd/shopify-pp-cli
SHOPIFY_API_VERSION="2026-04" shopify-pp-cli products get "gid://shopify/Product/8912800907568" --agent
# returns the product JSON instead of erroring
```

## Test plan

- [x] `go build ./...` succeeds in `library/commerce/shopify`.
- [x] `go test ./...` passes in `library/commerce/shopify` (including new `TestGetQueriesDeclareIDType`).
- [x] Manual end-to-end: failing command now succeeds against a live Shopify store on API version `2026-04`.
- [ ] Reviewer: sanity-check that no other in-repo callers depend on `$id: String!` literal text.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a client CLI fix shipped by `go install`. After publishing a new release, users will pick up the fix on their next install/upgrade. Validate by running any `<resource> get <gid>` command against a current Shopify API version and confirming a `200 OK` JSON response rather than the type-mismatch GraphQL error.