### PR TITLE
Add Cloudflare Registrar domain CLI

### DIFF
--- a/library/cloud/cf-domain/README.md
+++ b/library/cloud/cf-domain/README.md
@@ -1,0 +1,58 @@
+# Cloudflare Registrar domain CLI
+
+Small headless CLI for [Cloudflare Registrar](https://developers.cloudflare.com/registrar/) domain workflows.
+
+It wraps the Cloudflare Registrar API endpoints documented in the [Cloudflare API reference](https://developers.cloudflare.com/api/resources/registrar/) for headless agent and script workflows:
+
+- Search domain ideas
+- Check exact domain availability/pricing
+- Register a domain, gated by typed confirmation
+
+## Install
+
+```bash
+go install ./cmd/cf-domain-pp-cli
+```
+
+From the Printing Press library checkout:
+
+```bash
+cd library/cloud/cf-domain
+go install ./cmd/cf-domain-pp-cli
+```
+
+## Auth
+
+Required env:
+
+```bash
+export CLOUDFLARE_API_TOKEN=...
+export CLOUDFLARE_ACCOUNT_ID=...
+```
+
+Create the token using Cloudflare's [API token guide](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/).
+
+Minimum Cloudflare token permission:
+
+- Account → Registrar → Edit, scoped to the specific account
+
+Optional:
+
+- Account → Account Settings → Read, only if external tooling needs account discovery
+
+## Commands
+
+```bash
+cf-domain-pp-cli doctor
+cf-domain-pp-cli domain-search --query mybrand --limit 20
+cf-domain-pp-cli domain-check --domain mybrand.dev
+cf-domain-pp-cli domain-register --domain mybrand.dev --confirm-domain mybrand.dev
+```
+
+## Safety
+
+`domain-register` refuses to run unless `--confirm-domain` exactly matches `--domain`.
+
+Before registering, always run `domain-check` immediately before purchase and confirm the exact domain, availability, price, renewal price, and currency returned by Cloudflare.
+
+If Cloudflare returns an async/pending registration response, do not retry blindly.

--- a/library/cloud/cf-domain/SKILL.md
+++ b/library/cloud/cf-domain/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pp-cf-domain
+description: Cloudflare Registrar domain search, live check, and typed-confirm registration from the terminal.
+---
+
+# pp-cf-domain
+
+Use `cf-domain-pp-cli` when you need headless Cloudflare Registrar domain operations.
+
+## Required environment
+
+```bash
+export CLOUDFLARE_API_TOKEN=...
+export CLOUDFLARE_ACCOUNT_ID=...
+```
+
+Required token permission:
+
+- Account → Registrar → Edit, scoped to the specific account
+
+## Commands
+
+```bash
+cf-domain-pp-cli doctor
+cf-domain-pp-cli domain-search --query <name> --limit 20
+cf-domain-pp-cli domain-check --domain <domain.tld>
+cf-domain-pp-cli domain-register --domain <domain.tld> --confirm-domain <domain.tld>
+```
+
+## Safety gate
+
+Never run `domain-register` until the user confirms the exact domain and fresh returned price from `domain-check`.
+
+The CLI also enforces a typed confirmation gate: `--confirm-domain` must exactly match `--domain`.

--- a/library/cloud/cf-domain/cmd/cf-domain-pp-cli/main.go
+++ b/library/cloud/cf-domain/cmd/cf-domain-pp-cli/main.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const baseURL = "https://api.cloudflare.com/client/v4"
+
+var version = "dev"
+
+type cfEnvelope struct {
+	Success  bool            `json:"success"`
+	Errors   []cfMessage     `json:"errors,omitempty"`
+	Messages []cfMessage     `json:"messages,omitempty"`
+	Result   json.RawMessage `json:"result,omitempty"`
+}
+
+type cfMessage struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type config struct {
+	Token     string
+	AccountID string
+	HTTP      *http.Client
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 || args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		printUsage(stdout)
+		return nil
+	}
+	if args[0] == "--version" || args[0] == "version" {
+		fmt.Fprintln(stdout, version)
+		return nil
+	}
+
+	cfg := config{
+		Token:     firstNonEmpty(os.Getenv("CLOUDFLARE_API_TOKEN"), os.Getenv("CF_API_TOKEN")),
+		AccountID: firstNonEmpty(os.Getenv("CLOUDFLARE_ACCOUNT_ID"), os.Getenv("ACCOUNT_ID")),
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+	}
+
+	switch args[0] {
+	case "doctor":
+		return doctor(cfg, stdout)
+	case "domain-search":
+		return domainSearch(cfg, args[1:], stdout)
+	case "domain-check":
+		return domainCheck(cfg, args[1:], stdout)
+	case "domain-register":
+		return domainRegister(cfg, args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown command %q\nrun: cf-domain-pp-cli help", args[0])
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `cf-domain-pp-cli - Cloudflare Registrar domain CLI
+
+Commands:
+  doctor                         Validate required env without printing secrets
+  domain-search --query NAME     Search available domain ideas
+  domain-check --domain NAME     Live check availability/pricing for exact domain
+  domain-register --domain NAME --confirm-domain NAME
+                                 Register exact domain; confirmation is required
+  version                        Print version
+
+Env:
+  CLOUDFLARE_API_TOKEN or CF_API_TOKEN
+  CLOUDFLARE_ACCOUNT_ID or ACCOUNT_ID
+
+Safety:
+  domain-register refuses to run unless --confirm-domain exactly matches --domain.
+  Always run domain-check immediately before registering and confirm returned price.
+`)
+}
+
+func doctor(cfg config, w io.Writer) error {
+	missing := missingEnv(cfg)
+	out := map[string]any{
+		"ok":                  len(missing) == 0,
+		"missing":             missing,
+		"has_api_token":       cfg.Token != "",
+		"has_account_id":      cfg.AccountID != "",
+		"required_permission": "Account:Registrar:Edit scoped to the specific account",
+	}
+	return writeJSON(w, out)
+}
+
+func domainSearch(cfg config, args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("domain-search", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	query := fs.String("query", "", "search query")
+	limit := fs.String("limit", "20", "result limit")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*query) == "" {
+		return errors.New("domain-search requires --query")
+	}
+	if err := requireAuth(cfg); err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/accounts/%s/registrar/domain-search?q=%s&limit=%s", baseURL, url.PathEscape(cfg.AccountID), url.QueryEscape(*query), url.QueryEscape(*limit))
+	return callAndWrite(cfg, http.MethodGet, u, nil, w)
+}
+
+func domainCheck(cfg config, args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("domain-check", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	domain := fs.String("domain", "", "domain name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	name := normalizeDomain(*domain)
+	if name == "" {
+		return errors.New("domain-check requires --domain")
+	}
+	if err := requireAuth(cfg); err != nil {
+		return err
+	}
+	body := map[string][]string{"domains": {name}}
+	u := fmt.Sprintf("%s/accounts/%s/registrar/domain-check", baseURL, url.PathEscape(cfg.AccountID))
+	return callAndWrite(cfg, http.MethodPost, u, body, w)
+}
+
+func domainRegister(cfg config, args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("domain-register", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	domain := fs.String("domain", "", "domain name")
+	confirm := fs.String("confirm-domain", "", "must exactly match --domain")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	name := normalizeDomain(*domain)
+	if name == "" {
+		return errors.New("domain-register requires --domain")
+	}
+	if normalizeDomain(*confirm) != name {
+		return fmt.Errorf("refusing paid registration: --confirm-domain must exactly match %q", name)
+	}
+	if err := requireAuth(cfg); err != nil {
+		return err
+	}
+	body := map[string]string{"domain_name": name}
+	u := fmt.Sprintf("%s/accounts/%s/registrar/registrations", baseURL, url.PathEscape(cfg.AccountID))
+	return callAndWrite(cfg, http.MethodPost, u, body, w)
+}
+
+func callAndWrite(cfg config, method, endpoint string, body any, w io.Writer) error {
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequest(method, endpoint, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := cfg.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("cloudflare api failed: HTTP %d: %s", resp.StatusCode, sanitize(string(payload)))
+	}
+	var env cfEnvelope
+	if err := json.Unmarshal(payload, &env); err == nil && !env.Success && len(env.Errors) > 0 {
+		return fmt.Errorf("cloudflare api error: %s", summarizeMessages(env.Errors))
+	}
+	_, err = w.Write(append(payload, '\n'))
+	return err
+}
+
+func requireAuth(cfg config) error {
+	if missing := missingEnv(cfg); len(missing) > 0 {
+		return fmt.Errorf("missing required env: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func missingEnv(cfg config) []string {
+	var missing []string
+	if cfg.Token == "" {
+		missing = append(missing, "CLOUDFLARE_API_TOKEN")
+	}
+	if cfg.AccountID == "" {
+		missing = append(missing, "CLOUDFLARE_ACCOUNT_ID")
+	}
+	return missing
+}
+
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(b, '\n'))
+	return err
+}
+
+func normalizeDomain(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func summarizeMessages(messages []cfMessage) string {
+	parts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Code != 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", msg.Code, msg.Message))
+		} else {
+			parts = append(parts, msg.Message)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func sanitize(s string) string {
+	for _, env := range []string{"CLOUDFLARE_API_TOKEN", "CF_API_TOKEN"} {
+		if token := os.Getenv(env); token != "" {
+			s = strings.ReplaceAll(s, token, "[redacted]")
+		}
+	}
+	return s
+}

--- a/library/cloud/cf-domain/cmd/cf-domain-pp-cli/main_test.go
+++ b/library/cloud/cf-domain/cmd/cf-domain-pp-cli/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDoctorReportsMissingEnvWithoutSecrets(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+	var out bytes.Buffer
+	if err := run([]string{"doctor"}, &out, &bytes.Buffer{}); err != nil {
+		t.Fatalf("doctor failed: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "CLOUDFLARE_API_TOKEN") || !strings.Contains(got, "CLOUDFLARE_ACCOUNT_ID") {
+		t.Fatalf("expected missing env names, got %s", got)
+	}
+}
+
+func TestRegisterRequiresTypedConfirmationBeforeAuth(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+	var out bytes.Buffer
+	err := run([]string{"domain-register", "--domain", "example.com"}, &out, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--confirm-domain") {
+		t.Fatalf("expected confirmation error, got %v", err)
+	}
+}
+
+func TestRegisterConfirmationMustMatchDomain(t *testing.T) {
+	t.Setenv("CLOUDFLARE_API_TOKEN", "")
+	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "")
+	err := run([]string{"domain-register", "--domain", "example.com", "--confirm-domain", "other.com"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "must exactly match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}
+
+func TestDomainCheckRequiresDomain(t *testing.T) {
+	err := run([]string{"domain-check"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "requires --domain") {
+		t.Fatalf("expected --domain error, got %v", err)
+	}
+}
+
+func TestDomainSearchRequiresQuery(t *testing.T) {
+	err := run([]string{"domain-search"}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "requires --query") {
+		t.Fatalf("expected --query error, got %v", err)
+	}
+}
+
+func TestVersion(t *testing.T) {
+	var out bytes.Buffer
+	if err := run([]string{"version"}, &out, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out.String()) == "" {
+		t.Fatal("expected version output")
+	}
+}
+
+func TestMainDoesNotRequireEnvForHelp(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	var out bytes.Buffer
+	if err := run([]string{"help"}, &out, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Cloudflare Registrar domain CLI") {
+		t.Fatal(out.String())
+	}
+}

--- a/library/cloud/cf-domain/go.mod
+++ b/library/cloud/cf-domain/go.mod
@@ -1,0 +1,3 @@
+module github.com/mvanhorn/printing-press-library/library/cloud/cf-domain
+
+go 1.22

--- a/library/cloud/cf-domain/manifest.json
+++ b/library/cloud/cf-domain/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "cf-domain",
+  "category": "cloud",
+  "api": "Cloudflare Registrar",
+  "description": "Search, check, and register Cloudflare Registrar domains from a small headless CLI.",
+  "path": "library/cloud/cf-domain",
+  "printer": "dannyshmueli",
+  "printer_name": "Danny Shmueli"
+}

--- a/library/cloud/cf-domain/spec.yaml
+++ b/library/cloud/cf-domain/spec.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Cloudflare Registrar Domains Minimal API
+  version: 0.1.0
+paths:
+  /accounts/{account_id}/registrar/domain-search:
+    get:
+      summary: Search domain ideas
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: q
+          in: query
+          required: true
+          schema: { type: string }
+  /accounts/{account_id}/registrar/domain-check:
+    post:
+      summary: Check exact domain availability and pricing
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [domains]
+              properties:
+                domains:
+                  type: array
+                  items: { type: string }
+  /accounts/{account_id}/registrar/registrations:
+    post:
+      summary: Register exact domain
+      description: Paid operation. CLI requires typed --confirm-domain gate before calling this endpoint.
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [domain_name]
+              properties:
+                domain_name: { type: string }


### PR DESCRIPTION
## Summary

Adds a minimal Cloudflare Registrar domain CLI:

- `cf-domain-pp-cli doctor`
- `cf-domain-pp-cli domain-search --query <name>`
- `cf-domain-pp-cli domain-check --domain <domain.tld>`
- `cf-domain-pp-cli domain-register --domain <domain.tld> --confirm-domain <domain.tld>`

## Safety

- Uses `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
- Requires Account → Registrar → Edit for registrar operations
- Does not print tokens
- Refuses paid registration unless `--confirm-domain` exactly matches `--domain`

## Test plan

- `go test ./...`
- `go build ./cmd/cf-domain-pp-cli`
- `./cf-domain-pp-cli doctor`
- `./cf-domain-pp-cli domain-register --domain example.com` confirms the registration gate blocks without `--confirm-domain`
