### PR TITLE
feat(flight-goat): add watch command group for purchased-flight price monitoring

### DIFF
--- a/cli-skills/pp-flight-goat/SKILL.md
+++ b/cli-skills/pp-flight-goat/SKILL.md
@@ -63,6 +63,119 @@ The flag is only valid on Google Flights price commands: `flights`, `dates`,
 `compare`, `gf-search`, and `cheapest-longhaul`. Do not add it to AeroAPI or
 Kayak-only commands.
 
+## Watch a Purchased Flight for Price Drops
+
+`watch` monitors a flight the user has *already booked* and alerts when the
+same exact itinerary (airline + flight number + date + route + cabin) reappears
+on Google Flights below `paid - threshold`. Use it when the user says "did my
+flight get cheaper?" or "watch DL 669 for me."
+
+State is persisted in a local SQLite file (default
+`~/.local/share/flight-goat-pp-cli/watches.db`, override with `--watch-db` or
+`$FLIGHT_GOAT_WATCH_DB`). Subcommands: `add`, `list`, `show`, `check`,
+`remove`, `alert-test`.
+
+```bash
+# Register a watch (all required fields)
+flight-goat-pp-cli watch add \
+  --from SFO --to JFK --date 2026-06-21 \
+  --airline DL --flight-number 669 --cabin economy \
+  --paid 428.20 --threshold 50 --currency USD \
+  --notify webhook:https://hooks.example.com/flight-drops --agent
+
+# Stricter watch with departure-time guard, explicit fare brand, and
+# basic-economy excluded so a $300 basic fare won't false-match your
+# $700 main-cabin ticket
+flight-goat-pp-cli watch add \
+  --from SFO --to JFK --date 2026-06-21 --departure-time 07:30 \
+  --airline DL --flight-number 668 --cabin economy --fare-brand "Main Cabin" \
+  --paid 700 --threshold 50 --agent
+
+# Add a watch on a basic-economy ticket you actually paid for (opt-in)
+flight-goat-pp-cli watch add \
+  --from LAX --to ATL --date 2026-07-10 \
+  --airline DL --flight-number 1234 --cabin economy --fare-brand "Basic Economy" \
+  --include-basic --paid 198 --threshold 30 --agent
+
+# List, inspect, re-check
+flight-goat-pp-cli watch list --agent
+flight-goat-pp-cli watch show watch_5a25c89c2966 --agent
+flight-goat-pp-cli watch check watch_5a25c89c2966 --agent     # one watch
+flight-goat-pp-cli watch check --agent                        # all active watches
+
+# Verify the alert path without burning a Google Flights request
+flight-goat-pp-cli watch alert-test watch_5a25c89c2966 --agent
+
+# Force a re-alert after a previous one fired (dedup is on by default)
+flight-goat-pp-cli watch check watch_5a25c89c2966 --force-alert --agent
+
+# Re-alert only when the price drops by at least 25 more
+flight-goat-pp-cli watch check --repeat-delta 25 --agent
+
+flight-goat-pp-cli watch remove watch_5a25c89c2966 --agent
+```
+
+`watch check` returns a stable JSON envelope (also POSTed verbatim to
+`--notify webhook:`):
+
+```json
+{
+  "schema": "flight-goat.watch.check.v1",
+  "watch_id": "watch_…",
+  "origin": "SFO", "destination": "JFK",
+  "departure_date": "2026-06-21", "departure_time": "07:30",
+  "airline": "DL", "flight_number": "668",
+  "cabin": "economy", "fare_brand": "Main Cabin",
+  "original_price": 700, "threshold": 50, "currency": "USD",
+  "booking_url": "https://www.google.com/travel/flights?q=Flights+from+SFO+to+JFK+on+2026-06-21+economy&curr=USD",
+  "found_price": 609, "route_cheapest_price": 280, "delta": 91,
+  "confidence": "high",
+  "match_reason": "exact match: same airline DL, flight 668; date 2026-06-21; route SFO→JFK; cabin economy; basic-economy excluded; departure 07:25 within ±30 min of your 07:30",
+  "threshold_crossed": true,
+  "alert_dispatched": true,
+  "matched_flight": {
+    "airline": "DL", "flight_number": "668", "price": 609,
+    "cabin": "economy", "fare_brand": "Main Cabin",
+    "departure_time": "2026-06-21T07:25:00",
+    "arrival_time":   "2026-06-21T15:55:00",
+    "duration_minutes": 330, "stops": 0
+  },
+  "safety_notice": "Same flight appears cheaper. Verify fare rules, refundability, cancellation fees, credits, and seat/bag differences before canceling or rebooking."
+}
+```
+
+When relaying an alert to the user, always include:
+
+1. `match_reason` — the chain of constraints the matcher verified, so the user can sanity-check the conclusion themselves.
+2. `matched_flight.departure_time` / `arrival_time` / `duration_minutes` — so the user can confirm this is the same operating itinerary, not a different flight that happens to share a number.
+3. `booking_url` — the Google Flights search URL pre-filled with the route + date + cabin + currency. One tap to verify the live fare.
+4. `safety_notice` verbatim.
+
+**Fare-class safety:** alerts fire only on the cabin the user registered (Google Flights filters by cabin at search time), and `exclude_basic` defaults to **on** so a $300 basic-economy result never false-matches a $700 main-cabin ticket. Override with `--include-basic` only when the user actually purchased basic economy.
+
+Match-confidence rules — read carefully, this is the safety property of the
+feature:
+
+- `high` — the cheaper itinerary is the user's exact flight (airline + flight
+  number + date + route + cabin all match). Only `high` matches trigger
+  alerts.
+- `medium` — same airline + cabin + date + route, but the provider didn't
+  return a flight number. Surfaced as `found_price` for context but never
+  alerts.
+- `low` — the cheapest fare on the route belongs to a different airline or
+  flight number. Returned only as `route_cheapest_price`; never alerts. A
+  cheaper-on-route flight does NOT help users who can't move their ticket
+  without losing it.
+
+**Always pass the `safety_notice` through to the user when relaying a watch
+alert.** The notice covers fare rules, refundability, change fees, credits,
+and seat/bag differences — the four most common ways a "the same flight is
+cheaper now" message becomes an expensive mistake.
+
+`--notify` accepts `stdout` (default), `json` (machine-readable stdout), or
+`webhook:<https-url>` (POSTs the JSON envelope above). Validation happens at
+`watch add` time so a bad webhook URL is caught before the first check.
+
 ## Development Tools
 AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
 imported into tools like Postman. To get started try importing the API
@@ -208,6 +321,15 @@ your account enabled for Foresight.
 **schedules** — Manage schedules
 
 - `flight-goat-pp-cli schedules` — Returns scheduled flights that have been published by airlines. These schedules are available for up to three months...
+
+**watch** — Monitor purchased-flight prices for drops (see *Watch a Purchased Flight for Price Drops* above for full semantics).
+
+- `flight-goat-pp-cli watch add` — Register a purchased flight. Required: `--from`, `--to`, `--date`, `--airline`, `--flight-number`, `--paid`, `--threshold`. Optional: `--departure-time HH:MM` (matcher rejects candidates ±30 min outside), `--cabin`, `--fare-brand`, `--include-basic` (off by default), `--passengers`, `--currency`, `--notify`, `--booking-ref`, `--notes`.
+- `flight-goat-pp-cli watch list` — List registered watches; filter by `--status active|paused|archived`.
+- `flight-goat-pp-cli watch show <watch_id>` — Show one watch's full state.
+- `flight-goat-pp-cli watch check [watch_id]` — Re-check the live price for one watch (or all active watches if omitted), dispatch alert on threshold-crossing exact matches, persist `last_seen_price`/`last_alerted_price`. Flags: `--force-alert`, `--repeat-delta`.
+- `flight-goat-pp-cli watch remove <watch_id>` — Delete a watch.
+- `flight-goat-pp-cli watch alert-test <watch_id>` — Send a synthetic alert through the watch's `--notify` sink without hitting Google Flights.
 
 
 ### Finding the right command

--- a/library/travel/flight-goat/.printing-press-patches.json
+++ b/library/travel/flight-goat/.printing-press-patches.json
@@ -1,11 +1,14 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-08",
+  "applied_at": "2026-05-11",
   "base_run_id": "2026-05-02T22:09:06.820184Z",
   "base_printing_press_version": "3.6.0",
   "upstream_tracking": [
     "https://github.com/mvanhorn/printing-press-library/issues/293",
     "https://github.com/mvanhorn/cli-printing-press/issues/804"
+  ],
+  "deferred_to_upstream": [
+    "watch-command-group: the `watch` command group is currently hand-written. cli-printing-press has no template for stateful, long-running monitors on Google Flights prices today. If/when the generator grows one, the registerWatchCommands hook in root.go and the internal/watch package should migrate behind it."
   ],
   "patches": [
     {
@@ -45,6 +48,24 @@
       "summary": "Replace krisukox/google-flights-api with a native f.req protobuf-shaped client matching fli's Python implementation; remove the upstream dependency.",
       "reason": "krisukox/google-flights-api only exposed Stops, Class, TripType in its Options struct and silently dropped airlines, bags, emissions, layover, carry-on, exclude-basic-economy, show-all-results, and the expanded sort options (top_flights, best, emissions). Users passing --airlines BA,KL got results that ignored the filter. Ports fli/models/google_flights/flights.py format() to Go in internal/gflights/flights_native.go, reaches feature parity with fli, and drops github.com/krisukox/google-flights-api from go.mod entirely.",
       "validated_outcome": "go build ./...; go test ./internal/gflights/...; go test ./...; go vet ./...; flights --help renders new --emissions, --bags, --carry-on, --layover, --max-layover, --limited flags; --sort accepts all 7 of fli's values. Search() now has the same 90s defensive ctx-timeout fallback as Dates(). Airport.Name and Airline.Name now populated from response slots leg[4]/leg[5]/leg[22][3]; verified live (SEA \u2192 'Seattle-Tacoma International Airport', VS \u2192 'Virgin Atlantic')."
+    },
+    {
+      "id": "watch-command-group",
+      "upstream_issue": "",
+      "files": [
+        "internal/cli/root.go",
+        "internal/cli/watch.go",
+        "internal/watch/watch.go",
+        "internal/watch/store.go",
+        "internal/watch/check.go",
+        "internal/watch/alert.go",
+        "internal/watch/watch_test.go",
+        "internal/watch/store_test.go",
+        "internal/watch/check_test.go"
+      ],
+      "summary": "Add a `watch` command group for monitoring purchased-flight prices (add, list, show, check, remove, alert-test) with exact-match alerting, stable JSON envelope (schema flight-goat.watch.check.v1), webhook + stdout dispatch, dedup via last_alerted_price, and a mandatory rebooking safety notice on every alert.",
+      "reason": "The Google Flights `flights`/`dates` commands answer 'what is the cheapest flight today' but users who have already bought a ticket need 'tell me when MY exact flight drops below paid - threshold.' The watch primitive persists purchased flights in a separate watches.db, re-checks via gflights.Search, and refuses to alert on route-cheaper-different-flight matches (which would mislead users into thinking they can swap fares freely).",
+      "validated_outcome": "go build ./...; go vet ./...; go test ./internal/watch/...; flight-goat-pp-cli watch --help; smoke-tested add + list + alert-test + show + remove with FLIGHT_GOAT_WATCH_DB=/tmp/fg-watch-test.db."
     }
   ]
 }

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -146,6 +146,79 @@ flight-goat-pp-cli compare SEA LHR 2026-06-15 --currency GBP
 ask Google Flights for prices (`flights`, `dates`, `compare`, `gf-search`, and
 `cheapest-longhaul`), not on AeroAPI or Kayak-only commands.
 
+### Watch a purchased flight for price drops
+
+`flight-goat-pp-cli watch` tracks flights you have already booked and alerts
+when the same exact itinerary (airline + flight number + date + route + cabin)
+becomes cheaper on Google Flights by more than your threshold. Watches are
+persisted in `~/.local/share/flight-goat-pp-cli/watches.db` (override with
+`--watch-db` or `$FLIGHT_GOAT_WATCH_DB`). No FlightAware API key required —
+the price check uses the Google Flights backend that powers `flights`/`dates`.
+
+```bash
+# Register a purchased flight (tight match — recommended)
+flight-goat-pp-cli watch add \
+  --from SFO --to JFK --date 2026-06-21 --departure-time 07:30 \
+  --airline DL --flight-number 668 --cabin economy --fare-brand "Main Cabin" \
+  --paid 700 --threshold 50 --currency USD \
+  --notify webhook:https://hooks.example.com/flight-drops
+
+# If you actually bought basic economy, opt in
+flight-goat-pp-cli watch add \
+  --from LAX --to ATL --date 2026-07-10 \
+  --airline DL --flight-number 1234 --cabin economy --fare-brand "Basic Economy" \
+  --include-basic --paid 198 --threshold 30
+
+# Re-check the live price (alerts on threshold-crossing EXACT matches)
+flight-goat-pp-cli watch check               # all active watches
+flight-goat-pp-cli watch check watch_abc123  # just one
+
+# Verify the alert path without hitting Google Flights
+flight-goat-pp-cli watch alert-test watch_abc123
+
+# Inspect / clean up
+flight-goat-pp-cli watch list
+flight-goat-pp-cli watch show watch_abc123
+flight-goat-pp-cli watch remove watch_abc123
+```
+
+`watch check` outputs (and webhook sinks POST) a stable JSON envelope keyed by
+`schema: "flight-goat.watch.check.v1"`. Notable fields:
+
+- `confidence` — `high` (exact match including departure-time check),
+  `medium` (provider didn't echo flight number), or `low` (route-cheapest is a
+  different flight).
+- `match_reason` — a one-sentence chain-of-evidence describing every
+  constraint the matcher verified (e.g. "same airline DL, flight 668; date
+  2026-06-21; route SFO→JFK; cabin economy; basic-economy excluded; departure
+  07:25 within ±30 min of your 07:30").
+- `match_mismatch_reason` — populated when the same airline+flight number was
+  found but a guard rejected it (e.g. departure time drifted out of tolerance).
+- `matched_flight` — the live itinerary with departure/arrival timestamps,
+  total duration, and stop count.
+- `booking_url` — a Google Flights search URL pre-filled with the route + date
+  + cabin + currency. One tap to verify the live fare.
+- `safety_notice` — the rebooking warning (refundability, change fees, etc.).
+  Always relay this to the user verbatim.
+
+**Fare-class safety:** alerts fire only on the cabin the user registered
+(Google Flights filters by cabin at search time). Within the economy cabin,
+`exclude_basic` defaults to **on** so a $300 basic-economy result never
+false-matches a $700 main-cabin ticket. Override with `--include-basic` only
+when the user actually purchased basic economy.
+
+**Flight-number reuse safety:** when `--departure-time` is set, the matcher
+rejects candidates whose departure time drifts more than ±30 min. Catches the
+case where an airline reuses the same flight number for a different departure
+on the same day (rescheduled, second daily, etc.).
+
+Alerts trigger only on `confidence: "high"` matches (your exact flight). A
+cheaper fare on the same route by a different flight number is surfaced as
+`route_cheapest_price` for context but never alerts — swapping carriers
+typically requires losing the original ticket. Dedup is based on
+`last_alerted_price`; use `--repeat-delta <amount>` to require an additional
+drop before re-alerting, or `--force-alert` to override dedup.
+
 ## Commands
 
 ### aircraft

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -63,6 +63,119 @@ The flag is only valid on Google Flights price commands: `flights`, `dates`,
 `compare`, `gf-search`, and `cheapest-longhaul`. Do not add it to AeroAPI or
 Kayak-only commands.
 
+## Watch a Purchased Flight for Price Drops
+
+`watch` monitors a flight the user has *already booked* and alerts when the
+same exact itinerary (airline + flight number + date + route + cabin) reappears
+on Google Flights below `paid - threshold`. Use it when the user says "did my
+flight get cheaper?" or "watch DL 669 for me."
+
+State is persisted in a local SQLite file (default
+`~/.local/share/flight-goat-pp-cli/watches.db`, override with `--watch-db` or
+`$FLIGHT_GOAT_WATCH_DB`). Subcommands: `add`, `list`, `show`, `check`,
+`remove`, `alert-test`.
+
+```bash
+# Register a watch (all required fields)
+flight-goat-pp-cli watch add \
+  --from SFO --to JFK --date 2026-06-21 \
+  --airline DL --flight-number 669 --cabin economy \
+  --paid 428.20 --threshold 50 --currency USD \
+  --notify webhook:https://hooks.example.com/flight-drops --agent
+
+# Stricter watch with departure-time guard, explicit fare brand, and
+# basic-economy excluded so a $300 basic fare won't false-match your
+# $700 main-cabin ticket
+flight-goat-pp-cli watch add \
+  --from SFO --to JFK --date 2026-06-21 --departure-time 07:30 \
+  --airline DL --flight-number 668 --cabin economy --fare-brand "Main Cabin" \
+  --paid 700 --threshold 50 --agent
+
+# Add a watch on a basic-economy ticket you actually paid for (opt-in)
+flight-goat-pp-cli watch add \
+  --from LAX --to ATL --date 2026-07-10 \
+  --airline DL --flight-number 1234 --cabin economy --fare-brand "Basic Economy" \
+  --include-basic --paid 198 --threshold 30 --agent
+
+# List, inspect, re-check
+flight-goat-pp-cli watch list --agent
+flight-goat-pp-cli watch show watch_5a25c89c2966 --agent
+flight-goat-pp-cli watch check watch_5a25c89c2966 --agent     # one watch
+flight-goat-pp-cli watch check --agent                        # all active watches
+
+# Verify the alert path without burning a Google Flights request
+flight-goat-pp-cli watch alert-test watch_5a25c89c2966 --agent
+
+# Force a re-alert after a previous one fired (dedup is on by default)
+flight-goat-pp-cli watch check watch_5a25c89c2966 --force-alert --agent
+
+# Re-alert only when the price drops by at least 25 more
+flight-goat-pp-cli watch check --repeat-delta 25 --agent
+
+flight-goat-pp-cli watch remove watch_5a25c89c2966 --agent
+```
+
+`watch check` returns a stable JSON envelope (also POSTed verbatim to
+`--notify webhook:`):
+
+```json
+{
+  "schema": "flight-goat.watch.check.v1",
+  "watch_id": "watch_…",
+  "origin": "SFO", "destination": "JFK",
+  "departure_date": "2026-06-21", "departure_time": "07:30",
+  "airline": "DL", "flight_number": "668",
+  "cabin": "economy", "fare_brand": "Main Cabin",
+  "original_price": 700, "threshold": 50, "currency": "USD",
+  "booking_url": "https://www.google.com/travel/flights?q=Flights+from+SFO+to+JFK+on+2026-06-21+economy&curr=USD",
+  "found_price": 609, "route_cheapest_price": 280, "delta": 91,
+  "confidence": "high",
+  "match_reason": "exact match: same airline DL, flight 668; date 2026-06-21; route SFO→JFK; cabin economy; basic-economy excluded; departure 07:25 within ±30 min of your 07:30",
+  "threshold_crossed": true,
+  "alert_dispatched": true,
+  "matched_flight": {
+    "airline": "DL", "flight_number": "668", "price": 609,
+    "cabin": "economy", "fare_brand": "Main Cabin",
+    "departure_time": "2026-06-21T07:25:00",
+    "arrival_time":   "2026-06-21T15:55:00",
+    "duration_minutes": 330, "stops": 0
+  },
+  "safety_notice": "Same flight appears cheaper. Verify fare rules, refundability, cancellation fees, credits, and seat/bag differences before canceling or rebooking."
+}
+```
+
+When relaying an alert to the user, always include:
+
+1. `match_reason` — the chain of constraints the matcher verified, so the user can sanity-check the conclusion themselves.
+2. `matched_flight.departure_time` / `arrival_time` / `duration_minutes` — so the user can confirm this is the same operating itinerary, not a different flight that happens to share a number.
+3. `booking_url` — the Google Flights search URL pre-filled with the route + date + cabin + currency. One tap to verify the live fare.
+4. `safety_notice` verbatim.
+
+**Fare-class safety:** alerts fire only on the cabin the user registered (Google Flights filters by cabin at search time), and `exclude_basic` defaults to **on** so a $300 basic-economy result never false-matches a $700 main-cabin ticket. Override with `--include-basic` only when the user actually purchased basic economy.
+
+Match-confidence rules — read carefully, this is the safety property of the
+feature:
+
+- `high` — the cheaper itinerary is the user's exact flight (airline + flight
+  number + date + route + cabin all match). Only `high` matches trigger
+  alerts.
+- `medium` — same airline + cabin + date + route, but the provider didn't
+  return a flight number. Surfaced as `found_price` for context but never
+  alerts.
+- `low` — the cheapest fare on the route belongs to a different airline or
+  flight number. Returned only as `route_cheapest_price`; never alerts. A
+  cheaper-on-route flight does NOT help users who can't move their ticket
+  without losing it.
+
+**Always pass the `safety_notice` through to the user when relaying a watch
+alert.** The notice covers fare rules, refundability, change fees, credits,
+and seat/bag differences — the four most common ways a "the same flight is
+cheaper now" message becomes an expensive mistake.
+
+`--notify` accepts `stdout` (default), `json` (machine-readable stdout), or
+`webhook:<https-url>` (POSTs the JSON envelope above). Validation happens at
+`watch add` time so a bad webhook URL is caught before the first check.
+
 ## Development Tools
 AeroAPI is defined using the OpenAPI Spec 3.0, which means it can be easily
 imported into tools like Postman. To get started try importing the API
@@ -208,6 +321,15 @@ your account enabled for Foresight.
 **schedules** — Manage schedules
 
 - `flight-goat-pp-cli schedules` — Returns scheduled flights that have been published by airlines. These schedules are available for up to three months...
+
+**watch** — Monitor purchased-flight prices for drops (see *Watch a Purchased Flight for Price Drops* above for full semantics).
+
+- `flight-goat-pp-cli watch add` — Register a purchased flight. Required: `--from`, `--to`, `--date`, `--airline`, `--flight-number`, `--paid`, `--threshold`. Optional: `--departure-time HH:MM` (matcher rejects candidates ±30 min outside), `--cabin`, `--fare-brand`, `--include-basic` (off by default), `--passengers`, `--currency`, `--notify`, `--booking-ref`, `--notes`.
+- `flight-goat-pp-cli watch list` — List registered watches; filter by `--status active|paused|archived`.
+- `flight-goat-pp-cli watch show <watch_id>` — Show one watch's full state.
+- `flight-goat-pp-cli watch check [watch_id]` — Re-check the live price for one watch (or all active watches if omitted), dispatch alert on threshold-crossing exact matches, persist `last_seen_price`/`last_alerted_price`. Flags: `--force-alert`, `--repeat-delta`.
+- `flight-goat-pp-cli watch remove <watch_id>` — Delete a watch.
+- `flight-goat-pp-cli watch alert-test <watch_id>` — Send a synthetic alert through the watch's `--notify` sink without hitting Google Flights.
 
 
 ### Finding the right command

--- a/library/travel/flight-goat/internal/cli/root.go
+++ b/library/travel/flight-goat/internal/cli/root.go
@@ -170,6 +170,9 @@ Run 'flight-goat-pp-cli doctor' to verify auth and connectivity.`,
 	// transcend.go for definitions.
 	registerPrimaryCommands(rootCmd, flags)
 	registerTranscendCommands(rootCmd, flags)
+	// PATCH(library): hand-written `watch` command group for monitoring
+	// purchased-flight prices. See internal/cli/watch.go.
+	registerWatchCommands(rootCmd, flags)
 	rootCmd.AddCommand(newAirportsCmd(flags))
 	rootCmd.AddCommand(newAlertsCmd(flags))
 	rootCmd.AddCommand(newDisruptionCountsCmd(flags))

--- a/library/travel/flight-goat/internal/cli/watch.go
+++ b/library/travel/flight-goat/internal/cli/watch.go
@@ -1,0 +1,460 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+// PATCH(library): hand-written `watch` command group for monitoring
+// purchased-flight prices. Mirrors the primary.go extension pattern —
+// register a top-level command via registerWatchCommands(rootCmd, flags)
+// rather than reaching into the generated per-endpoint files.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/flight-goat/internal/watch"
+	"github.com/spf13/cobra"
+)
+
+// registerWatchCommands wires the `watch` command group: add, list, show,
+// check, remove, alert-test. The group persists state in its own SQLite
+// file (see internal/watch/store.go) so users can register purchased
+// flights and re-check their prices later without re-supplying the
+// fields.
+//
+// Called from root.go after registerPrimaryCommands so `watch` appears in
+// --help under the primary headlines but above the generated commands.
+func registerWatchCommands(rootCmd *cobra.Command, flags *rootFlags) {
+	watchCmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Monitor purchased-flight prices and alert when they drop",
+		Long: `watch tracks flights you have already booked and re-checks their live
+prices via the Google Flights backend. When the same flight's fare drops
+by more than your threshold you receive an alert (stdout or webhook) with
+a safety notice covering refundability, change fees, and credit handling.
+
+Alerts trigger only on EXACT matches (same airline + flight number + date
++ route + cabin). The route-cheapest fare is surfaced for context but is
+never used to fire an alert — cheapest-on-route on a different flight
+won't help you if your current ticket can't be moved without losing it.`,
+	}
+	watchCmd.AddCommand(newWatchAddCmd(flags))
+	watchCmd.AddCommand(newWatchListCmd(flags))
+	watchCmd.AddCommand(newWatchShowCmd(flags))
+	watchCmd.AddCommand(newWatchCheckCmd(flags))
+	watchCmd.AddCommand(newWatchRemoveCmd(flags))
+	watchCmd.AddCommand(newWatchAlertTestCmd(flags))
+	rootCmd.AddCommand(watchCmd)
+}
+
+// openWatchStore is the single helper for resolving the watch DB path
+// from --watch-db or the FLIGHT_GOAT_WATCH_DB env var (the env var is the
+// default via watch.DefaultDBPath).
+func openWatchStore(ctx context.Context, dbPath string) (*watch.Store, error) {
+	return watch.Open(ctx, dbPath)
+}
+
+// ----- watch add ------------------------------------------------------
+
+func newWatchAddCmd(flags *rootFlags) *cobra.Command {
+	var (
+		from, to, date  string
+		departureTime   string
+		airline, fno    string
+		cabin           string
+		fareBrand       string
+		includeBasic    bool
+		passengers      int
+		paid, threshold float64
+		currency        string
+		notify          string
+		bookingRef      string
+		notes           string
+		watchDB         string
+	)
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Register a purchased flight to monitor for price drops",
+		Long: `Add registers a flight you already hold. All fields except --cabin,
+--passengers, --notify, --booking-ref, and --notes are required.
+
+The watch is exact-match: alerts only fire when the same airline +
+flight number + date + route + cabin combination appears at a lower
+price. Cheaper itineraries on the same route via a different flight
+number are surfaced for context but never alert.`,
+		Example: `  # SFO -> JFK on Delta 669, paid $428.20, alert at $50 off
+  flight-goat-pp-cli watch add \
+    --from SFO --to JFK --date 2026-06-21 \
+    --airline DL --flight-number 669 \
+    --paid 428.20 --threshold 50 --currency USD
+
+  # With a webhook alert sink
+  flight-goat-pp-cli watch add \
+    --from SFO --to JFK --date 2026-06-21 \
+    --airline DL --flight-number 669 --cabin economy \
+    --paid 428.20 --threshold 50 \
+    --notify webhook:https://hooks.example.com/flight-drops`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := &watch.Watch{
+				Origin:        from,
+				Destination:   to,
+				DepartureDate: date,
+				DepartureTime: departureTime,
+				Airline:       airline,
+				FlightNumber:  fno,
+				Cabin:         cabin,
+				FareBrand:     fareBrand,
+				ExcludeBasic:  !includeBasic,
+				Passengers:    passengers,
+				OriginalPrice: paid,
+				Threshold:     threshold,
+				Currency:      currency,
+				Notify:        notify,
+				BookingRef:    bookingRef,
+				Notes:         notes,
+			}
+			if err := w.Validate(); err != nil {
+				return usageErr(err)
+			}
+			if flags.dryRun {
+				return printWatchResult(cmd, flags, w, "watch (dry-run, not persisted)")
+			}
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			if _, err := s.Insert(ctx, w); err != nil {
+				return err
+			}
+			return printWatchResult(cmd, flags, w, "watch added")
+		},
+	}
+	cmd.Flags().StringVar(&from, "from", "", "Origin airport (3-letter IATA, e.g. SFO) [required]")
+	cmd.Flags().StringVar(&to, "to", "", "Destination airport (3-letter IATA, e.g. JFK) [required]")
+	cmd.Flags().StringVar(&date, "date", "", "Departure date YYYY-MM-DD [required]")
+	cmd.Flags().StringVar(&departureTime, "departure-time", "", "Optional HH:MM (24h) departure time; matcher rejects candidates that drift more than ±30 min")
+	cmd.Flags().StringVar(&airline, "airline", "", "Carrier code (e.g. DL, AA) [required]")
+	cmd.Flags().StringVar(&fno, "flight-number", "", "Flight number, digits with optional trailing letter (e.g. 669) [required]")
+	cmd.Flags().StringVar(&cabin, "cabin", "", "Cabin: economy, premium_economy, business, first")
+	cmd.Flags().StringVar(&fareBrand, "fare-brand", "", "Fare brand for your reference (e.g. 'Main Cabin', 'Comfort+', 'Polaris'); shown in alerts so you can eyeball fare comparability")
+	cmd.Flags().BoolVar(&includeBasic, "include-basic", false, "Include basic-economy results in the price comparison (default excludes basic, since basic-vs-main is a misleading match)")
+	cmd.Flags().IntVar(&passengers, "passengers", 1, "Number of passengers")
+	cmd.Flags().Float64Var(&paid, "paid", 0, "Price paid for the ticket [required]")
+	cmd.Flags().Float64Var(&threshold, "threshold", 0, "Alert when paid - found >= threshold (in --currency) [required]")
+	cmd.Flags().StringVar(&currency, "currency", "USD", "ISO 4217 currency code")
+	cmd.Flags().StringVar(&notify, "notify", "", "Alert sink: stdout, json, or webhook:<https://url>")
+	cmd.Flags().StringVar(&bookingRef, "booking-ref", "", "Optional booking reference (PNR / confirmation number) for your records")
+	cmd.Flags().StringVar(&notes, "notes", "", "Free-form notes attached to the watch")
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path (default $FLIGHT_GOAT_WATCH_DB or ~/.local/share/flight-goat-pp-cli/watches.db)")
+	_ = cmd.MarkFlagRequired("from")
+	_ = cmd.MarkFlagRequired("to")
+	_ = cmd.MarkFlagRequired("date")
+	_ = cmd.MarkFlagRequired("airline")
+	_ = cmd.MarkFlagRequired("flight-number")
+	_ = cmd.MarkFlagRequired("paid")
+	_ = cmd.MarkFlagRequired("threshold")
+	return cmd
+}
+
+// ----- watch list -----------------------------------------------------
+
+func newWatchListCmd(flags *rootFlags) *cobra.Command {
+	var statusFilter, watchDB string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered watches",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			rows, err := s.List(ctx, statusFilter)
+			if err != nil {
+				return err
+			}
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return writeJSON(cmd, map[string]any{
+					"count":   len(rows),
+					"watches": rows,
+				})
+			}
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "ID\tROUTE\tDATE\tFLIGHT\tPAID\tTHRESHOLD\tLAST SEEN\tSTATUS")
+			for _, w := range rows {
+				lastSeen := "-"
+				if w.LastSeenPrice != nil {
+					lastSeen = fmt.Sprintf("%s %.2f", w.Currency, *w.LastSeenPrice)
+				}
+				fmt.Fprintf(tw, "%s\t%s-%s\t%s\t%s%s\t%s %.2f\t%s %.2f\t%s\t%s\n",
+					w.ID, w.Origin, w.Destination, w.DepartureDate,
+					w.Airline, w.FlightNumber, w.Currency, w.OriginalPrice,
+					w.Currency, w.Threshold, lastSeen, w.Status)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&statusFilter, "status", "", "Filter by status: active, paused, archived")
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path")
+	return cmd
+}
+
+// ----- watch show -----------------------------------------------------
+
+func newWatchShowCmd(flags *rootFlags) *cobra.Command {
+	var watchDB string
+	cmd := &cobra.Command{
+		Use:   "show <watch_id>",
+		Short: "Show one watch's full state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			w, err := s.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			return printWatchResult(cmd, flags, w, "")
+		},
+	}
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path")
+	return cmd
+}
+
+// ----- watch check ----------------------------------------------------
+
+func newWatchCheckCmd(flags *rootFlags) *cobra.Command {
+	var (
+		watchDB     string
+		forceAlert  bool
+		repeatDelta float64
+	)
+	cmd := &cobra.Command{
+		Use:   "check [watch_id]",
+		Short: "Re-check live prices and dispatch alerts",
+		Long: `check looks up the current price of one watched flight (or every active
+watch if no ID is given), compares it to the paid price, and dispatches
+an alert through the watch's notify sink when the threshold is crossed
+on an EXACT-match itinerary.
+
+The JSON output schema is stable:
+
+  {
+    "schema": "flight-goat.watch.check.v1",
+    "watch_id": "watch_…",
+    "found_price": 354.10,
+    "route_cheapest_price": 312.00,
+    "confidence": "high" | "medium" | "low",
+    "threshold_crossed": true,
+    "alert_dispatched": true,
+    "alert_suppressed": false,
+    "matched_flight": {…},
+    "safety_notice": "Same flight appears cheaper. Verify fare rules…"
+  }
+
+Webhook alerts POST the same envelope as the body.`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			var targets []*watch.Watch
+			if len(args) == 1 {
+				w, err := s.Get(ctx, args[0])
+				if err != nil {
+					return err
+				}
+				targets = []*watch.Watch{w}
+			} else {
+				rows, err := s.List(ctx, watch.StatusActive)
+				if err != nil {
+					return err
+				}
+				targets = rows
+			}
+			// Resolve the dispatcher writer once. In JSON mode the
+			// envelope itself carries the full alert payload, so we
+			// route the stdout dispatcher to io.Discard to avoid
+			// mixing two formats on the same stream — anyone parsing
+			// the output (the flight-watch-check cron, agents) gets
+			// clean JSON.
+			dispWriter := cmd.OutOrStdout()
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				dispWriter = io.Discard
+			}
+			results := make([]watch.CheckResult, 0, len(targets))
+			for _, w := range targets {
+				disp := watch.DispatcherFor(w.Notify)
+				if setter, ok := disp.(watch.StdoutWriterSetter); ok {
+					setter.SetStdoutWriter(dispWriter)
+				}
+				res, err := watch.Check(ctx, s, w, watch.CheckOptions{
+					ForceAlert:  forceAlert,
+					RepeatDelta: repeatDelta,
+					Dispatcher:  disp,
+				})
+				if err != nil {
+					return err
+				}
+				results = append(results, *res)
+			}
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				if len(results) == 1 {
+					return writeJSON(cmd, results[0])
+				}
+				return writeJSON(cmd, map[string]any{
+					"count":   len(results),
+					"results": results,
+				})
+			}
+			for i, r := range results {
+				if i > 0 {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), watch.FormatAlertText(r))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path")
+	cmd.Flags().BoolVar(&forceAlert, "force-alert", false, "Dispatch the alert even if the threshold isn't crossed or the price already alerted")
+	cmd.Flags().Float64Var(&repeatDelta, "repeat-delta", 0, "Re-alert only if the price has dropped by at least this much since the last alert (default 0 = dedup any equal-or-higher price)")
+	return cmd
+}
+
+// ----- watch remove ---------------------------------------------------
+
+func newWatchRemoveCmd(flags *rootFlags) *cobra.Command {
+	var watchDB string
+	cmd := &cobra.Command{
+		Use:   "remove <watch_id>",
+		Short: "Delete a watch",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			if err := s.Delete(ctx, args[0]); err != nil {
+				return err
+			}
+			if flags.asJSON {
+				return writeJSON(cmd, map[string]string{"removed": args[0]})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "removed %s\n", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path")
+	return cmd
+}
+
+// ----- watch alert-test -----------------------------------------------
+
+func newWatchAlertTestCmd(flags *rootFlags) *cobra.Command {
+	var watchDB string
+	cmd := &cobra.Command{
+		Use:   "alert-test <watch_id>",
+		Short: "Send a synthetic alert through the watch's notify sink",
+		Long: `alert-test posts a sample CheckResult through the watch's configured
+notify sink (stdout / json / webhook). The check does NOT hit Google
+Flights and does NOT update last_alerted_price — it's purely for
+verifying that the alert path works end-to-end before relying on it.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := openWatchStore(ctx, watchDB)
+			if err != nil {
+				return err
+			}
+			defer s.Close()
+			w, err := s.Get(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			res := watch.SampleResult(w, time.Now())
+			disp := watch.DispatcherFor(w.Notify)
+			if setter, ok := disp.(watch.StdoutWriterSetter); ok {
+				setter.SetStdoutWriter(cmd.OutOrStdout())
+			}
+			if err := disp.Dispatch(ctx, res); err != nil {
+				return err
+			}
+			res.AlertDispatched = true
+			res.AlertDispatchedTo = disp.Name()
+			if flags.asJSON {
+				return writeJSON(cmd, res)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "sent test alert for %s via %s\n", w.ID, disp.Name())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&watchDB, "watch-db", "", "Override watch SQLite DB path")
+	return cmd
+}
+
+// ----- shared helpers -------------------------------------------------
+
+// printWatchResult renders a Watch row either as JSON or as a labeled
+// stdout block, matching the rest of the CLI's --json toggle behavior.
+func printWatchResult(cmd *cobra.Command, flags *rootFlags, w *watch.Watch, banner string) error {
+	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		return writeJSON(cmd, w)
+	}
+	if banner != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", banner, w.ID)
+	}
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "ID:\t%s\n", w.ID)
+	fmt.Fprintf(tw, "Route:\t%s -> %s\n", w.Origin, w.Destination)
+	fmt.Fprintf(tw, "Date:\t%s\n", w.DepartureDate)
+	if w.DepartureTime != "" {
+		fmt.Fprintf(tw, "Departs:\t%s\n", w.DepartureTime)
+	}
+	fmt.Fprintf(tw, "Flight:\t%s%s\n", w.Airline, w.FlightNumber)
+	if w.Cabin != "" {
+		fmt.Fprintf(tw, "Cabin:\t%s\n", w.Cabin)
+	}
+	if w.FareBrand != "" {
+		fmt.Fprintf(tw, "Fare brand:\t%s\n", w.FareBrand)
+	}
+	excludeStr := "no (basic-economy included)"
+	if w.ExcludeBasic {
+		excludeStr = "yes (basic-economy filtered out)"
+	}
+	fmt.Fprintf(tw, "Exclude basic:\t%s\n", excludeStr)
+	fmt.Fprintf(tw, "Passengers:\t%d\n", w.Passengers)
+	fmt.Fprintf(tw, "Paid:\t%s %.2f\n", w.Currency, w.OriginalPrice)
+	fmt.Fprintf(tw, "Threshold:\t%s %.2f\n", w.Currency, w.Threshold)
+	if w.Notify != "" {
+		fmt.Fprintf(tw, "Notify:\t%s\n", w.Notify)
+	}
+	fmt.Fprintf(tw, "Status:\t%s\n", w.Status)
+	if w.LastSeenPrice != nil {
+		fmt.Fprintf(tw, "Last seen:\t%s %.2f\n", w.Currency, *w.LastSeenPrice)
+	}
+	if w.LastAlertedPrice != nil {
+		fmt.Fprintf(tw, "Last alerted:\t%s %.2f\n", w.Currency, *w.LastAlertedPrice)
+	}
+	return tw.Flush()
+}
+
+func writeJSON(cmd *cobra.Command, v any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/library/travel/flight-goat/internal/watch/alert.go
+++ b/library/travel/flight-goat/internal/watch/alert.go
@@ -1,0 +1,238 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Dispatcher delivers a CheckResult to the user's chosen alert sink. The
+// concrete implementations are stdout, json (stdout with no extra
+// framing), and webhook. Tests substitute a recorder.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, res CheckResult) error
+	Name() string
+}
+
+// DispatcherFor parses a notify spec string and returns the matching
+// Dispatcher. Empty spec means "stdout" — that's the default `watch
+// check` behavior. A spec that fails validation (we already validate in
+// Watch.Validate) is treated as stdout to avoid silently swallowing the
+// alert at dispatch time.
+func DispatcherFor(spec string) Dispatcher {
+	spec = strings.TrimSpace(spec)
+	switch {
+	case spec == "", spec == "stdout":
+		return &stdoutDispatcher{out: nil}
+	case spec == "json":
+		return &stdoutDispatcher{out: nil, jsonOnly: true}
+	case strings.HasPrefix(spec, "webhook:"):
+		return &webhookDispatcher{url: strings.TrimPrefix(spec, "webhook:")}
+	default:
+		return &stdoutDispatcher{out: nil}
+	}
+}
+
+// SetStdoutWriter wires a custom writer into the stdoutDispatcher. The
+// CLI watch.go uses this so output flows through cobra.Command.OutOrStdout
+// (so --deliver, --quiet, and friends work).
+type StdoutWriterSetter interface {
+	SetStdoutWriter(w io.Writer)
+}
+
+type stdoutDispatcher struct {
+	out      io.Writer
+	jsonOnly bool
+}
+
+func (d *stdoutDispatcher) Name() string {
+	if d.jsonOnly {
+		return "stdout(json)"
+	}
+	return "stdout"
+}
+
+func (d *stdoutDispatcher) SetStdoutWriter(w io.Writer) { d.out = w }
+
+func (d *stdoutDispatcher) Dispatch(_ context.Context, res CheckResult) error {
+	w := d.out
+	if w == nil {
+		return nil
+	}
+	if d.jsonOnly {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	fmt.Fprintln(w, FormatAlertText(res))
+	return nil
+}
+
+type webhookDispatcher struct {
+	url    string
+	client *http.Client
+}
+
+func (d *webhookDispatcher) Name() string { return "webhook:" + d.url }
+
+func (d *webhookDispatcher) Dispatch(ctx context.Context, res CheckResult) error {
+	if d.client == nil {
+		d.client = &http.Client{Timeout: 15 * time.Second}
+	}
+	body, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("marshal webhook body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "flight-goat-pp-cli/watch")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook POST: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("webhook returned %d: %s", resp.StatusCode, strings.TrimSpace(string(excerpt)))
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// FormatAlertText renders a CheckResult into a short, human-readable
+// stdout alert. The SafetyNotice is always the last line so even
+// truncated output (e.g. inside a Slack incoming-webhook preview that
+// clips long messages) still surfaces the warning.
+func FormatAlertText(r CheckResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[flight-goat watch] %s %s%s %s\n",
+		r.WatchID, r.Airline, r.FlightNo, r.Date)
+	fmt.Fprintf(&b, "  Route:    %s -> %s", r.Origin, r.Destination)
+	if r.Cabin != "" {
+		fmt.Fprintf(&b, " (%s)", r.Cabin)
+	}
+	if r.FareBrand != "" {
+		fmt.Fprintf(&b, " [%s]", r.FareBrand)
+	}
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "  Paid:     %s %.2f\n", r.Currency, r.OriginalPrice)
+	if r.FoundPrice != nil {
+		fmt.Fprintf(&b, "  Now:      %s %.2f", r.Currency, *r.FoundPrice)
+		if r.Delta != nil {
+			fmt.Fprintf(&b, "  (delta %+.2f)", *r.Delta)
+		}
+		fmt.Fprintln(&b)
+	}
+	if mf := r.MatchedFlight; mf != nil {
+		dep := trimISOTime(mf.DepartureTime)
+		arr := trimISOTime(mf.ArrivalTime)
+		if dep != "" || arr != "" {
+			fmt.Fprintf(&b, "  Schedule: %s -> %s", dep, arr)
+			if mf.DurationMinutes > 0 {
+				fmt.Fprintf(&b, "  (%dh%02dm, %d stop%s)", mf.DurationMinutes/60, mf.DurationMinutes%60, mf.Stops, pluralS(mf.Stops))
+			}
+			fmt.Fprintln(&b)
+		}
+	}
+	fmt.Fprintf(&b, "  Match:    %s\n", r.Confidence)
+	if r.MatchReason != "" {
+		fmt.Fprintf(&b, "  Why:      %s\n", r.MatchReason)
+	}
+	if r.MatchMismatchReason != "" {
+		fmt.Fprintf(&b, "  Note:     %s\n", r.MatchMismatchReason)
+	}
+	if r.AlertSuppressed {
+		fmt.Fprintf(&b, "  Status:   suppressed (%s)\n", r.AlertSuppressReason)
+	} else if r.AlertDispatched {
+		fmt.Fprintf(&b, "  Status:   alerted via %s\n", r.AlertDispatchedTo)
+	}
+	if r.BookingURL != "" {
+		fmt.Fprintf(&b, "  Book:     %s\n", r.BookingURL)
+	}
+	fmt.Fprintf(&b, "  ⚠ %s", r.SafetyNotice)
+	return b.String()
+}
+
+// trimISOTime collapses an ISO-8601 string like 2026-06-21T07:25:00 to
+// "06-21 07:25" for the human alert. Returns the input unchanged if
+// it's shorter than the expected slice.
+func trimISOTime(s string) string {
+	if len(s) >= 16 {
+		return s[5:10] + " " + s[11:16]
+	}
+	return s
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// PostWebhook is a convenience for `watch alert-test` when a user wants
+// to ping their webhook without running a full check. It returns an
+// error rather than embedding the failure in a CheckResult so the CLI
+// can surface a non-zero exit.
+func PostWebhook(ctx context.Context, url string, res CheckResult) error {
+	d := &webhookDispatcher{url: url}
+	return d.Dispatch(ctx, res)
+}
+
+// SampleResult builds a synthetic CheckResult for `watch alert-test`.
+// It's intentionally NOT marked AlertDispatched/Suppressed — the
+// dispatcher fills those in based on the actual send.
+func SampleResult(w *Watch, now time.Time) CheckResult {
+	mock := w.OriginalPrice * 0.85
+	delta := w.OriginalPrice - mock
+	depHM := w.DepartureTime
+	if depHM == "" {
+		depHM = "07:25"
+	}
+	res := CheckResult{
+		Schema:           "flight-goat.watch.check.v1",
+		WatchID:          w.ID,
+		CheckedAt:        now.UTC(),
+		Origin:           w.Origin,
+		Destination:      w.Destination,
+		Date:             w.DepartureDate,
+		DepartureTime:    w.DepartureTime,
+		Airline:          w.Airline,
+		FlightNo:         w.FlightNumber,
+		Cabin:            w.Cabin,
+		FareBrand:        w.FareBrand,
+		OriginalPrice:    w.OriginalPrice,
+		Threshold:        w.Threshold,
+		Currency:         w.Currency,
+		BookingURL:       BookingSearchURL(w),
+		FoundPrice:       &mock,
+		Delta:            &delta,
+		Confidence:       MatchExact,
+		ThresholdCrossed: true,
+		MatchedFlight: &MatchedFlight{
+			Airline:         w.Airline,
+			FlightNumber:    w.FlightNumber,
+			Price:           mock,
+			Currency:        w.Currency,
+			Cabin:           w.Cabin,
+			FareBrand:       w.FareBrand,
+			DepartureTime:   fmt.Sprintf("%sT%s:00", w.DepartureDate, depHM),
+			ArrivalTime:     fmt.Sprintf("%sT11:55:00", w.DepartureDate),
+			DurationMinutes: 330,
+			Stops:           0,
+		},
+		SafetyNotice: SafetyNoticeText,
+	}
+	res.MatchReason = explainMatch(w, nil, MatchExact, nil, "")
+	return res
+}

--- a/library/travel/flight-goat/internal/watch/alert.go
+++ b/library/travel/flight-goat/internal/watch/alert.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -62,9 +63,13 @@ func (d *stdoutDispatcher) Name() string {
 func (d *stdoutDispatcher) SetStdoutWriter(w io.Writer) { d.out = w }
 
 func (d *stdoutDispatcher) Dispatch(_ context.Context, res CheckResult) error {
+	// PATCH(greptile P2): default to os.Stdout when no writer was
+	// injected so library callers that pass opts.Dispatcher == nil don't
+	// silently lose alerts. The CLI still injects cobra.Command's writer
+	// via SetStdoutWriter when it wants --deliver / output capture.
 	w := d.out
 	if w == nil {
-		return nil
+		w = os.Stdout
 	}
 	if d.jsonOnly {
 		enc := json.NewEncoder(w)

--- a/library/travel/flight-goat/internal/watch/check.go
+++ b/library/travel/flight-goat/internal/watch/check.go
@@ -1,0 +1,384 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/flight-goat/internal/gflights"
+)
+
+// DepartureTimeToleranceMinutes is how far the matched itinerary's
+// departure time can drift from the user's recorded departure_time
+// before the matcher rejects it. Catches the case where an airline
+// reuses the same flight number for a later departure on the same day
+// after a major schedule change.
+const DepartureTimeToleranceMinutes = 30
+
+// Searcher is the subset of internal/gflights we depend on. Tests
+// substitute a fake to avoid hitting Google during unit tests.
+type Searcher interface {
+	Search(ctx context.Context, opts gflights.SearchOptions) (*gflights.SearchResult, error)
+}
+
+// gflightsSearcher is the production Searcher; it delegates to
+// gflights.Search. Production callers don't need to depend on this — they
+// call CheckWithSearcher(nil, ...) and the default kicks in.
+type gflightsSearcher struct{}
+
+func (gflightsSearcher) Search(ctx context.Context, opts gflights.SearchOptions) (*gflights.SearchResult, error) {
+	return gflights.Search(ctx, opts)
+}
+
+// CheckOptions tunes the behavior of one Check call.
+type CheckOptions struct {
+	// ForceAlert dispatches the alert payload even if the threshold isn't
+	// crossed and even if last_alerted_price is set. Used for `watch
+	// alert-test`.
+	ForceAlert bool
+
+	// RepeatDelta is the minimum additional drop (in the watch's
+	// currency) since last_alerted_price that re-triggers an alert.
+	// Default is 0, which dedups any price equal to or above the last
+	// alerted price.
+	RepeatDelta float64
+
+	// Now overrides time.Now for tests.
+	Now func() time.Time
+
+	// Searcher overrides the gflights backend. Nil means production.
+	Searcher Searcher
+
+	// Dispatcher overrides the alert dispatch surface. Nil means a
+	// dispatcher built from the watch's Notify spec.
+	Dispatcher Dispatcher
+}
+
+func (o *CheckOptions) now() time.Time {
+	if o.Now != nil {
+		return o.Now()
+	}
+	return time.Now().UTC()
+}
+
+func (o *CheckOptions) searcher() Searcher {
+	if o.Searcher != nil {
+		return o.Searcher
+	}
+	return gflightsSearcher{}
+}
+
+// Check looks up the current price for the watch's exact flight, decides
+// whether to dispatch an alert, persists the result, and returns the
+// CheckResult envelope. It does NOT return an error for "no match" or
+// "above threshold" — those are normal, expressed in the envelope. Errors
+// are reserved for transport failures and bad inputs.
+func Check(ctx context.Context, store *Store, w *Watch, opts CheckOptions) (*CheckResult, error) {
+	now := opts.now()
+	res := &CheckResult{
+		Schema:        "flight-goat.watch.check.v1",
+		WatchID:       w.ID,
+		CheckedAt:     now,
+		Origin:        w.Origin,
+		Destination:   w.Destination,
+		Date:          w.DepartureDate,
+		DepartureTime: w.DepartureTime,
+		Airline:       w.Airline,
+		FlightNo:      w.FlightNumber,
+		Cabin:         w.Cabin,
+		FareBrand:     w.FareBrand,
+		OriginalPrice: w.OriginalPrice,
+		Threshold:     w.Threshold,
+		Currency:      w.Currency,
+		BookingURL:    BookingSearchURL(w),
+		Confidence:    MatchRouteOnly,
+		SafetyNotice:  SafetyNoticeText,
+	}
+
+	searchOpts := gflights.SearchOptions{
+		Origin:        w.Origin,
+		Destination:   w.Destination,
+		DepartureDate: w.DepartureDate,
+		CabinClass:    w.Cabin,
+		Passengers:    w.Passengers,
+		Currency:      w.Currency,
+		// ExcludeBasic prevents a $300 basic-economy result from
+		// "matching" a $700 main-cabin ticket. The default is set at
+		// watch-add time (true unless the user opts out via
+		// --include-basic).
+		ExcludeBasic: w.ExcludeBasic,
+		// We intentionally do not pre-filter by airline: the user's
+		// flight could appear in a code-share alongside the operating
+		// carrier, and the match logic below handles airline filtering
+		// itself. Restricting via SearchOptions.Airlines would risk
+		// dropping the user's flight when the response uses a different
+		// marketing code.
+	}
+	result, err := opts.searcher().Search(ctx, searchOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	matched, confidence, cheapest, mismatchReason := matchFlight(result, w)
+	if mismatchReason != "" {
+		res.MatchMismatchReason = mismatchReason
+	}
+	res.MatchReason = explainMatch(w, matched, confidence, cheapest, mismatchReason)
+	if cheapest != nil {
+		p := cheapest.Price
+		res.RouteCheapestPrice = &p
+	}
+	res.Confidence = confidence
+	if matched != nil {
+		mf := flightToMatched(matched, w.Cabin, w.FareBrand)
+		res.MatchedFlight = &mf
+		fp := matched.Price
+		res.FoundPrice = &fp
+		delta := w.OriginalPrice - matched.Price
+		res.Delta = &delta
+		res.ThresholdCrossed = (w.OriginalPrice - matched.Price) >= w.Threshold
+	}
+
+	// Decide whether to dispatch.
+	dispatch := false
+	switch {
+	case opts.ForceAlert:
+		dispatch = matched != nil
+		if !dispatch {
+			res.AlertSuppressed = true
+			res.AlertSuppressReason = "force-alert requested but no matching itinerary returned"
+		}
+	case confidence != MatchExact:
+		res.AlertSuppressed = true
+		res.AlertSuppressReason = "match confidence below high (would alert on a flight the user does not hold)"
+	case !res.ThresholdCrossed:
+		res.AlertSuppressed = true
+		res.AlertSuppressReason = "delta below threshold"
+	case w.LastAlertedPrice != nil && matched != nil && matched.Price >= *w.LastAlertedPrice-opts.RepeatDelta:
+		res.AlertSuppressed = true
+		res.AlertSuppressReason = "price has not dropped by --repeat-delta since the last alert"
+	default:
+		dispatch = true
+	}
+
+	if dispatch {
+		dispatcher := opts.Dispatcher
+		if dispatcher == nil {
+			dispatcher = DispatcherFor(w.Notify)
+		}
+		if dispatcher != nil {
+			if err := dispatcher.Dispatch(ctx, *res); err != nil {
+				return nil, err
+			}
+			res.AlertDispatched = true
+			res.AlertDispatchedTo = dispatcher.Name()
+		}
+	}
+
+	// Persist tracking fields. Skip when store is nil (alert-test in dry
+	// mode + unit tests).
+	if store != nil {
+		if err := store.RecordCheck(ctx, w.ID, now, res.FoundPrice, res.AlertDispatched); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// matchFlight scans the result for the user's exact flight, falling back
+// to confidence levels described in MatchConfidence. It returns:
+//   - (matched, MatchExact, cheapest, "") when airline + flight number +
+//     cabin all match a single itinerary AND the optional departure-time
+//     window is satisfied;
+//   - (matched, MatchProbable, cheapest, "") when airline + cabin match
+//     and the provider didn't echo a flight number;
+//   - (nil, MatchRouteOnly, cheapest, reason) when the cheapest result
+//     has a different airline or flight number, or every airline+number
+//     match failed a sanity check (departure-time drift). `reason` carries
+//     the rejection so the alert envelope can explain why a near-match
+//     was demoted.
+func matchFlight(r *gflights.SearchResult, w *Watch) (matched *gflights.Flight, conf MatchConfidence, cheapest *gflights.Flight, mismatchReason string) {
+	// gflights does not always return flights sorted by price, and some
+	// entries come back with Price == 0 when Google didn't surface a fare
+	// (operator-only, codeshare with missing fare, etc.). Skip those when
+	// computing the route-cheapest so we don't surface a misleading $0.
+	for i := range r.Flights {
+		if r.Flights[i].Price <= 0 {
+			continue
+		}
+		if cheapest == nil || r.Flights[i].Price < cheapest.Price {
+			cheapest = &r.Flights[i]
+		}
+	}
+
+	wantAirline := strings.ToUpper(strings.TrimSpace(w.Airline))
+	wantNum := strings.ToUpper(strings.TrimSpace(w.FlightNumber))
+
+	var probable *gflights.Flight
+	var timeRejected bool
+	for i := range r.Flights {
+		f := &r.Flights[i]
+		if len(f.Legs) == 0 {
+			continue
+		}
+		// Only single-leg itineraries can be the user's flight by
+		// flight number — connecting itineraries have multiple flight
+		// numbers and would never match a single-flight watch.
+		if len(f.Legs) > 1 {
+			continue
+		}
+		leg := f.Legs[0]
+		airline := strings.ToUpper(strings.TrimSpace(leg.Airline.Code))
+		number := strings.ToUpper(strings.TrimSpace(leg.FlightNumber))
+		if airline != wantAirline {
+			continue
+		}
+		if number == wantNum {
+			if w.DepartureTime != "" && !departureTimeMatches(leg.DepartureTime, w.DepartureTime) {
+				timeRejected = true
+				continue
+			}
+			return f, MatchExact, cheapest, ""
+		}
+		if number == "" && probable == nil {
+			probable = f
+		}
+	}
+	if timeRejected {
+		mismatchReason = fmt.Sprintf("flight %s%s found but departure time differs from watched %s by more than %d min", wantAirline, wantNum, w.DepartureTime, DepartureTimeToleranceMinutes)
+	}
+	if probable != nil {
+		return probable, MatchProbable, cheapest, mismatchReason
+	}
+	return nil, MatchRouteOnly, cheapest, mismatchReason
+}
+
+// departureTimeMatches returns true if the candidate ISO-8601 timestamp
+// (e.g. "2026-06-21T07:25:00") falls within ±DepartureTimeToleranceMinutes
+// of the user's HH:MM watch time. A parse failure on either side is
+// treated as "match" — we don't want a malformed Google response to
+// drop an otherwise-good exact match.
+func departureTimeMatches(candidateISO, wantHHMM string) bool {
+	if len(candidateISO) < 16 {
+		return true
+	}
+	candHM := candidateISO[11:16]
+	candT, err1 := time.Parse("15:04", candHM)
+	wantT, err2 := time.Parse("15:04", wantHHMM)
+	if err1 != nil || err2 != nil {
+		return true
+	}
+	diff := candT.Sub(wantT)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= time.Duration(DepartureTimeToleranceMinutes)*time.Minute
+}
+
+// explainMatch returns a one-sentence chain-of-evidence string covering
+// every constraint the matcher actually checked. Users see this in the
+// alert so they can decide whether to trust the match without
+// reverse-engineering the code. Kept short on purpose — anything that
+// doesn't change the human's "is this really my flight?" decision stays
+// out.
+func explainMatch(w *Watch, matched *gflights.Flight, conf MatchConfidence, cheapest *gflights.Flight, mismatchReason string) string {
+	switch conf {
+	case MatchExact:
+		parts := []string{
+			fmt.Sprintf("same airline %s, flight %s", w.Airline, w.FlightNumber),
+			fmt.Sprintf("date %s", w.DepartureDate),
+			fmt.Sprintf("route %s→%s", w.Origin, w.Destination),
+		}
+		if w.Cabin != "" {
+			parts = append(parts, fmt.Sprintf("cabin %s", strings.ReplaceAll(w.Cabin, "_", " ")))
+		}
+		if w.ExcludeBasic {
+			parts = append(parts, "basic-economy excluded")
+		} else {
+			parts = append(parts, "basic-economy included (per your watch)")
+		}
+		if w.DepartureTime != "" && matched != nil && len(matched.Legs) > 0 {
+			candHM := trimDepartureHM(matched.Legs[0].DepartureTime)
+			parts = append(parts, fmt.Sprintf("departure %s within ±%d min of your %s", candHM, DepartureTimeToleranceMinutes, w.DepartureTime))
+		}
+		return "exact match: " + strings.Join(parts, "; ")
+	case MatchProbable:
+		parts := []string{
+			fmt.Sprintf("same airline %s", w.Airline),
+			fmt.Sprintf("date %s", w.DepartureDate),
+			fmt.Sprintf("route %s→%s", w.Origin, w.Destination),
+		}
+		if w.Cabin != "" {
+			parts = append(parts, fmt.Sprintf("cabin %s", strings.ReplaceAll(w.Cabin, "_", " ")))
+		}
+		parts = append(parts, "flight number not returned by Google Flights for this itinerary")
+		return "probable match: " + strings.Join(parts, "; ")
+	default: // MatchRouteOnly
+		if mismatchReason != "" {
+			return "no exact match — " + mismatchReason
+		}
+		if cheapest != nil && len(cheapest.Legs) > 0 {
+			leg := cheapest.Legs[0]
+			return fmt.Sprintf("no exact match: your %s%s did not appear in the response; the cheapest result on this route is %s%s at %s %.2f (different from your flight)",
+				w.Airline, w.FlightNumber, leg.Airline.Code, leg.FlightNumber, cheapest.Currency, cheapest.Price)
+		}
+		return fmt.Sprintf("no exact match: your %s%s did not appear in the live Google Flights response for %s→%s on %s",
+			w.Airline, w.FlightNumber, w.Origin, w.Destination, w.DepartureDate)
+	}
+}
+
+// trimDepartureHM pulls HH:MM out of an ISO timestamp; returns the
+// original on parse miss.
+func trimDepartureHM(iso string) string {
+	if len(iso) >= 16 {
+		return iso[11:16]
+	}
+	return iso
+}
+
+// BookingSearchURL returns a Google Flights search URL pre-filled with
+// the watch's route, date, and cabin so users can open the cheaper
+// itinerary in one tap. Google Flights' canonical search URL takes a
+// natural-language `q` parameter and applies the right filters — much
+// more durable than building the encoded `tfs` protobuf.
+func BookingSearchURL(w *Watch) string {
+	if w == nil {
+		return ""
+	}
+	q := fmt.Sprintf("Flights from %s to %s on %s", w.Origin, w.Destination, w.DepartureDate)
+	if w.Cabin != "" {
+		q += " " + strings.ReplaceAll(w.Cabin, "_", " ")
+	}
+	u := url.URL{
+		Scheme: "https",
+		Host:   "www.google.com",
+		Path:   "/travel/flights",
+	}
+	qs := u.Query()
+	qs.Set("q", q)
+	qs.Set("curr", strings.ToUpper(strings.TrimSpace(w.Currency)))
+	u.RawQuery = qs.Encode()
+	return u.String()
+}
+
+func flightToMatched(f *gflights.Flight, cabin, fareBrand string) MatchedFlight {
+	mf := MatchedFlight{
+		Price:           f.Price,
+		Currency:        f.Currency,
+		Cabin:           cabin,
+		FareBrand:       fareBrand,
+		Stops:           f.Stops,
+		DurationMinutes: f.DurationMinutes,
+	}
+	if len(f.Legs) > 0 {
+		mf.Airline = f.Legs[0].Airline.Code
+		mf.FlightNumber = f.Legs[0].FlightNumber
+		mf.DepartureTime = f.Legs[0].DepartureTime
+		mf.ArrivalTime = f.Legs[len(f.Legs)-1].ArrivalTime
+	}
+	return mf
+}

--- a/library/travel/flight-goat/internal/watch/check.go
+++ b/library/travel/flight-goat/internal/watch/check.go
@@ -147,10 +147,20 @@ func Check(ctx context.Context, store *Store, w *Watch, opts CheckOptions) (*Che
 	dispatch := false
 	switch {
 	case opts.ForceAlert:
-		dispatch = matched != nil
+		// PATCH(greptile P1): force-alert overrides threshold + dedup,
+		// but it must NOT bypass the confidence filter. A MatchProbable
+		// hit (same airline + cabin but Google didn't echo the flight
+		// number) is informational only — alerting on it would update
+		// last_alerted_price for a flight the user may not hold and
+		// suppress the next legitimate high-confidence alert.
+		dispatch = matched != nil && confidence == MatchExact
 		if !dispatch {
 			res.AlertSuppressed = true
-			res.AlertSuppressReason = "force-alert requested but no matching itinerary returned"
+			if matched == nil {
+				res.AlertSuppressReason = "force-alert requested but no matching itinerary returned"
+			} else {
+				res.AlertSuppressReason = "force-alert requested but match confidence below high (refusing to alert on a flight the user may not hold)"
+			}
 		}
 	case confidence != MatchExact:
 		res.AlertSuppressed = true
@@ -272,9 +282,17 @@ func departureTimeMatches(candidateISO, wantHHMM string) bool {
 	if err1 != nil || err2 != nil {
 		return true
 	}
+	// PATCH(greptile P1): treat HH:MM as a point on a 24-hour clock so a
+	// 23:50 watch matches a 00:10 candidate by 20 min, not 23h40m. Both
+	// timestamps are anchored on the zero date by time.Parse, so a naive
+	// Sub gives the linear distance; wrap to the shorter arc whenever the
+	// raw diff exceeds 12h.
 	diff := candT.Sub(wantT)
 	if diff < 0 {
 		diff = -diff
+	}
+	if diff > 12*time.Hour {
+		diff = 24*time.Hour - diff
 	}
 	return diff <= time.Duration(DepartureTimeToleranceMinutes)*time.Minute
 }

--- a/library/travel/flight-goat/internal/watch/check_test.go
+++ b/library/travel/flight-goat/internal/watch/check_test.go
@@ -1,0 +1,482 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/flight-goat/internal/gflights"
+)
+
+// fakeSearcher returns a canned SearchResult; tests build it inline.
+type fakeSearcher struct {
+	res *gflights.SearchResult
+	err error
+}
+
+func (f fakeSearcher) Search(_ context.Context, _ gflights.SearchOptions) (*gflights.SearchResult, error) {
+	return f.res, f.err
+}
+
+// recordDispatcher captures dispatches without sending anything.
+type recordDispatcher struct {
+	got []CheckResult
+}
+
+func (d *recordDispatcher) Name() string { return "test-dispatcher" }
+func (d *recordDispatcher) Dispatch(_ context.Context, r CheckResult) error {
+	d.got = append(d.got, r)
+	return nil
+}
+
+func flightOpt(airline, fno string, price float64) gflights.Flight {
+	return gflights.Flight{
+		Price:    price,
+		Currency: "USD",
+		Stops:    0,
+		Legs: []gflights.Leg{{
+			DepartureAirport: gflights.Airport{Code: "SFO"},
+			ArrivalAirport:   gflights.Airport{Code: "JFK"},
+			Airline:          gflights.Airline{Code: airline},
+			FlightNumber:     fno,
+		}},
+	}
+}
+
+func TestCheckExactMatchAndAlert(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Success:    true,
+		Source:     "test",
+		DataSource: "test",
+		Flights: []gflights.Flight{
+			flightOpt("UA", "200", 300), // route-cheaper, different airline
+			flightOpt("DL", "669", 354), // exact match, below threshold-crossing price (428.20 - 354.10 = 74)
+			flightOpt("DL", "700", 400), // same airline, different flight
+		},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{
+		Searcher:   fake,
+		Dispatcher: rec,
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchExact {
+		t.Fatalf("want high confidence, got %q", res.Confidence)
+	}
+	if res.FoundPrice == nil || *res.FoundPrice != 354 {
+		t.Fatalf("FoundPrice = %v, want 354", res.FoundPrice)
+	}
+	if res.RouteCheapestPrice == nil || *res.RouteCheapestPrice != 300 {
+		t.Fatalf("RouteCheapestPrice = %v, want 300", res.RouteCheapestPrice)
+	}
+	if !res.ThresholdCrossed {
+		t.Fatalf("ThresholdCrossed should be true: delta=%v threshold=%v", res.Delta, res.Threshold)
+	}
+	if !res.AlertDispatched {
+		t.Fatalf("AlertDispatched should be true: %+v", res)
+	}
+	if len(rec.got) != 1 {
+		t.Fatalf("dispatcher should have received exactly 1 alert, got %d", len(rec.got))
+	}
+
+	// Persisted last_alerted_price should reflect the alerted price.
+	got, _ := s.Get(ctx, w.ID)
+	if got.LastAlertedPrice == nil || *got.LastAlertedPrice != 354 {
+		t.Fatalf("LastAlertedPrice = %v, want 354", got.LastAlertedPrice)
+	}
+}
+
+func TestCheckBelowThresholdDoesNotAlert(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Paid 428.20, threshold 50 -> need at least 50 off to alert.
+	// Use 400 -> only 28.20 off, below threshold.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 400)},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: rec})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchExact {
+		t.Fatalf("want high confidence, got %q", res.Confidence)
+	}
+	if res.ThresholdCrossed {
+		t.Fatalf("ThresholdCrossed should be false")
+	}
+	if res.AlertDispatched {
+		t.Fatalf("AlertDispatched should be false")
+	}
+	if !res.AlertSuppressed || !strings.Contains(res.AlertSuppressReason, "threshold") {
+		t.Fatalf("expected suppression reason mentioning threshold, got %q", res.AlertSuppressReason)
+	}
+	if len(rec.got) != 0 {
+		t.Fatalf("dispatcher should not have been called")
+	}
+}
+
+func TestCheckRouteOnlyDoesNotAlert(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Only a different airline / different flight number is cheaper.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{
+			flightOpt("B6", "100", 250),
+			flightOpt("AA", "200", 260),
+		},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: rec})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchRouteOnly {
+		t.Fatalf("want route-only, got %q", res.Confidence)
+	}
+	if res.FoundPrice != nil {
+		t.Fatalf("FoundPrice should be nil when no flight matches: %v", res.FoundPrice)
+	}
+	if res.RouteCheapestPrice == nil || *res.RouteCheapestPrice != 250 {
+		t.Fatalf("RouteCheapestPrice = %v, want 250", res.RouteCheapestPrice)
+	}
+	if res.AlertDispatched {
+		t.Fatalf("should not alert on route-only match")
+	}
+	if len(rec.got) != 0 {
+		t.Fatalf("dispatcher should not have been called for route-only match")
+	}
+}
+
+func TestCheckMissingFlightNumberIsProbable(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Provider omitted the flight number on the same-airline result.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "", 300)},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: rec})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchProbable {
+		t.Fatalf("want medium confidence, got %q", res.Confidence)
+	}
+	if res.AlertDispatched {
+		t.Fatalf("medium confidence should not alert: %+v", res)
+	}
+}
+
+func TestCheckDedupsRepeatAlertViaRepeatDelta(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// First check alerts at 354.
+	fake1 := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 354)},
+	}}
+	if _, err := Check(ctx, s, w, CheckOptions{Searcher: fake1, Dispatcher: &recordDispatcher{}}); err != nil {
+		t.Fatalf("first Check: %v", err)
+	}
+	// Reload watch from store so LastAlertedPrice is populated.
+	fresh, _ := s.Get(ctx, w.ID)
+
+	// Second check at the same price (no further drop) should be suppressed.
+	fake2 := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 354)},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, fresh, CheckOptions{Searcher: fake2, Dispatcher: rec, RepeatDelta: 10})
+	if err != nil {
+		t.Fatalf("second Check: %v", err)
+	}
+	if res.AlertDispatched {
+		t.Fatalf("repeat at same price should be suppressed: %+v", res)
+	}
+	if !res.AlertSuppressed || !strings.Contains(res.AlertSuppressReason, "repeat-delta") {
+		t.Fatalf("expected repeat-delta suppression, got %q", res.AlertSuppressReason)
+	}
+	if len(rec.got) != 0 {
+		t.Fatalf("dispatcher should not have been called on dedup")
+	}
+
+	// A further drop of more than RepeatDelta should re-alert.
+	fresh2, _ := s.Get(ctx, w.ID)
+	fake3 := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 340)}, // 14 below last alerted
+	}}
+	rec2 := &recordDispatcher{}
+	res2, err := Check(ctx, s, fresh2, CheckOptions{Searcher: fake3, Dispatcher: rec2, RepeatDelta: 10})
+	if err != nil {
+		t.Fatalf("third Check: %v", err)
+	}
+	if !res2.AlertDispatched {
+		t.Fatalf("further drop past repeat-delta should re-alert: %+v", res2)
+	}
+	if len(rec2.got) != 1 {
+		t.Fatalf("dispatcher should have been called exactly once on the re-alert, got %d", len(rec2.got))
+	}
+}
+
+func TestCheckForceAlertOverridesDedupAndThreshold(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Price slightly below paid, far above the threshold-crossing line.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 425)},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: rec, ForceAlert: true})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !res.AlertDispatched {
+		t.Fatalf("force-alert should dispatch despite threshold not crossed")
+	}
+	if len(rec.got) != 1 {
+		t.Fatalf("dispatcher should have received the forced alert")
+	}
+}
+
+func TestCheckResultJSONSchemaShape(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "669", 354)},
+	}}
+	res, err := Check(ctx, s, w, CheckOptions{
+		Searcher:   fake,
+		Dispatcher: &recordDispatcher{},
+		Now:        func() time.Time { return time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	buf, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s2 := string(buf)
+	wantFields := []string{
+		`"schema":"flight-goat.watch.check.v1"`,
+		`"watch_id":`,
+		`"origin":"SFO"`,
+		`"destination":"JFK"`,
+		`"airline":"DL"`,
+		`"flight_number":"669"`,
+		`"confidence":"high"`,
+		`"threshold_crossed":true`,
+		`"alert_dispatched":true`,
+		`"safety_notice":"Same flight appears cheaper`,
+		`"matched_flight":`,
+	}
+	for _, f := range wantFields {
+		if !strings.Contains(s2, f) {
+			t.Fatalf("JSON missing %q\n%s", f, s2)
+		}
+	}
+	if !strings.Contains(s2, "Verify fare rules") {
+		t.Fatalf("safety notice missing rebooking warning: %s", s2)
+	}
+}
+
+func TestSampleResultCarriesSafetyNotice(t *testing.T) {
+	w := newSampleWatch()
+	w.ID = "watch_test"
+	r := SampleResult(w, time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC))
+	if r.SafetyNotice != SafetyNoticeText {
+		t.Fatalf("SampleResult dropped safety notice: %q", r.SafetyNotice)
+	}
+	text := FormatAlertText(r)
+	if !strings.Contains(text, "Verify fare rules") {
+		t.Fatalf("FormatAlertText missing safety notice: %s", text)
+	}
+	if !strings.Contains(text, "Book:") || !strings.Contains(text, "google.com/travel/flights") {
+		t.Fatalf("FormatAlertText missing Google Flights booking URL: %s", text)
+	}
+	if !strings.Contains(text, "Why:") || !strings.Contains(text, "exact match") {
+		t.Fatalf("FormatAlertText missing MatchReason line: %s", text)
+	}
+}
+
+func TestCheckRejectsDepartureTimeDrift(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	w.DepartureTime = "07:30" // user holds the morning departure
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Same airline + flight number, but Google returned an 11pm departure
+	// (e.g., DL reused the flight number for an evening reschedule).
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{{
+			Price:    300,
+			Currency: "USD",
+			Legs: []gflights.Leg{{
+				DepartureAirport: gflights.Airport{Code: "SFO"},
+				ArrivalAirport:   gflights.Airport{Code: "JFK"},
+				DepartureTime:    "2026-06-21T23:00:00",
+				Airline:          gflights.Airline{Code: "DL"},
+				FlightNumber:     "669",
+			}},
+		}},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: rec})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence == MatchExact {
+		t.Fatalf("departure-time drift should NOT yield high confidence: %+v", res)
+	}
+	if res.MatchMismatchReason == "" {
+		t.Fatalf("expected MatchMismatchReason populated when time drifts; got empty")
+	}
+	if res.AlertDispatched {
+		t.Fatalf("alert should NOT dispatch on time-drift rejection")
+	}
+}
+
+func TestCheckAcceptsDepartureTimeWithinTolerance(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	w.DepartureTime = "07:30"
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// 07:50 is 20 min from user's 07:30 -> within ±30 min.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{{
+			Price:    300,
+			Currency: "USD",
+			Legs: []gflights.Leg{{
+				DepartureTime: "2026-06-21T07:50:00",
+				Airline:       gflights.Airline{Code: "DL"},
+				FlightNumber:  "669",
+			}},
+		}},
+	}}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: &recordDispatcher{}})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchExact {
+		t.Fatalf("within-tolerance time should match exact: %q", res.Confidence)
+	}
+}
+
+func TestCheckPassesExcludeBasicToSearch(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	w.ExcludeBasic = true
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Capture the SearchOptions to verify ExcludeBasic propagated.
+	var seen gflights.SearchOptions
+	fake := capturingSearcher{
+		seen: &seen,
+		res:  &gflights.SearchResult{Flights: []gflights.Flight{flightOpt("DL", "669", 300)}},
+	}
+	if _, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: &recordDispatcher{}}); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !seen.ExcludeBasic {
+		t.Fatalf("SearchOptions.ExcludeBasic should be true when w.ExcludeBasic is set")
+	}
+}
+
+func TestCheckMatchReasonExplainsExactMatch(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	w.DepartureTime = "07:30"
+	w.ExcludeBasic = true
+	w.FareBrand = "Main Cabin"
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{{
+			Price:    300, Currency: "USD",
+			Legs: []gflights.Leg{{
+				DepartureTime: "2026-06-21T07:25:00",
+				Airline:       gflights.Airline{Code: "DL"},
+				FlightNumber:  "669",
+			}},
+		}},
+	}}
+	res, err := Check(ctx, s, w, CheckOptions{Searcher: fake, Dispatcher: &recordDispatcher{}})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	for _, want := range []string{"exact match", "same airline DL", "flight 669", "economy", "basic-economy excluded", "departure 07:25"} {
+		if !strings.Contains(res.MatchReason, want) {
+			t.Fatalf("MatchReason should mention %q; got %q", want, res.MatchReason)
+		}
+	}
+}
+
+func TestCheckBookingURLContainsRouteAndDate(t *testing.T) {
+	w := newSampleWatch()
+	url := BookingSearchURL(w)
+	for _, want := range []string{"google.com/travel/flights", "SFO", "JFK", "2026-06-21", "curr=USD"} {
+		if !strings.Contains(url, want) {
+			t.Fatalf("BookingURL should contain %q; got %q", want, url)
+		}
+	}
+}
+
+// capturingSearcher records the SearchOptions it received and returns a
+// canned result. Used to assert that flags propagate from Watch into the
+// gflights call.
+type capturingSearcher struct {
+	seen *gflights.SearchOptions
+	res  *gflights.SearchResult
+	err  error
+}
+
+func (c capturingSearcher) Search(_ context.Context, opts gflights.SearchOptions) (*gflights.SearchResult, error) {
+	*c.seen = opts
+	return c.res, c.err
+}

--- a/library/travel/flight-goat/internal/watch/check_test.go
+++ b/library/travel/flight-goat/internal/watch/check_test.go
@@ -5,6 +5,8 @@ package watch
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -247,6 +249,83 @@ func TestCheckDedupsRepeatAlertViaRepeatDelta(t *testing.T) {
 	}
 }
 
+// Regression for greptile P1: departureTimeMatches must wrap around
+// midnight on the 24-hour clock so a red-eye watch at 23:50 matches a
+// 00:10 candidate by 20 min, not by 23h40m. Without the wrap the alert
+// is silently demoted to MatchRouteOnly and the price drop never fires.
+func TestDepartureTimeMatchesWrapsMidnight(t *testing.T) {
+	cases := []struct {
+		watch     string
+		candidate string
+		want      bool
+	}{
+		{"23:50", "2026-06-21T00:10:00", true},  // 20 min after midnight
+		{"00:10", "2026-06-21T23:50:00", true},  // 20 min before midnight
+		{"23:30", "2026-06-21T00:01:00", true},  // 31 min apart -> just over tolerance? actually within
+		{"23:00", "2026-06-21T00:35:00", false}, // 95 min apart, outside tolerance
+		{"12:00", "2026-06-21T11:45:00", true},  // boring non-wrap case
+		{"12:00", "2026-06-21T13:00:00", false}, // 60 min, outside tolerance
+	}
+	// 23:30 -> 00:01 is actually 31 min; tolerance is 30 — fix the
+	// expected case to be within tolerance only at 23:30 vs 23:59.
+	cases[2] = struct {
+		watch, candidate string
+		want             bool
+	}{"23:30", "2026-06-22T00:00:00", true} // 30 min apart, on the boundary
+	for _, tc := range cases {
+		got := departureTimeMatches(tc.candidate, tc.watch)
+		if got != tc.want {
+			t.Errorf("departureTimeMatches(%q, %q) = %v, want %v",
+				tc.candidate, tc.watch, got, tc.want)
+		}
+	}
+}
+
+// Regression for greptile P1: ForceAlert must not dispatch on
+// MatchProbable. A probable match (same airline + cabin but no flight
+// number returned) is informational only; alerting would update
+// last_alerted_price for a flight the user may not hold and suppress
+// the next legitimate high-confidence alert.
+func TestCheckForceAlertSuppressesMatchProbable(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	w := newSampleWatch()
+	if _, err := s.Insert(ctx, w); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	// Same airline + cabin, but Google omitted the flight number ->
+	// MatchProbable. With --force-alert, the old code would still
+	// dispatch; the fixed code suppresses with a confidence reason.
+	fake := fakeSearcher{res: &gflights.SearchResult{
+		Flights: []gflights.Flight{flightOpt("DL", "", 300)},
+	}}
+	rec := &recordDispatcher{}
+	res, err := Check(ctx, s, w, CheckOptions{
+		Searcher: fake, Dispatcher: rec, ForceAlert: true,
+	})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if res.Confidence != MatchProbable {
+		t.Fatalf("expected MatchProbable, got %q", res.Confidence)
+	}
+	if res.AlertDispatched {
+		t.Fatalf("force-alert must not dispatch on MatchProbable: %+v", res)
+	}
+	if !res.AlertSuppressed || !strings.Contains(res.AlertSuppressReason, "confidence") {
+		t.Fatalf("expected confidence-based suppression, got %q", res.AlertSuppressReason)
+	}
+	if len(rec.got) != 0 {
+		t.Fatalf("dispatcher must not be called on MatchProbable force-alert")
+	}
+	// And critically: last_alerted_price must NOT be updated, otherwise
+	// the next legitimate high-confidence alert gets dedup-suppressed.
+	got, _ := s.Get(ctx, w.ID)
+	if got.LastAlertedPrice != nil {
+		t.Fatalf("LastAlertedPrice must remain nil after suppressed MatchProbable force-alert, got %v", *got.LastAlertedPrice)
+	}
+}
+
 func TestCheckForceAlertOverridesDedupAndThreshold(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)
@@ -438,7 +517,7 @@ func TestCheckMatchReasonExplainsExactMatch(t *testing.T) {
 	}
 	fake := fakeSearcher{res: &gflights.SearchResult{
 		Flights: []gflights.Flight{{
-			Price:    300, Currency: "USD",
+			Price: 300, Currency: "USD",
 			Legs: []gflights.Leg{{
 				DepartureTime: "2026-06-21T07:25:00",
 				Airline:       gflights.Airline{Code: "DL"},
@@ -479,4 +558,46 @@ type capturingSearcher struct {
 func (c capturingSearcher) Search(_ context.Context, opts gflights.SearchOptions) (*gflights.SearchResult, error) {
 	*c.seen = opts
 	return c.res, c.err
+}
+
+// Regression for greptile P2: DispatcherFor("") returns a stdout
+// dispatcher whose Dispatch must NOT silently drop the alert when the
+// embedded writer hasn't been wired via SetStdoutWriter. The CLI path
+// always wires one, but library callers (and the eventual
+// flight-watch-check cron path that calls Check with Dispatcher=nil)
+// would otherwise lose alerts.
+func TestStdoutDispatcherFallsBackToOsStdout(t *testing.T) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	d := DispatcherFor("") // intentionally no SetStdoutWriter
+	res := CheckResult{
+		Schema:        "flight-goat.watch.check.v1",
+		WatchID:       "watch_test",
+		Airline:       "DL",
+		FlightNo:      "668",
+		Date:          "2026-06-21",
+		Origin:        "SFO",
+		Destination:   "JFK",
+		OriginalPrice: 700,
+		Currency:      "USD",
+		Confidence:    MatchExact,
+		SafetyNotice:  SafetyNoticeText,
+	}
+	if err := d.Dispatch(context.Background(), res); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	_ = w.Close()
+	buf, _ := io.ReadAll(r)
+	if len(buf) == 0 {
+		t.Fatalf("DispatcherFor(\"\").Dispatch wrote nothing; the nil-writer fallback dropped the alert")
+	}
+	if !strings.Contains(string(buf), "watch_test") || !strings.Contains(string(buf), "Verify fare rules") {
+		t.Fatalf("fallback dispatcher output missing expected fields: %q", string(buf))
+	}
 }

--- a/library/travel/flight-goat/internal/watch/store.go
+++ b/library/travel/flight-goat/internal/watch/store.go
@@ -1,0 +1,312 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SchemaVersion is the on-disk schema version this binary writes. It's
+// stamped into PRAGMA user_version on fresh DBs and checked on open so a
+// future schema change is detectable.
+//
+// v1 → v2: added departure_time, fare_brand, exclude_basic for fare-class
+// safety. Migration is forward-only: existing rows get the columns with
+// NULL/0 defaults, which match the pre-v2 behavior (no time match,
+// no brand surfaced, exclude-basic OFF).
+const SchemaVersion = 2
+
+// Store wraps the SQLite DB that backs the watch list. It owns its own
+// connection pool — intentionally separate from the generator-owned
+// internal/store package to avoid coupling watches to migrations on the
+// generated FlightAware tables.
+type Store struct {
+	db   *sql.DB
+	path string
+}
+
+// DefaultDBPath returns the file path where watches are persisted. It
+// honors FLIGHT_GOAT_WATCH_DB (used by tests and by users who want a
+// non-standard location), falling back to ~/.local/share/flight-goat-pp-cli/watches.db.
+func DefaultDBPath() string {
+	if v := os.Getenv("FLIGHT_GOAT_WATCH_DB"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", "flight-goat-pp-cli", "watches.db")
+}
+
+// Open creates or opens the watches SQLite file and runs the schema
+// migration. The directory tree is created if it doesn't exist.
+func Open(ctx context.Context, dbPath string) (*Store, error) {
+	if dbPath == "" {
+		dbPath = DefaultDBPath()
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, fmt.Errorf("creating watch db directory: %w", err)
+	}
+	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON")
+	if err != nil {
+		return nil, fmt.Errorf("opening watch db: %w", err)
+	}
+	db.SetMaxOpenConns(2)
+	s := &Store{db: db, path: dbPath}
+	if err := s.migrate(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrating watch db: %w", err)
+	}
+	return s, nil
+}
+
+// Close releases the underlying database handle.
+func (s *Store) Close() error { return s.db.Close() }
+
+// Path returns the on-disk DB path. Useful for `doctor` and tests.
+func (s *Store) Path() string { return s.path }
+
+func (s *Store) migrate(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS watches (
+			id                  TEXT PRIMARY KEY,
+			origin              TEXT NOT NULL,
+			destination         TEXT NOT NULL,
+			departure_date      TEXT NOT NULL,
+			departure_time      TEXT NOT NULL DEFAULT '',
+			airline             TEXT NOT NULL,
+			flight_number       TEXT NOT NULL,
+			cabin               TEXT NOT NULL DEFAULT '',
+			fare_brand          TEXT NOT NULL DEFAULT '',
+			exclude_basic       INTEGER NOT NULL DEFAULT 0,
+			passengers          INTEGER NOT NULL DEFAULT 1,
+			original_price      REAL NOT NULL,
+			threshold           REAL NOT NULL,
+			currency            TEXT NOT NULL DEFAULT 'USD',
+			notify              TEXT NOT NULL DEFAULT '',
+			booking_ref         TEXT NOT NULL DEFAULT '',
+			notes               TEXT NOT NULL DEFAULT '',
+			status              TEXT NOT NULL DEFAULT 'active',
+			created_at          TEXT NOT NULL,
+			last_checked_at     TEXT,
+			last_seen_price     REAL,
+			last_alerted_price  REAL
+		);
+		CREATE INDEX IF NOT EXISTS idx_watches_status ON watches(status);
+		CREATE INDEX IF NOT EXISTS idx_watches_route_date ON watches(origin, destination, departure_date);
+	`)
+	if err != nil {
+		return fmt.Errorf("creating watches table: %w", err)
+	}
+	// v1 → v2 forward migration: add the columns to any existing DB.
+	// SQLite errors on duplicate ALTER, so we probe table_info first.
+	for _, col := range []struct{ name, decl string }{
+		{"departure_time", "TEXT NOT NULL DEFAULT ''"},
+		{"fare_brand", "TEXT NOT NULL DEFAULT ''"},
+		{"exclude_basic", "INTEGER NOT NULL DEFAULT 0"},
+	} {
+		if err := s.ensureColumn(ctx, col.name, col.decl); err != nil {
+			return err
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`PRAGMA user_version = %d`, SchemaVersion)); err != nil {
+		return fmt.Errorf("stamping schema version: %w", err)
+	}
+	return nil
+}
+
+// ensureColumn adds a column to the watches table if it doesn't already
+// exist. Used to forward-migrate v1 databases to v2 without losing data.
+func (s *Store) ensureColumn(ctx context.Context, name, decl string) error {
+	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(watches)`)
+	if err != nil {
+		return fmt.Errorf("table_info: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var n, typ string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
+			return fmt.Errorf("scan table_info: %w", err)
+		}
+		if n == name {
+			return nil
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE watches ADD COLUMN %s %s`, name, decl)); err != nil {
+		return fmt.Errorf("add column %s: %w", name, err)
+	}
+	return nil
+}
+
+// NewWatchID mints a stable, opaque identifier for a new watch. The
+// `watch_` prefix is part of the public JSON contract so users can grep
+// for IDs in their logs.
+func NewWatchID() string {
+	var buf [6]byte
+	_, _ = rand.Read(buf[:])
+	return "watch_" + hex.EncodeToString(buf[:])
+}
+
+// Insert persists a fully-validated Watch. Watch.ID is filled if empty,
+// and Watch.CreatedAt is set if zero. The ID is returned.
+func (s *Store) Insert(ctx context.Context, w *Watch) (string, error) {
+	if err := w.Validate(); err != nil {
+		return "", err
+	}
+	if w.ID == "" {
+		w.ID = NewWatchID()
+	}
+	if w.CreatedAt.IsZero() {
+		w.CreatedAt = time.Now().UTC()
+	}
+	excludeBasic := 0
+	if w.ExcludeBasic {
+		excludeBasic = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO watches (
+			id, origin, destination, departure_date, departure_time,
+			airline, flight_number, cabin, fare_brand, exclude_basic,
+			passengers, original_price, threshold, currency, notify,
+			booking_ref, notes, status, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		w.ID, w.Origin, w.Destination, w.DepartureDate, w.DepartureTime,
+		w.Airline, w.FlightNumber, w.Cabin, w.FareBrand, excludeBasic,
+		w.Passengers, w.OriginalPrice, w.Threshold, w.Currency, w.Notify,
+		w.BookingRef, w.Notes, w.Status, w.CreatedAt.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE") {
+			return "", fmt.Errorf("watch %q already exists", w.ID)
+		}
+		return "", fmt.Errorf("insert watch: %w", err)
+	}
+	return w.ID, nil
+}
+
+// Get returns the Watch matching id, or ErrNotFound if it doesn't exist.
+func (s *Store) Get(ctx context.Context, id string) (*Watch, error) {
+	rows, err := s.query(ctx, `WHERE id = ?`, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, ErrNotFound
+	}
+	return rows[0], nil
+}
+
+// List returns watches in a stable order (newest first). Pass empty
+// `status` for all rows; otherwise only the matching status is returned.
+func (s *Store) List(ctx context.Context, status string) ([]*Watch, error) {
+	if status == "" {
+		return s.query(ctx, `ORDER BY created_at DESC`)
+	}
+	return s.query(ctx, `WHERE status = ? ORDER BY created_at DESC`, status)
+}
+
+// Delete removes a watch. Returns ErrNotFound if no row matched.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM watches WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete watch: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// RecordCheck updates the live-price tracking fields after a check. If
+// alerted is true, last_alerted_price is also updated to the foundPrice.
+func (s *Store) RecordCheck(ctx context.Context, id string, checkedAt time.Time, foundPrice *float64, alerted bool) error {
+	stmt := `UPDATE watches SET last_checked_at = ?, last_seen_price = ?`
+	args := []any{checkedAt.UTC().Format(time.RFC3339Nano), nullableFloat(foundPrice)}
+	if alerted && foundPrice != nil {
+		stmt += `, last_alerted_price = ?`
+		args = append(args, *foundPrice)
+	}
+	stmt += ` WHERE id = ?`
+	args = append(args, id)
+	res, err := s.db.ExecContext(ctx, stmt, args...)
+	if err != nil {
+		return fmt.Errorf("record check: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func nullableFloat(f *float64) any {
+	if f == nil {
+		return nil
+	}
+	return *f
+}
+
+// ErrNotFound is returned when an ID lookup misses.
+var ErrNotFound = errors.New("watch not found")
+
+// query is the shared row-loader for all Watch reads.
+func (s *Store) query(ctx context.Context, tail string, args ...any) ([]*Watch, error) {
+	q := `SELECT id, origin, destination, departure_date, departure_time,
+		airline, flight_number, cabin, fare_brand, exclude_basic,
+		passengers, original_price, threshold, currency, notify,
+		booking_ref, notes, status, created_at, last_checked_at,
+		last_seen_price, last_alerted_price FROM watches ` + tail
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query watches: %w", err)
+	}
+	defer rows.Close()
+	var out []*Watch
+	for rows.Next() {
+		w := &Watch{}
+		var createdAt string
+		var checkedAt sql.NullString
+		var lastSeen, lastAlerted sql.NullFloat64
+		var excludeBasic int
+		if err := rows.Scan(
+			&w.ID, &w.Origin, &w.Destination, &w.DepartureDate, &w.DepartureTime,
+			&w.Airline, &w.FlightNumber, &w.Cabin, &w.FareBrand, &excludeBasic,
+			&w.Passengers, &w.OriginalPrice, &w.Threshold, &w.Currency, &w.Notify,
+			&w.BookingRef, &w.Notes, &w.Status, &createdAt, &checkedAt,
+			&lastSeen, &lastAlerted,
+		); err != nil {
+			return nil, fmt.Errorf("scan watch: %w", err)
+		}
+		w.ExcludeBasic = excludeBasic != 0
+		w.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+		if checkedAt.Valid {
+			if t, err := time.Parse(time.RFC3339Nano, checkedAt.String); err == nil {
+				w.LastCheckedAt = &t
+			}
+		}
+		if lastSeen.Valid {
+			v := lastSeen.Float64
+			w.LastSeenPrice = &v
+		}
+		if lastAlerted.Valid {
+			v := lastAlerted.Float64
+			w.LastAlertedPrice = &v
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}

--- a/library/travel/flight-goat/internal/watch/store_test.go
+++ b/library/travel/flight-goat/internal/watch/store_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "watches.db")
+	s, err := Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestStoreInsertAndGet(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	w := newSampleWatch()
+	id, err := s.Insert(ctx, w)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if id == "" || id != w.ID {
+		t.Fatalf("expected ID populated, got %q vs %q", id, w.ID)
+	}
+
+	got, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Origin != "SFO" || got.Destination != "JFK" || got.Airline != "DL" || got.FlightNumber != "669" {
+		t.Fatalf("round-trip lost fields: %+v", got)
+	}
+	if got.OriginalPrice != 428.20 || got.Threshold != 50 {
+		t.Fatalf("round-trip lost numeric fields: %+v", got)
+	}
+	if !got.CreatedAt.Before(time.Now().Add(time.Minute)) || got.CreatedAt.IsZero() {
+		t.Fatalf("CreatedAt looks wrong: %v", got.CreatedAt)
+	}
+	if got.LastCheckedAt != nil || got.LastSeenPrice != nil || got.LastAlertedPrice != nil {
+		t.Fatalf("fresh watch should have nil tracking fields: %+v", got)
+	}
+}
+
+func TestStoreListAndDelete(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	a, _ := s.Insert(ctx, newSampleWatch())
+	b := newSampleWatch()
+	b.FlightNumber = "100"
+	bID, _ := s.Insert(ctx, b)
+
+	rows, err := s.List(ctx, "")
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("List: %v len=%d", err, len(rows))
+	}
+
+	if err := s.Delete(ctx, a); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := s.Delete(ctx, a); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("second Delete should be ErrNotFound, got %v", err)
+	}
+
+	rows, _ = s.List(ctx, "")
+	if len(rows) != 1 || rows[0].ID != bID {
+		t.Fatalf("unexpected remaining rows: %+v", rows)
+	}
+}
+
+func TestStoreRecordCheckUpdatesAlertedPrice(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	id, _ := s.Insert(ctx, newSampleWatch())
+
+	now := time.Now().UTC()
+	price := 354.10
+	if err := s.RecordCheck(ctx, id, now, &price, true); err != nil {
+		t.Fatalf("RecordCheck: %v", err)
+	}
+	got, _ := s.Get(ctx, id)
+	if got.LastSeenPrice == nil || *got.LastSeenPrice != 354.10 {
+		t.Fatalf("LastSeenPrice should be 354.10, got %v", got.LastSeenPrice)
+	}
+	if got.LastAlertedPrice == nil || *got.LastAlertedPrice != 354.10 {
+		t.Fatalf("LastAlertedPrice should be 354.10, got %v", got.LastAlertedPrice)
+	}
+
+	// A subsequent check that doesn't alert should NOT overwrite last_alerted_price.
+	lower := 200.0
+	if err := s.RecordCheck(ctx, id, now, &lower, false); err != nil {
+		t.Fatalf("RecordCheck (no alert): %v", err)
+	}
+	got, _ = s.Get(ctx, id)
+	if *got.LastSeenPrice != 200.0 {
+		t.Fatalf("LastSeenPrice should be 200, got %v", *got.LastSeenPrice)
+	}
+	if got.LastAlertedPrice == nil || *got.LastAlertedPrice != 354.10 {
+		t.Fatalf("LastAlertedPrice should still be 354.10, got %v", got.LastAlertedPrice)
+	}
+}
+
+func TestStoreReturnsErrNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	if _, err := s.Get(ctx, "watch_doesnotexist"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/library/travel/flight-goat/internal/watch/watch.go
+++ b/library/travel/flight-goat/internal/watch/watch.go
@@ -1,0 +1,294 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// Package watch implements purchased-flight price monitoring for
+// flight-goat-pp-cli. Users register a watch on a specific flight they've
+// already booked (airline + flight number + date + route + cabin), and the
+// `watch check` command compares the live Google Flights price against the
+// paid price and surfaces alerts when the same itinerary becomes cheaper by
+// more than the user's threshold.
+//
+// The package is intentionally separate from internal/store: that store is
+// generator-owned and migration-controlled for the FlightAware API surface.
+// Watches are a hand-written extension, so we keep them in their own SQLite
+// database file (default ~/.local/share/flight-goat-pp-cli/watches.db) to
+// avoid migration coupling with the generated schema.
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Status values for a watch row.
+const (
+	StatusActive   = "active"
+	StatusPaused   = "paused"
+	StatusArchived = "archived"
+)
+
+// MatchConfidence describes how confident the check is that the cheaper
+// price it found is the *same* flight the user holds, vs. just a cheaper
+// option on the same route.
+type MatchConfidence string
+
+const (
+	// MatchExact: same airline + flight number + date + route + cabin.
+	// Safe to alert on — this is the user's exact flight.
+	MatchExact MatchConfidence = "high"
+
+	// MatchProbable: same airline + date + route + cabin, but the provider
+	// did not return a flight number for the cheaper itinerary. Could be
+	// the same flight; surface as informational but don't alert by default.
+	MatchProbable MatchConfidence = "medium"
+
+	// MatchRouteOnly: cheapest fare on the same route, but a different
+	// airline or flight number. NEVER triggers an alert — it's the
+	// classic "another carrier is cheaper" case which doesn't help if
+	// the user can't move their ticket without losing it.
+	MatchRouteOnly MatchConfidence = "low"
+)
+
+// Watch is one user-registered flight price watch.
+type Watch struct {
+	ID            string `json:"id"`
+	Origin        string `json:"origin"`
+	Destination   string `json:"destination"`
+	DepartureDate string `json:"departure_date"`
+	// DepartureTime is the optional HH:MM local-departure time of the
+	// user's flight. When set, the matcher rejects candidate
+	// itineraries whose departure time differs by more than ±30 min —
+	// guards against airlines reusing the same flight number on a
+	// rescheduled departure later in the same day.
+	DepartureTime string `json:"departure_time,omitempty"`
+	Airline       string `json:"airline"`
+	FlightNumber  string `json:"flight_number"`
+	Cabin         string `json:"cabin,omitempty"`
+	// FareBrand is free-form: "Main Cabin", "Comfort+", "Polaris",
+	// "First Saver", etc. Surfaced in the alert so the user can
+	// eyeball whether the cheaper fare is comparable (Google Flights
+	// doesn't reliably expose brand codes, so we can't auto-verify).
+	FareBrand string `json:"fare_brand,omitempty"`
+	// ExcludeBasic, when true, filters out basic-economy fares from
+	// the search so a $300 basic-economy result does NOT compare
+	// against a $700 main-cabin paid ticket. Defaults to true at
+	// watch-add time — opt out via --include-basic if the user
+	// actually paid for basic economy.
+	ExcludeBasic  bool    `json:"exclude_basic"`
+	Passengers    int     `json:"passengers"`
+	OriginalPrice float64 `json:"original_price"`
+	Threshold     float64 `json:"threshold"`
+	Currency      string  `json:"currency"`
+	Notify        string  `json:"notify,omitempty"`
+	BookingRef    string  `json:"booking_ref,omitempty"`
+	Notes         string  `json:"notes,omitempty"`
+	Status        string  `json:"status"`
+
+	CreatedAt        time.Time  `json:"created_at"`
+	LastCheckedAt    *time.Time `json:"last_checked_at,omitempty"`
+	LastSeenPrice    *float64   `json:"last_seen_price,omitempty"`
+	LastAlertedPrice *float64   `json:"last_alerted_price,omitempty"`
+}
+
+// CheckResult is the JSON envelope returned by `watch check` and posted to
+// webhook sinks. The shape is stable: SKILL.md documents it and downstream
+// tooling consumes it.
+type CheckResult struct {
+	Schema        string    `json:"schema"`
+	WatchID       string    `json:"watch_id"`
+	CheckedAt     time.Time `json:"checked_at"`
+	Origin        string    `json:"origin"`
+	Destination   string    `json:"destination"`
+	Date          string    `json:"departure_date"`
+	DepartureTime string    `json:"departure_time,omitempty"`
+	Airline       string    `json:"airline"`
+	FlightNo      string    `json:"flight_number"`
+	Cabin         string    `json:"cabin,omitempty"`
+	FareBrand     string    `json:"fare_brand,omitempty"`
+
+	OriginalPrice float64 `json:"original_price"`
+	Threshold     float64 `json:"threshold"`
+	Currency      string  `json:"currency"`
+
+	// BookingURL is a Google Flights search URL pre-filled with the
+	// route + date so the user can open the cheaper itinerary in one
+	// tap. We deliberately use the search URL (not a deep link to the
+	// specific itinerary) because Google's itinerary URLs require an
+	// opaque base64 protobuf that's fragile to construct.
+	BookingURL string `json:"booking_url"`
+
+	// FoundPrice is the live price for the *matched* itinerary (nil if no
+	// itinerary above MatchRouteOnly was found). RouteCheapestPrice is the
+	// cheapest fare seen on the route regardless of match — useful for
+	// context but never used to trigger an alert.
+	FoundPrice          *float64        `json:"found_price,omitempty"`
+	RouteCheapestPrice  *float64        `json:"route_cheapest_price,omitempty"`
+	Delta               *float64        `json:"delta,omitempty"`
+	Confidence          MatchConfidence `json:"confidence"`
+	ThresholdCrossed    bool            `json:"threshold_crossed"`
+	AlertDispatched     bool            `json:"alert_dispatched"`
+	AlertDispatchedTo   string          `json:"alert_dispatched_to,omitempty"`
+	AlertSuppressed     bool            `json:"alert_suppressed"`
+	AlertSuppressReason string          `json:"alert_suppress_reason,omitempty"`
+	// MatchMismatchReason is set when a near-match (same airline +
+	// flight number) was rejected for a verifiable mismatch, e.g.
+	// departure-time drift outside ±30 min. Surfaced so the user can
+	// see "your flight number ran but at a different time" instead of
+	// a silent "no match."
+	MatchMismatchReason string `json:"match_mismatch_reason,omitempty"`
+
+	// MatchReason is a one-sentence explanation of how the matcher
+	// arrived at this Confidence — every constraint that was checked
+	// AND passed. Surfaced in the alert so users see the chain of
+	// evidence ("same airline DL, flight 668, departure 07:25 within
+	// ±30 min of your 07:30, economy cabin, basic-economy excluded")
+	// rather than a bare confidence label they have to trust.
+	MatchReason string `json:"match_reason,omitempty"`
+
+	// SafetyNotice is the exact rebooking-warning string the alert payload
+	// must carry. Surfaced here so JSON consumers (the OpenClaw skill,
+	// scripts) cannot accidentally elide it.
+	SafetyNotice string `json:"safety_notice"`
+
+	// MatchedFlight describes the live itinerary that matched, when
+	// Confidence is MatchExact or MatchProbable.
+	MatchedFlight *MatchedFlight `json:"matched_flight,omitempty"`
+}
+
+// MatchedFlight is the subset of the gflights.Flight surface we surface
+// alongside an alert. We intentionally don't echo every Leg field — alerts
+// stay small.
+type MatchedFlight struct {
+	Airline         string  `json:"airline"`
+	FlightNumber    string  `json:"flight_number"`
+	Price           float64 `json:"price"`
+	Currency        string  `json:"currency"`
+	Cabin           string  `json:"cabin,omitempty"`
+	FareBrand       string  `json:"fare_brand,omitempty"`
+	DepartureTime   string  `json:"departure_time,omitempty"`
+	ArrivalTime     string  `json:"arrival_time,omitempty"`
+	DurationMinutes int     `json:"duration_minutes,omitempty"`
+	Stops           int     `json:"stops"`
+}
+
+// SafetyNoticeText is the rebooking-warning string every alert payload
+// surfaces. Keep it stable; tests assert on its presence.
+const SafetyNoticeText = "Same flight appears cheaper. Verify fare rules, refundability, cancellation fees, credits, and seat/bag differences before canceling or rebooking."
+
+// Validation
+
+var (
+	iataAirportRe = regexp.MustCompile(`^[A-Z]{3}$`)
+	// Airline codes are typically IATA 2-letter (DL, AA) but a few
+	// providers use 3-letter ICAO (DAL, AAL). Accept both.
+	iataAirlineRe = regexp.MustCompile(`^[A-Z0-9]{2,3}$`)
+	flightNoRe    = regexp.MustCompile(`^[0-9]{1,5}[A-Z]?$`)
+	hhmmRe        = regexp.MustCompile(`^([01]?[0-9]|2[0-3]):[0-5][0-9]$`)
+	cabinSet      = map[string]struct{}{
+		"":                {},
+		"economy":         {},
+		"premium_economy": {},
+		"business":        {},
+		"first":           {},
+	}
+)
+
+// Validate checks the user-supplied fields on a Watch. Returns the first
+// problem found; callers should surface this as a usage error.
+func (w *Watch) Validate() error {
+	if w == nil {
+		return errors.New("watch is nil")
+	}
+	w.Origin = strings.ToUpper(strings.TrimSpace(w.Origin))
+	w.Destination = strings.ToUpper(strings.TrimSpace(w.Destination))
+	w.Airline = strings.ToUpper(strings.TrimSpace(w.Airline))
+	w.FlightNumber = strings.ToUpper(strings.TrimSpace(w.FlightNumber))
+	w.Cabin = strings.ToLower(strings.TrimSpace(w.Cabin))
+	w.Currency = strings.ToUpper(strings.TrimSpace(w.Currency))
+
+	if !iataAirportRe.MatchString(w.Origin) {
+		return fmt.Errorf("origin %q is not a 3-letter IATA airport code", w.Origin)
+	}
+	if !iataAirportRe.MatchString(w.Destination) {
+		return fmt.Errorf("destination %q is not a 3-letter IATA airport code", w.Destination)
+	}
+	if w.Origin == w.Destination {
+		return fmt.Errorf("origin and destination cannot match (%s)", w.Origin)
+	}
+	if _, err := time.Parse("2006-01-02", w.DepartureDate); err != nil {
+		return fmt.Errorf("departure date %q is not YYYY-MM-DD", w.DepartureDate)
+	}
+	w.DepartureTime = strings.TrimSpace(w.DepartureTime)
+	if w.DepartureTime != "" && !hhmmRe.MatchString(w.DepartureTime) {
+		return fmt.Errorf("departure time %q must be HH:MM in 24-hour format", w.DepartureTime)
+	}
+	w.FareBrand = strings.TrimSpace(w.FareBrand)
+	if !iataAirlineRe.MatchString(w.Airline) {
+		return fmt.Errorf("airline %q is not a 2- or 3-character carrier code", w.Airline)
+	}
+	if !flightNoRe.MatchString(w.FlightNumber) {
+		return fmt.Errorf("flight number %q must be digits with an optional trailing letter (e.g. 669, 1234A)", w.FlightNumber)
+	}
+	if _, ok := cabinSet[w.Cabin]; !ok {
+		return fmt.Errorf("cabin %q must be one of economy, premium_economy, business, first", w.Cabin)
+	}
+	if w.Passengers <= 0 {
+		w.Passengers = 1
+	}
+	if w.OriginalPrice <= 0 {
+		return fmt.Errorf("paid price must be > 0, got %v", w.OriginalPrice)
+	}
+	if w.Threshold < 0 {
+		return fmt.Errorf("threshold must be >= 0, got %v", w.Threshold)
+	}
+	if w.Currency == "" {
+		w.Currency = "USD"
+	}
+	if len(w.Currency) != 3 {
+		return fmt.Errorf("currency %q must be a 3-letter ISO 4217 code", w.Currency)
+	}
+	if w.Notify != "" {
+		if err := validateNotify(w.Notify); err != nil {
+			return err
+		}
+	}
+	if w.Status == "" {
+		w.Status = StatusActive
+	}
+	switch w.Status {
+	case StatusActive, StatusPaused, StatusArchived:
+	default:
+		return fmt.Errorf("status %q must be one of active, paused, archived", w.Status)
+	}
+	return nil
+}
+
+// validateNotify accepts the same dispatch surface as alert.go: stdout,
+// json, webhook:<https-url>. Anything else is a usage error.
+func validateNotify(spec string) error {
+	switch {
+	case spec == "stdout", spec == "json":
+		return nil
+	case strings.HasPrefix(spec, "webhook:"):
+		raw := strings.TrimPrefix(spec, "webhook:")
+		if raw == "" {
+			return errors.New("notify webhook: needs a URL")
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("notify webhook URL %q is invalid: %w", raw, err)
+		}
+		if u.Scheme != "https" && u.Scheme != "http" {
+			return fmt.Errorf("notify webhook URL %q must use http or https", raw)
+		}
+		if u.Host == "" {
+			return fmt.Errorf("notify webhook URL %q has no host", raw)
+		}
+		return nil
+	default:
+		return fmt.Errorf("notify %q must be stdout, json, or webhook:<url>", spec)
+	}
+}

--- a/library/travel/flight-goat/internal/watch/watch_test.go
+++ b/library/travel/flight-goat/internal/watch/watch_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package watch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAcceptsHappyPath(t *testing.T) {
+	w := &Watch{
+		Origin:        "sfo",
+		Destination:   "jfk",
+		DepartureDate: "2026-06-21",
+		Airline:       "dl",
+		FlightNumber:  "669",
+		Cabin:         "economy",
+		OriginalPrice: 428.20,
+		Threshold:     50,
+		Currency:      "usd",
+	}
+	if err := w.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	// Validate is expected to normalize casing.
+	if w.Origin != "SFO" || w.Destination != "JFK" || w.Airline != "DL" || w.Currency != "USD" {
+		t.Fatalf("Validate did not normalize casing: %+v", w)
+	}
+	if w.Status != StatusActive {
+		t.Fatalf("Validate did not default status to active: %q", w.Status)
+	}
+	if w.Passengers != 1 {
+		t.Fatalf("Validate did not default passengers to 1: %d", w.Passengers)
+	}
+}
+
+func TestValidateRejectsBadInput(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*Watch)
+		want string
+	}{
+		{"bad origin", func(w *Watch) { w.Origin = "S F" }, "origin"},
+		{"bad date", func(w *Watch) { w.DepartureDate = "2026/06/21" }, "departure date"},
+		{"same airport", func(w *Watch) { w.Destination = w.Origin }, "origin and destination"},
+		{"bad airline", func(w *Watch) { w.Airline = "Delta" }, "airline"},
+		{"bad flight number", func(w *Watch) { w.FlightNumber = "DL669" }, "flight number"},
+		{"bad cabin", func(w *Watch) { w.Cabin = "first-class" }, "cabin"},
+		{"zero paid", func(w *Watch) { w.OriginalPrice = 0 }, "paid price"},
+		{"negative threshold", func(w *Watch) { w.Threshold = -1 }, "threshold"},
+		{"bad notify", func(w *Watch) { w.Notify = "slack://foo" }, "notify"},
+		{"bad webhook scheme", func(w *Watch) { w.Notify = "webhook:ftp://nope" }, "http or https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Watch{
+				Origin: "SFO", Destination: "JFK",
+				DepartureDate: "2026-06-21",
+				Airline:       "DL", FlightNumber: "669",
+				OriginalPrice: 100, Threshold: 5, Currency: "USD",
+			}
+			tc.mut(w)
+			err := w.Validate()
+			if err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", tc.want)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.want) {
+				t.Fatalf("expected error to mention %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsThreeLetterAirlineCode(t *testing.T) {
+	w := newSampleWatch()
+	w.Airline = "DAL" // ICAO 3-letter
+	if err := w.Validate(); err != nil {
+		t.Fatalf("3-letter airline should validate: %v", err)
+	}
+}
+
+func newSampleWatch() *Watch {
+	return &Watch{
+		Origin:        "SFO",
+		Destination:   "JFK",
+		DepartureDate: "2026-06-21",
+		Airline:       "DL",
+		FlightNumber:  "669",
+		Cabin:         "economy",
+		OriginalPrice: 428.20,
+		Threshold:     50,
+		Currency:      "USD",
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `flight-goat-pp-cli watch` command group for monitoring purchased-flight prices. Users register a flight they've already booked; `watch check` re-queries Google Flights and alerts when the *same exact itinerary* (airline + flight number + date + route + cabin) appears at a lower price than `paid - threshold`. State persists in its own SQLite file (decoupled from the generator-owned `internal/store` schema) and every alert carries a stable JSON envelope plus a mandatory rebooking safety notice.

## What Changed

- New package `library/travel/flight-goat/internal/watch/` — `Watch` model with validation, SQLite store (modernc.org/sqlite, schema v2 with forward-only migration), match logic, webhook + stdout dispatch with dedup via `last_alerted_price`.
- New hand-written extension `library/travel/flight-goat/internal/cli/watch.go` — Cobra commands `watch add | list | show | check | remove | alert-test`. Mirrors the existing `primary.go` extension pattern.
- One-line hook into `internal/cli/root.go` (`registerWatchCommands(rootCmd, flags)`), tagged with a `// PATCH(library):` comment and recorded in `.printing-press-patches.json`.
- Tests covering: validation, persistence round-trip, exact-match dispatch, threshold suppression, route-only no-alert, missing-flight-number = medium confidence, departure-time drift rejection + within-tolerance acceptance, ExcludeBasic propagation, MatchReason content, BookingURL contents, dedup, force-alert override, JSON-schema shape, safety-notice presence.
- SKILL.md + README.md sections documenting usage, JSON envelope shape, and fare-class safety semantics. `cli-skills/pp-flight-goat/SKILL.md` regenerated via `tools/generate-skills`.

## CLI Shape

```bash
$ flight-goat-pp-cli watch --help
watch tracks flights you have already booked and re-checks their live
prices via the Google Flights backend. When the same flight's fare drops
by more than your threshold you receive an alert (stdout or webhook) with
a safety notice covering refundability, change fees, and credit handling.

Alerts trigger only on EXACT matches (same airline + flight number + date
+ route + cabin). The route-cheapest fare is surfaced for context but is
never used to fire an alert — cheapest-on-route on a different flight
won't help you if your current ticket can't be moved without losing it.

Available Commands:
  add         Register a purchased flight to monitor for price drops
  alert-test  Send a synthetic alert through the watch's notify sink
  check       Re-check live prices and dispatch alerts
  list        List registered watches
  remove      Delete a watch
  show        Show one watch's full state
```

## Design Notes

- **Match-confidence policy.** `high` (exact: airline + flight # + date + route + cabin + optional ±30 min time window) is the only level that alerts. `medium` (same airline + cabin, no flight # echoed) and `low` (route-only) are surfaced as context but never fire. The route-cheapest fare is reported as `route_cheapest_price` so users can see what a different itinerary costs without that being mistaken for "your flight got cheaper."
- **Fare-class safety.** Cabin tier is filtered at search time by Google Flights. Within the economy bucket, `exclude_basic` defaults to true so a $300 basic-economy result never false-matches a $700 main-cabin ticket; users who paid for basic economy opt in with `--include-basic`.
- **Flight-number reuse.** Optional `--departure-time HH:MM` adds a ±30 min sanity check — catches the case where an airline reuses the same flight number for a rescheduled departure later in the day. The matcher demotes from `high` to `low` and sets `match_mismatch_reason` so the alert can explain "your flight # ran but at a different time" instead of going silent.
- **Reasoning surfaced.** Every alert carries `match_reason` — a one-sentence chain of evidence (e.g. `"exact match: same airline DL, flight 668; date 2026-06-21; route SFO→JFK; cabin economy; basic-economy excluded; departure 11:30 within ±30 min of your 11:30"`) so users (and downstream agents) can sanity-check the conclusion.
- **Booking URL.** Each alert includes a Google Flights search URL pre-filled with route + date + cabin + currency. Uses the search-URL form (`?q=...`) rather than the itinerary deep-link (which requires an opaque base64 protobuf) so the link stays durable.
- **State isolation.** Watches live in their own SQLite file (default `~/.local/share/flight-goat-pp-cli/watches.db`, override with `--watch-db` or `$FLIGHT_GOAT_WATCH_DB`) to avoid coupling with the generator-owned `internal/store` migration schedule.
- **Generator path.** This is a hand-written extension; cli-printing-press has no template for stateful long-running monitors today. Recorded in `.printing-press-patches.json` (`watch-command-group`) under `deferred_to_upstream` so future regeneration can absorb it behind a generator hook.

## Match Confidence Truth Table

| Scenario | Confidence | Alert? |
|---|---|---|
| Same airline + flight # + cabin + date + route, departure within ±30 min of user's time (or time unset) | `high` | ✅ if threshold crossed |
| Same airline + flight # + cabin + date + route, but departure drifts > ±30 min | `low` + `match_mismatch_reason` | ❌ |
| Same airline + cabin + date + route, provider didn't echo flight # | `medium` | ❌ (informational) |
| Different airline / different flight # cheaper on the same route | `low` | ❌ (`route_cheapest_price` set for context) |

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/flight-goat/` → all checks passed
- [x] `go build ./...` from the CLI root → clean
- [x] `go vet ./...` from the CLI root → clean
- [x] `go test ./...` from the CLI root → all packages PASS (internal/cli, internal/cliutil, internal/gflights, internal/store, internal/watch)
- [x] `govulncheck ./...` from the CLI root → No vulnerabilities found
- [x] `go run ./tools/generate-skills/main.go` → mirrored 78 skills, including pp-flight-goat
- [x] `git diff --check` → no whitespace issues
- [x] Live end-to-end smoke test with a real Google Flights query (DL 668 SFO→JFK 2026-06-21): exact match resolved, JSON envelope clean, webhook + stdout dispatch verified, safety notice rendered, booking URL pre-filled.

## Gaps / Follow-Up

- The watch DB lives at `~/.local/share/flight-goat-pp-cli/watches.db`. If the generator later grows a stateful-monitor template, the `internal/watch/` package and the `registerWatchCommands` hook should migrate behind it (recorded in `.printing-press-patches.json`).
- Currency-drift handling: today we don't FX-convert if Google's response is tagged in a different currency than the watch. The compare uses the watch's currency directly. If the response currency differs, the comparison would be incorrect — currently rare but worth a follow-up.
- Google Flights doesn't reliably expose fare brand codes (Y, K, M, etc.), so `fare_brand` is a free-text user note for context only; we can't auto-verify brand-vs-brand matches.