### PR TITLE
fix(flight-goat): return per-seat price for multi-passenger flights queries

### DIFF
--- a/library/travel/flight-goat/.printing-press-patches.json
+++ b/library/travel/flight-goat/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-08",
+  "applied_at": "2026-05-12",
   "base_run_id": "2026-05-02T22:09:06.820184Z",
   "base_printing_press_version": "3.6.0",
   "upstream_tracking": [
@@ -8,6 +8,17 @@
     "https://github.com/mvanhorn/cli-printing-press/issues/804"
   ],
   "patches": [
+    {
+      "id": "flights-passengers-per-seat-price",
+      "upstream_issue": "",
+      "files": [
+        "internal/gflights/flights_native.go",
+        "internal/gflights/flights_native_test.go"
+      ],
+      "summary": "Divide multi-passenger `flights` results' price by N so JSON `price` is per-seat.",
+      "reason": "Google Flights' shopping endpoint returns the group total when the request carries `--passengers N`; the parser was copying that straight into Flight.Price without dividing, so any multi-pax query silently reported the group total as per-seat. SEA->DCA 2026-10-09 DL786 first: 1 pax = $869, 3 pax was $2,606 (= 3 * $869) — now $868.67 per seat. Aligns with dates_native.go (hardcoded 1 adult) and the documented per-person contract in the agent SKILL.",
+      "validated_outcome": "go test ./internal/gflights/... -run TestApplyPerPassengerPrice -count=1; live cli run for SEA->DCA 2026-10-09 first nonstop, DL: pax=1 -> 869, pax=3 -> 868.67."
+    },
     {
       "id": "293-schedules-date-path-params",
       "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/293",

--- a/library/travel/flight-goat/internal/gflights/flights_native.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native.go
@@ -117,6 +117,11 @@ func searchNativeDirect(ctx context.Context, opts SearchOptions) (*SearchResult,
 	if err != nil {
 		return nil, fmt.Errorf("parsing response: %w", err)
 	}
+	// PATCH(library): Google Flights returns the group total for `--passengers N`;
+	// divide back down so the JSON `price` field is per-seat. Aligns with the
+	// per-person contract documented in the flight-goat agent skill and matches
+	// dates_native.go (which hardcodes 1 adult and therefore has no analogue).
+	applyPerPassengerPrice(flights, opts.Passengers)
 
 	tripTypeName := "ONE_WAY"
 	if tripType == tripTypeRoundTrip {
@@ -471,6 +476,23 @@ func parseOfferLeg(legRaw any) (Leg, bool) {
 		Airline:          Airline{Code: airlineCode, Name: airlineName},
 		FlightNumber:     flightNumber,
 	}, true
+}
+
+// applyPerPassengerPrice rewrites each flight's Price from the group total
+// (what Google Flights' shopping endpoint actually returns when the request
+// carries `--passengers N`) to the per-seat fare. No-op for N <= 1.
+//
+// PATCH(library): Without this, JSON output for any multi-passenger query
+// reported the group total in the `price` field, which agents and humans
+// alike were treating as per-seat — silently inflating per-seat numbers by
+// the passenger count.
+func applyPerPassengerPrice(flights []Flight, passengers int) {
+	if passengers <= 1 {
+		return
+	}
+	for i := range flights {
+		flights[i].Price /= float64(passengers)
+	}
 }
 
 // parseOfferPrice returns the numeric price from the flight row.

--- a/library/travel/flight-goat/internal/gflights/flights_native_test.go
+++ b/library/travel/flight-goat/internal/gflights/flights_native_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package gflights
+
+import "testing"
+
+// Verifies that the multi-passenger price normalization divides the group
+// total Google Flights returns back down to a per-seat fare. Empirical repro
+// (SEA->DCA 2026-10-09, DL786 first): 1 pax = $869, 3 pax = $2606 = 3 * $869.
+func TestApplyPerPassengerPriceDividesGroupTotal(t *testing.T) {
+	flights := []Flight{{Price: 2606}, {Price: 1500}}
+	applyPerPassengerPrice(flights, 3)
+
+	if got, want := flights[0].Price, 2606.0/3.0; got != want {
+		t.Fatalf("flights[0].Price = %.4f, want %.4f", got, want)
+	}
+	if got, want := flights[1].Price, 500.0; got != want {
+		t.Fatalf("flights[1].Price = %.4f, want %.4f", got, want)
+	}
+}
+
+func TestApplyPerPassengerPriceNoopForSinglePassenger(t *testing.T) {
+	flights := []Flight{{Price: 869}}
+	applyPerPassengerPrice(flights, 1)
+
+	if flights[0].Price != 869 {
+		t.Fatalf("flights[0].Price = %.2f, want 869 (unchanged)", flights[0].Price)
+	}
+}
+
+func TestApplyPerPassengerPriceNoopForZeroOrNegative(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		flights := []Flight{{Price: 869}}
+		applyPerPassengerPrice(flights, n)
+		if flights[0].Price != 869 {
+			t.Fatalf("passengers=%d: flights[0].Price = %.2f, want 869 (unchanged)", n, flights[0].Price)
+		}
+	}
+}
+
+func TestApplyPerPassengerPriceEmptySliceSafe(t *testing.T) {
+	applyPerPassengerPrice(nil, 3)
+	applyPerPassengerPrice([]Flight{}, 3)
+}


### PR DESCRIPTION
## Summary

The `flights` command returns the **group total** in the `price` field whenever `--passengers N` is set (N > 1), while the agent skill docs, `dates_native.go`, and the rest of the CLI's contract all treat `price` as **per-seat**. This silently inflated per-seat numbers by the passenger count in any multi-pax JSON output.

## Repro (live, against Google Flights today)

SEA -> DCA on 2026-10-09, DL786 (Delta First Class, nonstop):

```
$ flight-goat-pp-cli flights SEA DCA 2026-10-09 --class first --stops non_stop --airlines DL --passengers 1 --json --compact
... "price": 869   # per-seat ✓

$ flight-goat-pp-cli flights SEA DCA 2026-10-09 --class first --stops non_stop --airlines DL --passengers 3 --json --compact
... "price": 2606  # this is 3 × $869 — the GROUP TOTAL, mislabeled as per-seat
```

After the fix:

```
$ flight-goat-pp-cli flights SEA DCA 2026-10-09 --class first --stops non_stop --airlines DL --passengers 3 --json --compact
... "price": 868.67   # per-seat ✓ (matches single-pax to within rounding)
```

## How discovered

Surfaced while researching a real first-class booking with the upstream `omarshahine-plugins/travel-agent:google-flights` skill, which wraps this CLI. The skill ingested `price` as per-seat and multiplied by passengers for the group total, producing a 3× inflated quote. Sanity-checking against a known prior booking on the same route flagged the discrepancy; tracing through `cmd/flight-goat-pp-cli/main.go` -> `internal/gflights/flights_native.go` showed the parser was copying upstream `o.Price` straight into `Flight.Price` without dividing.

## Root cause

`parseOfferRow` in `internal/gflights/flights_native.go` extracts the price from the Google Flights `f.req` response and assigns it directly to `Flight.Price`. Google's response carries the **product** of (per-seat fare × passengers) — there is no separate per-seat field in the protobuf-shaped response. `dates_native.go` doesn't have this bug because `passengerAdults()` is hardcoded to 1.

## Fix

- Added `applyPerPassengerPrice(flights, n)` helper that divides each flight's `Price` by N (no-op for N ≤ 1).
- Called it in `searchNativeDirect` after `parseOffersResponse` returns.
- Marked both sites with `// PATCH(library):` comments per AGENTS.md.
- Cataloged in `library/travel/flight-goat/.printing-press-patches.json` (entry `flights-passengers-per-seat-price`).

## Tests

New `internal/gflights/flights_native_test.go` covers:

- Group total -> per-seat division (`TestApplyPerPassengerPriceDividesGroupTotal`)
- Single-passenger no-op (`TestApplyPerPassengerPriceNoopForSinglePassenger`)
- Zero/negative no-op (`TestApplyPerPassengerPriceNoopForZeroOrNegative`)
- Nil and empty slice safety (`TestApplyPerPassengerPriceEmptySliceSafe`)

## Validation

| Check | Result |
|---|---|
| `go build ./...` (flight-goat) | ✅ |
| `go vet ./...` (flight-goat) | ✅ |
| `go test ./... -count=1` (flight-goat) | ✅ (gflights, cli, cliutil, store all pass) |
| `verify_skill.py --dir library/travel/flight-goat/` | ✅ all checks |
| Live API: SEA→DCA 2026-10-09 DL nonstop first, pax=1 | $869 (unchanged) |
| Live API: same query, pax=3 | $868.67/seat (was $2606 group total mislabeled) |

## Files

- `library/travel/flight-goat/internal/gflights/flights_native.go` — helper + call site, `// PATCH(library)` comments
- `library/travel/flight-goat/internal/gflights/flights_native_test.go` — new
- `library/travel/flight-goat/.printing-press-patches.json` — manifest entry