### PR TITLE
fix(granola): hydrate-pagination misses pages 2+ because Granola omits has_more

### DIFF
--- a/library/productivity/granola/internal/granola/api_documents.go
+++ b/library/productivity/granola/internal/granola/api_documents.go
@@ -75,22 +75,17 @@ func HydrateDocumentsFromAPI(cache *Cache, client *InternalClient) (int, error) 
 			cache.Documents[d.ID] = d
 			added++
 		}
-		// Prefer the API's own has_more signal when present (wrapped envelope).
-		// Fall back to short-page detection for the legacy bare-array shape,
-		// which has no pagination metadata and may falsely report HasMore=false.
-		if env.HasMore {
-			continue
-		}
+		// Pagination termination: short-page detection only.
+		// Granola's /v2/get-documents response envelope declares a
+		// has_more field in its OpenAPI shape but does not actually emit
+		// it in practice (verified empirically against the live API;
+		// only `docs` and `deleted` are present). Trusting env.HasMore
+		// here would terminate after page 1 because the zero value is
+		// false. Until Granola starts emitting has_more, the only
+		// reliable end-of-stream signal is a short page.
 		if len(env.Docs) < DefaultDocumentsPageSize {
 			break
 		}
-		// Page was exactly full and has_more is not set. With the wrapped
-		// envelope this means "no more pages"; with bare-array it's
-		// ambiguous. Bias toward trusting the explicit signal - the
-		// modern envelope is wrapped, and the cost of under-fetching on
-		// the rare bare-array exactly-full-page edge case is much smaller
-		// than the cost of always making one extra round-trip.
-		break
 	}
 	// If we exited via the for-condition rather than a break, the API
 	// kept signaling more documents past maxPages. Surface this so the

--- a/library/productivity/granola/internal/granola/api_documents_test.go
+++ b/library/productivity/granola/internal/granola/api_documents_test.go
@@ -56,19 +56,18 @@ func TestHydrateDocumentsFromAPI_Pagination(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
-		// First call returns a full page (100 docs) with has_more=true; second
-		// returns 1 doc with has_more=false signaling end-of-stream.
+		// First call returns a full page (100 docs); second returns 1 (short
+		// page signals end-of-stream, since Granola's API doesn't emit
+		// has_more in practice).
 		var docs []map[string]any
-		hasMore := false
 		if calls == 1 {
 			for i := 0; i < 100; i++ {
 				docs = append(docs, map[string]any{"id": fmt.Sprintf("p1-%d", i)})
 			}
-			hasMore = true
 		} else {
 			docs = []map[string]any{{"id": "p2-0"}}
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"docs": docs, "has_more": hasMore})
+		_ = json.NewEncoder(w).Encode(map[string]any{"docs": docs})
 	}))
 	defer srv.Close()
 
@@ -91,19 +90,28 @@ func TestHydrateDocumentsFromAPI_Pagination(t *testing.T) {
 	}
 }
 
-// TestHydrateDocumentsFromAPI_FullPageNoHasMore covers the precise scenario
-// Greptile flagged: a wrapped envelope returning exactly DefaultDocumentsPageSize
-// rows with has_more=false (or absent) must stop without a follow-up round-trip.
-func TestHydrateDocumentsFromAPI_FullPageNoHasMore(t *testing.T) {
+// TestHydrateDocumentsFromAPI_FullPageWithoutHasMore documents the
+// real-world Granola API behavior: the /v2/get-documents wrapped
+// envelope omits has_more entirely, so the hydrate loop must continue
+// past every full page even when env.HasMore is the false zero-value.
+// This test reproduces the production bug where trusting has_more=false
+// terminated the loop after a single page of 100 documents.
+func TestHydrateDocumentsFromAPI_FullPageWithoutHasMore(t *testing.T) {
 	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		var docs []map[string]any
-		for i := 0; i < 100; i++ {
-			docs = append(docs, map[string]any{"id": fmt.Sprintf("only-%d", i)})
+		// First two pages are exactly full with no has_more; third is short.
+		count := 100
+		if calls == 3 {
+			count = 47
 		}
-		// has_more explicitly false even though page is exactly full.
-		_ = json.NewEncoder(w).Encode(map[string]any{"docs": docs, "has_more": false})
+		idPrefix := fmt.Sprintf("p%d", calls)
+		for i := 0; i < count; i++ {
+			docs = append(docs, map[string]any{"id": fmt.Sprintf("%s-%d", idPrefix, i)})
+		}
+		// Note absence of has_more / next_cursor / cursor - matches real Granola.
+		_ = json.NewEncoder(w).Encode(map[string]any{"docs": docs})
 	}))
 	defer srv.Close()
 
@@ -118,11 +126,11 @@ func TestHydrateDocumentsFromAPI_FullPageNoHasMore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HydrateDocumentsFromAPI: %v", err)
 	}
-	if n != 100 {
-		t.Errorf("expected 100 docs from single page, got %d", n)
+	if n != 247 {
+		t.Errorf("expected 247 docs (100+100+47), got %d", n)
 	}
-	if calls != 1 {
-		t.Errorf("expected 1 API call (no extra round-trip), got %d", calls)
+	if calls != 3 {
+		t.Errorf("expected 3 API calls (continue past full pages without has_more), got %d", calls)
 	}
 }
 


### PR DESCRIPTION
PR #510's polish round wired `env.HasMore` into `HydrateDocumentsFromAPI` loop termination on the assumption that Granola's `/v2/get-documents` wrapped envelope emits the field. Verified against the live API: it does not. Real responses contain only `docs` and `deleted` keys, so `env.HasMore` was always the false zero-value and the loop terminated after page 1.

**Symptom**: `granola-pp-cli sync` reported `documents_fetched: 100` for any account with more than 100 meetings, regardless of actual count.

**Fix**: revert to short-page-only termination (the pre-polish behavior from #510 round-1). Inline comment explains why `has_more` is documented in the `GetDocumentsResponse` type but not trusted at runtime.

**Tests**:
- `TestHydrateDocumentsFromAPI_Pagination` updated to drop `has_more` from the mock response (matches the real API shape).
- New `TestHydrateDocumentsFromAPI_FullPageWithoutHasMore` explicitly reproduces the production bug: 3 pages (100 + 100 + 47) with no `has_more` in any response. Expects 247 docs across 3 API calls.

**Verified end-to-end**: against the live install, `sync` now reports `documents_fetched: 747` (correct total) instead of `100`.

208 tests pass. Follow-up to #510 (merged ~30 min ago).