### PR TITLE
fix(flight-goat): booking URLs that actually work one-tap

### DIFF
--- a/cli-skills/pp-flight-goat/SKILL.md
+++ b/cli-skills/pp-flight-goat/SKILL.md
@@ -259,6 +259,32 @@ Commands that read from the local store or the API wrap output in a provenance e
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
 
+### Flight booking URLs
+
+Each result from `flights` carries `booking_urls` for one-tap booking handoff:
+
+```json
+{
+  "booking_urls": {
+    "primary": "https://www.delta.com/flightsearch/book-a-flight?...",
+    "primary_kind": "prefill",
+    "airline_url": "https://www.delta.com/flightsearch/book-a-flight?...",
+    "airline_kind": "prefill",
+    "google_url": "https://www.google.com/travel/flights/search?tfs=..."
+  }
+}
+```
+
+- `primary` is the recommended single URL. Click once, land on a booking surface.
+- `primary_kind` tells you what to call it:
+  - `prefill` — airline form pre-filled with route + dates. Render as "Book on <airline>".
+  - `landing` — airline booking page; user may need to retype dates. Render as "Open <airline> booking".
+  - `search` — Google Flights search executed with the user's query. Render as "View on Google Flights".
+- `airline_url` and `airline_kind` are present only when the itinerary is operated end-to-end by a single carrier in the curated table (~35 carriers, see `internal/gflights/testdata/airline_url_captures.md`). Codeshare itineraries and unknown carriers omit these.
+- `google_url` is always populated.
+
+If you only render one URL, render `primary` and use `primary_kind` to pick the call-to-action text.
+
 ## Agent Feedback
 
 When you (or the agent) notice something off about this CLI, record it:

--- a/library/travel/flight-goat/.printing-press-patches.json
+++ b/library/travel/flight-goat/.printing-press-patches.json
@@ -9,6 +9,31 @@
   ],
   "patches": [
     {
+      "id": "google-flights-tfs-schema-fix",
+      "upstream_issue": "",
+      "files": [
+        "internal/gflights/booking_urls.go",
+        "internal/gflights/booking_urls_test.go"
+      ],
+      "summary": "Replace the broken hand-rolled tfs= protobuf encoding with the canonical schema from krisukox/google-flights-api url.proto (tripType=19, Location nested at 13/14, Travelers repeated enum at 8, base64.RawURLEncoding, curr+hl URL params).",
+      "reason": "The previous encoding used invented field numbers and produced URLs that landed on the Google Flights homepage instead of executing the search. Schema confirmed by fetching url.proto directly. Browser-verified two emitted URLs (SEA-LHR one-way and SEA-PNH round-trip 4-pax with PNH->KTI remap) both load the search results page.",
+      "validated_outcome": "go test ./internal/gflights/... -run TestBuildGoogleFlightsURL -count=1; live `flights SEA LHR 2026-06-15 --agent` and `flights SEA PNH 2026-12-24 --return 2027-01-01 --passengers 4 --agent` emit Google URLs that open to the search results page."
+    },
+    {
+      "id": "airline-booking-urls-expanded",
+      "upstream_issue": "",
+      "files": [
+        "internal/gflights/booking_urls.go",
+        "internal/gflights/booking_urls_test.go",
+        "internal/gflights/gflights.go",
+        "internal/gflights/testdata/airline_url_captures.md",
+        "SKILL.md"
+      ],
+      "summary": "Expand airlineTemplates from 6 to 35 carriers, add kind field (prefill vs landing) classifying each per testdata/airline_url_captures.md, restructure BookingURLs as {primary, primary_kind, airline_url, airline_kind, google_url} so consumers know what UI text to render.",
+      "reason": "PR #512 shipped a 6-entry airline table with only US-major carriers, leaving international searches (the Cambodia query was the proximate trigger) with no airline-direct link. Research found that only ~4 carriers (DL, LH, LX, WN) have documented prefill patterns; the rest run SPAs that hold search state client-side. The new kind field captures this honestly so agents can render Book on Delta vs Open Condor booking vs View on Google Flights based on what the URL actually does. BREAKING CHANGE for any PR #512 consumer: field names changed from {google, airline} to {google_url, airline_url, ...}.",
+      "validated_outcome": "go test ./internal/gflights/... -count=1 (49 tests); live `flights SEA LAX 2026-07-15 --airlines DL --agent` returns flights with primary pointing at delta.com prefill URL; live `flights SEA PNH 2026-12-24 --return 2027-01-01 --passengers 4 --agent` returns flights with primary pointing at a working Google Flights search (codeshare itinerary)."
+    },
+    {
       "id": "airport-alias-table",
       "upstream_issue": "",
       "files": [

--- a/library/travel/flight-goat/AGENTS.md
+++ b/library/travel/flight-goat/AGENTS.md
@@ -88,6 +88,24 @@ flight-goat-pp-cli flights SEA <retired-code> 2026-12-24 --return 2027-01-01 --a
 
 The response should populate `airport_remapped: {destination: {from: "<old>", to: "<new>"}}` and `query.destination` should still echo the user-supplied code unchanged.
 
+## Airline URL maintenance
+
+Each `Flight` result carries `booking_urls` with an optional airline-direct URL when the itinerary is operated end-to-end by a single carrier in the curated table at `internal/gflights/booking_urls.go` (`airlineTemplates` map). Source of truth for each entry is `internal/gflights/testdata/airline_url_captures.md`, which classifies each URL as:
+
+- `prefill` — the carrier's booking form pre-fills route + dates from URL params. Verified by visiting the URL in a browser. Today: DL, WN, LH, LX.
+- `landing` — the URL points at the carrier's booking entry; user may need to retype dates. All other carriers default to landing.
+
+To upgrade a landing entry to prefill: visit the carrier's booking page in a browser, submit a sample search, and observe whether the resulting URL contains the origin/destination/date as params. If yes, generalize the URL pattern with `{origin}`, `{destination}`, `{depart}`, `{return}`, `{pax}` placeholders (plus carrier-specific `{trip_type_*}` if needed) and update both the `airlineTemplates` map and the captures markdown with the new pattern, date, and source.
+
+Carrier-specific trip-type placeholder variants currently supported:
+
+- `{trip_type}` — `OneWay` / `RoundTrip` (AA, AS)
+- `{trip_type_int}` — `1` / `2` (UA)
+- `{trip_type_dl}` — `ONE_WAY` / `ROUND_TRIP` (DL)
+- `{trip_type_wn}` — `oneway` / `roundtrip` (WN)
+
+When the carrier discriminator is one of these forms, reuse the existing placeholder. When it's something new (rare), add it to the replacer in `buildAirlineURL`.
+
 ## Parser fixture refresh
 
 `internal/gflights/testdata/*.json` contains captured `GetShoppingResults` responses used as regression fixtures. Refresh them by re-running the build-tagged capture tests:

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -259,6 +259,32 @@ Commands that read from the local store or the API wrap output in a provenance e
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
 
+### Flight booking URLs
+
+Each result from `flights` carries `booking_urls` for one-tap booking handoff:
+
+```json
+{
+  "booking_urls": {
+    "primary": "https://www.delta.com/flightsearch/book-a-flight?...",
+    "primary_kind": "prefill",
+    "airline_url": "https://www.delta.com/flightsearch/book-a-flight?...",
+    "airline_kind": "prefill",
+    "google_url": "https://www.google.com/travel/flights/search?tfs=..."
+  }
+}
+```
+
+- `primary` is the recommended single URL. Click once, land on a booking surface.
+- `primary_kind` tells you what to call it:
+  - `prefill` — airline form pre-filled with route + dates. Render as "Book on <airline>".
+  - `landing` — airline booking page; user may need to retype dates. Render as "Open <airline> booking".
+  - `search` — Google Flights search executed with the user's query. Render as "View on Google Flights".
+- `airline_url` and `airline_kind` are present only when the itinerary is operated end-to-end by a single carrier in the curated table (~35 carriers, see `internal/gflights/testdata/airline_url_captures.md`). Codeshare itineraries and unknown carriers omit these.
+- `google_url` is always populated.
+
+If you only render one URL, render `primary` and use `primary_kind` to pick the call-to-action text.
+
 ## Agent Feedback
 
 When you (or the agent) notice something off about this CLI, record it:

--- a/library/travel/flight-goat/internal/gflights/booking_urls.go
+++ b/library/travel/flight-goat/internal/gflights/booking_urls.go
@@ -32,25 +32,49 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
-// BookingURLs lives on Flight. Google is always populated for valid queries;
-// Airline is populated only when the itinerary qualifies.
+// BookingURLs lives on Flight and carries one-tap handoff URLs.
+//
+// Primary is the recommended single URL for one-tap UX; PrimaryKind tells the
+// agent or UI what to call it: "Book on Delta" (prefill), "Open Delta booking"
+// (landing), "View on Google Flights" (search).
+//
+// AirlineURL and AirlineKind are populated only when the itinerary qualifies
+// (single-carrier operator in airlineTemplates). GoogleURL is always
+// populated and points at a Google Flights search that executes on visit.
 type BookingURLs struct {
-	Google  string `json:"google"`
-	Airline string `json:"airline,omitempty"`
+	Primary      string `json:"primary"`
+	PrimaryKind  string `json:"primary_kind"`
+	AirlineURL   string `json:"airline_url,omitempty"`
+	AirlineKind  string `json:"airline_kind,omitempty"`
+	GoogleURL    string `json:"google_url"`
 }
+
+// PrimaryKind values: "prefill" and "landing" are airline-direct; "search"
+// is the Google Flights fallback.
+const (
+	primaryKindPrefill = "prefill"
+	primaryKindLanding = "landing"
+	primaryKindSearch  = "search"
+)
 
 const googleFlightsSearchBase = "https://www.google.com/travel/flights/search"
 
-// buildBookingURLs composes the per-flight booking URLs. The opts argument
-// carries the user's original query (origin/destination/dates/pax). The
-// flight argument supplies the operating airline(s) to decide whether a
-// direct airline link is appropriate.
+// buildBookingURLs composes the per-flight booking URLs. Always populates
+// Primary and GoogleURL; populates AirlineURL+AirlineKind only when the
+// itinerary qualifies for an airline-direct link. Primary preference:
+// airline (any kind) over google search.
 func buildBookingURLs(opts SearchOptions, fl Flight) BookingURLs {
+	googleURL := buildGoogleFlightsURL(opts)
 	out := BookingURLs{
-		Google: buildGoogleFlightsURL(opts),
+		GoogleURL:   googleURL,
+		Primary:     googleURL,
+		PrimaryKind: primaryKindSearch,
 	}
-	if airlineURL, ok := buildAirlineURL(opts, fl); ok {
-		out.Airline = airlineURL
+	if airlineURL, kind, ok := buildAirlineURL(opts, fl); ok {
+		out.AirlineURL = airlineURL
+		out.AirlineKind = kind
+		out.Primary = airlineURL
+		out.PrimaryKind = kind
 	}
 	return out
 }
@@ -169,84 +193,140 @@ func encodeLocation(iata string) []byte {
 }
 
 // airlineTemplate maps an IATA airline code to a deeplink template plus
-// flags for which substitutions the carrier accepts.
+// metadata about what kind of URL it produces.
+//
+// kind classifies the URL's behavior when visited:
+//
+//	prefill — URL params survive page load and pre-fill the booking form.
+//	          User clicks once and sees results ready.
+//	landing — URL lands the user on the carrier's booking entry; route
+//	          and dates may not pre-fill. Still a one-tap improvement
+//	          since the user already chose this airline.
+//
+// See testdata/airline_url_captures.md for the source of truth on each entry.
 type airlineTemplate struct {
-	// URL with placeholders {origin}, {destination}, {depart}, {return}, {pax}.
 	urlTemplate string
+	kind        string // "prefill" or "landing"
 	// roundTripOnly templates omit themselves for one-way; oneWayOnly the opposite.
 	// Empty means "supports both".
 	mode string
 }
 
-// airlineTemplates is a curated set of carrier booking-search-form URLs.
-// Each entry was constructed from live carrier sites and the patterns the
-// search forms emit when submitted. Patterns drift; when one breaks, the
-// fix is one line and the Google fallback continues to serve users.
+// airlineTemplates is a curated set of carrier booking URLs. Each entry is
+// classified prefill or landing per testdata/airline_url_captures.md.
+//
+// Patterns drift; when one breaks, recapture by visiting the carrier's site
+// and updating both the map and the captures log. The Google fallback in
+// buildGoogleFlightsURL continues to serve users when any entry is broken.
 var airlineTemplates = map[string]airlineTemplate{
-	// Alaska Airlines — standard alaskaair.com booking form.
-	"AS": {
-		urlTemplate: "https://www.alaskaair.com/planbook?from={origin}&to={destination}&departureDate={depart}&returnDate={return}&adults={pax}&tripType={trip_type}",
+	// ---- prefill (params survive and pre-fill the form) ----
+
+	// Delta — directly observable URL params.
+	"DL": {
+		urlTemplate: "https://www.delta.com/flightsearch/book-a-flight?tripType={trip_type_dl}&originCity={origin}&destinationCity={destination}&departureDate={depart}&returnDate={return}&paxCount={pax}",
+		kind:        "prefill",
 	},
-	// American Airlines — aa.com search-flights endpoint.
-	"AA": {
-		urlTemplate: "https://www.aa.com/booking/find-flights?from={origin}&to={destination}&departDate={depart}&returnDate={return}&adultPassengerCount={pax}&type={trip_type}",
+	// Southwest — param names from mobile.southwest.com URL bar.
+	"WN": {
+		urlTemplate: "https://www.southwest.com/air/booking/?originationAirportCode={origin}&destinationAirportCode={destination}&departureDate={depart}&returnDate={return}&adultPassengersCount={pax}&tripType={trip_type_wn}",
+		kind:        "prefill",
 	},
-	// United Airlines — united.com flight search.
-	"UA": {
-		urlTemplate: "https://www.united.com/en/us/fsr/choose-flights?f={origin}&t={destination}&d={depart}&r={return}&px={pax}&tt={trip_type_int}&sc=7&taxng=1&clm=7",
+	// Lufthansa — officially documented at developer.lufthansa.com.
+	"LH": {
+		urlTemplate: "https://www.lufthansa.com/deeplink/partner?airlineCode=LH&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}",
+		kind:        "prefill",
 	},
-	// JetBlue — jetblue.com booking entry.
-	"B6": {
-		urlTemplate: "https://www.jetblue.com/booking/flights?from={origin}&to={destination}&depart={depart}&return={return}&isMultiCity=false&noOfRoute=1&adults={pax}",
+	// Swiss — same Lufthansa Group spec, airlineCode=LX.
+	"LX": {
+		urlTemplate: "https://www.lufthansa.com/deeplink/partner?airlineCode=LX&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}",
+		kind:        "prefill",
 	},
-	// Air Canada — aircanada.com flight finder.
-	"AC": {
-		urlTemplate: "https://www.aircanada.com/aco/en_us/aco-booking-flights/flight-search?orgCity1={origin}&destCity1={destination}&date1={depart}&date2={return}&numAdults={pax}",
-	},
-	// British Airways — britishairways.com flight search.
-	"BA": {
-		urlTemplate: "https://www.britishairways.com/travel/fx/public/en_us?eId=120001&depAirport={origin}&arrAirport={destination}&outboundDate={depart}&inboundDate={return}&adults={pax}",
-	},
+
+	// ---- landing (URL lands user on carrier's booking surface) ----
+
+	"AS": {urlTemplate: "https://www.alaskaair.com/search/flights?O={origin}&D={destination}&OD={depart}&RD={return}&A={pax}", kind: "landing"},
+	"AA": {urlTemplate: "https://www.aa.com/booking/find-flights?from={origin}&to={destination}&departDate={depart}&returnDate={return}&adultPassengerCount={pax}&type={trip_type}", kind: "landing"},
+	"UA": {urlTemplate: "https://www.united.com/en/us/fsr/choose-flights?f={origin}&t={destination}&d={depart}&r={return}&px={pax}&tt={trip_type_int}&sc=7&taxng=1&clm=7", kind: "landing"},
+	"B6": {urlTemplate: "https://www.jetblue.com/booking/flights?from={origin}&to={destination}&depart={depart}&return={return}&isMultiCity=false&noOfRoute=1&adults={pax}", kind: "landing"},
+	"F9": {urlTemplate: "https://booking.flyfrontier.com/", kind: "landing"},
+	"AC": {urlTemplate: "https://www.aircanada.com/aco/en_us/aco-booking-flights/flight-search?orgCity1={origin}&destCity1={destination}&date1={depart}&date2={return}&numAdults={pax}", kind: "landing"},
+	"BA": {urlTemplate: "https://www.britishairways.com/travel/fx/public/en_us?eId=120001&depAirport={origin}&arrAirport={destination}&outboundDate={depart}&inboundDate={return}&adults={pax}", kind: "landing"},
+	"AF": {urlTemplate: "https://wwws.airfrance.us/", kind: "landing"},
+	"KL": {urlTemplate: "https://www.klm.com/en-us/flights", kind: "landing"},
+	"IB": {urlTemplate: "https://www.iberia.com/us/flight-search-engine/", kind: "landing"},
+	"VS": {urlTemplate: "https://www.virginatlantic.com/en-US", kind: "landing"},
+	"SK": {urlTemplate: "https://www.flysas.com/en", kind: "landing"},
+	"AY": {urlTemplate: "https://www.finnair.com/us/en", kind: "landing"},
+	"EI": {urlTemplate: "https://www.aerlingus.com/html/dashboard.html", kind: "landing"},
+	"DE": {urlTemplate: "https://www.condor.com/us/", kind: "landing"},
+	"EK": {urlTemplate: "https://www.emirates.com/english/book/", kind: "landing"},
+	"QR": {urlTemplate: "https://booking.qatarairways.com/nsp/views/deepLinkLoader.xhtml", kind: "landing"},
+	"EY": {urlTemplate: "https://www.etihad.com/en-us/book", kind: "landing"},
+	"SQ": {urlTemplate: "https://www.singaporeair.com/en_UK/us/home", kind: "landing"},
+	"BR": {urlTemplate: "https://booking.evaair.com/flyeva/eva/b2c/booking-online.aspx?lang=en-us", kind: "landing"},
+	"CX": {urlTemplate: "https://www.cathaypacific.com/cx/en_US.html", kind: "landing"},
+	"KE": {urlTemplate: "https://www.koreanair.com/booking/search", kind: "landing"},
+	"NH": {urlTemplate: "https://www.ana.co.jp/en/us/plan-book/", kind: "landing"},
+	"JL": {urlTemplate: "https://www.jal.co.jp/jp/en/inter/booking/", kind: "landing"},
+	"TG": {urlTemplate: "https://www.thaiairways.com/en/book/booking.page", kind: "landing"},
+	"PG": {urlTemplate: "https://www.bangkokair.com/flight/booking", kind: "landing"},
+	"HU": {urlTemplate: "https://www.hainanairlines.com/US/US/Search", kind: "landing"},
+	"CI": {urlTemplate: "https://www.china-airlines.com/us/en/booking/book-flights", kind: "landing"},
+	"OZ": {urlTemplate: "https://flyasiana.com/C/US/EN/index", kind: "landing"},
+	"JX": {urlTemplate: "https://www.starlux-airlines.com/en-US/booking/book-flight/search-a-flight", kind: "landing"},
+	"ET": {urlTemplate: "https://www.ethiopianairlines.com/us/book/booking/flight", kind: "landing"},
 }
 
+// airlineKindPrefill and airlineKindLanding are the two valid values for
+// airlineTemplate.kind and BookingURLs.AirlineKind / PrimaryKind.
+const (
+	airlineKindPrefill = "prefill"
+	airlineKindLanding = "landing"
+)
+
 // buildAirlineURL returns an airline-direct URL when the itinerary
-// qualifies. Qualification: all legs operated by a single carrier in
-// airlineTemplates. Codeshare flights, regional carriers outside the
-// table, and itineraries with mixed operators omit the airline URL
-// (the Google fallback always populates).
-func buildAirlineURL(opts SearchOptions, fl Flight) (string, bool) {
+// qualifies. Returns (url, kind, ok) where kind is "prefill" or "landing".
+// Qualification: all legs operated by a single carrier in airlineTemplates.
+// Codeshare flights, regional carriers outside the table, and itineraries
+// with mixed operators return ("", "", false). The Google fallback in
+// buildGoogleFlightsURL always populates regardless.
+func buildAirlineURL(opts SearchOptions, fl Flight) (string, string, bool) {
 	if len(fl.Legs) == 0 {
-		return "", false
+		return "", "", false
 	}
 	first := strings.ToUpper(fl.Legs[0].Airline.Code)
 	if first == "" {
-		return "", false
+		return "", "", false
 	}
 	for _, leg := range fl.Legs[1:] {
 		if !strings.EqualFold(leg.Airline.Code, first) {
-			return "", false
+			return "", "", false
 		}
 	}
 	tmpl, ok := airlineTemplates[first]
 	if !ok {
-		return "", false
+		return "", "", false
 	}
 	// PATCH(greptile P2): enforce the documented mode contract so a future
 	// roundTripOnly/oneWayOnly entry doesn't silently generate URLs for
 	// the unsupported trip type.
 	isRoundTrip := opts.ReturnDate != ""
 	if tmpl.mode == "roundTripOnly" && !isRoundTrip {
-		return "", false
+		return "", "", false
 	}
 	if tmpl.mode == "oneWayOnly" && isRoundTrip {
-		return "", false
+		return "", "", false
 	}
 
 	tripType := "OneWay"
 	tripTypeInt := "1"
+	tripTypeDL := "ONE_WAY"
+	tripTypeWN := "oneway"
 	if isRoundTrip {
 		tripType = "RoundTrip"
 		tripTypeInt = "2"
+		tripTypeDL = "ROUND_TRIP"
+		tripTypeWN = "roundtrip"
 	}
 	pax := opts.Passengers
 	if pax < 1 {
@@ -261,18 +341,18 @@ func buildAirlineURL(opts SearchOptions, fl Flight) (string, bool) {
 		"{pax}", fmt.Sprintf("%d", pax),
 		"{trip_type}", tripType,
 		"{trip_type_int}", tripTypeInt,
+		"{trip_type_dl}", tripTypeDL,
+		"{trip_type_wn}", tripTypeWN,
 	)
 	built := r.Replace(tmpl.urlTemplate)
 	// PATCH(greptile P2): one-way searches leave the {return} placeholder
-	// expanding to an empty string. Carriers without an explicit trip-type
-	// param (B6, BA) treat returnDate=/inboundDate= as round-trip with
-	// missing dates and may default the form to a round-trip search.
-	// Strip query params with empty values so the form sees a clean
-	// one-way query.
+	// expanding to an empty string. Strip query params with empty values
+	// so carrier forms without an explicit trip-type indicator (B6, BA, etc.)
+	// see a clean one-way query.
 	if !isRoundTrip {
 		built = stripEmptyQueryParams(built)
 	}
-	return built, true
+	return built, tmpl.kind, true
 }
 
 // stripEmptyQueryParams removes query parameters whose value is empty

--- a/library/travel/flight-goat/internal/gflights/booking_urls.go
+++ b/library/travel/flight-goat/internal/gflights/booking_urls.go
@@ -39,8 +39,9 @@ import (
 // (landing), "View on Google Flights" (search).
 //
 // AirlineURL and AirlineKind are populated only when the itinerary qualifies
-// (single-carrier operator in airlineTemplates). GoogleURL is always
-// populated and points at a Google Flights search that executes on visit.
+// (single-carrier operator in airlineTemplates). GoogleURL and Primary are
+// populated for any valid query (Origin, Destination, DepartureDate all
+// non-empty); buildBookingURLs returns a zero value otherwise.
 type BookingURLs struct {
 	Primary      string `json:"primary"`
 	PrimaryKind  string `json:"primary_kind"`
@@ -59,12 +60,15 @@ const (
 
 const googleFlightsSearchBase = "https://www.google.com/travel/flights/search"
 
-// buildBookingURLs composes the per-flight booking URLs. Always populates
-// Primary and GoogleURL; populates AirlineURL+AirlineKind only when the
-// itinerary qualifies for an airline-direct link. Primary preference:
-// airline (any kind) over google search.
+// buildBookingURLs composes the per-flight booking URLs. Returns a zero
+// value for degenerate queries (missing Origin / Destination / DepartureDate)
+// so SKILL.md's "always populated" contract on Primary and GoogleURL holds
+// for any non-zero return. Primary preference: airline (any kind) over google.
 func buildBookingURLs(opts SearchOptions, fl Flight) BookingURLs {
 	googleURL := buildGoogleFlightsURL(opts)
+	if googleURL == "" {
+		return BookingURLs{}
+	}
 	out := BookingURLs{
 		GoogleURL:   googleURL,
 		Primary:     googleURL,
@@ -224,64 +228,66 @@ var airlineTemplates = map[string]airlineTemplate{
 	// Delta — directly observable URL params.
 	"DL": {
 		urlTemplate: "https://www.delta.com/flightsearch/book-a-flight?tripType={trip_type_dl}&originCity={origin}&destinationCity={destination}&departureDate={depart}&returnDate={return}&paxCount={pax}",
-		kind:        "prefill",
+		kind:        airlineKindPrefill,
 	},
 	// Southwest — param names from mobile.southwest.com URL bar.
 	"WN": {
 		urlTemplate: "https://www.southwest.com/air/booking/?originationAirportCode={origin}&destinationAirportCode={destination}&departureDate={depart}&returnDate={return}&adultPassengersCount={pax}&tripType={trip_type_wn}",
-		kind:        "prefill",
+		kind:        airlineKindPrefill,
 	},
 	// Lufthansa — officially documented at developer.lufthansa.com.
 	"LH": {
 		urlTemplate: "https://www.lufthansa.com/deeplink/partner?airlineCode=LH&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}",
-		kind:        "prefill",
+		kind:        airlineKindPrefill,
 	},
 	// Swiss — same Lufthansa Group spec, airlineCode=LX.
 	"LX": {
 		urlTemplate: "https://www.lufthansa.com/deeplink/partner?airlineCode=LX&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}",
-		kind:        "prefill",
+		kind:        airlineKindPrefill,
 	},
 
 	// ---- landing (URL lands user on carrier's booking surface) ----
 
-	"AS": {urlTemplate: "https://www.alaskaair.com/search/flights?O={origin}&D={destination}&OD={depart}&RD={return}&A={pax}", kind: "landing"},
-	"AA": {urlTemplate: "https://www.aa.com/booking/find-flights?from={origin}&to={destination}&departDate={depart}&returnDate={return}&adultPassengerCount={pax}&type={trip_type}", kind: "landing"},
-	"UA": {urlTemplate: "https://www.united.com/en/us/fsr/choose-flights?f={origin}&t={destination}&d={depart}&r={return}&px={pax}&tt={trip_type_int}&sc=7&taxng=1&clm=7", kind: "landing"},
-	"B6": {urlTemplate: "https://www.jetblue.com/booking/flights?from={origin}&to={destination}&depart={depart}&return={return}&isMultiCity=false&noOfRoute=1&adults={pax}", kind: "landing"},
-	"F9": {urlTemplate: "https://booking.flyfrontier.com/", kind: "landing"},
-	"AC": {urlTemplate: "https://www.aircanada.com/aco/en_us/aco-booking-flights/flight-search?orgCity1={origin}&destCity1={destination}&date1={depart}&date2={return}&numAdults={pax}", kind: "landing"},
-	"BA": {urlTemplate: "https://www.britishairways.com/travel/fx/public/en_us?eId=120001&depAirport={origin}&arrAirport={destination}&outboundDate={depart}&inboundDate={return}&adults={pax}", kind: "landing"},
-	"AF": {urlTemplate: "https://wwws.airfrance.us/", kind: "landing"},
-	"KL": {urlTemplate: "https://www.klm.com/en-us/flights", kind: "landing"},
-	"IB": {urlTemplate: "https://www.iberia.com/us/flight-search-engine/", kind: "landing"},
-	"VS": {urlTemplate: "https://www.virginatlantic.com/en-US", kind: "landing"},
-	"SK": {urlTemplate: "https://www.flysas.com/en", kind: "landing"},
-	"AY": {urlTemplate: "https://www.finnair.com/us/en", kind: "landing"},
-	"EI": {urlTemplate: "https://www.aerlingus.com/html/dashboard.html", kind: "landing"},
-	"DE": {urlTemplate: "https://www.condor.com/us/", kind: "landing"},
-	"EK": {urlTemplate: "https://www.emirates.com/english/book/", kind: "landing"},
-	"QR": {urlTemplate: "https://booking.qatarairways.com/nsp/views/deepLinkLoader.xhtml", kind: "landing"},
-	"EY": {urlTemplate: "https://www.etihad.com/en-us/book", kind: "landing"},
-	"SQ": {urlTemplate: "https://www.singaporeair.com/en_UK/us/home", kind: "landing"},
-	"BR": {urlTemplate: "https://booking.evaair.com/flyeva/eva/b2c/booking-online.aspx?lang=en-us", kind: "landing"},
-	"CX": {urlTemplate: "https://www.cathaypacific.com/cx/en_US.html", kind: "landing"},
-	"KE": {urlTemplate: "https://www.koreanair.com/booking/search", kind: "landing"},
-	"NH": {urlTemplate: "https://www.ana.co.jp/en/us/plan-book/", kind: "landing"},
-	"JL": {urlTemplate: "https://www.jal.co.jp/jp/en/inter/booking/", kind: "landing"},
-	"TG": {urlTemplate: "https://www.thaiairways.com/en/book/booking.page", kind: "landing"},
-	"PG": {urlTemplate: "https://www.bangkokair.com/flight/booking", kind: "landing"},
-	"HU": {urlTemplate: "https://www.hainanairlines.com/US/US/Search", kind: "landing"},
-	"CI": {urlTemplate: "https://www.china-airlines.com/us/en/booking/book-flights", kind: "landing"},
-	"OZ": {urlTemplate: "https://flyasiana.com/C/US/EN/index", kind: "landing"},
-	"JX": {urlTemplate: "https://www.starlux-airlines.com/en-US/booking/book-flight/search-a-flight", kind: "landing"},
-	"ET": {urlTemplate: "https://www.ethiopianairlines.com/us/book/booking/flight", kind: "landing"},
+	"AS": {urlTemplate: "https://www.alaskaair.com/search/flights?O={origin}&D={destination}&OD={depart}&RD={return}&A={pax}", kind: airlineKindLanding},
+	"AA": {urlTemplate: "https://www.aa.com/booking/find-flights?from={origin}&to={destination}&departDate={depart}&returnDate={return}&adultPassengerCount={pax}&type={trip_type}", kind: airlineKindLanding},
+	"UA": {urlTemplate: "https://www.united.com/en/us/fsr/choose-flights?f={origin}&t={destination}&d={depart}&r={return}&px={pax}&tt={trip_type_int}&sc=7&taxng=1&clm=7", kind: airlineKindLanding},
+	"B6": {urlTemplate: "https://www.jetblue.com/booking/flights?from={origin}&to={destination}&depart={depart}&return={return}&isMultiCity=false&noOfRoute=1&adults={pax}", kind: airlineKindLanding},
+	"F9": {urlTemplate: "https://booking.flyfrontier.com/", kind: airlineKindLanding},
+	"AC": {urlTemplate: "https://www.aircanada.com/aco/en_us/aco-booking-flights/flight-search?orgCity1={origin}&destCity1={destination}&date1={depart}&date2={return}&numAdults={pax}", kind: airlineKindLanding},
+	"BA": {urlTemplate: "https://www.britishairways.com/travel/fx/public/en_us?eId=120001&depAirport={origin}&arrAirport={destination}&outboundDate={depart}&inboundDate={return}&adults={pax}", kind: airlineKindLanding},
+	"AF": {urlTemplate: "https://wwws.airfrance.us/", kind: airlineKindLanding},
+	"KL": {urlTemplate: "https://www.klm.com/en-us/flights", kind: airlineKindLanding},
+	"IB": {urlTemplate: "https://www.iberia.com/us/flight-search-engine/", kind: airlineKindLanding},
+	"VS": {urlTemplate: "https://www.virginatlantic.com/en-US", kind: airlineKindLanding},
+	"SK": {urlTemplate: "https://www.flysas.com/en", kind: airlineKindLanding},
+	"AY": {urlTemplate: "https://www.finnair.com/us/en", kind: airlineKindLanding},
+	"EI": {urlTemplate: "https://www.aerlingus.com/html/dashboard.html", kind: airlineKindLanding},
+	"DE": {urlTemplate: "https://www.condor.com/us/", kind: airlineKindLanding},
+	"EK": {urlTemplate: "https://www.emirates.com/english/book/", kind: airlineKindLanding},
+	"QR": {urlTemplate: "https://booking.qatarairways.com/nsp/views/deepLinkLoader.xhtml", kind: airlineKindLanding},
+	"EY": {urlTemplate: "https://www.etihad.com/en-us/book", kind: airlineKindLanding},
+	"SQ": {urlTemplate: "https://www.singaporeair.com/en_UK/us/home", kind: airlineKindLanding},
+	"BR": {urlTemplate: "https://booking.evaair.com/flyeva/eva/b2c/booking-online.aspx?lang=en-us", kind: airlineKindLanding},
+	"CX": {urlTemplate: "https://www.cathaypacific.com/cx/en_US.html", kind: airlineKindLanding},
+	"KE": {urlTemplate: "https://www.koreanair.com/booking/search", kind: airlineKindLanding},
+	"NH": {urlTemplate: "https://www.ana.co.jp/en/us/plan-book/", kind: airlineKindLanding},
+	"JL": {urlTemplate: "https://www.jal.co.jp/jp/en/inter/booking/", kind: airlineKindLanding},
+	"TG": {urlTemplate: "https://www.thaiairways.com/en/book/booking.page", kind: airlineKindLanding},
+	"PG": {urlTemplate: "https://www.bangkokair.com/flight/booking", kind: airlineKindLanding},
+	"HU": {urlTemplate: "https://www.hainanairlines.com/US/US/Search", kind: airlineKindLanding},
+	"CI": {urlTemplate: "https://www.china-airlines.com/us/en/booking/book-flights", kind: airlineKindLanding},
+	"OZ": {urlTemplate: "https://flyasiana.com/C/US/EN/index", kind: airlineKindLanding},
+	"JX": {urlTemplate: "https://www.starlux-airlines.com/en-US/booking/book-flight/search-a-flight", kind: airlineKindLanding},
+	"ET": {urlTemplate: "https://www.ethiopianairlines.com/us/book/booking/flight", kind: airlineKindLanding},
 }
 
-// airlineKindPrefill and airlineKindLanding are the two valid values for
-// airlineTemplate.kind and BookingURLs.AirlineKind / PrimaryKind.
+// airlineKind* alias the matching primaryKind* constants so airlineTemplate.kind
+// and BookingURLs.AirlineKind / PrimaryKind share one source of truth.
+// PATCH(greptile P2): single set of string values prevents callers and tests
+// from accidentally mixing two parallel const blocks.
 const (
-	airlineKindPrefill = "prefill"
-	airlineKindLanding = "landing"
+	airlineKindPrefill = primaryKindPrefill
+	airlineKindLanding = primaryKindLanding
 )
 
 // buildAirlineURL returns an airline-direct URL when the itinerary

--- a/library/travel/flight-goat/internal/gflights/booking_urls.go
+++ b/library/travel/flight-goat/internal/gflights/booking_urls.go
@@ -55,85 +55,114 @@ func buildBookingURLs(opts SearchOptions, fl Flight) BookingURLs {
 	return out
 }
 
-// buildGoogleFlightsURL constructs the tfs= deeplink. The protobuf shape is:
+// buildGoogleFlightsURL constructs the tfs= deeplink against Google Flights'
+// documented protobuf schema. The canonical .proto lives at
+// https://github.com/krisukox/google-flights-api/blob/main/flights/internal/urlpb/url.proto
 //
-//	field 2 (varint): trip type — 1=one-way, 2=round-trip
-//	field 3 (length-delimited, repeated): travel slice {
-//	    field 2 (length-delimited, message): origin {
-//	        field 2 (length-delimited, string): IATA code
-//	    }
-//	    field 6 (length-delimited, message): destination {
-//	        field 2 (length-delimited, string): IATA code
-//	    }
-//	    field 13 (length-delimited, string): YYYY-MM-DD
+//	message Url {
+//	    repeated Flight flight = 3;
+//	    repeated Traveler travelers = 8;   // one enum value per passenger
+//	    Class class = 9;                    // 1=economy
+//	    TripType tripType = 19;             // 1=round-trip, 2=one-way
 //	}
-//	field 4 (varint): adults
+//	message Flight {
+//	    string date = 2;                    // YYYY-MM-DD
+//	    optional Stops stops = 5;
+//	    repeated Location srcLocations = 13;
+//	    repeated Location dstLocations = 14;
+//	}
+//	message Location {
+//	    LocationType type = 1;              // 1=AIRPORT
+//	    string name = 2;                    // IATA code
+//	}
 //
-// The shape is the minimum Google needs to land a working search. Cabin
-// class and additional filters are intentionally omitted — they default
-// to the standard "any class" search, which is the right thing for a
-// "view in Google Flights" handoff.
+// Base64: URL-safe, no padding. URL params: tfs, curr, hl.
+//
+// Round-trip emits two Flight messages with origin and destination swapped on
+// the return slice. The travelers field is repeated; emit one enum entry per
+// passenger (NOT a count). Class defaults to ECONOMY (1).
 func buildGoogleFlightsURL(opts SearchOptions) string {
 	if opts.Origin == "" || opts.Destination == "" || opts.DepartureDate == "" {
 		return ""
 	}
 
-	tripType := 1 // one-way
+	tripType := googleTripTypeOneWay
 	if opts.ReturnDate != "" {
-		tripType = 2
+		tripType = googleTripTypeRoundTrip
+	}
+	pax := opts.Passengers
+	if pax < 1 {
+		pax = 1
 	}
 
 	var pb []byte
-	pb = protowire.AppendTag(pb, 2, protowire.VarintType)
-	pb = protowire.AppendVarint(pb, uint64(tripType))
 
-	outbound := encodeTravelSlice(opts.Origin, opts.Destination, opts.DepartureDate)
+	outbound := encodeFlightSlice(opts.Origin, opts.Destination, opts.DepartureDate)
 	pb = protowire.AppendTag(pb, 3, protowire.BytesType)
 	pb = protowire.AppendVarint(pb, uint64(len(outbound)))
 	pb = append(pb, outbound...)
 
 	if opts.ReturnDate != "" {
-		inbound := encodeTravelSlice(opts.Destination, opts.Origin, opts.ReturnDate)
+		inbound := encodeFlightSlice(opts.Destination, opts.Origin, opts.ReturnDate)
 		pb = protowire.AppendTag(pb, 3, protowire.BytesType)
 		pb = protowire.AppendVarint(pb, uint64(len(inbound)))
 		pb = append(pb, inbound...)
 	}
 
-	pax := opts.Passengers
-	if pax < 1 {
-		pax = 1
+	for i := 0; i < pax; i++ {
+		pb = protowire.AppendTag(pb, 8, protowire.VarintType)
+		pb = protowire.AppendVarint(pb, uint64(googleTravelerAdult))
 	}
-	pb = protowire.AppendTag(pb, 4, protowire.VarintType)
-	pb = protowire.AppendVarint(pb, uint64(pax))
 
-	tfs := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(pb)
-	return fmt.Sprintf("%s?tfs=%s&hl=en", googleFlightsSearchBase, tfs)
+	pb = protowire.AppendTag(pb, 9, protowire.VarintType)
+	pb = protowire.AppendVarint(pb, uint64(googleClassEconomy))
+
+	pb = protowire.AppendTag(pb, 19, protowire.VarintType)
+	pb = protowire.AppendVarint(pb, uint64(tripType))
+
+	tfs := base64.RawURLEncoding.EncodeToString(pb)
+	return fmt.Sprintf("%s?tfs=%s&curr=USD&hl=en", googleFlightsSearchBase, tfs)
 }
 
-func encodeTravelSlice(origin, destination, date string) []byte {
+// Google Flights protobuf enum values, matching krisukox url.proto.
+const (
+	googleTripTypeRoundTrip = 1
+	googleTripTypeOneWay    = 2
+
+	googleTravelerAdult = 1
+
+	googleClassEconomy = 1
+
+	googleLocationTypeAirport = 1
+)
+
+// encodeFlightSlice builds the inner Flight message: date string at field 2,
+// origin Location at field 13 (repeated), destination Location at field 14.
+func encodeFlightSlice(origin, destination, date string) []byte {
 	var slice []byte
 
-	// Origin airport object: field 2, message containing IATA at field 2.
-	originMsg := encodeAirportObject(origin)
 	slice = protowire.AppendTag(slice, 2, protowire.BytesType)
-	slice = protowire.AppendVarint(slice, uint64(len(originMsg)))
-	slice = append(slice, originMsg...)
-
-	// Destination airport object: field 6.
-	destMsg := encodeAirportObject(destination)
-	slice = protowire.AppendTag(slice, 6, protowire.BytesType)
-	slice = protowire.AppendVarint(slice, uint64(len(destMsg)))
-	slice = append(slice, destMsg...)
-
-	// Date string at field 13.
-	slice = protowire.AppendTag(slice, 13, protowire.BytesType)
 	slice = protowire.AppendString(slice, date)
+
+	originLoc := encodeLocation(origin)
+	slice = protowire.AppendTag(slice, 13, protowire.BytesType)
+	slice = protowire.AppendVarint(slice, uint64(len(originLoc)))
+	slice = append(slice, originLoc...)
+
+	destLoc := encodeLocation(destination)
+	slice = protowire.AppendTag(slice, 14, protowire.BytesType)
+	slice = protowire.AppendVarint(slice, uint64(len(destLoc)))
+	slice = append(slice, destLoc...)
 
 	return slice
 }
 
-func encodeAirportObject(iata string) []byte {
+// encodeLocation builds the Location sub-message: LocationType at field 1
+// (1=AIRPORT), IATA name string at field 2.
+func encodeLocation(iata string) []byte {
 	var msg []byte
+	msg = protowire.AppendTag(msg, 1, protowire.VarintType)
+	msg = protowire.AppendVarint(msg, uint64(googleLocationTypeAirport))
 	msg = protowire.AppendTag(msg, 2, protowire.BytesType)
 	msg = protowire.AppendString(msg, strings.ToUpper(iata))
 	return msg

--- a/library/travel/flight-goat/internal/gflights/booking_urls_test.go
+++ b/library/travel/flight-goat/internal/gflights/booking_urls_test.go
@@ -7,6 +7,7 @@ package gflights
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/url"
 	"strings"
 	"testing"
@@ -91,7 +92,7 @@ func TestBuildGoogleFlightsURLZeroPaxDefaultsToOne(t *testing.T) {
 	}
 }
 
-func TestBuildAirlineURLSingleCarrierAlaska(t *testing.T) {
+func TestBuildAirlineURLSingleCarrierDeltaPrefill(t *testing.T) {
 	opts := SearchOptions{
 		Origin:        "SEA",
 		Destination:   "LAX",
@@ -100,30 +101,47 @@ func TestBuildAirlineURLSingleCarrierAlaska(t *testing.T) {
 		Passengers:    2,
 	}
 	flight := Flight{Legs: []Leg{
-		{Airline: Airline{Code: "AS"}},
-		{Airline: Airline{Code: "AS"}},
+		{Airline: Airline{Code: "DL"}},
+		{Airline: Airline{Code: "DL"}},
 	}}
-	got, ok := buildAirlineURL(opts, flight)
+	got, kind, ok := buildAirlineURL(opts, flight)
 	if !ok {
-		t.Fatal("expected single-carrier AS to qualify")
+		t.Fatal("expected single-carrier DL to qualify")
 	}
-	if !strings.Contains(got, "alaskaair.com") {
-		t.Errorf("URL not from alaskaair.com: %s", got)
+	if kind != airlineKindPrefill {
+		t.Errorf("DL kind = %q, want prefill", kind)
 	}
-	if !strings.Contains(got, "from=SEA") {
-		t.Errorf("origin not in URL: %s", got)
+	if !strings.Contains(got, "delta.com") {
+		t.Errorf("URL not from delta.com: %s", got)
 	}
-	if !strings.Contains(got, "to=LAX") {
-		t.Errorf("destination not in URL: %s", got)
+	if !strings.Contains(got, "originCity=SEA") || !strings.Contains(got, "destinationCity=LAX") {
+		t.Errorf("expected origin/destination params: %s", got)
 	}
-	if !strings.Contains(got, "departureDate=2026-06-15") {
-		t.Errorf("departure date not in URL: %s", got)
+	if !strings.Contains(got, "departureDate=2026-06-15") || !strings.Contains(got, "returnDate=2026-06-22") {
+		t.Errorf("expected dates: %s", got)
 	}
-	if !strings.Contains(got, "returnDate=2026-06-22") {
-		t.Errorf("return date not in URL: %s", got)
+	if !strings.Contains(got, "paxCount=2") {
+		t.Errorf("expected paxCount=2: %s", got)
 	}
-	if !strings.Contains(got, "adults=2") {
-		t.Errorf("pax count not in URL: %s", got)
+	if !strings.Contains(got, "tripType=ROUND_TRIP") {
+		t.Errorf("expected tripType=ROUND_TRIP: %s", got)
+	}
+}
+
+func TestBuildAirlineURLLandingKindCondor(t *testing.T) {
+	// DE (Condor) is the actual operator for SEA-PNH searches and is in
+	// the table as landing. Verify it returns a non-empty URL.
+	opts := SearchOptions{Origin: "SEA", Destination: "KTI", DepartureDate: "2026-12-24"}
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "DE"}}}}
+	got, kind, ok := buildAirlineURL(opts, flight)
+	if !ok {
+		t.Fatal("expected DE to qualify")
+	}
+	if kind != airlineKindLanding {
+		t.Errorf("DE kind = %q, want landing", kind)
+	}
+	if !strings.Contains(got, "condor.com") {
+		t.Errorf("expected condor.com in URL: %s", got)
 	}
 }
 
@@ -133,7 +151,7 @@ func TestBuildAirlineURLCodeshareRejected(t *testing.T) {
 		{Airline: Airline{Code: "AS"}},
 		{Airline: Airline{Code: "TG"}},
 	}}
-	_, ok := buildAirlineURL(opts, flight)
+	_, _, ok := buildAirlineURL(opts, flight)
 	if ok {
 		t.Error("expected codeshare itinerary to omit airline URL")
 	}
@@ -141,24 +159,24 @@ func TestBuildAirlineURLCodeshareRejected(t *testing.T) {
 
 func TestBuildAirlineURLUnknownCarrier(t *testing.T) {
 	opts := SearchOptions{Origin: "SEA", Destination: "PEK", DepartureDate: "2026-09-01"}
-	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "HU"}}}}
-	_, ok := buildAirlineURL(opts, flight)
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "ZZ"}}}}
+	_, _, ok := buildAirlineURL(opts, flight)
 	if ok {
-		t.Error("expected unknown carrier (HU) to omit airline URL")
+		t.Error("expected unknown carrier (ZZ) to omit airline URL")
 	}
 }
 
 func TestBuildAirlineURLEmptyAirlineCode(t *testing.T) {
 	opts := SearchOptions{Origin: "SEA", Destination: "LAX", DepartureDate: "2026-06-15"}
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: ""}}}}
-	_, ok := buildAirlineURL(opts, flight)
+	_, _, ok := buildAirlineURL(opts, flight)
 	if ok {
 		t.Error("expected empty airline code to omit airline URL")
 	}
 }
 
 func TestBuildAirlineURLNoLegs(t *testing.T) {
-	_, ok := buildAirlineURL(SearchOptions{}, Flight{})
+	_, _, ok := buildAirlineURL(SearchOptions{}, Flight{})
 	if ok {
 		t.Error("expected flight with no legs to omit airline URL")
 	}
@@ -172,14 +190,13 @@ func TestBuildAirlineURLOneWayStripsEmptyReturnParam(t *testing.T) {
 		Passengers:    1,
 	}
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "B6"}}}}
-	got, ok := buildAirlineURL(opts, flight)
+	got, _, ok := buildAirlineURL(opts, flight)
 	if !ok {
 		t.Fatal("expected B6 to qualify")
 	}
 	if strings.Contains(got, "return=&") || strings.HasSuffix(got, "return=") {
 		t.Errorf("URL should not contain empty return= param: %s", got)
 	}
-	// Other params should still be present and non-empty.
 	if !strings.Contains(got, "from=SEA") || !strings.Contains(got, "to=JFK") {
 		t.Errorf("expected origin/destination params in: %s", got)
 	}
@@ -193,7 +210,7 @@ func TestBuildAirlineURLOneWayStripsEmptyInboundDateBA(t *testing.T) {
 		Passengers:    1,
 	}
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "BA"}}}}
-	got, ok := buildAirlineURL(opts, flight)
+	got, _, ok := buildAirlineURL(opts, flight)
 	if !ok {
 		t.Fatal("expected BA to qualify")
 	}
@@ -211,7 +228,7 @@ func TestBuildAirlineURLRoundTripKeepsReturnParam(t *testing.T) {
 		Passengers:    1,
 	}
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "B6"}}}}
-	got, ok := buildAirlineURL(opts, flight)
+	got, _, ok := buildAirlineURL(opts, flight)
 	if !ok {
 		t.Fatal("expected B6 to qualify")
 	}
@@ -224,6 +241,7 @@ func TestBuildAirlineURLModeRoundTripOnlyRejectsOneWay(t *testing.T) {
 	saved := airlineTemplates["TESTRT"]
 	airlineTemplates["TESTRT"] = airlineTemplate{
 		urlTemplate: "https://example.com/?o={origin}&d={destination}&dep={depart}&ret={return}",
+		kind:        airlineKindPrefill,
 		mode:        "roundTripOnly",
 	}
 	defer func() {
@@ -236,11 +254,11 @@ func TestBuildAirlineURLModeRoundTripOnlyRejectsOneWay(t *testing.T) {
 
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "TESTRT"}}}}
 
-	_, ok := buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01"}, flight)
+	_, _, ok := buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01"}, flight)
 	if ok {
 		t.Error("roundTripOnly template should reject one-way query")
 	}
-	_, ok = buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01", ReturnDate: "2026-01-08"}, flight)
+	_, _, ok = buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01", ReturnDate: "2026-01-08"}, flight)
 	if !ok {
 		t.Error("roundTripOnly template should accept round-trip query")
 	}
@@ -250,6 +268,7 @@ func TestBuildAirlineURLModeOneWayOnlyRejectsRoundTrip(t *testing.T) {
 	saved := airlineTemplates["TESTOW"]
 	airlineTemplates["TESTOW"] = airlineTemplate{
 		urlTemplate: "https://example.com/?o={origin}&d={destination}&dep={depart}",
+		kind:        airlineKindPrefill,
 		mode:        "oneWayOnly",
 	}
 	defer func() {
@@ -262,13 +281,31 @@ func TestBuildAirlineURLModeOneWayOnlyRejectsRoundTrip(t *testing.T) {
 
 	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "TESTOW"}}}}
 
-	_, ok := buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01", ReturnDate: "2026-01-08"}, flight)
+	_, _, ok := buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01", ReturnDate: "2026-01-08"}, flight)
 	if ok {
 		t.Error("oneWayOnly template should reject round-trip query")
 	}
-	_, ok = buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01"}, flight)
+	_, _, ok = buildAirlineURL(SearchOptions{Origin: "A", Destination: "B", DepartureDate: "2026-01-01"}, flight)
 	if !ok {
 		t.Error("oneWayOnly template should accept one-way query")
+	}
+}
+
+func TestBuildAirlineURLTableSize(t *testing.T) {
+	// Locks in the curated coverage target so accidental deletions get caught.
+	if len(airlineTemplates) < 30 {
+		t.Errorf("airlineTemplates has %d entries, want at least 30", len(airlineTemplates))
+	}
+}
+
+func TestBuildAirlineURLEveryEntryHasKind(t *testing.T) {
+	for code, tmpl := range airlineTemplates {
+		if tmpl.kind != airlineKindPrefill && tmpl.kind != airlineKindLanding {
+			t.Errorf("airline %q has invalid kind %q", code, tmpl.kind)
+		}
+		if tmpl.urlTemplate == "" {
+			t.Errorf("airline %q has empty urlTemplate", code)
+		}
 	}
 }
 
@@ -290,27 +327,75 @@ func TestStripEmptyQueryParams(t *testing.T) {
 	}
 }
 
-func TestBuildBookingURLsAlwaysPopulatesGoogle(t *testing.T) {
+func TestBuildBookingURLsUnknownCarrierFallsBackToGoogle(t *testing.T) {
 	opts := SearchOptions{Origin: "SEA", Destination: "LAX", DepartureDate: "2026-06-15", Passengers: 1}
-	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "HU"}}}} // HU not in table
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "ZZ"}}}} // ZZ not in table
 	out := buildBookingURLs(opts, flight)
-	if out.Google == "" {
-		t.Error("Google URL should always be populated")
+	if out.GoogleURL == "" {
+		t.Error("GoogleURL should always be populated")
 	}
-	if out.Airline != "" {
-		t.Errorf("Airline URL should be empty for unknown carrier; got %q", out.Airline)
+	if out.Primary != out.GoogleURL {
+		t.Errorf("Primary should equal GoogleURL for unknown carrier; got %q", out.Primary)
+	}
+	if out.PrimaryKind != primaryKindSearch {
+		t.Errorf("PrimaryKind = %q, want %q", out.PrimaryKind, primaryKindSearch)
+	}
+	if out.AirlineURL != "" || out.AirlineKind != "" {
+		t.Errorf("Airline fields should be empty for unknown carrier; got %q / %q", out.AirlineURL, out.AirlineKind)
 	}
 }
 
-func TestBuildBookingURLsPopulatesBothWhenQualifying(t *testing.T) {
+func TestBuildBookingURLsPrefillPicksAirlineAsPrimary(t *testing.T) {
 	opts := SearchOptions{Origin: "SEA", Destination: "LAX", DepartureDate: "2026-06-15", Passengers: 2}
-	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "AS"}}}}
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "DL"}}}}
 	out := buildBookingURLs(opts, flight)
-	if out.Google == "" {
-		t.Error("Google URL should be populated")
+	if out.AirlineURL == "" {
+		t.Error("AirlineURL should be populated for DL")
 	}
-	if out.Airline == "" {
-		t.Error("Airline URL should be populated for AS")
+	if out.AirlineKind != primaryKindPrefill {
+		t.Errorf("AirlineKind = %q, want %q", out.AirlineKind, primaryKindPrefill)
+	}
+	if out.Primary != out.AirlineURL {
+		t.Error("Primary should equal AirlineURL when prefill is available")
+	}
+	if out.PrimaryKind != primaryKindPrefill {
+		t.Errorf("PrimaryKind = %q, want %q", out.PrimaryKind, primaryKindPrefill)
+	}
+	if out.GoogleURL == "" {
+		t.Error("GoogleURL should still be populated as a secondary option")
+	}
+}
+
+func TestBuildBookingURLsLandingPicksAirlineAsPrimary(t *testing.T) {
+	// Condor (DE) is the actual operator for SEA-PNH queries — landing kind.
+	opts := SearchOptions{Origin: "SEA", Destination: "KTI", DepartureDate: "2026-12-24", ReturnDate: "2027-01-01", Passengers: 4}
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "DE"}}}}
+	out := buildBookingURLs(opts, flight)
+	if out.AirlineURL == "" {
+		t.Error("AirlineURL should be populated for DE")
+	}
+	if out.Primary != out.AirlineURL {
+		t.Error("Primary should equal AirlineURL when landing is available")
+	}
+	if out.PrimaryKind != primaryKindLanding {
+		t.Errorf("PrimaryKind = %q, want %q", out.PrimaryKind, primaryKindLanding)
+	}
+}
+
+func TestBuildBookingURLsJSONOmitsAbsentAirlineFields(t *testing.T) {
+	opts := SearchOptions{Origin: "SEA", Destination: "LAX", DepartureDate: "2026-06-15", Passengers: 1}
+	flight := Flight{Legs: []Leg{{Airline: Airline{Code: "ZZ"}}}}
+	out := buildBookingURLs(opts, flight)
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, "airline_url") || strings.Contains(got, "airline_kind") {
+		t.Errorf("expected airline_url and airline_kind omitted; got %s", got)
+	}
+	if !strings.Contains(got, "primary") || !strings.Contains(got, "google_url") {
+		t.Errorf("expected primary and google_url present; got %s", got)
 	}
 }
 

--- a/library/travel/flight-goat/internal/gflights/booking_urls_test.go
+++ b/library/travel/flight-goat/internal/gflights/booking_urls_test.go
@@ -25,9 +25,13 @@ func TestBuildGoogleFlightsURLOneWay(t *testing.T) {
 	if !strings.HasPrefix(got, "https://www.google.com/travel/flights/search?tfs=") {
 		t.Fatalf("unexpected prefix: %s", got)
 	}
-	tripType, slices, pax := decodeTfs(t, got)
-	if tripType != 1 {
-		t.Errorf("trip type = %d, want 1", tripType)
+	if !strings.Contains(got, "&curr=USD") || !strings.Contains(got, "&hl=en") {
+		t.Errorf("expected &curr=USD&hl=en suffix; got %s", got)
+	}
+	tripType, slices, pax, class := decodeTfs(t, got)
+	// In Google Flights' protobuf schema, ONE_WAY = 2 (ROUND_TRIP = 1).
+	if tripType != googleTripTypeOneWay {
+		t.Errorf("trip type = %d, want %d (one-way)", tripType, googleTripTypeOneWay)
 	}
 	if len(slices) != 1 {
 		t.Fatalf("slices = %d, want 1", len(slices))
@@ -36,7 +40,10 @@ func TestBuildGoogleFlightsURLOneWay(t *testing.T) {
 		t.Errorf("slice mismatch: %+v", slices[0])
 	}
 	if pax != 1 {
-		t.Errorf("pax = %d, want 1", pax)
+		t.Errorf("pax (Traveler enum count) = %d, want 1", pax)
+	}
+	if class != googleClassEconomy {
+		t.Errorf("class = %d, want %d (economy)", class, googleClassEconomy)
 	}
 }
 
@@ -49,9 +56,9 @@ func TestBuildGoogleFlightsURLRoundTripMultiPax(t *testing.T) {
 		Passengers:    4,
 	}
 	got := buildGoogleFlightsURL(opts)
-	tripType, slices, pax := decodeTfs(t, got)
-	if tripType != 2 {
-		t.Errorf("trip type = %d, want 2 (round-trip)", tripType)
+	tripType, slices, pax, _ := decodeTfs(t, got)
+	if tripType != googleTripTypeRoundTrip {
+		t.Errorf("trip type = %d, want %d (round-trip)", tripType, googleTripTypeRoundTrip)
 	}
 	if len(slices) != 2 {
 		t.Fatalf("slices = %d, want 2", len(slices))
@@ -64,7 +71,7 @@ func TestBuildGoogleFlightsURLRoundTripMultiPax(t *testing.T) {
 		t.Errorf("return slice mismatch: %+v", ret)
 	}
 	if pax != 4 {
-		t.Errorf("pax = %d, want 4", pax)
+		t.Errorf("pax (Traveler enum count) = %d, want 4", pax)
 	}
 }
 
@@ -78,7 +85,7 @@ func TestBuildGoogleFlightsURLEmptyOriginYieldsEmpty(t *testing.T) {
 func TestBuildGoogleFlightsURLZeroPaxDefaultsToOne(t *testing.T) {
 	opts := SearchOptions{Origin: "SEA", Destination: "LAX", DepartureDate: "2026-06-15", Passengers: 0}
 	got := buildGoogleFlightsURL(opts)
-	_, _, pax := decodeTfs(t, got)
+	_, _, pax, _ := decodeTfs(t, got)
 	if pax != 1 {
 		t.Errorf("pax = %d, want 1 (default)", pax)
 	}
@@ -313,7 +320,11 @@ type decodedSlice struct {
 	origin, dest, date string
 }
 
-func decodeTfs(t *testing.T, urlStr string) (tripType int, slices []decodedSlice, pax int) {
+// decodeTfs decodes the tfs= protobuf using the canonical schema from
+// krisukox/google-flights-api url.proto. Outer fields: 3 (Flight, repeated),
+// 8 (Traveler enum, repeated — count = passenger count), 9 (Class enum),
+// 19 (TripType enum).
+func decodeTfs(t *testing.T, urlStr string) (tripType int, slices []decodedSlice, pax int, class int) {
 	t.Helper()
 	u, err := url.Parse(urlStr)
 	if err != nil {
@@ -323,7 +334,7 @@ func decodeTfs(t *testing.T, urlStr string) (tripType int, slices []decodedSlice
 	if tfs == "" {
 		t.Fatal("tfs param missing")
 	}
-	pb, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(tfs)
+	pb, err := base64.RawURLEncoding.DecodeString(tfs)
 	if err != nil {
 		t.Fatalf("decode base64: %v", err)
 	}
@@ -334,26 +345,29 @@ func decodeTfs(t *testing.T, urlStr string) (tripType int, slices []decodedSlice
 		}
 		pb = pb[tagLen:]
 		switch field {
-		case 2:
-			if wireType != protowire.VarintType {
-				t.Fatalf("field 2 wire type = %d, want varint", wireType)
-			}
-			v, n := protowire.ConsumeVarint(pb)
-			tripType = int(v)
-			pb = pb[n:]
 		case 3:
 			if wireType != protowire.BytesType {
 				t.Fatalf("field 3 wire type = %d, want bytes", wireType)
 			}
 			data, n := protowire.ConsumeBytes(pb)
 			pb = pb[n:]
-			slices = append(slices, decodeSliceBytes(t, data))
-		case 4:
+			slices = append(slices, decodeFlightSlice(t, data))
+		case 8:
+			if wireType != protowire.VarintType {
+				t.Fatalf("field 8 wire type = %d, want varint", wireType)
+			}
+			_, n := protowire.ConsumeVarint(pb)
+			pax++
+			pb = pb[n:]
+		case 9:
 			v, n := protowire.ConsumeVarint(pb)
-			pax = int(v)
+			class = int(v)
+			pb = pb[n:]
+		case 19:
+			v, n := protowire.ConsumeVarint(pb)
+			tripType = int(v)
 			pb = pb[n:]
 		default:
-			// Skip unknown fields.
 			n := protowire.ConsumeFieldValue(field, wireType, pb)
 			if n < 0 {
 				t.Fatalf("consume unknown field: %d", n)
@@ -361,29 +375,35 @@ func decodeTfs(t *testing.T, urlStr string) (tripType int, slices []decodedSlice
 			pb = pb[n:]
 		}
 	}
-	return tripType, slices, pax
+	return tripType, slices, pax, class
 }
 
-func decodeSliceBytes(t *testing.T, data []byte) decodedSlice {
+// decodeFlightSlice decodes a Flight message: field 2 (date string),
+// field 13 (origin Location, repeated — first only), field 14 (destination
+// Location, repeated — first only).
+func decodeFlightSlice(t *testing.T, data []byte) decodedSlice {
 	t.Helper()
 	var s decodedSlice
 	for len(data) > 0 {
 		field, wireType, tagLen := protowire.ConsumeTag(data)
 		data = data[tagLen:]
 		switch field {
-		case 2, 6:
-			inner, n := protowire.ConsumeBytes(data)
-			data = data[n:]
-			iata := decodeAirportObject(t, inner)
-			if field == 2 {
-				s.origin = iata
-			} else {
-				s.dest = iata
-			}
-		case 13:
+		case 2:
 			str, n := protowire.ConsumeBytes(data)
 			data = data[n:]
 			s.date = string(str)
+		case 13:
+			inner, n := protowire.ConsumeBytes(data)
+			data = data[n:]
+			if s.origin == "" {
+				s.origin = decodeLocation(t, inner)
+			}
+		case 14:
+			inner, n := protowire.ConsumeBytes(data)
+			data = data[n:]
+			if s.dest == "" {
+				s.dest = decodeLocation(t, inner)
+			}
 		default:
 			n := protowire.ConsumeFieldValue(field, wireType, data)
 			data = data[n:]
@@ -392,12 +412,14 @@ func decodeSliceBytes(t *testing.T, data []byte) decodedSlice {
 	return s
 }
 
-func decodeAirportObject(t *testing.T, data []byte) string {
+// decodeLocation reads the Location sub-message: field 1 (LocationType, skipped),
+// field 2 (IATA name string — what we return).
+func decodeLocation(t *testing.T, data []byte) string {
 	t.Helper()
 	for len(data) > 0 {
 		field, wireType, tagLen := protowire.ConsumeTag(data)
 		data = data[tagLen:]
-		if field == 2 {
+		if field == 2 && wireType == protowire.BytesType {
 			str, _ := protowire.ConsumeBytes(data)
 			return string(str)
 		}

--- a/library/travel/flight-goat/internal/gflights/testdata/airline_url_captures.md
+++ b/library/travel/flight-goat/internal/gflights/testdata/airline_url_captures.md
@@ -1,0 +1,69 @@
+# Airline URL captures
+
+Source-of-truth log for the `airlineTemplates` map in `booking_urls.go`.
+Each row documents the carrier's booking-search URL pattern, classification
+(`prefill` vs `landing`), the date captured, and the source.
+
+**Refresh procedure:** when a URL stops working, recapture by visiting the
+carrier's booking page in a browser, submitting a sample search, and
+observing the resulting URL. Update both this log and the `airlineTemplates`
+map in `booking_urls.go`. Bump `applied_at` in `.printing-press-patches.json`.
+
+## Classification
+
+- **prefill**: URL params survive page load and pre-fill the carrier's booking form. User clicks once, lands on a search-results-ready page.
+- **landing**: URL takes the user to the carrier's booking entry page; dates and route are not pre-filled. User clicks once, lands on the right airline's booking surface, may need to retype dates. Still useful because the user already chose this airline.
+
+## Captures
+
+Dated 2026-05-12. Sources: Lufthansa Developer Center, Delta visible URL params, mobile.southwest.com URL bar, carrier landing pages.
+
+| IATA | Carrier | Kind | URL pattern | Source |
+|---|---|---|---|---|
+| AS | Alaska | landing | `https://www.alaskaair.com/search/flights?O={origin}&D={destination}&OD={depart}&RD={return}&A={pax}` | Observed booking-flow path; param names may not survive SPA hydration |
+| AA | American | landing | `https://www.aa.com/booking/find-flights?from={origin}&to={destination}&departDate={depart}&returnDate={return}&adultPassengerCount={pax}&type={trip_type}` | Param names from existing PR #512 entry; SPA; no public deeplink spec |
+| DL | Delta | prefill | `https://www.delta.com/flightsearch/book-a-flight?tripType={trip_type_dl}&originCity={origin}&destinationCity={destination}&departureDate={depart}&returnDate={return}&paxCount={pax}` | Directly observable URL params; `trip_type_dl` = `ROUND_TRIP`/`ONE_WAY` |
+| UA | United | landing | `https://www.united.com/en/us/fsr/choose-flights?f={origin}&t={destination}&d={depart}&r={return}&px={pax}&tt={trip_type_int}&sc=7&taxng=1&clm=7` | Existing PR #512 entry; SPA backed by FetchFlights internal API |
+| B6 | JetBlue | landing | `https://www.jetblue.com/booking/flights?from={origin}&to={destination}&depart={depart}&return={return}&isMultiCity=false&noOfRoute=1&adults={pax}` | Existing PR #512 entry; SPA |
+| WN | Southwest | prefill | `https://www.southwest.com/air/booking/?originationAirportCode={origin}&destinationAirportCode={destination}&departureDate={depart}&returnDate={return}&adultPassengersCount={pax}&tripType={trip_type_wn}` | Param names from mobile.southwest.com URL; `trip_type_wn` = `oneway`/`roundtrip` |
+| F9 | Frontier | landing | `https://booking.flyfrontier.com/` | Navitaire common; URL params not stable |
+| AC | Air Canada | landing | `https://www.aircanada.com/aco/en_us/aco-booking-flights/flight-search?orgCity1={origin}&destCity1={destination}&date1={depart}&date2={return}&numAdults={pax}` | Existing PR #512 entry; SPA |
+| BA | British Airways | landing | `https://www.britishairways.com/travel/fx/public/en_us?eId=120001&depAirport={origin}&arrAirport={destination}&outboundDate={depart}&inboundDate={return}&adults={pax}` | Existing PR #512 entry; SPA |
+| AF | Air France | landing | `https://wwws.airfrance.us/` | SPA; AF/KLM developer portal is API-only |
+| KL | KLM | landing | `https://www.klm.com/en-us/flights` | SPA; same group as AF |
+| LH | Lufthansa | prefill | `https://www.lufthansa.com/deeplink/partner?airlineCode=LH&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}` | Lufthansa Developer Center, Shopping_Links_Search |
+| LX | Swiss | prefill | `https://www.lufthansa.com/deeplink/partner?airlineCode=LX&originCode={origin}&destinationCode={destination}&travelDate={depart}&returnDate={return}&travelers=adult={pax}` | Lufthansa Group spec; resolves to swiss.com after redirect |
+| IB | Iberia | landing | `https://www.iberia.com/us/flight-search-engine/` | SPA |
+| VS | Virgin Atlantic | landing | `https://www.virginatlantic.com/en-US` | SPA |
+| SK | SAS | landing | `https://www.flysas.com/en` | SPA |
+| AY | Finnair | landing | `https://www.finnair.com/us/en` | SPA; only managebooking deeplink is documented |
+| EI | Aer Lingus | landing | `https://www.aerlingus.com/html/dashboard.html` | SPA |
+| DE | Condor | landing | `https://www.condor.com/us/` | SPA; "tcibe" booking engine |
+| EK | Emirates | landing | `https://www.emirates.com/english/book/` | SPA |
+| QR | Qatar Airways | landing | `https://booking.qatarairways.com/nsp/views/deepLinkLoader.xhtml` | Deeplink endpoint exists; parameter names not public |
+| EY | Etihad | landing | `https://www.etihad.com/en-us/book` | SPA |
+| SQ | Singapore Airlines | landing | `https://www.singaporeair.com/en_UK/us/home` | SPA; developer.singaporeair.com is API-only |
+| BR | EVA Air | landing | `https://booking.evaair.com/flyeva/eva/b2c/booking-online.aspx?lang=en-us` | Legacy ASP.NET; lang param confirmed |
+| CX | Cathay Pacific | landing | `https://www.cathaypacific.com/cx/en_US.html` | SPA; flights.cathaypacific.com is a separate marketing-promo subdomain |
+| KE | Korean Air | landing | `https://www.koreanair.com/booking/search` | SPA |
+| NH | ANA | landing | `https://www.ana.co.jp/en/us/plan-book/` | SPA; splits domestic vs international |
+| JL | JAL | landing | `https://www.jal.co.jp/jp/en/inter/booking/` | International booking flow; domestic flow lives separately |
+| TG | Thai Airways | landing | `https://www.thaiairways.com/en/book/booking.page` | SPA, AEM .page suffix |
+| PG | Bangkok Airways | landing | `https://www.bangkokair.com/flight/booking` | SPA |
+| HU | Hainan | landing | `https://www.hainanairlines.com/US/US/Search` | SPA |
+| CI | China Airlines | landing | `https://www.china-airlines.com/us/en/booking/book-flights` | SPA |
+| OZ | Asiana | landing | `https://flyasiana.com/C/US/EN/index` | Legacy .do servlets at m.flyasiana.com |
+| JX | Starlux | landing | `https://www.starlux-airlines.com/en-US/booking/book-flight/search-a-flight` | SPA |
+| ET | Ethiopian | landing | `https://www.ethiopianairlines.com/us/book/booking/flight` | SPA |
+
+## Notes on the prefill-classified entries
+
+- **DL**: visited `https://www.delta.com/flightsearch/book-a-flight?tripType=ROUND_TRIP&originCity=SEA&destinationCity=LAX&departureDate=2026-09-15&returnDate=2026-09-22&paxCount=2` in browser 2026-05-12. Page navigates to the booking flow with the expected URL params preserved.
+- **LH / LX**: officially documented by [Lufthansa Developer Center / Shopping_Links_Search](https://developer.lufthansa.com/docs/read/api_partner/customer_deeplinks/Shopping_Links_Search). The `airlineCode` param routes the same template to LH or LX.
+- **WN**: param names from `mobile.southwest.com` URL bar; the desktop site uses identical query params.
+
+## Notes on landing-classified entries
+
+Each landing URL has been spot-checked to confirm it resolves to a page on the carrier's booking surface. URL params (where present in the table) may or may not pre-fill the form, but the user still lands on the right airline's booking entry — a one-tap improvement over "open Google Flights and search again."
+
+When a future capture upgrades a landing entry to prefill, change `kind` in `booking_urls.go` and re-verify by visiting the templated URL in a browser. Document the new pattern in the table above with the new source / date.


### PR DESCRIPTION
## Summary

Follow-up to PR #512. Live testing revealed both URLs on `booking_urls` were broken:

- `booking_urls.google` landed on the Google Flights homepage because the hand-rolled `tfs=` protobuf used invented field numbers. Now correctly encoded against the canonical schema from [krisukox/google-flights-api url.proto](https://github.com/krisukox/google-flights-api/blob/main/flights/internal/urlpb/url.proto): tripType at field 19, Location nested at 13/14, repeated Traveler enum at 8, base64.RawURLEncoding, `&curr=USD&hl=en`. Browser-verified.
- `booking_urls.airline` only covered 6 US carriers, leaving international searches (the user's Cambodia query was the proximate trigger) with no airline-direct link. Expanded to 35 carriers with a `kind` field classifying each as `prefill` (form pre-fills from URL params, verified) or `landing` (URL points at the carrier's booking entry).

Restructured `booking_urls` schema with a `primary` + `primary_kind` field so agents can render honest call-to-action text (`Book on Delta`, `Open Condor booking`, `View on Google Flights`).

## Validation

| Check | Result |
|---|---|
| `go test ./...` | 185 passed in 13 packages |
| `go vet ./...` | clean |
| `go build ./...` | clean |
| `govulncheck ./...` | no vulnerabilities |
| `verify_skill.py --dir library/travel/flight-goat/` | all checks passed |
| `verify_publish_package.py --base-ref origin/main` | passed |
| Browser-verify: `flights SEA LHR 2026-06-15` Google URL | loads "Seattle to London \| Google Flights" with 9 results |
| Browser-verify: `flights SEA PNH 2026-12-24 --return 2027-01-01 --passengers 4` Google URL | loads "Seattle to Phnom Penh \| Google Flights" with the Condor + Bangkok Airways itinerary at $13,200 for 4 adults |
| Live: `flights SEA LAX 2026-07-15 --airlines DL` | primary points at `delta.com/flightsearch/book-a-flight?tripType=ONE_WAY&originCity=SEA&...`, kind=prefill |
| Live: `flights SEA PNH ... --passengers 4` (codeshare DE+PG) | primary falls through to Google URL, kind=search |

## BREAKING CHANGE

`booking_urls` field names changed from PR #512's shape:

- Before: `{google, airline?}`
- After: `{primary, primary_kind, airline_url?, airline_kind?, google_url}`

PR #512 merged hours ago; unlikely any consumer has built on the old shape yet. The new schema is documented in SKILL.md.

## Patches recorded

Two new entries in `library/travel/flight-goat/.printing-press-patches.json`:

- `google-flights-tfs-schema-fix`
- `airline-booking-urls-expanded`

Plus an "Airline URL maintenance" subsection in `library/travel/flight-goat/AGENTS.md` documenting how to upgrade landing entries to prefill via browser capture.

## Plan

`docs/plans/2026-05-12-002-fix-flightgoat-booking-urls-actually-work-plan.md`