### PR TITLE
chore(greptile): require status check reviews

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,4 +1,6 @@
 {
+  "statusCheck": true,
+  "triggerOnUpdates": true,
   "customContext": {
     "files": [
       {


### PR DESCRIPTION
Greptile reviews can now participate in GitHub branch protection as a required status check. The config also re-runs Greptile when PR branches receive new commits, so the required check reflects the latest reviewed diff.

Validated with `python3 -m json.tool greptile.json` and `git diff --check`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
