### PR TITLE
chore(greptile): trigger status check

### DIFF
--- a/.github/greptile-status-check-trigger.md
+++ b/.github/greptile-status-check-trigger.md
@@ -1,0 +1,3 @@
+Temporary PR used to surface the Greptile status check name for branch protection.
+
+Do not merge.


### PR DESCRIPTION
Temporary PR to make Greptile publish its GitHub status check so the repo admin can select the exact check name and app source in branch protection.

Do not merge. Close after the Greptile check appears.
