### PR TITLE
ci: gate merges on Greptile score

### DIFF
--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -1,0 +1,143 @@
+name: Greptile policy gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to evaluate
+        required: true
+
+permissions:
+  checks: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Greptile policy gate
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MIN_GREPTILE_SCORE: "4"
+    steps:
+      - name: Resolve pull request
+        id: pr
+        env:
+          DISPATCH_PR: ${{ inputs.pr }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            echo "number=${EVENT_PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+            echo "head_sha=${EVENT_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR}")"
+          echo "number=$(jq -r '.number' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=$(jq -r '.head.sha' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
+
+      - name: Require Greptile score
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          echo "Evaluating PR #${PR_NUMBER} at ${HEAD_SHA}"
+
+          deadline=$((SECONDS + 600))
+          greptile_check=""
+          while [ "${SECONDS}" -lt "${deadline}" ]; do
+            checks_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs")"
+            greptile_check="$(jq -c '[.check_runs[] | select(.app.slug == "greptile-apps" and .name == "Greptile Review")] | .[0] // empty' <<<"${checks_json}")"
+
+            if [ -z "${greptile_check}" ]; then
+              echo "Greptile Review check not found yet; waiting..."
+              sleep 15
+              continue
+            fi
+
+            status="$(jq -r '.status' <<<"${greptile_check}")"
+            conclusion="$(jq -r '.conclusion // ""' <<<"${greptile_check}")"
+            echo "Greptile Review status=${status} conclusion=${conclusion:-pending}"
+
+            if [ "${status}" = "completed" ]; then
+              if [ "${conclusion}" != "success" ]; then
+                echo "::error::Greptile Review did not complete successfully for ${HEAD_SHA}."
+                exit 1
+              fi
+              break
+            fi
+
+            sleep 15
+          done
+
+          if [ -z "${greptile_check}" ] || [ "$(jq -r '.status // ""' <<<"${greptile_check}")" != "completed" ]; then
+            echo "::error::Timed out waiting for Greptile Review to complete for ${HEAD_SHA}."
+            exit 1
+          fi
+
+          comments_file="${RUNNER_TEMP}/comments-pages.json"
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" > "${comments_file}"
+
+          python3 - "${comments_file}" "${HEAD_SHA}" "${MIN_GREPTILE_SCORE}" <<'PY'
+          import json
+          import re
+          import sys
+
+          comments_path, head_sha, min_score_raw = sys.argv[1:]
+          min_score = int(min_score_raw)
+
+          pages = json.load(open(comments_path, encoding="utf-8"))
+          comments = [comment for page in pages for comment in page]
+          greptile_comments = [
+              comment
+              for comment in comments
+              if (comment.get("user") or {}).get("login") == "greptile-apps[bot]"
+              and "Confidence Score:" in (comment.get("body") or "")
+          ]
+
+          if not greptile_comments:
+              print("::error::No Greptile confidence-score comment found.")
+              sys.exit(1)
+
+          current_head_comments = [
+              comment for comment in greptile_comments if head_sha in (comment.get("body") or "")
+          ]
+          if not current_head_comments:
+              latest = greptile_comments[-1]
+              print("::error::Latest Greptile confidence-score comment does not reference the current head SHA.")
+              print(f"Current head: {head_sha}")
+              print(f"Latest Greptile comment: {latest.get('html_url')}")
+              sys.exit(1)
+
+          latest = current_head_comments[-1]
+          body = latest.get("body") or ""
+          match = re.search(r"Confidence Score:\s*(\d)\s*/\s*5", body)
+          if not match:
+              print(f"::error::Could not parse Greptile confidence score from {latest.get('html_url')}.")
+              sys.exit(1)
+
+          score = int(match.group(1))
+          print(f"Greptile confidence score: {score}/5")
+          print(f"Greptile comment: {latest.get('html_url')}")
+
+          if score < min_score:
+              print(f"::error::Greptile confidence score {score}/5 is below required threshold {min_score}/5.")
+              sys.exit(1)
+
+          print(f"Greptile confidence score meets threshold: {score}/5 >= {min_score}/5.")
+          PY

--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -25,6 +25,9 @@ jobs:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    concurrency:
+      group: greptile-policy-gate-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
+      cancel-in-progress: true
     env:
       GH_TOKEN: ${{ github.token }}
       MIN_GREPTILE_SCORE: "4"
@@ -43,6 +46,11 @@ jobs:
             echo "number=${EVENT_PR_NUMBER}" >> "${GITHUB_OUTPUT}"
             echo "head_sha=${EVENT_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
             exit 0
+          fi
+
+          if ! [[ "${DISPATCH_PR}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Input 'pr' must be a positive integer; got: ${DISPATCH_PR}"
+            exit 1
           fi
 
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR}")"
@@ -75,8 +83,8 @@ jobs:
             echo "Greptile Review status=${status} conclusion=${conclusion:-pending}"
 
             if [ "${status}" = "completed" ]; then
-              if [ "${conclusion}" != "success" ]; then
-                echo "::error::Greptile Review did not complete successfully for ${HEAD_SHA}."
+              if [ "${conclusion}" != "success" ] && [ "${conclusion}" != "neutral" ]; then
+                echo "::error::Greptile Review completed with unsupported conclusion '${conclusion}' for ${HEAD_SHA}."
                 exit 1
               fi
               break

--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -69,7 +69,7 @@ jobs:
           deadline=$((SECONDS + 600))
           greptile_check=""
           while [ "${SECONDS}" -lt "${deadline}" ]; do
-            checks_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs")"
+            checks_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?per_page=100&check_name=Greptile+Review")"
             greptile_check="$(jq -c '[.check_runs[] | select(.app.slug == "greptile-apps" and .name == "Greptile Review")] | .[0] // empty' <<<"${checks_json}")"
 
             if [ -z "${greptile_check}" ]; then


### PR DESCRIPTION
PRs with Greptile feedback below `4/5` now get a clear failing check instead of looking merge-ready because the native Greptile status check only means the review completed.

The new `pull_request_target` workflow waits for `Greptile Review`, reads the latest Greptile summary for the current head SHA, and fails when the confidence score is below `4/5`. It does not checkout or execute PR code, so it is safe for fork PRs.

Validated with `actionlint .github/workflows/greptile-policy-gate.yml`, YAML parsing, `git diff --check`, and a local parser smoke test against mvanhorn/printing-press-library#533 showing `3/5` would fail the new gate.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
