### PR TITLE
fix(instacart): omit ShopCollectionScoped coordinates when unset (fixes #501)

### DIFF
--- a/library/commerce/instacart/.printing-press-patches.json
+++ b/library/commerce/instacart/.printing-press-patches.json
@@ -1,7 +1,20 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-08",
+  "applied_at": "2026-05-13",
   "base_run_id": "2026-04-11T06:12:25Z",
   "base_printing_press_version": "1.2.1",
-  "patches": []
+  "patches": [
+    {
+      "id": "fix-shop-collection-coordinates",
+      "summary": "Omit `coordinates` from ShopCollectionScoped variables when the user has not configured latitude/longitude, instead of sending the invalid {0,0} pair.",
+      "reason": "Reported in #501. Every `search`, `add`, and `cart show` failed at the bootstrap step with `ShopCollectionScoped returned no shops` because the CLI always built `coordinates: {latitude: cfg.Latitude, longitude: cfg.Longitude}` even when both were zero. The Coordinates struct has no omitempty on its float64 fields, so the pointer-with-omitempty on the parent struct never fires when the caller unconditionally allocates the pointer. Instacart's UsersCoordinatesInput rejects {0,0} (it's a point in the Atlantic Ocean, no retailer scope possible), surfacing as a server-side error that the CLI translates to 'no shops'. The local op declares coordinates as optional (no `!`), so omitting it when unset is the correct shape. A new `NewShopCollectionScopedVars` constructor builds the variable bundle with conditional coordinates; both call sites now route through it.",
+      "files": [
+        "internal/instacart/types.go",
+        "internal/instacart/types_test.go",
+        "internal/gql/search.go",
+        "internal/cli/retailers.go"
+      ],
+      "validated_outcome": "Unit tests pin the JSON shape: no `coordinates` key when lat/lng are both zero; coordinates included when at least one is non-zero; addressId omitted when empty."
+    }
+  ]
 }

--- a/library/commerce/instacart/.printing-press-patches.json
+++ b/library/commerce/instacart/.printing-press-patches.json
@@ -7,7 +7,7 @@
     {
       "id": "fix-shop-collection-coordinates",
       "summary": "Omit `coordinates` from ShopCollectionScoped variables when the user has not configured latitude/longitude, instead of sending the invalid {0,0} pair.",
-      "reason": "Reported in #501. Every `search`, `add`, and `cart show` failed at the bootstrap step with `ShopCollectionScoped returned no shops` because the CLI always built `coordinates: {latitude: cfg.Latitude, longitude: cfg.Longitude}` even when both were zero. The Coordinates struct has no omitempty on its float64 fields, so the pointer-with-omitempty on the parent struct never fires when the caller unconditionally allocates the pointer. Instacart's UsersCoordinatesInput rejects {0,0} (it's a point in the Atlantic Ocean, no retailer scope possible), surfacing as a server-side error that the CLI translates to 'no shops'. The local op declares coordinates as optional (no `!`), so omitting it when unset is the correct shape. A new `NewShopCollectionScopedVars` constructor builds the variable bundle with conditional coordinates; both call sites now route through it.",
+      "reason": "Reported in #501. Both call sites unconditionally allocated a Coordinates pointer with zero-valued fields, so the parent struct's pointer-with-omitempty never fired and Instacart's UsersCoordinatesInput rejected the invalid {0,0} pair with 'no shops'.",
       "files": [
         "internal/instacart/types.go",
         "internal/instacart/types_test.go",

--- a/library/commerce/instacart/internal/cli/retailers.go
+++ b/library/commerce/instacart/internal/cli/retailers.go
@@ -14,9 +14,9 @@ import (
 
 func newRetailersCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "retailers",
+		Use:         "retailers",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "List and inspect retailers available at your address",
+		Short:       "List and inspect retailers available at your address",
 	}
 	cmd.AddCommand(newRetailersListCmd(), newRetailersShowCmd())
 	return cmd
@@ -24,9 +24,9 @@ func newRetailersCmd() *cobra.Command {
 
 func newRetailersListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
+		Use:         "list",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "List retailers that deliver to your saved address",
+		Short:       "List retailers that deliver to your saved address",
 		Long: `Shows retailers cached locally. If the cache is empty or stale, hits
 Instacart's ShopCollectionUnscoped query to refresh. Use --refresh to force.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,10 +61,10 @@ Instacart's ShopCollectionUnscoped query to refresh. Use --refresh to force.`,
 
 func newRetailersShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <slug>",
+		Use:         "show <slug>",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		Short: "Look up a retailer by slug and cache it locally",
-		Args:  cobra.ExactArgs(1),
+		Short:       "Look up a retailer by slug and cache it locally",
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slug := strings.ToLower(strings.TrimSpace(args[0]))
 			app, err := newAppContext(cmd)
@@ -100,13 +100,11 @@ func resolveRetailer(app *AppContext, slug string) (*store.Retailer, error) {
 		return nil, coded(ExitNotFound, "retailer %q not cached and no postal code configured (set `postal_code` in ~/.config/instacart/config.json)", slug)
 	}
 	client := gql.NewClient(app.Session, app.Cfg, app.Store)
-	vars := instacart.ShopCollectionScopedVars{
-		RetailerSlug:           slug,
-		PostalCode:             app.Cfg.PostalCode,
-		Coordinates:            &instacart.Coordinates{Latitude: app.Cfg.Latitude, Longitude: app.Cfg.Longitude},
-		AddressID:              app.Cfg.AddressID,
-		AllowCanonicalFallback: false,
-	}
+	// PATCH (fix-shop-collection-coordinates):
+	// Use the typed constructor so coordinates is omitted when neither
+	// latitude nor longitude is set, instead of sending the invalid {0,0}
+	// pair. See mvanhorn/printing-press-library#501.
+	vars := instacart.NewShopCollectionScopedVars(slug, app.Cfg.PostalCode, app.Cfg.AddressID, app.Cfg.Latitude, app.Cfg.Longitude)
 	resp, err := client.Query(app.Ctx, "ShopCollectionScoped", vars)
 	if err != nil {
 		return nil, err

--- a/library/commerce/instacart/internal/gql/search.go
+++ b/library/commerce/instacart/internal/gql/search.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/auth"
 	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/instacart"
 	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/store"
 )
 
@@ -147,16 +148,14 @@ func ensureInventoryToken(ctx context.Context, client *Client, st *store.Store, 
 		return cached, nil
 	}
 
-	vars := map[string]any{
-		"retailerSlug": slug,
-		"postalCode":   cfg.PostalCode,
-		"coordinates": map[string]any{
-			"latitude":  cfg.Latitude,
-			"longitude": cfg.Longitude,
-		},
-		"addressId":              cfg.AddressID,
-		"allowCanonicalFallback": false,
-	}
+	// PATCH (fix-shop-collection-coordinates):
+	// Use the typed constructor so coordinates is omitted entirely when
+	// neither latitude nor longitude is set (the common config path for
+	// users who only set postal_code). Previously this builder always
+	// sent {latitude: 0, longitude: 0}, which Instacart's UsersCoordinates
+	// input rejects, causing every search/add/cart-show bootstrap to fail
+	// with "no shops" — see mvanhorn/printing-press-library#501.
+	vars := instacart.NewShopCollectionScopedVars(slug, cfg.PostalCode, cfg.AddressID, cfg.Latitude, cfg.Longitude)
 	resp, err := client.Query(ctx, "ShopCollectionScoped", vars)
 	if err != nil {
 		return nil, fmt.Errorf("ShopCollectionScoped: %w", err)

--- a/library/commerce/instacart/internal/instacart/types.go
+++ b/library/commerce/instacart/internal/instacart/types.go
@@ -19,6 +19,28 @@ type ShopCollectionScopedVars struct {
 	AllowCanonicalFallback bool         `json:"allowCanonicalFallback"`
 }
 
+// PATCH (fix-shop-collection-coordinates):
+// NewShopCollectionScopedVars builds the variable bundle and omits
+// `coordinates` entirely when neither latitude nor longitude is set, instead
+// of sending the zero-valued {0,0} pair. Instacart's `UsersCoordinatesInput`
+// rejects {0,0} as invalid (it's a point in the Atlantic Ocean) which surfaces
+// as a server-side "no shops" / "variable was provided invalid value" failure
+// at every search/add/cart-show bootstrap when the user has only configured
+// postal_code. The local op declaration types coordinates as optional, so
+// omitting it is the correct shape when the caller has none to provide.
+// Reported in mvanhorn/printing-press-library#501.
+func NewShopCollectionScopedVars(retailerSlug, postalCode, addressID string, latitude, longitude float64) ShopCollectionScopedVars {
+	v := ShopCollectionScopedVars{
+		RetailerSlug: retailerSlug,
+		PostalCode:   postalCode,
+		AddressID:    addressID,
+	}
+	if latitude != 0 || longitude != 0 {
+		v.Coordinates = &Coordinates{Latitude: latitude, Longitude: longitude}
+	}
+	return v
+}
+
 type AutosuggestionsVars struct {
 	RetailerInventorySessionToken string `json:"retailerInventorySessionToken,omitempty"`
 	Query                         string `json:"query"`

--- a/library/commerce/instacart/internal/instacart/types_test.go
+++ b/library/commerce/instacart/internal/instacart/types_test.go
@@ -1,0 +1,84 @@
+package instacart
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestNewShopCollectionScopedVars_OmitsCoordinatesWhenUnset pins the fix for
+// mvanhorn/printing-press-library#501: when the user has only configured
+// postal_code (no latitude/longitude), the marshalled JSON must NOT contain
+// a "coordinates" key, instead of sending {"coordinates":{"latitude":0,"longitude":0}}
+// which Instacart's UsersCoordinatesInput rejects as invalid.
+func TestNewShopCollectionScopedVars_OmitsCoordinatesWhenUnset(t *testing.T) {
+	v := NewShopCollectionScopedVars("qfc", "98052", "", 0, 0)
+	if v.Coordinates != nil {
+		t.Fatalf("Coordinates should be nil when both lat/lng are 0, got %+v", v.Coordinates)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "coordinates") {
+		t.Fatalf("JSON should not contain a coordinates key when both lat/lng are 0, got: %s", string(out))
+	}
+}
+
+func TestNewShopCollectionScopedVars_IncludesCoordinatesWhenSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		lat, lng float64
+	}{
+		{"both set", 47.6740, -122.1215},
+		{"latitude only", 47.6740, 0},
+		{"longitude only", 0, -122.1215},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewShopCollectionScopedVars("qfc", "98052", "", tc.lat, tc.lng)
+			if v.Coordinates == nil {
+				t.Fatalf("Coordinates should be non-nil when at least one of lat/lng is non-zero")
+			}
+			if v.Coordinates.Latitude != tc.lat || v.Coordinates.Longitude != tc.lng {
+				t.Fatalf("Coordinates round-trip: want lat=%v lng=%v, got %+v", tc.lat, tc.lng, v.Coordinates)
+			}
+			out, err := json.Marshal(v)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(out), `"coordinates"`) {
+				t.Fatalf("JSON should contain a coordinates key when set, got: %s", string(out))
+			}
+		})
+	}
+}
+
+func TestNewShopCollectionScopedVars_OmitsEmptyAddressID(t *testing.T) {
+	v := NewShopCollectionScopedVars("qfc", "98052", "", 47.6740, -122.1215)
+	if v.AddressID != "" {
+		t.Fatalf("AddressID should be empty string, got %q", v.AddressID)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// addressId has omitempty on the struct tag; empty string should drop.
+	if strings.Contains(string(out), `"addressId"`) {
+		t.Fatalf("JSON should omit addressId when empty, got: %s", string(out))
+	}
+}
+
+func TestNewShopCollectionScopedVars_RequiredFieldsRoundTrip(t *testing.T) {
+	v := NewShopCollectionScopedVars("qfc", "98052", "addr-123", 47.6740, -122.1215)
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{`"retailerSlug":"qfc"`, `"postalCode":"98052"`, `"addressId":"addr-123"`, `"coordinates":`, `"allowCanonicalFallback":false`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("JSON missing %q; full: %s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #501. Credit to @kmanan for the report + repro.

## Bug

Every `instacart search`, `add`, and `cart show` failed at the bootstrap step with `ShopCollectionScoped returned no shops`. `carts` (list) still worked because it uses a different GraphQL op.

## Root cause

The two call sites that build the `ShopCollectionScoped` variables always allocated `Coordinates`, even when the user had only configured `postal_code`:

- `internal/gql/search.go:ensureInventoryToken` built a `map[string]any` with `"coordinates": {latitude: cfg.Latitude, longitude: cfg.Longitude}`. When `cfg.Latitude` and `cfg.Longitude` are unset (the common config path), this serialized as `{"coordinates":{"latitude":0,"longitude":0}}`.
- `internal/cli/retailers.go:resolveRetailer` literal-constructed `instacart.ShopCollectionScopedVars{Coordinates: &instacart.Coordinates{...}, ...}` with the same problem.

The `Coordinates` struct's `Latitude` / `Longitude` fields have no `omitempty`, so they always serialize as `0` rather than being dropped. The pointer-with-`omitempty` on the parent struct's `Coordinates` field never fires because the pointer is never nil.

Instacart's `UsersCoordinatesInput` rejects `{0,0}` as invalid (it's a point in the Atlantic Ocean, no retailer scope possible), surfacing as the "no shops" error that #501 captured.

## Fix

Introduces `NewShopCollectionScopedVars(retailerSlug, postalCode, addressID, latitude, longitude)` in `internal/instacart/types.go`. The constructor leaves `Coordinates` as `nil` when both `latitude` and `longitude` are zero, so the pointer-with-`omitempty` correctly drops the field from the marshalled JSON. Both call sites now route through it.

The local op declaration types `coordinates` as optional (`$coordinates: ShopCollectionCoordinatesInput`, no `!`), so the omission is the correct shape — matches the schema and matches what the persisted-query hash accepts.

This is the simpler of the two options @kmanan suggested in the issue (omit coordinates when not set). The richer fix (geocode the ZIP at bootstrap time, or read from `GetAddressById`) can layer on top without changing the surface: if the user later configures `latitude`/`longitude`, the coordinates path lights up automatically.

## Test

`internal/instacart/types_test.go` pins the JSON shape:

- `TestNewShopCollectionScopedVars_OmitsCoordinatesWhenUnset` — the regression test for #501. Both lat/lng zero ⇒ no `coordinates` key in the marshalled JSON.
- `TestNewShopCollectionScopedVars_IncludesCoordinatesWhenSet` — non-zero values round-trip through (table-driven: both set, lat-only, lng-only).
- `TestNewShopCollectionScopedVars_OmitsEmptyAddressID` — empty `addressId` drops via the existing struct-tag `omitempty`.
- `TestNewShopCollectionScopedVars_RequiredFieldsRoundTrip` — `retailerSlug`, `postalCode`, `addressId` (when set), `coordinates` (when set), `allowCanonicalFallback` all marshal as expected.

All pass: `go test ./internal/instacart/...` and the existing `./internal/cli/...` suite both green.

## Not addressed here

- `doctor: api: logged in as ()` showing empty name + email — @kmanan flagged it as a separate minor issue; out of scope for this PR.
- Pre-existing `printing-press publish validate` failures on this CLI (missing `run_id` in `.printing-press.json`, no `novel_features`, no Phase 5 acceptance proof) are unchanged by this PR. The library's CI doesn't gate on them; backfilling would expand this PR well beyond the bug fix.

## Patch index

`.printing-press-patches.json` updated with one new entry (`fix-shop-collection-coordinates`) per the library's `verify-publish-package` contract. Each touched Go file carries a `// PATCH (fix-shop-collection-coordinates):` marker referencing this entry and the issue.
