### PR TITLE
chore: ignore local AI agent instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ Thumbs.db
 
 # Conductor workspace state
 .conductor/
+
+# Local AI agent instructions (not for sharing)
+CLAUDE.local.md
+AGENTS.override.md
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `CLAUDE.local.md`, `AGENTS.override.md`, and `.claude/settings.local.json` to `.gitignore` so per-developer AI agent customizations aren't accidentally committed.

## Test plan
- [x] `git check-ignore CLAUDE.local.md AGENTS.override.md .claude/settings.local.json` matches each path