### PR TITLE
fix(ci): use pull-requests:write for Greptile nudge comment

### DIFF
--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -16,8 +16,8 @@ on:
 permissions:
   checks: read
   contents: read
-  issues: write
-  pull-requests: read
+  issues: read
+  pull-requests: write
 
 jobs:
   gate:


### PR DESCRIPTION
## Summary

#543's auto-nudge has been failing silently with HTTP 403 on every PR since it merged. Swap `issues: write` for `pull-requests: write` so the `gh api .../issues/{n}/comments` POST actually has the right scope when the "issue" is a pull request.

## What went wrong

#543 added a 3-minute auto-nudge that posts `@greptileai review` as a PR comment when no `Greptile Review` check appears. The implementation correctly fires at 183 s, but the comment POST returns HTTP 403:

```
2026-05-13T22:26:28Z Greptile Review still missing after 183s; posting @greptileai review nudge.
2026-05-13T22:26:28Z gh: Resource not accessible by integration (HTTP 403)
2026-05-13T22:26:28Z ##[error]Process completed with exit code 1.
```

(Seen on PR #548's `greptile-policy-gate` run #25829890476.)

## Root cause

The endpoint `POST /repos/{owner}/{repo}/issues/{issue_number}/comments` is shared between issues and PRs. Required permission depends on the resource type:

- **Issue comment** → `issues: write`
- **PR comment** → `pull-requests: write`

`pull_request_target` always operates on PRs, so `pull-requests: write` is the correct scope. #543 set `issues: write` and left `pull-requests: read`, so the token lacks the required scope.

## Fix

```diff
 permissions:
   checks: read
   contents: read
-  issues: write
-  pull-requests: read
+  issues: read
+  pull-requests: write
```

`issues: read` matches what the workflow actually needs (no issue-side writes happen here).

## Test plan

- [ ] Land this PR.
- [ ] Next large new-CLI PR (or any PR Greptile silent-skips) should see the auto-nudge comment post successfully ~3 min after gate start, no 403.
- [ ] Confirm the gate now waits to the full 15-min deadline instead of failing fast at 3m6s.