### PR TITLE
fix(skills): restore truncated SKILL.md descriptions across 9 CLIs

### DIFF
--- a/cli-skills/pp-google-ads/SKILL.md
+++ b/cli-skills/pp-google-ads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-google-ads
-description: "Printing Press CLI for Google Ads. Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning,..."
+description: "Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations. Trigger phrases: `pull a Google Ads report`, `GAQL query`, `check campaign performance`, `use google-ads`."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata:

--- a/cli-skills/pp-mercury/SKILL.md
+++ b/cli-skills/pp-mercury/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-mercury
-description: "Printing Press CLI for Mercury. Streamline financial tasks with secure account management and transaction processing. Enables user registration,..."
+description: "Mercury banking API for account management, transaction processing, balance tracking, and payment handling. Trigger phrases: `mercury account balance`, `mercury transactions`, `send a Mercury payment`, `use mercury`."
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-nvd/SKILL.md
+++ b/cli-skills/pp-nvd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-nvd
-description: "Printing Press CLI for Nvd. The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword,..."
+description: "Search the U.S. National Vulnerability Database for CVEs, CVSS scores, affected versions, and severity ratings — by keyword, product (CPE name), CVE ID, or date range. Trigger phrases: `look up CVE`, `CVSS score for`, `vulnerabilities in <product>`, `use nvd`."
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-openalex/SKILL.md
+++ b/cli-skills/pp-openalex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-openalex
-description: "Printing Press CLI for Openalex. The OpenAlex API provides access to a comprehensive catalog of scholarly works, authors, sources, institutions,..."
+description: "Search OpenAlex's catalog of 250M+ scholarly works, authors, sources, institutions, topics, keywords, publishers, and funders. Trigger phrases: `find scholarly papers on`, `look up research by <author>`, `citations for <work>`, `use openalex`."
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-podscan/SKILL.md
+++ b/cli-skills/pp-podscan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-podscan
-description: "Printing Press CLI for Podscan. Podscan REST API — search 51M+ podcast episodes and 4.4M+ podcasts. Full transcripts, AI-extracted entities,..."
+description: "Search 51M+ podcast episodes and 4.4M+ podcasts via Podscan — full transcripts, AI-extracted entities, mentions, and brand-safety analysis. Trigger phrases: `search podcast transcripts`, `find podcasts mentioning`, `who's talked about <topic> on podcasts`, `use podscan`."
 author: "Greg Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-recipe-goat/SKILL.md
+++ b/cli-skills/pp-recipe-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-recipe-goat
-description: "Printing Press CLI for Recipe Goat. Recipe GOAT — find the best version of any recipe across 37 trusted sites, with offline cookbook, pantry match,..."
+description: "Find the best version of any recipe across 37 trusted sites — with offline cookbook, pantry match, substitution lookup, meal planning, and USDA-backed nutrition. Trigger phrases: `find the best recipe for`, `what can I make with`, `substitute for <ingredient>`, `nutrition for <recipe>`, `use recipe-goat`."
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-sec-edgar/SKILL.md
+++ b/cli-skills/pp-sec-edgar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-sec-edgar
-description: "Every SEC filing, every XBRL fact, every insider trade — synced into a local SQLite store you can pivot, search,... Trigger phrases: `look up an SEC filing`, `check insider trading on`, `compare quarterly financials for`, `find restatements in the last quarter`, `watch SEC filings for`, `use sec-edgar`, `run sec-edgar`."
+description: "Every SEC filing, every XBRL fact, every insider trade — synced into a local SQLite store you can pivot, search, and watch offline. Trigger phrases: `look up an SEC filing`, `check insider trading on`, `compare quarterly financials for`, `watch SEC filings for`, `use sec-edgar`."
 author: "Chris Drit"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-steam-web/SKILL.md
+++ b/cli-skills/pp-steam-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-steam-web
-description: "Every Steam Web API endpoint, plus a local SQLite store that turns friend playtimes, achievement progress, and... Trigger phrases: `what should I play next on steam`, `find friends who own this game`, `easiest steam achievement to unlock`, `who in my friends has the most hours in`, `audit my steam backlog`, `use steam-web`, `run steam-web`."
+description: "Every Steam Web API endpoint, plus a local SQLite store that turns friend playtimes, achievement progress, and library backlogs into single SQL queries no other tool can answer. Trigger phrases: `what should I play next on steam`, `find friends who own this game`, `easiest steam achievement to unlock`, `audit my steam backlog`, `use steam-web`."
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/cli-skills/pp-table-reservation-goat/SKILL.md
+++ b/cli-skills/pp-table-reservation-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-table-reservation-goat
-description: "One reservation CLI for OpenTable, Tock, and Resy — search each network at once, watch for cancellations, book, and... Trigger phrases: `book a table`, `find me a reservation`, `watch for a cancellation`, `tasting menu availability`, `earliest reservation across these restaurants`, `use table-reservation-goat`, `run table-reservation-goat`."
+description: "One reservation CLI for OpenTable, Tock, and Resy — search each network at once, watch for cancellations, book, and track changes from a local store agents can query. Trigger phrases: `book a table`, `find me a reservation`, `watch for a cancellation`, `use table-reservation-goat`."
 author: "Pejman Pour-Moezzi"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/nvd/SKILL.md
+++ b/library/developer-tools/nvd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-nvd
-description: "Printing Press CLI for Nvd. The NVD is the U.S. government repository of standards-based vulnerability management data. Search CVEs by keyword,..."
+description: "Search the U.S. National Vulnerability Database for CVEs, CVSS scores, affected versions, and severity ratings — by keyword, product (CPE name), CVE ID, or date range. Trigger phrases: `look up CVE`, `CVSS score for`, `vulnerabilities in <product>`, `use nvd`."
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/developer-tools/sec-edgar/SKILL.md
+++ b/library/developer-tools/sec-edgar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-sec-edgar
-description: "Every SEC filing, every XBRL fact, every insider trade — synced into a local SQLite store you can pivot, search,... Trigger phrases: `look up an SEC filing`, `check insider trading on`, `compare quarterly financials for`, `find restatements in the last quarter`, `watch SEC filings for`, `use sec-edgar`, `run sec-edgar`."
+description: "Every SEC filing, every XBRL fact, every insider trade — synced into a local SQLite store you can pivot, search, and watch offline. Trigger phrases: `look up an SEC filing`, `check insider trading on`, `compare quarterly financials for`, `watch SEC filings for`, `use sec-edgar`."
 author: "Chris Drit"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-recipe-goat
-description: "Printing Press CLI for Recipe Goat. Recipe GOAT — find the best version of any recipe across 37 trusted sites, with offline cookbook, pantry match,..."
+description: "Find the best version of any recipe across 37 trusted sites — with offline cookbook, pantry match, substitution lookup, meal planning, and USDA-backed nutrition. Trigger phrases: `find the best recipe for`, `what can I make with`, `substitute for <ingredient>`, `nutrition for <recipe>`, `use recipe-goat`."
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/table-reservation-goat/SKILL.md
+++ b/library/food-and-dining/table-reservation-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-table-reservation-goat
-description: "One reservation CLI for OpenTable, Tock, and Resy — search each network at once, watch for cancellations, book, and... Trigger phrases: `book a table`, `find me a reservation`, `watch for a cancellation`, `tasting menu availability`, `earliest reservation across these restaurants`, `use table-reservation-goat`, `run table-reservation-goat`."
+description: "One reservation CLI for OpenTable, Tock, and Resy — search each network at once, watch for cancellations, book, and track changes from a local store agents can query. Trigger phrases: `book a table`, `find me a reservation`, `watch for a cancellation`, `use table-reservation-goat`."
 author: "Pejman Pour-Moezzi"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/marketing/google-ads/SKILL.md
+++ b/library/marketing/google-ads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-google-ads
-description: "Printing Press CLI for Google Ads. Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning,..."
+description: "Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations. Trigger phrases: `pull a Google Ads report`, `GAQL query`, `check campaign performance`, `use google-ads`."
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata:

--- a/library/media-and-entertainment/podscan/SKILL.md
+++ b/library/media-and-entertainment/podscan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-podscan
-description: "Printing Press CLI for Podscan. Podscan REST API — search 51M+ podcast episodes and 4.4M+ podcasts. Full transcripts, AI-extracted entities,..."
+description: "Search 51M+ podcast episodes and 4.4M+ podcasts via Podscan — full transcripts, AI-extracted entities, mentions, and brand-safety analysis. Trigger phrases: `search podcast transcripts`, `find podcasts mentioning`, `who's talked about <topic> on podcasts`, `use podscan`."
 author: "Greg Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/media-and-entertainment/steam-web/SKILL.md
+++ b/library/media-and-entertainment/steam-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-steam-web
-description: "Every Steam Web API endpoint, plus a local SQLite store that turns friend playtimes, achievement progress, and... Trigger phrases: `what should I play next on steam`, `find friends who own this game`, `easiest steam achievement to unlock`, `who in my friends has the most hours in`, `audit my steam backlog`, `use steam-web`, `run steam-web`."
+description: "Every Steam Web API endpoint, plus a local SQLite store that turns friend playtimes, achievement progress, and library backlogs into single SQL queries no other tool can answer. Trigger phrases: `what should I play next on steam`, `find friends who own this game`, `easiest steam achievement to unlock`, `audit my steam backlog`, `use steam-web`."
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/other/openalex/SKILL.md
+++ b/library/other/openalex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-openalex
-description: "Printing Press CLI for Openalex. The OpenAlex API provides access to a comprehensive catalog of scholarly works, authors, sources, institutions,..."
+description: "Search OpenAlex's catalog of 250M+ scholarly works, authors, sources, institutions, topics, keywords, publishers, and funders. Trigger phrases: `find scholarly papers on`, `look up research by <author>`, `citations for <work>`, `use openalex`."
 author: "Hiten Shah"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/payments/mercury/SKILL.md
+++ b/library/payments/mercury/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-mercury
-description: "Printing Press CLI for Mercury. Streamline financial tasks with secure account management and transaction processing. Enables user registration,..."
+description: "Mercury banking API for account management, transaction processing, balance tracking, and payment handling. Trigger phrases: `mercury account balance`, `mercury transactions`, `send a Mercury payment`, `use mercury`."
 author: "Cathryn Lavery"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"


### PR DESCRIPTION
## Summary

Nine published CLIs shipped `SKILL.md` frontmatter `description:` fields truncated mid-sentence with a trailing `,...` or `, and...`. The frontmatter description is the only signal the model uses to decide whether to fire a skill, so a description that trails off mid-sentence materially shrinks the CLI's trigger surface.

This PR replaces each truncated description with a single complete sentence grounded in the CLI's README, plus a curated set of trigger phrases (3–4 high-signal phrases + `use <slug>` — no spam). The `cli-skills/` mirror is regenerated via `tools/generate-skills/` so it matches.

## Affected CLIs

| Category | CLI |
|---|---|
| developer-tools | `nvd`, `sec-edgar` |
| food-and-dining | `recipe-goat`, `table-reservation-goat` |
| marketing | `google-ads` |
| media-and-entertainment | `podscan`, `steam-web` |
| other | `openalex` |
| payments | `mercury` |

## Why this matters

Per the issue filed upstream (mvanhorn/cli-printing-press#1350), an on-disk skill description ending in `,...` is materially weaker for model routing than a complete sentence. The reporter found the defect during a skills-quality audit; the originally-filed bug was scoped to `pp-recipe-goat`, but a quick `grep` of `library/**/SKILL.md` surfaced the same pattern in eight more CLIs — same template bug, manifested across the catalog.

## Why the fix is here, not in the generator

Per `AGENTS.md`:

> A broken published CLI gets patched here first, regardless of root cause. \[…\] If the same defect also reproduces in other published CLIs, it's a genuine multi-CLI template bug — fix the generator in parallel, but the local patch still lands first.

This PR is the "local patch lands first" half. A parallel issue will be filed on `mvanhorn/cli-printing-press` for the generator-side fix (description-length cap that emits `,...` when triggered, and a guard that refuses to emit any description ending in trailing `,` / `,...` / `...`).

## Source of replacement text

Each new description was reconstructed from the CLI's `README.md` and product purpose — not re-fetched from the upstream API description (where applicable, the original API description was already the source that got truncated). Trigger phrases were selected for signal: natural user phrasings that match what someone would actually type when they need that CLI, plus the canonical `use <slug>` explicit-invocation phrase.

## Validation

- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/<cat>/<slug>/` passes on all 9 affected CLIs.
- `go run ./tools/generate-skills/main.go` runs cleanly; `cli-skills/pp-*/SKILL.md` mirrors match.
- No code changed — `.printing-press-patches.json` is not required per `AGENTS.md` ("SKILL.md / README.md edits \[…\] don't need a patch manifest; this convention is for code-level customizations").

## Test plan

- [ ] CI: `verify-skills.yml` passes for every CLI in the catalog
- [ ] CI: `verify-library-conventions.yml` passes
- [ ] Greptile review resolved (P0/P1 addressed before merge)
- [ ] Manual spot-check: each modified `library/<cat>/<slug>/SKILL.md` `description:` is a complete sentence ending in `."` with no `,...` / `, and...`

Closes mvanhorn/cli-printing-press#1350 from the public-library side.