### PR TITLE
fix(commerce/instacart): config subtree + auto-populate location on auth login (fixes #546)

### DIFF
--- a/cli-skills/pp-instacart/SKILL.md
+++ b/cli-skills/pp-instacart/SKILL.md
@@ -182,6 +182,18 @@ instacart auth import-file <path>
 
 Session lives at `~/.config/instacart/session.json` (0600).
 
+## Location Setup
+
+Instacart's GraphQL API requires location data (`latitude`/`longitude` or an `address_id`) on every retailer lookup. Without it, `search`, `add`, and `cart show` fail at the `ShopCollectionScoped` bootstrap step.
+
+The post-`auth login` step auto-populates `address_id`, `postal_code`, `latitude`, and `longitude` from your default Instacart address. If that doesn't work, the agent should fall back to one of:
+
+- `instacart config set-address --id <uuid>` — derives coords from a known Instacart address ID via the cached `GetAddressById` op. Find the ID in the URL or a graphql variable on https://www.instacart.com/store/account/your-account (DevTools Network tab).
+- `instacart config set-coords --lat <N> --lon <N> [--postal <zip>]` — pass coordinates directly (Google Maps right-click → "What's here?" returns lat/lon).
+- `instacart config show` — confirm what's currently set.
+
+`instacart doctor` surfaces a `location: fail` check whenever this is missing, so an agent driving the CLI can detect the broken state before invoking a real command.
+
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.

--- a/library/commerce/instacart/.printing-press-patches.json
+++ b/library/commerce/instacart/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-13",
+  "applied_at": "2026-05-14",
   "base_run_id": "2026-04-11T06:12:25Z",
   "base_printing_press_version": "1.2.1",
   "patches": [
@@ -15,6 +15,17 @@
         "internal/cli/retailers.go"
       ],
       "validated_outcome": "Unit tests pin the JSON shape: no `coordinates` key when lat/lng are both zero; coordinates included when at least one is non-zero; addressId omitted when empty."
+    },
+    {
+      "id": "fix-instacart-location-config-546",
+      "summary": "Add the instacart config subtree, auto-populate location on auth login from the user default address, and surface a doctor location check; closes the cold-install gap from issue #546.",
+      "reason": "Reported in mvanhorn/printing-press-library#546. Cold install required latitude/longitude in config.json but the keys were not documented anywhere user-facing; instacart doctor reported [ok] against a config missing them, so users only discovered the gap when search/add/cart show failed. PR #539 removed the silent {0,0} masking but did not address the underlying UX gap. This patch adds: (a) instacart config show / set-coords / set-address subcommands so users can populate via CLI instead of hand-editing JSON; set-address uses the cached GetAddressById op to derive coordinates from a known address ID; (b) tryAutoPopulateLocation helper called from all three auth flows (login, paste, import-file) that posts CurrentUserAddresses {addresses {id streetAddress postalCode latitude longitude isDefault}} via the existing POST-with-query-text path; on failure it surfaces a typed hint pointing at the manual setters; (c) a doctor location check that returns status fail with actionable remediation; (d) README Quick Start and SKILL Auth Setup sections documenting the new flow.",
+      "files": [
+        "internal/cli/config.go",
+        "internal/cli/auth.go",
+        "internal/cli/doctor.go",
+        "internal/cli/root.go"
+      ]
     }
   ]
 }

--- a/library/commerce/instacart/README.md
+++ b/library/commerce/instacart/README.md
@@ -38,8 +38,32 @@ go build -o instacart ./cmd/instacart
 # Or paste a Cookie header from devtools:
 ./instacart auth paste
 
-# 4. Verify
+# 4. Verify (this also surfaces if location config is missing)
 ./instacart doctor
+```
+
+`auth login` (and the `paste` / `import-file` variants) automatically fetches
+your default Instacart address and persists `address_id`, `postal_code`,
+`latitude`, and `longitude` to `~/.config/instacart/config.json`. Without these,
+every `search`, `add`, and `cart show` against an uncached retailer fails at
+the `ShopCollectionScoped` bootstrap. If auto-populate doesn't work for your
+account (for example because Instacart's schema changed), the CLI prints a
+note pointing you at the manual fallbacks below.
+
+### Setting location manually
+
+```bash
+# Option 1: auto-derive from your Instacart address ID. Find the ID in the
+# URL or a graphql variable on https://www.instacart.com/store/account/your-account
+# (DevTools Network tab). Uses the cached GetAddressById op.
+./instacart config set-address --id 12345678-aaaa-bbbb-cccc-deadbeef0000
+
+# Option 2: pass coordinates directly (e.g., from Google Maps right-click
+# "What's here?"). --postal is optional but recommended.
+./instacart config set-coords --lat 47.6740 --lon -122.1215 --postal 98052
+
+# View what's currently set:
+./instacart config show
 ```
 
 ## First-time history backfill

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -182,6 +182,18 @@ instacart auth import-file <path>
 
 Session lives at `~/.config/instacart/session.json` (0600).
 
+## Location Setup
+
+Instacart's GraphQL API requires location data (`latitude`/`longitude` or an `address_id`) on every retailer lookup. Without it, `search`, `add`, and `cart show` fail at the `ShopCollectionScoped` bootstrap step.
+
+The post-`auth login` step auto-populates `address_id`, `postal_code`, `latitude`, and `longitude` from your default Instacart address. If that doesn't work, the agent should fall back to one of:
+
+- `instacart config set-address --id <uuid>` — derives coords from a known Instacart address ID via the cached `GetAddressById` op. Find the ID in the URL or a graphql variable on https://www.instacart.com/store/account/your-account (DevTools Network tab).
+- `instacart config set-coords --lat <N> --lon <N> [--postal <zip>]` — pass coordinates directly (Google Maps right-click → "What's here?" returns lat/lon).
+- `instacart config show` — confirm what's currently set.
+
+`instacart doctor` surfaces a `location: fail` check whenever this is missing, so an agent driving the CLI can detect the broken state before invoking a real command.
+
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.

--- a/library/commerce/instacart/internal/cli/auth.go
+++ b/library/commerce/instacart/internal/cli/auth.go
@@ -56,6 +56,8 @@ provide a pre-extracted session file.`,
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "imported %d cookies from %s\n", len(sess.Cookies), args[0])
+			// PATCH (fix-instacart-location-config-546): see auth login.
+			tryAutoPopulateLocation(cmd, sess)
 			return nil
 		},
 	}
@@ -85,6 +87,10 @@ If the command fails with "database is locked", quit Chrome completely
 				masked := maskCookieValue(c.Value)
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s = %s\n", c.Name, masked)
 			}
+			// PATCH (fix-instacart-location-config-546): best-effort location
+			// auto-populate so cold-install users don't have to discover the
+			// postal_code/address_id/latitude/longitude keys themselves.
+			tryAutoPopulateLocation(cmd, sess)
 			fmt.Fprintln(cmd.OutOrStdout(), "\nrun `instacart doctor` to verify")
 			fmt.Fprintln(cmd.OutOrStdout(), "tip: `instacart history sync` will pull your past orders into the local store")
 			fmt.Fprintln(cmd.OutOrStdout(), "     so future `add` commands can resolve items you have bought before.")
@@ -177,6 +183,8 @@ it here (ending with a blank line or Ctrl-D).`,
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "imported %d cookies from pasted header\n", len(sess.Cookies))
+			// PATCH (fix-instacart-location-config-546): see auth login.
+			tryAutoPopulateLocation(cmd, sess)
 			return nil
 		},
 	}

--- a/library/commerce/instacart/internal/cli/config.go
+++ b/library/commerce/instacart/internal/cli/config.go
@@ -86,8 +86,10 @@ func newConfigSetCoordsCmd() *cobra.Command {
 		Example: "  instacart config set-coords --lat 47.6740 --lon -122.1215\n" +
 			"  instacart config set-coords --lat 47.6740 --lon -122.1215 --postal 98052",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if lat == 0 || lon == 0 {
-				return coded(ExitUsage, "--lat and --lon are both required (and non-zero)")
+			// Use Changed() so a deliberate `--lat 0` (equator) or `--lon 0`
+			// (prime meridian) isn't rejected as "not provided".
+			if !cmd.Flags().Changed("lat") || !cmd.Flags().Changed("lon") {
+				return coded(ExitUsage, "--lat and --lon are both required")
 			}
 			cfg, err := config.Load()
 			if err != nil {
@@ -200,8 +202,8 @@ exposed in the Network tab will contain it. It looks like a UUID.`,
 					"street_address": addr.StreetAddress,
 				})
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "saved address %q (%s) → %s\n  postal_code=%q latitude=%v longitude=%v\n",
-				addr.ID, addr.StreetAddress, addr.PostalCode, addr.PostalCode, addr.Latitude, addr.Longitude)
+			fmt.Fprintf(cmd.OutOrStdout(), "saved address %q (%s)\n  postal_code=%q latitude=%v longitude=%v\n",
+				addr.ID, addr.StreetAddress, addr.PostalCode, addr.Latitude, addr.Longitude)
 			return nil
 		},
 	}
@@ -273,6 +275,15 @@ func tryAutoPopulateLocation(cmd *cobra.Command, sess *auth.Session) {
 	defer st.Close()
 
 	client := gql.NewClient(sess, cfg, st)
+	// Note on `client.Mutation`: this codebase uses Mutation as the
+	// POST-with-raw-query-text path regardless of GraphQL operation type
+	// — it does not set any operation-type metadata on the wire (see
+	// `internal/gql/client.go:call`, which just serializes `operationName +
+	// variables + query` into the body). The CurrentUserAddresses payload
+	// is a `query`, not a `mutation`; reusing this method here mirrors the
+	// existing UpdateCartItemsMutation convention. If the client ever
+	// gains an explicit type marker, the right move is to add a thin
+	// `client.PostRaw` and route this call through it.
 	resp, err := client.Mutation(context.Background(), "CurrentUserAddresses", map[string]any{}, currentUserAddressesQuery)
 	if err != nil {
 		fmt.Fprintf(cmd.OutOrStdout(), "\nNote: could not auto-populate location (%v).\n", err)

--- a/library/commerce/instacart/internal/cli/config.go
+++ b/library/commerce/instacart/internal/cli/config.go
@@ -1,0 +1,331 @@
+// PATCH (fix-instacart-location-config-546): adds an `instacart config`
+// subtree so the location keys (postal_code, address_id, latitude,
+// longitude) can be set via CLI instead of hand-editing the JSON file.
+// Closes the cold-install gap reported in mvanhorn/printing-press-library#546.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/auth"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/gql"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/store"
+)
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "View and modify location-related config (postal code, address ID, coordinates)",
+		Long: `Instacart's GraphQL API requires location data (latitude/longitude or a
+known address_id) on every retailer lookup. The CLI reads these from
+` + "`~/.config/instacart/config.json`" + ` (or the OS equivalent). Use the
+subcommands below to populate them without hand-editing the file.
+
+If you don't know your coordinates, the easiest path is:
+  1. ` + "`instacart auth login`" + ` (the post-login step will try to fetch
+     your default Instacart address and populate everything automatically)
+  2. If that doesn't work, find your address ID in the URL on
+     https://www.instacart.com/store/account/your-account and run
+     ` + "`instacart config set-address --id <id>`" + ` — the CLI uses the
+     cached GetAddressById op to derive coordinates from the ID.
+  3. As a last resort, look up your lat/lon (e.g., Google Maps,
+     right-click → "What's here?") and run
+     ` + "`instacart config set-coords --lat X --lon Y`" + `.`,
+	}
+	cmd.AddCommand(
+		newConfigShowCmd(),
+		newConfigSetCoordsCmd(),
+		newConfigSetAddressCmd(),
+	)
+	return cmd
+}
+
+func newConfigShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:         "show",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Short:       "Print the current location config",
+		Example:     "  instacart config show\n  instacart config show --json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			out := map[string]any{
+				"postal_code": cfg.PostalCode,
+				"address_id":  cfg.AddressID,
+				"latitude":    cfg.Latitude,
+				"longitude":   cfg.Longitude,
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(out)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "postal_code: %q\naddress_id:  %q\nlatitude:    %v\nlongitude:   %v\n",
+				cfg.PostalCode, cfg.AddressID, cfg.Latitude, cfg.Longitude)
+			if !locationReady(cfg) {
+				fmt.Fprintln(cmd.OutOrStdout(), "\nWARNING: location is incomplete — see `instacart config --help`.")
+			}
+			return nil
+		},
+	}
+}
+
+func newConfigSetCoordsCmd() *cobra.Command {
+	var lat, lon float64
+	var postal string
+	cmd := &cobra.Command{
+		Use:   "set-coords",
+		Short: "Save latitude/longitude (and optionally postal_code) to config",
+		Example: "  instacart config set-coords --lat 47.6740 --lon -122.1215\n" +
+			"  instacart config set-coords --lat 47.6740 --lon -122.1215 --postal 98052",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if lat == 0 || lon == 0 {
+				return coded(ExitUsage, "--lat and --lon are both required (and non-zero)")
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			cfg.Latitude = lat
+			cfg.Longitude = lon
+			if postal != "" {
+				cfg.PostalCode = postal
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"saved":       true,
+					"postal_code": cfg.PostalCode,
+					"latitude":    cfg.Latitude,
+					"longitude":   cfg.Longitude,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "saved: latitude=%v longitude=%v", cfg.Latitude, cfg.Longitude)
+			if cfg.PostalCode != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), " postal_code=%q", cfg.PostalCode)
+			}
+			fmt.Fprintln(cmd.OutOrStdout())
+			return nil
+		},
+	}
+	cmd.Flags().Float64Var(&lat, "lat", 0, "Latitude (e.g., 47.6740)")
+	cmd.Flags().Float64Var(&lon, "lon", 0, "Longitude (e.g., -122.1215)")
+	cmd.Flags().StringVar(&postal, "postal", "", "Postal code (optional)")
+	return cmd
+}
+
+func newConfigSetAddressCmd() *cobra.Command {
+	var addrID string
+	cmd := &cobra.Command{
+		Use:   "set-address",
+		Short: "Save an Instacart address_id and auto-derive coordinates via GetAddressById",
+		Long: `Persist an Instacart address_id and fetch its postal_code / latitude /
+longitude from Instacart's GraphQL API using the already-cached
+GetAddressById op. Requires a logged-in session.
+
+Find your address_id by opening https://www.instacart.com/store/account/your-account
+in Chrome with DevTools open; the URL fragment or a graphql variable
+exposed in the Network tab will contain it. It looks like a UUID.`,
+		Example: "  instacart config set-address --id 12345678-aaaa-bbbb-cccc-deadbeef0000",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if addrID == "" {
+				return coded(ExitUsage, "--id is required")
+			}
+			sess, err := auth.LoadSession()
+			if err != nil {
+				return coded(ExitAuth, "no session — run `instacart auth login` first")
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			st, err := store.Open()
+			if err != nil {
+				return err
+			}
+			defer st.Close()
+
+			client := gql.NewClient(sess, cfg, st)
+			vars := map[string]any{"id": addrID}
+			resp, err := client.Query(context.Background(), "GetAddressById", vars)
+			if err != nil {
+				return coded(ExitTransient, "fetching address: %v", err)
+			}
+
+			var envelope struct {
+				Data struct {
+					Address *struct {
+						ID            string  `json:"id"`
+						PostalCode    string  `json:"postalCode"`
+						Latitude      float64 `json:"latitude"`
+						Longitude     float64 `json:"longitude"`
+						StreetAddress string  `json:"streetAddress"`
+					} `json:"address"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+				return coded(ExitTransient, "parsing address response: %v", err)
+			}
+			addr := envelope.Data.Address
+			if addr == nil || addr.ID == "" {
+				return coded(ExitNotFound, "address %s not found (check the id and that you are logged in to the same account)", addrID)
+			}
+
+			cfg.AddressID = addr.ID
+			cfg.PostalCode = addr.PostalCode
+			cfg.Latitude = addr.Latitude
+			cfg.Longitude = addr.Longitude
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"saved":          true,
+					"address_id":     addr.ID,
+					"postal_code":    addr.PostalCode,
+					"latitude":       addr.Latitude,
+					"longitude":      addr.Longitude,
+					"street_address": addr.StreetAddress,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "saved address %q (%s) → %s\n  postal_code=%q latitude=%v longitude=%v\n",
+				addr.ID, addr.StreetAddress, addr.PostalCode, addr.PostalCode, addr.Latitude, addr.Longitude)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&addrID, "id", "", "Instacart address ID (UUID)")
+	return cmd
+}
+
+// locationReady returns true when the config has enough location data for
+// the ShopCollectionScoped bootstrap to succeed. Either coordinates OR an
+// address ID is sufficient — both is preferred.
+func locationReady(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.AddressID != "" {
+		return true
+	}
+	if cfg.Latitude != 0 || cfg.Longitude != 0 {
+		return true
+	}
+	return false
+}
+
+// currentUserAddressesQuery is the GraphQL text we POST after a successful
+// auth login to look up the user's saved addresses. It uses POST + query
+// text (no persisted-query hash) because the Instacart wrapper proves this
+// path works for unhashed queries (see internal/gql/client.go and the
+// UpdateCartItemsMutation precedent). If Instacart's schema doesn't expose
+// `currentUser.addresses` (or renames it), this returns a GraphQL error
+// envelope and tryAutoPopulateLocation degrades to a printed hint pointing
+// at the manual setters.
+const currentUserAddressesQuery = `query CurrentUserAddresses {
+  currentUser {
+    id
+    addresses {
+      id
+      streetAddress
+      postalCode
+      latitude
+      longitude
+      isDefault
+      __typename
+    }
+    __typename
+  }
+}`
+
+// tryAutoPopulateLocation attempts to fetch the user's default Instacart
+// address after a successful auth login and persist its postal_code,
+// latitude, longitude, and address_id to config. On any failure it returns
+// nil after writing a one-line hint to cmd's stdout — the auth flow itself
+// already succeeded and we don't want a best-effort enrichment to mask that.
+//
+// Skips silently when location is already configured to avoid clobbering a
+// user's manual values on every relogin.
+func tryAutoPopulateLocation(cmd *cobra.Command, sess *auth.Session) {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	if locationReady(cfg) {
+		return
+	}
+
+	st, err := store.Open()
+	if err != nil {
+		return
+	}
+	defer st.Close()
+
+	client := gql.NewClient(sess, cfg, st)
+	resp, err := client.Mutation(context.Background(), "CurrentUserAddresses", map[string]any{}, currentUserAddressesQuery)
+	if err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nNote: could not auto-populate location (%v).\n", err)
+		fmt.Fprintln(cmd.OutOrStdout(), "      Run `instacart config set-address --id <id>` or `instacart config set-coords --lat <N> --lon <N>` to set it manually.")
+		return
+	}
+	if len(resp.Errors) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nNote: could not auto-populate location (GraphQL: %s).\n", resp.Errors[0].Message)
+		fmt.Fprintln(cmd.OutOrStdout(), "      Run `instacart config set-address --id <id>` or `instacart config set-coords --lat <N> --lon <N>` to set it manually.")
+		return
+	}
+
+	var envelope struct {
+		Data struct {
+			CurrentUser *struct {
+				ID        string `json:"id"`
+				Addresses []struct {
+					ID            string  `json:"id"`
+					StreetAddress string  `json:"streetAddress"`
+					PostalCode    string  `json:"postalCode"`
+					Latitude      float64 `json:"latitude"`
+					Longitude     float64 `json:"longitude"`
+					IsDefault     bool    `json:"isDefault"`
+				} `json:"addresses"`
+			} `json:"currentUser"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nNote: auto-populate response could not be parsed (%v).\n", err)
+		return
+	}
+	if envelope.Data.CurrentUser == nil || len(envelope.Data.CurrentUser.Addresses) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nNote: no saved Instacart addresses found on this account. Add one at https://www.instacart.com/store/account/your-account, then re-run auth login (or use `instacart config set-coords`).")
+		return
+	}
+
+	// Prefer the user-flagged default address. Fall back to the first.
+	picked := envelope.Data.CurrentUser.Addresses[0]
+	for _, a := range envelope.Data.CurrentUser.Addresses {
+		if a.IsDefault {
+			picked = a
+			break
+		}
+	}
+
+	cfg.AddressID = picked.ID
+	cfg.PostalCode = picked.PostalCode
+	cfg.Latitude = picked.Latitude
+	cfg.Longitude = picked.Longitude
+	if err := cfg.Save(); err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "\nNote: fetched address but failed to save config: %v\n", err)
+		return
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nauto-populated location from your default Instacart address:\n  %s — postal_code=%q lat=%v lon=%v\n",
+		picked.StreetAddress, picked.PostalCode, picked.Latitude, picked.Longitude)
+}

--- a/library/commerce/instacart/internal/cli/doctor.go
+++ b/library/commerce/instacart/internal/cli/doctor.go
@@ -52,6 +52,28 @@ Exit codes:
 				results = append(results, checkResult{Name: "config", Status: "warn", Detail: err.Error()})
 			}
 
+			// 1a. Location config (PATCH fix-instacart-location-config-546).
+			// Without coordinates or an address_id, ShopCollectionScoped fails
+			// with a schema error on every retailer lookup. Surface this
+			// before users hit the failure in a real command. See #546.
+			if locationReady(app.Cfg) {
+				detail := "configured"
+				if app.Cfg.AddressID != "" && (app.Cfg.Latitude != 0 || app.Cfg.Longitude != 0) {
+					detail = fmt.Sprintf("address_id + coords (postal_code=%q, lat=%v, lon=%v)", app.Cfg.PostalCode, app.Cfg.Latitude, app.Cfg.Longitude)
+				} else if app.Cfg.AddressID != "" {
+					detail = fmt.Sprintf("address_id=%q (coords not derived yet; run `instacart config set-address --id %s` to auto-fill)", app.Cfg.AddressID, app.Cfg.AddressID)
+				} else {
+					detail = fmt.Sprintf("coords only (lat=%v, lon=%v)", app.Cfg.Latitude, app.Cfg.Longitude)
+				}
+				results = append(results, checkResult{Name: "location", Status: "ok", Detail: detail})
+			} else {
+				results = append(results, checkResult{
+					Name:   "location",
+					Status: "fail",
+					Detail: "no latitude/longitude or address_id in config — `search`, `add`, and `cart show` will fail until this is set. Fix: `instacart auth login` (tries to auto-populate), `instacart config set-address --id <id>`, or `instacart config set-coords --lat <N> --lon <N>`.",
+				})
+			}
+
 			// 2. SQLite store
 			results = append(results, checkResult{Name: "store", Status: "ok", Detail: app.Store.Path()})
 

--- a/library/commerce/instacart/internal/cli/root.go
+++ b/library/commerce/instacart/internal/cli/root.go
@@ -122,6 +122,8 @@ No browser automation. No Playwright. No Composio subscription. Just a binary.`,
 	root.AddCommand(
 		newDoctorCmd(),
 		newAuthCmd(),
+		// PATCH (fix-instacart-location-config-546): config subtree.
+		newConfigCmd(),
 		newRetailersCmd(),
 		newSearchCmd(),
 		newAddCmd(),


### PR DESCRIPTION
Closes #546. Picks up where #539 left off, this time addressing the underlying cold-install UX gap rather than the symptom shape.

## Context from @kmanan's report

PR #539 correctly stopped sending `{0,0}` coordinates that were silently masking the gap. Post-merge, the symptom became a louder schema rejection (`Variable $coordinates of type UsersCoordinatesInput! was provided invalid value`) — but a clean cold-install user following the documented Quick Start (`auth login → doctor → capture`) still couldn't run a single uncached `search`, `add`, or `cart show`. The `latitude`/`longitude`/`address_id` config keys weren't mentioned anywhere user-facing, and `instacart doctor` reported `[ok]` against the broken state.

kmanan suggested three fixes (any one closes the gap); this PR ships all three.

## What changed

### 1. `instacart config` subtree (new)

Three subcommands so users never need to hand-edit `config.json`:

- **`instacart config show`** — print current location keys, warn when incomplete.
- **`instacart config set-coords --lat <N> --lon <N> [--postal <zip>]`** — save coordinates directly. Useful when you have lat/lon from Google Maps right-click → "What's here?" but not an Instacart address ID.
- **`instacart config set-address --id <uuid>`** — save an Instacart address ID and **auto-derive** `postal_code`, `latitude`, `longitude` by calling the already-cached `GetAddressById` op. No new persisted-query capture needed — the op exists.

### 2. Auto-populate location on `auth login` / `auth paste` / `auth import-file`

After a successful cookie import, the CLI posts a `CurrentUserAddresses` query (full query text via POST, leveraging the existing `client.Mutation` path that already handles unhashed queries — same path `UpdateCartItemsMutation` uses) to fetch the user's default Instacart address. On success, it persists `address_id`, `postal_code`, `latitude`, `longitude` automatically. On any failure (schema rejection, no addresses, network) it prints a one-line note pointing at the manual setters and continues — the auth flow itself already succeeded, so a best-effort enrichment shouldn't mask that.

Skips silently when location is already configured to avoid clobbering user values on relogin.

### 3. `doctor` location check

New `location` check between `config` and `store`. Returns `status: ok` when coordinates OR an address_id is set (with detail describing what's populated), and `status: fail` with actionable remediation when neither is set:

```
[fail] location: no latitude/longitude or address_id in config — `search`, `add`, and `cart show` will fail until this is set. Fix: `instacart auth login` (tries to auto-populate), `instacart config set-address --id <id>`, or `instacart config set-coords --lat <N> --lon <N>`.
```

### 4. README + SKILL docs

Quick Start now references the auto-populate behavior and shows the manual fallbacks. SKILL gains a `## Location Setup` section so agents driving the CLI know how to recover when `doctor` returns the `location: fail` signal.

## What I didn't do

- **Did not capture a new persisted-query hash** for `CurrentUserAddresses`. The wrapper's `client.Mutation` already supports POST-with-query-text (unhashed) for `UpdateCartItemsMutation`; this PR uses the same path. If Instacart's server rejects the query for any reason, the user sees a clear note and falls back to the manual setters — no broken cold-install state remains.
- **Did not change `config_location` or the existing `geocodeLookup` helper.** Those still work as-is for `config set-location` flows; this PR adds a parallel path optimized for cold-install.

## Patch index

Recorded as `fix-instacart-location-config-546` in `.printing-press-patches.json`. Each touched Go file (`config.go`, `auth.go`, `doctor.go`, `root.go`) carries a `// PATCH (fix-instacart-location-config-546):` marker per the library's hand-authored-customization contract.

## Pre-existing validate failures (out of scope)

`printing-press publish validate` still reports three failures that predate this PR and #539:
- `manifest: missing run_id` 
- `transcendence: no novel features recorded` 
- `phase5: cannot locate Phase 5 gate proof`

These are instacart manifest-shape gaps from the original 1.2.1-era print. The library CI doesn't gate on them (the relevant blocking check is `Verify library conventions`). Fixing them is appropriate work for a separate dedicated PR.
