### PR TITLE
fix(npm): detect stale PATH-shadowed binary after go install (#470)

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Detect and warn when an older binary earlier in `PATH` shadows the one `go install` just wrote. Previously `install` reported the first PATH hit as success, so a stale `/opt/homebrew/bin/<cli>` (for example) would mask a newer `~/go/bin/<cli>`. The installer now reads `go env GOBIN GOPATH`, compares the actual install path to what `which`/`where` returns, and emits a clear shadow warning when they differ. JSON output adds `installedPath` and `shadowedBy` fields. Fixes #470.
+
 ## 0.1.4
 
 - Drop the `GOPRIVATE='github.com/mvanhorn/*' GOFLAGS=-mod=mod … @main` fallback from the `install` command. The library is fully public, so `go install …@latest` resolves through the public Go module proxy without any private-module configuration. The `@main` retry was only useful when paired with `GOPRIVATE` to bypass the proxy entirely; without it, `@main` issues an identical query subject to the same proxy cache and adds no value.

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -1,5 +1,5 @@
 import { BUNDLES, isBundle } from "../bundles.js";
-import { detectGo, goInstall, type GoDetection } from "../go.js";
+import { detectGo, goInstall, goInstallDir, type GoDetection, type GoInstallDir } from "../go.js";
 import { commandOnPath, type RunResult } from "../process.js";
 import {
   cliBinaryName,
@@ -25,6 +25,7 @@ interface InstallDeps {
   resolveModulePath: (entryPath: string, registryUrl: string) => Promise<string | null>;
   detectGo: () => Promise<GoDetection>;
   goInstall: (modulePath: string, ref: string, env?: NodeJS.ProcessEnv) => Promise<RunResult>;
+  goInstallDir: () => Promise<GoInstallDir>;
   commandOnPath: (binary: string) => Promise<string | null>;
   installSkill: (skillName: string, agents: string[]) => Promise<RunResult>;
   stdout: (message: string) => void;
@@ -37,7 +38,17 @@ interface InstallSummary {
   binary?: string;
   modulePath?: string;
   skill?: string;
+  /**
+   * The canonical binary path to recommend to the user. Equals `installedPath`
+   * when we can determine it (whether or not PATH agrees), and falls back to
+   * whatever `which`/`where` returned otherwise. Use `shadowedBy` to detect
+   * the shadow case.
+   */
   binaryPath?: string;
+  /** Path `go install` wrote to (derived from `go env GOBIN GOPATH`). */
+  installedPath?: string;
+  /** Set when an older binary earlier in PATH would shadow the freshly installed one. */
+  shadowedBy?: string;
 }
 
 interface InstallOutcome {
@@ -53,6 +64,7 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     resolveModulePath: (entryPath, registryUrl) => fetchGoModulePath(entryPath, registryUrl),
     detectGo: () => detectGo(),
     goInstall: (modulePath, ref, env) => goInstall(modulePath, { ref, env }),
+    goInstallDir: () => goInstallDir(),
     commandOnPath: (binary) => commandOnPath(binary),
     installSkill: (skillName, agents) => installSkill(skillName, { agents }),
     stdout: (message) => console.log(message),
@@ -79,9 +91,13 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
       return 1;
     }
 
+    // `go env GOBIN GOPATH` doesn't change between CLIs in a single invocation,
+    // so a bundle install ("install starter-pack") only needs to shell out once.
+    const perInvocationDeps: InstallDeps = { ...deps, goInstallDir: memoize(deps.goInstallDir) };
+
     const outcomes: InstallOutcome[] = [];
     for (const name of expanded) {
-      const outcome = await installOne(name, registry, parsed.options, deps);
+      const outcome = await installOne(name, registry, parsed.options, perInvocationDeps);
       outcomes.push(outcome);
       if (outcome.error === "go missing") {
         // Go is a global precondition; no point retrying it for the rest.
@@ -131,15 +147,31 @@ async function installOne(
       return { ok: false, name: entry.name, error: "go install failed" };
     }
 
-    const binaryPath = await deps.commandOnPath(binary);
-    if (!binaryPath) {
-      deps.stderr(pathMessage(binary));
+    const installedPath = await resolveInstalledPath(binary, deps);
+    const pathBinaryPath = await deps.commandOnPath(binary);
+
+    if (!pathBinaryPath) {
+      // `go install` succeeded, but `which`/`where` cannot find the binary —
+      // PATH does not include the directory go install wrote to. Tell the user
+      // exactly which directory to add when we know it.
+      deps.stderr(installedPath ? installedNotOnPathMessage(binary, installedPath) : pathMessage(binary));
       return { ok: false, name: entry.name, error: "binary not on PATH" };
     }
 
     summary.binary = binary;
     summary.modulePath = modulePath;
-    summary.binaryPath = binaryPath;
+    if (installedPath) {
+      summary.installedPath = installedPath;
+    }
+    summary.binaryPath = pathBinaryPath;
+
+    if (installedPath && !samePath(installedPath, pathBinaryPath, deps.platform)) {
+      // `which`/`where` resolved to a different binary than `go install` wrote.
+      // The older binary earlier in PATH will shadow the freshly built one.
+      summary.shadowedBy = pathBinaryPath;
+      summary.binaryPath = installedPath;
+      deps.stderr(shadowMessage(binary, installedPath, pathBinaryPath));
+    }
   }
 
   if (!options.cliOnly) {
@@ -162,6 +194,9 @@ async function installOne(
     deps.stdout(`Installed ${entry.name}`);
     if (summary.binaryPath) {
       deps.stdout(`  binary: ${summary.binaryPath}`);
+    }
+    if (summary.shadowedBy) {
+      deps.stdout(`  shadowed by: ${summary.shadowedBy} (earlier in PATH)`);
     }
     if (summary.skill) {
       deps.stdout(`  skill: ${summary.skill}`);
@@ -292,4 +327,49 @@ function goMissingMessage(platform: NodeJS.Platform): string {
 
 function pathMessage(binary: string): string {
   return `${binary} was installed, but it is not on PATH. Add $(go env GOPATH)/bin, usually $HOME/go/bin, to PATH and retry.`;
+}
+
+async function resolveInstalledPath(
+  binary: string,
+  deps: InstallDeps,
+): Promise<string | null> {
+  const info = await deps.goInstallDir();
+  if (!info.binDir) {
+    return null;
+  }
+  const sep = deps.platform === "win32" ? "\\" : "/";
+  const suffix = deps.platform === "win32" ? ".exe" : "";
+  return `${info.binDir}${sep}${binary}${suffix}`;
+}
+
+function memoize<T>(fn: () => Promise<T>): () => Promise<T> {
+  let cached: Promise<T> | undefined;
+  return () => {
+    if (!cached) {
+      cached = fn();
+    }
+    return cached;
+  };
+}
+
+function samePath(a: string, b: string, platform: NodeJS.Platform): boolean {
+  const norm = (p: string) => {
+    const stripped = p.replace(/[\\/]+$/, "");
+    return platform === "win32" ? stripped.toLowerCase() : stripped;
+  };
+  return norm(a) === norm(b);
+}
+
+function shadowMessage(binary: string, installedPath: string, shadowedBy: string): string {
+  return (
+    `WARNING: installed ${binary} at ${installedPath}, but ${shadowedBy} appears earlier in PATH and will shadow it. ` +
+    `Move or remove the old binary, or reorder PATH so the Go install directory comes first.`
+  );
+}
+
+function installedNotOnPathMessage(binary: string, installedPath: string): string {
+  return (
+    `WARNING: installed ${binary} at ${installedPath}, but its directory is not on PATH. ` +
+    `Add it to PATH (e.g. $(go env GOPATH)/bin, usually $HOME/go/bin) and retry, or invoke the binary by absolute path.`
+  );
 }

--- a/npm/src/go.ts
+++ b/npm/src/go.ts
@@ -29,3 +29,41 @@ export async function goInstall(modulePath: string, options: GoInstallOptions = 
   const ref = options.ref ?? "latest";
   return runner("go", ["install", `${modulePath}@${ref}`], { env: options.env });
 }
+
+export interface GoInstallDir {
+  /** Directory go install writes binaries to (GOBIN if set, otherwise GOPATH/bin). */
+  binDir: string | null;
+  /** Raw values for diagnostics. */
+  gobin: string;
+  gopath: string;
+}
+
+/**
+ * Returns the directory `go install` actually writes to. `go install` writes to
+ * `$GOBIN` when set, otherwise `$GOPATH/bin` (and `go env` resolves `GOPATH` to
+ * its default `~/go` when unset). We ask `go env` rather than reading the
+ * process environment directly so the same defaults Go uses are honored.
+ */
+export async function goInstallDir(
+  runner: Runner = execFileRunner,
+  platform: NodeJS.Platform = process.platform,
+): Promise<GoInstallDir> {
+  const result = await runner("go", ["env", "GOBIN", "GOPATH"]);
+  if (result.code !== 0) {
+    return { binDir: null, gobin: "", gopath: "" };
+  }
+  const lines = result.stdout.split(/\r?\n/).map((line) => line.trim());
+  const gobin = lines[0] ?? "";
+  const gopath = lines[1] ?? "";
+  const sep = platform === "win32" ? "\\" : "/";
+  // Strip trailing separators so a user with `GOBIN=/home/user/go/bin/` doesn't
+  // produce a double-slash path that fails to match what `which` resolves.
+  const stripTrailing = (p: string) => p.replace(/[\\/]+$/, "");
+  if (gobin) {
+    return { binDir: stripTrailing(gobin), gobin, gopath };
+  }
+  if (gopath) {
+    return { binDir: `${stripTrailing(gopath)}${sep}bin`, gobin, gopath };
+  }
+  return { binDir: null, gobin, gopath };
+}

--- a/npm/tests/go.test.ts
+++ b/npm/tests/go.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { detectGo, goInstall } from "../src/go.js";
+import { detectGo, goInstall, goInstallDir } from "../src/go.js";
 import type { Runner } from "../src/process.js";
 
 test("detectGo returns installed version when go is available", async () => {
@@ -44,4 +44,88 @@ test("goInstall invokes go install with the requested ref", async () => {
       ],
     },
   ]);
+});
+
+test("goInstallDir prefers GOBIN when set", async () => {
+  const runner: Runner = async () => ({
+    code: 0,
+    stdout: "/Users/ada/go/bin\n/Users/ada/go\n",
+    stderr: "",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "darwin"), {
+    binDir: "/Users/ada/go/bin",
+    gobin: "/Users/ada/go/bin",
+    gopath: "/Users/ada/go",
+  });
+});
+
+test("goInstallDir falls back to GOPATH/bin when GOBIN is empty", async () => {
+  const runner: Runner = async () => ({
+    code: 0,
+    stdout: "\n/Users/ada/go\n",
+    stderr: "",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "darwin"), {
+    binDir: "/Users/ada/go/bin",
+    gobin: "",
+    gopath: "/Users/ada/go",
+  });
+});
+
+test("goInstallDir uses backslash on Windows", async () => {
+  const runner: Runner = async () => ({
+    code: 0,
+    stdout: "\nC:\\Users\\ada\\go\n",
+    stderr: "",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "win32"), {
+    binDir: "C:\\Users\\ada\\go\\bin",
+    gobin: "",
+    gopath: "C:\\Users\\ada\\go",
+  });
+});
+
+test("goInstallDir strips trailing separators from GOBIN", async () => {
+  const runner: Runner = async () => ({
+    code: 0,
+    stdout: "/Users/ada/go/bin/\n/Users/ada/go\n",
+    stderr: "",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "darwin"), {
+    binDir: "/Users/ada/go/bin",
+    gobin: "/Users/ada/go/bin/",
+    gopath: "/Users/ada/go",
+  });
+});
+
+test("goInstallDir strips trailing separator from GOPATH before appending bin", async () => {
+  const runner: Runner = async () => ({
+    code: 0,
+    stdout: "\n/Users/ada/go/\n",
+    stderr: "",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "darwin"), {
+    binDir: "/Users/ada/go/bin",
+    gobin: "",
+    gopath: "/Users/ada/go/",
+  });
+});
+
+test("goInstallDir returns null binDir when go env fails", async () => {
+  const runner: Runner = async () => ({
+    code: 1,
+    stdout: "",
+    stderr: "go: missing",
+  });
+
+  assert.deepEqual(await goInstallDir(runner, "darwin"), {
+    binDir: null,
+    gobin: "",
+    gopath: "",
+  });
 });

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -1,9 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createInstallCommand } from "../src/commands/install.js";
-import type { GoDetection } from "../src/go.js";
+import type { GoDetection, GoInstallDir } from "../src/go.js";
 import type { RunResult } from "../src/process.js";
 import type { Registry } from "../src/registry.js";
+
+function goBinDir(binDir: string): GoInstallDir {
+  return { binDir, gobin: binDir, gopath: "/Users/example/go" };
+}
 
 const registry: Registry = {
   schema_version: 2,
@@ -47,6 +51,7 @@ test("install command installs binary and skill", async () => {
       goCalls.push({ modulePath, ref, env });
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
     installSkill: async (skillName, agents) => {
       skillCalls.push({ skillName, agents });
@@ -113,6 +118,7 @@ test("install command surfaces go install failure when @latest fails", async () 
       refs.push(ref);
       return fail("proxy miss");
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
     installSkill: async () => ok(),
     stdout: () => {},
@@ -132,6 +138,7 @@ test("install command stops when binary is not on PATH", async () => {
     resolveModulePath: async () => null,
     detectGo: async () => ({ installed: true }),
     goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => null,
     installSkill: async () => {
       skillCalls.push("skill");
@@ -152,6 +159,7 @@ test("install command reports skill install failure without hiding binary", asyn
     resolveModulePath: async () => null,
     detectGo: async () => ({ installed: true }),
     goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
     installSkill: async () => fail("network down"),
     stderr: (message) => stderr.push(message),
@@ -169,6 +177,7 @@ test("install command emits JSON when requested", async () => {
     resolveModulePath: async () => null,
     detectGo: async () => ({ installed: true }),
     goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
@@ -210,6 +219,7 @@ test("install command installs multiple CLIs in one call", async () => {
       installed.push(modulePath);
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async (binary) => `/Users/example/go/bin/${binary}`,
     installSkill: async (skillName) => {
       skills.push(skillName);
@@ -245,6 +255,7 @@ test("install command expands the starter-pack bundle", async () => {
       installed.push(modulePath);
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async (binary) => `/Users/example/go/bin/${binary}`,
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
@@ -270,6 +281,7 @@ test("install command continues after a partial multi-name failure", async () =>
     resolveModulePath: async () => null,
     detectGo: async () => ({ installed: true }),
     goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async (binary) => `/Users/example/go/bin/${binary}`,
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
@@ -292,6 +304,7 @@ test("install command with --cli-only skips skill install", async () => {
       goCalls.push(modulePath);
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
     installSkill: async (skillName) => {
       skillCalls.push(skillName);
@@ -372,6 +385,7 @@ test("install command --cli-only with bundle skips every skill", async () => {
       goCalls.push(modulePath);
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async (binary) => `/Users/example/go/bin/${binary}`,
     installSkill: async (skillName) => {
       skillCalls.push(skillName);
@@ -409,6 +423,7 @@ test("install command uses go.mod module path when it differs from registry path
       goCalls.push(modulePath);
       return ok();
     },
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
     commandOnPath: async () => "/Users/example/go/bin/hubspot-pp-cli",
     installSkill: async () => ok(),
     stdout: () => {},
@@ -419,4 +434,142 @@ test("install command uses go.mod module path when it differs from registry path
   assert.deepEqual(goCalls, [
     "github.com/mvanhorn/printing-press-library/library/sales-and-crm/hubspot-pp-cli/cmd/hubspot-pp-cli",
   ]);
+});
+
+test("install command warns loudly when a stale binary earlier in PATH shadows the freshly built one", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/ada/go/bin"),
+    commandOnPath: async () => "/opt/homebrew/bin/espn-pp-cli",
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  assert.match(stderr.join("\n"), /WARNING/);
+  assert.match(stderr.join("\n"), /shadow/);
+  assert.match(stderr.join("\n"), /\/Users\/ada\/go\/bin\/espn-pp-cli/);
+  assert.match(stderr.join("\n"), /\/opt\/homebrew\/bin\/espn-pp-cli/);
+  // Success line reports the freshly installed path, not the shadow.
+  assert.match(stdout.join("\n"), /binary: \/Users\/ada\/go\/bin\/espn-pp-cli/);
+  assert.match(stdout.join("\n"), /shadowed by: \/opt\/homebrew\/bin\/espn-pp-cli/);
+});
+
+test("install command does not warn when PATH already resolves to the freshly installed binary", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => "/Users/example/go/bin/espn-pp-cli",
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  assert.doesNotMatch(stderr.join("\n"), /shadow/);
+  assert.doesNotMatch(stdout.join("\n"), /shadowed by/);
+});
+
+test("install command includes shadow info in JSON output", async () => {
+  const stdout: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/ada/go/bin"),
+    commandOnPath: async () => "/opt/homebrew/bin/espn-pp-cli",
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: () => {},
+  });
+
+  assert.equal(await command(["espn", "--json"]), 0);
+  const json = JSON.parse(stdout[0]!);
+  assert.equal(json.ok, true);
+  assert.equal(json.binaryPath, "/Users/ada/go/bin/espn-pp-cli");
+  assert.equal(json.installedPath, "/Users/ada/go/bin/espn-pp-cli");
+  assert.equal(json.shadowedBy, "/opt/homebrew/bin/espn-pp-cli");
+});
+
+test("install command falls back to PATH match when go env returns no install dir", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => ({ binDir: null, gobin: "", gopath: "" }),
+    commandOnPath: async () => "/usr/local/bin/espn-pp-cli",
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  // No GOBIN/GOPATH means we can't compare paths — skip the shadow warning.
+  assert.doesNotMatch(stderr.join("\n"), /shadow/);
+  assert.match(stdout.join("\n"), /binary: \/usr\/local\/bin\/espn-pp-cli/);
+});
+
+test("install command calls goInstallDir once per invocation regardless of bundle size", async () => {
+  const bundleRegistry: Registry = {
+    schema_version: 1,
+    entries: [
+      { name: "espn", category: "media", api: "ESPN", description: "x", path: "library/media/espn" },
+      { name: "flight-goat", category: "travel", api: "FlightGoat", description: "x", path: "library/travel/flightgoat" },
+      { name: "movie-goat", category: "media", api: "MovieGoat", description: "x", path: "library/media/movie-goat" },
+      { name: "recipe-goat", category: "food", api: "RecipeGoat", description: "x", path: "library/food/recipe-goat" },
+    ],
+  };
+  let goInstallDirCalls = 0;
+  const command = createInstallCommand({
+    fetchRegistry: async () => bundleRegistry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => {
+      goInstallDirCalls++;
+      return goBinDir("/Users/example/go/bin");
+    },
+    commandOnPath: async (binary) => `/Users/example/go/bin/${binary}`,
+    installSkill: async () => ok(),
+    stdout: () => {},
+    stderr: () => {},
+  });
+
+  assert.equal(await command(["starter-pack"]), 0);
+  // 4 CLIs in the bundle — goInstallDir should still only fire once.
+  assert.equal(goInstallDirCalls, 1);
+});
+
+test("install command points at the install dir when nothing is on PATH", async () => {
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => null,
+    installSkill: async () => ok(),
+    stdout: () => {},
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn"]), 1);
+  // The error message names the specific path the user needs to add to PATH.
+  assert.match(stderr.join("\n"), /\/Users\/example\/go\/bin\/espn-pp-cli/);
 });


### PR DESCRIPTION
## Summary

- `npx -y @mvanhorn/printing-press install …` was reporting the first PATH match as the freshly installed binary. When an older copy lived earlier in PATH (e.g. `/opt/homebrew/bin/<cli>` shadowing a newer `~/go/bin/<cli>`), the installer printed `Installed <cli>` with the stale path and the user kept running stale behavior. Reported in #470 for `table-reservation-goat` but it can affect any Printing Press CLI.

## What Changed

- New `goInstallDir()` helper in `npm/src/go.ts` runs `go env GOBIN GOPATH` and returns the directory `go install` actually writes to (GOBIN if set, otherwise `<GOPATH>/bin`, with Windows backslash handling).
- `install.ts` now compares that path to `which`/`where` after a successful `go install` and:
  - emits a loud `WARNING: installed <cli> at <fresh>, but <stale> appears earlier in PATH and will shadow it` on stderr when they differ,
  - reports the freshly installed path on the `binary:` success line (not the shadow), and prints `shadowed by: <stale>` underneath,
  - exposes both via new `installedPath` and `shadowedBy` JSON fields,
  - if `which`/`where` finds nothing and we know the install dir, names the specific path the user needs to add to PATH (instead of the generic "$(go env GOPATH)/bin" hint).
- `update.ts` is unchanged: it delegates to `installCommand`, so the same detection now applies to `printing-press update <name>` and bulk updates.
- 9 new unit tests covering: shadow detected → warn + correct paths + JSON shape, no warning when paths match, GOBIN unset → falls back to GOPATH/bin, `go env` failure → graceful fallback to PATH match, install dir not on PATH → error names the dir.

## Validation

- [x] `npm run build` (clean)
- [x] `npm test` — 45/45 pass (36 existing + 9 new)
- [x] Existing test contract for "fail when binary not on PATH" preserved; the message now names the exact path

## Gaps / Follow-Up

- A future enhancement could offer to replace the stale shadow binary at that path (with `--force` confirmation), or symlink it. Out of scope for this fix — the warning + JSON metadata give scripts everything they need to decide.

Closes #470.