### PR TITLE
fix(notion): search 400 on empty sort + sync --full 400 on views

### DIFF
--- a/library/productivity/notion/.printing-press-patches.json
+++ b/library/productivity/notion/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-09",
+  "applied_at": "2026-05-14",
   "base_run_id": "20260508-225745",
   "base_printing_press_version": "4.0.6",
   "patches": [
@@ -22,6 +22,24 @@
         "internal/cli/pages_markdown_update-page.go"
       ],
       "validated_outcome": "pages markdown import <id> --markdown '# Title\\n\\nBody' returns 200 and replaces page content."
+    },
+    {
+      "id": "fix-search-omit-empty-sort-333",
+      "summary": "Send only `query` in the POST /v1/search body; drop the empty sort/filter/page_size/start_cursor fields the API rejects.",
+      "reason": "Reported in #333. Notion's POST /v1/search rejects an empty `sort: {}` because the sort object, when present, must include both `direction` and `timestamp`. The same constraint applies to `filter` (needs `value` + `property`) and `start_cursor` (must be a valid cursor from a prior response). The generated handler unconditionally included all four as empty/nil values, so every `search` call returned HTTP 400 validation_error. Until this CLI surfaces flags for sort/filter/pagination, the cleanest fix is to send only the `query` field and let the API apply its own defaults.",
+      "files": [
+        "internal/cli/search.go"
+      ],
+      "validated_outcome": "notion-pp-cli search \"\" now returns 200 with the API's default ordering; previously returned HTTP 400 'body.sort.timestamp should be defined'."
+    },
+    {
+      "id": "fix-sync-views-requires-scope-334",
+      "summary": "Drop `views` from the default sync resource list because /v1/views cannot be called without a database_id/data_source_id scope.",
+      "reason": "Reported in #334. Notion's GET /v1/views rejects every unscoped call with HTTP 400 'At least one of database_id or data_source_id must be provided.' Notion exposes no listing endpoint for databases or data sources either (databases are discovered via POST /v1/search; data sources via /v1/databases/{id}/data_sources), so there is no parent-table enumeration path in the local store today. `sync --full` therefore always errored on the views resource, and the dependent `queries` resource never had a parent table to iterate. Removing views from defaultSyncResources stops the error; users who want views populated can run `notion-pp-cli views list --data-source-id <id>` per data source.",
+      "files": [
+        "internal/cli/sync.go"
+      ],
+      "validated_outcome": "notion-pp-cli sync --full no longer emits a sync_error for views; the views resource is simply skipped. Per-data-source population via `views list --data-source-id <id>` remains available."
     }
   ]
 }

--- a/library/productivity/notion/internal/cli/pages_markdown_update-page.go
+++ b/library/productivity/notion/internal/cli/pages_markdown_update-page.go
@@ -120,6 +120,8 @@ func newPagesMarkdownUpdatePageCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&stdinBody, "stdin", false, "Read request body as JSON from stdin (advanced: full discriminated union body)")
+	// PATCH(markdown-import-flag): hand-added user-facing flag that wraps content
+	// in Notion's required {type: replace_content, replace_content: {...}} body.
 	cmd.Flags().StringVar(&markdownContent, "markdown", "", "Replace page content with this markdown string")
 
 	return cmd

--- a/library/productivity/notion/internal/cli/search.go
+++ b/library/productivity/notion/internal/cli/search.go
@@ -117,13 +117,15 @@ In local mode: searches locally synced data only.`,
 				if err != nil {
 					return err
 				}
-				data, _, getErr := c.Post("/v1/search", map[string]any{
-					"query": query,
-					"filter": map[string]any{},
-					"page_size": nil,
-					"sort": map[string]any{},
-					"start_cursor": "",
-				})
+				// PATCH (fix-search-omit-empty-sort-333): Notion rejects an empty
+				// `sort: {}` with HTTP 400 because, when sort is present, it
+				// requires both `direction` and `timestamp`. The same is true of
+				// `filter` (needs `value` + `property`) and `start_cursor` (must
+				// be a valid cursor). Send only `query`; let the API apply its
+				// own defaults for everything else until this CLI surfaces flags
+				// for sort/filter/pagination.
+				body := map[string]any{"query": query}
+				data, _, getErr := c.Post("/v1/search", body)
 				if getErr == nil {
 					// Live search succeeded
 					results := extractSearchResults(data)

--- a/library/productivity/notion/internal/cli/sync.go
+++ b/library/productivity/notion/internal/cli/sync.go
@@ -873,6 +873,10 @@ func syncResourcePath(resource string) (string, error) {
 		"custom-emojis": "/v1/custom_emojis",
 		"file-uploads": "/v1/file_uploads",
 		"users": "/v1/users",
+		// PATCH (fix-sync-views-requires-scope-334): retained in the lookup so
+		// `--resources views` still resolves to the canonical endpoint and
+		// surfaces the API's own scope-required error. Removed from
+		// defaultSyncResources() because /v1/views rejects every unscoped call.
 		"views": "/v1/views",
 	}
 	if p, ok := paths[resource]; ok {

--- a/library/productivity/notion/internal/cli/sync.go
+++ b/library/productivity/notion/internal/cli/sync.go
@@ -849,12 +849,18 @@ func parseSinceDuration(s string) (time.Time, error) {
 }
 
 func defaultSyncResources() []string {
+	// PATCH (fix-sync-views-requires-scope-334): `views` is intentionally
+	// excluded. Notion's GET /v1/views rejects any unscoped call with HTTP 400
+	// "At least one of database_id or data_source_id must be provided." Notion
+	// also exposes no global GET /v1/databases or GET /v1/data_sources listing
+	// endpoint, so there is no parent-table enumeration path in the local
+	// store today. Populate views per data source via:
+	//   notion-pp-cli views list --data-source-id <id>
 	return []string{
 		"comments",
 		"custom-emojis",
 		"file-uploads",
 		"users",
-		"views",
 	}
 }
 

--- a/library/productivity/notion/internal/cli/sync_views_test.go
+++ b/library/productivity/notion/internal/cli/sync_views_test.go
@@ -1,0 +1,20 @@
+// PATCH (fix-sync-views-requires-scope-334): regression guard so a future
+// regeneration or hand-edit cannot quietly re-add `views` to the default sync
+// resource list. /v1/views requires a database_id or data_source_id scope, so
+// including it in an unscoped sync errors every time. See
+// .printing-press-patches.json entry fix-sync-views-requires-scope-334.
+
+package cli
+
+import "testing"
+
+func TestDefaultSyncResourcesExcludesViews(t *testing.T) {
+	for _, r := range defaultSyncResources() {
+		if r == "views" {
+			t.Fatalf("defaultSyncResources() must not include %q: "+
+				"the Notion /v1/views endpoint rejects every unscoped call "+
+				"with HTTP 400. See .printing-press-patches.json entry "+
+				"fix-sync-views-requires-scope-334.", r)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two Notion CLI bugs reported by @dubber-icf during a fresh install. Both are single-CLI manifestations of API constraints that the generated code didn't model. Hand-edits to `library/productivity/notion/`, recorded in `.printing-press-patches.json` per the repo convention.

### #333 — `search` always returns HTTP 400

`POST /v1/search` was sending `sort: {}` (and empty `filter`, `page_size: nil`, `start_cursor: \"\"`). Notion's API rejects an empty sort object because, when sort is present, it must include both `direction` and `timestamp`. Same constraint applies to `filter` (needs `value` + `property`) and `start_cursor` (must be a real cursor from a prior response).

**Fix:** send only `{\"query\": <query>}` and let the API apply its defaults. Until this CLI surfaces flags for sort/filter/pagination, that's the cleanest body — and matches the issue reporter's option (b).

### #334 — `sync --full` errors on the views resource

`GET /v1/views` requires `database_id` or `data_source_id`; an unscoped call returns 400. Notion exposes no global listing endpoint for databases (`/v1/search` is the only path) or for data sources (they live under `/v1/databases/{id}/data_sources`), so there is no parent-table enumeration today in the local store.

**Fix:** drop `views` from `defaultSyncResources()`. Users who want views populated can run `notion-pp-cli views list --data-source-id <id>` per data source. The dependent `queries` resource already skips cleanly when the `views` parent table is empty (existing \"parent table is empty, sync it first\" code path), so removing views doesn't create a new gap.

Both edits are marked with `// PATCH (...)` source comments. A regression test (`sync_views_test.go`) fails if `views` is re-added to `defaultSyncResources()`.

## Why not fix the generator

Both fits the AGENTS.md \"single-CLI manifestation\" criterion:

- #333 is a Notion-specific API constraint on the search body shape — most search endpoints accept empty optional objects, so a generator change here would either special-case Notion or change a default that other CLIs may rely on.
- #334 is a Notion-specific API constraint plus a Notion-specific listing-endpoint gap. A generator change would need both to detect endpoints that require a scope param and to know how to enumerate the scope, neither of which generalizes from a single API.

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green, new regression test passes
- [x] `govulncheck ./...` — \"No vulnerabilities found\"

Closes #333.  
Closes #334.