### PR TITLE
fix(yahoo-finance): dry-run URL preview joins params with `&` not `?`

### DIFF
--- a/library/commerce/yahoo-finance/.printing-press-patches.json
+++ b/library/commerce/yahoo-finance/.printing-press-patches.json
@@ -1,7 +1,18 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-08",
+  "applied_at": "2026-05-14",
   "base_run_id": "20260411-210148",
   "base_printing_press_version": "1.3.2",
-  "patches": []
+  "patches": [
+    {
+      "id": "fix-fundamentals-dry-run-url-506",
+      "summary": "Render the dry-run URL via url.Values so every query param after the first is joined with `&` instead of `?`.",
+      "reason": "Reported in #506. dryRunWithCrumb printed each param on its own line prefixed with `?`, so `--dry-run` output looked like the live URL was malformed (e.g. `...?type=...?period1=...?crumb=...`). The actual HTTP path always used net/http's q.Encode() and was fine; only the preview was misleading. Building the preview through url.Values matches what the real request sends and removes the false signal.",
+      "files": [
+        "internal/client/client.go",
+        "internal/client/client_test.go"
+      ],
+      "validated_outcome": "Dry-run preview for `fundamentals NVDA --period1 ... --type ...` now prints a single line `GET https://...?type=...&period1=...&crumb=...`. New TestDryRunURLJoinsParamsWithAmpersand asserts the preview never produces a second `?` prefix in the query string."
+    }
+  ]
 }

--- a/library/commerce/yahoo-finance/internal/client/client.go
+++ b/library/commerce/yahoo-finance/internal/client/client.go
@@ -572,18 +572,34 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	return c.dryRunWithCrumb(method, targetURL, path, params, body, headerOverrides, c.Crumb())
 }
 
-func (c *Client) dryRunWithCrumb(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, crumb string) (json.RawMessage, int, error) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
-	if params != nil {
-		for k, v := range params {
-			if v != "" {
-				fmt.Fprintf(os.Stderr, "  ?%s=%s\n", k, v)
-			}
+// dryRunDisplayURL is the helper behind dryRunWithCrumb. It mirrors the
+// net/http q.Encode() path the real request takes, so the --dry-run preview
+// faithfully represents the URL that would be sent.
+//
+// PATCH (fix-fundamentals-dry-run-url-506): the old printer wrote each
+// parameter on its own line prefixed with `?`, which made the preview look
+// like the live URL was malformed (e.g. `...?type=...?period1=...?crumb=...`).
+// The live HTTP path always used q.Encode() and was fine; only the preview
+// was wrong.
+func dryRunDisplayURL(targetURL string, params map[string]string, crumb string) string {
+	q := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
 		}
 	}
 	if crumb != "" {
-		fmt.Fprintf(os.Stderr, "  ?crumb=%s\n", crumb)
+		q.Set("crumb", crumb)
 	}
+	encoded := q.Encode()
+	if encoded == "" {
+		return targetURL
+	}
+	return targetURL + "?" + encoded
+}
+
+func (c *Client) dryRunWithCrumb(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, crumb string) (json.RawMessage, int, error) {
+	fmt.Fprintf(os.Stderr, "%s %s\n", method, dryRunDisplayURL(targetURL, params, crumb))
 	if body != nil {
 		var pretty json.RawMessage
 		if json.Unmarshal(body, &pretty) == nil {

--- a/library/commerce/yahoo-finance/internal/client/client_test.go
+++ b/library/commerce/yahoo-finance/internal/client/client_test.go
@@ -1,0 +1,62 @@
+// PATCH (fix-fundamentals-dry-run-url-506): regression guard for the dry-run
+// URL preview. Issue #506 reported that --dry-run printed every query param
+// prefixed with `?`, suggesting the live URL was malformed. The live HTTP path
+// always used net/http's q.Encode(); only the preview was wrong. These tests
+// pin the corrected behavior so a future regen or hand-edit cannot quietly
+// reintroduce the per-param `?` prefix.
+
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDryRunURLJoinsParamsWithAmpersand(t *testing.T) {
+	got := dryRunDisplayURL(
+		"https://query1.finance.yahoo.com/ws/fundamentals/v1/finance/timeseries/NVDA",
+		map[string]string{
+			"type":    "annualTotalRevenue,quarterlyTotalRevenue",
+			"period1": "1683911800",
+		},
+		"c60pJpDxZC8",
+	)
+	// Exactly one `?` separator — every subsequent param must join with `&`.
+	if strings.Count(got, "?") != 1 {
+		t.Fatalf("expected exactly one `?` in URL, got %d in %q", strings.Count(got, "?"), got)
+	}
+	for _, key := range []string{"type=", "period1=", "crumb="} {
+		if !strings.Contains(got, key) {
+			t.Errorf("expected %q in URL, got %q", key, got)
+		}
+	}
+}
+
+func TestDryRunURLOmitsQueryStringWhenNoParams(t *testing.T) {
+	got := dryRunDisplayURL("https://example.com/path", nil, "")
+	if got != "https://example.com/path" {
+		t.Errorf("expected URL unchanged when no params/crumb, got %q", got)
+	}
+}
+
+func TestDryRunURLSkipsEmptyParamValues(t *testing.T) {
+	// Mirrors the real-request path which also drops empty-string values.
+	got := dryRunDisplayURL(
+		"https://example.com/path",
+		map[string]string{"keep": "yes", "skip": ""},
+		"",
+	)
+	if !strings.Contains(got, "keep=yes") {
+		t.Errorf("expected keep=yes in URL, got %q", got)
+	}
+	if strings.Contains(got, "skip=") {
+		t.Errorf("expected skip= to be dropped, got %q", got)
+	}
+}
+
+func TestDryRunURLIncludesCrumbWhenNoOtherParams(t *testing.T) {
+	got := dryRunDisplayURL("https://example.com/path", nil, "abc123")
+	if got != "https://example.com/path?crumb=abc123" {
+		t.Errorf("expected crumb-only query, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Reported in #506. `yahoo-finance-pp-cli fundamentals NVDA --period1 ... --type ... --dry-run` printed:

```
GET https://query1.finance.yahoo.com/ws/fundamentals/v1/finance/timeseries/NVDA
  ?type=annualTotalRevenue,quarterlyTotalRevenue
  ?period1=1683911800
  ?crumb=c60pJpDxZC8
```

— a leading `?` on every parameter, which made the preview look like the live URL was malformed.

**Root cause:** the bug was in the dry-run *printer*, not the URL builder. The live HTTP path always went through `net/http`'s `q.Encode()` (correct), but `dryRunWithCrumb` looped each param and wrote `fmt.Fprintf(os.Stderr, \"  ?%s=%s\\n\", k, v)`. The reporter only saw it on `fundamentals` because that's what they were debugging — `quote` has the same dry-run printer and the same display bug, just nobody noticed.

## Fix

Extract a `dryRunDisplayURL` helper that mirrors the live `q.Encode()` path and call it from `dryRunWithCrumb`. The dry-run printer now emits a single line:

```
GET https://query1.finance.yahoo.com/ws/fundamentals/v1/finance/timeseries/NVDA?type=...&period1=...&crumb=...
```

— faithfully representing what would be sent over the wire.

## A note on the HTTP 500

The issue mentions Yahoo returns HTTP 500 in non-dry-run mode. The live request URL was always well-formed (verified by reading `client.go:486-497`), so this fix doesn't directly target the 500. If the 500 persists after this fix, it's a Yahoo-side issue worth investigating separately (perhaps a fundamentals-endpoint quirk, missing required combo of params, etc.).

## Why not fix the generator

Single-CLI manifestation. The shared client code is per-printed-CLI and the bug is a one-line printf, not a generator template pattern. Recording in `.printing-press-patches.json` per repo convention.

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — 4 new unit tests cover canonical case, no-params, empty-value skip, crumb-only
- [x] `govulncheck ./...` — \"No vulnerabilities found.\"
- [x] Local publish-package verifier pass

Closes #506.