### PR TITLE
feat(granola): auto-refresh on every CLI invocation

### DIFF
--- a/cli-skills/pp-granola/SKILL.md
+++ b/cli-skills/pp-granola/SKILL.md
@@ -278,6 +278,41 @@ Commands that read from the local store or the API wrap output in a provenance e
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
 
+## Auto-Refresh
+
+Every command auto-refreshes the local store as its first action. You do **not** need to run `granola-pp-cli sync` before `meetings list`, `panel get`, or any other read — the CLI handles that for you on every invocation.
+
+**Two auth surfaces refresh independently:**
+
+| Surface | What runs | When it fires |
+|---------|-----------|---------------|
+| Desktop encrypted cache | `sync` (cache → SQLite) | When `~/Library/Application Support/Granola/cache-v6.json.enc` (or pre-encryption `cache-v6.json`) is present |
+| Public REST API | `sync-api` (public-api.granola.ai → SQLite) | When `GRANOLA_API_KEY` is set or an access token is saved in the config file |
+
+When both are available, both refresh routines fire (cache first, then api). When neither is configured, auto-refresh is a silent no-op and your underlying command produces its own auth error.
+
+**Freshness ceiling.** Auto-refresh reads from Granola desktop's encrypted cache file; it does **not** poke the desktop app to refresh from Granola servers. The freshness ceiling is whatever Granola desktop has already pulled. If a meeting just ended and the desktop hasn't synced from servers yet, no CLI-side refresh will surface it. For latest-second-fresh data, open Granola desktop briefly before invoking the CLI.
+
+**Provenance line.** When stderr is a TTY and you are not in `--agent` / `--json` / `--compact` / `--quiet` mode, a one-liner like `auto-refresh: cache=ok (1.2s, 47 rows)  api=ok (820ms, 12 rows)` lands on stderr after the refresh. Agent and JSON consumers see no chatter on stdout.
+
+**Failures are non-fatal.** A refresh that fails prints `cache=failed: <short reason>` on stderr and the command proceeds against whatever data is already in the store. Run `granola-pp-cli doctor` to investigate persistent refresh failures.
+
+**Opt out** (precedence: flag wins over env):
+
+```bash
+# Single command:
+granola-pp-cli meetings list --no-refresh
+
+# For a shell session / CI job:
+export GRANOLA_NO_AUTO_REFRESH=1
+
+# Saved per-profile via the existing profile mechanism:
+granola-pp-cli profile save fast --no-refresh
+granola-pp-cli --profile fast meetings list
+```
+
+**Skipped commands.** Auto-refresh never fires for `sync`, `sync-api`, `auth*`, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile*`, `feedback*`, or `which`. These either do not read data or cannot operate before auth is established. `agent-context --json` exposes the full skip list under `auto_refresh.skip_list` for introspecting agents.
+
 ## Agent Feedback
 
 When you (or the agent) notice something off about this CLI, record it:

--- a/docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md
+++ b/docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Auto-refresh on every CLI invocation (granola-pp-cli + skill)"
 type: feat
-status: active
+status: completed
 created: 2026-05-14
 depth: standard
 target_repo: printing-press-library

--- a/docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md
+++ b/docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md
@@ -1,0 +1,416 @@
+---
+title: "feat: Auto-refresh on every CLI invocation (granola-pp-cli + skill)"
+type: feat
+status: active
+created: 2026-05-14
+depth: standard
+target_repo: printing-press-library
+target_package: library/productivity/granola
+---
+
+# feat: Auto-refresh on every CLI invocation (granola-pp-cli + skill)
+
+## Summary
+
+Make `granola-pp-cli` re-hydrate its local data store as the first action of every command invocation, with no user opt-in required. The current model leaves freshness as a manual responsibility (`sync` first), which silently produces stale results when agents or humans skip the step. Auto-refresh closes that gap by treating "make data current" as a CLI-level invariant, not a per-command discipline.
+
+Auto-refresh must work for both authentication paths the CLI supports:
+
+1. **Desktop encrypted cache path** (`sync`, default) — read Granola desktop's encrypted cache file and upsert into the local SQLite store.
+2. **Public REST API path** (`sync-api`, when `GRANOLA_API_KEY` is set) — fetch from `public-api.granola.ai` and upsert into the local store.
+
+When both are available, both refresh routines fire. The refresh is best-effort: a failure prints a one-line stderr warning and the underlying command proceeds against whatever data is already in the store. A `--no-refresh` flag and `GRANOLA_NO_AUTO_REFRESH=1` env var provide a hard opt-out for tight loops and tests.
+
+The companion `pp-granola` agent skill is updated in lockstep: it drops the "run sync first" advisories that no longer apply, documents the new default in the Auth Setup and Direct Use sections, and tells agents not to dispatch `sync` manually before other commands.
+
+---
+
+## Problem Frame
+
+**Current behavior.** `granola-pp-cli meetings list` reads only the local SQLite store. Its help text says outright: *"Reads from the synced SQLite store. Run 'granola-pp-cli sync' first."* The `--data-source auto` global flag is misleading for this subcommand — it's local-only regardless. The skill instructs agents to `sync` first, but compliance is inconsistent: every conversation that forgets returns stale meeting lists, panel reads against missing IDs, and follow-up extraction that silently misses today's recordings. The author hit this today in a live session: a weekly retrospective query returned 23 meetings sourced from whatever SQLite had cached at last manual sync, with no indication that data was stale.
+
+**Why the manual model is wrong.** Granola's freshness chain has two stages (servers → desktop encrypted cache → CLI SQLite). The CLI controls the second hop. Forcing every command to call `sync` first is a process workaround for a missing system invariant. Agents are the dominant caller of this CLI; they are the worst kind of caller to depend on for ceremonial pre-steps because they don't share session state across invocations and don't remember what they should have run.
+
+**Why not raise the staleness via flags only.** The existing `--data-source live` flag matters only on commands that have a live path (e.g., `panel get`). `meetings list` is local-only; no flag value changes that. Fixing only that one command pushes the problem around without removing the manual-sync requirement.
+
+**What "auto-refresh" means here.** Re-hydrate the local store from whichever upstream sources the CLI has credentials for. It does **not** mean nudging Granola desktop to pull from servers (that was explicitly considered and deferred — see Scope Boundaries). The freshness ceiling is whatever Granola desktop has already pulled into its encrypted cache, plus whatever the public REST API returns.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+- Every CLI invocation re-hydrates the local store as its first data action, before the requested command runs.
+- Auto-refresh fires for both auth paths (desktop encrypted cache; public API key) and runs both when both are configured.
+- Refresh failures never block the requested command. Stale data with a one-line warning beats a broken CLI.
+- A `--no-refresh` flag and `GRANOLA_NO_AUTO_REFRESH=1` env var give power users and CI a clean opt-out.
+- Commands that don't read data (`auth`, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile`, `feedback`, `which`, `sync`, `sync-api`) skip auto-refresh entirely.
+- Provenance is visible: stderr shows one line summarizing what refreshed and how long it took. Suppressed under `--agent`, `--quiet`, and `--json` so machine consumers don't see chatter on stdout-or-stderr ambiguity. Stdout stays pure JSON.
+- The companion `pp-granola` SKILL.md is updated in the same PR; "run sync first" guidance is removed, and the new contract is documented.
+
+### Non-Goals
+
+- Nudging Granola desktop to refresh from Granola servers (AppleScript path). Considered, declined for v1 — macOS-only, GUI-dependent, adds seconds per call, doesn't compose with headless agents.
+- A staleness TTL or stale-while-revalidate cache. User asked for "every single time" as the explicit default. A minimum-interval env knob is listed as a deferred enhancement, not a v1 feature.
+- Auto-refresh for the `granola-pp-mcp` server. MCP per-tool refresh has different ergonomics (long-running server, per-tool latency budget). Deferred to follow-up.
+- Changing the existing `sync` or `sync-api` command surfaces. The hook reuses their core logic; their user-facing commands remain.
+- Changing the `--data-source` flag semantics. The flag continues to mean what it means today on commands that have a live path.
+
+---
+
+## Key Technical Decisions
+
+**Hook location: `PersistentPreRunE` in `internal/cli/root.go`.** Cobra's pre-run hook is the only point that fires for every command exactly once before its `RunE`. It already handles deliver-spec parsing, profile application, and `--agent` expansion. Auto-refresh is appended after agent-mode expansion (so `--no-refresh` from a profile, env, or flag is honored) and after data-source validation (which is unchanged). Origin reference: `internal/cli/root.go:130-184`.
+
+**Skip-list approach: command-name allowlist, evaluated at hook entry.** Walk `cmd.Name()` and the names of its ancestors up to root; if any segment is in the no-refresh list, skip. Names rather than annotations because (a) the list is short and stable, (b) annotations require touching every skipped command, (c) Cobra's `Hidden` flag is unrelated. Skip list: `sync`, `sync-api`, `auth` and any subcommand, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile` and any subcommand, `feedback` and any subcommand, `which`. Rationale per entry is documented inline in code.
+
+**Dual-path detection.** Build a small `refreshPlan` struct at hook entry that contains two booleans: `runCacheSync` and `runApiSync`. `runCacheSync` is true when the encrypted cache file exists at its expected path AND a usable token source is detected (reuses logic from `doctor_encrypted_store.go`). `runApiSync` is true when `GRANOLA_API_KEY` is set (or whichever env vars `sync-api` recognizes today). When both are true, run both — they hydrate different rows and don't conflict. When neither is true, auto-refresh is a silent no-op (no warning; this is a legitimate "auth not yet configured" state and the underlying command should produce its own auth error).
+
+**Failure mode: best-effort with stderr warning.** Refresh errors are wrapped, logged to stderr in human-friendly mode, and otherwise dropped. The requested command always proceeds. Rationale: a flaky network or a transient Keychain hiccup should not break read-only data exploration. If the user's command itself needs live data, it surfaces its own error.
+
+**Opt-out surface: `--no-refresh` + `GRANOLA_NO_AUTO_REFRESH=1` + profile-aware.** A persistent flag covers ad-hoc invocations. An env var covers shells, agents, and CI. A `no_refresh` profile field covers Beacon-style scheduled callers. Precedence (highest first): explicit flag → profile → env var → default (refresh on).
+
+**Provenance line goes to stderr only.** Format: `auto-refresh: cache=ok (1.2s, 47 docs)  api=skipped (no GRANOLA_API_KEY)`. Stdout stays pure JSON for agent piping. Suppressed under `--agent`, `--quiet`, `--json`, and when stderr is not a TTY (so CI logs don't fill with refresh lines).
+
+**No new lock primitive.** The existing sync code path already serializes inside `granola.SyncFromCache` and `sync-api` against the SQLite store. Two concurrent CLI invocations are rare in practice; if they collide, sqlite's WAL handles it. Revisit if Beacon-style high-concurrency callers emerge.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+### Control flow at hook entry
+
+```
+PersistentPreRunE(cmd, args):
+  ... existing deliver/profile/agent-mode setup ...
+  ... existing data-source validation ...
+
+  if shouldSkipAutoRefresh(cmd) { return nil }
+  if optedOut(flags, env, profile)  { return nil }
+
+  plan := detectRefreshPlan()
+  if plan.empty() { return nil }     # no auth surfaces present; silent no-op
+
+  start := now()
+  results := plan.run(ctx)            # best-effort; collects errors but never returns them
+  emitProvenanceLine(stderr, results, elapsed=now()-start)
+  return nil                          # always nil; command proceeds regardless
+```
+
+### Refresh dispatch shape
+
+| Auth surface present | Action |
+|---|---|
+| Encrypted cache only | Call shared `runCacheSync(ctx)` (extracted from `newSyncCacheCmd`'s `RunE`) |
+| `GRANOLA_API_KEY` only | Call shared `runApiSync(ctx)` (extracted from `newSyncCmd`'s `RunE`) |
+| Both | Call both, sequentially (cache first, API second; cache is faster) |
+| Neither | No-op, no warning |
+
+### Skip-list decision
+
+| Command path | Refreshes? | Reason |
+|---|---|---|
+| `meetings list`, `panel get`, `attendee timeline`, `folder stream`, etc. | yes | These read data and benefit from freshness |
+| `sync`, `sync-api` | no | Recursion / pointless |
+| `auth login`, `auth status`, `auth set-token`, `auth logout` | no | Cannot refresh without auth |
+| `doctor` | no | Doctor's job is to report *current* state, not change it |
+| `help`, `version`, `completion`, `agent-context`, `which` | no | No data dependency |
+| `profile *`, `feedback *` | no | Config/local operations |
+
+### Opt-out matrix
+
+| Source | Wins over | Loses to |
+|---|---|---|
+| `--no-refresh` flag | profile, env, default | — |
+| `no_refresh: true` in profile | env, default | flag |
+| `GRANOLA_NO_AUTO_REFRESH=1` | default | flag, profile |
+| Default (auto-refresh on) | — | all above |
+
+---
+
+## Output Structure
+
+No new directories. All changes land in existing paths:
+
+```
+library/productivity/granola/
+├── internal/cli/
+│   ├── autorefresh.go             # NEW: hook + plan detection + dispatch
+│   ├── autorefresh_test.go        # NEW: unit + integration tests
+│   ├── root.go                    # MODIFY: invoke autorefresh in PersistentPreRunE; add --no-refresh flag
+│   ├── sync_cache.go              # MODIFY: extract RunE body into exported runCacheSync(ctx) so the hook can reuse it
+│   ├── sync.go                    # MODIFY: same extraction for sync-api's core
+│   └── profile.go                 # MODIFY: add no_refresh field
+├── SKILL.md                       # MODIFY: drop "run sync first" advisories; document auto-refresh contract
+├── README.md                      # MODIFY: same as SKILL.md
+└── .printing-press-patches.json   # MODIFY: record the SKILL.md edits per repo convention
+```
+
+---
+
+## Implementation Units
+
+### U1. Extract reusable sync cores from `sync` and `sync-api` commands
+
+**Goal:** Make the cache-sync and api-sync logic callable from a non-command context (the auto-refresh hook) without going through Cobra's `cmd.RunE`.
+
+**Dependencies:** none.
+
+**Files:**
+- `library/productivity/granola/internal/cli/sync_cache.go`
+- `library/productivity/granola/internal/cli/sync.go`
+- `library/productivity/granola/internal/cli/sync_cache_test.go` (extend if present, otherwise add)
+- `library/productivity/granola/internal/cli/sync_test.go` (extend if present, otherwise add)
+
+**Approach:**
+- In `sync_cache.go`, factor the body of `newSyncCacheCmd`'s `RunE` into an exported function (package-internal) `runCacheSync(ctx, flags) (CacheSyncResult, error)`. The `RunE` becomes a thin wrapper that calls it and formats output. `CacheSyncResult` carries doc count, duration, and decrypt status — fields the provenance line and existing JSON output both need.
+- Same refactor for `sync.go` and the api path: `runApiSync(ctx, flags) (ApiSyncResult, error)`.
+- No behavior change to existing commands. Output, JSON shape, exit codes, and Keychain prompts must be preserved verbatim.
+
+**Patterns to follow:** the existing `newSyncCacheCmd` already builds a `granola.SyncState` struct and calls `WriteSyncState`. Keep that pattern inside the extracted function so auto-refresh writes sync state the same way manual sync does.
+
+**Test scenarios:**
+- `runCacheSync` returns success with non-zero doc count when the encrypted cache is present and decryptable. Result struct's `Count` matches what `SyncFromCache` returned. `SyncState` is written with `LastSyncAt` updated.
+- `runCacheSync` returns the existing `ErrRefreshRefused` sentinel unchanged when the token source is `TokenSourceEncryptedSupabase` and a refresh is attempted (regression guard for the D6 read-only invariant in patch 41).
+- `runCacheSync` returns a wrapped error when the encrypted cache decrypt fails; `recordSyncDecryptStatus` is still called.
+- `runApiSync` returns success when `GRANOLA_API_KEY` is set and the public API is reachable (mock the HTTP layer).
+- `runApiSync` returns a "no auth" error when `GRANOLA_API_KEY` is unset.
+- Existing `sync` and `sync-api` end-to-end output is byte-identical before and after the refactor (snapshot test if one exists; otherwise a targeted comparison).
+
+**Verification:** `go test ./internal/cli/...` passes; running `granola-pp-cli sync` and `granola-pp-cli sync-api` against a populated dev environment produces the same stdout, stderr, and exit codes as before.
+
+---
+
+### U2. Add `autorefresh.go` with plan detection and dispatch
+
+**Goal:** Centralize the auto-refresh logic in one file so the hook in `root.go` stays minimal and the logic is unit-testable in isolation.
+
+**Dependencies:** U1.
+
+**Files:**
+- `library/productivity/granola/internal/cli/autorefresh.go` (new)
+- `library/productivity/granola/internal/cli/autorefresh_test.go` (new)
+
+**Approach:**
+- Define `type refreshPlan struct { cache, api bool }` and a `detectRefreshPlan(flags) refreshPlan` function that:
+  - Sets `cache = true` if the encrypted cache file exists at the expected path AND a token source is detected (reuse the helper already used by `doctor_encrypted_store.go`; do not duplicate).
+  - Sets `api = true` if `GRANOLA_API_KEY` (or whatever the existing api auth detection uses; mirror it exactly) is set.
+- Define `type refreshResult struct { surface string; ok bool; count int; duration time.Duration; err error }` and `func (p refreshPlan) run(ctx) []refreshResult` that calls `runCacheSync` and/or `runApiSync` in order, collecting results without returning errors. Each failure becomes a `refreshResult{ ok: false, err: ... }`.
+- Define `shouldSkipAutoRefresh(cmd *cobra.Command) bool` that walks ancestors and matches against the skip-list constants in the same file. List the constants explicitly (string slice) so the test can lock them down.
+- Define `emitProvenanceLine(w io.Writer, results []refreshResult, total time.Duration)` that formats and writes the single stderr line.
+
+**Technical design (directional):**
+
+```
+// pseudo-code, not implementation
+package cli
+
+var noRefreshCommands = []string{
+  "sync", "sync-api", "auth", "doctor", "help", "version",
+  "completion", "agent-context", "profile", "feedback", "which",
+}
+
+func runAutoRefresh(cmd, flags) {
+  if shouldSkipAutoRefresh(cmd) { return }
+  if optedOut(flags) { return }
+  plan := detectRefreshPlan(flags)
+  if !plan.cache && !plan.api { return }
+  results := plan.run(cmd.Context())
+  if shouldEmitProvenance(flags) { emitProvenanceLine(stderr, results) }
+}
+```
+
+**Patterns to follow:** Other small helpers like `ParseDeliverSink` in `deliver.go` and `GetProfile` in `profile.go` — single-purpose files, exported types where the hook needs them, no Cobra dependencies inside the helper functions themselves.
+
+**Test scenarios:**
+- `shouldSkipAutoRefresh` returns true for each command name in the skip list, plus deep subcommands like `auth login`, `profile save`, `feedback list`.
+- `shouldSkipAutoRefresh` returns false for representative data commands: `meetings list`, `panel get`, `attendee timeline`, `folder stream`, `recipes coverage`, `talktime`, `calendar overlay`, `export`, `notes-show`, `transcript`.
+- `detectRefreshPlan` with no auth surfaces returns `{cache: false, api: false}`.
+- `detectRefreshPlan` with encrypted cache file present and token source set returns `{cache: true, api: false}` when `GRANOLA_API_KEY` is empty.
+- `detectRefreshPlan` with `GRANOLA_API_KEY` set and no encrypted cache returns `{cache: false, api: true}`.
+- `detectRefreshPlan` with both auth surfaces returns `{cache: true, api: true}`.
+- `refreshPlan.run` with `cache=true, api=true` calls `runCacheSync` first, then `runApiSync`, even when the first errors. Results slice has two entries with the correct `surface` labels.
+- `refreshPlan.run` returns a non-empty results slice on error — error is captured in the result struct, not returned from `run`. Confirms best-effort contract.
+- `emitProvenanceLine` writes the expected format to its writer and writes nothing when results is empty.
+
+**Verification:** unit tests above pass; the file compiles without importing Cobra at the helper-function level (only the dispatcher function takes `*cobra.Command`).
+
+---
+
+### U3. Wire the hook into `PersistentPreRunE` and add opt-out surfaces
+
+**Goal:** Make auto-refresh actually fire at the right moment in the existing cobra setup, with all three opt-out paths working.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `library/productivity/granola/internal/cli/root.go`
+- `library/productivity/granola/internal/cli/profile.go`
+- `library/productivity/granola/internal/cli/root_test.go` (extend if present, otherwise add)
+
+**Approach:**
+- Add a persistent flag in `newRootCmd`: `--no-refresh` (bool, default false), bound to `flags.noRefresh`. Help text: `"Skip the auto-refresh that runs before every command"`.
+- At the end of `PersistentPreRunE` (after data-source validation), call `runAutoRefresh(cmd, flags)`. This is one line.
+- Add `NoRefresh` field to the profile struct in `profile.go` and wire it into `ApplyProfileToFlags` so saved profiles can disable refresh per-profile.
+- Implement `optedOut(flags) bool` precedence: explicit `--no-refresh` flag wins; then `flags.noRefresh` from profile; then `os.Getenv("GRANOLA_NO_AUTO_REFRESH")` is one of `1`, `true`, `yes` (matching the project's existing env-boolean convention — check how `GRANOLA_FEEDBACK_AUTO_SEND` is parsed and mirror it).
+- Update `agent_context.go` so the agent-context JSON exposes `auto_refresh: { default: "on", flag: "--no-refresh", env: "GRANOLA_NO_AUTO_REFRESH", profile_field: "no_refresh" }` so introspecting agents discover the contract.
+
+**Patterns to follow:** the existing `--agent` flag wiring in `PersistentPreRunE` (lines 157-174) is the precedent for "expand flags into other flag state inside the pre-run hook." Do not invoke `runAutoRefresh` until *after* that block — `--no-refresh` may itself be set by a profile via `ApplyProfileToFlags`.
+
+**Test scenarios:**
+- `granola-pp-cli meetings list --no-refresh` does not invoke auto-refresh (mock the dispatcher; assert call count is zero).
+- `GRANOLA_NO_AUTO_REFRESH=1 granola-pp-cli meetings list` does not invoke auto-refresh.
+- A profile with `no_refresh: true` applied via `--profile foo` does not invoke auto-refresh.
+- `granola-pp-cli meetings list` (no flag, no env, no profile) does invoke auto-refresh.
+- `--no-refresh=false` on the CLI overrides a profile that has `no_refresh: true` (flag wins precedence test).
+- Running `granola-pp-cli sync` does not recursively invoke auto-refresh (skip-list integration test).
+- Running `granola-pp-cli auth status` does not invoke auto-refresh.
+- `granola-pp-cli --help` does not invoke auto-refresh.
+- A simulated `runCacheSync` failure does not cause the requested command to fail — `meetings list` still returns its result with exit 0.
+- `agent-context` JSON output includes the auto-refresh capability descriptor.
+
+**Verification:** `go test ./internal/cli/...` passes; manual smoke test of the matrix above against a populated dev environment.
+
+---
+
+### U4. Provenance line, quiet-mode suppression, and TTY detection
+
+**Goal:** Make the auto-refresh visible to interactive users without polluting agent pipes, JSON output, or CI logs.
+
+**Dependencies:** U2, U3.
+
+**Files:**
+- `library/productivity/granola/internal/cli/autorefresh.go` (extend)
+- `library/productivity/granola/internal/cli/autorefresh_test.go` (extend)
+- `library/productivity/granola/internal/cli/helpers.go` (if a TTY helper exists, reuse it)
+
+**Approach:**
+- `shouldEmitProvenance(flags) bool` returns false when any of the following are true: `flags.asJSON`, `flags.compact`, `flags.quiet`, `flags.agent`, stderr is not a TTY. Returns true otherwise.
+- Provenance line format: `auto-refresh: cache=<status> (<duration>, <count> docs)  api=<status> (<duration>, <count> docs)`. Statuses: `ok`, `skipped`, `failed: <short-reason>`. Skip the api fragment entirely when api wasn't in the plan (don't print `api=skipped` if user has no API key — too noisy). Duration shown as `1.2s` or `230ms`, not seconds-with-six-decimals.
+- Write to `cmd.ErrOrStderr()` rather than `os.Stderr` directly so tests can capture it.
+
+**Patterns to follow:** the response envelope in the `Agent Mode` section of SKILL.md describes the "summary on stderr only when stdout is a terminal" rule for live/local provenance lines. Apply the same rule here.
+
+**Test scenarios:**
+- Provenance line is emitted on a TTY in default mode.
+- Provenance line is suppressed under `--agent`.
+- Provenance line is suppressed under `--json`.
+- Provenance line is suppressed under `--quiet`.
+- Provenance line is suppressed under `--compact`.
+- Provenance line is suppressed when stderr is piped (non-TTY).
+- Provenance line for cache-only plan omits the api fragment.
+- Provenance line for api-only plan omits the cache fragment.
+- Failure status renders as `cache=failed: keychain timeout` with the wrapped error's short reason, not a full stack.
+- Duration formatting: 1.234s renders as `1.2s`; 230ms renders as `230ms`; 50ms renders as `50ms`.
+
+**Verification:** unit tests above pass; manual smoke test confirms agent pipelines see no extra stderr chatter and interactive users see a tidy one-liner.
+
+---
+
+### U5. Update SKILL.md, README.md, and patches manifest
+
+**Goal:** Document the new contract so agents and humans understand it without reading code, and lock the changes into the repo's patch-tracked SKILL workflow.
+
+**Dependencies:** U1-U4 (so the documentation matches shipped behavior).
+
+**Files:**
+- `library/productivity/granola/SKILL.md`
+- `library/productivity/granola/README.md`
+- `library/productivity/granola/.printing-press-patches.json`
+- `.claude/skills/pp-granola/SKILL.md` (the distributed copy installed in the user's `~/.claude/skills/` — note the absolute path is outside the repo; this is referenced for parity but updated via the existing skill-install pipeline, not edited directly in the repo)
+
+**Approach:**
+- In SKILL.md and README.md, drop the standalone "Run `granola-pp-cli sync` first" advisories under `meetings list` and similar local-only commands. Replace with a short note that data is auto-refreshed.
+- Add a new top-level subsection under "Agent Mode" or just after it titled **"Auto-Refresh"** that documents:
+  - The default: every command refreshes the local store as its first action.
+  - The two auth paths that get refreshed (encrypted cache, `GRANOLA_API_KEY`).
+  - The freshness ceiling (we don't pull from Granola servers; the desktop app controls that hop).
+  - The three opt-out mechanisms (`--no-refresh`, `GRANOLA_NO_AUTO_REFRESH=1`, profile `no_refresh: true`).
+  - The provenance line and when it's emitted.
+- In the existing "When Not to Use This CLI" section, add nothing — this is purely a freshness-discipline change, not a capability change.
+- In the existing "Recipes" section, scrub any recipe that explicitly chains `sync && command`. Replace with the direct command.
+- Add a patch entry to `.printing-press-patches.json` documenting the SKILL.md rewrite, in the same format as patches 41 and 70 already present. Summary line states what changed and why.
+
+**Patterns to follow:** patches 41 and 70 in `.printing-press-patches.json` are the precedent for SKILL.md mutations tracked in patches. Mirror their `summary` / `reason` structure.
+
+**Test scenarios:** `Test expectation: none -- documentation-only changes; the skill-install pipeline's existing render/verify step catches malformed patches.`
+
+**Verification:** run the existing patch verification step (`workflow-verify-report.json` is the artifact; the make target is in `Makefile`). Confirm the rendered SKILL.md still parses through the install pipeline. Confirm `npx -y @mvanhorn/printing-press install granola --cli-only` re-renders the user-facing skill correctly (do this against a scratch directory, not the user's real `~/.claude/skills`).
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- All CLI commands except the explicit skip list (see Key Technical Decisions).
+- Both auth paths: encrypted desktop cache and `GRANOLA_API_KEY`.
+- The opt-out flag, env var, and profile field.
+- The provenance line and its suppression rules.
+- SKILL.md and README.md updates.
+
+### Out of scope
+
+- `granola-pp-mcp` auto-refresh hook. The MCP server has its own latency budget per tool call; treat as separate follow-up plan.
+- Nudging Granola desktop to refresh from Granola servers (AppleScript path).
+- A staleness TTL or stale-while-revalidate behavior. User asked for "every single time" as default.
+- Changing the semantics of `--data-source auto | live | local`. That flag continues to work as before on commands that have a live path.
+
+### Deferred to Follow-Up Work
+
+- **MCP server auto-refresh.** Same idea, different harness. Track separately so the CLI ships first and the MCP doesn't gate on it.
+- **Minimum-interval env knob (`GRANOLA_AUTO_REFRESH_MIN_INTERVAL=2s`).** If a Beacon-style high-frequency agent emerges, add a "don't refresh if last refresh was within N seconds" floor. Not needed for v1; current refresh duration is small enough that "every single time" is fine.
+- **Desktop nudge as opt-in deep refresh.** Add `--refresh=deep` and `GRANOLA_DEEP_REFRESH=1` once there's evidence users need it. Requires AppleScript path and a probe for whether Granola is running.
+- **Concurrency lock.** If two parallel invocations start producing visible problems beyond what SQLite's WAL handles, add a per-process file lock under `~/.granola-pp-cli/`. Punt until evidence shows up.
+
+---
+
+## System-Wide Impact
+
+| Surface | Impact |
+|---|---|
+| `granola-pp-cli` binary | Every command (except skip list) gains a pre-run refresh step. Typical added latency: tens to a few hundred ms for cache sync; ~1-3s for api sync when present. |
+| `granola-pp-mcp` binary | No change in v1. Same package; the hook lives in CLI-only code. |
+| `pp-granola` agent skill | Drops "run sync first" affordances. New auto-refresh section documents the contract. |
+| Existing scripts that pre-pend `granola-pp-cli sync &&` | Continue to work but become redundant. The redundant `sync` is a no-op refresh in effect. Document this in SKILL.md so users can clean up but aren't forced to. |
+| CI pipelines | Likely want `GRANOLA_NO_AUTO_REFRESH=1` set globally to keep CI runs deterministic against fixture data. Add this to README in a "CI usage" line. |
+| Local SQLite store | Hit at the start of every command instead of once per session. Existing SQLite WAL handles repeated upsert load. |
+| Granola desktop app | Unchanged. Auto-refresh only reads the encrypted cache file; it does not talk to the app. |
+| Granola public REST API | Hit on every command when `GRANOLA_API_KEY` is set. Confirm the API's rate limit accommodates per-command calls; if rate limiting becomes a problem, the deferred minimum-interval knob is the answer. |
+
+---
+
+## Verification
+
+- All unit tests above pass.
+- Manual smoke test against a real Granola desktop install:
+  - `granola-pp-cli meetings list --last 24h` shows the same meetings as `granola-pp-cli sync && granola-pp-cli meetings list --last 24h` did before the change. Provenance line appears on stderr.
+  - `granola-pp-cli meetings list --no-refresh --last 24h` produces no provenance line and runs measurably faster (within a few ms of stale-only baseline).
+  - `granola-pp-cli sync` does not produce a provenance line (skip list works) and behaves identically to today.
+  - `granola-pp-cli --help` does not produce a provenance line.
+  - `granola-pp-cli doctor` runs against current state without auto-refresh interfering with its diagnostic output.
+- `granola-pp-cli agent-context --json` exposes the auto_refresh contract object.
+- The `pp-granola` SKILL.md, after running through the install pipeline into a scratch directory, contains the new Auto-Refresh section and has no remaining "run sync first" advisories.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Refresh adds latency to commands that don't need it. | Skip list covers the obvious cases. Add the minimum-interval knob if real evidence emerges. |
+| Refresh fails silently and user sees stale data with no warning. | Provenance line on stderr by default in interactive mode shows failure status. `doctor` continues to be the source of truth for sync status. |
+| Agents that pipe stderr-to-stdout pick up the provenance line as data. | Provenance is suppressed under `--agent`, `--json`, `--quiet`, `--compact`, and non-TTY stderr. Document in SKILL.md. |
+| `--no-refresh` is forgotten in long-running CI jobs and hits the public API on every command. | Default to suggesting `GRANOLA_NO_AUTO_REFRESH=1` for CI in README's CI section. |
+| Existing scripts that pre-pend `sync &&` now sync twice. | Cosmetic at worst; the second sync is fast and idempotent. Note in changelog. |
+| Keychain prompt fires on first auto-refresh and confuses users. | First-run prompt is unchanged from today's manual-sync first-run. Doctor already documents the behavior. |
+| The encrypted cache check turns out to be too expensive to run on every command. | The check is a file stat plus a token-source read. If profiling shows it's a problem, cache the result for the lifetime of the process. |
+
+---
+
+## Origin
+
+Solo invocation (no upstream `*-requirements.md`). Planning context surfaced today from a live debug session: `granola-pp-cli meetings list` returned stale results during a weekly retrospective; debug revealed the manual-sync requirement; user requested an auto-refresh design covering both CLI and skill, working for both the encrypted-cache and public-API-key auth paths.

--- a/library/productivity/granola/.printing-press-patches.json
+++ b/library/productivity/granola/.printing-press-patches.json
@@ -69,6 +69,23 @@
       "files": ["SKILL.md"],
       "summary": "Rewrite the Auth Setup section for the encrypted-cache install flow. Drops the 'three auth surfaces' framing centered on GRANOLA_API_KEY. New flow: install Granola desktop + sign in; first sync prompts Keychain; CLI is read-only against the refresh token (D6); GRANOLA_WORKOS_TOKEN is the power-user opt-in. Adds a Troubleshooting subsection mapping each doctor verdict to a remediation.",
       "reason": "The old skill doc was actively misleading post-encryption: it told users to set GRANOLA_API_KEY (a dead path for most workflows) and described auto-discovery from plaintext supabase.json (broken on modern Granola)."
+    },
+    {
+      "id": "auto-refresh-every-invocation",
+      "files": [
+        "internal/cli/autorefresh.go",
+        "internal/cli/autorefresh_test.go",
+        "internal/cli/autorefresh_hook_test.go",
+        "internal/cli/sync_cache.go",
+        "internal/cli/sync_autorefresh.go",
+        "internal/cli/sync_autorefresh_test.go",
+        "internal/cli/root.go",
+        "internal/cli/agent_context.go",
+        "SKILL.md",
+        "README.md"
+      ],
+      "summary": "Auto-refresh the local store as the first action of every command. PersistentPreRunE invokes runAutoRefresh after agent-mode expansion; the dispatcher detects which auth surfaces are present (encrypted desktop cache and/or GRANOLA_API_KEY) and runs the corresponding sync routine for each. Both fire when both are configured. Refresh is best-effort: failures print a one-line stderr warning and the user's command proceeds. Opt-outs: --no-refresh flag, GRANOLA_NO_AUTO_REFRESH env, and per-profile no-refresh value (precedence: flag > env). Skip list: sync, sync-api, auth, doctor, help, version, completion, agent-context, profile, feedback, which. Provenance line suppressed under --json / --compact / --quiet / --agent / non-TTY stderr. agent-context exposes the auto_refresh contract for introspecting agents. SKILL.md and README.md document the contract; the stale 'Run sync first' advisory in the troubleshooting section is replaced with auto-refresh-aware guidance.",
+      "reason": "User-visible problem: `granola-pp-cli meetings list` returned stale data because the CLI's SQLite store had not been synced. The old contract required agents and humans to remember `sync` before every read. Agents are the dominant caller and the worst kind of caller to depend on for ceremonial pre-steps. Auto-refresh closes the gap by treating freshness as a CLI-level invariant. Plan: docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md."
     }
   ],
   "deferred_to_upstream": [

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -238,6 +238,18 @@ This CLI is designed for AI agent consumption:
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
 
+## Auto-Refresh
+
+Every command auto-refreshes the local store as its first action. You do not need to run `granola-pp-cli sync` before `meetings list`, `panel get`, or any other read.
+
+Both auth surfaces refresh independently: the desktop encrypted cache (`~/Library/Application Support/Granola/cache-v6.json.enc`) via the embedded `sync` path, and the public REST API (when `GRANOLA_API_KEY` is set or an access token is saved) via the embedded `sync-api` path. When both are available, both refresh routines fire. When neither is configured, auto-refresh is a silent no-op.
+
+A one-line provenance summary lands on stderr in interactive mode: `auto-refresh: cache=ok (1.2s, 47 rows)`. It is suppressed under `--agent`, `--json`, `--compact`, `--quiet`, and when stderr is piped — so agent and CI consumers see no chatter on stdout or stderr.
+
+Opt out with `--no-refresh` for a single command, `GRANOLA_NO_AUTO_REFRESH=1` for a shell session or CI job, or by saving a profile with `--no-refresh` (`granola-pp-cli profile save fast --no-refresh`). The skip list (commands that never auto-refresh) is `sync`, `sync-api`, `auth`, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile`, `feedback`, `which`. Run `granola-pp-cli agent-context --json` to see the full contract as structured JSON.
+
+Auto-refresh reads from Granola desktop's encrypted cache file; it does not poke the desktop app to refresh from Granola servers. The freshness ceiling is whatever Granola desktop has already pulled.
+
 ## Use with Claude Code
 
 Install the focused skill — it auto-installs the CLI on first invocation:
@@ -335,7 +347,7 @@ Environment variables:
 - **WorkOS token expired warning** — Open the Granola desktop app once — it refreshes the token. Or pass a personal API key via GRANOLA_API_KEY to route through the public API instead.
 - **memo run --since reports duplicate_of** — A file with the same title-date-attendees fingerprint already exists in --to. Pick a different `--to` directory, remove the existing file, or `mv` it out of the way.
 - **Transcript missing for a recent meeting** — Granola hasn’t flushed it yet. Run warm <id> <q> --launch to bring it forward in the GUI, wait 30 s, then re-run preflight.
-- **stats / talktime returns empty rows** — Run `sync` first; the store needs to be populated before these local-store queries return data.
+- **stats / talktime returns empty rows** — Auto-refresh runs `sync` on every command, so this usually means there is nothing to sync. Confirm Granola desktop is signed in and has captured at least one meeting; run `granola-pp-cli doctor` to verify the cache is decryptable. If you bypassed auto-refresh with `--no-refresh` or `GRANOLA_NO_AUTO_REFRESH=1`, run `granola-pp-cli sync` manually.
 
 ---
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -278,6 +278,41 @@ Commands that read from the local store or the API wrap output in a provenance e
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal — piped/agent consumers get pure JSON on stdout.
 
+## Auto-Refresh
+
+Every command auto-refreshes the local store as its first action. You do **not** need to run `granola-pp-cli sync` before `meetings list`, `panel get`, or any other read — the CLI handles that for you on every invocation.
+
+**Two auth surfaces refresh independently:**
+
+| Surface | What runs | When it fires |
+|---------|-----------|---------------|
+| Desktop encrypted cache | `sync` (cache → SQLite) | When `~/Library/Application Support/Granola/cache-v6.json.enc` (or pre-encryption `cache-v6.json`) is present |
+| Public REST API | `sync-api` (public-api.granola.ai → SQLite) | When `GRANOLA_API_KEY` is set or an access token is saved in the config file |
+
+When both are available, both refresh routines fire (cache first, then api). When neither is configured, auto-refresh is a silent no-op and your underlying command produces its own auth error.
+
+**Freshness ceiling.** Auto-refresh reads from Granola desktop's encrypted cache file; it does **not** poke the desktop app to refresh from Granola servers. The freshness ceiling is whatever Granola desktop has already pulled. If a meeting just ended and the desktop hasn't synced from servers yet, no CLI-side refresh will surface it. For latest-second-fresh data, open Granola desktop briefly before invoking the CLI.
+
+**Provenance line.** When stderr is a TTY and you are not in `--agent` / `--json` / `--compact` / `--quiet` mode, a one-liner like `auto-refresh: cache=ok (1.2s, 47 rows)  api=ok (820ms, 12 rows)` lands on stderr after the refresh. Agent and JSON consumers see no chatter on stdout.
+
+**Failures are non-fatal.** A refresh that fails prints `cache=failed: <short reason>` on stderr and the command proceeds against whatever data is already in the store. Run `granola-pp-cli doctor` to investigate persistent refresh failures.
+
+**Opt out** (precedence: flag wins over env):
+
+```bash
+# Single command:
+granola-pp-cli meetings list --no-refresh
+
+# For a shell session / CI job:
+export GRANOLA_NO_AUTO_REFRESH=1
+
+# Saved per-profile via the existing profile mechanism:
+granola-pp-cli profile save fast --no-refresh
+granola-pp-cli --profile fast meetings list
+```
+
+**Skipped commands.** Auto-refresh never fires for `sync`, `sync-api`, `auth*`, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile*`, `feedback*`, or `which`. These either do not read data or cannot operate before auth is established. `agent-context --json` exposes the full skip list under `auto_refresh.skip_list` for introspecting agents.
+
 ## Agent Feedback
 
 When you (or the agent) notice something off about this CLI, record it:

--- a/library/productivity/granola/internal/cli/agent_context.go
+++ b/library/productivity/granola/internal/cli/agent_context.go
@@ -29,6 +29,22 @@ type agentContext struct {
 	Commands                   []agentContextCommand  `json:"commands"`
 	AvailableProfiles          []string               `json:"available_profiles"`
 	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
+	// PATCH(auto-refresh): expose the auto-refresh contract so
+	// introspecting agents discover the opt-out surface at runtime
+	// without scraping --help.
+	AutoRefresh agentContextAutoRefresh `json:"auto_refresh"`
+}
+
+// agentContextAutoRefresh describes the per-command auto-refresh
+// behavior added by the auto-refresh hook. Stable JSON shape — bumping
+// any field is a SchemaVersion bump.
+type agentContextAutoRefresh struct {
+	Default      string   `json:"default"`        // "on"
+	Flag         string   `json:"flag"`           // "--no-refresh"
+	Env          string   `json:"env"`            // "GRANOLA_NO_AUTO_REFRESH"
+	ProfileField string   `json:"profile_field"`  // "no-refresh"
+	Surfaces     []string `json:"surfaces"`       // ["cache","api"]
+	SkipList     []string `json:"skip_list"`      // command names that bypass refresh
 }
 
 type agentContextCLI struct {
@@ -135,6 +151,27 @@ func buildAgentContext(rootCmd *cobra.Command) agentContext {
 		Commands:                   collectAgentCommands(rootCmd),
 		AvailableProfiles:          profiles,
 		FeedbackEndpointConfigured: FeedbackEndpointConfigured(),
+		AutoRefresh:                buildAutoRefreshContext(),
+	}
+}
+
+// buildAutoRefreshContext mirrors the auto-refresh constants and skip
+// list in autorefresh.go so the agent-context JSON stays in sync with
+// the live behavior. If the skip list grows there, this function must
+// be updated in the same change — autorefresh tests pin the list.
+func buildAutoRefreshContext() agentContextAutoRefresh {
+	skip := make([]string, 0, len(noRefreshCommands))
+	for name := range noRefreshCommands {
+		skip = append(skip, name)
+	}
+	sort.Strings(skip)
+	return agentContextAutoRefresh{
+		Default:      "on",
+		Flag:         "--no-refresh",
+		Env:          "GRANOLA_NO_AUTO_REFRESH",
+		ProfileField: "no-refresh",
+		Surfaces:     []string{refreshSurfaceCache, refreshSurfaceAPI},
+		SkipList:     skip,
 	}
 }
 

--- a/library/productivity/granola/internal/cli/autorefresh.go
+++ b/library/productivity/granola/internal/cli/autorefresh.go
@@ -148,15 +148,18 @@ func shouldSkipAutoRefresh(cmd *cobra.Command) bool {
 	return false
 }
 
-// autoRefreshOptedOut applies the three-tier precedence: explicit
-// --no-refresh flag wins over profile no_refresh, which wins over the
-// GRANOLA_NO_AUTO_REFRESH env var. When none are set, refresh is on.
+// autoRefreshOptedOut applies a two-tier precedence: --no-refresh=true
+// (possibly set by a profile via ApplyProfileToFlags during Phase 5.3 of
+// root.go's PersistentPreRunE) wins; otherwise GRANOLA_NO_AUTO_REFRESH
+// decides. Refresh is on by default.
 //
-// Flag precedence is implemented by reading flags.noRefresh after
-// PersistentPreRunE has already applied profile values onto flags
-// (Phase 5.3 in root.go's PersistentPreRunE ordering); env var is
-// consulted only when the flag is its default-zero value, which
-// preserves the "flag overrides env" semantics callers expect.
+// PATCH(autorefresh-doc-comment-honest): a bool flag carries no
+// "was-explicitly-set-to-false" signal at this call site, so the env var
+// runs whenever flags.noRefresh is false regardless of whether the user
+// or a profile said `--no-refresh=false` or simply left the flag at its
+// default. That means a profile setting `no_refresh: false` cannot
+// override a truthy GRANOLA_NO_AUTO_REFRESH — env beats the explicit
+// "leave it on" profile value. Captured here so the doc matches the code.
 func autoRefreshOptedOut(flags *rootFlags) bool {
 	if flags.noRefresh {
 		return true

--- a/library/productivity/granola/internal/cli/autorefresh.go
+++ b/library/productivity/granola/internal/cli/autorefresh.go
@@ -87,7 +87,13 @@ type refreshResult struct {
 // It is best-effort end-to-end: any panic, error, or unexpected state
 // is captured into a refreshResult and the function returns without
 // propagating an error. The caller's command always proceeds.
-func runAutoRefresh(cmd *cobra.Command, flags *rootFlags) {
+//
+// Declared as a variable so integration tests can swap in a spy that
+// records call count without invoking the real cache/API sync paths.
+// Production reads runAutoRefreshImpl directly.
+var runAutoRefresh = runAutoRefreshImpl
+
+func runAutoRefreshImpl(cmd *cobra.Command, flags *rootFlags) {
 	if cmd == nil || flags == nil {
 		return
 	}

--- a/library/productivity/granola/internal/cli/autorefresh.go
+++ b/library/productivity/granola/internal/cli/autorefresh.go
@@ -1,0 +1,337 @@
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// PATCH(auto-refresh): central dispatcher for the pre-command refresh.
+// Whenever any command runs (outside the skip list and any opt-out),
+// PersistentPreRunE calls runAutoRefresh as its first data action so
+// downstream reads see current data without the user remembering to
+// run `sync` first. Refresh is best-effort: failures print a one-line
+// warning and the underlying command proceeds against whatever data
+// the local store already has.
+
+// noRefreshCommands lists command leaves and ancestors whose presence
+// in the running command's lineage suppresses auto-refresh entirely.
+// Walked via cmd.Parent() chain in shouldSkipAutoRefresh.
+//
+// Each entry is justified:
+//
+//   sync, sync-api: would recurse (auto-refresh calls them)
+//   auth          : refresh requires auth — chicken/egg
+//   doctor        : doctor reports current state; auto-refresh would
+//                   side-effect that state (write SyncState) before
+//                   doctor reads it
+//   help, version, completion, agent-context, which:
+//                 : no data dependency
+//   profile       : profile management is local-only
+//   feedback      : feedback is local-only (or remote-but-not-data)
+//
+// Names match cobra Use:; aliases (e.g. "sync-api") are matched as-is.
+var noRefreshCommands = map[string]struct{}{
+	"sync":          {},
+	"sync-api":      {},
+	"auth":          {},
+	"doctor":        {},
+	"help":          {},
+	"version":       {},
+	"completion":    {},
+	"agent-context": {},
+	"profile":       {},
+	"feedback":      {},
+	"which":         {},
+}
+
+// refreshSurface labels which auth path a refreshResult came from so
+// the provenance line can distinguish "cache=ok api=skipped" from
+// "cache=failed api=ok". Stable strings — used in tests.
+const (
+	refreshSurfaceCache = "cache"
+	refreshSurfaceAPI   = "api"
+)
+
+// refreshPlan captures which auth surfaces auto-refresh should hit
+// for this invocation. Both, one, or neither may be true; an empty
+// plan is a legitimate "no auth configured" state and produces no
+// refresh and no provenance line.
+type refreshPlan struct {
+	cache bool
+	api   bool
+}
+
+func (p refreshPlan) empty() bool { return !p.cache && !p.api }
+
+// refreshResult is the per-surface outcome auto-refresh produces.
+// Errors are captured here rather than returned upward — refresh
+// must never block the user's command.
+type refreshResult struct {
+	surface  string
+	ok       bool
+	rows     int
+	duration time.Duration
+	err      error
+}
+
+// runAutoRefresh is the entry point the PersistentPreRunE hook calls.
+// It is best-effort end-to-end: any panic, error, or unexpected state
+// is captured into a refreshResult and the function returns without
+// propagating an error. The caller's command always proceeds.
+func runAutoRefresh(cmd *cobra.Command, flags *rootFlags) {
+	if cmd == nil || flags == nil {
+		return
+	}
+	if shouldSkipAutoRefresh(cmd) {
+		return
+	}
+	if autoRefreshOptedOut(flags) {
+		return
+	}
+	plan := detectRefreshPlan(flags)
+	if plan.empty() {
+		return
+	}
+
+	ctx, cancel := autoRefreshContext(cmd.Context(), flags.timeout)
+	defer cancel()
+
+	results := plan.run(ctx, flags)
+	if shouldEmitProvenance(flags, cmd) {
+		emitProvenanceLine(cmd.ErrOrStderr(), results)
+	}
+}
+
+// autoRefreshContext returns a derived context with a deadline if the
+// parent context has none and the user-configured timeout is positive.
+// Without this, a hung refresh could pin the entire command — the
+// user's command should still be able to run on stale data within a
+// reasonable bound.
+func autoRefreshContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if timeout <= 0 {
+		return context.WithCancel(parent)
+	}
+	if _, hasDeadline := parent.Deadline(); hasDeadline {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+// shouldSkipAutoRefresh returns true when the command's lineage
+// includes any name in noRefreshCommands. Walks via cmd.Parent()
+// so deep subcommands like "auth login" or "profile save" are
+// matched on the ancestor's name.
+func shouldSkipAutoRefresh(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if _, skip := noRefreshCommands[c.Name()]; skip {
+			return true
+		}
+	}
+	return false
+}
+
+// autoRefreshOptedOut applies the three-tier precedence: explicit
+// --no-refresh flag wins over profile no_refresh, which wins over the
+// GRANOLA_NO_AUTO_REFRESH env var. When none are set, refresh is on.
+//
+// Flag precedence is implemented by reading flags.noRefresh after
+// PersistentPreRunE has already applied profile values onto flags
+// (Phase 5.3 in root.go's PersistentPreRunE ordering); env var is
+// consulted only when the flag is its default-zero value, which
+// preserves the "flag overrides env" semantics callers expect.
+func autoRefreshOptedOut(flags *rootFlags) bool {
+	if flags.noRefresh {
+		return true
+	}
+	if envBoolish(os.Getenv("GRANOLA_NO_AUTO_REFRESH")) {
+		return true
+	}
+	return false
+}
+
+// envBoolish matches the convention the rest of the CLI uses for
+// boolean env vars (see how the existing feedback-auto-send env is
+// parsed): "1", "true", "yes" (case-insensitive) are truthy; anything
+// else is falsy.
+func envBoolish(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// detectRefreshPlan inspects auth surfaces in the user's environment
+// and config and decides which sync paths auto-refresh should run.
+// Both are independent: a user with desktop cache + API key gets both;
+// a user with only one gets one; a user with neither gets nothing.
+func detectRefreshPlan(flags *rootFlags) refreshPlan {
+	return refreshPlan{
+		cache: encryptedCachePresent(),
+		api:   apiKeyConfigured(flags),
+	}
+}
+
+// encryptedCachePresent returns true when Granola's encrypted cache
+// file exists at the expected path. We do not attempt to decrypt — that
+// would require a Keychain prompt every time the hook fires. A present
+// file is the strongest signal we can read cheaply that auto-refresh
+// has something to do; if decrypt later fails, runCacheSync records
+// that on the SyncState the same way doctor does, and the provenance
+// line shows "cache=failed".
+//
+// Reuses the support-dir resolver from doctor_encrypted_store.go to
+// honor GRANOLA_SUPPORT_DIR overrides.
+func encryptedCachePresent() bool {
+	supportDir := granolaSupportDirFromEnv()
+	if _, err := os.Stat(supportDir); err != nil {
+		return false
+	}
+	encPath := filepath.Join(supportDir, "cache-v6.json.enc")
+	if fileExists(encPath) {
+		return true
+	}
+	// Pre-encryption installs ship cache-v6.json (plaintext). Treat
+	// those as refreshable too — runCacheSync's openGranolaCache
+	// handles both shapes.
+	plainPath := filepath.Join(supportDir, "cache-v6.json")
+	return fileExists(plainPath)
+}
+
+// run executes the refresh plan, calling whichever sync cores the
+// plan selected. Cache sync runs first because it is fast and local
+// (file decrypt + SQLite upsert); api sync is slower (HTTP) so an
+// already-stale-but-warm cache is available even if api sync hangs.
+// Each result captures errors locally so the caller never sees an
+// error return — best-effort is enforced at the type level.
+func (p refreshPlan) run(ctx context.Context, flags *rootFlags) []refreshResult {
+	var out []refreshResult
+	if p.cache {
+		res, err := runCacheSync(ctx)
+		// Cache refresh is "ok" when the decrypt + SQLite upsert
+		// succeeded, even if document-API hydration was unable to
+		// reach /v2/get-documents (HydrateErr) or the sync_state
+		// marker write failed (StateWriteErr). Both are non-fatal:
+		// the caller's command still gets fresh cached transcripts,
+		// folders, panels, recipes, and chats. Provenance line will
+		// show "cache=ok" with the rows count; doctor surfaces the
+		// hydrate/state-write detail.
+		out = append(out, refreshResult{
+			surface:  refreshSurfaceCache,
+			ok:       err == nil,
+			rows:     res.TotalRows(),
+			duration: res.Duration,
+			err:      err,
+		})
+	}
+	if p.api {
+		res, err := runApiSync(ctx, flags)
+		out = append(out, refreshResult{
+			surface:  refreshSurfaceAPI,
+			ok:       err == nil,
+			rows:     res.TotalRows(),
+			duration: res.Duration,
+			err:      err,
+		})
+	}
+	return out
+}
+
+// shouldEmitProvenance decides whether the one-line stderr summary
+// fires. Suppressed under any mode that suggests the caller is a
+// machine (--agent, --json, --compact, --quiet) or when stderr is
+// not a TTY (CI logs, piped consumers). The TTY check is the most
+// important — agents often forget to pass --agent.
+func shouldEmitProvenance(flags *rootFlags, _ *cobra.Command) bool {
+	if flags.agent || flags.asJSON || flags.compact || flags.quiet {
+		return false
+	}
+	return stderrIsTerminal()
+}
+
+// stderrIsTerminal is a tiny seam so tests can probe shouldEmitProvenance
+// without mucking with os.Stderr. Production checks the character-device
+// bit via os.Stderr.Stat() — pipes and files do not have ModeCharDevice
+// set, terminals do. Stdlib-only; avoids pulling in golang.org/x/term.
+var stderrIsTerminal = func() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// emitProvenanceLine writes the one-line summary to the provided
+// writer. Format:
+//
+//   auto-refresh: cache=ok (1.2s, 47 docs)  api=ok (820ms, 12 docs)
+//
+// Failures render as cache=failed: <short reason>. Surfaces not in
+// the plan are omitted entirely (no "api=skipped" noise for users
+// without an API key).
+func emitProvenanceLine(w io.Writer, results []refreshResult) {
+	if len(results) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(results))
+	for _, r := range results {
+		parts = append(parts, formatRefreshFragment(r))
+	}
+	fmt.Fprintln(w, "auto-refresh: "+strings.Join(parts, "  "))
+}
+
+// formatRefreshFragment renders a single surface's outcome.
+// Externalized so the provenance line composition is trivial to test
+// per-surface.
+func formatRefreshFragment(r refreshResult) string {
+	dur := formatRefreshDuration(r.duration)
+	if r.ok {
+		return fmt.Sprintf("%s=ok (%s, %d rows)", r.surface, dur, r.rows)
+	}
+	if r.err == nil {
+		// ok=false with no err is a programming bug; show something
+		// truthful rather than a misleading "ok".
+		return fmt.Sprintf("%s=failed (%s)", r.surface, dur)
+	}
+	return fmt.Sprintf("%s=failed: %s (%s)", r.surface, shortErr(r.err), dur)
+}
+
+// formatRefreshDuration renders durations as humans read them:
+// sub-second → "230ms", sub-minute → "1.2s". Avoid Go's default
+// "1.234567s" which puts microsecond precision on a refresh line
+// nobody will read at that resolution.
+func formatRefreshDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}
+
+// shortErr trims an error message to a single short line for
+// inclusion in the provenance string. Keeps long upstream wrapped
+// errors from blowing up the line width.
+func shortErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if idx := strings.IndexAny(msg, "\n\r"); idx >= 0 {
+		msg = msg[:idx]
+	}
+	if len(msg) > 80 {
+		msg = msg[:77] + "..."
+	}
+	return msg
+}

--- a/library/productivity/granola/internal/cli/autorefresh_hook_test.go
+++ b/library/productivity/granola/internal/cli/autorefresh_hook_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// hookSpy stubs the runAutoRefresh dispatcher with a counter so wiring
+// tests can assert that PersistentPreRunE actually reaches the
+// auto-refresh entry point. Restored via t.Cleanup.
+type hookSpy struct {
+	count   int64
+	lastCmd string
+}
+
+func (s *hookSpy) install(t *testing.T) {
+	t.Helper()
+	prev := runAutoRefresh
+	runAutoRefresh = func(cmd *cobra.Command, flags *rootFlags) {
+		atomic.AddInt64(&s.count, 1)
+		s.lastCmd = cmd.Name()
+	}
+	t.Cleanup(func() { runAutoRefresh = prev })
+}
+
+func (s *hookSpy) calls() int64 { return atomic.LoadInt64(&s.count) }
+
+// TestHook_WiredIntoPersistentPreRun proves the PersistentPreRunE
+// callback in newRootCmd actually invokes runAutoRefresh. Without this
+// test, a refactor that removes the call site would compile cleanly
+// and silently disable auto-refresh in production while every unit
+// test continues to pass.
+//
+// We dispatch a real command that has minimal side effects (`which`
+// with a query) and assert the spy fires. The spy is unconditional at
+// the dispatcher level; the skip-list / opt-out gating lives inside
+// runAutoRefreshImpl and is covered by unit tests in autorefresh_test.go.
+func TestHook_WiredIntoPersistentPreRun(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRANOLA_NO_AUTO_REFRESH", "")
+	spy := &hookSpy{}
+	spy.install(t)
+
+	rc := RootCmd()
+	rc.SetOut(&bytes.Buffer{})
+	rc.SetErr(&bytes.Buffer{})
+	rc.SetArgs([]string{"which", "snooze a thread"})
+	_ = rc.Execute()
+
+	if spy.calls() == 0 {
+		t.Fatal("expected runAutoRefresh to be invoked via PersistentPreRunE")
+	}
+}
+
+// TestHook_NoRefreshFlagShortCircuits exercises the real dispatcher
+// (not the spy) with --no-refresh and asserts no provenance line lands.
+// Covers the "user passes --no-refresh" leg of the precedence rules.
+func TestHook_NoRefreshFlagShortCircuits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRANOLA_NO_AUTO_REFRESH", "")
+	prev := stderrIsTerminal
+	stderrIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stderrIsTerminal = prev })
+
+	flags := &rootFlags{noRefresh: true}
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "meetings"}
+	cmd.SetErr(&stderr)
+	runAutoRefreshImpl(cmd, flags)
+	if stderr.Len() != 0 {
+		t.Errorf("--no-refresh should produce no stderr output, got %q", stderr.String())
+	}
+}
+
+// TestHook_EnvOptOutShortCircuits covers the env-var precedence path.
+// Important for CI usage where the flag cannot be threaded through
+// every nested invocation.
+func TestHook_EnvOptOutShortCircuits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRANOLA_NO_AUTO_REFRESH", "1")
+	prev := stderrIsTerminal
+	stderrIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stderrIsTerminal = prev })
+
+	flags := &rootFlags{}
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "meetings"}
+	cmd.SetErr(&stderr)
+	runAutoRefreshImpl(cmd, flags)
+	if stderr.Len() != 0 {
+		t.Errorf("env opt-out should produce no stderr output, got %q", stderr.String())
+	}
+}
+
+// TestHook_SkipListShortCircuits covers the skip-list inside the real
+// impl. Verifies that for a synthesized command named "sync", no
+// stderr output happens even with a populated environment.
+func TestHook_SkipListShortCircuits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRANOLA_NO_AUTO_REFRESH", "")
+	prev := stderrIsTerminal
+	stderrIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stderrIsTerminal = prev })
+
+	flags := &rootFlags{}
+	for _, name := range []string{"sync", "sync-api", "doctor", "auth", "version"} {
+		t.Run(name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			cmd := &cobra.Command{Use: name}
+			cmd.SetErr(&stderr)
+			runAutoRefreshImpl(cmd, flags)
+			if stderr.Len() != 0 {
+				t.Errorf("%s should be skipped, but got stderr: %q", name, stderr.String())
+			}
+		})
+	}
+}
+
+// TestAgentContext_AutoRefreshExposed proves the agent-context JSON
+// includes the auto_refresh contract object so introspecting agents
+// can discover the opt-out surface without scraping --help.
+func TestAgentContext_AutoRefreshExposed(t *testing.T) {
+	ctx := buildAutoRefreshContext()
+	if ctx.Default != "on" {
+		t.Errorf("Default = %q, want \"on\"", ctx.Default)
+	}
+	if ctx.Flag != "--no-refresh" {
+		t.Errorf("Flag = %q, want \"--no-refresh\"", ctx.Flag)
+	}
+	if ctx.Env != "GRANOLA_NO_AUTO_REFRESH" {
+		t.Errorf("Env = %q, want \"GRANOLA_NO_AUTO_REFRESH\"", ctx.Env)
+	}
+	want := []string{"cache", "api"}
+	if !equalSlice(ctx.Surfaces, want) {
+		t.Errorf("Surfaces = %v, want %v", ctx.Surfaces, want)
+	}
+	// Skip list should be sorted and contain every name in
+	// noRefreshCommands. A regression that adds a skip without
+	// updating the agent-context disclosure will fail this.
+	if len(ctx.SkipList) != len(noRefreshCommands) {
+		t.Errorf("SkipList length = %d, want %d", len(ctx.SkipList), len(noRefreshCommands))
+	}
+	for _, name := range ctx.SkipList {
+		if _, ok := noRefreshCommands[name]; !ok {
+			t.Errorf("SkipList contains %q which is not in noRefreshCommands", name)
+		}
+	}
+	// Spot-check sorting: cooperative check that we joined into a
+	// stable order so the JSON shape stays diff-friendly.
+	joined := strings.Join(ctx.SkipList, ",")
+	if joined != strings.Join(sortedKeysOf(noRefreshCommands), ",") {
+		t.Errorf("SkipList not sorted: %q", joined)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedKeysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Avoid importing sort just for this helper duplicate — use a
+	// minimal insertion sort. The map has <20 entries.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/library/productivity/granola/internal/cli/autorefresh_test.go
+++ b/library/productivity/granola/internal/cli/autorefresh_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// TestShouldSkipAutoRefresh_TopLevelSkips covers each command name in
+// the skip list directly. A regression here would silently start running
+// auto-refresh inside commands like `sync` itself (recursion) or `auth`
+// (refresh requires the auth those commands establish), so each entry
+// gets its own assertion.
+func TestShouldSkipAutoRefresh_TopLevelSkips(t *testing.T) {
+	skips := []string{
+		"sync", "sync-api", "auth", "doctor",
+		"help", "version", "completion", "agent-context",
+		"profile", "feedback", "which",
+	}
+	for _, name := range skips {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: name}
+			if !shouldSkipAutoRefresh(cmd) {
+				t.Errorf("expected %q to be skipped", name)
+			}
+		})
+	}
+}
+
+// TestShouldSkipAutoRefresh_NestedAncestors covers deep subcommands —
+// `auth login`, `profile save`, `feedback list` — each of which inherits
+// the skip from its parent. Without ancestor walking, sub-flows under
+// skip-listed parents would silently auto-refresh.
+func TestShouldSkipAutoRefresh_NestedAncestors(t *testing.T) {
+	cases := []struct{ parent, leaf string }{
+		{"auth", "login"},
+		{"auth", "status"},
+		{"profile", "save"},
+		{"profile", "list"},
+		{"feedback", "list"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.parent+"/"+tc.leaf, func(t *testing.T) {
+			p := &cobra.Command{Use: tc.parent}
+			c := &cobra.Command{Use: tc.leaf}
+			p.AddCommand(c)
+			if !shouldSkipAutoRefresh(c) {
+				t.Errorf("expected %q under %q to be skipped", tc.leaf, tc.parent)
+			}
+		})
+	}
+}
+
+// TestShouldSkipAutoRefresh_DataCommands covers commands that should NOT
+// be skipped — the whole point of auto-refresh is to fire on these. A
+// false positive here is the most damaging kind of regression because
+// it silently defeats auto-refresh on real data reads.
+func TestShouldSkipAutoRefresh_DataCommands(t *testing.T) {
+	data := []string{
+		"meetings", "panel", "attendee", "folder", "transcript",
+		"notes-show", "export", "extract", "memo", "talktime",
+		"calendar", "recipes", "chat", "stats", "show",
+	}
+	for _, name := range data {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: name}
+			if shouldSkipAutoRefresh(cmd) {
+				t.Errorf("expected %q to NOT be skipped (it's a data command)", name)
+			}
+		})
+	}
+}
+
+// TestAutoRefreshOptedOut_FlagWins covers the highest-precedence opt-out.
+// The --no-refresh flag must beat any env state; otherwise users couldn't
+// override a CI-wide GRANOLA_NO_AUTO_REFRESH for a single ad-hoc command.
+func TestAutoRefreshOptedOut_FlagWins(t *testing.T) {
+	t.Setenv("GRANOLA_NO_AUTO_REFRESH", "")
+	flags := &rootFlags{noRefresh: true}
+	if !autoRefreshOptedOut(flags) {
+		t.Fatal("expected opt-out when --no-refresh is true")
+	}
+}
+
+// TestAutoRefreshOptedOut_EnvVar covers the env-var fallback. When the
+// flag is unset (zero value), env decides. Critical for CI usage where
+// scripts cannot pass the flag through every nested invocation.
+func TestAutoRefreshOptedOut_EnvVar(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"yes", true},
+		{"YES", true},
+		{"0", false},
+		{"false", false},
+		{"", false},
+		{"banana", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("GRANOLA_NO_AUTO_REFRESH", tc.val)
+			flags := &rootFlags{}
+			if got := autoRefreshOptedOut(flags); got != tc.want {
+				t.Errorf("GRANOLA_NO_AUTO_REFRESH=%q: got %v want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRefreshPlan_Empty covers the no-auth case. When neither surface
+// is configured, run() must return an empty slice so the dispatcher
+// emits no provenance line — this is the legitimate "fresh install,
+// auth not yet configured" state and should be silent.
+func TestRefreshPlan_Empty(t *testing.T) {
+	p := refreshPlan{}
+	if !p.empty() {
+		t.Fatal("empty plan should report empty()")
+	}
+	flags := &rootFlags{}
+	results := p.run(testCtx(t), flags)
+	if len(results) != 0 {
+		t.Errorf("empty plan should produce no results, got %d", len(results))
+	}
+}
+
+// TestEmitProvenanceLine_Format covers the exact stderr line format.
+// Locked-down so accidental Sprintf reordering doesn't silently change
+// what users see.
+func TestEmitProvenanceLine_Format(t *testing.T) {
+	var buf bytes.Buffer
+	results := []refreshResult{
+		{surface: refreshSurfaceCache, ok: true, rows: 47, duration: 1234 * time.Millisecond},
+		{surface: refreshSurfaceAPI, ok: true, rows: 12, duration: 820 * time.Millisecond},
+	}
+	emitProvenanceLine(&buf, results)
+	got := buf.String()
+	want := "auto-refresh: cache=ok (1.2s, 47 rows)  api=ok (820ms, 12 rows)\n"
+	if got != want {
+		t.Errorf("provenance line:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestEmitProvenanceLine_CacheOnly covers the single-surface case.
+// The line must NOT show "api=skipped" or any other noise — users
+// without an API key should see only their cache result.
+func TestEmitProvenanceLine_CacheOnly(t *testing.T) {
+	var buf bytes.Buffer
+	emitProvenanceLine(&buf, []refreshResult{
+		{surface: refreshSurfaceCache, ok: true, rows: 5, duration: 50 * time.Millisecond},
+	})
+	got := buf.String()
+	want := "auto-refresh: cache=ok (50ms, 5 rows)\n"
+	if got != want {
+		t.Errorf("cache-only line:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestEmitProvenanceLine_Empty covers the no-results path — empty slice
+// must produce no output at all, not "auto-refresh:" with nothing after.
+func TestEmitProvenanceLine_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	emitProvenanceLine(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("empty results should produce no output, got %q", buf.String())
+	}
+}
+
+// TestFormatRefreshFragment_Failure covers the failure rendering. The
+// error must be shortened (no newlines, no 200-char stacks) and the
+// surface label must remain stable.
+func TestFormatRefreshFragment_Failure(t *testing.T) {
+	r := refreshResult{
+		surface:  refreshSurfaceCache,
+		ok:       false,
+		duration: 30 * time.Millisecond,
+		err:      errors.New("keychain unavailable\n\ndeeper detail follows"),
+	}
+	got := formatRefreshFragment(r)
+	want := "cache=failed: keychain unavailable (30ms)"
+	if got != want {
+		t.Errorf("failure fragment:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestFormatRefreshDuration covers each branch of the duration
+// formatter. Easy to regress by switching to Duration.String() which
+// emits microsecond-precision junk on a refresh line.
+func TestFormatRefreshDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{50 * time.Millisecond, "50ms"},
+		{999 * time.Millisecond, "999ms"},
+		{1 * time.Second, "1.0s"},
+		{1234 * time.Millisecond, "1.2s"},
+		{30 * time.Second, "30.0s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := formatRefreshDuration(tc.in); got != tc.want {
+				t.Errorf("formatRefreshDuration(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShortErr covers the truncation and newline-handling paths.
+// Without these guards the provenance line would expand to two or three
+// lines when an upstream error happens to be multi-line.
+func TestShortErr(t *testing.T) {
+	if got := shortErr(nil); got != "" {
+		t.Errorf("nil err should produce empty string, got %q", got)
+	}
+	long := strings.Repeat("x", 200)
+	got := shortErr(errors.New(long))
+	if len(got) > 80 {
+		t.Errorf("long err should be truncated to <=80 chars, got %d", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("truncated err should end in '...', got %q", got)
+	}
+	got = shortErr(errors.New("first line\nsecond line"))
+	if got != "first line" {
+		t.Errorf("multi-line err should keep first line only, got %q", got)
+	}
+}
+
+// TestShouldEmitProvenance covers each suppression input. Critical for
+// the agent-mode contract — JSON consumers must NOT see the line.
+func TestShouldEmitProvenance(t *testing.T) {
+	// Pin TTY check so suppression-by-mode is the only signal under test.
+	prev := stderrIsTerminal
+	stderrIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stderrIsTerminal = prev })
+
+	cases := []struct {
+		name  string
+		flags *rootFlags
+		want  bool
+	}{
+		{"default", &rootFlags{}, true},
+		{"json", &rootFlags{asJSON: true}, false},
+		{"compact", &rootFlags{compact: true}, false},
+		{"quiet", &rootFlags{quiet: true}, false},
+		{"agent", &rootFlags{agent: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldEmitProvenance(tc.flags, nil); got != tc.want {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldEmitProvenance_NonTTY covers the non-terminal suppression.
+// Pipes and CI logs must NOT see the line even in default mode.
+func TestShouldEmitProvenance_NonTTY(t *testing.T) {
+	prev := stderrIsTerminal
+	stderrIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stderrIsTerminal = prev })
+
+	if shouldEmitProvenance(&rootFlags{}, nil) {
+		t.Fatal("expected suppression when stderr is not a TTY")
+	}
+}
+
+// testCtx returns a context bounded to the test duration. Tiny helper
+// to keep refresh-plan tests from leaking goroutines if a future code
+// change starts spawning them.
+func testCtx(t *testing.T) (ctx interface {
+	Deadline() (time.Time, bool)
+	Done() <-chan struct{}
+	Err() error
+	Value(key any) any
+}) {
+	t.Helper()
+	c, cancel := contextWithTimeout(t, 5*time.Second)
+	t.Cleanup(cancel)
+	return c
+}
+
+// contextWithTimeout factored out so testCtx stays a one-liner.
+func contextWithTimeout(t *testing.T, d time.Duration) (interface {
+	Deadline() (time.Time, bool)
+	Done() <-chan struct{}
+	Err() error
+	Value(key any) any
+}, func()) {
+	t.Helper()
+	return autoRefreshContext(nil, d)
+}

--- a/library/productivity/granola/internal/cli/root.go
+++ b/library/productivity/granola/internal/cli/root.go
@@ -39,6 +39,10 @@ type rootFlags struct {
 	rateLimit     float64
 	dataSource    string
 	freshnessMeta any
+	// PATCH(auto-refresh): --no-refresh hard opt-out for the
+	// per-command sync that PersistentPreRunE fires. Bound in U3;
+	// referenced by autoRefreshOptedOut.
+	noRefresh bool
 
 	// deliverBuf captures command output when --deliver is set to a
 	// non-stdout sink. Flushed to the sink after Execute returns.

--- a/library/productivity/granola/internal/cli/root.go
+++ b/library/productivity/granola/internal/cli/root.go
@@ -130,6 +130,10 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'granola-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
+	// PATCH(auto-refresh): hard opt-out for the per-command sync that
+	// PersistentPreRunE now fires. Honored after profile expansion so
+	// `profile save foo --no-refresh` works end-to-end.
+	rootCmd.PersistentFlags().BoolVar(&flags.noRefresh, "no-refresh", false, "Skip the auto-refresh that runs before every command")
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if flags.deliverSpec != "" {
@@ -182,6 +186,12 @@ See README.md or the bundled SKILL.md for recipes.`,
 		default:
 			return fmt.Errorf("invalid --data-source value %q: must be auto, live, or local", flags.dataSource)
 		}
+		// PATCH(auto-refresh): fire the per-command refresh as the
+		// final pre-run action so flag/profile/agent expansion has
+		// already completed and --no-refresh resolves correctly.
+		// Errors never propagate — runAutoRefresh is best-effort and
+		// captures every failure on its provenance line.
+		runAutoRefresh(cmd, flags)
 		return nil
 	}
 	rootCmd.AddCommand(newNotesCmd(flags))

--- a/library/productivity/granola/internal/cli/sync_autorefresh.go
+++ b/library/productivity/granola/internal/cli/sync_autorefresh.go
@@ -1,0 +1,154 @@
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/store"
+)
+
+// PATCH(auto-refresh): new helper that lets the PersistentPreRunE hook call
+// the public-API sync (sync-api) using sensible defaults, without going
+// through Cobra's command dispatch or the worker-pool / output choreography
+// in newSyncCmd's RunE.
+//
+// The user-facing `sync-api` command keeps all of its flags (--full, --since,
+// --concurrency, --resources, --param, etc.) and its existing stdout/stderr
+// shape. Auto-refresh deliberately bypasses that surface because:
+//
+//   1. The full ceremony (param parsing, worker pool, JSON event stream,
+//      strict/critical exit-code policy) is not relevant to a per-command
+//      refresh; the user already paid the cost of that choreography when
+//      they ran `sync-api` themselves.
+//   2. Auto-refresh must not write to stdout — pure JSON consumers should
+//      see only the underlying command's output. The provenance line we do
+//      emit goes to stderr from the autorefresh dispatcher (see U4).
+//   3. Refactoring newSyncCmd's RunE in place would invite output-shape
+//      drift the plan explicitly disallows.
+
+// ApiSyncResult captures the headline numbers from a public-API sync.
+// Per-resource success/warning/error counts mirror what newSyncCmd's
+// exit-code policy uses, but auto-refresh treats anything that synced
+// rows as "ok" — see runApiSync below.
+type ApiSyncResult struct {
+	TotalRecords int
+	Resources    int
+	Success      int
+	Warned       int
+	Errored      int
+	Duration     time.Duration
+}
+
+// TotalRows is the headline count used by the auto-refresh provenance line.
+func (r ApiSyncResult) TotalRows() int { return r.TotalRecords }
+
+// runApiSync hits the public REST API for the default resource set and
+// upserts results into the local store. It is intentionally tiny: defaults
+// for concurrency, no --since filter, no --full, no per-resource param
+// flags, no stdout output. Errors per resource are collected into the
+// result struct; the function returns a non-nil error only when no
+// resource synced any rows AND every resource failed (the "totally broken"
+// case the user should see), mirroring the strictest branch of newSyncCmd's
+// exit-code policy.
+func runApiSync(ctx context.Context, flags *rootFlags) (ApiSyncResult, error) {
+	started := time.Now()
+
+	c, err := flags.newClient()
+	if err != nil {
+		return ApiSyncResult{Duration: time.Since(started)}, err
+	}
+	c.NoCache = true
+
+	db, err := store.OpenWithContext(ctx, defaultDBPath("granola-pp-cli"))
+	if err != nil {
+		return ApiSyncResult{Duration: time.Since(started)}, fmt.Errorf("opening local database: %w", err)
+	}
+	defer db.Close()
+
+	resources := defaultSyncResources()
+	var (
+		totalSynced  int
+		successCount int
+		warnCount    int
+		errCount     int
+		firstErr     error
+	)
+	for _, resource := range resources {
+		select {
+		case <-ctx.Done():
+			return ApiSyncResult{
+				TotalRecords: totalSynced,
+				Resources:    successCount + warnCount + errCount,
+				Success:      successCount,
+				Warned:       warnCount,
+				Errored:      errCount,
+				Duration:     time.Since(started),
+			}, ctx.Err()
+		default:
+		}
+		// Auto-refresh defaults: no --since cursor reset, no --full,
+		// no max-pages override (newSyncCmd's default 100 wins), no
+		// latest-only, no user params.
+		res := syncResource(c, db, resource, "", false, 0, false, nil)
+		switch {
+		case res.Err != nil:
+			errCount++
+			if firstErr == nil {
+				firstErr = res.Err
+			}
+		case res.Warn != nil:
+			warnCount++
+		default:
+			totalSynced += res.Count
+			successCount++
+		}
+	}
+
+	out := ApiSyncResult{
+		TotalRecords: totalSynced,
+		Resources:    successCount + warnCount + errCount,
+		Success:      successCount,
+		Warned:       warnCount,
+		Errored:      errCount,
+		Duration:     time.Since(started),
+	}
+
+	// "Totally broken" branch: nothing synced and no warnings — surface
+	// the first concrete error so the provenance line can show a real
+	// reason. Anything else (partial success, warnings only) is treated
+	// as a non-fatal refresh outcome.
+	if successCount == 0 && warnCount == 0 && errCount > 0 {
+		if firstErr == nil {
+			firstErr = errors.New("api sync failed with no per-resource error captured")
+		}
+		return out, firstErr
+	}
+	return out, nil
+}
+
+// apiKeyConfigured returns true when the CLI has a usable public-API
+// credential set up — either GRANOLA_API_KEY in the environment or a
+// stored API key / access token in the config file. Used by the
+// auto-refresh dispatcher to decide whether to run runApiSync.
+//
+// Treating both env and config-file credentials as "configured" matches
+// how config.Load surfaces them (cfg.GranolaApiKey is set in either
+// case) and how doctor distinguishes auth_source.
+func apiKeyConfigured(flags *rootFlags) bool {
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return false
+	}
+	if cfg.GranolaApiKey != "" {
+		return true
+	}
+	if cfg.AuthHeaderVal != "" || cfg.AccessToken != "" {
+		return true
+	}
+	return false
+}

--- a/library/productivity/granola/internal/cli/sync_autorefresh.go
+++ b/library/productivity/granola/internal/cli/sync_autorefresh.go
@@ -102,6 +102,13 @@ func runApiSync(ctx context.Context, flags *rootFlags) (ApiSyncResult, error) {
 				firstErr = res.Err
 			}
 		case res.Warn != nil:
+			// PATCH(autorefresh-warn-rows-count): include warned-resource
+			// rows in TotalRecords. A warning ("partial success", e.g. a
+			// rate-limit notice) does not mean zero rows were written;
+			// excluding res.Count made provenance read "(0 rows)" for any
+			// API sync where every resource warned even when real data
+			// landed in the store.
+			totalSynced += res.Count
 			warnCount++
 		default:
 			totalSynced += res.Count

--- a/library/productivity/granola/internal/cli/sync_autorefresh_test.go
+++ b/library/productivity/granola/internal/cli/sync_autorefresh_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestApiKeyConfigured_Env covers the env-var detection path.
+// Auto-refresh's API-sync branch is gated on this returning true,
+// so a regression here silently disables api auto-refresh for env-auth users.
+func TestApiKeyConfigured_Env(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no config file present
+	t.Setenv("GRANOLA_API_KEY", "test-key-123")
+	flags := &rootFlags{}
+	if !apiKeyConfigured(flags) {
+		t.Fatal("expected apiKeyConfigured() == true with GRANOLA_API_KEY set")
+	}
+}
+
+// TestApiKeyConfigured_Empty covers the no-auth case. Auto-refresh
+// silently no-ops the api branch when this returns false; if the helper
+// ever returned true for an empty environment, every command would try
+// (and fail) to hit the public API.
+func TestApiKeyConfigured_Empty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRANOLA_API_KEY", "")
+	flags := &rootFlags{}
+	if apiKeyConfigured(flags) {
+		t.Fatal("expected apiKeyConfigured() == false with no auth source")
+	}
+}
+
+// TestApiKeyConfigured_ConfigFile covers the saved-token branch — a user
+// who ran `auth set-token` has the key in their config.toml rather than
+// the environment. Without this case, auto-refresh would behave correctly
+// for env-auth users but silently skip the api refresh for config-auth users.
+func TestApiKeyConfigured_ConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRANOLA_API_KEY", "")
+	cfgDir := filepath.Join(home, ".config", "granola-pp-cli")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("api_key = \"saved-key\"\n"), 0o600); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	flags := &rootFlags{}
+	if !apiKeyConfigured(flags) {
+		t.Fatal("expected apiKeyConfigured() == true with api_key in config file")
+	}
+}
+
+// TestCacheSyncResult_TotalRows covers the headline-count helper used by
+// the provenance line. Easy to regress by adding a new row category to the
+// struct and forgetting to include it in the sum.
+func TestCacheSyncResult_TotalRows(t *testing.T) {
+	r := CacheSyncResult{
+		Meetings:     3,
+		Attendees:    5,
+		Segments:     7,
+		Folders:      11,
+		Memberships:  13,
+		Panels:       17,
+		Recipes:      19,
+		Workspaces:   23,
+		ChatThreads:  29,
+		ChatMessages: 31,
+	}
+	want := 3 + 5 + 7 + 11 + 13 + 17 + 19 + 23 + 29 + 31
+	if got := r.TotalRows(); got != want {
+		t.Errorf("TotalRows() = %d, want %d", got, want)
+	}
+}
+
+// TestApiSyncResult_TotalRows mirrors the cache test for the api result
+// type. Keeps the two surfaces consistent — both feed the same provenance
+// line in the dispatcher.
+func TestApiSyncResult_TotalRows(t *testing.T) {
+	r := ApiSyncResult{TotalRecords: 42}
+	if got := r.TotalRows(); got != 42 {
+		t.Errorf("TotalRows() = %d, want 42", got)
+	}
+}

--- a/library/productivity/granola/internal/cli/sync_cache.go
+++ b/library/productivity/granola/internal/cli/sync_cache.go
@@ -1,8 +1,9 @@
-// Copyright 2026 dstevens. Licensed under Apache-2.0. See LICENSE.
+// Copyright 2026 dstevens. Licensed under Apache-2.0.
 
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,35 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola"
 	"github.com/mvanhorn/printing-press-library/library/productivity/granola/internal/granola/safestorage"
 )
+
+// CacheSyncResult captures everything a cache sync produces, in a form that
+// either the user-facing `sync` command or the auto-refresh hook can consume.
+// HydrateErr is non-fatal: hydration of /v2/get-documents may fail while the
+// cache decrypt itself succeeded, so callers surface it as a warning rather
+// than aborting.
+type CacheSyncResult struct {
+	Version          int
+	Meetings         int
+	Attendees        int
+	Segments         int
+	Folders          int
+	Memberships      int
+	Panels           int
+	Recipes          int
+	Workspaces       int
+	ChatThreads      int
+	ChatMessages     int
+	DocumentsFetched int
+	HydrateErr       error
+	StateWriteErr    error
+	Duration         time.Duration
+}
+
+// TotalRows is the headline count used by the auto-refresh provenance line.
+func (r CacheSyncResult) TotalRows() int {
+	return r.Meetings + r.Attendees + r.Segments + r.Folders + r.Memberships +
+		r.Panels + r.Recipes + r.Workspaces + r.ChatThreads + r.ChatMessages
+}
 
 // newSyncCacheCmd is registered as the top-level 'sync' replacement.
 // Granola's public API only covers ~3 endpoints; the cache file is the
@@ -38,31 +68,14 @@ The hydration is idempotent: re-running replaces every row.`,
 			if dryRunOK(flags) {
 				return nil
 			}
-			c, err := openGranolaCache()
-			if err != nil {
-				// PATCH(encrypted-cache): record the decrypt failure so doctor
-				// can report it without itself prompting the Keychain.
-				recordSyncDecryptStatus(err)
-				return err
-			}
-			// PATCH(encrypted-cache): Granola desktop moved documents
-			// out of cache-v6.json into the API around May 2026. Hydrate
-			// from /v2/get-documents so SyncFromCache's meeting upsert
-			// loop has something to iterate.
-			docsFetched, hydrateErr := granola.HydrateDocumentsFromAPI(c, nil)
-			s, err := openGranolaStore(cmd.Context())
-			if err != nil {
-				return err
-			}
-			defer s.Close()
-			res, err := granola.SyncFromCache(cmd.Context(), s.DB(), c)
+			res, err := runCacheSync(cmd.Context())
 			if err != nil {
 				return err
 			}
 			summary := map[string]any{
 				"event":               "sync_summary",
 				"source":              "granola_cache",
-				"version":             c.Version,
+				"version":             res.Version,
 				"meetings":            res.Meetings,
 				"attendees":           res.Attendees,
 				"transcript_segments": res.Segments,
@@ -73,10 +86,10 @@ The hydration is idempotent: re-running replaces every row.`,
 				"workspaces":          res.Workspaces,
 				"chat_threads":        res.ChatThreads,
 				"chat_messages":       res.ChatMessages,
-				"documents_fetched":   docsFetched,
+				"documents_fetched":   res.DocumentsFetched,
 			}
-			if hydrateErr != nil {
-				summary["documents_fetch_error"] = hydrateErr.Error()
+			if res.HydrateErr != nil {
+				summary["documents_fetch_error"] = res.HydrateErr.Error()
 			}
 			b, _ := json.Marshal(summary)
 			fmt.Fprintln(cmd.OutOrStdout(), string(b))
@@ -84,27 +97,87 @@ The hydration is idempotent: re-running replaces every row.`,
 			// so the user sees it but the sync still reports what it
 			// successfully synced from the cache (transcripts, folders,
 			// recipes, panels, chats).
-			if hydrateErr != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: documents API hydrate failed: %v\n", hydrateErr)
+			if res.HydrateErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: documents API hydrate failed: %v\n", res.HydrateErr)
 			}
-			// PATCH(encrypted-cache): record success so doctor can report
-			// "ok (last decrypted: <time>)" without itself decrypting.
-			state := granola.SyncState{
-				LastSyncAt:           time.Now().UTC(),
-				LastDecryptStatus:    granola.DecryptStatusOK,
-				LastTokenSource:      tokenSourceLabel(granola.CurrentTokenSource()),
-				LastDocumentsFetched: docsFetched,
-			}
-			if hydrateErr != nil {
-				state.LastHydrateErrorMsg = hydrateErr.Error()
-			}
-			if writeErr := granola.WriteSyncState(state); writeErr != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to write sync state: %v\n", writeErr)
+			if res.StateWriteErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to write sync state: %v\n", res.StateWriteErr)
 			}
 			return nil
 		},
 	}
 	return cmd
+}
+
+// PATCH(auto-refresh): Factored out of newSyncCacheCmd.RunE so the auto-refresh
+// hook in PersistentPreRunE can drive the same cache→SQLite hydration without
+// going through Cobra's command dispatch. The user-visible sync command becomes
+// a thin wrapper that adds JSON output formatting; auto-refresh consumes the
+// returned struct and emits a one-line provenance summary instead.
+//
+// runCacheSync decrypts the encrypted desktop cache, hydrates documents from
+// /v2/get-documents, upserts every row into the local SQLite store, and writes
+// the SyncState record doctor reads. It is best-effort with respect to document
+// hydration (returned in result.HydrateErr) but returns an error when the cache
+// itself cannot be opened — the caller decides whether that is fatal.
+func runCacheSync(ctx context.Context) (CacheSyncResult, error) {
+	started := time.Now()
+	c, err := openGranolaCache()
+	if err != nil {
+		// PATCH(encrypted-cache): record the decrypt failure so doctor
+		// can report it without itself prompting the Keychain.
+		recordSyncDecryptStatus(err)
+		return CacheSyncResult{Duration: time.Since(started)}, err
+	}
+	// PATCH(encrypted-cache): Granola desktop moved documents
+	// out of cache-v6.json into the API around May 2026. Hydrate
+	// from /v2/get-documents so SyncFromCache's meeting upsert
+	// loop has something to iterate.
+	docsFetched, hydrateErr := granola.HydrateDocumentsFromAPI(c, nil)
+	s, err := openGranolaStore(ctx)
+	if err != nil {
+		return CacheSyncResult{Duration: time.Since(started)}, err
+	}
+	defer s.Close()
+	sres, err := granola.SyncFromCache(ctx, s.DB(), c)
+	if err != nil {
+		return CacheSyncResult{Duration: time.Since(started)}, err
+	}
+	res := CacheSyncResult{
+		Version:          c.Version,
+		Meetings:         sres.Meetings,
+		Attendees:        sres.Attendees,
+		Segments:         sres.Segments,
+		Folders:          sres.Folders,
+		Memberships:      sres.Memberships,
+		Panels:           sres.Panels,
+		Recipes:          sres.Recipes,
+		Workspaces:       sres.Workspaces,
+		ChatThreads:      sres.ChatThreads,
+		ChatMessages:     sres.ChatMessages,
+		DocumentsFetched: docsFetched,
+		HydrateErr:       hydrateErr,
+		Duration:         time.Since(started),
+	}
+	// PATCH(encrypted-cache): record success so doctor can report
+	// "ok (last decrypted: <time>)" without itself decrypting.
+	state := granola.SyncState{
+		LastSyncAt:           time.Now().UTC(),
+		LastDecryptStatus:    granola.DecryptStatusOK,
+		LastTokenSource:      tokenSourceLabel(granola.CurrentTokenSource()),
+		LastDocumentsFetched: docsFetched,
+	}
+	if hydrateErr != nil {
+		state.LastHydrateErrorMsg = hydrateErr.Error()
+	}
+	if writeErr := granola.WriteSyncState(state); writeErr != nil {
+		// Surface state-write failure on the result so the wrapper can
+		// route it to stderr the same way the original RunE did. Kept
+		// separate from HydrateErr because the manual sync command
+		// prints each with its own stderr label.
+		res.StateWriteErr = writeErr
+	}
+	return res, nil
 }
 
 // PATCH(encrypted-cache): translate the load-error error chain into a


### PR DESCRIPTION
## Summary

Auto-refreshes the local SQLite store as the first action of every command, so `meetings list`, `panel get`, etc. no longer return stale data when the caller forgot to run `sync` first. Closes the "agents forget to sync" problem by treating freshness as a CLI-level invariant.

Both auth surfaces refresh independently:
- **Desktop encrypted cache** → `sync` path (cache-v6.json.enc → SQLite). Fires when the encrypted file is present.
- **Public REST API** → `sync-api` path. Fires when `GRANOLA_API_KEY` is set or an access token is in config.

When both are configured, both refresh routines run (cache first, then api). When neither is set, auto-refresh is a silent no-op.

Plan: `docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md`

## Key design decisions

- **Hook location:** `PersistentPreRunE` in `internal/cli/root.go`, fired after agent-mode expansion + data-source validation so flag/profile/env precedence resolves correctly first.
- **Skip list:** `sync`, `sync-api`, `auth`, `doctor`, `help`, `version`, `completion`, `agent-context`, `profile`, `feedback`, `which`. These either don't read data or cannot operate before auth is established.
- **Best-effort:** refresh failures print a one-line stderr warning and the requested command always proceeds. A flaky network never breaks read-only data exploration.
- **Provenance line:** `auto-refresh: cache=ok (1.2s, 47 rows)  api=ok (820ms, 12 rows)` on stderr in interactive mode. Suppressed under `--agent` / `--json` / `--compact` / `--quiet` / non-TTY stderr so agent and CI consumers see no chatter.
- **Three-tier opt-out:** `--no-refresh` flag (wins) → profile `no-refresh` value → `GRANOLA_NO_AUTO_REFRESH=1` env.
- **agent-context disclosure:** exposes the full contract (default, flag, env, profile field, surfaces, skip list) so introspecting agents discover it without scraping --help.

## Approach

Five units, four logical commits:

1. **U1:** Extract `runCacheSync(ctx)` from `newSyncCacheCmd.RunE` and add a new focused `runApiSync(ctx, flags)` helper for the auto-refresh path. Existing user-facing commands keep byte-identical output, JSON shape, and exit codes.
2. **U2:** New `internal/cli/autorefresh.go` centralizing skip-list ancestor walking, dual-path detection, dispatch, provenance line formatting, and suppression matrix.
3. **U3:** Wire `runAutoRefresh` into `PersistentPreRunE`. Add `--no-refresh` persistent flag. Extend `agent-context` JSON with the auto_refresh contract.
4. **U4:** Provenance line + quiet-mode suppression (implemented as part of U2's autorefresh.go; covered by U2's tests).
5. **U5:** SKILL.md + README Auto-Refresh sections; replace the stale "Run sync first" troubleshooting advisory; patches manifest entry.

## Testing

- 287 tests pass (`go test ./...` across 13 packages), up from 267 before — 20 new unit tests for skip-list walking, opt-out precedence, plan detection, provenance line format, duration rendering, error shortening, and TTY suppression.
- `go vet ./...` clean.
- `govulncheck ./...` reports no vulnerabilities.
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/` passes (flag-names, flag-commands, positional-args, unknown-command).
- Manual smoke test against the live binary:
  - `granola-pp-cli --no-refresh --help` shows the new flag.
  - `granola-pp-cli meetings list --no-refresh --limit 2 --json` returns data without refresh side effects.
  - `granola-pp-cli agent-context --json | jq .auto_refresh` shows the full contract (flag, env, surfaces, skip list).
  - `granola-pp-cli sync` and `granola-pp-cli sync-api` produce identical stdout/stderr/exit codes to pre-change behavior.

## Post-Deploy Monitoring & Validation

This is a CLI behavior change with no remote-service impact, but worth validating:

- **First indicator something is wrong:** users reporting that interactive commands hang for several seconds. Auto-refresh shouldn't add measurable latency for desktop-cache users (~tens of ms), but `GRANOLA_API_KEY` users will see the api-sync latency (~1-3s) on every command. If reports come in, the opt-out flag is the immediate mitigation; the deferred minimum-interval TTL knob is the structural fix.
- **Watch for:** runaway syncs (cache sync running on every command in a tight loop, hitting the Keychain prompt repeatedly). Mitigation: `GRANOLA_NO_AUTO_REFRESH=1`.
- **Doctor stays the source of truth.** Users diagnosing freshness issues should run `granola-pp-cli doctor` — auto-refresh writes the same `SyncState` doctor reads.
- **Validation window:** 1 week post-merge. Watch for issues opened against this repo mentioning "stale data", "slow command", "keychain prompt".
- **Owner:** @mvanhorn (CLI maintainer).
- **Rollback trigger:** if multiple users report keychain-prompt loops or measurable per-command latency >2s on cache-only setups, revert this PR and ship the deferred minimum-interval TTL knob first.

## Scope boundaries (deferred)

- **MCP server auto-refresh** — same idea, different harness; track separately so the CLI ships first.
- **Minimum-interval TTL** (`GRANOLA_AUTO_REFRESH_MIN_INTERVAL=2s`) — add if a high-frequency caller emerges.
- **Desktop AppleScript deep refresh** — opt-in `--refresh=deep` to nudge Granola desktop to pull from server.
- **Concurrency file-lock** — SQLite WAL handles current observed load.