### PR TITLE
fix(openart): surface experimental flag and document nano-banana family

### DIFF
--- a/cli-skills/pp-openart/SKILL.md
+++ b/cli-skills/pp-openart/SKILL.md
@@ -42,10 +42,14 @@ These capabilities aren't available in any other tool for this API.
   openart-pp-cli video gen --prompt "..." --model byte-plus-seedance-2 --duration 10 --count 2 --wait --download ./out/
   ```
 
-- **`image gen`** — Submit + poll + download images in one command. Nano Banana is verified; other image models (GPT Image 2, FLUX 2 Pro, Seedream, Imagen 4, Qwen Image) require `--accept-experimental` because their submit shapes are inferred from the JS bundle but not individually verified live.
+- **`image gen`** — Submit + poll + download images in one command. The Nano Banana family has two variants: `nano-banana` (50 credits, verified) and `nano-banana-pro` (120 credits, higher quality, experimental). There is no `nano-banana-2` — Pro is the upgrade path. The other image models (`gpt-image-2`, `gpt-image-1-5`, `flux-2-pro`, `byte-plus-seedream-4`, `byte-plus-seedream-4-5`, `google-imagen-4`, `qwen-image-max`) are also experimental: their submit shapes were inferred from the JS bundle but not individually verified live, so they require `--accept-experimental`. Run `openart-pp-cli models list --family image` to see slugs, costs, and the `experimental` flag before picking.
 
   ```bash
+  # verified, cheapest path
   openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana --count 2 --wait --download ./out/
+
+  # higher-quality Pro variant — opt in with --accept-experimental
+  openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana-pro --count 2 --accept-experimental --wait --download ./out/
   ```
 
 - **`video gen --no-audio`** — Disables Seedance's auto-generated audio. Workaround for `OutputAudioSensitiveContentDetected` failures; halves the cost on Seedance 2.0 normal mode.

--- a/library/ai/openart/.printing-press-patches.json
+++ b/library/ai/openart/.printing-press-patches.json
@@ -32,6 +32,19 @@
         "internal/cli/credits_novel.go"
       ],
       "validated_outcome": "go test ./... passes. credits burn buckets by observation date, credits forecast's 28-day window only matches recently-observed spends. Migration is idempotent and backfills pre-existing rows from synced_at."
+    },
+    {
+      "id": "modelrow-surface-experimental",
+      "summary": "Add the catalog's Experimental flag to modelRow() output so models list / models show JSON exposes which models need --accept-experimental.",
+      "reason": "The Experimental field was set correctly on every catalog entry but modelRow() omitted it from the returned map, so callers parsing the JSON had no way to filter or warn before submitting. Discovered in the 2026-05-14 donkey-photo session: the agent picked nano-banana-pro from JSON output with no experimental signal, then learned about the opt-in flag only after the submit rejected it. Paired with SKILL.md / README.md / image gen --help updates that document the nano-banana family explicitly (regular vs Pro, no v2).",
+      "files": [
+        "internal/cli/models_novel.go",
+        "internal/cli/models_novel_test.go",
+        "internal/cli/image.go",
+        "SKILL.md",
+        "README.md"
+      ],
+      "validated_outcome": "go test ./... passes (193 in 12 packages, including 3 new modelRow tests). go vet clean. verify_skill.py clean. `models show nano-banana-pro --agent` returns experimental=true; `models show nano-banana --agent` returns experimental=false; `image gen --help` shows both variants in examples."
     }
   ]
 }

--- a/library/ai/openart/README.md
+++ b/library/ai/openart/README.md
@@ -101,10 +101,14 @@ These capabilities aren't available in any other tool for this API.
   openart-pp-cli video gen --prompt "a phoenix" --model byte-plus-seedance-2 --duration 10 --count 2 --wait --download ./out/
   ```
 
-- **`image gen`** — Submit + poll + download images in one command. Nano Banana is verified end-to-end; GPT Image 2, FLUX 2 Pro, Seedream 4, Imagen 4, and Qwen Image are gated as `--accept-experimental` (their submit shapes are inferred from the JS bundle but not individually exercised live).
+- **`image gen`** — Submit + poll + download images in one command. The Nano Banana family has two variants: `nano-banana` (50 credits, verified end-to-end) and `nano-banana-pro` (120 credits, higher quality, gated as experimental). There is no `nano-banana-2` — Pro is the upgrade path. The other image models (`gpt-image-2`, `gpt-image-1-5`, `flux-2-pro`, `byte-plus-seedream-4`, `byte-plus-seedream-4-5`, `google-imagen-4`, `qwen-image-max`) are also gated as `--accept-experimental` (their submit shapes were inferred from the JS bundle but not individually exercised live). Run `openart-pp-cli models list --family image` to see slugs, costs, and the `experimental` flag before picking.
 
   ```bash
+  # verified, cheapest path
   openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana --count 2 --wait --download ./out/
+
+  # higher-quality Pro variant — opt in with --accept-experimental
+  openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana-pro --count 2 --accept-experimental --wait --download ./out/
   ```
 
 - **`video gen --no-audio`** — Disables Seedance's auto-generated audio track. Workaround for `OutputAudioSensitiveContentDetected` moderation failures, and also halves the cost on Seedance 2.0 normal mode.

--- a/library/ai/openart/SKILL.md
+++ b/library/ai/openart/SKILL.md
@@ -42,10 +42,14 @@ These capabilities aren't available in any other tool for this API.
   openart-pp-cli video gen --prompt "..." --model byte-plus-seedance-2 --duration 10 --count 2 --wait --download ./out/
   ```
 
-- **`image gen`** — Submit + poll + download images in one command. Nano Banana is verified; other image models (GPT Image 2, FLUX 2 Pro, Seedream, Imagen 4, Qwen Image) require `--accept-experimental` because their submit shapes are inferred from the JS bundle but not individually verified live.
+- **`image gen`** — Submit + poll + download images in one command. The Nano Banana family has two variants: `nano-banana` (50 credits, verified) and `nano-banana-pro` (120 credits, higher quality, experimental). There is no `nano-banana-2` — Pro is the upgrade path. The other image models (`gpt-image-2`, `gpt-image-1-5`, `flux-2-pro`, `byte-plus-seedream-4`, `byte-plus-seedream-4-5`, `google-imagen-4`, `qwen-image-max`) are also experimental: their submit shapes were inferred from the JS bundle but not individually verified live, so they require `--accept-experimental`. Run `openart-pp-cli models list --family image` to see slugs, costs, and the `experimental` flag before picking.
 
   ```bash
+  # verified, cheapest path
   openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana --count 2 --wait --download ./out/
+
+  # higher-quality Pro variant — opt in with --accept-experimental
+  openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana-pro --count 2 --accept-experimental --wait --download ./out/
   ```
 
 - **`video gen --no-audio`** — Disables Seedance's auto-generated audio. Workaround for `OutputAudioSensitiveContentDetected` failures; halves the cost on Seedance 2.0 normal mode.

--- a/library/ai/openart/internal/cli/image.go
+++ b/library/ai/openart/internal/cli/image.go
@@ -59,19 +59,26 @@ func newImageGenCmd(flags *rootFlags) *cobra.Command {
 		Long: `Submit an image generation, optionally poll until completion, and
 optionally download the resulting PNG/WebP(s) to local disk.
 
-The model can be referenced by slug (e.g. nano-banana, gpt-image-2) or
-display name. Run 'openart-pp-cli models list --family image' to see
-what is available. Verified models submit cleanly; experimental models
-print a warning and require --accept-experimental to proceed because
-their submit contract has not been individually verified end-to-end.
+Pick a model first. Run 'openart-pp-cli models list --family image' to
+see slugs, costs, and the 'experimental' flag, then pass --model with
+the slug (e.g. --model nano-banana for the verified default, or --model
+nano-banana-pro for the higher-quality variant). The Nano Banana family
+has two members: nano-banana (50 credits, verified) and nano-banana-pro
+(120 credits, experimental). There is no nano-banana-2 — Pro is the
+upgrade path. Experimental models print a warning and require
+--accept-experimental because their submit contract has not been
+individually verified end-to-end.
 
 By default this returns immediately with the historyId + resourceIds.
 Pass --wait to poll until each resource has status='completed'. Combine
 with --download <dir> to stream the finished images to disk.`,
-		Example: `  # Generate two nano-banana images
+		Example: `  # Verified, cheapest path: nano-banana (50 credits per image)
   openart-pp-cli image gen --prompt "a phoenix soaring over molten gold canyons" --model nano-banana --count 2 --wait --download ./out/
 
-  # Try GPT Image 2 (marked experimental — opt in)
+  # Higher-quality Pro variant: nano-banana-pro (120 credits, opt-in)
+  openart-pp-cli image gen --prompt "donkey on Mercer Island" --model nano-banana-pro --count 2 --accept-experimental --wait --download ./out/
+
+  # Other experimental models follow the same pattern
   openart-pp-cli image gen --prompt "donkey on Mercer Island" --model gpt-image-2 --accept-experimental --wait --download ./out/
 
   # Square 1024x1024 with explicit aspect ratio

--- a/library/ai/openart/internal/cli/models_novel.go
+++ b/library/ai/openart/internal/cli/models_novel.go
@@ -164,6 +164,9 @@ func modelRow(m openartmodels.Model) map[string]any {
 		"credits_per_video_default":  m.CreditsPerVideoDefault,
 		"tier":                       m.Tier,
 		"recommended":                m.Recommended,
+		// PATCH: surface Experimental in models list/show JSON so callers know
+		// which models need --accept-experimental before submitting.
+		"experimental":               m.Experimental,
 	}
 }
 

--- a/library/ai/openart/internal/cli/models_novel_test.go
+++ b/library/ai/openart/internal/cli/models_novel_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/ai/openart/internal/openartmodels"
+)
+
+// modelRow must surface the Experimental flag so callers can tell which
+// models need --accept-experimental before submitting. Skipping this key
+// caused real friction in the 2026-05-14 donkey-photo session: the
+// agent picked nano-banana-pro from JSON output that had no experimental
+// signal, then learned about the opt-in flag only after the submit
+// rejected it. Keeping this test red-lines the omission.
+func TestModelRow_IncludesExperimentalForVerifiedModel(t *testing.T) {
+	m := openartmodels.Resolve("nano-banana")
+	if m == nil {
+		t.Fatal("nano-banana missing from catalog")
+	}
+	row := modelRow(*m)
+	got, ok := row["experimental"]
+	if !ok {
+		t.Fatal("modelRow output missing experimental key")
+	}
+	if got != false {
+		t.Errorf("nano-banana experimental: want false, got %v", got)
+	}
+}
+
+func TestModelRow_IncludesExperimentalForExperimentalModel(t *testing.T) {
+	m := openartmodels.Resolve("nano-banana-pro")
+	if m == nil {
+		t.Fatal("nano-banana-pro missing from catalog")
+	}
+	row := modelRow(*m)
+	got, ok := row["experimental"]
+	if !ok {
+		t.Fatal("modelRow output missing experimental key")
+	}
+	if got != true {
+		t.Errorf("nano-banana-pro experimental: want true, got %v", got)
+	}
+}
+
+// Every catalog entry must surface the experimental key, even when the
+// value is false. Omitting the key for verified models would force
+// callers to treat "missing key" as "not experimental" — the exact
+// ambiguity this change removes.
+func TestModelRow_EveryCatalogEntryExposesExperimental(t *testing.T) {
+	for _, m := range openartmodels.Catalog {
+		row := modelRow(m)
+		if _, ok := row["experimental"]; !ok {
+			t.Errorf("catalog entry %q (family=%s) missing experimental key in modelRow output", m.Slug, m.Family)
+		}
+	}
+}


### PR DESCRIPTION
## openart

Stacked on PR #554. Three small patches caught while using the CLI live: agents and humans had no way to tell which image models need `--accept-experimental` until the submit was rejected, and the docs never mentioned that `nano-banana-pro` exists.

### What changed

- `internal/cli/models_novel.go` — Add `experimental` to `modelRow()` next to `recommended`, so `models list` and `models show` JSON expose the catalog's Experimental flag. Without this, the field was set correctly on every catalog entry but silently dropped from output.
- `internal/cli/models_novel_test.go` — New test file with three table-driven cases: verified model (nano-banana) returns experimental=false, experimental model (nano-banana-pro) returns experimental=true, every catalog entry exposes the key regardless of value.
- `internal/cli/image.go` — Sharpen `image gen --help` Long+Example block to point at `models list --family image` for discovery and show both Nano Banana variants in examples.
- `SKILL.md` + `README.md` — Enumerate the Nano Banana family (regular 50cr verified, Pro 120cr experimental), state explicitly that there is no `nano-banana-2` (Pro is the upgrade path), show both example commands side by side.
- `.printing-press-patches.json` — Catalog the customization (id `modelrow-surface-experimental`).
- `cli-skills/pp-openart/SKILL.md` — Regenerated mirror via `go run ./tools/generate-skills/main.go`.

### Validation

- `go test ./...` — 193 passed in 12 packages (3 new modelRow tests)
- `go vet ./...` — clean
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/ai/openart/` — clean
- `openart-pp-cli models show nano-banana-pro --agent` returns `experimental: true`
- `openart-pp-cli models show nano-banana --agent` returns `experimental: false`
- `openart-pp-cli image gen --help` shows both Nano Banana variants in examples