### PR TITLE
docs(agents): align sweep-canonical rule with no-hand-edit cli-skills guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,7 @@ When a SKILL.md or README.md shape change must propagate across **all library CL
 cd tools/sweep-canonical && GO111MODULE=off go test .
 ```
 
-The tool runs in GOPATH mode (no `go.mod`) so it stays decoupled from the rest of the repo's module graph. After running the sweep, regenerate `cli-skills/` so the mirror reflects the updated library content (see the section above).
+The tool runs in GOPATH mode (no `go.mod`) so it stays decoupled from the rest of the repo's module graph. Don't commit `cli-skills/` changes alongside the sweep — the PR-time parity step in `verify-library-conventions.yml` auto-commits any mirror drift as `github-actions[bot]`, and `generate-skills.yml` re-mirrors post-merge. Hand-committing the regen trips the `Guard against hand-edits to cli-skills mirror` step (see the section above).
 
 ## Commit style
 


### PR DESCRIPTION
## Why

The `tools/sweep-canonical/` section of `AGENTS.md` (line 330) still instructed contributors to "regenerate `cli-skills/` so the mirror reflects the updated library content" after running the sweep. That contradicts the **Generated artifacts** section (added in #464), which now says don't commit `cli-skills/` changes at all — the PR-time parity step in `verify-library-conventions.yml` auto-commits any drift as `github-actions[bot]`, and the `Guard against hand-edits to cli-skills mirror` step **hard-fails** the PR if a non-bot commit touches the mirror.

Contributors following the sweep-canonical instruction would hit the new guard and have to undo their own work. The two sections need to give the same answer.

## What

One-line doc update: replace the "regenerate `cli-skills/`" sentence in the sweep-canonical section with the same don't-commit-the-mirror rule the Generated artifacts section already states, and point back to that section for the rationale.

No code or workflow changes.