### PR TITLE
ci(verify-skills): drop duplicate cli-skills drift gate that races with auto-fix

### DIFF
--- a/.github/workflows/verify-skills.yml
+++ b/.github/workflows/verify-skills.yml
@@ -3,22 +3,18 @@ name: Verify SKILL.md
 on:
   pull_request:
     paths:
-      - 'cli-skills/**'
       - 'library/**/.printing-press.json'
       - 'library/**/SKILL.md'
       - 'library/**/internal/cli/**'
       - '.github/workflows/verify-skills.yml'
       - '.github/scripts/verify-skill/**'
-      - 'tools/generate-skills/**'
   push:
     branches: [main]
     paths:
-      - 'cli-skills/**'
       - 'library/**/.printing-press.json'
       - 'library/**/SKILL.md'
       - 'library/**/internal/cli/**'
       - '.github/scripts/verify-skill/**'
-      - 'tools/generate-skills/**'
 
 jobs:
   verify:
@@ -37,26 +33,16 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.23'
-
-      - name: Verify cli-skills mirror is generated
-        run: |
-          set -euo pipefail
-          go run ./tools/generate-skills/main.go
-
-          drift=$(git status --porcelain -- cli-skills/)
-          if [ -n "$drift" ]; then
-            echo "::error title=cli-skills mirror is stale::cli-skills/ must be generated from library/<category>/<slug>/SKILL.md. Run \`go run ./tools/generate-skills/main.go\` and commit the generated mirror changes."
-            echo "Out-of-sync cli-skills entries:"
-            echo "$drift"
-            git diff -- cli-skills/
-            exit 1
-          fi
-
-          echo "cli-skills/ matches generated output."
+      # cli-skills/ drift handling lives in verify-library-conventions.yml's
+      # `cli-skills mirror parity` + `Commit generated convention fixes` steps,
+      # which soft-pass on PRs and auto-commit the regen as github-actions[bot].
+      # An additional strict drift gate here is redundant and was racy: this
+      # workflow defaults to actions/checkout's `refs/pull/<n>/merge` ref
+      # (a merge with main), while verify-library-conventions.yml checks out
+      # `head.ref` directly. The two trees disagree whenever main is stale
+      # relative to what the generator produces, which makes one workflow fail
+      # while the other passes on the same commit. Leave drift to the
+      # auto-fix path; this workflow's job is verify_skill.py.
 
       - name: Run verifier against affected CLI skills
         id: verify


### PR DESCRIPTION
## Why

\`verify-skills.yml\`'s **"Verify cli-skills mirror is generated"** step duplicated the drift check that already lives in \`verify-library-conventions.yml\`'s \`cli-skills mirror parity\` step, and the two workflows reached different verdicts on the same commit because they check out different trees:

| Workflow | Checkout ref | Tree |
|---|---|---|
| \`verify-skills.yml\` (before this PR) | default (\`refs/pull/<n>/merge\` on PRs) | PR head **merged with main** |
| \`verify-library-conventions.yml\` | explicit \`head.ref\` | PR head **alone**, no merge |

Whenever main's \`cli-skills/\` was stale relative to what \`tools/generate-skills/main.go\` produces — which it has been since the \`<!-- GENERATED FILE — DO NOT EDIT -->\` header was added without bulk-regenerating main (fixed in #597) — the merge tree pulled main's old-format files into \`verify-skills.yml\`'s working tree and the strict drift gate hard-failed, while the \`verify-library-conventions.yml\` parity step on the same commit saw no drift in \`head.ref\`'s tree and passed. This false-failed nearly every active PR.

## What

- Drop the **"Verify cli-skills mirror is generated"** step entirely.
- Drop the **"Set up Go"** step (no longer needed; \`verify_skill.py\` is Python).
- Drop \`cli-skills/**\` and \`tools/generate-skills/**\` from the \`paths\` triggers (not relevant to the verifier).
- Leave a comment in the workflow file explaining why drift handling lives in the other workflow, so a future agent doesn't re-add the gate.

\`verify-skills.yml\`'s actual value-add — running \`verify_skill.py\` against affected CLI skills to validate \`--flag\` references, command names, and positional args against the shipped CLI source — is unchanged.

## Why drift handling belongs in \`verify-library-conventions.yml\` only

Its \`cli-skills mirror parity\` step:

1. Runs the generator and detects drift.
2. **Soft-passes on PRs** (exits 0, sets \`changed=true\`) instead of failing the check.
3. The next step, \`Commit generated convention fixes\`, commits the regenerated mirror back to the branch **as \`github-actions[bot]\`** on same-repo PRs.

That's the real fix for drift: regenerate and push. The strict gate this PR removes added no information beyond what parity already detects, and broke when the two workflows disagreed.

## Companion PR

Stacks on #597 (one-shot bulk-regen of main's \`cli-skills/\` to inject the GENERATED FILE header). With #597 alone, the drift between merge tree and head.ref tree disappears; with this PR alone, the gate stops being a foot-gun even if a future generator-template change introduces another stale-main window. Both together close the issue end-to-end.