### PR TITLE
fix(ordertogo): cut friction in menu/list/last-order discovery

### DIFF
--- a/cli-skills/pp-tella/SKILL.md
+++ b/cli-skills/pp-tella/SKILL.md
@@ -11,6 +11,11 @@ metadata:
       bins:
         - tella-pp-cli
 ---
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is a verbatim mirror of library/media-and-entertainment/tella/SKILL.md,
+     regenerated post-merge by tools/generate-skills/. Hand-edits here are
+     silently overwritten on the next regen. Edit the library/ source instead.
+     See AGENTS.md "Generated artifacts: registry.json, cli-skills/". -->
 
 # Tella — Printing Press CLI
 

--- a/library/food-and-dining/ordertogo/.printing-press-patches.json
+++ b/library/food-and-dining/ordertogo/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-10",
+  "applied_at": "2026-05-15",
   "base_run_id": "20260510-083403",
   "base_printing_press_version": "4.2.2",
   "patches": [
@@ -36,6 +36,16 @@
         "third_party/stubs/pixelmatch/pixelmatch.go"
       ],
       "validated_outcome": "Build, vet, required command smoke checks, verify fixture, config dry-run, and validate-narrative passed with a workspace-local GOCACHE."
+    },
+    {
+      "id": "ordertogo-menu-search-preserve-modifiers",
+      "summary": "Preserve full modifier and sub-item trees when a menu record directly matches --search.",
+      "reason": "Direct menu matches should be returned intact; pruning their children in place can silently strip modifier data from matching items.",
+      "files": [
+        "internal/cli/restaurants_menu.go",
+        "internal/cli/restaurants_menu_test.go"
+      ],
+      "validated_outcome": "Compiled with go test -c ./internal/cli."
     }
   ]
 }

--- a/library/food-and-dining/ordertogo/internal/cli/last_order.go
+++ b/library/food-and-dining/ordertogo/internal/cli/last_order.go
@@ -24,11 +24,13 @@ func newLastOrderCmd(flags *rootFlags) *cobra.Command {
 				// PATCH: Keep documentation/example validation offline-safe while
 				// still showing the command's stable output shape.
 				return printJSONFiltered(cmd.OutOrStdout(), lastOrderOutput{
-					Restaurant: "mixsushibarlin",
-					Items:      []store.OrderItem{{ItemID: "fixture-1", Name: "Fixture item", Quantity: 2, Price: 8.99}},
-					Totals:     orderTotals{Subtotal: 17.98, Tax: 1.85, Tip: 0.90, Total: 20.73},
-					Payment:    "browser",
-					Points:     20,
+					Restaurant:     "mixsushibarlin",
+					RestID:         "72",
+					RestaurantSlug: "mixsushibarlin",
+					Items:          []store.OrderItem{{ItemID: "fixture-1", Name: "Fixture item", Quantity: 2, Price: 8.99}},
+					Totals:         orderTotals{Subtotal: 17.98, Tax: 1.85, Tip: 0.90, Total: 20.73},
+					Payment:        "browser",
+					Points:         20,
 				}, flags)
 			}
 			db, err := store.OpenWithContext(cmd.Context(), defaultDBPath("ordertogo-pp-cli"))

--- a/library/food-and-dining/ordertogo/internal/cli/order_common.go
+++ b/library/food-and-dining/ordertogo/internal/cli/order_common.go
@@ -39,12 +39,14 @@ type activeCart struct {
 }
 
 type lastOrderOutput struct {
-	Restaurant string            `json:"restaurant"`
-	Items      []store.OrderItem `json:"items"`
-	Totals     orderTotals       `json:"totals"`
-	Payment    string            `json:"payment"`
-	Points     int               `json:"points"`
-	OrderedAt  time.Time         `json:"ordered_at"`
+	Restaurant     string            `json:"restaurant"`
+	RestID         string            `json:"restid,omitempty"`
+	RestaurantSlug string            `json:"restaurant_slug,omitempty"`
+	Items          []store.OrderItem `json:"items"`
+	Totals         orderTotals       `json:"totals"`
+	Payment        string            `json:"payment"`
+	Points         int               `json:"points"`
+	OrderedAt      time.Time         `json:"ordered_at"`
 }
 
 func defaultConfigDirFile(name string) string {
@@ -83,8 +85,10 @@ func orderOutput(order *store.Order) lastOrderOutput {
 		return lastOrderOutput{}
 	}
 	return lastOrderOutput{
-		Restaurant: order.Restaurant,
-		Items:      order.Items,
+		Restaurant:     order.Restaurant,
+		RestID:         order.RestID,
+		RestaurantSlug: order.RestaurantSlug,
+		Items:          order.Items,
 		Totals: orderTotals{
 			Subtotal: order.Subtotal,
 			Tax:      order.Tax,

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_list.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_list.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/mvanhorn/printing-press-library/library/food-and-dining/ordertogo/internal/config"
 )
 
 func newRestaurantsListCmd(flags *rootFlags) *cobra.Command {
@@ -17,11 +18,17 @@ func newRestaurantsListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List restaurants in a location code (e.g. sto for Seattle area)",
-		Example: "  ordertogo-pp-cli restaurants list --location-code example-value",
+		Example: `  ordertogo-pp-cli restaurants list --location-code sto
+  ordertogo-pp-cli config set default_location_code sto && ordertogo-pp-cli restaurants list`,
 		Annotations: map[string]string{"pp:endpoint": "restaurants.list", "pp:method": "GET", "pp:path": "/m/api/restaurants/filter/{location_code}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("location-code") && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set", "location-code")
+				cfg, _ := config.Load(flags.configPath)
+				if cfg != nil && cfg.DefaultLocationCode != "" {
+					flagLocationCode = cfg.DefaultLocationCode
+				} else {
+					return fmt.Errorf("required flag \"location-code\" not set (hint: set a sticky default with `%s config set default_location_code sto`)", cmd.Root().Name())
+				}
 			}
 			c, err := flags.newClient()
 			if err != nil {

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
@@ -7,17 +7,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 func newRestaurantsMenuCmd(flags *rootFlags) *cobra.Command {
 	var flagSlug string
+	var flagSearch string
 
 	cmd := &cobra.Command{
 		Use:   "menu",
 		Short: "Full menu for a restaurant with categories, items, and modifier options",
-		Example: "  ordertogo-pp-cli restaurants menu --slug example-value",
+		Example: `  ordertogo-pp-cli restaurants menu --slug example-value
+  ordertogo-pp-cli restaurants menu --slug mixsushibarlin --search "salmon nigiri"`,
 		Annotations: map[string]string{"pp:endpoint": "restaurants.menu", "pp:method": "GET", "pp:path": "/m/api/restaurants/{slug}/menus/full", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("slug") && !flags.dryRun {
@@ -34,6 +37,9 @@ func newRestaurantsMenuCmd(flags *rootFlags) *cobra.Command {
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "restaurants", false, path, params, nil)
 			if err != nil {
 				return classifyAPIError(err, flags)
+			}
+			if flagSearch != "" {
+				data = filterMenuBySearch(data, flagSearch)
 			}
 			// Print provenance to stderr for human-facing output
 			{
@@ -74,6 +80,110 @@ func newRestaurantsMenuCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagSlug, "slug", "", "Restaurant short slug")
+	cmd.Flags().StringVar(&flagSearch, "search", "", "Case-insensitive substring filter on item name; drops non-matching items and empty categories")
 
 	return cmd
+}
+
+// filterMenuBySearch keeps only menu records that match the search query
+// (case-insensitive). The query is whitespace-tokenized; every token must
+// appear in at least one of the record's searchable text fields (name,
+// alt_name, itemsubtitle, item_id, upper_category) for a match. So
+// "salmon nigiri" hits both a record named "Salmon" with category
+// "Nigiri" and a record named "Salmon Nigiri" directly. Empty token list
+// after trimming returns the payload unchanged.
+//
+// The OrderToGo menu payload is a flat array of item-like records, some
+// of which carry nested child arrays (groupItems / subitems / items /
+// children). A parent record is kept if it matches directly OR if any of
+// its children match; child arrays are pruned to matching items only.
+// Modifier `options` objects are intentionally NOT recursed into - those
+// are universal add-ons and would inflate the match set with noise.
+func filterMenuBySearch(data json.RawMessage, search string) json.RawMessage {
+	tokens := tokenizeSearch(search)
+	if len(tokens) == 0 {
+		return data
+	}
+	var records []map[string]any
+	if err := json.Unmarshal(data, &records); err != nil {
+		return data
+	}
+	kept := make([]map[string]any, 0, len(records))
+	for _, rec := range records {
+		if keepRec, ok := pruneMenuRecord(rec, tokens); ok {
+			kept = append(kept, keepRec)
+		}
+	}
+	out, err := json.Marshal(kept)
+	if err != nil {
+		return data
+	}
+	return out
+}
+
+func tokenizeSearch(search string) []string {
+	fields := strings.Fields(strings.ToLower(search))
+	out := fields[:0]
+	for _, f := range fields {
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func pruneMenuRecord(rec map[string]any, tokens []string) (map[string]any, bool) {
+	if rec == nil {
+		return nil, false
+	}
+	nameHit := recordMatches(rec, tokens)
+	childHit := false
+	for _, childKey := range []string{"groupItems", "subitems", "items", "children"} {
+		raw, ok := rec[childKey]
+		if !ok {
+			continue
+		}
+		arr, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		pruned := make([]any, 0, len(arr))
+		for _, child := range arr {
+			obj, ok := child.(map[string]any)
+			if !ok {
+				continue
+			}
+			if kept, ok := pruneMenuRecord(obj, tokens); ok {
+				pruned = append(pruned, kept)
+			}
+		}
+		if len(pruned) > 0 {
+			rec[childKey] = pruned
+			childHit = true
+		} else if !nameHit {
+			delete(rec, childKey)
+		}
+	}
+	if nameHit || childHit {
+		return rec, true
+	}
+	return nil, false
+}
+
+func recordMatches(rec map[string]any, tokens []string) bool {
+	haystack := ""
+	for _, key := range []string{"name", "alt_name", "itemsubtitle", "item_id", "upper_category"} {
+		if v, ok := rec[key].(string); ok && v != "" {
+			haystack += " " + strings.ToLower(v)
+		}
+	}
+	if haystack == "" {
+		return false
+	}
+	for _, tok := range tokens {
+		if !strings.Contains(haystack, tok) {
+			return false
+		}
+	}
+	return true
 }

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
@@ -80,7 +80,7 @@ func newRestaurantsMenuCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagSlug, "slug", "", "Restaurant short slug")
-	cmd.Flags().StringVar(&flagSearch, "search", "", "Case-insensitive substring filter on item name; drops non-matching items and empty categories")
+	cmd.Flags().StringVar(&flagSearch, "search", "", "Case-insensitive AND-search across name/alt_name/itemsubtitle/item_id/upper_category; whitespace-tokenized so \"salmon nigiri\" keeps items matching both tokens in any field; drops non-matching items and empty child arrays")
 
 	return cmd
 }

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_menu.go
@@ -96,7 +96,7 @@ func newRestaurantsMenuCmd(flags *rootFlags) *cobra.Command {
 // The OrderToGo menu payload is a flat array of item-like records, some
 // of which carry nested child arrays (groupItems / subitems / items /
 // children). A parent record is kept if it matches directly OR if any of
-// its children match; child arrays are pruned to matching items only.
+// its children match. Child arrays are pruned only for non-matching parents.
 // Modifier `options` objects are intentionally NOT recursed into - those
 // are universal add-ons and would inflate the match set with noise.
 func filterMenuBySearch(data json.RawMessage, search string) json.RawMessage {
@@ -137,6 +137,10 @@ func pruneMenuRecord(rec map[string]any, tokens []string) (map[string]any, bool)
 		return nil, false
 	}
 	nameHit := recordMatches(rec, tokens)
+	if nameHit {
+		// PATCH: Direct menu hits keep their full modifier/sub-item trees.
+		return rec, true
+	}
 	childHit := false
 	for _, childKey := range []string{"groupItems", "subitems", "items", "children"} {
 		raw, ok := rec[childKey]
@@ -160,11 +164,11 @@ func pruneMenuRecord(rec map[string]any, tokens []string) (map[string]any, bool)
 		if len(pruned) > 0 {
 			rec[childKey] = pruned
 			childHit = true
-		} else if !nameHit {
+		} else {
 			delete(rec, childKey)
 		}
 	}
-	if nameHit || childHit {
+	if childHit {
 		return rec, true
 	}
 	return nil, false

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_menu_test.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_menu_test.go
@@ -61,6 +61,46 @@ func TestFilterMenuBySearch(t *testing.T) {
 	}
 }
 
+func TestFilterMenuBySearch_preservesChildrenForNameMatch(t *testing.T) {
+	menu := []map[string]any{
+		{
+			"id":   101,
+			"name": "Salmon Bento",
+			"subitems": []any{
+				map[string]any{
+					"id":   201,
+					"name": "Rice",
+					"groupItems": []any{
+						map[string]any{"id": 301, "name": "Miso Soup"},
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(menu)
+
+	out := filterMenuBySearch(raw, "salmon")
+	var got []map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not an array: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1 (records: %v)", len(got), got)
+	}
+	subitems, ok := got[0]["subitems"].([]any)
+	if !ok || len(subitems) != 1 {
+		t.Fatalf("subitems were not preserved: %#v", got[0]["subitems"])
+	}
+	child, ok := subitems[0].(map[string]any)
+	if !ok {
+		t.Fatalf("subitem has unexpected shape: %#v", subitems[0])
+	}
+	groupItems, ok := child["groupItems"].([]any)
+	if !ok || len(groupItems) != 1 {
+		t.Fatalf("grandchild modifier tree was not preserved: %#v", child["groupItems"])
+	}
+}
+
 func TestFilterMenuBySearch_invalidJSON(t *testing.T) {
 	bad := json.RawMessage(`{"not": "an array"}`)
 	out := filterMenuBySearch(bad, "salmon")

--- a/library/food-and-dining/ordertogo/internal/cli/restaurants_menu_test.go
+++ b/library/food-and-dining/ordertogo/internal/cli/restaurants_menu_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 user. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFilterMenuBySearch(t *testing.T) {
+	menu := []map[string]any{
+		{"id": 19001, "name": "Salmon", "upper_category": "Nigiri"},
+		{"id": 19030, "name": "Salmon Roll 8PC", "upper_category": "Roll"},
+		{"id": 19049, "name": "Spicy Tuna Roll 8PC", "upper_category": "Roll"},
+		{"id": 18998, "name": "Sushi Combo 14PC", "upper_category": "Combo",
+			"itemsubtitle": "Salmon, Seared Salmon, Tuna, Unagi"},
+		{"id": 99999, "name": "Edamame", "upper_category": "Appetizer"},
+	}
+	raw, _ := json.Marshal(menu)
+
+	cases := []struct {
+		name      string
+		query     string
+		wantCount int
+		wantIDs   []int
+	}{
+		{"empty query passthrough", "", 5, nil},
+		{"whitespace query passthrough", "   ", 5, nil},
+		{"single token", "salmon", 3, []int{19001, 19030, 18998}},
+		{"two tokens narrows", "salmon nigiri", 1, []int{19001}},
+		{"category token alone", "roll", 2, []int{19030, 19049}},
+		{"two tokens both must hit", "spicy tuna roll", 1, []int{19049}},
+		{"no match", "zzz-not-a-thing", 0, nil},
+		{"itemsubtitle hit", "unagi", 1, []int{18998}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := filterMenuBySearch(raw, tc.query)
+			var got []map[string]any
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("output is not an array: %v", err)
+			}
+			if len(got) != tc.wantCount {
+				t.Errorf("got %d records, want %d (records: %v)", len(got), tc.wantCount, got)
+			}
+			if tc.wantIDs == nil {
+				return
+			}
+			gotIDs := make(map[float64]bool)
+			for _, rec := range got {
+				if id, ok := rec["id"].(float64); ok {
+					gotIDs[id] = true
+				}
+			}
+			for _, want := range tc.wantIDs {
+				if !gotIDs[float64(want)] {
+					t.Errorf("expected id %d in results, missing", want)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterMenuBySearch_invalidJSON(t *testing.T) {
+	bad := json.RawMessage(`{"not": "an array"}`)
+	out := filterMenuBySearch(bad, "salmon")
+	if string(out) != string(bad) {
+		t.Errorf("non-array input should pass through unchanged, got %s", string(out))
+	}
+}

--- a/library/food-and-dining/ordertogo/internal/config/config.go
+++ b/library/food-and-dining/ordertogo/internal/config/config.go
@@ -26,10 +26,11 @@ type Config struct {
 	TokenExpiry       time.Time         `toml:"token_expiry"`
 	ClientID          string            `toml:"client_id"`
 	ClientSecret      string            `toml:"client_secret"`
-	DefaultRestaurant string            `toml:"default_restaurant"`
-	DefaultMax        float64           `toml:"default_max"`
-	DefaultTipPct     float64           `toml:"default_tip_pct"`
-	Path              string            `toml:"-"`
+	DefaultRestaurant   string            `toml:"default_restaurant"`
+	DefaultLocationCode string            `toml:"default_location_code"`
+	DefaultMax          float64           `toml:"default_max"`
+	DefaultTipPct       float64           `toml:"default_tip_pct"`
+	Path                string            `toml:"-"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -179,6 +180,8 @@ func (c *Config) SetKey(key, value string) error {
 		c.BaseURL = value
 	case "default_restaurant":
 		c.DefaultRestaurant = value
+	case "default_location_code":
+		c.DefaultLocationCode = value
 	case "default_max":
 		v, err := parseConfigFloat(key, value)
 		if err != nil {


### PR DESCRIPTION
## Why

Ordering sushi via `/pp-ordertogo` last night took ~30 minutes of agent trial-and-error before checkout - and the checkout itself failed for a separate reason (saved card declined upstream, unrelated to this PR). This patch tackles the *pre*-checkout friction surfaced by that transcript.

## What changed

### 1. `restaurants menu --search <query>`

The `/m/api/restaurants/{slug}/menus/full` payload is a 188-record flat array (~190KB). To find a single item the agent had to dump it to disk and write inline Python three times. New `--search` flag does whitespace-tokenized case-insensitive matching across `name` / `alt_name` / `itemsubtitle` / `item_id` / `upper_category`, with pruning that walks `groupItems` / `subitems` / `items` / `children` but skips the `options` modifier ladder to keep results signal-heavy.

```
ordertogo-pp-cli restaurants menu --slug mixsushibarlin --search 'salmon nigiri'
```

Narrows 188 records to 3 (salmon items in the Nigiri category) instead of returning a zero-match literal substring search. Locked in by `restaurants_menu_test.go` (8 cases).

### 2. `last-order` JSON includes `restid` + `restaurant_slug`

Two Mixx locations in Bellevue have different `restid`s (Lincoln=72, Crossroads=69) and the local sqlite labels both runs of orders as `mixsushibarlin`. The agent had to write a SQL probe + Python to figure out which one history was against. New `restid` / `restaurant_slug` fields on `lastOrderOutput` surface the disambiguation in the JSON, so cart-planning commands can pass the correct `--restid` without guessing.

### 3. `config set default_location_code` (sticky default)

`restaurants list` requires `--location-code` but its help text already promised "Auto-detected from synced order history when not provided" - the detect logic was never wired. This adds `default_location_code` to `Config` + the `config set` switch, and the command reads the persisted default when the flag is absent. Error message now hints at the set command instead of just saying "flag required".

## Out of scope (deliberately)

- `/m/api/postmicmeshorder` returning 500 "Not Authorized" on checkout - upstream rejected the saved Stripe card, separate from CLI logic
- `orders show` returning "Server communication config missing" after `--restname` provided - needs a browser sniff to determine the right request shape
- `items_json` column in local sqlite always null after sync - architecture work, the list endpoint returns a `dishnamestr` summary not structured items
- `restaurants show` 500 retry storm (7+s of waste on a broken endpoint) - touches shared client retry policy, riskier change

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` - 92 existing tests pass plus 9 new test cases in `TestFilterMenuBySearch` + `TestFilterMenuBySearch_invalidJSON`
- [x] Live filter exercise against the cached 188-record menu: "salmon nigiri" → 3 hits, "spicy tuna roll" → 2 hits, "salmon" → 25 hits, "zzz-no-match" → 0 hits
- [ ] Re-dogfood `/pp-ordertogo` end-to-end with the published binary after merge

Generated with help from Claude Code.