### PR TITLE
fix(ci): push mirror auto-commit with PAT so required checks re-run

### DIFF
--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -261,6 +261,15 @@ jobs:
           fi
 
           git commit -m "${message}"
+
+          # set -u doesn't catch this: GitHub Actions expands a missing
+          # secret to an empty string, not an unset variable. Without
+          # this check the push fails with an opaque auth error.
+          if [ -z "${PUSH_TOKEN}" ]; then
+            echo "::error::MIRROR_AUTOPUSH_TOKEN repo secret is missing or empty. Create a fine-grained PAT with contents:write + workflows:write on this repo and store it as MIRROR_AUTOPUSH_TOKEN (Settings -> Secrets and variables -> Actions)."
+            exit 1
+          fi
+
           git push "https://x-access-token:${PUSH_TOKEN}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"
           echo "Committed generated convention fixes to the PR branch."
 

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -231,7 +231,12 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.registry-diff.outputs.changed == 'true' || steps.skill-diff.outputs.changed == 'true')
         env:
           BASE_REPO: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
+          # PAT (not GITHUB_TOKEN) so the resulting push triggers
+          # pull_request_target workflows like greptile-policy-gate;
+          # GITHUB_TOKEN-authored pushes are suppressed by GitHub's
+          # anti-recursion rule and leave required checks missing on
+          # the new head SHA.
+          PUSH_TOKEN: ${{ secrets.MIRROR_AUTOPUSH_TOKEN }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           REGISTRY_CHANGED: ${{ steps.registry-diff.outputs.changed }}
           SKILL_CHANGED: ${{ steps.skill-diff.outputs.changed }}
@@ -256,7 +261,7 @@ jobs:
           fi
 
           git commit -m "${message}"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${BASE_REPO}.git" "HEAD:${HEAD_REF}"
           echo "Committed generated convention fixes to the PR branch."
 
       - name: Fail on cli-skills drift from fork

--- a/cli-skills/pp-tella/SKILL.md
+++ b/cli-skills/pp-tella/SKILL.md
@@ -11,6 +11,11 @@ metadata:
       bins:
         - tella-pp-cli
 ---
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is a verbatim mirror of library/media-and-entertainment/tella/SKILL.md,
+     regenerated post-merge by tools/generate-skills/. Hand-edits here are
+     silently overwritten on the next regen. Edit the library/ source instead.
+     See AGENTS.md "Generated artifacts: registry.json, cli-skills/". -->
 
 # Tella — Printing Press CLI
 


### PR DESCRIPTION
## Problem

`verify-library-conventions.yml`'s "Commit generated convention fixes" step pushes the regenerated `cli-skills/` mirror back to the PR branch as `github-actions[bot]`, using `GITHUB_TOKEN`. GitHub deliberately **suppresses workflow runs for pushes authored by `GITHUB_TOKEN`** to prevent infinite loops. So:

1. Author pushes a real commit → `pull_request_target` fires → Greptile policy gate runs
2. This workflow detects mirror drift, regenerates, auto-commits → new head SHA
3. The bot's push fires nothing → required checks (`Greptile policy gate`, `Greptile Review`) never run on the new SHA
4. PR is `mergeable=MERGEABLE` but `mergeStateStatus=BLOCKED` forever

PR #588 was the canonical victim; manually closing and reopening cleared it because that fires fresh `pull_request_target reopened` events. Maintainers have been working around this with "Reopening this PR to trigger the newly-required Greptile policy gate check" comments — that's the workaround this fixes.

## Fix

Push using a fine-grained PAT (`secrets.MIRROR_AUTOPUSH_TOKEN`) instead of `GITHUB_TOKEN`. Pushes authored by anything other than the default token trigger workflows normally.

The PAT is repo-scoped to `mvanhorn/printing-press-library` with `Contents: write` and `Workflows: write`. The secret was created alongside this PR.

## Test plan

- [ ] Merge this PR
- [ ] On the next PR that triggers cli-skills drift, confirm the auto-commit fires AND its new head SHA receives `Greptile policy gate` + `Greptile Review` results
- [ ] No more "Reopening this PR to trigger the newly-required Greptile policy gate check" comments needed

## Rollback

Revert this PR. Behavior returns to pre-fix (auto-commit works but leaves PRs gate-blocked).