### PR TITLE
feat(ci): surface unresolved review threads as a status check

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -129,7 +129,7 @@ jobs:
                 ($u | length) as $count |
                 "**" + ($count|tostring) + " unresolved review thread(s):**\n\n" +
                 ([$u[0:10] | .[] |
-                  "- `" + .path + ":" + (.line // 0 | tostring) + "` by `" +
+                  "- `" + .path + (if .line then ":" + (.line | tostring) else "" end) + "` by `" +
                   (.comments.nodes[0].author.login // "unknown") + "`" +
                   (if .isOutdated then " *(outdated — line no longer exists; likely addressed by a later commit)*" else "" end)
                 ] | join("\n")) +

--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -1,0 +1,154 @@
+name: Conversation resolution check
+
+# Surfaces unresolved review threads as a status check on the PR head SHA.
+# Not an enforcement gate — the `pull_request.required_review_thread_resolution`
+# ruleset rule on main is what actually blocks merge. This workflow exists
+# because that ruleset rule has no native status-check representation, so an
+# author looking at a wall of green checks has no obvious signal that an
+# unresolved Greptile (or human) thread is the actual blocker. The check
+# posted here shows up in the same list, with the same visual weight, so
+# the blocker is impossible to miss.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+  pull_request_review_comment:
+    types: [created, deleted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to evaluate
+        required: true
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  evaluate:
+    name: All conversations resolved
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Coalesce bursts (a push + Greptile review + several thread resolves can
+    # fire within seconds). Latest run wins; older runs are cancelled.
+    concurrency:
+      group: conversation-resolution-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
+      cancel-in-progress: true
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve PR number + head SHA
+        id: pr
+        env:
+          DISPATCH_PR: ${{ inputs.pr }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${EVENT_PR_NUMBER:-}" ] && [ -n "${EVENT_HEAD_SHA:-}" ]; then
+            echo "number=${EVENT_PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+            echo "head_sha=${EVENT_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if ! [[ "${DISPATCH_PR:-}" =~ ^[0-9]+$ ]]; then
+            echo "::error::PR number not in event payload and 'pr' input is not a positive integer."
+            exit 1
+          fi
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${DISPATCH_PR}")"
+          echo "number=$(jq -r '.number' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=$(jq -r '.head.sha' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
+
+      - name: Evaluate review threads and post check_run
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          threads_json="$(mktemp)"
+          gh api graphql --paginate \
+            -F owner="${owner}" -F repo="${repo}" -F number="${PR_NUMBER}" \
+            -f query='
+              query($owner: String!, $repo: String!, $number: Int!, $endCursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        isResolved
+                        isOutdated
+                        path
+                        line
+                        comments(first: 1) { nodes { author { login } } }
+                      }
+                    }
+                  }
+                }
+              }
+            ' \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[]' \
+            | jq -s '.' > "${threads_json}"
+
+          total=$(jq 'length' "${threads_json}")
+          unresolved=$(jq '[.[] | select(.isResolved == false)] | length' "${threads_json}")
+          unresolved_active=$(jq '[.[] | select(.isResolved == false and .isOutdated == false)] | length' "${threads_json}")
+          unresolved_outdated=$((unresolved - unresolved_active))
+
+          echo "total=${total} unresolved=${unresolved} (active=${unresolved_active} outdated=${unresolved_outdated})"
+
+          if [ "${unresolved}" -eq 0 ]; then
+            conclusion="success"
+            title="All ${total} conversation(s) resolved"
+            summary=$'No unresolved review threads on this PR.'
+          else
+            conclusion="failure"
+            if [ "${unresolved_active}" -gt 0 ] && [ "${unresolved_outdated}" -gt 0 ]; then
+              title="${unresolved} unresolved (${unresolved_active} on current code, ${unresolved_outdated} outdated)"
+            elif [ "${unresolved_active}" -gt 0 ]; then
+              title="${unresolved} unresolved conversation(s)"
+            else
+              title="${unresolved} unresolved on outdated lines (likely addressed)"
+            fi
+
+            summary=$(jq -r '
+              def listing:
+                [.[] | select(.isResolved == false)] as $u |
+                ($u | length) as $count |
+                "**" + ($count|tostring) + " unresolved review thread(s):**\n\n" +
+                ([$u[0:10] | .[] |
+                  "- `" + .path + ":" + (.line // 0 | tostring) + "` by `" +
+                  (.comments.nodes[0].author.login // "unknown") + "`" +
+                  (if .isOutdated then " *(outdated — line no longer exists; likely addressed by a later commit)*" else "" end)
+                ] | join("\n")) +
+                (if $count > 10 then "\n\n_… and " + ($count - 10 | tostring) + " more._" else "" end) +
+                "\n\n---\n\n**To unblock the merge**, click \"Resolve conversation\" on each unresolved thread in the GitHub UI.\n\nThis check mirrors the `pull_request.required_review_thread_resolution` ruleset rule on `main`. The ruleset is the gate; this check is the visibility layer.\n\nMaintainers with bypass can override via `gh pr merge " + $PR_NUMBER + " --admin --squash` (use sparingly — see AGENTS.md cardinal rule #1 on Greptile findings)."
+              ;
+              listing
+            ' --arg PR_NUMBER "${PR_NUMBER}" "${threads_json}")
+          fi
+
+          payload="$(mktemp)"
+          jq -n \
+            --arg name "All conversations resolved" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg conclusion "${conclusion}" \
+            --arg title "${title}" \
+            --arg summary "${summary}" \
+            '{name: $name, head_sha: $head_sha, status: "completed", conclusion: $conclusion, output: {title: $title, summary: $summary}}' \
+            > "${payload}"
+
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/check-runs" --input "${payload}" >/dev/null
+          echo "Posted check_run: ${title} (${conclusion}) on ${HEAD_SHA}"


### PR DESCRIPTION
## Problem

The `pull_request.required_review_thread_resolution` ruleset rule on `main` already blocks merge when any review thread is unresolved (including Greptile inline findings). But that rule type has **no native check-run representation**, so an author looking at a wall of green status checks has no obvious signal that an unresolved thread is the actual blocker. The merge widget's "1 unresolved conversation" note is easy to skim past when every check is green.

**PR #609 is the canonical example** as of today: 11/12 threads resolved, a single P1 on `library/devices/adminbyrequest/internal/mcp/tools.go:455` still open, `mergeStateStatus=BLOCKED` — but every status check is green. Author has no obvious "fix this" signal.

## Fix

Add `.github/workflows/conversation-resolution-check.yml`. On every relevant PR event it queries the PR's review threads via GraphQL and posts a `check_run` named **"All conversations resolved"** to the PR head SHA:

- ✅ success when `unresolved == 0`
- ❌ failure when any thread is unresolved, with a markdown summary listing the first 10 unresolved threads (path, line, who flagged them, and whether the line is outdated)

The check is **informational only** — the existing ruleset rule remains the actual gate. The check just gives the gate a visible representation in the same list the author already scans.

### Lifecycle coverage

| Trigger | Why |
|---|---|
| `pull_request_target` (opened/reopened/synchronize/ready_for_review) | New commits → re-evaluate |
| `pull_request_review` (submitted) | Greptile (or human) posts a new review → re-evaluate |
| `pull_request_review_thread` (resolved/unresolved) | Author clicks "Resolve conversation" → re-evaluate |
| `pull_request_review_comment` (created/deleted) | New inline finding or removal → re-evaluate |
| `workflow_dispatch` with `pr` input | Manual re-trigger / debug |

`concurrency.cancel-in-progress: true` coalesces bursts (a push that fires synchronize + a Greptile review + several thread resolves can all land within seconds).

## Test plan

- [ ] Merge this PR
- [ ] On PR #609, verify a check named "All conversations resolved" appears with `failure` conclusion citing the unresolved tools.go:455 thread
- [ ] Have Chris-Coombes (or admin) resolve the thread → verify the check re-runs and flips to `success`
- [ ] Open any future PR; verify check appears within ~30s of Greptile's review

## Non-goals

- **Not** adding this check as a `required_status_checks` entry in the ruleset. The ruleset rule already enforces the same thing more efficiently; adding a parallel required check would be redundant and would require this workflow to never fail unexpectedly.
- **Not** auto-resolving outdated threads — that's a separate optional layer worth doing after this lands if author churn becomes a real annoyance.