### PR TITLE
fix(ci): drop unsupported pull_request_review_thread trigger

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -18,10 +18,13 @@ on:
       - ready_for_review
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   pull_request_review_comment:
     types: [created, deleted]
+  # Note: GitHub Actions does NOT support a `pull_request_review_thread`
+  # event trigger (despite that event existing in the webhook payload set).
+  # So clicking "Resolve conversation" in the UI does not auto-fire this
+  # workflow. The check_run will refresh on the next push, review, or
+  # comment event. workflow_dispatch is the manual escape hatch.
   workflow_dispatch:
     inputs:
       pr:


### PR DESCRIPTION
Hotfix for parse failure introduced in #620.

GitHub Actions does not support `pull_request_review_thread` as an event trigger, despite the event existing in the webhook payload set. The workflow file fails to parse with HTTP 422 `Unexpected value 'pull_request_review_thread'`, breaking event-driven runs on every PR.

Drop the trigger and document the gap inline. Check_run still refreshes on push, new reviews, and new inline comments — only the immediate refresh on UI "Resolve conversation" click is lost. workflow_dispatch covers manual cases.

## Test plan
- [x] YAML parses locally
- [ ] After merge: dispatch against PR #609 and verify the check_run lands on its head SHA