### PR TITLE
fix(ci): cancel-in-progress=false so cancelled check_runs don't pile up

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -49,11 +49,20 @@ jobs:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Coalesce bursts (a push + Greptile review + several thread resolves can
-    # fire within seconds). Latest run wins; older runs are cancelled.
+    # Serialize concurrent triggers via the concurrency group, but do NOT
+    # cancel in-progress runs. Cancellation freezes the auto-created
+    # check_run in `cancelled` state forever (we can't PATCH it post-Feb
+    # 2025), and a single push commonly fires 3-5 events in seconds
+    # (synchronize + Greptile's review.submitted + multiple
+    # review_comment.created), which left a row of `cancelled` check_runs
+    # making the PR look "partially failed" even when the real result
+    # was success. With cancel-in-progress: false, queued runs execute
+    # serially, each completes with a terminal success/failure, and the
+    # required-check rollup uses the latest by completed_at. UI shows
+    # N consistent entries instead of cancelled noise.
     concurrency:
       group: conversation-resolution-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
## Problem (the residual wart from #623)

#623 redesigned the workflow to use the job's auto-created check_run + exit code, which fixed the POST/PATCH-403 issue. But one wart remained: `cancel-in-progress: true` combined with the deprecation of workflow-side check_run mutation.

A single push routinely fires multiple events within seconds:
- `pull_request_target.synchronize` from the push
- `pull_request_review.submitted` when Greptile reviews
- `pull_request_review_comment.created` for each inline comment in the review batch (5+ on a typical review)

With cancel-in-progress on, all but the latest run gets cancelled. Each cancelled run leaves its auto-created check_run frozen in `cancelled` state. We can't PATCH those away (the Feb 2025 deprecation that necessitated the #623 redesign in the first place). So:

```
All conversations resolved   success    23:09:23Z   ← latest, real result
All conversations resolved   cancelled  23:09:16Z   ← shown as 'fail' in gh pr checks
All conversations resolved   cancelled  23:09:16Z   ← shown as 'fail' in gh pr checks
```

The merge widget shows "partially failed" forever. #623 hit this on its own merge widget.

## Fix

Flip `cancel-in-progress: false`. Queued runs execute serially in the concurrency group. Each completes with a terminal `success`/`failure` conclusion. Required-check rollup picks the latest by completed_at, which is correct. The UI shows N consistent entries instead of mixed cancelled noise.

## Tradeoff

3-5 workflow runs per push burst instead of 1. Each is ~20s, serial = ~100s total per push. For this repo's volume that's negligible.

## What stays unchanged

- `sleep 8` settle delay on `synchronize` — still needed for the auto-resolution race that #623 addressed
- All event triggers — we need `pull_request_review.submitted` to catch Greptile reviews that land minutes after a push; dropping it would miss the most important case
- exit-code based reporting — still drives the auto check_run conclusion natively

## Test plan

- [ ] Merge this PR
- [ ] On the next push to any PR, verify the workflow runs serially (queue → start → complete → next start) and no check_run shows `cancelled`
- [ ] Multi-event bursts (push + Greptile review landing within seconds) should produce N `success` or N `failure` rows, never mixed with `cancelled`

## Followup

Mirror in cli-printing-press is the next PR.