### PR TITLE
feat(instacart): named address profiles + per-call --profile flag

### DIFF
--- a/cli-skills/pp-instacart/SKILL.md
+++ b/cli-skills/pp-instacart/SKILL.md
@@ -199,6 +199,22 @@ The post-`auth login` step auto-populates `address_id`, `postal_code`, `latitude
 
 `instacart doctor` surfaces a `location: fail` check whenever this is missing, so an agent driving the CLI can detect the broken state before invoking a real command.
 
+### Multiple addresses (named profiles)
+
+`config profiles` is a named-address store on top of the single active-location config. Use it when the user has more than one delivery address (home, work, vacation house) and wants to switch without re-running `config set-address` each time.
+
+- `instacart config profiles list` — show saved profiles; the active one is marked with `*`.
+- `instacart config profiles add <name> --id <address_id> [--label "..."] [--use]` — save a profile by Instacart address ID (uses `GetAddressById` to fill coords). Pass `--use` to also activate it.
+- `instacart config profiles add <name> --lat <N> --lon <N> [--postal <zip>] [--label "..."]` — save a profile by raw coordinates, no network call.
+- `instacart config profiles use <name>` — switch the active profile (copies its location onto the top-level config keys so every downstream call uses it).
+- `instacart config profiles show <name>` — print one profile.
+- `instacart config profiles rm <name>` — delete a profile. If it was active, the active profile is cleared and the existing top-level config still applies.
+- `instacart config profiles import [--prefix <p>] [--overwrite] [--use <name>]` — fetch every saved address from the user's Instacart account (via `CurrentUserAddresses`) and save each as a profile, slugifying the street address for the name.
+
+Per-call override: pass `--profile <name>` to any command that needs location (e.g. `instacart --profile work add safeway "cold brew"`). This applies the named profile for that single call without changing the active profile.
+
+When no profiles are defined, the CLI behaves exactly as before — `config set-coords` / `set-address` / `show` continue to drive the top-level location keys directly.
+
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.

--- a/library/commerce/instacart/.printing-press-patches.json
+++ b/library/commerce/instacart/.printing-press-patches.json
@@ -26,6 +26,21 @@
         "internal/cli/doctor.go",
         "internal/cli/root.go"
       ]
+    },
+    {
+      "id": "instacart-address-profiles",
+      "summary": "Add a named-address profile store under `instacart config profiles` (list / show / add / use / rm / import) plus a `--profile <name>` per-call persistent flag so users with multiple delivery addresses can switch without re-running `config set-address` each time.",
+      "reason": "Single-address config forces a destructive overwrite every time a user switches addresses (home vs. work vs. vacation house). The fix-instacart-location-config-546 patch already added a CurrentUserAddresses lookup; this builds on it to persist named profiles, with `import` reusing the same GraphQL query to seed one profile per saved Instacart address. Backwards-compatible: when `profiles` and `active_profile` are absent from config.json, behavior is identical to today.",
+      "files": [
+        "internal/config/config.go",
+        "internal/config/profiles_test.go",
+        "internal/cli/config.go",
+        "internal/cli/profiles.go",
+        "internal/cli/profiles_test.go",
+        "internal/cli/root.go",
+        "SKILL.md"
+      ],
+      "validated_outcome": "Unit tests cover profile CRUD, --use side-effects, JSON output shape, slug generation, and the --profile root flag applying through newAppContext."
     }
   ]
 }

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -194,6 +194,22 @@ The post-`auth login` step auto-populates `address_id`, `postal_code`, `latitude
 
 `instacart doctor` surfaces a `location: fail` check whenever this is missing, so an agent driving the CLI can detect the broken state before invoking a real command.
 
+### Multiple addresses (named profiles)
+
+`config profiles` is a named-address store on top of the single active-location config. Use it when the user has more than one delivery address (home, work, vacation house) and wants to switch without re-running `config set-address` each time.
+
+- `instacart config profiles list` — show saved profiles; the active one is marked with `*`.
+- `instacart config profiles add <name> --id <address_id> [--label "..."] [--use]` — save a profile by Instacart address ID (uses `GetAddressById` to fill coords). Pass `--use` to also activate it.
+- `instacart config profiles add <name> --lat <N> --lon <N> [--postal <zip>] [--label "..."]` — save a profile by raw coordinates, no network call.
+- `instacart config profiles use <name>` — switch the active profile (copies its location onto the top-level config keys so every downstream call uses it).
+- `instacart config profiles show <name>` — print one profile.
+- `instacart config profiles rm <name>` — delete a profile. If it was active, the active profile is cleared and the existing top-level config still applies.
+- `instacart config profiles import [--prefix <p>] [--overwrite] [--use <name>]` — fetch every saved address from the user's Instacart account (via `CurrentUserAddresses`) and save each as a profile, slugifying the street address for the name.
+
+Per-call override: pass `--profile <name>` to any command that needs location (e.g. `instacart --profile work add safeway "cold brew"`). This applies the named profile for that single call without changing the active profile.
+
+When no profiles are defined, the CLI behaves exactly as before — `config set-coords` / `set-address` / `show` continue to drive the top-level location keys directly.
+
 ## Agent Mode
 
 The CLI is agent-native by default. Pass `--json` on any command for machine-readable output. `--dry-run` previews `add` without firing the mutation and surfaces which resolver (`history`, `live`, or `item-id`) would have fired.

--- a/library/commerce/instacart/internal/cli/config.go
+++ b/library/commerce/instacart/internal/cli/config.go
@@ -42,6 +42,8 @@ If you don't know your coordinates, the easiest path is:
 		newConfigShowCmd(),
 		newConfigSetCoordsCmd(),
 		newConfigSetAddressCmd(),
+		// PATCH (instacart-address-profiles): named multi-address store.
+		newConfigProfilesCmd(),
 	)
 	return cmd
 }

--- a/library/commerce/instacart/internal/cli/profiles.go
+++ b/library/commerce/instacart/internal/cli/profiles.go
@@ -1,0 +1,557 @@
+// PATCH (instacart-address-profiles): adds an `instacart config profiles`
+// subtree so users with multiple delivery addresses (home, work, second
+// residence) can save each as a named profile and switch between them with
+// `instacart config profiles use <name>` instead of re-running
+// `config set-address --id` every time. Also adds a per-call `--profile`
+// persistent flag (wired in root.go) and an `import` command that pulls
+// every saved Instacart address via the existing CurrentUserAddresses
+// GraphQL query and persists each as a profile.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/auth"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/gql"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/store"
+)
+
+func newConfigProfilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "Manage named address profiles (home, work, second residence, ...)",
+		Long: `Profiles are named snapshots of location data. The CLI's GraphQL calls
+only ever read one location at a time, so switching between addresses
+normally means re-running ` + "`config set-address --id`" + ` each time.
+A profile is a saved copy of those four fields (postal_code, address_id,
+latitude, longitude) under a short name like "home" or "work".
+
+Switch the active profile with ` + "`instacart config profiles use <name>`" + `,
+or override for a single call with the persistent ` + "`--profile <name>`" + `
+flag (e.g., ` + "`instacart --profile work add safeway 'cold brew'`" + `).
+
+When no profiles are defined the CLI behaves exactly as before — the
+top-level config keys remain authoritative.`,
+	}
+	cmd.AddCommand(
+		newConfigProfilesListCmd(),
+		newConfigProfilesShowCmd(),
+		newConfigProfilesAddCmd(),
+		newConfigProfilesUseCmd(),
+		newConfigProfilesRmCmd(),
+		newConfigProfilesImportCmd(),
+	)
+	return cmd
+}
+
+func newConfigProfilesListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:         "list",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Short:       "List saved profiles (active one is marked with *)",
+		Example:     "  instacart config profiles list\n  instacart config profiles list --json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			names := cfg.ProfileNames()
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				rows := make([]map[string]any, 0, len(names))
+				for _, n := range names {
+					p, _ := cfg.GetProfile(n)
+					rows = append(rows, map[string]any{
+						"name":        p.Name,
+						"label":       p.Label,
+						"postal_code": p.PostalCode,
+						"address_id":  p.AddressID,
+						"latitude":    p.Latitude,
+						"longitude":   p.Longitude,
+						"active":      cfg.ActiveProfile == p.Name,
+					})
+				}
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"active":   cfg.ActiveProfile,
+					"profiles": rows,
+				})
+			}
+			if len(names) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no profiles saved. Add one with `instacart config profiles add <name> --id <address_id>` or `--lat ... --lon ...`.")
+				return nil
+			}
+			for _, n := range names {
+				p, _ := cfg.GetProfile(n)
+				marker := "  "
+				if cfg.ActiveProfile == n {
+					marker = "* "
+				}
+				label := p.Label
+				if label == "" {
+					label = "(no label)"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s%-20s %s\n", marker, p.Name, label)
+			}
+			return nil
+		},
+	}
+}
+
+func newConfigProfilesShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:         "show <name>",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Short:       "Print the full contents of one profile",
+		Args:        cobra.ExactArgs(1),
+		Example:     "  instacart config profiles show home",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			p, ok := cfg.GetProfile(args[0])
+			if !ok {
+				return coded(ExitNotFound, "profile %q not found", args[0])
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(p)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"name:        %s\nlabel:       %s\nactive:      %t\npostal_code: %q\naddress_id:  %q\nlatitude:    %v\nlongitude:   %v\nzone_id:     %q\n",
+				p.Name, p.Label, cfg.ActiveProfile == p.Name, p.PostalCode, p.AddressID, p.Latitude, p.Longitude, p.ZoneID)
+			return nil
+		},
+	}
+}
+
+func newConfigProfilesAddCmd() *cobra.Command {
+	var (
+		addrID string
+		label  string
+		lat    float64
+		lon    float64
+		postal string
+		zoneID string
+		use    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a profile, either by Instacart address_id or by raw coordinates",
+		Long: `Add a profile under <name>. Two modes:
+
+  By Instacart address_id (recommended — looks up the real address via
+  the cached GetAddressById GraphQL op):
+      instacart config profiles add home --id 73256642
+
+  By raw coordinates (no network call required):
+      instacart config profiles add wildwood --lat 48.6768 --lon -122.3165 \
+        --postal 98284 --label "Sedro-Woolley vacation house"
+
+` + "`--use`" + ` also activates the profile in the same call.`,
+		Args: cobra.ExactArgs(1),
+		Example: "  instacart config profiles add home --id 73256642\n" +
+			"  instacart config profiles add work --lat 47.6740 --lon -122.1215 --postal 98052 --label \"Microsoft Building 33\"\n" +
+			"  instacart config profiles add home --id 73256642 --use",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !config.ValidProfileName(name) {
+				return coded(ExitUsage, "invalid profile name %q (use lowercase letters, digits, '.', '-', '_')", name)
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			hasID := addrID != ""
+			hasCoords := cmd.Flags().Changed("lat") && cmd.Flags().Changed("lon")
+			if !hasID && !hasCoords {
+				return coded(ExitUsage, "provide either --id <address_id> or --lat <N> --lon <N>")
+			}
+			if hasID && hasCoords {
+				return coded(ExitUsage, "--id and --lat/--lon are mutually exclusive (use --id and the lookup fills coords for you)")
+			}
+
+			p := config.Profile{Name: name, Label: label, ZoneID: zoneID}
+
+			if hasID {
+				addr, err := fetchAddressByID(cmd.Context(), addrID)
+				if err != nil {
+					return err
+				}
+				p.AddressID = addr.ID
+				p.PostalCode = addr.PostalCode
+				p.Latitude = addr.Latitude
+				p.Longitude = addr.Longitude
+				if p.Label == "" {
+					p.Label = addr.StreetAddress
+				}
+			} else {
+				p.Latitude = lat
+				p.Longitude = lon
+				p.PostalCode = postal
+			}
+
+			if err := cfg.SetProfile(p); err != nil {
+				return coded(ExitUsage, "%v", err)
+			}
+			if use {
+				if err := cfg.UseProfile(name); err != nil {
+					return coded(ExitTransient, "%v", err)
+				}
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"saved":   true,
+					"profile": p,
+					"active":  cfg.ActiveProfile,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "saved profile %q (%s) postal=%q lat=%v lon=%v\n",
+				p.Name, p.Label, p.PostalCode, p.Latitude, p.Longitude)
+			if use {
+				fmt.Fprintf(cmd.OutOrStdout(), "now active: %s\n", cfg.ActiveProfile)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&addrID, "id", "", "Instacart address_id (looked up via GetAddressById)")
+	cmd.Flags().StringVar(&label, "label", "", "Human-readable hint shown in `profiles list` (optional)")
+	cmd.Flags().Float64Var(&lat, "lat", 0, "Latitude (use with --lon, alternative to --id)")
+	cmd.Flags().Float64Var(&lon, "lon", 0, "Longitude (use with --lat, alternative to --id)")
+	cmd.Flags().StringVar(&postal, "postal", "", "Postal code (used with --lat/--lon)")
+	cmd.Flags().StringVar(&zoneID, "zone", "", "Override Instacart zone_id for this profile (rarely needed)")
+	cmd.Flags().BoolVar(&use, "use", false, "Also activate this profile immediately")
+	return cmd
+}
+
+func newConfigProfilesUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "use <name>",
+		Short:   "Switch the active profile (copies its location to top-level config)",
+		Args:    cobra.ExactArgs(1),
+		Example: "  instacart config profiles use work",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if err := cfg.UseProfile(args[0]); err != nil {
+				return coded(ExitNotFound, "%v", err)
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"active":      cfg.ActiveProfile,
+					"postal_code": cfg.PostalCode,
+					"address_id":  cfg.AddressID,
+					"latitude":    cfg.Latitude,
+					"longitude":   cfg.Longitude,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "active profile: %s (postal=%q lat=%v lon=%v)\n",
+				cfg.ActiveProfile, cfg.PostalCode, cfg.Latitude, cfg.Longitude)
+			return nil
+		},
+	}
+}
+
+func newConfigProfilesRmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "rm <name>",
+		Short:   "Delete a profile (clears active_profile if it was the one removed)",
+		Args:    cobra.ExactArgs(1),
+		Example: "  instacart config profiles rm wildwood",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			wasActive := cfg.ActiveProfile == args[0]
+			if err := cfg.DeleteProfile(args[0]); err != nil {
+				return coded(ExitNotFound, "%v", err)
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"removed":          args[0],
+					"cleared_active":   wasActive,
+					"remaining_active": cfg.ActiveProfile,
+				})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "removed profile %q\n", args[0])
+			if wasActive {
+				fmt.Fprintln(cmd.OutOrStdout(), "(was active — no profile is currently active; top-level config still applies)")
+			}
+			return nil
+		},
+	}
+}
+
+func newConfigProfilesImportCmd() *cobra.Command {
+	var (
+		prefix    string
+		overwrite bool
+		setActive string
+	)
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Create one profile per saved Instacart address (via CurrentUserAddresses GraphQL)",
+		Long: `Fetches the addresses on your Instacart account and saves each as a
+profile. Profile names are slugified from the street address (e.g.,
+"1528 37th Ave E" -> "1528-37th-ave-e"). Collisions get a numeric
+suffix.
+
+Use ` + "`--prefix`" + ` to namespace the imported profiles (e.g., ` + "`--prefix omar-`" + `
+to get ` + "`omar-1528-37th-ave-e`" + ` etc.). Use ` + "`--overwrite`" + ` to replace
+existing profiles with the same name; otherwise existing profiles are
+left untouched and reported as skipped.
+
+After importing, rename anything ugly with ` + "`profiles rm`" + ` + ` + "`profiles add`" + `
+or just leave them; the CLI treats every profile equally.`,
+		Example: "  instacart config profiles import\n  instacart config profiles import --prefix omar- --overwrite",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sess, err := auth.LoadSession()
+			if err != nil {
+				return coded(ExitAuth, "no session — run `instacart auth login` first")
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			addrs, err := fetchUserAddresses(cmd.Context(), sess, cfg)
+			if err != nil {
+				return err
+			}
+			if len(addrs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no saved Instacart addresses found on this account")
+				return nil
+			}
+
+			type result struct {
+				Name    string `json:"name"`
+				Status  string `json:"status"` // "created", "updated", "skipped"
+				Street  string `json:"street"`
+				Default bool   `json:"default,omitempty"`
+			}
+			results := make([]result, 0, len(addrs))
+			seen := map[string]bool{}
+			for n := range cfg.Profiles {
+				seen[n] = true
+			}
+			for _, a := range addrs {
+				base := prefix + slugifyName(a.StreetAddress)
+				if base == prefix || base == "" {
+					base = prefix + "address-" + a.ID
+				}
+				name := base
+				for i := 2; seen[name] && !(overwrite && profileMatchesAddr(cfg.Profiles[name], a)); i++ {
+					name = fmt.Sprintf("%s-%d", base, i)
+				}
+				status := "created"
+				if _, existed := cfg.Profiles[name]; existed {
+					if !overwrite {
+						results = append(results, result{Name: name, Status: "skipped", Street: a.StreetAddress, Default: a.IsDefault})
+						continue
+					}
+					status = "updated"
+				}
+				p := config.Profile{
+					Name:       name,
+					Label:      a.StreetAddress,
+					AddressID:  a.ID,
+					PostalCode: a.PostalCode,
+					Latitude:   a.Latitude,
+					Longitude:  a.Longitude,
+				}
+				if err := cfg.SetProfile(p); err != nil {
+					return coded(ExitTransient, "%v", err)
+				}
+				seen[name] = true
+				results = append(results, result{Name: name, Status: status, Street: a.StreetAddress, Default: a.IsDefault})
+			}
+			if setActive != "" {
+				if err := cfg.UseProfile(setActive); err != nil {
+					return coded(ExitNotFound, "%v (after import — pick one of %s)", err, strings.Join(cfg.ProfileNames(), ", "))
+				}
+			}
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			if asJSON {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+					"imported": results,
+					"active":   cfg.ActiveProfile,
+				})
+			}
+			for _, r := range results {
+				marker := " "
+				if r.Default {
+					marker = "*"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %-8s %-32s %s\n", marker, r.Status, r.Name, r.Street)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "\n%d address(es) processed. Switch with `instacart config profiles use <name>`.\n", len(results))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&prefix, "prefix", "", "Prefix to prepend to every imported profile name")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace existing profiles whose names collide")
+	cmd.Flags().StringVar(&setActive, "use", "", "After importing, set this profile name as active")
+	return cmd
+}
+
+// fetchedAddress is the slim shape we need from GetAddressById /
+// CurrentUserAddresses. Keeping it scoped to this file avoids reaching
+// across the cli/internal layers for a private type.
+type fetchedAddress struct {
+	ID            string
+	StreetAddress string
+	PostalCode    string
+	Latitude      float64
+	Longitude     float64
+	IsDefault     bool
+}
+
+func fetchAddressByID(ctx context.Context, addrID string) (*fetchedAddress, error) {
+	sess, err := auth.LoadSession()
+	if err != nil {
+		return nil, coded(ExitAuth, "no session — run `instacart auth login` first")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	st, err := store.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+
+	client := gql.NewClient(sess, cfg, st)
+	resp, err := client.Query(ctx, "GetAddressById", map[string]any{"id": addrID})
+	if err != nil {
+		return nil, coded(ExitTransient, "fetching address: %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			Address *struct {
+				ID            string  `json:"id"`
+				PostalCode    string  `json:"postalCode"`
+				Latitude      float64 `json:"latitude"`
+				Longitude     float64 `json:"longitude"`
+				StreetAddress string  `json:"streetAddress"`
+			} `json:"address"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+		return nil, coded(ExitTransient, "parsing address response: %v", err)
+	}
+	addr := envelope.Data.Address
+	if addr == nil || addr.ID == "" {
+		return nil, coded(ExitNotFound, "address %s not found (check the id and that you are logged in to the same account)", addrID)
+	}
+	return &fetchedAddress{
+		ID:            addr.ID,
+		StreetAddress: addr.StreetAddress,
+		PostalCode:    addr.PostalCode,
+		Latitude:      addr.Latitude,
+		Longitude:     addr.Longitude,
+	}, nil
+}
+
+func fetchUserAddresses(ctx context.Context, sess *auth.Session, cfg *config.Config) ([]fetchedAddress, error) {
+	st, err := store.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close()
+	client := gql.NewClient(sess, cfg, st)
+
+	// Reuses the same payload tryAutoPopulateLocation does (see config.go).
+	resp, err := client.Mutation(ctx, "CurrentUserAddresses", map[string]any{}, currentUserAddressesQuery)
+	if err != nil {
+		return nil, coded(ExitTransient, "fetching addresses: %v", err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, coded(ExitTransient, "GraphQL error: %s", resp.Errors[0].Message)
+	}
+	var envelope struct {
+		Data struct {
+			CurrentUser *struct {
+				Addresses []struct {
+					ID            string  `json:"id"`
+					StreetAddress string  `json:"streetAddress"`
+					PostalCode    string  `json:"postalCode"`
+					Latitude      float64 `json:"latitude"`
+					Longitude     float64 `json:"longitude"`
+					IsDefault     bool    `json:"isDefault"`
+				} `json:"addresses"`
+			} `json:"currentUser"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+		return nil, coded(ExitTransient, "parsing addresses response: %v", err)
+	}
+	if envelope.Data.CurrentUser == nil {
+		return nil, nil
+	}
+	out := make([]fetchedAddress, 0, len(envelope.Data.CurrentUser.Addresses))
+	for _, a := range envelope.Data.CurrentUser.Addresses {
+		out = append(out, fetchedAddress{
+			ID:            a.ID,
+			StreetAddress: a.StreetAddress,
+			PostalCode:    a.PostalCode,
+			Latitude:      a.Latitude,
+			Longitude:     a.Longitude,
+			IsDefault:     a.IsDefault,
+		})
+	}
+	// Stable order: default first (so `--use <name-of-default-after-slug>` is easy
+	// to reason about), then by ID.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].IsDefault != out[j].IsDefault {
+			return out[i].IsDefault
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// slugifyName turns a free-text address into a profile-name-safe slug.
+// Lowercases, replaces runs of non-[a-z0-9] with "-", trims dashes,
+// caps at 40 chars (the same length the config validator enforces).
+var slugifyRE = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slugifyName(s string) string {
+	s = strings.ToLower(s)
+	s = slugifyRE.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 40 {
+		s = strings.TrimRight(s[:40], "-")
+	}
+	return s
+}
+
+func profileMatchesAddr(p config.Profile, a fetchedAddress) bool {
+	return p.AddressID == a.ID
+}

--- a/library/commerce/instacart/internal/cli/profiles.go
+++ b/library/commerce/instacart/internal/cli/profiles.go
@@ -183,7 +183,11 @@ func newConfigProfilesAddCmd() *cobra.Command {
 			p := config.Profile{Name: name, Label: label, ZoneID: zoneID}
 
 			if hasID {
-				addr, err := fetchAddressByID(cmd.Context(), addrID)
+				sess, err := auth.LoadSession()
+				if err != nil {
+					return coded(ExitAuth, "no session — run `instacart auth login` first")
+				}
+				addr, err := fetchAddressByID(cmd.Context(), sess, cfg, addrID)
 				if err != nil {
 					return err
 				}
@@ -204,8 +208,13 @@ func newConfigProfilesAddCmd() *cobra.Command {
 				return coded(ExitUsage, "%v", err)
 			}
 			if use {
+				// UseProfile only fails when the named profile is missing.
+				// Since we just SetProfile(name) one line above, this is
+				// effectively unreachable — but if UseProfile's contract
+				// ever changes, ExitNotFound is the honest signal (it's
+				// not a transient retryable condition).
 				if err := cfg.UseProfile(name); err != nil {
-					return coded(ExitTransient, "%v", err)
+					return coded(ExitNotFound, "%v", err)
 				}
 			}
 			if err := cfg.Save(); err != nil {
@@ -321,9 +330,16 @@ profile. Profile names are slugified from the street address (e.g.,
 suffix.
 
 Use ` + "`--prefix`" + ` to namespace the imported profiles (e.g., ` + "`--prefix omar-`" + `
-to get ` + "`omar-1528-37th-ave-e`" + ` etc.). Use ` + "`--overwrite`" + ` to replace
-existing profiles with the same name; otherwise existing profiles are
-left untouched and reported as skipped.
+to get ` + "`omar-1528-37th-ave-e`" + ` etc.). Use ` + "`--overwrite`" + ` to refresh profiles
+for addresses you already have saved (the same address_id) -- without it,
+re-imports of already-saved addresses are reported as skipped.
+
+` + "`--overwrite`" + ` only updates same-address re-imports. If two different
+Instacart addresses would slugify to the same name (e.g., two
+distinct addresses both producing ` + "`1528-37th-ave-e`" + `), the second one
+is suffixed (` + "`1528-37th-ave-e-2`" + `) regardless of ` + "`--overwrite`" + ` so the
+existing profile pointing at the first address isn't silently
+redirected.
 
 After importing, rename anything ugly with ` + "`profiles rm`" + ` + ` + "`profiles add`" + `
 or just leave them; the CLI treats every profile equally.`,
@@ -337,7 +353,7 @@ or just leave them; the CLI treats every profile equally.`,
 			if err != nil {
 				return err
 			}
-			addrs, err := fetchUserAddresses(cmd.Context(), sess, cfg)
+			addrs, err := userAddressFetcherFrom(cmd.Context())(cmd.Context(), sess, cfg)
 			if err != nil {
 				return err
 			}
@@ -351,29 +367,47 @@ or just leave them; the CLI treats every profile equally.`,
 				Status  string `json:"status"` // "created", "updated", "skipped"
 				Street  string `json:"street"`
 				Default bool   `json:"default,omitempty"`
+				// requestedBase is the slug we'd have used if there were no
+				// collision (`prefix + slugified(street)`). Tracked so
+				// `--use <base>` can resolve to the actual imported profile
+				// when collisions force a `-2` suffix; otherwise `UseProfile`
+				// would silently activate the colliding pre-existing profile.
+				requestedBase string `json:"-"`
 			}
 			results := make([]result, 0, len(addrs))
+			// `seen` tracks names taken either by existing config or by an
+			// earlier address in *this* import. We don't pre-seed it from
+			// cfg.Profiles because the idempotency rule below already
+			// special-cases that case: an existing profile pointing at the
+			// same address_id is a re-import (skip/update), and only when
+			// the same name is held by a *different* address do we suffix.
 			seen := map[string]bool{}
-			for n := range cfg.Profiles {
-				seen[n] = true
-			}
 			for _, a := range addrs {
 				base := prefix + slugifyName(a.StreetAddress)
 				if base == prefix || base == "" {
 					base = prefix + "address-" + a.ID
 				}
-				name := base
-				for i := 2; seen[name] && !(overwrite && profileMatchesAddr(cfg.Profiles[name], a)); i++ {
-					name = fmt.Sprintf("%s-%d", base, i)
+				// Truncate to ValidProfileName's cap with prefix included
+				// so a long street + prefix combination doesn't abort the
+				// whole import at SetProfile. profileNameMaxLen is mirrored
+				// from internal/config.
+				if len(base) > profileNameMaxLen {
+					base = strings.TrimRight(base[:profileNameMaxLen], "-")
 				}
-				status := "created"
-				if _, existed := cfg.Profiles[name]; existed {
-					if !overwrite {
-						results = append(results, result{Name: name, Status: "skipped", Street: a.StreetAddress, Default: a.IsDefault})
-						continue
-					}
-					status = "updated"
+
+				// Resolve the final name with idempotency: if a profile by
+				// this name already exists for the same address, treat it
+				// as a re-import; if for a different address, suffix until
+				// we find an unused slot (or hit an existing same-address
+				// match at the suffixed name).
+				name, kind := resolveImportName(base, a, cfg.Profiles, seen, overwrite)
+				switch kind {
+				case "skipped":
+					results = append(results, result{Name: name, Status: "skipped", Street: a.StreetAddress, Default: a.IsDefault, requestedBase: base})
+					seen[name] = true
+					continue
 				}
+				status := kind // "created" or "updated"
 				p := config.Profile{
 					Name:       name,
 					Label:      a.StreetAddress,
@@ -383,18 +417,43 @@ or just leave them; the CLI treats every profile equally.`,
 					Longitude:  a.Longitude,
 				}
 				if err := cfg.SetProfile(p); err != nil {
-					return coded(ExitTransient, "%v", err)
+					// SetProfile only fails on input-shape (invalid name) —
+					// typically because --prefix introduced an illegal
+					// character. Return ExitUsage so agent retry loops
+					// don't spin on the same bad prefix. ExitTransient
+					// here would tell agents "retry, the network is
+					// flaky" which is the opposite of what happened.
+					return coded(ExitUsage, "%v", err)
 				}
 				seen[name] = true
-				results = append(results, result{Name: name, Status: status, Street: a.StreetAddress, Default: a.IsDefault})
+				results = append(results, result{Name: name, Status: status, Street: a.StreetAddress, Default: a.IsDefault, requestedBase: base})
 			}
-			if setActive != "" {
-				if err := cfg.UseProfile(setActive); err != nil {
-					return coded(ExitNotFound, "%v (after import — pick one of %s)", err, strings.Join(cfg.ProfileNames(), ", "))
-				}
-			}
+			// Persist the imported profiles BEFORE attempting --use so a
+			// bad --use value (typo, mismatched name) doesn't silently
+			// discard everything we just imported. Greptile P1 on #643:
+			// the user would see a "not found" error and re-running would
+			// re-fetch + re-save 12 addresses they already had on disk.
 			if err := cfg.Save(); err != nil {
 				return err
+			}
+			if setActive != "" {
+				refs := make([]importedRef, 0, len(results))
+				for _, r := range results {
+					refs = append(refs, importedRef{Name: r.Name, Base: r.requestedBase})
+				}
+				resolved, warn, err := resolveSetActive(setActive, refs, cfg.Profiles)
+				if err != nil {
+					return coded(ExitNotFound, "%v (after import — pick one of %s)", err, strings.Join(cfg.ProfileNames(), ", "))
+				}
+				if err := cfg.UseProfile(resolved); err != nil {
+					return coded(ExitNotFound, "%v (after import — pick one of %s)", err, strings.Join(cfg.ProfileNames(), ", "))
+				}
+				if warn != "" {
+					fmt.Fprintln(cmd.ErrOrStderr(), warn)
+				}
+				if err := cfg.Save(); err != nil {
+					return err
+				}
 			}
 			asJSON, _ := cmd.Flags().GetBool("json")
 			if asJSON {
@@ -415,9 +474,33 @@ or just leave them; the CLI treats every profile equally.`,
 		},
 	}
 	cmd.Flags().StringVar(&prefix, "prefix", "", "Prefix to prepend to every imported profile name")
-	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace existing profiles whose names collide")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Re-import profiles for addresses already saved (update in place instead of skipping); name collisions with a different address still get a -N suffix")
 	cmd.Flags().StringVar(&setActive, "use", "", "After importing, set this profile name as active")
 	return cmd
+}
+
+// userAddressFetcher is the shape of fetchUserAddresses. It's a named type
+// so tests can stand in an in-memory fake without standing up the GraphQL
+// stack, and so the override can be propagated via context rather than a
+// mutable package-level variable.
+type userAddressFetcher func(ctx context.Context, sess *auth.Session, cfg *config.Config) ([]fetchedAddress, error)
+
+// userAddressFetcherKey is the context-value key tests use to inject a
+// fake fetcher. Using an unexported zero-sized type as the key (the
+// standard library idiom) prevents collisions with any other package
+// using context values, and using context — which is immutable from the
+// consumer side — means parallel tests that each set their own ctx value
+// don't race the way a mutable package-level variable would.
+type userAddressFetcherKey struct{}
+
+// userAddressFetcherFrom returns the test-injected fetcher when one is on
+// the context, otherwise the real implementation. Production code never
+// sets the key, so this is a noop overhead in the live path.
+func userAddressFetcherFrom(ctx context.Context) userAddressFetcher {
+	if f, ok := ctx.Value(userAddressFetcherKey{}).(userAddressFetcher); ok && f != nil {
+		return f
+	}
+	return fetchUserAddresses
 }
 
 // fetchedAddress is the slim shape we need from GetAddressById /
@@ -432,15 +515,12 @@ type fetchedAddress struct {
 	IsDefault     bool
 }
 
-func fetchAddressByID(ctx context.Context, addrID string) (*fetchedAddress, error) {
-	sess, err := auth.LoadSession()
-	if err != nil {
-		return nil, coded(ExitAuth, "no session — run `instacart auth login` first")
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return nil, err
-	}
+// fetchAddressByID takes a logged-in session + loaded config so it stays
+// symmetric with fetchUserAddresses below: the caller in
+// newConfigProfilesAddCmd has already loaded both, and re-reading them
+// here would duplicate disk I/O and silently mask a partially-edited
+// config the caller saw at command start.
+func fetchAddressByID(ctx context.Context, sess *auth.Session, cfg *config.Config, addrID string) (*fetchedAddress, error) {
 	st, err := store.Open()
 	if err != nil {
 		return nil, err
@@ -542,16 +622,119 @@ func fetchUserAddresses(ctx context.Context, sess *auth.Session, cfg *config.Con
 // caps at 40 chars (the same length the config validator enforces).
 var slugifyRE = regexp.MustCompile(`[^a-z0-9]+`)
 
+// profileNameMaxLen mirrors the cap baked into config.ValidProfileName's
+// regex. Keep these two in sync — diverging gives "regenerated a name that
+// then fails validation" bugs.
+const profileNameMaxLen = 40
+
 func slugifyName(s string) string {
 	s = strings.ToLower(s)
 	s = slugifyRE.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-")
-	if len(s) > 40 {
-		s = strings.TrimRight(s[:40], "-")
+	if len(s) > profileNameMaxLen {
+		s = strings.TrimRight(s[:profileNameMaxLen], "-")
 	}
 	return s
 }
 
-func profileMatchesAddr(p config.Profile, a fetchedAddress) bool {
-	return p.AddressID == a.ID
+// resolveImportName picks the final profile name for one imported address.
+//
+// Cases:
+//   - base unused in cfg + unused this run → ("base", "created")
+//   - base in cfg pointing at the same address → ("base", "skipped" or "updated")
+//   - base in cfg pointing at a DIFFERENT address, or already taken this run
+//     → suffix "-2", "-3", ... until either an unused slot is found, or a
+//     same-address match is found at the suffixed name.
+//
+// This is what makes `profiles import` idempotent: re-running without
+// `--overwrite` reports each existing address as "skipped" rather than
+// inventing a duplicate at "<name>-2".
+func resolveImportName(base string, a fetchedAddress, existing map[string]config.Profile, seenThisRun map[string]bool, overwrite bool) (string, string) {
+	name := base
+	for i := 2; ; i++ {
+		p, inCfg := existing[name]
+		if inCfg && p.AddressID == a.ID {
+			if overwrite {
+				return name, "updated"
+			}
+			return name, "skipped"
+		}
+		if !inCfg && !seenThisRun[name] {
+			return name, "created"
+		}
+		// Collision with a different address, or with a name already
+		// allocated earlier in this same import run. Suffix and retry.
+		next := fmt.Sprintf("%s-%d", base, i)
+		// Keep the suffixed name within the validator's length cap.
+		if len(next) > profileNameMaxLen {
+			next = strings.TrimRight(base[:profileNameMaxLen-len(fmt.Sprintf("-%d", i))], "-") + fmt.Sprintf("-%d", i)
+		}
+		name = next
+	}
+}
+
+// importedRef is a tuple of (final resolved name, the base slug we asked for)
+// for one row of the import result table. resolveSetActive operates on this
+// view so the two struct fields it cares about don't leak the rest of the
+// import result schema.
+type importedRef struct {
+	Name string
+	Base string
+}
+
+// resolveSetActive picks which profile `profiles import --use <name>` should
+// activate, given the user-supplied `setActive` value and the import result
+// rows. It returns the resolved profile name, an optional warning string
+// (empty when the resolution is unambiguous), and an error.
+//
+// Resolution order:
+//  1. An imported row whose final resolved Name == setActive.
+//  2. An imported row whose requestedBase == setActive and whose resolved
+//     Name differs (the collision case the Greptile P1 caught). When there
+//     are multiple such rows, ambiguity is an error.
+//  3. A pre-existing profile already in `existing` with that exact name —
+//     useful when the user wanted to keep an older profile active and
+//     `import` was just a top-up.
+//  4. Otherwise, a "no such profile" error.
+//
+// The function is package-private and exists only to keep newConfigProfilesImportCmd
+// readable; the import command otherwise can't see the `result` slice type defined
+// inside its own RunE closure.
+func resolveSetActive(setActive string, imported []importedRef, existing map[string]config.Profile) (string, string, error) {
+	// 1. Exact match on resolved name.
+	for _, r := range imported {
+		if r.Name == setActive {
+			return r.Name, "", nil
+		}
+	}
+	// 2. Match on requested base (collision case).
+	var baseMatches []importedRef
+	for _, r := range imported {
+		if r.Base == setActive && r.Name != setActive {
+			baseMatches = append(baseMatches, r)
+		}
+	}
+	switch len(baseMatches) {
+	case 1:
+		warn := fmt.Sprintf(
+			"note: --use %q matched a name already taken; activating the imported profile %q instead",
+			setActive, baseMatches[0].Name,
+		)
+		return baseMatches[0].Name, warn, nil
+	case 0:
+		// fall through to pre-existing match
+	default:
+		names := make([]string, 0, len(baseMatches))
+		for _, r := range baseMatches {
+			names = append(names, r.Name)
+		}
+		return "", "", fmt.Errorf("ambiguous --use %q: multiple imported profiles match that base (%s)",
+			setActive, strings.Join(names, ", "))
+	}
+	// 3. Pre-existing profile by exact name.
+	if _, ok := existing[setActive]; ok {
+		return setActive, "", nil
+	}
+	// 4. Nothing matched.
+	return "", "", fmt.Errorf("profile %q not found", setActive)
 }

--- a/library/commerce/instacart/internal/cli/profiles_test.go
+++ b/library/commerce/instacart/internal/cli/profiles_test.go
@@ -8,11 +8,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/auth"
 	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/config"
-	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/store"
 )
 
 // withTempConfig redirects config + store to a per-test temp dir.
@@ -26,13 +29,28 @@ func withTempConfig(t *testing.T) string {
 
 func runCmd(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runCmdCtx(t, context.Background(), args...)
+}
+
+// runCmdCtx is the variant that lets a test inject a fake
+// userAddressFetcher (via context) without mutating package globals.
+// Tests doing `profiles import` should call this with a context built by
+// withFetcher() so the real GraphQL stack is bypassed.
+func runCmdCtx(t *testing.T, ctx context.Context, args ...string) (string, error) {
+	t.Helper()
 	root := Root()
 	buf := &bytes.Buffer{}
 	root.SetOut(buf)
 	root.SetErr(buf)
 	root.SetArgs(args)
-	err := root.ExecuteContext(context.Background())
+	err := root.ExecuteContext(ctx)
 	return buf.String(), err
+}
+
+// withFetcher returns a context that pins f as the user-address fetcher
+// for the lifetime of one command run.
+func withFetcher(f userAddressFetcher) context.Context {
+	return context.WithValue(context.Background(), userAddressFetcherKey{}, f)
 }
 
 func TestProfilesAddListCoordsOnly(t *testing.T) {
@@ -223,6 +241,260 @@ func TestRootProfileFlagUnknownFails(t *testing.T) {
 	}
 }
 
-// silence unused-import warnings when go vet runs against this file alone.
-var _ = filepath.Join
-var _ = store.OpenAt
+// --- Codex review P2 follow-ups -------------------------------------------
+
+func TestResolveImportNameIdempotentReimport(t *testing.T) {
+	existing := map[string]config.Profile{
+		"1528-37th-ave-e": {Name: "1528-37th-ave-e", AddressID: "73256642"},
+	}
+	a := fetchedAddress{ID: "73256642", StreetAddress: "1528 37th Ave E"}
+
+	name, kind := resolveImportName("1528-37th-ave-e", a, existing, map[string]bool{}, false)
+	if name != "1528-37th-ave-e" || kind != "skipped" {
+		t.Errorf("re-import without --overwrite: got (%q,%q), want (1528-37th-ave-e, skipped)", name, kind)
+	}
+	name, kind = resolveImportName("1528-37th-ave-e", a, existing, map[string]bool{}, true)
+	if name != "1528-37th-ave-e" || kind != "updated" {
+		t.Errorf("re-import with --overwrite: got (%q,%q), want (1528-37th-ave-e, updated)", name, kind)
+	}
+}
+
+func TestResolveImportNameCollidesWithDifferentAddress(t *testing.T) {
+	existing := map[string]config.Profile{
+		"home": {Name: "home", AddressID: "111"},
+	}
+	a := fetchedAddress{ID: "222", StreetAddress: "Home"}
+	name, kind := resolveImportName("home", a, existing, map[string]bool{}, false)
+	if name != "home-2" || kind != "created" {
+		t.Errorf("different-address collision: got (%q,%q), want (home-2, created)", name, kind)
+	}
+}
+
+func TestResolveImportNameLongPrefixStillFits(t *testing.T) {
+	// Long prefix + long slug must still produce a name within the 40-char
+	// cap, otherwise SetProfile rejects it and the whole import aborts.
+	existing := map[string]config.Profile{}
+	a := fetchedAddress{ID: "1", StreetAddress: "1528 37th Avenue East"}
+	base := "very-long-prefix-" + slugifyName(a.StreetAddress)
+	if len(base) > profileNameMaxLen {
+		base = strings.TrimRight(base[:profileNameMaxLen], "-")
+	}
+	name, kind := resolveImportName(base, a, existing, map[string]bool{}, false)
+	if kind != "created" {
+		t.Fatalf("expected created, got %q", kind)
+	}
+	if !config.ValidProfileName(name) {
+		t.Errorf("resolveImportName produced an invalid name %q (len=%d)", name, len(name))
+	}
+}
+
+func TestApplyProfileClearsStaleZoneID(t *testing.T) {
+	c := &config.Config{
+		Profiles: map[string]config.Profile{
+			"a": {Name: "a", ZoneID: "42", PostalCode: "98112"},
+			"b": {Name: "b", PostalCode: "98052"}, // no ZoneID
+		},
+	}
+	if err := c.ApplyProfile("a"); err != nil {
+		t.Fatalf("apply a: %v", err)
+	}
+	if c.ZoneID != "42" {
+		t.Fatalf("ZoneID after apply(a) = %q, want 42", c.ZoneID)
+	}
+	if err := c.ApplyProfile("b"); err != nil {
+		t.Fatalf("apply b: %v", err)
+	}
+	if c.ZoneID != "" {
+		t.Errorf("ZoneID after apply(b) = %q, want empty (let EffectiveZoneID fall back to default)", c.ZoneID)
+	}
+}
+
+// TestResolveSetActivePrefersImportedOverExisting covers the Greptile P1:
+// when `--use home` is passed but an existing profile already holds the
+// name "home" for a different address, the import-loop creates the new
+// profile as "home-2"; resolveSetActive must point UseProfile at "home-2"
+// rather than letting it silently re-activate the stale "home".
+func TestResolveSetActivePrefersImportedOverExisting(t *testing.T) {
+	existing := map[string]config.Profile{
+		"home": {Name: "home", AddressID: "111", PostalCode: "98112"},
+	}
+	imported := []importedRef{
+		{Name: "home-2", Base: "home"},
+	}
+	got, warn, err := resolveSetActive("home", imported, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "home-2" {
+		t.Errorf("resolveSetActive(home) = %q, want %q", got, "home-2")
+	}
+	if warn == "" {
+		t.Errorf("expected a warning when --use silently rerouted; got empty string")
+	}
+}
+
+// TestResolveSetActiveExactImportedName covers the happy path: the user
+// names the import slug exactly, no collision, no warning.
+func TestResolveSetActiveExactImportedName(t *testing.T) {
+	imported := []importedRef{{Name: "home", Base: "home"}}
+	got, warn, err := resolveSetActive("home", imported, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "home" || warn != "" {
+		t.Errorf("got (%q, %q), want (\"home\", \"\")", got, warn)
+	}
+}
+
+// TestResolveSetActiveFallsBackToExisting: --use may name a pre-existing
+// profile that wasn't part of this import run (e.g., import was a top-up).
+// That should still succeed.
+func TestResolveSetActiveFallsBackToExisting(t *testing.T) {
+	existing := map[string]config.Profile{
+		"work": {Name: "work", AddressID: "999"},
+	}
+	imported := []importedRef{{Name: "home", Base: "home"}}
+	got, _, err := resolveSetActive("work", imported, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "work" {
+		t.Errorf("resolveSetActive(work) = %q, want \"work\"", got)
+	}
+}
+
+// TestResolveSetActiveAmbiguousBase: two imported rows shouldn't ever share
+// the same base in practice (each address has one slug + one suffix path),
+// but if it happens the function errors instead of silently picking.
+func TestResolveSetActiveAmbiguousBase(t *testing.T) {
+	imported := []importedRef{
+		{Name: "home-2", Base: "home"},
+		{Name: "home-3", Base: "home"},
+	}
+	_, _, err := resolveSetActive("home", imported, nil)
+	if err == nil {
+		t.Fatal("expected ambiguity error, got nil")
+	}
+}
+
+// TestResolveSetActiveUnknown: nothing matches → error.
+func TestResolveSetActiveUnknown(t *testing.T) {
+	_, _, err := resolveSetActive("nope", nil, nil)
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+}
+
+// seedFakeSession writes a minimal session.json into the temp config dir so
+// the import command's `auth.LoadSession()` precondition passes. The
+// cookies are inert because tests swap `fetchUserAddressesFn` to a fake
+// before any network call.
+func seedFakeSession(t *testing.T) {
+	t.Helper()
+	dir, err := config.Dir()
+	if err != nil {
+		t.Fatalf("config.Dir: %v", err)
+	}
+	sess := auth.Session{
+		Cookies:   []auth.Cookie{{Name: "__Host-instacart_sid", Value: "fake", Domain: ".instacart.com", Path: "/"}},
+		Source:    "test",
+		CreatedAt: time.Now(),
+	}
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(dir, "session.json"), data, 0o600); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+}
+
+// TestProfilesImportPersistsOnBadUse covers the Greptile P1 on PR #643's
+// second review: when `profiles import --use <bad-name>` is run, the
+// command must persist the imported profiles to disk BEFORE attempting
+// the --use activation. Otherwise a typo in --use would silently discard
+// every address we just fetched from Instacart, forcing a full re-import.
+func TestProfilesImportPersistsOnBadUse(t *testing.T) {
+	withTempConfig(t)
+	seedFakeSession(t)
+
+	ctx := withFetcher(func(ctx context.Context, sess *auth.Session, cfg *config.Config) ([]fetchedAddress, error) {
+		return []fetchedAddress{
+			{ID: "111", StreetAddress: "1 Apple St", PostalCode: "98101", Latitude: 47.6, Longitude: -122.3},
+			{ID: "222", StreetAddress: "2 Pear Ave", PostalCode: "98102", Latitude: 47.7, Longitude: -122.4},
+		}, nil
+	})
+
+	_, err := runCmdCtx(t, ctx, "config", "profiles", "import", "--use", "totally-bogus-name")
+	if err == nil {
+		t.Fatal("expected error from --use of a name that doesn't match any imported or pre-existing profile, got nil")
+	}
+
+	// Despite the --use failure, the two fetched addresses must be on disk
+	// as profiles (the whole point of the save-before-use ordering).
+	got, loadErr := config.Load()
+	if loadErr != nil {
+		t.Fatalf("reload: %v", loadErr)
+	}
+	if len(got.Profiles) != 2 {
+		t.Fatalf("expected 2 saved profiles after import (despite --use failure), got %d: %v",
+			len(got.Profiles), got.ProfileNames())
+	}
+	if got.ActiveProfile != "" {
+		t.Errorf("expected ActiveProfile to remain empty when --use failed, got %q", got.ActiveProfile)
+	}
+}
+
+// TestProfilesImportActivatesOnGoodUse covers the happy path: --use with a
+// resolvable imported name persists the profiles AND activates the named one.
+func TestProfilesImportActivatesOnGoodUse(t *testing.T) {
+	withTempConfig(t)
+	seedFakeSession(t)
+
+	ctx := withFetcher(func(ctx context.Context, sess *auth.Session, cfg *config.Config) ([]fetchedAddress, error) {
+		return []fetchedAddress{
+			{ID: "111", StreetAddress: "1 Apple St", PostalCode: "98101", Latitude: 47.6, Longitude: -122.3},
+		}, nil
+	})
+
+	if _, err := runCmdCtx(t, ctx, "config", "profiles", "import", "--use", "1-apple-st"); err != nil {
+		t.Fatalf("import --use: %v", err)
+	}
+	got, _ := config.Load()
+	if got.ActiveProfile != "1-apple-st" {
+		t.Errorf("ActiveProfile = %q, want %q", got.ActiveProfile, "1-apple-st")
+	}
+	if got.Latitude == 0 {
+		t.Errorf("expected ApplyProfile to have hydrated lat from the imported profile, got 0")
+	}
+}
+
+// TestProfilesImportBadPrefixIsUsageError covers Greptile P1 on PR #643's
+// third review: when `--prefix` introduces an invalid character into the
+// resulting slug, SetProfile rejects the name. The CLI must surface that
+// as ExitUsage (input is wrong) rather than ExitTransient (which agents
+// interpret as "retry, the network is flaky") — otherwise an agent loop
+// would spin on the same bad prefix forever.
+func TestProfilesImportBadPrefixIsUsageError(t *testing.T) {
+	withTempConfig(t)
+	seedFakeSession(t)
+
+	ctx := withFetcher(func(ctx context.Context, sess *auth.Session, cfg *config.Config) ([]fetchedAddress, error) {
+		return []fetchedAddress{
+			{ID: "111", StreetAddress: "1 Apple St", PostalCode: "98101", Latitude: 47.6, Longitude: -122.3},
+		}, nil
+	})
+
+	// Uppercase + spaces are rejected by ValidProfileName; the prefix
+	// drags those characters into the final name regardless of how the
+	// slugifier handles the street portion.
+	_, err := runCmdCtx(t, ctx, "config", "profiles", "import", "--prefix", "Bad Prefix!")
+	if err == nil {
+		t.Fatal("expected error from invalid --prefix, got nil")
+	}
+	ce, ok := err.(CodedError)
+	if !ok {
+		t.Fatalf("err type=%T, want CodedError", err)
+	}
+	if ce.Code() != ExitUsage {
+		t.Errorf("ExitCode = %d, want ExitUsage (%d) so agents stop retrying", ce.Code(), ExitUsage)
+	}
+}
+

--- a/library/commerce/instacart/internal/cli/profiles_test.go
+++ b/library/commerce/instacart/internal/cli/profiles_test.go
@@ -1,0 +1,228 @@
+package cli
+
+// PATCH (instacart-address-profiles): tests for `config profiles` subtree and
+// `--profile` per-call override. Stays in-package so we can drive the cobra
+// command tree directly and assert on persisted state through config.Load().
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/commerce/instacart/internal/store"
+)
+
+// withTempConfig redirects config + store to a per-test temp dir.
+func withTempConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+func runCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	root := Root()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+	err := root.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+func TestProfilesAddListCoordsOnly(t *testing.T) {
+	withTempConfig(t)
+
+	out, err := runCmd(t, "config", "profiles", "add", "home",
+		"--lat", "47.6331", "--lon", "-122.2850", "--postal", "98112",
+		"--label", "1528 37th Ave E")
+	if err != nil {
+		t.Fatalf("add home: %v (out=%s)", err, out)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p, ok := cfg.GetProfile("home")
+	if !ok {
+		t.Fatalf("home not saved (out=%s)", out)
+	}
+	if p.PostalCode != "98112" || p.Latitude != 47.6331 {
+		t.Errorf("home profile wrong: %+v", p)
+	}
+
+	listOut, err := runCmd(t, "config", "profiles", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !bytes.Contains([]byte(listOut), []byte("home")) {
+		t.Errorf("list output missing home: %s", listOut)
+	}
+}
+
+func TestProfilesAddIDAndCoordsMutuallyExclusive(t *testing.T) {
+	withTempConfig(t)
+	out, err := runCmd(t, "config", "profiles", "add", "x",
+		"--id", "73256642", "--lat", "1", "--lon", "1")
+	if err == nil {
+		t.Fatalf("expected error when both --id and --lat/--lon given (out=%s)", out)
+	}
+}
+
+func TestProfilesAddRequiresOneSource(t *testing.T) {
+	withTempConfig(t)
+	out, err := runCmd(t, "config", "profiles", "add", "x")
+	if err == nil {
+		t.Fatalf("expected error with neither --id nor --lat/--lon (out=%s)", out)
+	}
+}
+
+func TestProfilesAddRejectsInvalidName(t *testing.T) {
+	withTempConfig(t)
+	out, err := runCmd(t, "config", "profiles", "add", "BadName",
+		"--lat", "1", "--lon", "1")
+	if err == nil {
+		t.Fatalf("expected invalid-name error (out=%s)", out)
+	}
+}
+
+func TestProfilesUseAndRm(t *testing.T) {
+	withTempConfig(t)
+	if _, err := runCmd(t, "config", "profiles", "add", "home", "--lat", "47.63", "--lon", "-122.28", "--postal", "98112"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := runCmd(t, "config", "profiles", "use", "home"); err != nil {
+		t.Fatalf("use: %v", err)
+	}
+	cfg, _ := config.Load()
+	if cfg.ActiveProfile != "home" || cfg.PostalCode != "98112" {
+		t.Fatalf("after use: active=%q postal=%q", cfg.ActiveProfile, cfg.PostalCode)
+	}
+
+	if _, err := runCmd(t, "config", "profiles", "rm", "home"); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	cfg, _ = config.Load()
+	if _, ok := cfg.GetProfile("home"); ok {
+		t.Errorf("home still present after rm")
+	}
+	if cfg.ActiveProfile != "" {
+		t.Errorf("ActiveProfile not cleared on rm of active; got %q", cfg.ActiveProfile)
+	}
+
+	// rm of unknown profile must error
+	if _, err := runCmd(t, "config", "profiles", "rm", "nope"); err == nil {
+		t.Errorf("rm of unknown profile should error")
+	}
+}
+
+func TestProfilesUseAndAddWithUseFlag(t *testing.T) {
+	withTempConfig(t)
+	if _, err := runCmd(t, "config", "profiles", "add", "work",
+		"--lat", "47.67", "--lon", "-122.12", "--postal", "98052", "--use"); err != nil {
+		t.Fatalf("add --use: %v", err)
+	}
+	cfg, _ := config.Load()
+	if cfg.ActiveProfile != "work" {
+		t.Errorf("expected work active, got %q", cfg.ActiveProfile)
+	}
+}
+
+func TestProfilesListJSON(t *testing.T) {
+	withTempConfig(t)
+	if _, err := runCmd(t, "config", "profiles", "add", "home",
+		"--lat", "47.63", "--lon", "-122.28", "--postal", "98112", "--use"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	out, err := runCmd(t, "config", "profiles", "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	var got struct {
+		Active   string `json:"active"`
+		Profiles []struct {
+			Name   string `json:"name"`
+			Active bool   `json:"active"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse json: %v (raw=%s)", err, out)
+	}
+	if got.Active != "home" || len(got.Profiles) != 1 || !got.Profiles[0].Active {
+		t.Errorf("unexpected list payload: %+v", got)
+	}
+}
+
+func TestSlugifyName(t *testing.T) {
+	cases := map[string]string{
+		"1528 37th Ave E":             "1528-37th-ave-e",
+		"990 Lake Whatcom Boulevard":  "990-lake-whatcom-boulevard",
+		"  Padded   Spaces  ":         "padded-spaces",
+		"a/b/c":                       "a-b-c",
+		"!!!":                         "",
+		// Truncated to the 40-char cap; tail isn't a dash so no further trim happens.
+		"this is a way way way way way way way way way too long for forty characters": "this-is-a-way-way-way-way-way-way-way-wa",
+	}
+	for in, want := range cases {
+		if got := slugifyName(in); got != want {
+			t.Errorf("slugifyName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRootProfileFlagAppliesOnAppContext(t *testing.T) {
+	withTempConfig(t)
+	// Seed a profile + a different top-level coord, then verify --profile
+	// resolves through newAppContext (we use doctor as a no-network-required
+	// AppContext consumer).
+	if _, err := runCmd(t, "config", "profiles", "add", "work",
+		"--lat", "47.67", "--lon", "-122.12", "--postal", "98052"); err != nil {
+		t.Fatalf("add work: %v", err)
+	}
+	cfg, _ := config.Load()
+	cfg.Latitude = 1.0
+	cfg.Longitude = 2.0
+	cfg.PostalCode = "00000"
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Build an AppContext directly through the helper to keep this test
+	// independent of any one command's output. ctx must be non-nil because
+	// newAppContext calls context.WithCancel(cmd.Context()).
+	root := Root()
+	root.SetContext(context.Background())
+	if err := root.ParseFlags([]string{"--profile", "work"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	app, err := newAppContext(root)
+	if err != nil {
+		t.Fatalf("newAppContext: %v", err)
+	}
+	defer app.Store.Close()
+	if app.Cfg.PostalCode != "98052" || app.Cfg.Latitude != 47.67 {
+		t.Errorf("--profile work did not apply; cfg=%+v", app.Cfg)
+	}
+}
+
+func TestRootProfileFlagUnknownFails(t *testing.T) {
+	withTempConfig(t)
+	root := Root()
+	root.SetContext(context.Background())
+	if err := root.ParseFlags([]string{"--profile", "nope"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, err := newAppContext(root); err == nil {
+		t.Fatalf("expected error for unknown profile")
+	}
+}
+
+// silence unused-import warnings when go vet runs against this file alone.
+var _ = filepath.Join
+var _ = store.OpenAt

--- a/library/commerce/instacart/internal/cli/root.go
+++ b/library/commerce/instacart/internal/cli/root.go
@@ -53,6 +53,15 @@ func newAppContext(cmd *cobra.Command) (*AppContext, error) {
 	if err != nil {
 		return nil, err
 	}
+	// PATCH (instacart-address-profiles): per-call `--profile <name>`
+	// override copies the named profile's location onto the in-memory cfg
+	// so every downstream gql call uses it. Does NOT persist — switching
+	// the active profile is `config profiles use`.
+	if profileName, _ := cmd.Flags().GetString("profile"); profileName != "" {
+		if err := cfg.ApplyProfile(profileName); err != nil {
+			return nil, coded(ExitNotFound, "%v (run `instacart config profiles list` to see available profiles)", err)
+		}
+	}
 	st, err := store.Open()
 	if err != nil {
 		return nil, err
@@ -118,6 +127,8 @@ No browser automation. No Playwright. No Composio subscription. Just a binary.`,
 	root.PersistentFlags().Bool("json", false, "Output machine-readable JSON instead of pretty text")
 	root.PersistentFlags().Bool("dry-run", false, "Show what would happen without making network calls or writes")
 	root.PersistentFlags().Bool("verbose", false, "Verbose debug output")
+	// PATCH (instacart-address-profiles): per-call address override.
+	root.PersistentFlags().String("profile", "", "Use a named address profile for this call (see `instacart config profiles list`)")
 
 	root.AddCommand(
 		newDoctorCmd(),

--- a/library/commerce/instacart/internal/config/config.go
+++ b/library/commerce/instacart/internal/config/config.go
@@ -6,12 +6,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"time"
 )
 
 const (
 	AppName = "instacart"
 )
+
+// Profile is a named snapshot of location data for one delivery address.
+// PATCH (instacart-address-profiles): introduced to let users save several
+// addresses (home, work, second residence) and switch the active one with
+// a single command instead of re-running `config set-address` each time.
+type Profile struct {
+	Name       string  `json:"name"`
+	Label      string  `json:"label,omitempty"`
+	PostalCode string  `json:"postal_code,omitempty"`
+	AddressID  string  `json:"address_id,omitempty"`
+	Latitude   float64 `json:"latitude,omitempty"`
+	Longitude  float64 `json:"longitude,omitempty"`
+	ZoneID     string  `json:"zone_id,omitempty"`
+}
 
 type Config struct {
 	UserAgent  string  `json:"user_agent"`
@@ -30,6 +46,14 @@ type Config struct {
 	DefaultRetailer string    `json:"default_retailer,omitempty"`
 	BundleSHA       string    `json:"bundle_sha,omitempty"`
 	UpdatedAt       time.Time `json:"updated_at,omitempty"`
+
+	// PATCH (instacart-address-profiles): named address profiles + which one
+	// is active. The top-level location fields above still drive every
+	// GraphQL call; switching profiles is implemented by copying the
+	// selected profile's fields into them. When no profiles are defined,
+	// behavior is identical to pre-profile config files.
+	Profiles      map[string]Profile `json:"profiles,omitempty"`
+	ActiveProfile string             `json:"active_profile,omitempty"`
 }
 
 // EffectiveZoneID returns the user's configured zone id, defaulting to "38"
@@ -103,4 +127,100 @@ func defaultConfig() *Config {
 
 func defaultUserAgent() string {
 	return "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+}
+
+// --- Profile helpers ---------------------------------------------------
+// PATCH (instacart-address-profiles): kept in this file rather than a
+// separate `profiles.go` so a fresh generator print only has to merge
+// one config-shaped file.
+
+// profileNameRE constrains profile names to a forgiving but predictable
+// shape: lowercase letters, digits, dot, dash, underscore. Length 1-40.
+// This is intentionally narrower than "anything that can be a map key" so
+// the same name round-trips cleanly through shells, JSON, and the verifier.
+var profileNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,39}$`)
+
+// ValidProfileName reports whether s is acceptable as a profile key.
+func ValidProfileName(s string) bool {
+	return profileNameRE.MatchString(s)
+}
+
+// ProfileNames returns the names of all stored profiles in sorted order.
+// Returns nil when no profiles exist (callers should treat this as "no
+// profiles configured", not an error).
+func (c *Config) ProfileNames() []string {
+	if len(c.Profiles) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// GetProfile returns a copy of the named profile and whether it existed.
+// Returning a copy (not a pointer into the map) keeps callers from
+// mutating the persisted state by accident.
+func (c *Config) GetProfile(name string) (Profile, bool) {
+	if c.Profiles == nil {
+		return Profile{}, false
+	}
+	p, ok := c.Profiles[name]
+	return p, ok
+}
+
+// SetProfile inserts or replaces p in the profile map. It does not save.
+func (c *Config) SetProfile(p Profile) error {
+	if !ValidProfileName(p.Name) {
+		return fmt.Errorf("invalid profile name %q: must match %s", p.Name, profileNameRE.String())
+	}
+	if c.Profiles == nil {
+		c.Profiles = map[string]Profile{}
+	}
+	c.Profiles[p.Name] = p
+	return nil
+}
+
+// DeleteProfile removes the named profile. If it was the active profile,
+// ActiveProfile is cleared. Does not save.
+func (c *Config) DeleteProfile(name string) error {
+	if _, ok := c.Profiles[name]; !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+	delete(c.Profiles, name)
+	if c.ActiveProfile == name {
+		c.ActiveProfile = ""
+	}
+	return nil
+}
+
+// ApplyProfile copies the named profile's location fields onto the
+// top-level config so existing code paths (gql client, doctor, etc.)
+// pick them up unchanged. It does NOT mark the profile active or save —
+// that is what UseProfile is for. ApplyProfile is the right hook for a
+// per-call `--profile <name>` override.
+func (c *Config) ApplyProfile(name string) error {
+	p, ok := c.GetProfile(name)
+	if !ok {
+		return fmt.Errorf("profile %q not found", name)
+	}
+	c.PostalCode = p.PostalCode
+	c.AddressID = p.AddressID
+	c.Latitude = p.Latitude
+	c.Longitude = p.Longitude
+	if p.ZoneID != "" {
+		c.ZoneID = p.ZoneID
+	}
+	return nil
+}
+
+// UseProfile applies the named profile and marks it active. Does not save.
+func (c *Config) UseProfile(name string) error {
+	if err := c.ApplyProfile(name); err != nil {
+		return err
+	}
+	c.ActiveProfile = name
+	return nil
 }

--- a/library/commerce/instacart/internal/config/config.go
+++ b/library/commerce/instacart/internal/config/config.go
@@ -201,6 +201,11 @@ func (c *Config) DeleteProfile(name string) error {
 // pick them up unchanged. It does NOT mark the profile active or save —
 // that is what UseProfile is for. ApplyProfile is the right hook for a
 // per-call `--profile <name>` override.
+//
+// ZoneID is copied verbatim, including when the new profile's ZoneID is
+// empty: leaving the previous value in place would silently route GraphQL
+// calls for the new address through the previous address's delivery zone.
+// `EffectiveZoneID` already handles the empty case by falling back to "38".
 func (c *Config) ApplyProfile(name string) error {
 	p, ok := c.GetProfile(name)
 	if !ok {
@@ -210,9 +215,7 @@ func (c *Config) ApplyProfile(name string) error {
 	c.AddressID = p.AddressID
 	c.Latitude = p.Latitude
 	c.Longitude = p.Longitude
-	if p.ZoneID != "" {
-		c.ZoneID = p.ZoneID
-	}
+	c.ZoneID = p.ZoneID
 	return nil
 }
 

--- a/library/commerce/instacart/internal/config/profiles_test.go
+++ b/library/commerce/instacart/internal/config/profiles_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestValidProfileName(t *testing.T) {
+	// Digits are intentionally allowed as the first char so address-derived
+	// slugs like "1528-37th-ave-e" (produced by `profiles import`) round-trip.
+	good := []string{"home", "work", "home.seattle", "a", "weekend-house", "unit_42", "abc123", "1528-37th-ave-e"}
+	bad := []string{"", "Home", "-leading", ".dot", "has space", "has/slash", "way-too-long-name-that-exceeds-the-cap-by-a-lot"}
+	for _, s := range good {
+		if !ValidProfileName(s) {
+			t.Errorf("expected %q to be valid", s)
+		}
+	}
+	for _, s := range bad {
+		if ValidProfileName(s) {
+			t.Errorf("expected %q to be invalid", s)
+		}
+	}
+}
+
+func TestProfileCRUD(t *testing.T) {
+	c := &Config{}
+	if got := c.ProfileNames(); got != nil {
+		t.Fatalf("ProfileNames on empty config = %v, want nil", got)
+	}
+
+	if err := c.SetProfile(Profile{Name: "home", PostalCode: "98112", Latitude: 47.63, Longitude: -122.28}); err != nil {
+		t.Fatalf("SetProfile home: %v", err)
+	}
+	if err := c.SetProfile(Profile{Name: "work", PostalCode: "98052", Latitude: 47.67, Longitude: -122.12}); err != nil {
+		t.Fatalf("SetProfile work: %v", err)
+	}
+
+	if names := c.ProfileNames(); !reflect.DeepEqual(names, []string{"home", "work"}) {
+		t.Errorf("ProfileNames = %v, want [home work]", names)
+	}
+
+	if p, ok := c.GetProfile("home"); !ok || p.PostalCode != "98112" {
+		t.Errorf("GetProfile(home) = (%+v, %v); want postal=98112 ok=true", p, ok)
+	}
+	if _, ok := c.GetProfile("missing"); ok {
+		t.Errorf("GetProfile(missing) returned ok=true")
+	}
+
+	// Mutating the returned copy must not change the stored map.
+	if p, _ := c.GetProfile("home"); true {
+		p.PostalCode = "00000"
+		_ = p
+	}
+	if p, _ := c.GetProfile("home"); p.PostalCode != "98112" {
+		t.Errorf("GetProfile returned a live pointer; postal now %q", p.PostalCode)
+	}
+
+	if err := c.SetProfile(Profile{Name: "Invalid Name"}); err == nil {
+		t.Errorf("SetProfile with invalid name should error")
+	}
+}
+
+func TestUseAndApplyProfile(t *testing.T) {
+	c := &Config{
+		Profiles: map[string]Profile{
+			"home": {Name: "home", PostalCode: "98112", AddressID: "73256642", Latitude: 47.63, Longitude: -122.28},
+			"work": {Name: "work", PostalCode: "98052", AddressID: "12345", Latitude: 47.67, Longitude: -122.12, ZoneID: "42"},
+		},
+	}
+
+	if err := c.UseProfile("home"); err != nil {
+		t.Fatalf("UseProfile home: %v", err)
+	}
+	if c.ActiveProfile != "home" || c.PostalCode != "98112" || c.AddressID != "73256642" {
+		t.Errorf("after UseProfile(home), config = %+v", c)
+	}
+
+	// Apply (no active-profile change).
+	if err := c.ApplyProfile("work"); err != nil {
+		t.Fatalf("ApplyProfile work: %v", err)
+	}
+	if c.ActiveProfile != "home" {
+		t.Errorf("ApplyProfile should not change ActiveProfile; got %q", c.ActiveProfile)
+	}
+	if c.PostalCode != "98052" || c.AddressID != "12345" || c.ZoneID != "42" {
+		t.Errorf("ApplyProfile(work) did not copy fields: postal=%q addr=%q zone=%q",
+			c.PostalCode, c.AddressID, c.ZoneID)
+	}
+
+	if err := c.ApplyProfile("nope"); err == nil {
+		t.Errorf("ApplyProfile of missing profile should error")
+	}
+	if err := c.UseProfile("nope"); err == nil {
+		t.Errorf("UseProfile of missing profile should error")
+	}
+}
+
+func TestDeleteProfile(t *testing.T) {
+	c := &Config{
+		Profiles:      map[string]Profile{"home": {Name: "home"}, "work": {Name: "work"}},
+		ActiveProfile: "home",
+	}
+	if err := c.DeleteProfile("home"); err != nil {
+		t.Fatalf("DeleteProfile home: %v", err)
+	}
+	if c.ActiveProfile != "" {
+		t.Errorf("DeleteProfile of active should clear ActiveProfile; got %q", c.ActiveProfile)
+	}
+	if _, ok := c.GetProfile("home"); ok {
+		t.Errorf("home still present after delete")
+	}
+
+	if err := c.DeleteProfile("missing"); err == nil {
+		t.Errorf("DeleteProfile of missing profile should error")
+	}
+
+	// Deleting a non-active profile must leave ActiveProfile alone.
+	c.ActiveProfile = "work"
+	c.Profiles["spare"] = Profile{Name: "spare"}
+	if err := c.DeleteProfile("spare"); err != nil {
+		t.Fatalf("DeleteProfile spare: %v", err)
+	}
+	if c.ActiveProfile != "work" {
+		t.Errorf("ActiveProfile changed by unrelated delete; got %q", c.ActiveProfile)
+	}
+}
+
+func TestConfigBackwardsCompatibleJSON(t *testing.T) {
+	// Pre-profile config files have no `profiles` or `active_profile` keys.
+	// Loading + saving must not introduce them and must round-trip cleanly.
+	old := `{"user_agent":"test","postal_code":"98112","latitude":47.63,"longitude":-122.28}`
+	var c Config
+	if err := json.Unmarshal([]byte(old), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Profiles != nil || c.ActiveProfile != "" {
+		t.Errorf("legacy config produced profile state: profiles=%v active=%q", c.Profiles, c.ActiveProfile)
+	}
+	out, err := json.Marshal(&c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(out); !jsonOmits(got, `"profiles"`) || !jsonOmits(got, `"active_profile"`) {
+		t.Errorf("legacy round-trip should omit profile fields, got %s", got)
+	}
+}
+
+func jsonOmits(haystack, needle string) bool {
+	return !contains(haystack, needle)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Add a named-address profile store to instacart so users with multiple delivery addresses (home, work, vacation house, ...) can switch between them without re-running `config set-address` every time.

The single-address shape that today's `config set-coords` / `set-address` ships with means switching addresses is destructive — every switch overwrites the previous one. For users with several active addresses on their Instacart account (and the `CurrentUserAddresses` GraphQL query that fix-instacart-location-config-546 already added returns them all) this is just a missing layer of indirection.

## What this changes

- New subcommand tree: `instacart config profiles list | show | add | use | rm | import`
- New persistent root flag: `--profile <name>` — applies a named profile for a single call without changing the active profile (e.g., `instacart --profile work add safeway "cold brew"`)
- `internal/config` gains a `Profile` struct, a `Profiles` map, and an `ActiveProfile` key. Helpers do not auto-save; callers persist via `Save()`.
- `profiles import` reuses the existing `currentUserAddressesQuery` + `client.Mutation()` path (introduced for tryAutoPopulateLocation) to seed one profile per saved Instacart address, slugifying the street line for the name.

## Backwards compatibility

When `profiles` and `active_profile` are absent from `config.json`, behavior is identical to today — the top-level `postal_code` / `address_id` / `latitude` / `longitude` keys remain authoritative. Activating a profile copies its values onto those same top-level keys so every downstream `gql.NewClient(...)` consumer continues to work unchanged. Round-trip tests pin that legacy configs do not gain the new keys.

## Implementation notes

- All hand-edits carry `// PATCH (instacart-address-profiles): ...` comments and are catalogued in `.printing-press-patches.json` (id `instacart-address-profiles`).
- `newAppContext` reads the `--profile` flag after loading config and calls `ApplyProfile` in-memory; no persistence side-effect.
- `fetchAddressByID` and `fetchUserAddresses` live in `internal/cli/profiles.go` so the existing `internal/cli/config.go` surface doesn't widen further.
- `slugifyName` caps at 40 chars to match `ValidProfileName`'s regex; collisions in `import` get a `-2`, `-3` suffix.

## Validation Results

| Check | Status |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS — 5 new tests in `internal/config/profiles_test.go`, 9 new tests in `internal/cli/profiles_test.go` |
| `govulncheck ./...` | PASS — no vulnerabilities affecting reachable code |
| `.github/scripts/verify-skill/verify_skill.py --dir library/commerce/instacart/` | PASS |
| Live smoke (auth → `config profiles add home --id 73256642 --use` → `add safeway "cold brew" --dry-run`) | PASS — `resolved_via: live`, retailers shop reachable |

## Test plan

```bash
cd library/commerce/instacart
go test ./...
python3 ../../../.github/scripts/verify-skill/verify_skill.py --dir .
go install ./cmd/instacart-pp-cli

# functional smoke (after `instacart auth login` or `auth import-file`)
instacart config profiles import
instacart config profiles list
instacart config profiles use <name>
instacart --profile <other-name> retailers list
```
