### PR TITLE
fix(verifier): drop bidirectional // PATCH source-marker pairing check

### DIFF
--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Iterable
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -163,7 +161,7 @@ def validate_required_artifacts(cli_dir: Path, manifest: dict | None) -> list[Pr
                 problems.append(
                     Problem(
                         path,
-                        "new library CLI is missing .printing-press-patches.json. Fresh prints should include the empty patch index; hand-authored customizations should be recorded there with matching PATCH comments.",
+                        "new library CLI is missing .printing-press-patches.json. Fresh prints should include the empty patch index; hand-authored customizations are recorded there per the shape documented in AGENTS.md.",
                     )
                 )
             else:
@@ -335,54 +333,32 @@ def validate_novel_features(cli_dir: Path, manifest: dict | None) -> list[Proble
     return problems
 
 
-def candidate_patch_marker_files(cli_dir: Path) -> Iterable[Path]:
-    skip_parts = {".git", ".manuscripts"}
-    skip_names = {".printing-press-patches.json"}
-    for path in cli_dir.rglob("*"):
-        if not path.is_file() or path.name in skip_names:
-            continue
-        if skip_parts.intersection(path.relative_to(cli_dir).parts):
-            continue
-        if path.suffix == ".go":
-            yield path
-
-
-# Matches the inline marker convention documented in each printed CLI's
-# AGENTS.md:
-#
-#     // PATCH: <one-line summary>
-#     // PATCH(upstream cli-printing-press#<n>): ...
-#     // PATCH <patch-id>: <one-line summary>
-#
-# Anchored on the `// PATCH` comment prefix followed by an optional patch id
-# (matching the same `id` shape used in .printing-press-patches.json) and then
-# `:` or `(`. Intentionally excludes bare HTTP method literals like "PATCH"
-# that appear in generated client/handler code (case "PATCH":,
-# makeAPIHandler("PATCH", ...), {"pp:method": "PATCH"}, etc.), which are not
-# hand-authored customizations and would otherwise false-positive on any
-# printed CLI for an API that exposes HTTP PATCH endpoints.
-_PATCH_MARKER_RE = re.compile(r"//\s*PATCH(?:\s+[A-Za-z0-9_\-]+)?\s*[:(]")
-
-
-def has_patch_marker(path: Path) -> bool:
-    try:
-        return bool(_PATCH_MARKER_RE.search(path.read_text(errors="ignore")))
-    except OSError:
-        return False
-
-
 def validate_patch_manifest(
     cli_dir: Path,
     changed_files: set[str] | None,
 ) -> list[Problem]:
-    """Validate `.printing-press-patches.json`.
+    """Validate `.printing-press-patches.json` minimally.
 
-    When `changed_files` is non-None (typical PR mode), the verifier only runs
-    if the patches manifest itself or a file it references is in the diff —
-    this stops unrelated PRs (e.g. a docs-only README sweep) from re-validating
-    months-old patch state. Pass `None` to force validation regardless of the
-    diff (used by the strict path for newly added CLIs).
+    CI's role for the patches manifest is to catch the structural class of
+    bugs that would silently break downstream readers (the file is unparseable
+    JSON, or `patches` is set to something other than an array). Everything
+    else about the manifest's shape — per-patch fields, referenced-file
+    existence, inline source-marker pairing — is the authoring contract
+    described in this repo's AGENTS.md and is enforced by agent diligence
+    and code review, not by CI.
+
+    Rationale: the bi-directional source-marker / patches-entry pairing
+    that this verifier previously enforced added two commits to every
+    in-session customization PR (add the entry, add the matching marker)
+    without catching a class of bug git history + the manifest doesn't
+    already surface. AGENTS.md remains the source of truth for what
+    belongs in a well-formed patches entry.
+
+    The `changed_files` parameter is kept for API stability with the
+    surrounding caller but is unused — the two remaining checks (parse +
+    array-shape) are cheap and don't need diff-scoping.
     """
+    del changed_files  # unused; kept for caller-API stability
     problems: list[Problem] = []
     patch_path = cli_dir / ".printing-press-patches.json"
     if not patch_path.exists():
@@ -397,80 +373,6 @@ def validate_patch_manifest(
         patches = []
     if not isinstance(patches, list):
         problems.append(Problem(patch_path, "patches must be an array"))
-        return problems
-
-    if changed_files is not None:
-        relevant_paths = {".printing-press-patches.json"}
-        for patch in patches:
-            if not isinstance(patch, dict):
-                continue
-            for file_name in patch.get("files") or []:
-                if isinstance(file_name, str) and file_name:
-                    relevant_paths.add(file_name)
-        # When patches[] is empty, relevant_paths covers only the manifest
-        # itself, so a PR that adds // PATCH: markers to source files
-        # without updating the manifest would be silently skipped here
-        # and never reach the markers-without-manifest check below.
-        # Expand to every candidate marker file under cli_dir for that
-        # case. When patches[] is populated, the manifest's own file list
-        # is the source of truth and we keep the tighter scope.
-        if not patches:
-            for candidate in candidate_patch_marker_files(cli_dir):
-                try:
-                    relevant_paths.add(
-                        PurePosixPath(*candidate.relative_to(cli_dir).parts).as_posix()
-                    )
-                except ValueError:
-                    continue
-        if not (changed_files & relevant_paths):
-            return problems
-
-    source_markers = [path for path in candidate_patch_marker_files(cli_dir) if has_patch_marker(path)]
-    if source_markers and not patches:
-        problems.append(
-            Problem(
-                patch_path,
-                "source files contain PATCH markers but patches[] is empty. Record the customization so regen reviewers can preserve it.",
-            )
-        )
-
-    for idx, patch in enumerate(patches, start=1):
-        if not isinstance(patch, dict):
-            problems.append(Problem(patch_path, f"patches[{idx}] must be an object"))
-            continue
-
-        files = patch.get("files")
-        if not isinstance(files, list) or not files:
-            problems.append(Problem(patch_path, f"patches[{idx}] must list one or more files"))
-            continue
-
-        referenced_files: list[Path] = []
-        for file_name in files:
-            if not isinstance(file_name, str) or not file_name:
-                problems.append(Problem(patch_path, f"patches[{idx}] has an invalid file entry {file_name!r}"))
-                continue
-            file_path = cli_dir / file_name
-            referenced_files.append(file_path)
-            if not file_path.exists():
-                problems.append(
-                    Problem(
-                        patch_path,
-                        f"patch entry references {file_name}, but that file does not exist in the published CLI package.",
-                    )
-                )
-
-        # Marker check applies only to .go files: JSON/YAML manifest tweaks
-        # (the `.printing-press.json` schema bump, a `spec.json` redaction)
-        # are real customizations recorded in patches[] but can't carry an
-        # inline `// PATCH:` comment. The manifest entry IS the marker.
-        go_files = [p for p in referenced_files if p.suffix == ".go"]
-        if go_files and not any(path.exists() and has_patch_marker(path) for path in go_files):
-            problems.append(
-                Problem(
-                    patch_path,
-                    f"patches[{idx}] does not point at a Go file containing a PATCH marker.",
-                )
-            )
 
     return problems
 

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -182,164 +182,49 @@ class PublishPackageVerifierTest(unittest.TestCase):
 
         self.assertFalse(any("-pp-cli/-pp-mcp binary suffix" in msg for msg in messages))
 
-    def test_readme_only_touch_skips_unrelated_patch_manifest(self) -> None:
-        """A docs-only PR that touches README.md must not re-validate a
-        pre-existing patches manifest whose state didn't change in this PR.
+    def test_patch_manifest_with_marker_and_no_entry_passes(self) -> None:
+        """The bidirectional pairing rule that used to require markers and
+        patches[] entries to mirror each other is gone. A source file with a
+        `// PATCH:` comment but an empty patches[] is fine — markers are now
+        optional navigation aids, not CI-enforced contracts.
         """
         cli_dir = self.tmp / "library" / "cloud" / "legacy"
-        # Seed pre-existing state on the base ref (main): a patches manifest
-        # that references a source file missing a `// PATCH:` marker. This
-        # mirrors the real digitalocean/fireflies inconsistency we're guarding
-        # against.
-        self.git("checkout", "-B", "scenario-main", self.base)
-        patch_manifest = {
-            "schema_version": 1,
-            "applied_at": "2026-05-09",
-            "patches": [
-                {
-                    "id": "old-customization",
-                    "summary": "Historic tweak",
-                    "reason": "Pre-existing state.",
-                    "files": ["internal/cli/legacy.go"],
-                }
-            ],
-        }
-        self.write(
-            "library/cloud/legacy/.printing-press.json",
-            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
-        )
-        self.write("library/cloud/legacy/.printing-press-patches.json", json.dumps(patch_manifest))
-        self.write("library/cloud/legacy/internal/cli/legacy.go", "package cli\n")
-        self.write("library/cloud/legacy/README.md", "# Legacy\n")
-        self.git("add", ".")
-        self.git("commit", "-m", "seed legacy CLI on main")
-        new_base = self.git("rev-parse", "HEAD").stdout.strip()
-        self.git("switch", "feature")
-        self.git("merge", "--ff-only", "scenario-main")
-        # Now bump only the README on the feature branch.
-        self.write("library/cloud/legacy/README.md", "# Legacy v2\n")
-        self.git("add", ".")
-        self.git("commit", "-m", "docs: bump legacy README")
-
-        touched, files_by_dir = verifier.changed_cli_dirs(new_base)
-        self.assertEqual([cli_dir], touched)
-        problems = verifier.validate_cli_dir(
-            cli_dir,
-            strict=False,
-            changed_files=files_by_dir.get(cli_dir, set()),
-        )
-
-        self.assertFalse(
-            any("PATCH marker" in p.message for p in problems),
-            msg=f"docs-only touch should skip patch-manifest validation; got {[p.message for p in problems]}",
-        )
-
-    def test_touched_patches_file_triggers_validation(self) -> None:
-        """If the patches manifest itself changes in the PR, validation runs
-        even on an existing CLI (non-strict).
-        """
-        cli_dir = self.tmp / "library" / "cloud" / "legacy"
-        self.git("checkout", "-B", "scenario-main", self.base)
-        self.write(
-            "library/cloud/legacy/.printing-press.json",
-            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
-        )
-        self.write("library/cloud/legacy/internal/cli/legacy.go", "package cli\n")
-        self.git("add", ".")
-        self.git("commit", "-m", "seed legacy CLI without patches")
-        new_base = self.git("rev-parse", "HEAD").stdout.strip()
-        self.git("switch", "feature")
-        self.git("merge", "--ff-only", "scenario-main")
-
-        patch_manifest = {
-            "schema_version": 1,
-            "applied_at": "2026-05-09",
-            "patches": [
-                {
-                    "id": "added-now",
-                    "summary": "New tweak",
-                    "reason": "Reason.",
-                    "files": ["internal/cli/legacy.go"],
-                }
-            ],
-        }
-        self.write("library/cloud/legacy/.printing-press-patches.json", json.dumps(patch_manifest))
-        self.git("add", ".")
-        self.git("commit", "-m", "add patches manifest")
-
-        _, files_by_dir = verifier.changed_cli_dirs(new_base)
-        problems = verifier.validate_cli_dir(
-            cli_dir,
-            strict=False,
-            changed_files=files_by_dir.get(cli_dir, set()),
-        )
-
-        self.assertTrue(
-            any("PATCH marker" in p.message for p in problems),
-            msg=f"patches manifest changed → marker check should fire; got {[p.message for p in problems]}",
-        )
-
-    def test_marker_added_with_empty_patches_array_is_caught(self) -> None:
-        """Regression for greptile-flagged scope-guard bug on #587: if a PR
-        adds a // PATCH: marker to a source file but the CLI's
-        .printing-press-patches.json has patches: [], the prior scope guard
-        only added the manifest path to relevant_paths so the diff (which
-        touched only the .go file) bypassed the check entirely. Validation
-        must still fire and report markers-without-manifest.
-        """
-        cli_dir = self.tmp / "library" / "cloud" / "legacy"
-        # Seed pre-existing state on main: empty-patches manifest +
-        # marker-free source file.
-        self.git("checkout", "-B", "scenario-main", self.base)
         self.write(
             "library/cloud/legacy/.printing-press.json",
             json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
         )
         self.write(
             "library/cloud/legacy/.printing-press-patches.json",
-            json.dumps({"schema_version": 1, "applied_at": "2026-05-09", "patches": []}),
+            json.dumps({"schema_version": 1, "applied_at": "2026-05-17", "patches": []}),
         )
-        self.write("library/cloud/legacy/internal/cli/legacy.go", "package cli\n")
-        self.git("add", ".")
-        self.git("commit", "-m", "seed legacy CLI with empty patches[]")
-        new_base = self.git("rev-parse", "HEAD").stdout.strip()
-        self.git("switch", "feature")
-        self.git("merge", "--ff-only", "scenario-main")
-
-        # PR adds a PATCH marker to the Go file without touching the manifest.
         self.write(
             "library/cloud/legacy/internal/cli/legacy.go",
-            "// PATCH: tweak request envelope\npackage cli\n",
-        )
-        self.git("add", ".")
-        self.git("commit", "-m", "add patch marker but forget manifest entry")
-
-        _, files_by_dir = verifier.changed_cli_dirs(new_base)
-        problems = verifier.validate_cli_dir(
-            cli_dir,
-            strict=False,
-            changed_files=files_by_dir.get(cli_dir, set()),
-        )
-        self.assertTrue(
-            any("PATCH markers but patches[] is empty" in p.message for p in problems),
-            msg=f"empty patches[] + new marker should fire; got {[p.message for p in problems]}",
+            "// PATCH: leftover from a prior convention\npackage cli\n",
         )
 
-    def test_patch_entry_with_only_non_go_files_skips_marker_check(self) -> None:
-        """JSON/YAML-only customizations (e.g. spec.json redaction, schema
-        bump in .printing-press.json) record the patch in the manifest but
-        can't carry an inline // PATCH: comment. The manifest entry IS the
-        marker."""
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertEqual(
+            [],
+            problems,
+            msg=f"marker-without-entry must no longer fire; got {[p.message for p in problems]}",
+        )
+
+    def test_patch_entry_referencing_missing_go_file_passes(self) -> None:
+        """The per-patch schema validation (files[] required, referenced
+        files must exist, .go files must carry markers) is gone. Agents are
+        trusted to follow the AGENTS.md shape; CI catches only structural
+        bugs that break downstream readers.
+        """
         cli_dir = self.tmp / "library" / "cloud" / "legacy"
         patch_manifest = {
             "schema_version": 1,
-            "applied_at": "2026-05-09",
+            "applied_at": "2026-05-17",
             "patches": [
                 {
-                    "id": "spec-redaction",
-                    "summary": "Redacted example tokens in spec.",
-                    "reason": "Push-protection.",
-                    "files": ["spec.json"],
+                    "id": "spec-edit",
+                    "summary": "tweak",
+                    "reason": "test",
+                    "files": ["internal/cli/never-existed.go"],
                 }
             ],
         }
@@ -348,97 +233,74 @@ class PublishPackageVerifierTest(unittest.TestCase):
             json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
         )
         self.write("library/cloud/legacy/.printing-press-patches.json", json.dumps(patch_manifest))
-        self.write("library/cloud/legacy/spec.json", '{"openapi": "3.0.0"}\n')
 
         problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
-        self.assertFalse(
-            any("PATCH marker" in p.message for p in problems),
-            msg=f"JSON-only patch should skip marker check; got {[p.message for p in problems]}",
+        self.assertEqual(
+            [],
+            problems,
+            msg=f"missing referenced file must no longer fire; got {[p.message for p in problems]}",
         )
 
-
-class HasPatchMarkerTest(unittest.TestCase):
-    """Unit tests for ``has_patch_marker`` to ensure only the documented
-    ``// PATCH:`` / ``// PATCH(...)`` comment convention is detected, not bare
-    HTTP method literals or other coincidental occurrences of the word.
-    """
-
-    def setUp(self) -> None:
-        self.tmp = Path(tempfile.mkdtemp(prefix="has-patch-marker-"))
-        self.addCleanup(lambda: shutil.rmtree(self.tmp))
-
-    def _write(self, name: str, body: str) -> Path:
-        path = self.tmp / name
-        path.write_text(body)
-        return path
-
-    def test_detects_real_patch_marker(self) -> None:
-        path = self._write(
-            "real.go",
-            "// PATCH: align response envelope with upstream\nfunc foo() {}\n",
+    def test_patches_set_to_non_array_fails(self) -> None:
+        """The one shape check CI still enforces: `patches` must be an array.
+        Downstream readers iterate over patches[]; a string or object here
+        would break every consumer of the file.
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "legacy"
+        self.write(
+            "library/cloud/legacy/.printing-press.json",
+            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
         )
-        self.assertTrue(verifier.has_patch_marker(path))
-
-    def test_detects_patch_marker_with_upstream_ref(self) -> None:
-        path = self._write(
-            "real.go",
-            "    // PATCH(upstream cli-printing-press#842): auto-fill AccountSid\n",
+        self.write(
+            "library/cloud/legacy/.printing-press-patches.json",
+            json.dumps({"schema_version": 1, "patches": "not-an-array"}),
         )
-        self.assertTrue(verifier.has_patch_marker(path))
 
-    def test_ignores_http_method_string_literal(self) -> None:
-        path = self._write(
-            "client.go",
-            'return c.do("PATCH", path, nil, body, nil)\n',
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertTrue(
+            any("patches must be an array" in p.message for p in problems),
+            msg=f"non-array patches must fail; got {[p.message for p in problems]}",
         )
-        self.assertFalse(verifier.has_patch_marker(path))
 
-    def test_ignores_makeAPIHandler_PATCH(self) -> None:
-        path = self._write(
-            "tools.go",
-            'makeAPIHandler("PATCH", "/conversations/{id}", bindings, positional)\n',
+    def test_patches_set_to_null_passes(self) -> None:
+        """`patches: null` is treated as an empty array (the JSON spec's
+        documented shape uses an array literal, but `null` is a natural
+        intermediate state for an unedited template).
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "legacy"
+        self.write(
+            "library/cloud/legacy/.printing-press.json",
+            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
         )
-        self.assertFalse(verifier.has_patch_marker(path))
+        self.write(
+            "library/cloud/legacy/.printing-press-patches.json",
+            json.dumps({"schema_version": 1, "patches": None}),
+        )
 
-    def test_ignores_switch_case_PATCH(self) -> None:
-        path = self._write(
-            "tools.go",
-            'switch method {\ncase "POST", "PUT", "PATCH":\n    return body\n}\n',
-        )
-        self.assertFalse(verifier.has_patch_marker(path))
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertEqual([], problems)
 
-    def test_ignores_annotation_map_value(self) -> None:
-        path = self._write(
-            "cmd.go",
-            'Annotations: map[string]string{"pp:method": "PATCH", "pp:path": "/x"},\n',
+    def test_malformed_json_in_patches_file_fails(self) -> None:
+        """`read_json` records a problem when the file isn't parseable, so
+        validate_patch_manifest inherits that behavior — we just need to
+        confirm the verifier still surfaces it after the simplification.
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "legacy"
+        self.write(
+            "library/cloud/legacy/.printing-press.json",
+            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
         )
-        self.assertFalse(verifier.has_patch_marker(path))
+        self.write(
+            "library/cloud/legacy/.printing-press-patches.json",
+            "{ not valid json",
+        )
 
-    def test_ignores_word_PATCH_in_string_or_comment(self) -> None:
-        path = self._write(
-            "doc.go",
-            "// This handler issues HTTP PATCH requests against the upstream API.\n",
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertNotEqual(
+            [],
+            problems,
+            msg="malformed JSON should still surface as a problem",
         )
-        # Plain prose comment without the colon/paren marker shape is not a
-        # customization marker.
-        self.assertFalse(verifier.has_patch_marker(path))
-
-    def test_detects_marker_with_inline_patch_id(self) -> None:
-        # The `// PATCH <id>:` form is in use across pre-existing CLIs
-        # (e.g. openrouter, fireflies) and mirrors the `id` field shape from
-        # .printing-press-patches.json. Treat it as a documented third form.
-        path = self._write(
-            "marked.go",
-            "// PATCH mcp-http-transport: added --http :addr flag\n",
-        )
-        self.assertTrue(verifier.has_patch_marker(path))
-
-    def test_detects_marker_with_inline_patch_id_and_parens(self) -> None:
-        path = self._write(
-            "marked.go",
-            "// PATCH transcendence-commands(upstream cli-printing-press#825): hand-built\n",
-        )
-        self.assertTrue(verifier.has_patch_marker(path))
 
 
 if __name__ == "__main__":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,40 +184,34 @@ Some CLIs have no archived spec on disk (docs-driven, sniff-driven, plan-driven)
 
 ## `.printing-press-patches.json` records library-side customizations
 
-If you modify a published CLI under `library/<cat>/<slug>/` beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader. SKILL.md / README.md edits are owned by `tools/sweep-canonical/` or direct edit and don't need a patch manifest; this convention is for code-level customizations.
+If you modify a published CLI under `library/<cat>/<slug>/` beyond what the generator produced, **catalog the change in `.printing-press-patches.json`** at the CLI's root (parallel to `.printing-press.json`). SKILL.md / README.md edits are owned by `tools/sweep-canonical/` or direct edit and don't need a patch manifest; this convention is for code-level customizations.
 
-1. **Mark every changed site** in source with a comment summarizing the deviation:
+Minimum shape:
 
-    ```
-    // PATCH: <one-line summary>
-    ```
-
-    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#689): …`). `grep -rn 'PATCH' library/` then surfaces every customization.
-
-2. **Catalog the change** in a `.printing-press-patches.json` at the CLI's root (parallel to `.printing-press.json`). Minimum shape:
-
-    ```json
+```json
+{
+  "schema_version": 1,
+  "applied_at": "YYYY-MM-DD",
+  "base_run_id": "<copy from .printing-press.json>",
+  "base_printing_press_version": "<copy from .printing-press.json>",
+  "patches": [
     {
-      "schema_version": 1,
-      "applied_at": "YYYY-MM-DD",
-      "base_run_id": "<copy from .printing-press.json>",
-      "base_printing_press_version": "<copy from .printing-press.json>",
-      "patches": [
-        {
-          "id": "short-identifier",
-          "summary": "What changed (one sentence).",
-          "reason": "Why this customization was needed (one or two sentences).",
-          "files": ["internal/cli/foo.go"],
-          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-        }
-      ]
+      "id": "short-identifier",
+      "summary": "What changed (one sentence).",
+      "reason": "Why this customization was needed (one or two sentences).",
+      "files": ["internal/cli/foo.go"],
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
     }
-    ```
+  ]
+}
+```
 
-    Optional top-level fields the kalshi example uses when relevant: `upstream_tracking[]`, `deferred_to_upstream[]`.
+Optional top-level fields the kalshi example uses when relevant: `upstream_tracking[]`, `deferred_to_upstream[]`.
 
-This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short — if you find yourself writing tables of field renames or SQL transformations, that detail belongs in the source comment or commit message, not here. A fresh print from the generator overwrites this tree, and the manifest is what tells the next agent (or regeneration tooling) what was customized and why.
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the manifest is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short — if you find yourself writing tables of field renames or SQL transformations, that detail belongs in the commit message, not here. A fresh print from the generator overwrites this tree, and the manifest is what survives that overwrite.
+
+**Inline `// PATCH:` source comments are optional, not required.** Earlier guidance asked agents to mark each changed site in source alongside the manifest entry; `verify_publish_package.py` enforced a bidirectional pairing that doubled the commit count on every in-session customization without surfacing a class of bug git history and the manifest didn't already cover. The pairing requirement is gone; if you find a marker helpful as a navigation aid for yourself, fine, but the CI no longer cares whether you add one.
 
 **Delete stale workaround entries.** A `reason` field that describes a verifier or pipeline bug (e.g. *"the package verifier currently treats X as Y; this entry exists to silence the false positive"*) is a placeholder, not a real customization. When the underlying bug is fixed, delete the entry — leaving it behind makes future contributors think there's a hand-edit to preserve when there isn't.
 

--- a/cli-skills/pp-smartlead/SKILL.md
+++ b/cli-skills/pp-smartlead/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: pp-smartlead
+description: "Every SmartLead API feature, plus a local mirror that answers campaign-health, silent-lead, and cross-campaign... Trigger phrases: `check my smartlead campaigns`, `which leads went silent`, `is this domain already pitched`, `rank my sender accounts`, `use smartlead`, `run smartlead`."
+author: "bossriceshark"
+license: "Apache-2.0"
+argument-hint: "<command> [args] | install cli|mcp"
+allowed-tools: "Read Bash"
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - smartlead-pp-cli
+---
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is a verbatim mirror of library/sales-and-crm/smartlead/SKILL.md,
+     regenerated post-merge by tools/generate-skills/. Hand-edits here are
+     silently overwritten on the next regen. Edit the library/ source instead.
+     See AGENTS.md "Generated artifacts: registry.json, cli-skills/". -->
+
+# SmartLead — Printing Press CLI
+
+## Prerequisites: Install the CLI
+
+This skill drives the `smartlead-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
+
+1. Install via the Printing Press installer:
+   ```bash
+   npx -y @mvanhorn/printing-press install smartlead --cli-only
+   ```
+2. Verify: `smartlead-pp-cli --version`
+3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+
+If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+
+Beyond wrapping all 41 SmartLead REST endpoints with JSON-first, agent-native output, this CLI adds a local SQLite mirror no other SmartLead tool has. Sync once, then run health, silent, dupes, sender-health, warmup-gate, and drift offline — cross-campaign questions that otherwise cost a multi-call API loop per answer.
+
+## When to Use This CLI
+
+Use this CLI when an agent or operator needs to audit cold-email outreach in SmartLead: checking which campaigns are healthy, building follow-up lists of silent leads, deduplicating leads across campaigns before launch, or ranking sender accounts by deliverability. It is the right tool when the question spans multiple campaigns or needs week-over-week history, because those answers come from the local mirror rather than a single API call.
+
+## Unique Capabilities
+
+These capabilities aren't available in any other tool for this API.
+
+### Local state that compounds
+- **`health`** — One-shot scorecard for every campaign — bounce rate, reply rate, silent-lead count, sender count, and a stale flag — without clicking through the dashboard.
+
+  _Reach for this first when an agent needs to know which campaigns are healthy before drilling into any one of them._
+
+  ```bash
+  smartlead-pp-cli health --json
+  ```
+- **`silent`** — Finds leads that were emailed but have not replied within N days — the exact set to follow up with or retire.
+
+  _Use this to build a follow-up list instead of paging the whole lead set and diffing timestamps by hand._
+
+  ```bash
+  smartlead-pp-cli silent --campaign 12345 --days 7 --json
+  ```
+- **`dupes`** — Scans the whole lead mirror for emails or domains that appear in two or more campaigns; --domain prints the full pitch ledger for one site.
+
+  _Run this before adding leads to a campaign to avoid double-contacting a prospect already in flight._
+
+  ```bash
+  smartlead-pp-cli dupes --domain example.com --json
+  ```
+- **`drift`** — Computes week-over-week reply, open, and bounce deltas for a campaign by querying analytics one seven-day window at a time.
+
+  _Use this to catch a campaign decaying over time rather than judging it from a single point-in-time stat._
+
+  ```bash
+  smartlead-pp-cli drift --campaign 12345 --weeks 4 --json
+  ```
+
+### Deliverability intelligence
+- **`sender-health`** — Ranks every email sender account by a composite of inbox-warmup landing rate, SMTP/IMAP connection health, and sending utilization.
+
+  _Reach for this to find which sender accounts are dragging deliverability before they tank a campaign._
+
+  ```bash
+  smartlead-pp-cli sender-health --json
+  ```
+- **`warmup-gate`** — Checks each sender account against warmup thresholds (--min-days, --min-inbox-rate); with --strict it exits non-zero when any account fails — a scriptable launch gate.
+
+  _Call this in a launch script to block attaching a sender account that is not warmed up yet._
+
+  ```bash
+  smartlead-pp-cli warmup-gate --account 6789 --json
+  ```
+
+## Command Reference
+
+**campaigns** — Manage campaigns
+
+- `smartlead-pp-cli campaigns create` — Create a new campaign
+- `smartlead-pp-cli campaigns delete` — Delete a campaign
+- `smartlead-pp-cli campaigns get` — Get a campaign by ID
+- `smartlead-pp-cli campaigns list` — Retrieves every email campaign for the authenticated SmartLead account.
+
+**client** — Manage client
+
+- `smartlead-pp-cli client create` — Create a whitelabel client
+- `smartlead-pp-cli client list` — List all whitelabel clients
+
+**email-accounts** — Manage email accounts
+
+- `smartlead-pp-cli email-accounts create` — Add a new email sender account
+- `smartlead-pp-cli email-accounts list` — List all email sender accounts
+- `smartlead-pp-cli email-accounts reconnect-failed` — Trigger a reconnect of all disconnected email accounts
+- `smartlead-pp-cli email-accounts update` — Update an email sender account
+
+**leads** — Manage leads
+
+- `smartlead-pp-cli leads add-domain-block-list` — Add domains to the account-wide block list
+- `smartlead-pp-cli leads get-by-email` — Look up a lead by email address
+- `smartlead-pp-cli leads list-categories` — List all lead categories for the account
+- `smartlead-pp-cli leads update` — Update a lead's fields
+
+
+### Finding the right command
+
+When you know what you want to do but not which command does it, ask the CLI directly:
+
+```bash
+smartlead-pp-cli which "<capability in your own words>"
+```
+
+`which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+
+## Recipes
+
+
+### Morning campaign triage
+
+```bash
+smartlead-pp-cli sync && smartlead-pp-cli health --json
+```
+
+Refresh the mirror, then get the all-campaigns health scorecard in one structured payload.
+
+### Pre-launch dedupe check
+
+```bash
+smartlead-pp-cli dupes --domain prospect-site.com --json
+```
+
+See every campaign, category, and last-contact date for a domain before pitching it again.
+
+### Build a follow-up list
+
+```bash
+smartlead-pp-cli silent --campaign 12345 --days 10 --json
+```
+
+Pull leads emailed but silent for 10+ days to feed into a follow-up sequence.
+
+### Trim a verbose campaign payload
+
+```bash
+smartlead-pp-cli campaigns list --agent --select id,name,status
+```
+
+SmartLead campaign objects are large; --agent with --select narrows the response to just the fields an agent needs.
+
+### Gate a launch on sender warmup
+
+```bash
+smartlead-pp-cli warmup-gate --account 6789 --json
+```
+
+Returns a typed exit code so a launch script can block on a sender that is not warmed up.
+
+## Auth Setup
+
+SmartLead authenticates with an API key passed as the api_key query parameter. Set SMARTLEAD_API_KEY in your environment (find the key under Settings -> API in the SmartLead app). No OAuth, no login flow.
+
+Run `smartlead-pp-cli doctor` to verify setup.
+
+## Agent Mode
+
+Add `--agent` to any command. Expands to: `--json --compact --no-input --no-color --yes`.
+
+- **Pipeable** — JSON on stdout, errors on stderr
+- **Filterable** — `--select` keeps a subset of fields. Dotted paths descend into nested structures; arrays traverse element-wise. Critical for keeping context small on verbose APIs:
+
+  ```bash
+  smartlead-pp-cli campaigns list --agent --select id,name,status
+  ```
+- **Previewable** — `--dry-run` shows the request without sending
+- **Offline-friendly** — sync/search commands can use the local SQLite store when available
+- **Non-interactive** — never prompts, every input is a flag
+- **Explicit retries** — use `--idempotent` only when an already-existing create should count as success, and `--ignore-missing` only when a missing delete target should count as success
+
+### Response envelope
+
+Commands that read from the local store or the API wrap output in a provenance envelope:
+
+```json
+{
+  "meta": {"source": "live" | "local", "synced_at": "...", "reason": "..."},
+  "results": <data>
+}
+```
+
+Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set — piped/agent consumers and explicit-format runs get pure JSON on stdout.
+
+## Agent Feedback
+
+When you (or the agent) notice something off about this CLI, record it:
+
+```
+smartlead-pp-cli feedback "the --since flag is inclusive but docs say exclusive"
+smartlead-pp-cli feedback --stdin < notes.txt
+smartlead-pp-cli feedback list --json --limit 10
+```
+
+Entries are stored locally at `~/.smartlead-pp-cli/feedback.jsonl`. They are never POSTed unless `SMARTLEAD_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `SMARTLEAD_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+
+Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
+
+## Output Delivery
+
+Every command accepts `--deliver <sink>`. The output goes to the named sink in addition to (or instead of) stdout, so agents can route command results without hand-piping. Three sinks are supported:
+
+| Sink | Effect |
+|------|--------|
+| `stdout` | Default; write to stdout only |
+| `file:<path>` | Atomically write output to `<path>` (tmp + rename) |
+| `webhook:<url>` | POST the output body to the URL (`application/json` or `application/x-ndjson` when `--compact`) |
+
+Unknown schemes are refused with a structured error naming the supported set. Webhook failures return non-zero and log the URL + HTTP status on stderr.
+
+## Named Profiles
+
+A profile is a saved set of flag values, reused across invocations. Use it when a scheduled agent calls the same command every run with the same configuration - HeyGen's "Beacon" pattern.
+
+```
+smartlead-pp-cli profile save briefing --json
+smartlead-pp-cli --profile briefing campaigns list
+smartlead-pp-cli profile list --json
+smartlead-pp-cli profile show briefing
+smartlead-pp-cli profile delete briefing --yes
+```
+
+Explicit flags always win over profile values; profile values win over defaults. `agent-context` lists all available profiles under `available_profiles` so introspecting agents discover them at runtime.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 2 | Usage error (wrong arguments) |
+| 3 | Resource not found |
+| 4 | Authentication required |
+| 5 | API error (upstream issue) |
+| 7 | Rate limited (wait and retry) |
+| 10 | Config error |
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+1. **Empty, `help`, or `--help`** → show `smartlead-pp-cli --help` output
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → see Prerequisites above
+3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
+
+## MCP Server Installation
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release, then register it:
+
+```bash
+claude mcp add smartlead-pp-mcp -- smartlead-pp-mcp
+```
+
+Verify: `claude mcp list`
+
+## Direct Use
+
+1. Check if installed: `which smartlead-pp-cli`
+   If not found, offer to install (see Prerequisites at the top of this skill).
+2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
+3. Execute with the `--agent` flag:
+   ```bash
+   smartlead-pp-cli <command> [subcommand] [args] --agent
+   ```
+4. If ambiguous, drill into subcommand help: `smartlead-pp-cli <command> --help`.

--- a/cli-skills/pp-substack-creator/SKILL.md
+++ b/cli-skills/pp-substack-creator/SKILL.md
@@ -11,6 +11,11 @@ metadata:
       bins:
         - substack-creator-pp-cli
 ---
+<!-- GENERATED FILE — DO NOT EDIT.
+     This file is a verbatim mirror of library/media-and-entertainment/substack-creator/SKILL.md,
+     regenerated post-merge by tools/generate-skills/. Hand-edits here are
+     silently overwritten on the next regen. Edit the library/ source instead.
+     See AGENTS.md "Generated artifacts: registry.json, cli-skills/". -->
 
 <!-- // PATCH: skill-install-canonical — restored the canonical SKILL.md install section so verify-skill's canonical-sections drift check passes after manifest got a category. See .printing-press-patches.json. -->
 


### PR DESCRIPTION
## Summary

Drops the bidirectional `// PATCH` source-marker pairing rule from `verify_publish_package.py` and the corresponding instructions from `AGENTS.md`. CI's role for `.printing-press-patches.json` becomes minimal — the file must exist on new CLIs (unchanged), parse as JSON, and `patches` must be an array. Everything else about the manifest's shape is the authoring contract described in AGENTS.md and enforced by agent diligence + code review, not by CI.

## Why

The bidirectional pairing rule meant every in-session customization required **two** commits: one to add the `.printing-press-patches.json` entry, then a second after CI rejected the PR for missing source markers, to add `// PATCH <id>:` comments in the referenced `.go` files. The rule's stated rationale — "surfaces every customization via `grep -rn 'PATCH'`" — is real but redundant with the manifest itself, which already enumerates every customization with summary, reason, files list, and (optionally) upstream issue link. Git history adds diff, author, timestamp on top.

Surfaced concretely on emailoctopus publish [PR #638](https://github.com/mvanhorn/printing-press-library/pull/638): it cost three commits (`67c50e09` add manifest → `a0367cea` add markers in 3 files → `629e3b98` add marker in the 4th file) plus interleaved Greptile review threads to land what should have been a single fix. Multiply across every publish that ships an in-session customization.

The cli-printing-press generator side of this change ([cli-printing-press PR #1590](https://github.com/mvanhorn/cli-printing-press/pull/1590)) already shipped the empty-manifest emit so fresh prints pass Verify without hand-creating the file. This PR completes the other half — agents shouldn't have to add markers to make the manifest entry accepted.

## What changes

| File | Change |
|---|---|
| `.github/scripts/verify-publish-package/verify_publish_package.py` | `validate_patch_manifest` collapses to ~10 lines: parse + `patches`-is-an-array. Deletes `candidate_patch_marker_files`, `has_patch_marker`, `_PATCH_MARKER_RE`, the source-markers-without-manifest check, the per-patch schema validation (`files` required, file-exists check, .go marker pairing), and the diff-scoping that only existed to gate the deleted checks. `re` and `Iterable` imports drop with them. |
| `.github/scripts/verify-publish-package/verify_publish_package_test.py` | Deletes 4 marker-behavior tests + the entire `HasPatchMarkerTest` class (10 tests for a function that no longer exists). Adds 5 tests for the relaxed contract: marker-without-entry passes, patch-entry-with-missing-file passes, `patches: "string"` fails, `patches: null` normalizes to empty, malformed JSON still surfaces a problem. |
| `AGENTS.md` | `## .printing-press-patches.json records library-side customizations` section drops step 1 (the `// PATCH:` marker instruction). Adds a closing note: markers are now optional navigation aids; CI no longer cares whether you write one. |

Net diff: **-242 lines** across the three files.

## Net effect on agent workflow

| Step | Before | After |
|---|---|---|
| 1. Edit a `.go` file in a library CLI | Required | Required |
| 2. Add `// PATCH <id>:` source comment | Required (CI-enforced) | Optional |
| 3. Add an entry to `.printing-press-patches.json` | Required | Required |
| 4. Match `id` in source and manifest | Required (CI-enforced) | N/A |
| 5. Re-commit after marker-pairing CI failure | Typically required | Eliminated |

## Test plan

- [x] `python3 verify_publish_package_test.py` — 10/10 pass
- [x] All four scenarios that previously had dedicated tests are now passing tests for the *new* behavior (marker without entry passes, missing referenced file passes, etc.)
- [x] `read_json` error path (malformed JSON) still surfaces as expected
- [x] `patches` shape enforcement (must-be-array) still fires

## Backward compatibility

Existing library CLIs that ship `// PATCH:` markers are unaffected — the verifier just stops looking for them. No retrofit needed; they remain valid markers for any future reader who wants them.

The matching cli-printing-press PR ([#1592](https://github.com/mvanhorn/cli-printing-press/pull/new/fix/drop-patch-marker-instruction) — to be filed) updates `internal/generator/templates/agents.md.tmpl` so every **newly printed** CLI's `AGENTS.md` mirrors this repo's relaxed guidance. Existing CLIs' `AGENTS.md` files keep their old prose until they regen.
