### PR TITLE
chore(ci): unblock post-merge regen workflows

### DIFF
--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -56,6 +56,9 @@ jobs:
           # GITHUB_TOKEN's default ref is the merge commit; explicitly
           # check out main so the push at the end targets it.
           ref: main
+          # Admin-scoped PAT so the post-commit push bypasses the
+          # main-branch ruleset (default GITHUB_TOKEN cannot bypass).
+          token: ${{ secrets.ADMIN_PUSH_PAT }}
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.3'
@@ -78,4 +81,12 @@ jobs:
           # the sentinel region would normally re-trigger; this commit
           # itself is suppressed by [skip ci] so we don't loop.
           git commit -m "chore(registry): regenerate from library/ [skip ci]"
+          # Defense-in-depth against the cross-workflow race with
+          # generate-skills.yml — the concurrency group serializes most
+          # runs, but a rebase before push handles the moment when the
+          # sibling workflow lands between our checkout and our push.
+          # The two workflows touch disjoint paths (registry.json +
+          # README.md vs cli-skills/), so the rebase is conflict-free
+          # in practice.
+          git pull --rebase origin main
           git push

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
+          # Admin-scoped PAT so the post-commit push bypasses the
+          # main-branch ruleset (default GITHUB_TOKEN cannot bypass).
+          token: ${{ secrets.ADMIN_PUSH_PAT }}
 
       - uses: actions/setup-go@v6
         with:
@@ -44,5 +47,13 @@ jobs:
             echo "No skill changes to commit"
           else
             git commit -m "chore(skills): regenerate per-app skills [skip ci]"
+            # Defense-in-depth against the cross-workflow race with
+            # generate-registry.yml — the concurrency group serializes
+            # most runs, but a rebase before push handles the moment
+            # when the sibling workflow lands between our checkout and
+            # our push. The two workflows touch disjoint paths
+            # (cli-skills/ vs registry.json + README.md), so the rebase
+            # is conflict-free in practice.
+            git pull --rebase origin main
             git push
           fi

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -9,6 +9,7 @@ on:
       - 'library/**/SKILL.md'
       - 'library/**/README.md'
       - 'tools/generate-skills/main.go'
+  workflow_dispatch:
 
 jobs:
   generate:


### PR DESCRIPTION
## Summary

- Switch `generate-skills.yml` and `generate-registry.yml` to authenticate with `secrets.ADMIN_PUSH_PAT` so their post-commit push bypasses the `main` rulesets (default `GITHUB_TOKEN` cannot bypass)
- Add `git pull --rebase origin main` before each push to recover cleanly from the cross-workflow race when the sibling workflow lands between our checkout and our push

## Why

Both post-merge regen workflows have been failing on push since the main-branch rulesets started requiring `Greptile Review`, `Greptile policy gate`, and PR-mediated changes. Recent run history:

- `generate-skills.yml`: 9/15 success in last 15 main pushes
- `generate-registry.yml`: 0/15 success in last 15 main pushes

Failure mode on `generate-skills`:
\`\`\`
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Required status check \"Greptile Review\" is expected.
remote: - Required status check \"Greptile policy gate\" is expected.
remote: - Changes must be made through a pull request.
\`\`\`

Failure mode on `generate-registry` (separate, race-driven):
\`\`\`
! [rejected] main -> main (fetch first)
\`\`\`

As a result, `cli-skills/` and `registry.json` on `main` have been silently drifting from `library/` since the rulesets tightened.

## Operational prerequisites already done

- `Admin` role's `bypass_mode` on both `main protection` and `main requires Greptile policy gate` rulesets changed from `pull_request` to `always`
- `ADMIN_PUSH_PAT` added as a repo secret (admin-scoped PAT)

## After merge

1. Trigger both workflows via \`workflow_dispatch\` (or a no-op commit to a triggering path) to confirm the push succeeds
2. Backfill drift — manually run both generators against current \`main\`, push the resulting commits via the now-working workflows

## Related

Prerequisite for the bot-only PR-time enforcement architecture discussed in #590 — once post-merge regen is reliable, the in-PR Guard/drift check can be replaced with a single \"do not commit cli-skills/ or registry.json\" rule that resolves the fork-PR catch-22.

## Test plan

- [x] Local diff review
- [ ] After merge: `workflow_dispatch` both workflows, confirm push succeeds, confirm any drift commit lands cleanly on main
- [ ] If drift is non-empty: review the regenerated diff before it lands (manually run generator locally first to preview)