### PR TITLE
fix(digg): select fields inside result envelopes

### DIFF
--- a/library/media-and-entertainment/digg/internal/cli/digg_commands_test.go
+++ b/library/media-and-entertainment/digg/internal/cli/digg_commands_test.go
@@ -383,3 +383,32 @@ func TestSearchSince_HelpMentionsFlag(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchSelectFiltersResultsEnvelope(t *testing.T) {
+	srv := startMockSearchServer(t, cannedStories())
+	stdout, _, err := runSearchCmd(
+		t,
+		srv.URL,
+		"agents",
+		"--select",
+		"clusterUrlId,title,rank,postCount,uniqueAuthors,firstPostAge",
+	)
+	if err != nil {
+		t.Fatalf("search --select: %v", err)
+	}
+
+	var env searchEnvelopeForTest
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout)
+	}
+	if len(env.Results) == 0 {
+		t.Fatalf("expected selected results, got: %s", stdout)
+	}
+	first := env.Results[0]
+	if first.ClusterURLID == "" || first.Title == "" || first.Rank == 0 || first.PostCount == 0 || first.UniqueAuthors == 0 || first.FirstPostAge == "" {
+		t.Fatalf("selected result missing requested fields: %+v", first)
+	}
+	if first.ClusterID != "" {
+		t.Fatalf("unrequested clusterId should be omitted, got %q", first.ClusterID)
+	}
+}

--- a/library/media-and-entertainment/digg/internal/cli/helpers.go
+++ b/library/media-and-entertainment/digg/internal/cli/helpers.go
@@ -402,11 +402,42 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 				filtered[k] = filterFieldsRec(v, subs)
 			}
 		}
+		if len(filtered) == 0 {
+			if arrayField, raw, ok := singleNestedArrayField(obj); ok {
+				filtered[arrayField] = filterFieldsRec(raw, paths)
+			}
+		}
 		result, _ := json.Marshal(filtered)
 		return result
 	}
 
 	return data
+}
+
+func singleNestedArrayField(obj map[string]json.RawMessage) (string, json.RawMessage, bool) {
+	for _, field := range []string{"data", "items", "results", "messages", "members", "values"} {
+		if raw, ok := obj[field]; ok {
+			var nested []json.RawMessage
+			if json.Unmarshal(raw, &nested) == nil {
+				return field, raw, true
+			}
+		}
+	}
+
+	var (
+		field string
+		raw   json.RawMessage
+		count int
+	)
+	for k, candidate := range obj {
+		var nested []json.RawMessage
+		if json.Unmarshal(candidate, &nested) == nil {
+			field = k
+			raw = candidate
+			count++
+		}
+	}
+	return field, raw, count == 1
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.


### PR DESCRIPTION
## Summary
- keep `--select` useful for result-envelope commands like `digg-pp-cli search`
- when selected fields do not match top-level envelope keys, apply selection to the single nested result array and preserve that array key
- add a regression test for `search --select clusterUrlId,title,rank,postCount,uniqueAuthors,firstPostAge`

## Why
Dogfooding `digg-pp-cli` with last30days exposed that the documented agent recipe returned `{}`:

```bash
digg-pp-cli search "AI coding agents" --since 30d --agent --limit 2 --select clusterUrlId,title,rank,postCount,uniqueAuthors,firstPostAge
```

The search command emits a top-level envelope shaped like `{ "meta": ..., "results": [...] }`. The generic selector was matching only top-level fields, so result fields like `clusterUrlId` and `title` produced an empty object.

## Test plan
- `go test ./internal/cli -run TestSearchSelectFiltersResultsEnvelope`
- `go test ./internal/cli -run 'TestSearch|TestFilter|TestCompact|TestPrint'`
- `go test ./...`
- `make build`
- `bin/digg-pp-cli search "AI coding agents" --since 30d --agent --limit 2 --select clusterUrlId,title,rank,postCount,uniqueAuthors,firstPostAge`

