### PR TITLE
fix(ci): use base's verifier scripts + direct diff for generated-artifacts check

### DIFF
--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -63,6 +63,30 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Overlay verifier scripts from base
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Run the latest verifier scripts (from base) against the PR's
+          # tree, not whatever stale version the PR was branched from.
+          # Without this overlay, a PR opened against an old main runs
+          # the verifier as it existed back then — surfacing checks that
+          # have since been relaxed and missing checks that have since
+          # been added. It's also the right security default: fork PRs
+          # shouldn't be able to ship their own modified verifier.
+          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null \
+            || git remote set-url base "https://github.com/${BASE_REPO}.git"
+          base_remote_ref="refs/remotes/base/${BASE_REF}"
+          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
+            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
+          fi
+          git checkout "${base_remote_ref}" -- \
+            .github/scripts/verify-attribution \
+            .github/scripts/verify-publish-package
+
       - name: Fail on changes to generated artifacts
         if: github.event_name == 'pull_request'
         env:
@@ -88,7 +112,14 @@ jobs:
           base_remote_ref="refs/remotes/base/${BASE_REF}"
           git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
 
-          violations=$(git diff --name-only "${base_remote_ref}...HEAD" \
+          # Use `..` (direct diff), not `...` (merge-base diff). `...`
+          # blocks any PR whose history touched the file even when its
+          # final content matches current base — e.g., a stale-base PR
+          # that was caught up via `git checkout base -- <file>` to
+          # restore main's current content. `..` correctly compares the
+          # PR's HEAD state to current base and only fires when content
+          # actually differs.
+          violations=$(git diff --name-only "${base_remote_ref}..HEAD" \
             -- 'registry.json' 'cli-skills/pp-*/SKILL.md')
 
           if [ -z "$violations" ]; then

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -63,11 +63,26 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Overlay verifier scripts from base
+      - name: Fetch base ref
+        id: base
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
           BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Single authoritative fetch of base. Downstream steps reuse
+          # `refs/remotes/base/${BASE_REF}` so they all see the same
+          # base commit even if `main` advances mid-job.
+          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null \
+            || git remote set-url base "https://github.com/${BASE_REPO}.git"
+          git fetch --no-tags base "${BASE_REF}:refs/remotes/base/${BASE_REF}"
+          echo "ref=refs/remotes/base/${BASE_REF}" >> "${GITHUB_OUTPUT}"
+
+      - name: Overlay verifier scripts from base
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
           # Run the latest verifier scripts (from base) against the PR's
@@ -77,21 +92,14 @@ jobs:
           # have since been relaxed and missing checks that have since
           # been added. It's also the right security default: fork PRs
           # shouldn't be able to ship their own modified verifier.
-          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null \
-            || git remote set-url base "https://github.com/${BASE_REPO}.git"
-          base_remote_ref="refs/remotes/base/${BASE_REF}"
-          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
-            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
-          fi
-          git checkout "${base_remote_ref}" -- \
+          git checkout "${BASE_REMOTE_REF}" -- \
             .github/scripts/verify-attribution \
             .github/scripts/verify-publish-package
 
       - name: Fail on changes to generated artifacts
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
-          BASE_REPO: ${{ github.repository }}
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
 
@@ -107,20 +115,37 @@ jobs:
           # cli-skills/AGENTS.md and other meta files under cli-skills/
           # are hand-maintained; only pp-*/SKILL.md is generated.
 
-          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null \
-            || git remote set-url base "https://github.com/${BASE_REPO}.git"
-          base_remote_ref="refs/remotes/base/${BASE_REF}"
-          git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
+          # Flag a file only when BOTH conditions hold:
+          #   (a) the PR's commits touched it (merge-base aware: not
+          #       just "tree differs from base"), AND
+          #   (b) HEAD's content differs from current base
+          #
+          # (a) alone (the old `...` form) over-fires when a stale-base
+          # PR was caught up by checking out base's version of the file
+          # — the final tree matches base, but merge-base diff still
+          # sees a commit touching it.
+          #
+          # (b) alone (the previous `..` form) over-fires when the PR's
+          # commits never touched the file but its HEAD tree carries
+          # an older snapshot (every post-merge [skip ci] regen on main
+          # advances those paths; any unrebased PR will lag and trip).
+          #
+          # The intersection is the only signal that means "this PR
+          # introduced a divergent change to a generated file."
 
-          # Use `..` (direct diff), not `...` (merge-base diff). `...`
-          # blocks any PR whose history touched the file even when its
-          # final content matches current base — e.g., a stale-base PR
-          # that was caught up via `git checkout base -- <file>` to
-          # restore main's current content. `..` correctly compares the
-          # PR's HEAD state to current base and only fires when content
-          # actually differs.
-          violations=$(git diff --name-only "${base_remote_ref}..HEAD" \
-            -- 'registry.json' 'cli-skills/pp-*/SKILL.md')
+          touched=$(git log "${BASE_REMOTE_REF}..HEAD" --name-only --format= \
+            -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
+            | grep -v '^$' | sort -u)
+          differs=$(git diff --name-only "${BASE_REMOTE_REF}" HEAD \
+            -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
+            | sort -u)
+
+          if [ -z "$touched" ] || [ -z "$differs" ]; then
+            echo "No PR commits introduce divergent changes to generated artifacts. OK."
+            exit 0
+          fi
+
+          violations=$(comm -12 <(echo "$touched") <(echo "$differs"))
 
           if [ -z "$violations" ]; then
             echo "No changes to generated artifacts. OK."
@@ -141,27 +166,18 @@ jobs:
       - name: Guard CLI attribution
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
-          base_remote_ref="refs/remotes/base/${BASE_REF}"
-          python3 .github/scripts/verify-attribution/verify_attribution.py --base "${base_remote_ref}"
+          python3 .github/scripts/verify-attribution/verify_attribution.py --base "${BASE_REMOTE_REF}"
 
       - name: Publish package completeness
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
-          BASE_REPO: ${{ github.repository }}
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
-
-          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
-          base_remote_ref="refs/remotes/base/${BASE_REF}"
-          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
-            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
-          fi
-
-          python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref "${base_remote_ref}"
+          python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref "${BASE_REMOTE_REF}"
 
       - name: go.mod module path matches directory
         run: |


### PR DESCRIPTION
## Summary

Two follow-up fixes for `verify-library-conventions.yml`, both discovered while batch-unblocking ~30 stale fork PRs after #659 landed:

- **Generated-artifacts check:** switch from `base...HEAD` (merge-base diff) to `base..HEAD` (direct diff). The merge-base form fires on any PR whose history ever touched a generated file, even when the final content matches current base. Direct diff only fires when content actually differs from current base.
- **Verifier scripts:** overlay `.github/scripts/verify-attribution/` and `.github/scripts/verify-publish-package/` from base before running them. Previously these scripts ran from the PR's HEAD, meaning stale-base PRs ran old verifier code with checks that have since been relaxed (or missing checks that have since been added).

## Why

After #659 collapsed the cli-skills catch-22 into a single check, ~30 stale fork PRs that hit the old catch-22 were unblocked at the catch-22 layer but two new failure shapes surfaced:

| Bug | Symptom | Affected count (so far) |
|---|---|---|
| Merge-base diff too strict | PRs that restored cli-skills to current base content still flagged as "modified" | 1 confirmed (#589), likely more once CI completes |
| Stale verifier scripts | PRs hit `source files contain PATCH markers but patches[] is empty` from a verifier check that was removed from `validate_patch_manifest` on main | 2 confirmed (#410, #418) |

Both are the same architectural pattern: workflow YAML comes from base (default for `pull_request`), but everything else (CLI source, verifier scripts) comes from PR's HEAD. The mismatch surfaces as "I fixed the issue but it still fails" for fork contributors and maintainers driving batch fixes.

The verifier-script overlay is also a **security improvement**: without it, a fork PR could ship its own modified verifier to relax checks. Workflow YAML already comes from base for `pull_request` events; this extends the same property to the scripts the workflow invokes.

## Test plan

- [x] Local diff review.
- [ ] After merge: re-run Verify on the failing batch of stale-base PRs (#410, #418, #589 known affected) and confirm they pass the previously-failing steps.
- [ ] Confirm no regression on fresh same-repo PRs (they should be unaffected — overlay produces no diff when base and HEAD are at the same point).

## Related

- Prerequisite: #659 (collapsed cli-skills catch-22)
- Surfaced while unblocking stale fork PRs identified earlier today