### PR TITLE
fix(ci): bump greptile policy gate timeout 15min → 25min

### DIFF
--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -61,29 +61,7 @@ jobs:
           echo "number=$(jq -r '.number' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
           echo "head_sha=$(jq -r '.head.sha' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
 
-      - name: Detect Greptile-authored fix commit
-        id: bot-check
-        # "Fix in Codex/Claude/Cursor/Conductor" deeplinks in Greptile reviews
-        # produce a commit co-authored by greptile-apps[bot]. The gate would
-        # otherwise poll for a Greptile review of that commit specifically,
-        # but Greptile rarely re-reviews its own suggestions in time, so the
-        # gate times out on a commit Greptile already implicitly endorsed.
-        # Treat any head commit with the Greptile co-author trailer as
-        # already-reviewed and skip the polling loop.
-        env:
-          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          commit_msg="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message')"
-          if printf '%s' "${commit_msg}" | grep -qiE '^[[:space:]]*Co-authored-by:[[:space:]]*greptile-apps\[bot\]'; then
-            echo "::notice::Head commit ${HEAD_SHA} is co-authored by greptile-apps[bot] — treating as Greptile-approved and skipping the polling gate."
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Require Greptile score
-        if: steps.bot-check.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/greptile-policy-gate.yml
+++ b/.github/workflows/greptile-policy-gate.yml
@@ -24,7 +24,11 @@ jobs:
     name: Greptile policy gate
     if: github.event_name != 'pull_request_target' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 17
+    # 27min = 25min inner polling deadline + 2min buffer for checkout/setup.
+    # Bumped from 17 → 27 because Greptile re-reviews queue behind rate
+    # limits when a PR rapidly accumulates pushes; the prior 15-min inner
+    # deadline left zero headroom on busy days.
+    timeout-minutes: 27
     concurrency:
       group: greptile-policy-gate-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
       cancel-in-progress: true
@@ -57,7 +61,29 @@ jobs:
           echo "number=$(jq -r '.number' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
           echo "head_sha=$(jq -r '.head.sha' <<<"${pr_json}")" >> "${GITHUB_OUTPUT}"
 
+      - name: Detect Greptile-authored fix commit
+        id: bot-check
+        # "Fix in Codex/Claude/Cursor/Conductor" deeplinks in Greptile reviews
+        # produce a commit co-authored by greptile-apps[bot]. The gate would
+        # otherwise poll for a Greptile review of that commit specifically,
+        # but Greptile rarely re-reviews its own suggestions in time, so the
+        # gate times out on a commit Greptile already implicitly endorsed.
+        # Treat any head commit with the Greptile co-author trailer as
+        # already-reviewed and skip the polling loop.
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          commit_msg="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message')"
+          if printf '%s' "${commit_msg}" | grep -qiE '^[[:space:]]*Co-authored-by:[[:space:]]*greptile-apps\[bot\]'; then
+            echo "::notice::Head commit ${HEAD_SHA} is co-authored by greptile-apps[bot] — treating as Greptile-approved and skipping the polling gate."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Require Greptile score
+        if: steps.bot-check.outputs.skip != 'true'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
@@ -66,7 +92,7 @@ jobs:
 
           echo "Evaluating PR #${PR_NUMBER} at ${HEAD_SHA}"
 
-          deadline=$((SECONDS + 900))
+          deadline=$((SECONDS + 1500))
           nudge_after=180
           start="${SECONDS}"
           nudged=0


### PR DESCRIPTION
Small follow-up to #665. Bumps the Greptile policy gate's polling deadline because the 15-minute budget left zero headroom when Greptile re-reviews queue behind rate limits (#665 hit this).

## Change

- Inner polling: `deadline=$((SECONDS + 900))` → `deadline=$((SECONDS + 1500))` (15 → 25 min)
- Job timeout: `timeout-minutes: 17` → `timeout-minutes: 27` (preserving the 2-min buffer for checkout/setup)

## What was dropped

The original version of this PR also added a step to skip the gate when the head commit was co-authored by `greptile-apps[bot]` (intent: avoid the gate timing out on "Fix in Codex/Claude" deeplink commits, where Greptile rarely re-reviews its own suggestions). Greptile correctly flagged that as P1: any contributor — including fork PRs on `pull_request_target` — can write `Co-authored-by: greptile-apps[bot]` in a commit message and bypass the gate. Forgeable bypass in a security gate is worse than the problem it solved. Dropped.

For the original problem (Greptile not re-reviewing deeplink commits), the existing escape hatches stay: admin force-merge, or `@greptileai review` to manually trigger.

## Test plan

- [x] YAML parses
- [ ] In-the-wild observation over the next week — does the 25-min budget absorb Greptile's queue variance? If still tight, revisit.

No behavioral change beyond the timeout values.