### PR TITLE
fix(suno): detect expired __session JWT and refuse stale tokens

### DIFF
--- a/library/media-and-entertainment/suno/.printing-press-patches.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches.json
@@ -1,9 +1,21 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-15",
+  "applied_at": "2026-05-18",
   "base_run_id": "20260514-184203",
   "base_printing_press_version": "4.6.1",
   "patches": [
+    {
+      "id": "suno-jwt-staleness-check",
+      "summary": "Decode the __session JWT on login/refresh/doctor and refuse stale tokens with an actionable hint.",
+      "reason": "Suno's __session cookie carries a Clerk JWT with a ~1h lifetime. Chrome keeps the cookie row long after the JWT inside it expires, so a long-idle Suno tab leaves a stale value on disk. The previous flow silently saved the stale value: the read-side validation endpoint (eligible-discounts) accepted it so doctor reported 'valid', but every write endpoint (billing/info, generate/v2-web) returned HTTP 401 with no hint pointing back at the cookie. The patch adds a config.JWTExpiry helper, refuses to save an expired token in auth login/refresh, and surfaces token age + expiry in doctor so a silent failure becomes a visible one.",
+      "files": [
+        "internal/cli/auth.go",
+        "internal/cli/doctor.go",
+        "internal/config/jwt.go",
+        "internal/config/jwt_test.go"
+      ],
+      "validated_outcome": "go test ./internal/config 7/7 pass including 6 new JWT cases; go test ./... 175/175 pass; go vet clean; live doctor surfaces 'valid for 33m30s' on fresh token and 'expired 1h0m0s ago' + actionable hint on stale token; --fail-on=error exits 1 on stale token."
+    },
     {
       "id": "suno-transcendence-commands",
       "summary": "Adds local Suno workflow and analytics commands beyond the sniffed endpoint spec.",

--- a/library/media-and-entertainment/suno/internal/cli/auth.go
+++ b/library/media-and-entertainment/suno/internal/cli/auth.go
@@ -192,6 +192,26 @@ profile by name when the installed backend supports it.`,
 				composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
 			}
 
+			// PATCH(suno-jwt-staleness-check): Refuse to save a __session cookie
+			// whose embedded Clerk JWT is already expired. Chrome keeps the
+			// cookie row long after the JWT inside it expires (default 1h
+			// lifetime), so a long-idle Suno tab leaves a stale value sitting
+			// on disk. Without this check the CLI silently saves the stale
+			// token, the read-side validation endpoint accepts it (lenient
+			// auth check), but every write endpoint returns HTTP 401 with no
+			// signal that points back at the cookie. Tell the user to refresh
+			// suno.com so Chrome rotates the cookie, then re-run login.
+			if exp, ok := config.JWTExpiry(composed); ok {
+				if exp.Before(time.Now()) {
+					age := time.Since(exp).Round(time.Second)
+					fmt.Fprintln(w, red("Chrome's __session cookie carries an expired Clerk JWT (expired "+age.String()+" ago)."))
+					fmt.Fprintln(w, "")
+					fmt.Fprintln(w, "Open https://suno.com in Chrome (any page) so the cookie refreshes, then re-run:")
+					fmt.Fprintf(w, "\n  suno-pp-cli auth login --chrome\n")
+					return authErr(fmt.Errorf("stored __session JWT expired %s ago", age))
+				}
+			}
+
 			cfg, err := config.Load(flags.configPath)
 			if err != nil {
 				return configErr(err)
@@ -456,6 +476,16 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	composed := "Bearer {__session}"
 	for _, name := range requiredCookies {
 		composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
+	}
+	// PATCH(suno-jwt-staleness-check): see auth login --chrome above. The
+	// refresh path reads the same Chrome cookie store, so the same expired-
+	// JWT trap applies; surface it loudly here instead of overwriting the
+	// stored token with the same stale value.
+	if exp, ok := config.JWTExpiry(composed); ok {
+		if exp.Before(time.Now()) {
+			age := time.Since(exp).Round(time.Second)
+			return fmt.Errorf("Chrome's __session cookie carries an expired Clerk JWT (expired %s ago); open https://suno.com in Chrome to refresh it, then re-run auth refresh", age)
+		}
 	}
 	if err := cfg.SaveTokens("", "", composed, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving auth: %w", err))

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -110,6 +110,21 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						report["browser_session_proof"] = "missing or stale"
 						report["browser_session_proof_detail"] = proofDetail
 					}
+					// PATCH(suno-jwt-staleness-check): decode the bearer
+					// token and surface its remaining lifetime. The cookie-
+					// from-Chrome flow stores a Clerk JWT that expires every
+					// ~1h; the read-side validation endpoint accepts stale
+					// tokens, so without this signal doctor reports "valid"
+					// while every write endpoint 401s. Turns a silent failure
+					// into a visible one and tells the user the fix.
+					if exp, ok := config.JWTExpiry(header); ok {
+						if exp.Before(time.Now()) {
+							report["auth_token"] = fmt.Sprintf("expired %s ago", time.Since(exp).Round(time.Second))
+							report["auth_token_hint"] = "open https://suno.com in Chrome to refresh, then run suno-pp-cli auth login --chrome"
+						} else {
+							report["auth_token"] = fmt.Sprintf("valid for %s", time.Until(exp).Round(time.Second))
+						}
+					}
 				}
 			}
 			// Check cookie tool availability
@@ -245,6 +260,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			checkKeys := []struct{ key, label string }{
 				{"config", "Config"},
 				{"auth", "Auth"},
+				{"auth_token", "Auth Token"},
 				{"env_vars", "Env Vars"},
 				{"browser_session_proof", "Browser Session Proof"},
 				{"api", "API"},
@@ -268,7 +284,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					indicator = yellow("INFO")
 				case strings.Contains(s, "scope-limited"):
 					indicator = yellow("WARN")
-				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
+				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.HasPrefix(s, "expired "):
 					indicator = red("FAIL")
 				case s == "not required":
 					// Public APIs: no auth needed is a healthy state, not a warning.
@@ -387,7 +403,7 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 	for _, v := range report {
 		s, ok := v.(string)
 		if ok {
-			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") {
+			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.HasPrefix(s, "expired ") {
 				worstError = true
 			}
 		}

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -304,6 +304,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			if hint, ok := report["auth_hint"]; ok {
 				fmt.Fprintf(w, "  hint: %v\n", hint)
 			}
+			// PATCH(suno-jwt-staleness-check): mirror auth_hint rendering for
+			// the JWT-expiry hint so users running plain `doctor` see the
+			// recovery instruction, not just `FAIL Auth Token: expired Xs ago`.
+			if hint, ok := report["auth_token_hint"]; ok {
+				fmt.Fprintf(w, "  hint: %v\n", hint)
+			}
 			// Cache section: render after the primary health block so it
 			// sits next to version info, mirroring the JSON report layout.
 			if cacheAny, ok := report["cache"]; ok {

--- a/library/media-and-entertainment/suno/internal/config/jwt.go
+++ b/library/media-and-entertainment/suno/internal/config/jwt.go
@@ -1,0 +1,74 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// JWTClaims is the minimal claim subset needed to reason about expiry.
+type JWTClaims struct {
+	IssuedAt  int64 `json:"iat"`
+	ExpiresAt int64 `json:"exp"`
+}
+
+// DecodeJWTClaims parses the unverified payload of a Clerk-style JWT. The
+// signature is not validated — Suno's API enforces signature on every
+// request, so the CLI only inspects the payload to decide whether to bother
+// sending a token it already knows is expired. Returns ok=false for any
+// shape that isn't a parseable three-segment JWT (e.g. opaque tokens or
+// plain Bearer strings without a JWT body).
+func DecodeJWTClaims(token string) (JWTClaims, bool) {
+	t := strings.TrimSpace(token)
+	t = strings.TrimPrefix(t, "Bearer ")
+	t = strings.TrimPrefix(t, "bearer ")
+	parts := strings.Split(t, ".")
+	if len(parts) != 3 {
+		return JWTClaims{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(addBase64Padding(parts[1]))
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(addBase64Padding(parts[1]))
+		if err != nil {
+			return JWTClaims{}, false
+		}
+	}
+	var claims JWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return JWTClaims{}, false
+	}
+	if claims.ExpiresAt == 0 {
+		return JWTClaims{}, false
+	}
+	return claims, true
+}
+
+// JWTExpiry returns the expiry time of a JWT-shaped bearer token. Returns
+// ok=false for opaque tokens or for JWTs that omit the exp claim.
+func JWTExpiry(token string) (time.Time, bool) {
+	claims, ok := DecodeJWTClaims(token)
+	if !ok {
+		return time.Time{}, false
+	}
+	return time.Unix(claims.ExpiresAt, 0), true
+}
+
+// AuthHeaderExpiry returns the expiry time of the currently configured auth
+// header, when that header carries a decodable JWT. Returns ok=false for
+// configs with no auth header or with an opaque token.
+func (c *Config) AuthHeaderExpiry() (time.Time, bool) {
+	if c == nil {
+		return time.Time{}, false
+	}
+	return JWTExpiry(c.AuthHeader())
+}
+
+func addBase64Padding(s string) string {
+	if pad := len(s) % 4; pad != 0 {
+		return s + strings.Repeat("=", 4-pad)
+	}
+	return s
+}

--- a/library/media-and-entertainment/suno/internal/config/jwt.go
+++ b/library/media-and-entertainment/suno/internal/config/jwt.go
@@ -29,7 +29,10 @@ func DecodeJWTClaims(token string) (JWTClaims, bool) {
 	if len(parts) != 3 {
 		return JWTClaims{}, false
 	}
-	payload, err := base64.RawURLEncoding.DecodeString(addBase64Padding(parts[1]))
+	// JWT segments are unpadded base64url per RFC 7519, so RawURLEncoding is
+	// the correct decoder. Fall back to padded URLEncoding only for tokens
+	// from non-conforming issuers that happen to include `=` padding.
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		payload, err = base64.URLEncoding.DecodeString(addBase64Padding(parts[1]))
 		if err != nil {

--- a/library/media-and-entertainment/suno/internal/config/jwt_test.go
+++ b/library/media-and-entertainment/suno/internal/config/jwt_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	encode := func(v any) string {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	return strings.Join([]string{encode(header), encode(claims), "signature"}, ".")
+}
+
+func TestDecodeJWTClaims_ValidExpiry(t *testing.T) {
+	exp := time.Now().Add(45 * time.Minute).Unix()
+	token := makeJWT(t, map[string]any{"exp": exp, "iat": time.Now().Unix()})
+	claims, ok := DecodeJWTClaims(token)
+	if !ok {
+		t.Fatalf("expected ok=true for well-formed JWT")
+	}
+	if claims.ExpiresAt != exp {
+		t.Fatalf("exp mismatch: got %d want %d", claims.ExpiresAt, exp)
+	}
+}
+
+func TestDecodeJWTClaims_BearerPrefix(t *testing.T) {
+	exp := time.Now().Add(10 * time.Minute).Unix()
+	token := "Bearer " + makeJWT(t, map[string]any{"exp": exp})
+	if _, ok := DecodeJWTClaims(token); !ok {
+		t.Fatal("expected Bearer-prefixed JWT to decode")
+	}
+}
+
+func TestDecodeJWTClaims_OpaqueToken(t *testing.T) {
+	if _, ok := DecodeJWTClaims("opaque-not-a-jwt"); ok {
+		t.Fatal("expected ok=false for opaque token")
+	}
+	if _, ok := DecodeJWTClaims("Bearer opaque-not-a-jwt"); ok {
+		t.Fatal("expected ok=false for Bearer opaque token")
+	}
+}
+
+func TestDecodeJWTClaims_MissingExp(t *testing.T) {
+	token := makeJWT(t, map[string]any{"iat": time.Now().Unix()})
+	if _, ok := DecodeJWTClaims(token); ok {
+		t.Fatal("expected ok=false when exp claim is missing")
+	}
+}
+
+func TestJWTExpiry_ExpiredToken(t *testing.T) {
+	past := time.Now().Add(-2 * time.Hour).Unix()
+	token := makeJWT(t, map[string]any{"exp": past})
+	exp, ok := JWTExpiry(token)
+	if !ok {
+		t.Fatal("expected JWTExpiry to decode an expired-but-well-formed JWT")
+	}
+	if !exp.Before(time.Now()) {
+		t.Fatalf("expected exp in the past, got %s", exp)
+	}
+}
+
+func TestAuthHeaderExpiry_NilSafe(t *testing.T) {
+	var c *Config
+	if _, ok := c.AuthHeaderExpiry(); ok {
+		t.Fatal("expected ok=false for nil Config")
+	}
+}
+
+func TestAuthHeaderExpiry_FromAccessToken(t *testing.T) {
+	exp := time.Now().Add(30 * time.Minute).Unix()
+	token := makeJWT(t, map[string]any{"exp": exp})
+	c := &Config{AccessToken: token}
+	if _, ok := c.AuthHeaderExpiry(); !ok {
+		t.Fatal("expected AuthHeaderExpiry to decode token from AccessToken field")
+	}
+}

--- a/library/media-and-entertainment/suno/internal/config/jwt_test.go
+++ b/library/media-and-entertainment/suno/internal/config/jwt_test.go
@@ -78,6 +78,38 @@ func TestAuthHeaderExpiry_NilSafe(t *testing.T) {
 	}
 }
 
+// TestDecodeJWTClaims_PayloadNotDivisibleBy4 guards against the Greptile #673
+// finding: feeding addBase64Padding(parts[1]) to RawURLEncoding fails for any
+// payload whose base64 length isn't a multiple of 4 (RawURLEncoding rejects
+// any '=' padding). The fix is to pass the unpadded segment to
+// RawURLEncoding directly. This test exercises a claim set that produces a
+// non-aligned base64 length so a regression would surface immediately.
+func TestDecodeJWTClaims_PayloadNotDivisibleBy4(t *testing.T) {
+	exp := time.Now().Add(20 * time.Minute).Unix()
+	// Sweep tag lengths to find one whose base64url length mod 4 != 0; we
+	// don't care about the specific tag, only that the resulting segment
+	// exercises the padding path.
+	var token string
+	for n := 1; n <= 8; n++ {
+		candidate := makeJWT(t, map[string]any{"exp": exp, "tag": strings.Repeat("x", n)})
+		segLen := len(strings.Split(candidate, ".")[1])
+		if segLen%4 != 0 {
+			token = candidate
+			break
+		}
+	}
+	if token == "" {
+		t.Fatal("could not synthesize a JWT with non-aligned base64 payload")
+	}
+	claims, ok := DecodeJWTClaims(token)
+	if !ok {
+		t.Fatalf("expected non-aligned payload to decode via RawURLEncoding")
+	}
+	if claims.ExpiresAt != exp {
+		t.Fatalf("exp mismatch: got %d want %d", claims.ExpiresAt, exp)
+	}
+}
+
 func TestAuthHeaderExpiry_FromAccessToken(t *testing.T) {
 	exp := time.Now().Add(30 * time.Minute).Unix()
 	token := makeJWT(t, map[string]any{"exp": exp})


### PR DESCRIPTION
## Summary

Chrome's `__session` cookie carries a Clerk JWT with a ~1h lifetime. Chrome keeps the cookie row long after the JWT inside it expires, so a long-idle Suno tab leaves a stale value on disk.

The previous flow silently saved the stale value:
- `auth login --chrome` accepted the cookie verbatim
- doctor's read-side validation hit `/api/billing/eligible-discounts` which is lenient and returned 200 even on expired tokens
- every write endpoint (`/api/billing/info`, `/api/generate/v2-web/`) returned HTTP 401 with no hint that pointed back at the cookie

Repro on a fresh checkout: leave a Suno tab idle for >1h, then run `suno-pp-cli generate create ...` → silent 401 loop, even after re-running `auth login --chrome` because Chrome's stored cookie is the same stale JWT until you actually load suno.com again.

## Fix

- New `config.JWTExpiry(token) (time.Time, bool)` decodes the Bearer JWT payload without verifying signature (server enforces signature; we only want to avoid sending tokens we know are expired)
- `auth login --chrome` and `auth refresh` refuse to save an expired token and tell the user to open https://suno.com in Chrome so the cookie rotates
- `doctor` now reports `auth_token: valid for 33m30s` or `auth_token: expired 1h0m0s ago` + actionable hint
- `--fail-on=error` trips on `expired ...` so scheduled agents catch the silent staleness before issuing real requests

## Files

- `internal/config/jwt.go` — new (JWT payload decoder, Config.AuthHeaderExpiry)
- `internal/config/jwt_test.go` — new (6 cases: valid expiry, Bearer prefix, opaque token, missing exp, expired token, nil-safe)
- `internal/cli/auth.go` — refuse expired token on login + refresh, with hint
- `internal/cli/doctor.go` — surface auth_token age + hint; trip --fail-on=error on expiry
- `.printing-press-patches.json` — patch entry

## Test plan

- [x] `go test ./internal/config -v` — 7/7 pass (1 existing config + 6 new JWT)
- [x] `go test ./... -count=1` — 175/175 pass across 11 packages
- [x] `go vet ./...` — clean
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/suno/` — passes
- [x] Live doctor on fresh token: `"auth_token": "valid for 33m30s"`
- [x] Synthetic expired token: `"auth_token": "expired 1h0m0s ago"`, hint surfaces, `--fail-on=error` exits 1
- [x] Human-readable doctor renders `FAIL Auth Token: expired Xs ago`