### PR TITLE
fix: harden registry parsing and gate empty descriptions

### DIFF
--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -219,6 +219,12 @@ jobs:
         # regression at PR time so the npm installer never sees a malformed
         # entry. See tools/generate-registry/main.go validateEntries() for the
         # exact field set.
+        #
+        # The file-path form (./tools/generate-registry/main.go) is required
+        # because the repo root has no go.mod — Go locates the tool's go.mod
+        # by walking up from the source file. The package-path form
+        # (./tools/generate-registry) fails with "go.mod not found" from the
+        # repo root. Matches the invocation in generate-registry.yml.
         run: |
           set -euo pipefail
-          go run ./tools/generate-registry --validate
+          go run ./tools/generate-registry/main.go --validate

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -41,6 +41,7 @@ on:
       - 'library/**'
       - 'cli-skills/**'
       - 'registry.json'
+      - 'tools/generate-registry/**'
       - 'tools/generate-skills/**'
       - 'tools/sweep-canonical/**'
       - '.github/scripts/verify-attribution/**'
@@ -196,3 +197,22 @@ jobs:
             exit 1
           fi
           echo "All library/*/*/go.mod module declarations match their directories."
+
+      # Go is needed only for the next step's `go run ./tools/generate-registry`.
+      # Pinned to the same version as the post-merge regen workflow
+      # (generate-registry.yml) so a CI pass here implies the same generator
+      # binary that will run after merge.
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.3'
+
+      - name: Validate registry source descriptions
+        # Reject PRs whose .printing-press.json + .goreleaser.yaml sources would
+        # produce an empty `description` (or other required field) in the
+        # post-merge regenerated registry.json. Catches the lawhub-shape
+        # regression at PR time so the npm installer never sees a malformed
+        # entry. See tools/generate-registry/main.go validateEntries() for the
+        # exact field set.
+        run: |
+          set -euo pipefail
+          go run ./tools/generate-registry --validate

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -134,9 +134,15 @@ jobs:
           # The intersection is the only signal that means "this PR
           # introduced a divergent change to a generated file."
 
+          # `awk 'NF'` keeps non-blank lines; unlike `grep -v '^$'`, it exits
+          # 0 even when no lines pass through. With `set -o pipefail`, the
+          # previous `grep -v '^$'` form failed the assignment whenever
+          # `git log` produced empty output (the common no-touch case),
+          # making the whole step exit 1 with no stdout. awk's exit code
+          # reflects script errors only, not match counts.
           touched=$(git log "${BASE_REMOTE_REF}..HEAD" --name-only --format= \
             -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
-            | grep -v '^$' | sort -u)
+            | awk 'NF' | sort -u)
           differs=$(git diff --name-only "${BASE_REMOTE_REF}" HEAD \
             -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
             | sort -u)

--- a/docs/plans/2026-05-18-001-fix-registry-empty-description-gate-plan.md
+++ b/docs/plans/2026-05-18-001-fix-registry-empty-description-gate-plan.md
@@ -1,0 +1,253 @@
+---
+type: fix
+status: active
+created: 2026-05-18
+plan_id: 2026-05-18-001
+---
+
+# fix: harden registry parsing and gate empty descriptions
+
+## Summary
+
+`registry.json`'s `lawhub` entry shipped with `description: ""`. The npm installer (`@mvanhorn/printing-press@0.1.3`) throws `registry entry missing string field: description` on the first malformed entry it sees, which aborts the entire registry parse and makes every `printing-press install/search/list/update` invocation fail for every user — regardless of what CLI they were targeting.
+
+Two structural problems combined to produce this:
+
+1. The registry generator (`tools/generate-registry/main.go`) picks descriptions from `prior registry.json → .goreleaser.yaml brews → empty`. It never reads `.printing-press.json`'s `description` field even though every modern printed CLI populates it. `lawhub` has a populated `.printing-press.json` description (130 chars) but an empty `.goreleaser.yaml` brews block and no prior curated registry value, so it landed empty.
+2. There is no PR-time validation that the registry the generator would produce is internally valid. A new CLI added without a goreleaser brews description and without a curated registry value will silently ship `description: ""` and break the installer the same way.
+
+This plan adds the missing description fallback, backfills the two existing CLIs whose descriptions live only in the curated registry (`tiktok-shop`, `agent-capture`), adds a strict PR-time validation gate, and hardens the npm installer to skip malformed entries with a warning rather than aborting the whole parse.
+
+The PR does **not** commit the regenerated `registry.json`. The post-merge `generate-registry.yml` workflow handles regeneration on merge per the existing generated-artifact convention.
+
+## Target repo
+
+`mvanhorn/printing-press-library`. The plan file itself lives at `docs/plans/2026-05-18-001-fix-registry-empty-description-gate-plan.md` and all file paths below are repo-relative.
+
+## Requirements
+
+- R1. Every CLI in the library today must produce a non-empty `description` in the registry the generator would emit from sources alone (without falling back to prior registry values).
+- R2. Future CLIs that would produce an empty description must be blocked at PR time with a clear, slug-named error message naming the missing source.
+- R3. The npm installer must survive a malformed registry entry without aborting the entire parse; bad entries are skipped with a warning, valid entries continue to load.
+- R4. The fix must not regress curated registry description copy. Hand-curated values that are richer than source descriptions remain authoritative; the new source fallback only fires when no curated value exists.
+- R5. The PR must not commit regenerated `registry.json` or `README.md`. The post-merge `generate-registry.yml` workflow regenerates them on merge.
+
+## Scope Boundaries
+
+### In scope
+
+- Generator description-resolution change in `tools/generate-registry/main.go`.
+- Strict-validation mode for the generator (new `--validate` flag).
+- `.printing-press.json` description backfill for `tiktok-shop` and `agent-capture` (the only two CLIs whose curated description has no source-side counterpart today).
+- New step in `.github/workflows/verify-library-conventions.yml` that runs the validator on PRs.
+- Lenient parsing in `npm/src/registry.ts` (skip + warn instead of throw on per-entry errors).
+- Test updates in `tools/generate-registry/main_test.go` and `npm/tests/` covering the new behaviors.
+- npm patch version bump so the resilience fix reaches users via the existing auto-publish workflow.
+
+### Deferred to Follow-Up Work
+
+- Migrating all curated registry descriptions back into `.printing-press.json` so the registry becomes fully derivable from sources with no curated overlay. The current curated-preference logic stays; only the two CLIs without any source description get backfilled here.
+- Validating optional MCP block fields (e.g., `mcp.tool_count > 0`) beyond what the npm installer requires. This plan validates exactly what the installer's `parseRegistry` requires; richer invariants can land separately.
+- Hardening other generator outputs (`README.md` sentinel regions, `cli-skills/pp-*/SKILL.md`) against similar empty-string footguns.
+
+### Outside this product's identity
+
+- Restructuring how descriptions are sourced (e.g., a single `description.md` per CLI). The three-layer fallback (curated > goreleaser > pp manifest) reflects real history and stays.
+
+## Key Technical Decisions
+
+### KD1. Add `.printing-press.json` description as a third fallback, not the top of the order
+
+The existing source comment in `registryDescription` documents the curated-first preference deliberately: 29/42 entries' curated descriptions don't match the `.goreleaser.yaml` brews description, and that's the curated-copy-as-source-of-truth design. Hoisting `.printing-press.json` to the top would clobber curated headlines like Suno's "Every Suno feature, plus a local SQLite library...". Threading it in as the third fallback (after curated and goreleaser, before empty) fixes the lawhub-shape without regressing curated copy. (See: comments above `registryDescription` in `tools/generate-registry/main.go`.)
+
+### KD2. Validate strictly: every entry's description must resolve from sources
+
+The validator ignores the prior `registry.json` curated value when determining whether validation passes. Otherwise a future CLI could silently rely on someone hand-editing registry.json after the fact — exactly the path that produced lawhub. Validating sources-only catches lawhub-shape at PR time even when no curated value exists yet.
+
+Two CLIs today (`tiktok-shop`, `agent-capture`) have descriptions only in the curated registry — U3 backfills them so strict validation passes everywhere.
+
+### KD3. PR-time validation lives in `verify-library-conventions.yml`
+
+This workflow already runs on `library/**` paths, already overlays verifier scripts from base for fork-PR safety, and already represents the canonical library-invariant gate. Adding a `Validate registry source descriptions` step there reuses the existing trigger, checkout, and base-overlay scaffolding. Creating a new workflow file would duplicate all of that for one step.
+
+### KD4. Don't commit regenerated `registry.json` in the PR
+
+`verify-library-conventions.yml` explicitly rejects PRs that modify generated artifacts ("Fail on changes to generated artifacts" step). Whitelisting registry.json for this one PR would fight that convention. The accepted flow is: PR fixes the source (generator code + backfilled `.printing-press.json` files) → post-merge `generate-registry.yml` regenerates registry.json on merge → `lawhub` description becomes populated automatically.
+
+Trade-off: users hitting the broken npm installer between PR open and merge stay broken. Mitigated by U5's lenient npm parsing, which lands in the same PR and (once the auto-publish ships a patched npm version) fixes the user-visible failure even before the library-side regen runs.
+
+### KD5. npm parser: skip + warn, don't fail-open silently
+
+`parseRegistryEntry` returns `null` instead of throwing when a per-entry `requiredString` would fail; `parseRegistry` filters nulls. The warn goes to `stderr` so machine-readable `--json` output stays clean, and identifies the offending entry by name (or by index when name itself is missing). This degrades gracefully without hiding the underlying problem: users still see "skipped 1 malformed entry: lawhub" in their terminal.
+
+## System-Wide Impact
+
+- **`registry.json` consumers** (npm installer, `printing-press-library` plugin, any downstream tool that reads `https://raw.githubusercontent.com/.../registry.json`): unblocked once npm package republishes with U5. Library-side fix unblocks them after merge + post-merge regen.
+- **PR authors adding new CLIs**: A new CI step rejects PRs whose new CLI would produce an empty registry description. Error message tells them exactly which source file to populate (`.printing-press.json` description or `.goreleaser.yaml` brews description).
+- **Post-merge `generate-registry.yml`**: No workflow change. Picks up the new fallback automatically when the generator code lands.
+
+## Implementation Units
+
+### U1. Thread `.printing-press.json` description into the registry-description fallback chain
+
+- **Goal:** Add `.printing-press.json`'s `description` as a third fallback in `registryDescription` so lawhub-shape CLIs (populated pp manifest, empty goreleaser brews, no prior curated value) resolve correctly without operator intervention.
+- **Requirements:** R1, R4.
+- **Dependencies:** none.
+- **Files:**
+  - `tools/generate-registry/main.go` (modify `printingPressManifest`, `buildEntry`, `registryDescription`)
+  - `tools/generate-registry/main_test.go` (add cases for the new fallback)
+- **Approach:**
+  - Add a `Description string \`json:"description"\`` field to `printingPressManifest`. The `.printing-press.json` schema already populates this; adding it to the struct lets the existing `json.Unmarshal` capture it.
+  - Change `registryDescription`'s signature to accept a third argument (`ppDescription string`). New order: curated prior > goreleaser brews > pp manifest description > empty.
+  - `buildEntry` passes `pp.Description` through to `registryDescription`. No other caller of `registryDescription` exists.
+  - The bare-markdown-heading exception (`isBareMarkdownHeading`) continues to apply only to the prior curated value, not to the new sources. Goreleaser brews and pp manifest descriptions are author-written one-liners and don't have the legacy-bug shape.
+- **Patterns to follow:** the existing fallback chain shape; comment block at line 311-317 of `tools/generate-registry/main.go`. Mirror the comment style to document the new third fallback.
+- **Test scenarios:**
+  - Happy path: curated value present, goreleaser empty, pp empty → returns curated (existing behavior preserved).
+  - Happy path: curated empty, goreleaser populated → returns goreleaser (existing behavior preserved).
+  - New behavior: curated empty, goreleaser empty, pp description populated → returns pp description.
+  - New behavior: curated empty, goreleaser empty, pp empty → returns "" (validation in U2 catches this case).
+  - Regression: curated is a bare markdown heading like `"# Introduction"`, pp populated → returns pp (the bare-heading exception still fires for the curated tier; new sources backfill it).
+- **Verification:** `go test ./tools/generate-registry/...` passes. Manual smoke: `go run ./tools/generate-registry --print | jq '.entries[] | select(.name=="lawhub") | .description'` returns the lawhub `.printing-press.json` description verbatim.
+
+### U2. Add `--validate` mode to the generator
+
+- **Goal:** Hard-fail with field-named errors when any entry would have an empty required string after fallback resolution, considering only source-of-truth files (not prior `registry.json`).
+- **Requirements:** R2.
+- **Dependencies:** U1 (validation calls the same fallback resolution).
+- **Files:**
+  - `tools/generate-registry/main.go` (add `validate` flag, new `validateEntries` function, wire into `main`)
+  - `tools/generate-registry/main_test.go` (validation cases)
+- **Approach:**
+  - Add a `validate := flag.Bool("validate", false, "...")` flag.
+  - When `--validate`: call `buildEntries(libraryDir, map[string]RegistryEntry{})` — empty existing map so curated descriptions don't satisfy validation. Then call `validateEntries(entries)`.
+  - `validateEntries` walks the entries and collects errors. For each entry, check:
+    - `name`, `category`, `api`, `path` non-empty (these come from disk structure and the pp manifest; failing here means a malformed source file).
+    - `description` non-empty.
+    - If `mcp` is set: `mcp.binary` non-empty, `mcp.transports` non-empty array, `mcp.auth_type` non-empty (these are exactly the fields `npm/src/registry.ts`'s `parseRegistryEntry` requires).
+  - Error messages name the slug and the field, e.g., `lawhub: description is empty (sources checked: .printing-press.json description, .goreleaser.yaml brews description)`.
+  - Exit 0 when all entries valid; exit 2 with the joined error report when any entry fails. Stderr is the error channel.
+  - `--validate` is mutually exclusive with `--check` and `--print` (existing modes are already mutually exclusive via the if/else cascade in `main`).
+- **Patterns to follow:** existing `--check` mode's "drift detected" error reporting style (line 185-189). Reuse `log.Fatalf` only for unexpected failures; validation errors are expected output and should write to stderr explicitly + `os.Exit(2)`.
+- **Test scenarios:**
+  - Validation passes when every entry has a description in some source.
+  - Validation fails when one entry has no source description; error names the slug and field.
+  - Validation fails when multiple entries fail; all failures reported, not just the first.
+  - Validation ignores curated prior `registry.json` values — pass a fixture where the curated value exists but the source files don't and confirm validation fails.
+  - Validation passes when `mcp` block is absent (not all CLIs ship MCP).
+  - Validation fails when `mcp` block is present but `mcp.binary` empty.
+- **Verification:** `go test ./tools/generate-registry/...` passes. Manual smoke: `go run ./tools/generate-registry --validate` against the PR's tree (after U3 backfills land) exits 0; reverting one of the backfills produces a clear `tiktok-shop: description is empty` error.
+
+### U3. Backfill `description` in `.printing-press.json` for tiktok-shop and agent-capture
+
+- **Goal:** Restore source-reproducibility for the two CLIs whose descriptions exist only in the curated `registry.json` today. Without this, the U2 validator fails on the current tree.
+- **Requirements:** R1, R4.
+- **Dependencies:** U1 (the new fallback is what makes the backfilled value flow through to the regenerated registry).
+- **Files:**
+  - `library/commerce/tiktok-shop/.printing-press.json` (add or set `description`)
+  - `library/agent-tools/agent-capture/.printing-press.json` (add or set `description`)
+- **Approach:**
+  - Read the current curated value from `registry.json` for each slug. Copy it verbatim into the `description` field of the respective `.printing-press.json`.
+    - `tiktok-shop`: `"Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and read endpoints; pre-flight checks gate live writes by default."`
+    - `agent-capture`: `"Record, screenshot, and convert macOS windows and screens for AI agent evidence"` (verbatim from registry).
+  - These are the only two CLIs where this is needed today; the audit in research found no other CLIs with `pp=empty grls=empty reg=ok`.
+- **Patterns to follow:** Existing `.printing-press.json` files where `description` is populated. Field order can match whatever the file already uses; no schema-shape change.
+- **Test scenarios:** none — pure data files. The U2 validator running against the modified tree is the integration test (covered there).
+- **Verification:** `jq -r .description library/commerce/tiktok-shop/.printing-press.json` and `... agent-tools/agent-capture/.printing-press.json` return the expected strings. `go run ./tools/generate-registry --validate` exits 0 after U1 + U2 + U3 are in place.
+
+### U4. Add PR-time validation step to `verify-library-conventions.yml`
+
+- **Goal:** Reject any PR whose CLI source files would produce an empty required registry field. Catches lawhub-shape at the source.
+- **Requirements:** R2.
+- **Dependencies:** U2 (the workflow invokes the validator the generator now supports).
+- **Files:**
+  - `.github/workflows/verify-library-conventions.yml` (add `Validate registry source descriptions` step and `setup-go` action)
+- **Approach:**
+  - Add `actions/setup-go@v6` with `go-version: '1.26.3'` (matching the post-merge regen workflow) to the `verify` job's step list.
+  - Add a new step after the existing `go.mod module path matches directory` step:
+
+    ```yaml
+    - name: Validate registry source descriptions
+      run: |
+        set -euo pipefail
+        go run ./tools/generate-registry --validate
+    ```
+
+  - Add `'tools/generate-registry/**'` to the workflow's `paths:` trigger so changes to the validator itself also re-run this check.
+- **Patterns to follow:** the existing `setup-python` + step shape in the same workflow. Path-filter pattern in the workflow `on.pull_request.paths` list.
+- **Test scenarios:** none added in this unit — the validator's own tests cover its behavior. Manual verification of the workflow happens on PR open.
+- **Verification:** Open the PR; the new step appears in the GitHub Actions UI and exits 0 against the PR's tree. Push a deliberate breakage (delete one of the backfilled descriptions) in a draft branch and confirm the step exits non-zero with the expected slug-named error before reverting.
+
+### U5. Lenient registry parsing in the npm installer
+
+- **Goal:** Make the npm installer survive a malformed registry entry. Skip the bad entry with a stderr warning, return the valid remainder so `install`/`search`/`list`/`update` continue to work.
+- **Requirements:** R3.
+- **Dependencies:** none — this is independent defensive hardening on the npm side.
+- **Files:**
+  - `npm/src/registry.ts` (modify `parseRegistry` and `parseRegistryEntry`)
+  - `npm/tests/registry.test.ts` (or whichever existing test file covers registry parsing — confirm path during execution)
+- **Approach:**
+  - `parseRegistryEntry` continues to validate via `requiredString` etc., but catches its own thrown errors at the entry boundary. Returns `RegistryEntry | null`. On null, write a single-line warning to `process.stderr`: `[printing-press] skipping malformed registry entry: <name or "(unnamed)">: <error message>`.
+  - `parseRegistry` calls `parseRegistryEntry` per element and filters nulls: `entries: value.entries.map(parseRegistryEntry).filter((e): e is RegistryEntry => e !== null)`.
+  - The `schema_version !== 2` check at the registry level remains a thrown error — a wrong-schema registry is unrecoverable, not a per-entry typo.
+  - Surface the count of skipped entries: after parsing, if any were skipped, write `[printing-press] skipped N malformed registry entries; install/search may be missing items.` to stderr. Helps users notice the issue without halting them.
+- **Patterns to follow:** existing TypeScript style in `npm/src/registry.ts`. The `isRecord`/`requiredString` helpers stay as-is; only the entry-level exception handling changes.
+- **Test scenarios:**
+  - Happy path: valid registry parses with N entries; no warnings emitted.
+  - Mixed registry: one entry with `description: ""` → parse returns N-1 entries, stderr captured contains the slug and "description" in the warning.
+  - Multiple bad entries: all valid ones returned; one summary line at the end naming the skipped count.
+  - Unnamed bad entry: an entry missing both `name` and the field that would error → warning falls back to `(unnamed at index <i>)`.
+  - Registry-level failure: `schema_version: 1` still throws (not a per-entry concern); test asserts the existing error path is preserved.
+  - `parseRegistry` no longer rejects when one of N entries is invalid — regression coverage for the lawhub failure.
+- **Verification:** `npm test` in `npm/` passes. Manual smoke: `node npm/bin/printing-press.mjs search suno` against a copy of the current broken registry.json finds suno and prints the skip warning for lawhub.
+
+### U6. Bump npm patch version
+
+- **Goal:** Trigger the auto-publish workflow so the resilience fix in U5 reaches users via the existing release flow.
+- **Requirements:** R3.
+- **Dependencies:** U5.
+- **Files:**
+  - `npm/package.json` (`version` field)
+  - `npm/CHANGELOG.md` (add an entry for this version)
+- **Approach:**
+  - Bump `version` from `0.1.3` to `0.1.4`. Patch bump is correct: behavior change is a bug fix, public surface unchanged.
+  - Add a `CHANGELOG.md` entry under a `## 0.1.4` heading: brief description of the parser hardening, link to this plan or to the PR.
+  - Do not touch `npm/package-lock.json` directly; `npm install` regenerates it deterministically.
+- **Patterns to follow:** existing CHANGELOG entries in `npm/CHANGELOG.md`.
+- **Test scenarios:** none — pure version metadata.
+- **Verification:** After PR opens, the `auto-tag-npm.yml` and `npm-publish.yml` workflows pick up the version bump on merge and publish `@mvanhorn/printing-press@0.1.4` to npm. (No verification possible until merge; this is the documented release flow.)
+
+## Risks
+
+- **Risk:** The U5 lenient parser could mask legitimate registry corruption (e.g., a botched generator run produces all-empty entries; users get a near-empty install list without an obvious error).
+  - **Mitigation:** Per-skip stderr warning + final summary line. The library side's U4 PR gate catches the root cause at PR time before it reaches users. Users see the missing items in `search`/`list` output, not silent absence.
+
+- **Risk:** The U2 validator running with an empty existing-entries map could double-count work if `buildEntries` is expensive on the full library tree.
+  - **Mitigation:** `buildEntries` is filesystem-bound and runs in < 1s on the 134-CLI tree today. Validation cost is negligible.
+
+- **Risk:** A future printer adds a new CLI before this PR merges; their PR fails the new check despite being correct in isolation.
+  - **Mitigation:** This is the desired behavior. If their CLI is missing a description, fail loud. If their CLI has one, the validator passes.
+
+- **Risk:** U3 backfill conflicts with a parallel PR editing the same `.printing-press.json` files for unrelated reasons.
+  - **Mitigation:** Low likelihood (the two files are rarely-touched). Standard rebase resolves any conflict; the backfilled value is one field.
+
+## Verification
+
+- All new and existing tests pass in `tools/generate-registry/` and `npm/`.
+- `go run ./tools/generate-registry --validate` exits 0 against the PR's tree after U1–U4.
+- `go run ./tools/generate-registry --check` against the PR's tree exits non-zero (drift expected — registry.json is intentionally stale) and that's fine: the PR does NOT commit the regenerated artifact; the post-merge workflow handles regen.
+- The verify-library-conventions workflow on the PR shows the new "Validate registry source descriptions" step passing.
+- After merge, the post-merge `generate-registry.yml` workflow regenerates `registry.json` and `README.md`; the resulting `registry.json` shows `lawhub` with a populated description.
+- `npx -y -p @mvanhorn/printing-press printing-press install suno` succeeds against the post-publish 0.1.4 package, even before the library-side regen runs (because U5 makes parsing resilient).
+
+## Dependencies / Prerequisites
+
+- Local clone at `/Users/mvanhorn/printing-press-library` must be brought up to date with `origin/main` before starting `ce-work` (44 commits behind as of plan write).
+- Go 1.26.3 (matching the workflow). Already installed locally.
+- Node + npm for `npm/` tests. Already installed.
+
+## Out of Scope (one-line each)
+
+- Backfilling all curated registry descriptions back into `.printing-press.json` — only the two strictly required for source-reproducibility are touched here.
+- Generator output formatting / sort changes / canonical-name lookups — orthogonal concerns.
+- Any other generated artifact (`README.md` sentinel regions, `cli-skills/`) — those have their own pipelines and risk profiles.

--- a/library/commerce/tiktok-shop/.printing-press.json
+++ b/library/commerce/tiktok-shop/.printing-press.json
@@ -4,6 +4,7 @@
   "printing_press_version": "3.8.0",
   "api_name": "tiktok-shop",
   "display_name": "TikTok Shop",
+  "description": "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and read endpoints; pre-flight checks gate live writes by default.",
   "cli_name": "tiktok-shop-pp-cli",
   "owner": "cathryn-lavery",
   "printer": "cathrynlavery",

--- a/library/developer-tools/agent-capture/.printing-press.json
+++ b/library/developer-tools/agent-capture/.printing-press.json
@@ -3,6 +3,7 @@
   "printer": "mvanhorn",
   "printer_name": "Matt Van Horn",
   "api_name": "agent-capture",
+  "description": "Record, screenshot, and convert macOS windows and screens for AI agent evidence",
   "printing_press_version": "0.4.0",
   "generated_at": "2026-04-05T19:25:10Z",
   "run_id": "20260405-115134",

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.1.5
 
+- Survive malformed upstream registry entries instead of aborting the whole parse. `parseRegistry` now skips entries that fail per-entry validation, writes a one-line warning to stderr naming the offending slug + field, and returns the rest of the catalog intact. Registry-level shape failures (wrong `schema_version`, non-array `entries`) still throw. This is the defense-in-depth pair for the library-side `--validate` gate (see `tools/generate-registry --validate` and `verify-library-conventions.yml`) so a single broken upstream entry — lawhub-shape — can never wedge every `install` / `search` / `list` / `update` call again.
 - Detect and warn when an older binary earlier in `PATH` shadows the one `go install` just wrote. Previously `install` reported the first PATH hit as success, so a stale `/opt/homebrew/bin/<cli>` (for example) would mask a newer `~/go/bin/<cli>`. The installer now reads `go env GOBIN GOPATH`, compares the actual install path to what `which`/`where` returns, and emits a clear shadow warning when they differ. JSON output adds `installedPath` and `shadowedBy` fields. Fixes #470.
 
 ## 0.1.4

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -27,7 +27,23 @@ export interface Registry {
 
 type RegistryFetch = (url: string, init?: RequestInit) => Promise<Response>;
 
-export function parseRegistry(value: unknown): Registry {
+/**
+ * Parse a raw registry payload into a typed Registry.
+ *
+ * Per-entry validation errors are surfaced as warnings to `warn` (defaulting to
+ * stderr) and the offending entry is skipped. The remainder of the registry is
+ * returned intact. This is the defense-in-depth that paired with the library-side
+ * `--validate` gate keeps a single malformed upstream entry from breaking every
+ * installer call (the original lawhub failure mode).
+ *
+ * Registry-level shape failures (non-object payload, unsupported schema_version,
+ * non-array entries) still throw because they signal a wrong-protocol payload
+ * the installer cannot recover from.
+ */
+export function parseRegistry(
+  value: unknown,
+  warn: (message: string) => void = defaultWarn,
+): Registry {
   if (!isRecord(value)) {
     throw new Error("registry payload must be an object");
   }
@@ -38,10 +54,37 @@ export function parseRegistry(value: unknown): Registry {
     throw new Error("registry entries must be an array");
   }
 
+  const entries: RegistryEntry[] = [];
+  let skipped = 0;
+  for (let i = 0; i < value.entries.length; i++) {
+    const raw = value.entries[i];
+    try {
+      entries.push(parseRegistryEntry(raw));
+    } catch (error) {
+      const name =
+        isRecord(raw) && typeof raw.name === "string" && raw.name.trim() !== ""
+          ? raw.name
+          : `(unnamed at index ${i})`;
+      const message = error instanceof Error ? error.message : String(error);
+      warn(`[printing-press] skipping malformed registry entry: ${name}: ${message}`);
+      skipped++;
+    }
+  }
+  if (skipped > 0) {
+    const word = skipped === 1 ? "entry" : "entries";
+    warn(
+      `[printing-press] skipped ${skipped} malformed registry ${word}; install/search may be missing items.`,
+    );
+  }
+
   return {
     schema_version: 2,
-    entries: value.entries.map(parseRegistryEntry),
+    entries,
   };
+}
+
+function defaultWarn(message: string): void {
+  process.stderr.write(message + "\n");
 }
 
 export async function fetchRegistry(

--- a/npm/tests/registry.test.ts
+++ b/npm/tests/registry.test.ts
@@ -96,7 +96,7 @@ test("parseRegistry parses transports as a non-empty string array", () => {
   assert.deepEqual(registry.entries[0]?.mcp?.transports, ["stdio", "http"]);
 });
 
-test("parseRegistry rejects entries with empty or missing transports", () => {
+test("parseRegistry skips entries with empty or missing transports and warns", () => {
   const baseEntry = {
     name: "demo",
     category: "demo",
@@ -111,22 +111,111 @@ test("parseRegistry rejects entries with empty or missing transports", () => {
     env_vars: [],
   };
 
-  assert.throws(
-    () =>
-      parseRegistry({
-        schema_version: 2,
-        entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: [] } }],
-      }),
-    /transports/,
+  const warningsEmpty: string[] = [];
+  const r1 = parseRegistry(
+    {
+      schema_version: 2,
+      entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: [] } }],
+    },
+    (m) => warningsEmpty.push(m),
   );
-  assert.throws(
-    () =>
-      parseRegistry({
-        schema_version: 2,
-        entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: ["stdio", 7] } }],
-      }),
-    /transports/,
+  assert.equal(r1.entries.length, 0, "malformed entry must be skipped, not silently included");
+  assert.ok(
+    warningsEmpty.some((w) => w.includes("demo") && w.includes("transports")),
+    `expected a per-entry skip warning naming the entry and field; got: ${JSON.stringify(warningsEmpty)}`,
   );
+  assert.ok(
+    warningsEmpty.some((w) => w.includes("skipped 1 malformed registry entry")),
+    "expected a final summary warning",
+  );
+
+  const warningsNonString: string[] = [];
+  const r2 = parseRegistry(
+    {
+      schema_version: 2,
+      entries: [{ ...baseEntry, mcp: { ...baseMcp, transports: ["stdio", 7] } }],
+    },
+    (m) => warningsNonString.push(m),
+  );
+  assert.equal(r2.entries.length, 0);
+  assert.ok(warningsNonString.some((w) => w.includes("transports")));
+});
+
+test("parseRegistry keeps valid entries when one is malformed (lawhub-shape regression)", () => {
+  const warnings: string[] = [];
+  const registry = parseRegistry(
+    {
+      schema_version: 2,
+      entries: [
+        {
+          name: "ok",
+          category: "cat",
+          api: "OK",
+          description: "Has a description.",
+          path: "library/cat/ok",
+        },
+        // The lawhub case: description is empty. Old behavior threw; new
+        // behavior must skip this entry and keep the valid ones loadable.
+        {
+          name: "lawhub",
+          category: "education",
+          api: "LawHub",
+          description: "",
+          path: "library/education/lawhub",
+        },
+        {
+          name: "ok2",
+          category: "cat",
+          api: "OK2",
+          description: "Also fine.",
+          path: "library/cat/ok2",
+        },
+      ],
+    },
+    (m) => warnings.push(m),
+  );
+
+  assert.equal(registry.entries.length, 2, "valid entries must survive a malformed sibling");
+  assert.deepEqual(
+    registry.entries.map((e) => e.name).sort(),
+    ["ok", "ok2"],
+  );
+  assert.ok(
+    warnings.some((w) => w.includes("lawhub") && w.includes("description")),
+    "expected per-entry warning naming the offending slug and field",
+  );
+});
+
+test("parseRegistry uses fallback identifier when malformed entry has no name", () => {
+  const warnings: string[] = [];
+  const registry = parseRegistry(
+    {
+      schema_version: 2,
+      entries: [
+        {
+          // No name field at all — fallback to (unnamed at index N).
+          category: "cat",
+          api: "X",
+          description: "Has desc.",
+          path: "library/cat/x",
+        },
+      ],
+    },
+    (m) => warnings.push(m),
+  );
+
+  assert.equal(registry.entries.length, 0);
+  assert.ok(
+    warnings.some((w) => w.includes("(unnamed at index 0)")),
+    `expected unnamed-at-index fallback; got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test("parseRegistry preserves registry-level errors as throws (not per-entry)", () => {
+  // Wrong shape at the registry level is not recoverable per-entry.
+  assert.throws(() => parseRegistry({ schema_version: 1, entries: [] }), /unsupported registry/);
+  assert.throws(() => parseRegistry({ schema_version: 2, entries: "not-an-array" }), /must be an array/);
+  assert.throws(() => parseRegistry("not-an-object"), /must be an object/);
 });
 
 test("fetchRegistry sends GitHub token when available", async () => {

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -407,35 +407,49 @@ func registryDescription(prior, goreleaser, ppDescription string) string {
 // Returns an empty slice when every entry validates. Caller decides how to
 // surface the result (the --validate flag prints them and exits 2).
 func validateEntries(entries []RegistryEntry) []string {
+	// isBlank matches the npm installer's requiredString semantics
+	// (`.trim() === ""`). Using == "" here would let an all-whitespace
+	// value pass validation but still throw inside parseRegistryEntry,
+	// defeating the gate. Centralizing the check keeps the Go and TS
+	// acceptance criteria byte-for-byte aligned.
+	isBlank := func(s string) bool {
+		return strings.TrimSpace(s) == ""
+	}
+
 	var errs []string
 	for _, e := range entries {
-		slug := e.Name
+		slug := strings.TrimSpace(e.Name)
 		if slug == "" {
 			slug = "(unnamed)"
 		}
-		if e.Name == "" {
+		if isBlank(e.Name) {
 			errs = append(errs, fmt.Sprintf("%s: name is empty", slug))
 		}
-		if e.Category == "" {
+		if isBlank(e.Category) {
 			errs = append(errs, fmt.Sprintf("%s: category is empty", slug))
 		}
-		if e.API == "" {
+		if isBlank(e.API) {
 			errs = append(errs, fmt.Sprintf("%s: api is empty", slug))
 		}
-		if e.Path == "" {
+		if isBlank(e.Path) {
 			errs = append(errs, fmt.Sprintf("%s: path is empty", slug))
 		}
-		if e.Description == "" {
-			errs = append(errs, fmt.Sprintf("%s: description is empty (sources checked: .printing-press.json description, .goreleaser.yaml brews description)", slug))
+		if isBlank(e.Description) {
+			// Source order mirrors the resolution chain in registryDescription:
+			// goreleaser brews is the second tier, .printing-press.json description
+			// is the third. Listing them in resolution order helps a contributor
+			// reading this error understand which file would take precedence if
+			// they populated both.
+			errs = append(errs, fmt.Sprintf("%s: description is empty (sources checked: .goreleaser.yaml brews description, .printing-press.json description)", slug))
 		}
 		if e.MCP != nil {
-			if e.MCP.Binary == "" {
+			if isBlank(e.MCP.Binary) {
 				errs = append(errs, fmt.Sprintf("%s: mcp.binary is empty", slug))
 			}
 			if len(e.MCP.Transports) == 0 {
 				errs = append(errs, fmt.Sprintf("%s: mcp.transports is empty", slug))
 			}
-			if e.MCP.AuthType == "" {
+			if isBlank(e.MCP.AuthType) {
 				errs = append(errs, fmt.Sprintf("%s: mcp.auth_type is empty", slug))
 			}
 		}

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -116,6 +116,7 @@ type MCPBlock struct {
 type printingPressManifest struct {
 	APIName            string   `json:"api_name"`
 	DisplayName        string   `json:"display_name"`
+	Description        string   `json:"description"`
 	Printer            string   `json:"printer"`
 	PrinterName        string   `json:"printer_name"`
 	MCPBinary          string   `json:"mcp_binary"`
@@ -139,7 +140,32 @@ var brewsDescriptionRE = regexp.MustCompile(`^\s+description:\s*"?(.*?)"?\s*$`)
 func main() {
 	check := flag.Bool("check", false, "exit non-zero if generated outputs differ from on-disk registry.json or README.md sentinel regions")
 	printOnly := flag.Bool("print", false, "print generated registry to stdout instead of writing")
+	validate := flag.Bool("validate", false, "exit non-zero if any entry would have an empty required field after fallback resolution (sources only — ignores prior registry.json curated values). Designed for the PR-time CI gate.")
 	flag.Parse()
+
+	// --validate runs before the normal flow so it never depends on the
+	// current on-disk registry.json. It builds entries from sources alone
+	// (empty existing map) and fails when any required field would land
+	// empty — catching the lawhub-shape regression where a curated value
+	// in registry.json masks a missing source description.
+	if *validate {
+		sourceEntries, err := buildEntries(libraryDir, map[string]RegistryEntry{})
+		if err != nil {
+			log.Fatalf("building entries for validation: %v", err)
+		}
+		if errs := validateEntries(sourceEntries); len(errs) > 0 {
+			fmt.Fprintln(os.Stderr, "Registry validation failed:")
+			for _, e := range errs {
+				fmt.Fprintln(os.Stderr, "  - "+e)
+			}
+			fmt.Fprintln(os.Stderr, "\nFix the source files:")
+			fmt.Fprintln(os.Stderr, "  - description: populate .printing-press.json's `description` or the `.goreleaser.yaml` brews `description` for the affected CLI(s).")
+			fmt.Fprintln(os.Stderr, "  - mcp.*:       populate .printing-press.json's `mcp_binary`, `auth_type`, and related fields for any CLI advertising an MCP block.")
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "Registry validation passed (%d entries).\n", len(sourceEntries))
+		return
+	}
 
 	existing := loadExistingEntries(registryPath)
 
@@ -309,12 +335,24 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	}
 
 	// Description preference: existing registry value (curated) > goreleaser
-	// brew description (homebrew tap one-liner) > empty. Curated descriptions
-	// in registry.json are the documented surface and shouldn't be clobbered.
-	// Exception: an old generator bug let bare Markdown headings like
-	// "# Introduction" land as descriptions. Those are not real curated copy,
-	// so allow the source one-liner to repair them on the next regen.
-	entry.Description = registryDescription(prior.Description, readGoreleaserDescription(filepath.Join(dir, ".goreleaser.yaml")))
+	// brew description (homebrew tap one-liner) > .printing-press.json
+	// description (modern printed CLIs populate this from the publish-skill's
+	// narrative.headline) > empty. Curated descriptions in registry.json are
+	// the documented surface and shouldn't be clobbered. Exception: an old
+	// generator bug let bare Markdown headings like "# Introduction" land as
+	// descriptions. Those are not real curated copy, so allow the source
+	// one-liner to repair them on the next regen.
+	//
+	// The .printing-press.json fallback was added after the lawhub incident
+	// (registry shipped description="" because its .goreleaser.yaml brews
+	// block was empty and no prior curated value existed). Modern printed
+	// CLIs always carry a narrative description in .printing-press.json,
+	// so this fallback fires when both prior tiers come back empty.
+	entry.Description = registryDescription(
+		prior.Description,
+		readGoreleaserDescription(filepath.Join(dir, ".goreleaser.yaml")),
+		pp.Description,
+	)
 
 	// MCP block preference: derive from .printing-press.json when it
 	// declares mcp_binary (the modern, authoritative source) > preserve
@@ -338,11 +376,71 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 	return &entry, nil
 }
 
-func registryDescription(prior, fallback string) string {
+// registryDescription picks the final description for a registry entry from
+// three tiers in preference order: prior curated value > goreleaser brews
+// description > .printing-press.json description. The bare-markdown-heading
+// exception applies only to the prior tier — that's the only tier with the
+// legacy "# Introduction" bug history. The two source tiers are author-written
+// one-liners and don't need the exception.
+//
+// Returns "" only when every tier is empty. The --validate mode treats that
+// as a fail-stop; the regular write path lets it through so first-time runs
+// of new CLIs that intentionally have no description can complete (validation
+// is a separate concern from generation).
+func registryDescription(prior, goreleaser, ppDescription string) string {
 	if prior != "" && !isBareMarkdownHeading(prior) {
 		return prior
 	}
-	return fallback
+	if goreleaser != "" {
+		return goreleaser
+	}
+	return ppDescription
+}
+
+// validateEntries returns one human-readable error per missing required
+// field across the given entries. The required-field set mirrors the npm
+// installer's parseRegistry contract (every field it calls requiredString
+// on, plus the MCP-block fields it calls requiredString / requiredStringArray
+// on when the mcp object is present). A registry whose generation passes this
+// check round-trips through the npm parser without per-entry errors.
+//
+// Returns an empty slice when every entry validates. Caller decides how to
+// surface the result (the --validate flag prints them and exits 2).
+func validateEntries(entries []RegistryEntry) []string {
+	var errs []string
+	for _, e := range entries {
+		slug := e.Name
+		if slug == "" {
+			slug = "(unnamed)"
+		}
+		if e.Name == "" {
+			errs = append(errs, fmt.Sprintf("%s: name is empty", slug))
+		}
+		if e.Category == "" {
+			errs = append(errs, fmt.Sprintf("%s: category is empty", slug))
+		}
+		if e.API == "" {
+			errs = append(errs, fmt.Sprintf("%s: api is empty", slug))
+		}
+		if e.Path == "" {
+			errs = append(errs, fmt.Sprintf("%s: path is empty", slug))
+		}
+		if e.Description == "" {
+			errs = append(errs, fmt.Sprintf("%s: description is empty (sources checked: .printing-press.json description, .goreleaser.yaml brews description)", slug))
+		}
+		if e.MCP != nil {
+			if e.MCP.Binary == "" {
+				errs = append(errs, fmt.Sprintf("%s: mcp.binary is empty", slug))
+			}
+			if len(e.MCP.Transports) == 0 {
+				errs = append(errs, fmt.Sprintf("%s: mcp.transports is empty", slug))
+			}
+			if e.MCP.AuthType == "" {
+				errs = append(errs, fmt.Sprintf("%s: mcp.auth_type is empty", slug))
+			}
+		}
+	}
+	return errs
 }
 
 func isBareMarkdownHeading(s string) bool {

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -65,12 +65,200 @@ func TestFormatDescription(t *testing.T) {
 	}
 }
 
-func TestRegistryDescriptionReplacesBareMarkdownHeading(t *testing.T) {
-	if got := registryDescription("# Introduction", "Real catalog copy."); got != "Real catalog copy." {
-		t.Fatalf("registryDescription heading fallback = %q, want fallback", got)
+func TestRegistryDescription(t *testing.T) {
+	cases := []struct {
+		name           string
+		prior          string
+		goreleaser     string
+		ppDescription  string
+		want           string
+	}{
+		{
+			name:          "curated copy wins over both fallbacks",
+			prior:         "Curated catalog copy.",
+			goreleaser:    "Goreleaser brews copy.",
+			ppDescription: "Manifest copy.",
+			want:          "Curated catalog copy.",
+		},
+		{
+			name:          "bare-heading prior falls through to goreleaser",
+			prior:         "# Introduction",
+			goreleaser:    "Real catalog copy.",
+			ppDescription: "Manifest copy.",
+			want:          "Real catalog copy.",
+		},
+		{
+			name:          "empty prior falls through to goreleaser",
+			prior:         "",
+			goreleaser:    "Goreleaser copy.",
+			ppDescription: "Manifest copy.",
+			want:          "Goreleaser copy.",
+		},
+		{
+			name:          "empty prior and goreleaser fall through to pp manifest description (lawhub-shape repair)",
+			prior:         "",
+			goreleaser:    "",
+			ppDescription: "Local-first LSAT practice analytics.",
+			want:          "Local-first LSAT practice analytics.",
+		},
+		{
+			name:          "bare-heading prior with empty goreleaser falls through to pp",
+			prior:         "# Introduction",
+			goreleaser:    "",
+			ppDescription: "Manifest copy.",
+			want:          "Manifest copy.",
+		},
+		{
+			name:          "all empty returns empty (validation catches this separately)",
+			prior:         "",
+			goreleaser:    "",
+			ppDescription: "",
+			want:          "",
+		},
 	}
-	if got := registryDescription("Curated catalog copy.", "Fallback."); got != "Curated catalog copy." {
-		t.Fatalf("registryDescription curated copy = %q, want prior", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := registryDescription(tc.prior, tc.goreleaser, tc.ppDescription); got != tc.want {
+				t.Errorf("registryDescription(%q, %q, %q) = %q, want %q",
+					tc.prior, tc.goreleaser, tc.ppDescription, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateEntries exercises the source-only validation that backs the
+// --validate flag. The required-field set must stay in lockstep with the
+// npm installer's parseRegistry contract — any new requiredString check
+// added there should grow a case here.
+func TestValidateEntries(t *testing.T) {
+	mcpOK := &MCPBlock{Binary: "x-pp-mcp", Transports: []string{"stdio"}, AuthType: "api_key"}
+
+	cases := []struct {
+		name    string
+		entries []RegistryEntry
+		// wantSubstrs is a set of substrings that must appear in the joined
+		// error report. Using substrings avoids brittle exact-match coupling
+		// to the error-message phrasing while still pinning slug + field.
+		wantSubstrs []string
+		wantOK      bool
+	}{
+		{
+			name: "valid entry passes",
+			entries: []RegistryEntry{
+				{Name: "ok", Category: "tools", API: "OK", Description: "Does things.", Path: "library/tools/ok"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "empty description fails with sources-checked message",
+			entries: []RegistryEntry{
+				{Name: "lawhub", Category: "education", API: "LawHub", Description: "", Path: "library/education/lawhub"},
+			},
+			wantSubstrs: []string{
+				"lawhub: description is empty",
+				".printing-press.json description",
+				".goreleaser.yaml brews description",
+			},
+		},
+		{
+			name: "multiple entries each report independently",
+			entries: []RegistryEntry{
+				{Name: "a", Category: "tools", API: "A", Description: "", Path: "library/tools/a"},
+				{Name: "b", Category: "tools", API: "B", Description: "", Path: "library/tools/b"},
+				{Name: "c", Category: "tools", API: "C", Description: "Has desc.", Path: "library/tools/c"},
+			},
+			wantSubstrs: []string{
+				"a: description is empty",
+				"b: description is empty",
+			},
+		},
+		{
+			name: "missing mcp.binary fails when mcp block present",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					MCP: &MCPBlock{Binary: "", Transports: []string{"stdio"}, AuthType: "api_key"},
+				},
+			},
+			wantSubstrs: []string{"x: mcp.binary is empty"},
+		},
+		{
+			name: "missing mcp.transports fails when mcp block present",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					MCP: &MCPBlock{Binary: "x-pp-mcp", Transports: nil, AuthType: "api_key"},
+				},
+			},
+			wantSubstrs: []string{"x: mcp.transports is empty"},
+		},
+		{
+			name: "missing mcp.auth_type fails when mcp block present",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					MCP: &MCPBlock{Binary: "x-pp-mcp", Transports: []string{"stdio"}, AuthType: ""},
+				},
+			},
+			wantSubstrs: []string{"x: mcp.auth_type is empty"},
+		},
+		{
+			name: "non-mcp entry skips mcp checks",
+			entries: []RegistryEntry{
+				{Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "valid mcp block passes",
+			entries: []RegistryEntry{
+				{Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x", MCP: mcpOK},
+			},
+			wantOK: true,
+		},
+		{
+			name: "unnamed entry reports under (unnamed) prefix",
+			entries: []RegistryEntry{
+				{Name: "", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x"},
+			},
+			wantSubstrs: []string{"(unnamed): name is empty"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validateEntries(tc.entries)
+			joined := strings.Join(got, "\n")
+			if tc.wantOK {
+				if len(got) != 0 {
+					t.Fatalf("validateEntries: want no errors, got:\n%s", joined)
+				}
+				return
+			}
+			for _, sub := range tc.wantSubstrs {
+				if !strings.Contains(joined, sub) {
+					t.Errorf("validateEntries: missing substring %q in output:\n%s", sub, joined)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateEntries_IgnoresPriorCuratedValue is the regression test for
+// the lawhub-shape bug. The validator must NOT accept an entry whose only
+// non-empty description comes from a prior curated registry value — that
+// path is exactly what masked the original bug. This is enforced by the
+// caller (main passes an empty existing map), but we also assert
+// validateEntries' own contract: it judges only what's in the entry struct.
+func TestValidateEntries_IgnoresPriorCuratedValue(t *testing.T) {
+	// Entry with an empty description (post-source-only resolution) must
+	// fail validation regardless of any external curated value.
+	entries := []RegistryEntry{
+		{Name: "lawhub", Category: "education", API: "LawHub", Description: "", Path: "library/education/lawhub"},
+	}
+	got := validateEntries(entries)
+	if len(got) == 0 {
+		t.Fatal("validateEntries: expected failure for empty description, got none")
 	}
 }
 

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -150,15 +150,41 @@ func TestValidateEntries(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name: "empty description fails with sources-checked message",
+			name: "empty description fails with sources-checked message in resolution order",
 			entries: []RegistryEntry{
 				{Name: "lawhub", Category: "education", API: "LawHub", Description: "", Path: "library/education/lawhub"},
 			},
 			wantSubstrs: []string{
 				"lawhub: description is empty",
-				".printing-press.json description",
-				".goreleaser.yaml brews description",
+				// Sources appear in fallback-resolution order: goreleaser
+				// (second tier) is listed before .printing-press.json (third
+				// tier), matching what registryDescription consults.
+				".goreleaser.yaml brews description, .printing-press.json description",
 			},
+		},
+		{
+			name: "all-whitespace description fails (matches npm requiredString trim semantics)",
+			entries: []RegistryEntry{
+				{Name: "ws", Category: "tools", API: "WS", Description: "   \t\n  ", Path: "library/tools/ws"},
+			},
+			wantSubstrs: []string{"ws: description is empty"},
+		},
+		{
+			name: "all-whitespace name reports under (unnamed) prefix",
+			entries: []RegistryEntry{
+				{Name: "  ", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x"},
+			},
+			wantSubstrs: []string{"(unnamed): name is empty"},
+		},
+		{
+			name: "all-whitespace mcp.auth_type fails",
+			entries: []RegistryEntry{
+				{
+					Name: "x", Category: "tools", API: "X", Description: "Has desc.", Path: "library/tools/x",
+					MCP: &MCPBlock{Binary: "x-pp-mcp", Transports: []string{"stdio"}, AuthType: "   "},
+				},
+			},
+			wantSubstrs: []string{"x: mcp.auth_type is empty"},
 		},
 		{
 			name: "multiple entries each report independently",


### PR DESCRIPTION
## Summary

`registry.json`'s `lawhub` entry shipped with `description: ""`. The npm installer (`@mvanhorn/printing-press`) calls `requiredString(value, "description")` per entry, which throws on the first malformed entry and aborts the entire registry parse — breaking `install`, `search`, `list`, and `update` for every user, regardless of which CLI they were targeting. Reproduced as:

```
$ npx -y @mvanhorn/printing-press install suno
registry entry missing string field: description
```

Two structural problems combined to produce this:

1. `tools/generate-registry/main.go`'s `registryDescription()` picks descriptions from `prior registry.json → .goreleaser.yaml brews → empty`. It never reads `.printing-press.json`'s `description` field even though every modern printed CLI populates it (suno, etc.). `lawhub` had a populated `.printing-press.json` description (130 chars) but an empty `.goreleaser.yaml` brews block and no prior curated registry value, so the description landed empty.
2. There was no PR-time validation that the registry the generator would produce was internally valid. A new CLI added without a goreleaser brews description and without a curated registry value would silently ship `description: ""` the same way.

This PR adds the missing description fallback, backfills the two existing CLIs whose descriptions live only in the curated registry (`tiktok-shop`, `agent-capture`), adds a strict PR-time validation gate, and hardens the npm installer to skip malformed entries with a warning rather than aborting the whole parse.

Plan: [docs/plans/2026-05-18-001-fix-registry-empty-description-gate-plan.md](https://github.com/mvanhorn/printing-press-library/blob/fix/registry-empty-description-gate/docs/plans/2026-05-18-001-fix-registry-empty-description-gate-plan.md).

## What lands in this PR

| Commit | Change |
|---|---|
| `feat(registry)` | `tools/generate-registry`: add `.printing-press.json` description as a third fallback in `registryDescription()`; add `--validate` flag that builds entries from sources only and fails non-zero with field-named errors when any required string is empty. Required-field set mirrors `npm/src/registry.ts`'s `parseRegistry` contract. |
| `chore(library)` | Backfill `description` in `library/commerce/tiktok-shop/.printing-press.json` and `library/developer-tools/agent-capture/.printing-press.json` (verbatim from current curated registry values) so the registry becomes fully reproducible from sources. |
| `fix(ci)` | New `Validate registry source descriptions` step in `verify-library-conventions.yml` runs `go run ./tools/generate-registry --validate` on PRs. Go pinned to 1.26.3 to match the post-merge regen workflow. |
| `fix(npm)` | `parseRegistry` skips malformed entries with a stderr warning and returns valid ones intact; registry-level shape errors still throw. Tests updated. Patch bump to `0.1.5`. |

## Verification

- `go test ./...` in `tools/generate-registry/` — 37 tests pass (11 new across `TestRegistryDescription` and `TestValidateEntries`).
- `go run ./tools/generate-registry --validate` exits 0 against the PR tree (134 entries pass). Reverting one of the backfill descriptions produces `tiktok-shop: description is empty (sources checked: ...)` and exits 2.
- `npm test` in `npm/` — 51 tests pass (5 new covering skip+warn behavior, the lawhub regression, the `(unnamed at index N)` fallback, and that registry-level errors still throw).
- The PR intentionally does **not** commit a regenerated `registry.json`. Per the repo's "don't commit generated artifacts in PRs" rule (enforced by the existing `Fail on changes to generated artifacts` step), the post-merge `generate-registry.yml` workflow regenerates `registry.json` on merge — at which point lawhub picks up its `.printing-press.json` description and the user-visible npm failure clears.

## Defense in depth

The library-side fix (`feat(registry)` + `chore(library)` + `fix(ci)`) prevents new malformed entries from ever landing on main. The npm-side fix (`fix(npm)`) ensures any future upstream slip — or any malformed entry that's somehow already in flight — can't take down the entire installer again. Either layer alone closes the lawhub failure mode; both together close future variants too.

## Out of scope

- Migrating all curated registry descriptions back into `.printing-press.json` (only the two strictly required for source-reproducibility are touched).
- Validating optional MCP block fields beyond what the npm installer requires.
- Hardening other generated outputs (`README.md` sentinel regions, `cli-skills/pp-*/SKILL.md`) against similar empty-string footguns.

## Test plan

- [x] `go test ./...` from `tools/generate-registry/`
- [x] `go run ./tools/generate-registry --validate` (exits 0 against current tree)
- [x] `npm test` from `npm/`
- [ ] CI: `verify-library-conventions` new step exits 0
- [ ] CI: other verify-* workflows stay green
- [ ] Greptile: address every P0/P1 finding before merge
- [ ] Post-merge: confirm `generate-registry.yml` regenerates `registry.json` with lawhub's description populated
- [ ] Post-merge: confirm npm auto-publish ships `@mvanhorn/printing-press@0.1.5`
- [ ] Post-publish: `npx -y -p @mvanhorn/printing-press printing-press install suno` succeeds