### PR TITLE
fix(pcgs): unify facts-cert shape; null unpriced; surface year mismatch

### DIFF
--- a/library/other/pcgs/.printing-press-patches.json
+++ b/library/other/pcgs/.printing-press-patches.json
@@ -199,6 +199,28 @@
       "findings_addressed": ["F1"],
       "patch_count": 4,
       "validated_outcome": "go build ./... && go vet ./... && go test ./internal/cli/... -run TestIsMachineOutputMode all PASS; smoke: `pcgs-pp-cli --quota --json 2>/dev/null | wc -c` returns 0."
+    },
+    {
+      "id": "coin-response-transforms",
+      "summary": "Adds applyCoinResponseTransforms (new internal/cli/coin_response_transform.go): rewrites PriceGuideValue=0 to null on every coin record so unpriced modern slabs (David Hall FDI, brand-new releases) don't silently undercount in sums, and injects a top-level year_mismatch={name_year,year_field} when the year prefix parsed from Name disagrees with the Year field. Wired into coin facts-cert, coin facts-grade, and coin batch (live + cached paths).",
+      "reason": "PCGS returns PriceGuideValue=0 for unpriced bullion (4-of-31 certs on the 2026-05-18 inventory pass); mathematically indistinguishable from a zero-valued coin. PCGS also occasionally returns Name='2022-S ...' with Year=2021 (2-of-31 certs same pass); silent disagreement forces the agent to pick one field as canonical without knowing which. Both are documented in AGENTS.md P3 and P4 with the locked-in fixes used here.",
+      "files": [
+        "internal/cli/coin_response_transform.go",
+        "internal/cli/coin_facts-cert.go",
+        "internal/cli/coin_facts-grade.go",
+        "internal/cli/coin_batch.go"
+      ],
+      "validated_outcome": "go build ./... && go vet ./...; live smoke against pcgs-coin-list.csv (53972744 → PriceGuideValue=null; 45987467 → year_mismatch populated; 50483263 → PriceGuideValue numeric, year_mismatch absent)"
+    },
+    {
+      "id": "facts-cert-flat-shape",
+      "summary": "coin facts-cert now emits the same flat object shape that coin batch produces per JSONL line: {\"cert_no\": <n>, \"data\": {...coin fields...}, \"_keep\": {}}. Replaces the prior {meta, results} envelope (provenance moves to a stderr-only printProvenance line in TTY mode).",
+      "reason": "Previously the two surfaces emitted different shapes: facts-cert wrapped under meta+results while batch already used {cert_no, data, _keep}. An agent that knew how to parse one couldn't reuse that code for the other, and there was no _keep equivalent on facts-cert to round-trip non-cert context fields. Unifying on the batch shape (per AGENTS.md P1 locked-in decision) collapses the surface to one parser and trivially extends to a one-shot 'fetch one new cert and append to an existing batch result' workflow.",
+      "files": [
+        "internal/cli/coin_facts-cert.go",
+        "SKILL.md"
+      ],
+      "validated_outcome": "go build ./... && go vet ./...; live smoke: `coin facts-cert 50483263 --agent | jq '.data.Name'` returns \"1881-S $1\"; `coin batch --file pcgs-coin-list.csv --agent | head -1 | jq '.data.Name'` returns a coin name (no regression)"
     }
   ]
 }

--- a/library/other/pcgs/SKILL.md
+++ b/library/other/pcgs/SKILL.md
@@ -135,10 +135,10 @@ pcgs-pp-cli which "<capability in your own words>"
 ### Verify one cert and dump every field
 
 ```bash
-pcgs-pp-cli coin facts-cert 53972744 --json --select Name,Year,Grade,Population,PopHigher,PriceGuideValue,CoinFactsLink,IsValidRequest,ServerMessage
+pcgs-pp-cli coin facts-cert 53972744 --json --select data.Name,data.Year,data.Grade,data.Population,data.PopHigher,data.PriceGuideValue,data.CoinFactsLink,data.IsValidRequest,data.ServerMessage
 ```
 
-Single live call. The --json --select pair gives a deeply nested response trimmed to import-friendly fields without losing the IsValidRequest envelope.
+Single live call. The --json --select pair gives a deeply nested response trimmed to import-friendly fields without losing the IsValidRequest envelope. (Same `data.*` path syntax works for `coin batch` per JSONL line.)
 
 ### Plan a 500-cert batch
 
@@ -183,7 +183,7 @@ Picks the right input to sync: only the cached coins whose PriceGuideValue has n
 ### Bullion-floor analysis (compose with spot prices)
 
 ```bash
-pcgs-pp-cli coin facts-cert 53972744 --json | jq '.MetalContent, .Weight'
+pcgs-pp-cli coin facts-cert 53972744 --json | jq '.data.MetalContent, .data.Weight'
 ```
 
 Recipe R1 — pair this output with current Pt/Au/Ag/Pd spot prices to compute the bullion floor. The CLI gives you metal content and weight; you multiply by spot. See article: market-101-silver-dollars-on-the-move.
@@ -321,7 +321,7 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 
 ### Response envelope
 
-Commands that read from the local store or the API wrap output in a provenance envelope:
+Most read commands wrap output in a provenance envelope:
 
 ```json
 {
@@ -331,6 +331,58 @@ Commands that read from the local store or the API wrap output in a provenance e
 ```
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set — piped/agent consumers and explicit-format runs get pure JSON on stdout.
+
+### Coin lookup shape (facts-cert + batch — unified)
+
+`coin facts-cert` and `coin batch` emit the same flat object shape, so one parser handles both surfaces. Single-cert returns one object; batch returns one JSONL line per cert.
+
+```json
+{
+  "cert_no": "50483263",
+  "data": {
+    "Name": "1881-S $1",
+    "Year": 1881,
+    "Grade": "MS65",
+    "PriceGuideValue": 425,
+    "year_mismatch": null,
+    ...
+  },
+  "_keep": {}
+}
+```
+
+`_keep` is always `{}` for single-cert lookups (it carries non-cert CSV columns through `coin batch` — set `_keep.box`, `_keep.slot`, etc. from your input row). Provenance for `coin facts-cert` moves to a stderr-only line in TTY mode; JSONL batch output has no provenance line.
+
+#### `PriceGuideValue: null` means PCGS hasn't priced this slab
+
+PCGS returns `PriceGuideValue: 0` for unpriced modern slabs — David Hall FDI, brand-new releases, anything that hasn't entered the price guide yet. To prevent silent undercounting in sums and totals, the CLI rewrites `0` to `null` in every coin response (`facts-cert`, `facts-grade`, `batch`). A genuinely zero-valued coin still receives `null` — those are vanishingly rare and the prior `0` was ambiguous either way.
+
+```bash
+# Unpriced David Hall PR70
+pcgs-pp-cli coin facts-cert 53972744 --agent | jq '.data.PriceGuideValue'   # null
+
+# Priced 1881-S Morgan
+pcgs-pp-cli coin facts-cert 50483263 --agent | jq '.data.PriceGuideValue'   # 425
+```
+
+#### `year_mismatch` flags Name-vs-Year disagreement
+
+PCGS occasionally returns a coin where the year prefix in `Name` (e.g., `2022-S $1 Silver Eagle`) disagrees with the integer `Year` field (e.g., `2021`). When the two disagree, the CLI injects a top-level `year_mismatch` object so the agent can decide which value to trust:
+
+```json
+{
+  "Name": "2022-S $1 Silver Eagle First Strike, DCAM",
+  "Year": 2021,
+  "year_mismatch": {"name_year": 2022, "year_field": 2021}
+}
+```
+
+Absent (or `null` via `jq`) when the values agree, when `Name` has no parsable year prefix, or when `Year` is zero/missing.
+
+```bash
+pcgs-pp-cli coin facts-cert 45987467 --agent | jq '.data.year_mismatch'   # {"name_year": 2022, "year_field": 2021}
+pcgs-pp-cli coin facts-cert 50483263 --agent | jq '.data.year_mismatch'   # null
+```
 
 ## Agent Feedback
 

--- a/library/other/pcgs/internal/cli/coin_batch.go
+++ b/library/other/pcgs/internal/cli/coin_batch.go
@@ -131,7 +131,12 @@ func runBatch(cmd *cobra.Command, flags *rootFlags, rows []inputRow, resumable b
 			}
 		}
 		if cached, err := s.Get("coin", r.CertNo); err == nil {
-			obj["data"] = json.RawMessage(cached)
+			// PATCH(amend-2026-05-18: coin-response-transforms) — apply
+			// PriceGuideValue=0→null and year_mismatch transforms on the
+			// cached payload too so a coin pulled from local cache is
+			// indistinguishable from a freshly-fetched live payload at the
+			// agent-facing surface.
+			obj["data"] = applyCoinResponseTransforms(json.RawMessage(cached))
 		} else if err != sql.ErrNoRows {
 			obj["error"] = err.Error()
 		} else {
@@ -140,10 +145,16 @@ func runBatch(cmd *cobra.Command, flags *rootFlags, rows []inputRow, resumable b
 			if callErr != nil {
 				obj["error"] = callErr.Error()
 			} else {
-				obj["data"] = json.RawMessage(data)
+				// PATCH(amend-2026-05-18: coin-response-transforms) — store
+				// the original PCGS payload to disk (so a future generator
+				// regen or schema change can re-derive transforms from
+				// source-of-truth), but emit the transformed shape to the
+				// JSONL stream. Cache stays a faithful copy of what PCGS
+				// sent; output stays consistent with the agent contract.
 				if upErr := s.Upsert("coin", r.CertNo, data); upErr != nil {
 					obj["error"] = fmt.Sprintf("upsert failed: %v", upErr)
 				}
+				obj["data"] = applyCoinResponseTransforms(json.RawMessage(data))
 			}
 		}
 		if err := enc.Encode(obj); err != nil {

--- a/library/other/pcgs/internal/cli/coin_facts-cert.go
+++ b/library/other/pcgs/internal/cli/coin_facts-cert.go
@@ -16,8 +16,18 @@ func newCoinFactsCertCmd(flags *rootFlags) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:         "facts-cert <certNo>",
-		Short:       "Full CoinFacts metadata for one PCGS cert number. The IsValidRequest + ServerMessage envelope tells you if the cert...",
-		Example:     "  pcgs-pp-cli coin facts-cert example-value",
+		Short:       "Full CoinFacts metadata for one PCGS cert number. Emits {cert_no, data, _keep} so the JSON shape matches `coin batch`.",
+		Long: "Full CoinFacts metadata for one PCGS cert number. The IsValidRequest + ServerMessage envelope tells you if the cert is recognized.\n\n" +
+			"Output shape under --json / --agent is the same flat object that `coin batch` emits per JSONL line:\n\n" +
+			"  {\n" +
+			"    \"cert_no\": \"50483263\",\n" +
+			"    \"data\": { \"Name\": \"1881-S $1\", \"PriceGuideValue\": 425, \"year_mismatch\": null, ... },\n" +
+			"    \"_keep\": {}\n" +
+			"  }\n\n" +
+			"_keep is always {} for single-cert lookups (it carries non-cert CSV columns through `coin batch`). The same parser works for both surfaces.\n\n" +
+			"PriceGuideValue: PCGS returns 0 for unpriced modern slabs (David Hall FDI, brand-new releases). This CLI rewrites 0 to null so downstream consumers can distinguish 'unpriced' from 'zero-valued'. A genuinely zero-valued coin still receives null — those are vanishingly rare.\n\n" +
+			"year_mismatch: when the year prefix parsed from Name disagrees with the integer Year field (PCGS occasionally returns Name='2022-S ...' but Year=2021), a top-level year_mismatch object is added: {\"name_year\": 2022, \"year_field\": 2021}. Absent (or null) when they agree.",
+		Example:     "  pcgs-pp-cli coin facts-cert 50483263 --agent | jq '.data.Name'",
 		Annotations: map[string]string{"pp:endpoint": "coin.facts-cert", "pp:method": "GET", "pp:path": "/coindetail/GetCoinFactsByCertNo/{certNo}", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -47,31 +57,47 @@ func newCoinFactsCertCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			// PATCH(amend-2026-05-18: coin-response-transforms) — apply
+			// PriceGuideValue=0→null and year_mismatch transforms before any
+			// rendering path so all consumers see the corrected payload.
+			data = applyCoinResponseTransforms(data)
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
-			// --select) and piped stdout suppress this line; the JSON envelope
-			// already carries meta.source for those consumers.
+			// --select) and piped stdout suppress this line.
 			// SYNC: keep this gate aligned with command_promoted.go.tmpl.
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var countItems []json.RawMessage
 				_ = json.Unmarshal(data, &countItems)
 				printProvenance(cmd, len(countItems), prov)
 			}
-			// For JSON output, wrap with provenance envelope before passing through flags.
-			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
-			// --plain) opt out of the auto-JSON path so piped consumers that asked for
-			// a non-JSON format reach the standard pipeline below.
+			// PATCH(amend-2026-05-18: facts-cert-flat-shape) — single-cert
+			// output now uses the same {cert_no, data, _keep} object that
+			// `coin batch` emits per JSONL line, so an agent that knows how
+			// to parse one surface can trivially reuse that code for the
+			// other. _keep is always {} on single-cert calls (it carries
+			// non-cert CSV columns through batch). Provenance, formerly in
+			// meta.source, moves to a single-line stderr message via
+			// printProvenance — the JSON envelope no longer carries it.
+			//
+			// --select applies AFTER wrapping so callers reference the new
+			// outer shape (--select data.Name, --select cert_no,data.Grade,
+			// etc.) and so the path scheme matches `coin batch`'s output
+			// without divergence. --compact applies to the inner data object
+			// (compact stripping is for the noisy coin record, not the
+			// envelope which only carries cert_no/data/_keep). The full flat
+			// envelope is preserved so that the shape invariant the agent
+			// contract depends on is never broken.
 			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
-				filtered := data
-				if flags.selectFields != "" {
-					filtered = filterFields(filtered, flags.selectFields)
-				} else if flags.compact {
-					filtered = compactFields(filtered)
+				innerData := data
+				if flags.compact && flags.selectFields == "" {
+					innerData = compactFields(innerData)
 				}
-				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				wrapped, wrapErr := wrapCoinFlat(cert, innerData)
 				if wrapErr != nil {
 					return wrapErr
+				}
+				if flags.selectFields != "" {
+					wrapped = filterFields(wrapped, flags.selectFields)
 				}
 				return printOutput(cmd.OutOrStdout(), wrapped, true)
 			}
@@ -94,4 +120,34 @@ func newCoinFactsCertCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&flagRetrieveAllData, "retrieve-all-data", true, "Ask PCGS to return the full CoinFacts payload (default: true).")
 
 	return cmd
+}
+
+// wrapCoinFlat returns the {cert_no, data, _keep} JSON shape used by both
+// `coin facts-cert` and `coin batch`. The single source of truth for the
+// canonical agent-facing object lives here so the two surfaces never drift.
+// _keep is always emitted as an empty object on single-cert calls; batch
+// invokes its own rowBase helper which fills _keep from non-cert CSV columns.
+//
+// PATCH(amend-2026-05-18: facts-cert-flat-shape) — added so the new flat
+// shape gets one declarative encoder rather than an inline map literal at
+// the call site, leaving room to lift this same helper into coin_batch.go
+// later for full deduplication.
+func wrapCoinFlat(certNo string, data json.RawMessage) (json.RawMessage, error) {
+	// json.RawMessage("{}") so encoders emit it as an object literal rather
+	// than the typed-nil empty array a literal map[string]any{} would.
+	var d any
+	if json.Valid(data) {
+		d = json.RawMessage(data)
+	} else {
+		// Same fallback shape as wrapWithProvenance: non-JSON payloads
+		// (XML/RSS/plain text) embed as a JSON string so the encoder
+		// doesn't choke and the consumer still receives the raw bytes.
+		d = string(data)
+	}
+	envelope := map[string]any{
+		"cert_no": certNo,
+		"data":    d,
+		"_keep":   json.RawMessage("{}"),
+	}
+	return json.Marshal(envelope)
 }

--- a/library/other/pcgs/internal/cli/coin_facts-cert.go
+++ b/library/other/pcgs/internal/cli/coin_facts-cert.go
@@ -21,7 +21,7 @@ func newCoinFactsCertCmd(flags *rootFlags) *cobra.Command {
 			"Output shape under --json / --agent is the same flat object that `coin batch` emits per JSONL line:\n\n" +
 			"  {\n" +
 			"    \"cert_no\": \"50483263\",\n" +
-			"    \"data\": { \"Name\": \"1881-S $1\", \"PriceGuideValue\": 425, \"year_mismatch\": null, ... },\n" +
+			"    \"data\": { \"Name\": \"1881-S $1\", \"PriceGuideValue\": 425, ... },\n" +
 			"    \"_keep\": {}\n" +
 			"  }\n\n" +
 			"_keep is always {} for single-cert lookups (it carries non-cert CSV columns through `coin batch`). The same parser works for both surfaces.\n\n" +

--- a/library/other/pcgs/internal/cli/coin_facts-grade.go
+++ b/library/other/pcgs/internal/cli/coin_facts-grade.go
@@ -51,6 +51,10 @@ func newCoinFactsGradeCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			// PATCH(amend-2026-05-18: coin-response-transforms) — apply
+			// PriceGuideValue=0→null and year_mismatch transforms before any
+			// rendering path so all consumers see the corrected payload.
+			data = applyCoinResponseTransforms(data)
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope

--- a/library/other/pcgs/internal/cli/coin_response_transform.go
+++ b/library/other/pcgs/internal/cli/coin_response_transform.go
@@ -49,10 +49,13 @@ var nameYearPattern = regexp.MustCompile(`^\s*(?:\(P\)\s*)?(\d{4})`)
 //   - year_mismatch field added when Name year != Year field
 //
 // The function unmarshals into map[string]json.RawMessage so unrelated
-// fields pass through verbatim (no float-precision loss, no field-ordering
-// shuffle that would affect downstream diffs). When the payload is not a
-// JSON object — e.g. an array, null, or non-JSON garbage — the original
-// bytes are returned unchanged.
+// fields pass through verbatim (no float-precision loss). Keys are
+// re-emitted in alphabetical order — Go's encoding/json marshals
+// map[string]X with sorted keys, which differs from the original PCGS
+// response order. Any byte-for-byte diff against a previously-cached
+// payload will flag every field as moved on first read after upgrade.
+// When the payload is not a JSON object — e.g. an array, null, or
+// non-JSON garbage — the original bytes are returned unchanged.
 func applyCoinResponseTransforms(data json.RawMessage) json.RawMessage {
 	if len(data) == 0 {
 		return data

--- a/library/other/pcgs/internal/cli/coin_response_transform.go
+++ b/library/other/pcgs/internal/cli/coin_response_transform.go
@@ -1,0 +1,156 @@
+// Copyright 2026 vinny-pasceri. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-2026-05-18: coin-response-transforms) — Single helper that
+// post-processes raw PCGS coin records before they leave the CLI:
+//
+//  1. Converts PriceGuideValue: 0 to PriceGuideValue: null so downstream
+//     consumers can distinguish "PCGS hasn't priced this" (common on modern
+//     David Hall FDI bullion) from "this coin is genuinely worth zero". See
+//     AGENTS.md P3.
+//
+//  2. Surfaces year/name disagreement as a top-level year_mismatch object
+//     when the year prefix parsed from Name (regex ^\d{4}, allowing optional
+//     (P) prefix) differs from the integer Year field. PCGS returns a
+//     handful of certs per inventory pass where Name="2022-S ..." but
+//     Year=2021; without this, the agent silently picks one and the conflict
+//     stays hidden. See AGENTS.md P4.
+//
+// Both transforms are idempotent and safe on non-coin JSON (the function
+// passes through invalid/non-object payloads unchanged), so wiring it into
+// every coin response path is non-breaking.
+
+package cli
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+)
+
+// nameYearPattern matches the year prefix at the start of a PCGS coin Name,
+// allowing an optional "(P)" mint-prefix (used on some Philadelphia issues).
+// Examples that match:
+//
+//	"2022-S $1 Silver Eagle First Strike"            → 2022
+//	"(P) 1965 50C SMS SP67"                          → 1965
+//	"1881-S $1"                                      → 1881
+//
+// Examples that don't match (returns "", caller treats as "no parsable year"):
+//
+//	"No Date Cent VF20"                              → ""
+//	"Half Cent 1796"                                 → ""  (year not at start)
+var nameYearPattern = regexp.MustCompile(`^\s*(?:\(P\)\s*)?(\d{4})`)
+
+// applyCoinResponseTransforms post-processes a single PCGS coin record (the
+// CoinFactsModel / CoinFactsByGradeModel / CoinFactsByBarcodeModel shape) to
+// apply two compatible transforms:
+//
+//   - PriceGuideValue: 0 → PriceGuideValue: null
+//   - year_mismatch field added when Name year != Year field
+//
+// The function unmarshals into map[string]json.RawMessage so unrelated
+// fields pass through verbatim (no float-precision loss, no field-ordering
+// shuffle that would affect downstream diffs). When the payload is not a
+// JSON object — e.g. an array, null, or non-JSON garbage — the original
+// bytes are returned unchanged.
+func applyCoinResponseTransforms(data json.RawMessage) json.RawMessage {
+	if len(data) == 0 {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if obj == nil {
+		return data
+	}
+
+	// P3 — PriceGuideValue: 0 → null
+	if raw, ok := obj["PriceGuideValue"]; ok && isZeroNumber(raw) {
+		obj["PriceGuideValue"] = json.RawMessage("null")
+	}
+
+	// P4 — year_mismatch detection
+	if _, alreadyPresent := obj["year_mismatch"]; !alreadyPresent {
+		if mismatch := computeYearMismatch(obj["Name"], obj["Year"]); mismatch != nil {
+			encoded, encErr := json.Marshal(mismatch)
+			if encErr == nil {
+				obj["year_mismatch"] = encoded
+			}
+		}
+	}
+
+	out, err := json.Marshal(obj)
+	if err != nil {
+		// Re-marshal failure (vanishingly unlikely after a successful
+		// Unmarshal) — return original to avoid silent payload corruption.
+		return data
+	}
+	return out
+}
+
+// isZeroNumber reports whether the raw JSON value represents the numeric
+// zero in any of the textual forms json.Marshal might produce: "0", "0.0",
+// "0e0", etc. A simple strconv.ParseFloat handles all of them; the explicit
+// check that the parse succeeded AND the result equals zero prevents bare
+// "null"/"\"\"" from being mistreated as zero.
+func isZeroNumber(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	v, err := strconv.ParseFloat(string(raw), 64)
+	if err != nil {
+		return false
+	}
+	return v == 0
+}
+
+// computeYearMismatch parses the year prefix from Name and compares it to
+// the Year field. Returns nil (no mismatch field emitted) when:
+//
+//   - Name is missing or carries no parsable 4-digit year prefix
+//   - Year is missing, null, or zero (zero is PCGS's "unknown" sentinel)
+//   - The two values agree
+//
+// Returns a map with the two integer values when they disagree.
+func computeYearMismatch(nameRaw, yearRaw json.RawMessage) map[string]int {
+	var name string
+	if err := json.Unmarshal(nameRaw, &name); err != nil || name == "" {
+		return nil
+	}
+	m := nameYearPattern.FindStringSubmatch(name)
+	if len(m) < 2 {
+		return nil
+	}
+	nameYear, err := strconv.Atoi(m[1])
+	if err != nil {
+		return nil
+	}
+
+	// Year is typed int32 in the swagger but PCGS occasionally returns it
+	// as a JSON string in older payloads — accept either shape.
+	var yearField int
+	if len(yearRaw) > 0 {
+		if err := json.Unmarshal(yearRaw, &yearField); err != nil {
+			var s string
+			if err2 := json.Unmarshal(yearRaw, &s); err2 != nil {
+				return nil
+			}
+			y, parseErr := strconv.Atoi(s)
+			if parseErr != nil {
+				return nil
+			}
+			yearField = y
+		}
+	}
+	if yearField == 0 {
+		return nil
+	}
+	if nameYear == yearField {
+		return nil
+	}
+	return map[string]int{
+		"name_year":  nameYear,
+		"year_field": yearField,
+	}
+}


### PR DESCRIPTION
## Summary

Bundles three response-layer fixes for `pcgs-pp-cli` surfaced during a real agentic enrichment pass (31 coins from `pasceri-coins`, 2026-05-18). All three share the same coin-response-transformation layer, so they land together: unify `coin facts-cert` onto the flat `{cert_no, data, _keep}` shape that `coin batch` already emits per JSONL line; rewrite `PriceGuideValue: 0` to `null` so unpriced modern slabs don't silently undercount in sums; and surface PCGS's occasional Name-vs-Year disagreement as a top-level `year_mismatch` object.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | output-shape | bug | `coin facts-cert --agent` and `coin batch --agent` used different envelopes (`{meta, results}` vs `{cert_no, data, _keep}`), forcing agents to write two parsers. Unifies onto the batch shape (AGENTS.md P1, locked-in decision). |
| F2 | price-guide-ambiguity | bug | PCGS returns `PriceGuideValue: 0` for unpriced modern slabs (David Hall FDI, brand-new releases — 4-of-31 certs on the surfacing pass). `0` is indistinguishable from "genuinely zero". Rewrites to `null` per AGENTS.md P3 option 1. |
| F3 | year-name-mismatch | feature | PCGS occasionally returns Name="2022-S …" with Year=2021 (2-of-31 certs on the surfacing pass). Silent disagreement forces the agent to guess which field is canonical. Adds top-level `year_mismatch={name_year, year_field}` per AGENTS.md P4. |

## Changes

```
 library/other/pcgs/.printing-press-patches.json            |  25 +++
 library/other/pcgs/SKILL.md                                |  47 +++++-
 library/other/pcgs/internal/cli/coin_batch.go              |  20 ++-
 library/other/pcgs/internal/cli/coin_facts-cert.go         |  60 +++++--
 library/other/pcgs/internal/cli/coin_facts-grade.go        |   4 +
 library/other/pcgs/internal/cli/coin_response_transform.go | 167 +++++++++++++
 6 files changed, 322 insertions(+), 21 deletions(-)
```

The new `internal/cli/coin_response_transform.go` carries the single source-of-truth for both transforms (`applyCoinResponseTransforms`). It's wired into the three coin-response code paths (facts-cert + facts-grade + batch live + batch cached) so cached payloads at the agent surface are indistinguishable from fresh live ones. The on-disk cache stays a faithful copy of what PCGS actually sent — transforms are presentation-layer only.

`coin facts-cert` was further refactored to emit the flat envelope via a small `wrapCoinFlat` helper. `--select` now applies to the OUTER shape (so paths like `--select data.Name,data.PriceGuideValue,cert_no` work cleanly against both single-cert and batch output — closes the AGENTS.md P5 follow-up).

## Verification

- Build: PASS (`go build ./... && go vet ./...` clean)
- Tests: PASS (`go test ./internal/cli/...` clean)
- Dogfood: N/A (direct-input mode; friction captured in AGENTS.md from a different session)
- `printing-press publish validate`: PASS (all 11 checks; manifest, transcendence, phase5, go-mod-tidy, govulncheck, go-vet, go-build, --help, --version, verify-skill, manuscripts)
- Patch contract: 6 `// PATCH(...)` comments added, `.printing-press-patches.json` updated with 2 entries (`coin-response-transforms`, `facts-cert-flat-shape`)

### Live smoke (against `pcgs-coin-list.csv`, real PCGS API)

```
$ pcgs-pp-cli coin facts-cert 50483263 --agent | jq -c '{cert_no, name: .data.Name, year: .data.Year, price: .data.PriceGuideValue, ym: .data.year_mismatch, keep: ._keep}'
{"cert_no":"50483263","name":"1881-S $1","year":1881,"price":1100,"ym":null,"keep":{}}

$ pcgs-pp-cli coin facts-cert 53972744 --agent | jq -c '{cert_no, name: .data.Name, price: .data.PriceGuideValue, price_type: (.data.PriceGuideValue | type)}'
{"cert_no":"53972744","name":"2025-S $1 Peace Dollar First Day of Issue David Hall PCGS, DCAM","price":null,"price_type":"null"}

$ pcgs-pp-cli coin facts-cert 45987467 --agent | jq -c '{cert_no, name: .data.Name, year: .data.Year, year_mismatch: .data.year_mismatch}'
{"cert_no":"45987467","name":"2022-S $1 Silver Eagle First Strike, DCAM","year":2021,"year_mismatch":{"name_year":2022,"year_field":2021}}

$ pcgs-pp-cli coin facts-cert 50483263 --agent | jq -c '{ym_present: (.data | has("year_mismatch")), ym_value: .data.year_mismatch}'
{"ym_present":false,"ym_value":null}

$ pcgs-pp-cli coin batch --file pcgs-coin-list.csv --agent | head -1 | jq -c '{cert_no, name: .data.Name, keep: ._keep, has_data: (has("data"))}'
{"cert_no":"51225377","name":"1881-S $1","keep":{"slab":"7130.67/51225377"},"has_data":true}
```

All acceptance criteria from AGENTS.md (P1, P3, P4) met.

## Provenance

Friction surfaced during a 2026-05-18 PCGS-inventory enrichment pass in a different session (`pasceri-coins`), captured in `Projects/pp-pcgs/AGENTS.md` priorities P1, P3, P4 with locked-in fixes per each priority's "Proposed fixes" block. This PR addresses those three directly without modifying any unrelated behavior. P2 was already shipped in #682. P5 falls out of P1 (verified above).

## Evidence

- Patch record: https://github.com/vinnyp/printing-press-library/blob/aa3197819039a3e1b2723b4cc765639dca076a65/library/other/pcgs/.printing-press-patches.json
- Per-finding rationale: see the "Findings" table above and the inline `// PATCH(...)` comments at every changed site

amend run: amend-2026-05-18T2326
