### PR TITLE
fix(numista): route human --quota line to stderr in machine modes

### DIFF
--- a/library/other/numista/.printing-press-patches.json
+++ b/library/other/numista/.printing-press-patches.json
@@ -62,6 +62,22 @@
       ],
       "findings_addressed": ["F1", "F2"],
       "validated_outcome": "go build ./... PASS, go vet ./... PASS, go test ./... PASS (TestFuzzyFindCatalogues 9/9 sub-tests including pcgs_locks_to_id=1856_(exact_code)), printing-press publish validate PASS. Live smokes: 'numista-pp-cli catalogues find pcgs' returns id=1856 top hit (no API call); 'numista-pp-cli types search --catalogue 1856 --number 7130' returns N#1492."
+    },
+    {
+      "id": "amend-2026-05-18-quota-stdout-stderr-discipline",
+      "date": "2026-05-18",
+      "amend_run_id": "amend-2026-05-18T2030",
+      "summary": "Route the human --quota line to stderr when any machine-format flag is set (--json, --csv, --compact, --plain, --quiet, --agent, --select, --deliver) or when stdout is not a TTY; keep stdout-on-TTY for the interactive case; --quota-only (JSON) still goes to stdout.",
+      "reason": "AGENTS.md Priority 2 in pp-numista: `numista-pp-cli --quota --json 1>/tmp/out 2>/tmp/err` was writing the `[quota] X/2000 used...` line to /tmp/out, polluting jq / json.loads pipelines with `Extra data: line N column 1`. The PersistentPreRunE --quota short-circuit always wrote to cmd.OutOrStdout(); the pp-CLI agent-mode contract documented in SKILL.md requires human summaries to divert to stderr under any machine-format flag. Mirrors the canonical fix shape landed for pcgs-pp-cli in PR #682. Adds package-private isMachineOutputMode + stdoutIsTerminal helpers plus a TestIsMachineOutputMode table covering every gating flag. PersistentPostRunE was already correct (EmitQuotaLine writes to os.Stderr unconditionally); added a clarifying source comment for symmetry. Direct-input scope from /printing-press-amend numista.",
+      "files": [
+        "internal/cli/root.go",
+        "internal/cli/root_test.go"
+      ],
+      "findings_addressed": [
+        "F1"
+      ],
+      "patch_count": 4,
+      "validated_outcome": "go build ./... && go vet ./... && go test ./internal/cli/... -run TestIsMachineOutputMode all PASS; smoke: `numista-pp-cli --quota --json 2>/dev/null | wc -c` returns 0."
     }
   ]
 }

--- a/library/other/numista/internal/cli/root.go
+++ b/library/other/numista/internal/cli/root.go
@@ -227,11 +227,25 @@ See README.md or the bundled SKILL.md for recipes.`,
 				return err
 			}
 			if quotaPrintOnlyJSON {
+				// --quota-only is the machine form; JSON always goes to stdout
+				// since that IS the requested machine output.
 				if err := json.NewEncoder(cmd.OutOrStdout()).Encode(q); err != nil {
 					return fmt.Errorf("encode quota json: %w", err)
 				}
 			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), cliutil.FormatQuotaLine(q))
+				// PATCH(amend-2026-05-18: route human --quota line to stderr in
+				// machine modes) — was unconditionally written to stdout, which
+				// polluted JSON / agent pipelines combining --quota with --json
+				// or --agent. Per the pp-CLI agent-mode contract documented in
+				// SKILL.md, human summaries must go to stderr when ANY of the
+				// machine-format flags is set OR stdout is not a TTY. The
+				// interactive UX (bare `numista-pp-cli --quota` in a terminal)
+				// still emits to stdout.
+				w := cmd.OutOrStdout()
+				if isMachineOutputMode(flags) || !stdoutIsTerminal() {
+					w = cmd.ErrOrStderr()
+				}
+				fmt.Fprintln(w, cliutil.FormatQuotaLine(q))
 			}
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -290,6 +304,12 @@ See README.md or the bundled SKILL.md for recipes.`,
 		return nil
 	}
 	// PATCH: emit post-command quota usage summary for API-touching commands.
+	// PATCH(amend-2026-05-18: keep PostRunE on stderr unconditionally) — the
+	// post-command [quota] summary is always written to os.Stderr so it never
+	// pollutes machine-format stdout (e.g. `--json`, `--csv`, `--agent`). The
+	// PreRunE --quota path got a similar fix in the same amend; the PostRunE
+	// behavior was already correct (writes to os.Stderr via EmitQuotaLine)
+	// and is preserved here for symmetry with the rule documented in SKILL.md.
 	rootCmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
 		if flags.quiet || quotaPrintOnly || quotaPrintOnlyJSON {
 			return nil
@@ -451,4 +471,55 @@ func newVersionCliCmd() *cobra.Command {
 			fmt.Printf("numista-pp-cli %s\n", version)
 		},
 	}
+}
+
+// PATCH(amend-2026-05-18: machine-mode + tty detection for quota stdout/stderr discipline).
+//
+// isMachineOutputMode reports whether any flag that promises machine-shaped
+// output (or routes output away from the user's terminal) is currently set.
+// Used to decide whether human-readable summaries (the bracketed `[quota]`
+// line in particular) should be diverted from stdout to stderr so they
+// don't pollute downstream `jq` / `json.loads` consumers.
+//
+// The list mirrors the pp-CLI agent-mode contract enumerated in SKILL.md:
+// --json, --csv, --compact, --quiet, --plain, --select, --agent. The brief
+// also names --deliver because piping output to a non-stdout sink implies
+// the caller wants stdout clean for machine consumption.
+//
+// Kept as a package-private helper rather than promoted to cliutil so the
+// flag struct stays in one package.
+func isMachineOutputMode(f *rootFlags) bool {
+	if f == nil {
+		return false
+	}
+	if f.agent || f.asJSON || f.csv || f.compact || f.plain || f.quiet {
+		return true
+	}
+	if f.selectFields != "" {
+		return true
+	}
+	if f.deliverSpec != "" && f.deliverSpec != "stdout" {
+		return true
+	}
+	return false
+}
+
+// stdoutIsTerminal returns true when os.Stdout is attached to a terminal
+// (interactive use), false when it's a pipe, file, or detached. Uses a
+// stdlib-only file-mode check (os.Stat → mode.IsRegular / mode&CharDevice)
+// so we don't pull in golang.org/x/term as a direct dependency.
+//
+// The check is deliberately conservative: any error path returns false,
+// which biases toward stderr emission (the safe choice for machine-mode
+// pipelines). Worst case: interactive users with an unusual stdout setup
+// see the quota line on stderr instead of stdout — annoying but harmless.
+func stdoutIsTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	// On a real TTY the mode has the os.ModeCharDevice bit set AND is not
+	// a regular file. Pipes report os.ModeNamedPipe; redirected files
+	// report mode.IsRegular().
+	return (fi.Mode()&os.ModeCharDevice) != 0 && !fi.Mode().IsRegular()
 }

--- a/library/other/numista/internal/cli/root.go
+++ b/library/other/numista/internal/cli/root.go
@@ -242,7 +242,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 				// interactive UX (bare `numista-pp-cli --quota` in a terminal)
 				// still emits to stdout.
 				w := cmd.OutOrStdout()
-				if isMachineOutputMode(flags) || !stdoutIsTerminal() {
+				if isMachineOutputMode(flags) || !stdoutIsTerminal(cmd) {
 					w = cmd.ErrOrStderr()
 				}
 				fmt.Fprintln(w, cliutil.FormatQuotaLine(q))
@@ -504,17 +504,26 @@ func isMachineOutputMode(f *rootFlags) bool {
 	return false
 }
 
-// stdoutIsTerminal returns true when os.Stdout is attached to a terminal
-// (interactive use), false when it's a pipe, file, or detached. Uses a
-// stdlib-only file-mode check (os.Stat → mode.IsRegular / mode&CharDevice)
-// so we don't pull in golang.org/x/term as a direct dependency.
+// stdoutIsTerminal returns true when the writer Cobra will use for stdout
+// is attached to a terminal (interactive use), false when it's a pipe,
+// file, buffer, or otherwise non-TTY. Inspects cmd.OutOrStdout() rather
+// than os.Stdout directly so callers that redirect output via cmd.SetOut
+// (notably integration tests) see consistent routing — the production
+// binary is unaffected since cmd.OutOrStdout() falls through to os.Stdout.
 //
-// The check is deliberately conservative: any error path returns false,
-// which biases toward stderr emission (the safe choice for machine-mode
-// pipelines). Worst case: interactive users with an unusual stdout setup
-// see the quota line on stderr instead of stdout — annoying but harmless.
-func stdoutIsTerminal() bool {
-	fi, err := os.Stdout.Stat()
+// Uses a stdlib-only file-mode check (os.Stat → mode&CharDevice) so we
+// don't pull in golang.org/x/term as a direct dependency. The check is
+// deliberately conservative: a non-*os.File writer (e.g. bytes.Buffer in
+// tests) and any error path return false, which biases toward stderr
+// emission (the safe choice for machine-mode pipelines). Worst case:
+// interactive users with an unusual stdout setup see the quota line on
+// stderr instead of stdout — annoying but harmless.
+func stdoutIsTerminal(cmd *cobra.Command) bool {
+	f, ok := cmd.OutOrStdout().(*os.File)
+	if !ok || f == nil {
+		return false
+	}
+	fi, err := f.Stat()
 	if err != nil {
 		return false
 	}

--- a/library/other/numista/internal/cli/root_test.go
+++ b/library/other/numista/internal/cli/root_test.go
@@ -204,3 +204,50 @@ func TestFilterFields(t *testing.T) {
 		})
 	}
 }
+
+// PATCH(amend-2026-05-18): cover the isMachineOutputMode predicate that
+// gates --quota stdout-vs-stderr routing. The predicate must return true
+// for every flag the SKILL.md agent-mode contract enumerates, and for
+// --deliver when the sink is anything other than literal "stdout".
+func TestIsMachineOutputMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(*rootFlags)
+		want   bool
+	}{
+		{"zero value", func(*rootFlags) {}, false},
+		{"--json", func(f *rootFlags) { f.asJSON = true }, true},
+		{"--csv", func(f *rootFlags) { f.csv = true }, true},
+		{"--compact", func(f *rootFlags) { f.compact = true }, true},
+		{"--plain", func(f *rootFlags) { f.plain = true }, true},
+		{"--quiet", func(f *rootFlags) { f.quiet = true }, true},
+		{"--agent", func(f *rootFlags) { f.agent = true }, true},
+		{"--select <nonempty>", func(f *rootFlags) { f.selectFields = "id,name" }, true},
+		{"--select empty string", func(f *rootFlags) { f.selectFields = "" }, false},
+		{"--deliver file:/tmp/out", func(f *rootFlags) { f.deliverSpec = "file:/tmp/out" }, true},
+		{"--deliver webhook:https://x", func(f *rootFlags) { f.deliverSpec = "webhook:https://x" }, true},
+		{"--deliver stdout (explicit)", func(f *rootFlags) { f.deliverSpec = "stdout" }, false},
+		{"--deliver empty", func(f *rootFlags) { f.deliverSpec = "" }, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &rootFlags{}
+			tc.mutate(f)
+			if got := isMachineOutputMode(f); got != tc.want {
+				t.Errorf("isMachineOutputMode(%+v) = %v, want %v", f, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsMachineOutputMode_NilReceiver guards the nil-safety path so a
+// caller that passes a nil rootFlags does not panic.
+func TestIsMachineOutputMode_NilReceiver(t *testing.T) {
+	t.Parallel()
+	if got := isMachineOutputMode(nil); got != false {
+		t.Errorf("isMachineOutputMode(nil) = %v, want false", got)
+	}
+}


### PR DESCRIPTION
## Summary

`numista-pp-cli --quota` unconditionally wrote the human-readable `[quota] X/2000 used, …` line to stdout, polluting agent / JSON pipelines:

```bash
$ numista-pp-cli --quota --json 1>/tmp/out 2>/tmp/err
$ cat /tmp/out          # ← bug: human summary on stdout
[quota] 631/2000 used, 1369 left, resets 2026-06-01 UTC
$ cat /tmp/err          # ← (empty)
```

`json.loads(stdout)` then fails with `Extra data: line N column 1` because the stdout stream carries the JSON document followed by the non-JSON quota line.

This routes the human form to **stderr** whenever any machine-format flag is set (`--json`, `--csv`, `--compact`, `--plain`, `--quiet`, `--agent`, `--select`, `--deliver` with a non-stdout sink) OR stdout is not a TTY. The interactive UX (`numista-pp-cli --quota` in a terminal) is unchanged. `--quota-only` (the JSON form) still goes to stdout — that IS the requested machine output.

This is the canonical fix shape landed for `pcgs-pp-cli` in #682; the same bug existed verbatim in `numista-pp-cli` and is fixed here with the same predicate, helper layout, and table test.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1 | stdout-stderr-discipline | bug | `--quota` summary on stdout breaks `jq` / `json.loads` consumers; SKILL.md contract requires human summaries on stderr under any machine-format flag |

## Changes

```
 library/other/numista/.printing-press-patches.json | 16 +++++
 library/other/numista/internal/cli/root.go         | 73 +++++++++++++++++++++-
 library/other/numista/internal/cli/root_test.go    | 47 ++++++++++++++
 3 files changed, 135 insertions(+), 1 deletion(-)
```

Two package-private helpers added to `root.go`:

- `isMachineOutputMode(f *rootFlags) bool` — nil-safe predicate over the gating flags.
- `stdoutIsTerminal() bool` — stdlib-only `os.Stdout.Stat()` + mode-bit check; no `golang.org/x/term` dependency. Biased toward stderr on any error path.

`PersistentPreRunE` `--quota` branch now picks `cmd.ErrOrStderr()` when either predicate fires. `PersistentPostRunE` was already correct (`cliutil.EmitQuotaLine(os.Stderr, q)`); a clarifying source comment was added for symmetry.

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test ./...` — PASS (all packages: cli, client, cliutil, mcp, mcp/cobratree, store)
- `go test ./internal/cli/... -run TestIsMachineOutputMode -v` — PASS (13 sub-tests + nil receiver)
- `printing-press publish validate --dir library/other/numista` — PASS (manifest, transcendence, phase5, go mod tidy, govulncheck, go vet, go build, --help, --version)

### Smoke tests (against locally-built binary, live quota DB)

```
$ numista-pp-cli --quota --json 2>/dev/null | wc -c
0

$ numista-pp-cli --quota --json 2>&1 1>/dev/null | grep '\[quota\]'
[quota] 631/2000 used, 1369 left, resets 2026-06-01 UTC

$ numista-pp-cli --quota-only 2>/dev/null
{"used":631,"limit":2000,"remaining":1369,"reset":"2026-06-01T00:00:00Z"}

$ numista-pp-cli --quota --agent 1>/tmp/out 2>/tmp/err
$ cat /tmp/out          # empty (machine mode → stderr)
$ cat /tmp/err
[quota] 631/2000 used, 1369 left, resets 2026-06-01 UTC
```

Acceptance criteria from `AGENTS.md` Priority 2 (the originating brief):

- ✅ `numista-pp-cli --quota --json 2>/dev/null | jq` succeeds (stdout is empty — no `Extra data` parse failure).
- ✅ `numista-pp-cli types search --q "morgan" --issuer united-states --json` style invocations no longer have a stray `[quota]` line on stdout.

## Out of scope

- The "fold quota into JSON `meta` envelope" option from `AGENTS.md` Priority 2. That's a v2 contract change; PR #682 deferred it for the same reason. Tracked for a future amend.

## Patch contract

- 4 new `// PATCH(amend-2026-05-18:` source comments added; `.printing-press-patches.json` `patch_count: 4` matches.
- Mode: direct-input (slash-command argument, not transcript-mined).
- Scope brief: `~/Projects/pp-numista/AGENTS.md` Priority 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/printing-press-amend numista`
