### PR TITLE
feat(numista): catalogues find subcommand + PCGS direct-cross-walk cookbook

### DIFF
--- a/library/other/numista/.printing-press-patches.json
+++ b/library/other/numista/.printing-press-patches.json
@@ -49,6 +49,19 @@
         "internal/store/store.go"
       ],
       "validated_outcome": "go build ./... and go vet ./... pass; requested command help probes exit 0."
+    },
+    {
+      "id": "amend-2026-05-18-catalogues-find-and-pcgs-cookbook",
+      "summary": "Add 'numista-pp-cli catalogues find <query>' local-only fuzzy-search subcommand that resolves Numista reference-catalogue codes/titles/authors/publishers against the on-disk cache (3,106 rows). Also add a SKILL.md cookbook section 'If your input is a PCGS cert' documenting the direct PCGSNo -> N# cross-walk via catalogue id 1856 (PCGS CoinFacts).",
+      "reason": "Closes pp-numista/AGENTS.md Priority 4. The 'catalogues find' subcommand mirrors the 'issuers find' pattern shipped in PR #684 (loadXFromCache + scoreX + fuzzyFindX + Cobra attach), including the empty-cache discipline that fails with a warm-the-cache message rather than auto-fetching (a typo on the error path must not silently spend a quota call). Local DB has 'catalogues' rows persisted under resource_type='catalogues' in the resources table, so loadCataloguesFromCache reads via store.List('catalogues', limit) with no schema changes. The SKILL.md cookbook entry corrects a factual error in PR #684's draft (which I introduced during the AGENTS.md review by checking only the swagger spec, not the catalogue data): PCGS IS one of Numista's reference catalogues, registered at id=1856. Direct cross-walk verified 2026-05-18 with PCGSNos 7130 -> N#1492 (Morgan Dollar) and 7787 -> N#13432 (Coronet Head Quarter Eagle). The cookbook leads with this direct one-command bridge and keeps text search as a fallback (using --date for Gregorian year per swagger semantics, not --year which is 'as written on the item' and ambiguous for non-Gregorian dating systems on world coins). Tests cover exact-code, code/title-prefix, author-substring, publisher-substring, case-insensitive, diacritic-normalized, empty-query, and zero-limit edge cases.",
+      "files": [
+        "internal/cli/catalogues_amend.go",
+        "internal/cli/catalogues_amend_test.go",
+        "internal/cli/root.go",
+        "SKILL.md"
+      ],
+      "findings_addressed": ["F1", "F2"],
+      "validated_outcome": "go build ./... PASS, go vet ./... PASS, go test ./... PASS (TestFuzzyFindCatalogues 9/9 sub-tests including pcgs_locks_to_id=1856_(exact_code)), printing-press publish validate PASS. Live smokes: 'numista-pp-cli catalogues find pcgs' returns id=1856 top hit (no API call); 'numista-pp-cli types search --catalogue 1856 --number 7130' returns N#1492."
     }
   ]
 }

--- a/library/other/numista/SKILL.md
+++ b/library/other/numista/SKILL.md
@@ -201,6 +201,43 @@ numista-pp-cli collection value 12345 --json --select totals.estimated_value,tot
 
 Joins your locally-cached collection against the prices table; refuses to start if remaining quota would be exceeded.
 
+### If your input is a PCGS cert
+
+Pair with [`pcgs-pp-cli`](https://github.com/mvanhorn/printing-press-library/tree/main/library/other/pcgs) when you're starting from a PCGS-graded coin and need its Numista catalogue ID (N#). PCGS is one of Numista's reference catalogues — registered as catalogue id `1856` (code `PCGS`, title "PCGS CoinFacts") — so a PCGSNo resolves to an N# in one API call with no text-match guessing.
+
+**Direct cross-walk (recommended when you have a PCGSNo).**
+
+```bash
+# 1. Get the PCGSNo from PCGS (no Numista quota cost).
+pcgs-pp-cli coin facts-cert <cert-number> --json --select PCGSNo,Name,Year
+# → e.g. {"PCGSNo":"7130","Name":"1881-S Morgan Dollar","Year":"1881"}
+
+# 2. Look up the Numista N# directly via the catalogue cross-reference.
+numista-pp-cli types search --catalogue 1856 --number 7130 \
+  --agent --select types.id,types.title
+# → {"results":{"types":[{"id":1492,"title":"1 Dollar \"Morgan Dollar\""}]}}
+```
+
+Verify the catalogue id at any time with `numista-pp-cli catalogues find pcgs` (local-only, no quota cost; requires that `numista-pp-cli catalogues` has been run at least once to populate the local cache).
+
+**Text-search fallback (no PCGSNo, or the catalogue lookup misses).** The PCGS CoinFacts reference catalogue doesn't index every cert. When `--catalogue 1856 --number <PCGSNo>` returns no types, fall back to text search:
+
+```bash
+pcgs-pp-cli coin facts-cert <cert-number> --json --select Name,Year,CountryName
+# → e.g. {"Name":"1881-S Morgan Dollar","Year":"1881","CountryName":"United States"}
+
+numista-pp-cli types search --q "morgan dollar" --issuer united-states --date 1881 \
+  --agent --select types.id,types.title
+# → top result is usually the Numista N# you want.
+```
+
+Use `--date` (Gregorian calendar year) for the year PCGS returns, not `--year` — Numista's `--year` is the year *as written on the item* (relevant for Hijri / Republican / other non-Gregorian dating on world coins; for US coins they coincide).
+
+Tips:
+
+- Issuer slugs are hyphenated (`united-states`, `south-africa`). Run `numista-pp-cli issuers find <name>` to look one up — local-only, no quota cost.
+- This CLI does NOT depend on `pcgs-pp-cli`. No shell-out, no auto-detection — install it separately when you want grade / cert / population data on the coin Numista returned.
+
 ## Auth Setup
 
 Set `NUMISTA_API_KEY` in your environment (request one at https://en.numista.com/api/index.php — the free plan is 2000 calls/month). Catalogue and reference endpoints work with the API key alone. User-collection commands (`users collected-items add`, `collection value`, `users collections hydrate`) need an OAuth token — request an OAuth bearer with `numista-pp-cli oauth-token --grant-type client_credentials --scope view_collection` and save it via `numista-pp-cli auth set-token <token>` to grant the CLI access to your own account; the token is stored at ~/.numista-pp-cli/auth.json (mode 0600).

--- a/library/other/numista/internal/cli/catalogues_amend.go
+++ b/library/other/numista/internal/cli/catalogues_amend.go
@@ -5,7 +5,9 @@ package cli
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"sort"
 	"strings"
@@ -56,21 +58,27 @@ func (r catalogueRecord) extra() string {
 // warm-the-cache message instead of erroring. Numista has ~3,100 catalogues;
 // the 5000 limit covers the full set with headroom.
 func loadCataloguesFromCache() ([]catalogueRecord, error) {
-	s, err := store.OpenReadOnly(defaultDBPath("numista-pp-cli"))
+	dbPath := defaultDBPath("numista-pp-cli")
+	// Distinguish "DB file genuinely missing" (cache not warm — empty result
+	// is the right answer; caller renders the warm-the-cache message) from
+	// "DB file exists but unreadable" (permissions, disk error, corruption —
+	// must surface so the user doesn't follow the warm-the-cache advice,
+	// spend a quota call on `numista-pp-cli catalogues`, and loop). Greptile
+	// P1 on PR #688 review.
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("checking catalogues cache file %s: %w", dbPath, err)
+	}
+	s, err := store.OpenReadOnly(dbPath)
 	if err != nil {
-		// Missing or unopenable cache is functionally empty from the
-		// discovery surface's perspective — neither find nor the suggestion
-		// path should fail noisily on a fresh install.
-		return nil, nil
+		return nil, fmt.Errorf("opening catalogues cache: %w", err)
 	}
 	defer s.Close()
 	raws, err := s.List("catalogues", 5000)
 	if err != nil {
-		// sql.Open is lazy — a missing DB file (fresh install, wrong HOME)
-		// only surfaces when the first query runs. Treat any List error on
-		// a read-only store as "cache not warm" so the find surface degrades
-		// gracefully to the warm-the-cache message rather than a panic.
-		return nil, nil
+		return nil, fmt.Errorf("reading catalogues cache: %w", err)
 	}
 	if len(raws) == 0 {
 		return nil, nil
@@ -249,7 +257,15 @@ func scoreCatalogue(rec catalogueRecord, qNorm string) int {
 		strings.Contains(titleNorm, qNorm) ||
 		strings.Contains(authorNorm, qNorm) ||
 		strings.Contains(publisherNorm, qNorm) {
-		return 1000 + len(qNorm) - len(rec.Title)/10
+		// Floor at 1 so a pathological-length title never collapses a valid
+		// substring match to 0 (which fuzzyFindCatalogues filters out).
+		// Numista titles are short in practice but the formula needs a
+		// guarantee. Greptile P2 on PR #688 review.
+		s := 1000 + len(qNorm) - len(rec.Title)/10
+		if s < 1 {
+			s = 1
+		}
+		return s
 	}
 	return 0
 }
@@ -385,7 +401,11 @@ func renderCataloguesFind(cmd *cobra.Command, flags *rootFlags, matches []catalo
 		return json.NewEncoder(out).Encode(envelope)
 	}
 	if len(matches) == 0 {
-		fmt.Fprintln(os.Stderr, "no matches.")
+		// Use cmd.ErrOrStderr() not os.Stderr — every other diagnostic in
+		// this CLI goes through the command's error writer, and Cobra-based
+		// tests can only capture output that flows through it. Greptile P2
+		// on PR #688 review.
+		fmt.Fprintln(cmd.ErrOrStderr(), "no matches.")
 		return nil
 	}
 	tw := newTabWriter(out)

--- a/library/other/numista/internal/cli/catalogues_amend.go
+++ b/library/other/numista/internal/cli/catalogues_amend.go
@@ -1,0 +1,412 @@
+// Copyright 2026 vinny-pasceri. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/other/numista/internal/store"
+)
+
+// PATCH(amend-2026-05-18: catalogue-discovery): adds 'catalogues find <query>'
+// local-only subcommand for fuzzy-matching a Numista reference catalogue against
+// the local cache. Complements 'issuers find' (PR #684) and closes
+// pp-numista/AGENTS.md Priority 4 — agents starting from a PCGS cert can verify
+// that catalogue id=1856 is PCGS without spending a quota call or scrolling the
+// 3,106-row 'catalogues' dump.
+//
+// All edits in this file are hand-written, local-only, and never spend a quota
+// call. The cache is populated by 'numista-pp-cli catalogues' (one API call);
+// when empty, 'find' fails with a clear warm-the-cache message rather than
+// auto-fetching, matching the discipline established by 'issuers find'.
+
+// catalogueRecord is a slim view of a catalogue JSON object as stored in the
+// local resources table. Numista's /catalogues response shape is
+// {id (int), code, title, author, publisher, isbn13}; we project the four
+// fields the find surface uses and drop the rest. The 'extra' field holds
+// the publisher-or-author label rendered next to title in the human table.
+type catalogueRecord struct {
+	ID        int
+	Code      string
+	Title     string
+	Author    string
+	Publisher string
+}
+
+// extra returns the secondary identifier shown alongside title in the human
+// table. Author wins when present (most catalogues are author-named);
+// publisher is the fallback for institutional references like PCGS where
+// "author" is empty.
+func (r catalogueRecord) extra() string {
+	if r.Author != "" {
+		return r.Author
+	}
+	return r.Publisher
+}
+
+// loadCataloguesFromCache reads every catalogue the local store knows about.
+// Returns (nil, nil) when the cache is empty so callers can render the
+// warm-the-cache message instead of erroring. Numista has ~3,100 catalogues;
+// the 5000 limit covers the full set with headroom.
+func loadCataloguesFromCache() ([]catalogueRecord, error) {
+	s, err := store.OpenReadOnly(defaultDBPath("numista-pp-cli"))
+	if err != nil {
+		// Missing or unopenable cache is functionally empty from the
+		// discovery surface's perspective — neither find nor the suggestion
+		// path should fail noisily on a fresh install.
+		return nil, nil
+	}
+	defer s.Close()
+	raws, err := s.List("catalogues", 5000)
+	if err != nil {
+		// sql.Open is lazy — a missing DB file (fresh install, wrong HOME)
+		// only surfaces when the first query runs. Treat any List error on
+		// a read-only store as "cache not warm" so the find surface degrades
+		// gracefully to the warm-the-cache message rather than a panic.
+		return nil, nil
+	}
+	if len(raws) == 0 {
+		return nil, nil
+	}
+	out := make([]catalogueRecord, 0, len(raws))
+	for _, raw := range raws {
+		var obj map[string]any
+		if json.Unmarshal(raw, &obj) != nil {
+			continue
+		}
+		// id arrives as float64 from the generic JSON decoder; cast back to
+		// int. Skip rows missing an id — the find surface needs it for the
+		// definitive 'numista-pp-cli types search --catalogue <id>' lookup
+		// the cookbook recommends.
+		id, ok := intFromAny(obj["id"])
+		if !ok {
+			continue
+		}
+		code := stringField(obj, "code")
+		title := stringField(obj, "title")
+		if code == "" && title == "" {
+			continue
+		}
+		out = append(out, catalogueRecord{
+			ID:        id,
+			Code:      code,
+			Title:     title,
+			Author:    stringField(obj, "author"),
+			Publisher: stringField(obj, "publisher"),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Code != out[j].Code {
+			return out[i].Code < out[j].Code
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// intFromAny coerces a JSON-decoded value into an int. Numeric JSON values
+// decode as float64 through encoding/json's default map[string]any path, so
+// the generic int conversion has to handle both float64 (the common case)
+// and json.Number (set if a future caller installs a Decoder with UseNumber).
+func intFromAny(v any) (int, bool) {
+	switch x := v.(type) {
+	case float64:
+		return int(x), true
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return int(i), true
+		}
+	case string:
+		// Some upstream rows may store numeric ids as strings during
+		// migration; tolerate it and fall back to atoi.
+		var n int
+		if _, err := fmt.Sscanf(x, "%d", &n); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+// normalizeCatalogueQuery folds the input into the shape we compare against.
+// Lowercased, diacritics stripped (so 'schon' matches 'Schön'), hyphens and
+// underscores collapsed to spaces, repeated whitespace collapsed.
+//
+// Diacritic folding is targeted at the Latin-script catalogue corpus —
+// German umlauts, French accents, and Eastern-European combining marks
+// that show up in author and publisher names (Schön, Krämer, Müller).
+// We do it manually rather than pulling golang.org/x/text/unicode/norm
+// because the cost of one new module dep for a discovery surface this
+// small is not worth it, and the explicit table is auditable.
+func normalizeCatalogueQuery(q string) string {
+	q = strings.ToLower(strings.TrimSpace(q))
+	q = foldDiacritics(q)
+	q = strings.ReplaceAll(q, "-", " ")
+	q = strings.ReplaceAll(q, "_", " ")
+	return strings.Join(strings.Fields(q), " ")
+}
+
+// foldDiacritics rewrites the common Latin-script accented letters to their
+// unaccented ASCII equivalents. The table is intentionally compact and
+// covers the diacritics that actually appear in the Numista catalogue
+// corpus (German, French, Spanish, Scandinavian, Eastern European). A user
+// who types 'schon' should still hit 'Schön'; a user who types 'kramer'
+// should still hit 'Krämer'.
+func foldDiacritics(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		// German / Scandinavian
+		case 'ä', 'á', 'à', 'â', 'ã', 'å', 'ā', 'ă', 'ą':
+			b.WriteRune('a')
+		case 'ë', 'é', 'è', 'ê', 'ē', 'ĕ', 'ė', 'ę':
+			b.WriteRune('e')
+		case 'ï', 'í', 'ì', 'î', 'ī', 'į':
+			b.WriteRune('i')
+		case 'ö', 'ó', 'ò', 'ô', 'õ', 'ø', 'ō', 'ŏ', 'ő':
+			b.WriteRune('o')
+		case 'ü', 'ú', 'ù', 'û', 'ū', 'ŭ', 'ů', 'ű':
+			b.WriteRune('u')
+		case 'ý', 'ÿ':
+			b.WriteRune('y')
+		case 'ñ', 'ń', 'ň':
+			b.WriteRune('n')
+		case 'ç', 'ć', 'č':
+			b.WriteRune('c')
+		case 'ß':
+			b.WriteString("ss")
+		case 'ł':
+			b.WriteRune('l')
+		case 'š', 'ś':
+			b.WriteRune('s')
+		case 'ž', 'ź', 'ż':
+			b.WriteRune('z')
+		case 'ř':
+			b.WriteRune('r')
+		case 'ť':
+			b.WriteRune('t')
+		case 'ď':
+			b.WriteRune('d')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// scoreCatalogue ranks a record against the normalized query. Higher is
+// better. Scoring rules in priority order:
+//
+//  1. Exact code match (case-insensitive): 5000 — locks 'find KM' to id=3.
+//  2. Exact title match: 4500.
+//  3. Code prefix match: 3000 - len(code) (shorter codes win on ties).
+//  4. Title word-prefix on any token: 2000 - len(title).
+//  5. Substring in code OR title OR author OR publisher: 1000 + len(query)
+//     - len(title)/10 (longer titles score slightly lower to bias toward
+//     concise canonical references).
+//  6. No match: 0.
+//
+// Author/publisher matches at tier 5 are how 'find krause' surfaces KM
+// (publisher=Krause Publications) and 'find yeoman' surfaces Y (author=
+// Richard Sperry Yeoman). Tier 5 is intentionally last so a query that
+// matches a canonical code or title still wins over a query that only
+// matches deep metadata.
+func scoreCatalogue(rec catalogueRecord, qNorm string) int {
+	if qNorm == "" {
+		return 0
+	}
+	codeNorm := normalizeCatalogueQuery(rec.Code)
+	titleNorm := normalizeCatalogueQuery(rec.Title)
+	authorNorm := normalizeCatalogueQuery(rec.Author)
+	publisherNorm := normalizeCatalogueQuery(rec.Publisher)
+
+	if codeNorm == qNorm {
+		return 5000
+	}
+	if titleNorm == qNorm {
+		return 4500
+	}
+	if strings.HasPrefix(codeNorm, qNorm) {
+		return 3000 - len(rec.Code)
+	}
+	for _, tok := range strings.Fields(titleNorm) {
+		if strings.HasPrefix(tok, qNorm) {
+			return 2000 - len(rec.Title)
+		}
+	}
+	if strings.Contains(codeNorm, qNorm) ||
+		strings.Contains(titleNorm, qNorm) ||
+		strings.Contains(authorNorm, qNorm) ||
+		strings.Contains(publisherNorm, qNorm) {
+		return 1000 + len(qNorm) - len(rec.Title)/10
+	}
+	return 0
+}
+
+// fuzzyFindCatalogues returns the top n records ranked by scoreCatalogue.
+// Query normalized once; ties break on alphabetical code (then id) so
+// repeated calls return stable rankings — important for tests and for
+// agent prompts that depend on the top hit.
+func fuzzyFindCatalogues(records []catalogueRecord, query string, n int) []catalogueRecord {
+	if n <= 0 {
+		n = 5
+	}
+	qNorm := normalizeCatalogueQuery(query)
+	if qNorm == "" {
+		return nil
+	}
+	type scored struct {
+		rec catalogueRecord
+		s   int
+	}
+	pool := make([]scored, 0, len(records))
+	for _, rec := range records {
+		if s := scoreCatalogue(rec, qNorm); s > 0 {
+			pool = append(pool, scored{rec: rec, s: s})
+		}
+	}
+	// Tiebreak ordering, applied in this priority when scores collide:
+	//   1. Lower numista id wins — Numista assigns ids in roughly canonical
+	//      order (id=3 is KM, id=9 is Y, id=24 is Schön). For a query like
+	//      'krause' where KM (id=3) and Baker (id=2375) both score in the
+	//      publisher-substring tier, the canonical world-coin reference is
+	//      what the agent wants.
+	//   2. Alphabetical by code, as a stable fallback for deterministic
+	//      tests when ids are unavailable (shouldn't happen in practice).
+	sort.SliceStable(pool, func(i, j int) bool {
+		if pool[i].s != pool[j].s {
+			return pool[i].s > pool[j].s
+		}
+		if pool[i].rec.ID != pool[j].rec.ID {
+			return pool[i].rec.ID < pool[j].rec.ID
+		}
+		return pool[i].rec.Code < pool[j].rec.Code
+	})
+	if len(pool) > n {
+		pool = pool[:n]
+	}
+	out := make([]catalogueRecord, len(pool))
+	for i, p := range pool {
+		out[i] = p.rec
+	}
+	return out
+}
+
+// newCataloguesFindCmd returns the local-only fuzzy-match command.
+//
+// Output discipline mirrors 'issuers find': machine modes get JSON, terminal
+// mode gets a column-aligned table, and the warm-the-cache hint never lands
+// on stdout in machine modes so 'find pcgs --json | jq' stays clean for
+// agents.
+func newCataloguesFindCmd(flags *rootFlags) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "find <query>",
+		Short: "Fuzzy-match a reference catalogue by code, title, author, or publisher (no API call).",
+		Long: "Find a Numista reference catalogue id by fuzzy-matching against the local cache.\n" +
+			"Returns id, code, title, and author-or-publisher for the top matches.\n" +
+			"\n" +
+			"Local only. Never spends a quota call. Run 'numista-pp-cli catalogues' first\n" +
+			"to populate the cache (one API call) if it is empty.\n" +
+			"\n" +
+			"Use the returned id with 'types search --catalogue <id> --number <ref>' to do\n" +
+			"a direct cross-walk from a third-party catalogue reference (e.g. PCGSNo, KM#) to\n" +
+			"a Numista N#.\n" +
+			"\n" +
+			"Examples:\n" +
+			"  numista-pp-cli catalogues find pcgs            # → id=1856 (PCGS CoinFacts)\n" +
+			"  numista-pp-cli catalogues find krause          # → id=3 (KM, Standard Catalog of World Coins)\n" +
+			"  numista-pp-cli catalogues find yeoman --limit 10\n",
+		Args:        cobra.MinimumNArgs(1),
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			records, err := loadCataloguesFromCache()
+			if err != nil {
+				return apiErr(err)
+			}
+			if len(records) == 0 {
+				return usageErr(fmt.Errorf(
+					"local catalogues cache is empty. Run 'numista-pp-cli catalogues' to populate it (one API call), " +
+						"then re-run 'catalogues find'"))
+			}
+			matches := fuzzyFindCatalogues(records, query, limit)
+			return renderCataloguesFind(cmd, flags, matches)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 5, "Maximum number of matches to return")
+	return cmd
+}
+
+// renderCataloguesFind picks the output shape from rootFlags. JSON when any
+// machine-format flag is set OR stdout isn't a TTY; otherwise a compact
+// human table. Matches the gating used by 'issuers find' and every other
+// read command in this CLI.
+func renderCataloguesFind(cmd *cobra.Command, flags *rootFlags, matches []catalogueRecord) error {
+	out := cmd.OutOrStdout()
+	asJSON := flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain)
+	if flags.csv {
+		w := csv.NewWriter(out)
+		_ = w.Write([]string{"id", "code", "title", "author", "publisher"})
+		for _, m := range matches {
+			_ = w.Write([]string{fmt.Sprintf("%d", m.ID), m.Code, m.Title, m.Author, m.Publisher})
+		}
+		w.Flush()
+		return w.Error()
+	}
+	if asJSON {
+		items := make([]map[string]any, len(matches))
+		for i, m := range matches {
+			items[i] = map[string]any{
+				"id":        m.ID,
+				"code":      m.Code,
+				"title":     m.Title,
+				"author":    m.Author,
+				"publisher": m.Publisher,
+			}
+		}
+		// Wrap with the standard {meta, results} envelope so --select and
+		// downstream parsers behave identically to other read commands.
+		envelope := map[string]any{
+			"meta":    map[string]any{"source": "local", "resource_type": "catalogues"},
+			"results": items,
+		}
+		return json.NewEncoder(out).Encode(envelope)
+	}
+	if len(matches) == 0 {
+		fmt.Fprintln(os.Stderr, "no matches.")
+		return nil
+	}
+	tw := newTabWriter(out)
+	fmt.Fprintln(tw, "ID\tCODE\tTITLE\tAUTHOR/PUBLISHER")
+	for _, m := range matches {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", m.ID, m.Code, m.Title, m.extra())
+	}
+	return tw.Flush()
+}
+
+// attachCatalogueAmendments wires the hand-written 'find' subcommand onto
+// the generated 'catalogues' parent. Called from root.go AFTER
+// newCataloguesPromotedCmd has been added to rootCmd. Walking the command
+// tree (rather than editing promoted_catalogues.go directly) keeps the
+// generator's DO NOT EDIT contract intact and preserves the existing
+// zero-arg 'catalogues' invocation as a shortcut for 'catalogues get'.
+func attachCatalogueAmendments(rootCmd *cobra.Command, flags *rootFlags) {
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "catalogues" {
+			c.AddCommand(newCataloguesFindCmd(flags))
+			return
+		}
+	}
+}

--- a/library/other/numista/internal/cli/catalogues_amend.go
+++ b/library/other/numista/internal/cli/catalogues_amend.go
@@ -353,7 +353,12 @@ func newCataloguesFindCmd(flags *rootFlags) *cobra.Command {
 				return apiErr(err)
 			}
 			if len(records) == 0 {
-				return usageErr(fmt.Errorf(
+				// apiErr (exit 5) rather than usageErr (exit 2): empty cache
+				// is a precondition-not-met / data-state error, not a wrong-
+				// flag error — usageErr is conventionally reserved for the
+				// latter. Same fix applied to issuers find in PR #684 after
+				// Greptile P2 review.
+				return apiErr(fmt.Errorf(
 					"local catalogues cache is empty. Run 'numista-pp-cli catalogues' to populate it (one API call), " +
 						"then re-run 'catalogues find'"))
 			}
@@ -371,7 +376,6 @@ func newCataloguesFindCmd(flags *rootFlags) *cobra.Command {
 // read command in this CLI.
 func renderCataloguesFind(cmd *cobra.Command, flags *rootFlags, matches []catalogueRecord) error {
 	out := cmd.OutOrStdout()
-	asJSON := flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain)
 	if flags.csv {
 		w := csv.NewWriter(out)
 		_ = w.Write([]string{"id", "code", "title", "author", "publisher"})
@@ -381,7 +385,12 @@ func renderCataloguesFind(cmd *cobra.Command, flags *rootFlags, matches []catalo
 		w.Flush()
 		return w.Error()
 	}
-	if asJSON {
+	// Route JSON through the standard output pipeline so --select and
+	// --compact behave identically to every other read command. Previously
+	// wrote the envelope directly via json.NewEncoder, which silently
+	// bypassed filterFields / compactFields — same fix applied to issuers
+	// find in PR #684 after Greptile P2 review.
+	if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
 		items := make([]map[string]any, len(matches))
 		for i, m := range matches {
 			items[i] = map[string]any{
@@ -392,13 +401,20 @@ func renderCataloguesFind(cmd *cobra.Command, flags *rootFlags, matches []catalo
 				"publisher": m.Publisher,
 			}
 		}
-		// Wrap with the standard {meta, results} envelope so --select and
-		// downstream parsers behave identically to other read commands.
 		envelope := map[string]any{
 			"meta":    map[string]any{"source": "local", "resource_type": "catalogues"},
 			"results": items,
 		}
-		return json.NewEncoder(out).Encode(envelope)
+		data, err := json.Marshal(envelope)
+		if err != nil {
+			return fmt.Errorf("marshal catalogues find envelope: %w", err)
+		}
+		if flags.selectFields != "" {
+			data = filterFields(data, flags.selectFields)
+		} else if flags.compact {
+			data = compactFields(data)
+		}
+		return printOutput(out, data, true)
 	}
 	if len(matches) == 0 {
 		// Use cmd.ErrOrStderr() not os.Stderr — every other diagnostic in

--- a/library/other/numista/internal/cli/catalogues_amend_test.go
+++ b/library/other/numista/internal/cli/catalogues_amend_test.go
@@ -70,7 +70,7 @@ func TestFuzzyFindCatalogues(t *testing.T) {
 		{"yeoman locks to id=9 Y (author substring, shortest title wins)", "yeoman", 5, 9, false},
 		{"KM exact code locks to id=3", "KM", 5, 3, false},
 		{"Schön locks to id=24 (exact code match)", "Schön", 5, 24, false},
-		{"schon normalized still locks to id=24 (substring)", "schon", 5, 24, false},
+		{"schon normalized still locks to id=24 (exact code after diacritic fold)", "schon", 5, 24, false},
 		{"empty query returns nil", "", 5, 0, true},
 		{"limit zero falls back to default", "krause", 0, 3, false},
 	}

--- a/library/other/numista/internal/cli/catalogues_amend_test.go
+++ b/library/other/numista/internal/cli/catalogues_amend_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 vinny-pasceri. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+)
+
+// testCatalogues mirrors the rows that matter for the find surface, taken
+// verbatim from a 2026-05-18 snapshot of Vinny's local Numista cache
+// (3,106 rows total). The fixture is deliberately small — just the rows
+// the test cases assert on plus a handful of decoys that exercise tier
+// boundaries (e.g. another author named Yeoman, another Krause-published
+// catalogue). Adding more rows is fine; removing one will tighten the
+// assertions because the tiebreak order matters when scores collide.
+var testCatalogues = []catalogueRecord{
+	// Exact-code test target: 'find KM' must lock to id=3.
+	{ID: 3, Code: "KM", Title: "Standard Catalog of World Coins",
+		Author: "Chester Lee Krause, Clifford Mishler, Colin R. Bruce",
+		Publisher: "Krause Publications"},
+	// Code-prefix tiebreaker decoys: same publisher, different code shapes.
+	{ID: 3144, Code: "Curto", Title: "Military Tokens of the United States",
+		Author: "James J. Curto", Publisher: "Krause Publications"},
+	{ID: 1844, Code: "Bruce", Title: "The Standard Guide to South Asian Coins and Paper Money Since 1556 AD",
+		Author: "Colin R. Bruce", Publisher: "Krause Publications"},
+	// Title-prefix and author-substring target: 'find yeoman' must lock
+	// to id=9 (author match on a canonical reference) before id=925
+	// (Yeoman as a co-author on a longer-titled work).
+	{ID: 9, Code: "Y", Title: "R. S. Yeoman's Modern & Current World Coins",
+		Author: "Richard Sperry Yeoman, Neil Shafer, Holland Wallace",
+		Publisher: "Whitman Publishing"},
+	{ID: 925, Code: "Raymond", Title: "The Silver Dollars of North and South America",
+		Author: "Wayte Raymond, Imre Molnar, Richard Sperry Yeoman",
+		Publisher: "Whitman Publishing"},
+	{ID: 1556, Code: "Y US", Title: "A Guide Book of United States Coins",
+		Author: "Richard Sperry Yeoman, Kenneth Edward Bressett",
+		Publisher: "Whitman Publishing"},
+	// Diacritic-bearing target: 'find Schön' (or 'find schon' after
+	// normalization) must lock to id=24. Title is in German; the author
+	// surname carries the diacritic and the query is the canonical lookup.
+	{ID: 24, Code: "Schön", Title: "Weltmünzkatalog",
+		Author: "Gerhard Schön, Sebastian Krämer",
+		Publisher: "Battenberg Gietl Verlag"},
+	// Exact-code target for 'find pcgs' — the cross-walk anchor that
+	// closes pp-numista/AGENTS.md Priority 4.
+	{ID: 1856, Code: "PCGS", Title: "PCGS CoinFacts",
+		Author: "", Publisher: "Professional Coin Grading Services"},
+	// Decoy that contains "krause" in publisher to confirm the publisher-
+	// substring tier doesn't dethrone the canonical KM (id=3) match.
+	{ID: 2375, Code: "Baker", Title: "Medallic Portraits of Washington",
+		Author: "William Spohn Baker", Publisher: "Krause Publications"},
+}
+
+// TestFuzzyFindCatalogues asserts the top hit for each canonical query
+// matches AGENTS.md's expected mapping. The full ranking matters less than
+// the top result — agents pipe the first row into 'types search --catalogue
+// <id>' for the definitive cross-walk.
+func TestFuzzyFindCatalogues(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		query     string
+		limit     int
+		wantTopID int
+		wantEmpty bool
+	}{
+		{"pcgs locks to id=1856 (exact code)", "pcgs", 5, 1856, false},
+		{"PCGS uppercase locks to id=1856 (exact code, case-insensitive)", "PCGS", 5, 1856, false},
+		{"krause locks to id=3 KM (publisher substring + alpha tiebreak)", "krause", 5, 3, false},
+		{"yeoman locks to id=9 Y (author substring, shortest title wins)", "yeoman", 5, 9, false},
+		{"KM exact code locks to id=3", "KM", 5, 3, false},
+		{"Schön locks to id=24 (exact code match)", "Schön", 5, 24, false},
+		{"schon normalized still locks to id=24 (substring)", "schon", 5, 24, false},
+		{"empty query returns nil", "", 5, 0, true},
+		{"limit zero falls back to default", "krause", 0, 3, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fuzzyFindCatalogues(testCatalogues, tc.query, tc.limit)
+			if tc.wantEmpty {
+				if len(got) != 0 {
+					t.Fatalf("expected empty result, got %d matches: %+v", len(got), got)
+				}
+				return
+			}
+			if len(got) == 0 {
+				t.Fatalf("expected at least one match for %q, got none", tc.query)
+			}
+			if got[0].ID != tc.wantTopID {
+				t.Errorf("top match for %q: got id=%d (code=%s, title=%s), want id=%d",
+					tc.query, got[0].ID, got[0].Code, got[0].Title, tc.wantTopID)
+			}
+		})
+	}
+}
+
+// TestFuzzyFindCataloguesLimit verifies the limit flag caps the returned
+// slice. When the query has more matches than the limit, the function must
+// return exactly limit rows, ranked best-first.
+func TestFuzzyFindCataloguesLimit(t *testing.T) {
+	t.Parallel()
+	// "krause" matches id=3, id=3144, id=1844, id=2375 (publisher) — 4 rows.
+	matches := fuzzyFindCatalogues(testCatalogues, "krause", 2)
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches with limit=2, got %d", len(matches))
+	}
+	if matches[0].ID != 3 {
+		t.Errorf("top match for krause limit=2: got id=%d, want id=3", matches[0].ID)
+	}
+}
+
+// TestScoreCatalogueTiers covers the boundary between scoring tiers. Each
+// tier must outrank the one below it, regardless of the magnitudes within
+// a tier — the test fails if a future scoring tweak inverts a tier
+// boundary (e.g. a long-title prefix beating an exact-code match).
+func TestScoreCatalogueTiers(t *testing.T) {
+	t.Parallel()
+	exactCode := catalogueRecord{ID: 1, Code: "PCGS", Title: "PCGS CoinFacts"}
+	exactTitle := catalogueRecord{ID: 2, Code: "X", Title: "pcgs"}
+	codePrefix := catalogueRecord{ID: 3, Code: "PCGSExtra", Title: "Something"}
+	titleWordPrefix := catalogueRecord{ID: 4, Code: "Z", Title: "PCGSExtended Reference"}
+	substring := catalogueRecord{ID: 5, Code: "Q", Title: "Modern References including PCGS data"}
+	noMatch := catalogueRecord{ID: 6, Code: "Foo", Title: "Bar"}
+
+	q := normalizeCatalogueQuery("pcgs")
+	scores := []struct {
+		name string
+		rec  catalogueRecord
+	}{
+		{"exact code", exactCode},
+		{"exact title", exactTitle},
+		{"code prefix", codePrefix},
+		{"title word prefix", titleWordPrefix},
+		{"substring", substring},
+		{"no match", noMatch},
+	}
+	prev := 1 << 30
+	for _, s := range scores {
+		got := scoreCatalogue(s.rec, q)
+		if got >= prev {
+			t.Errorf("tier %q scored %d, expected strictly less than previous tier (%d)",
+				s.name, got, prev)
+		}
+		prev = got
+	}
+	if prev != 0 {
+		t.Errorf("no-match tier scored %d, expected 0", prev)
+	}
+}
+
+// TestLoadCataloguesFromCacheMissing exercises the empty-cache contract:
+// when the on-disk store can't be opened (no file, wrong permissions,
+// schema mismatch), loadCataloguesFromCache returns (nil, nil) so the
+// caller can render the warm-the-cache message rather than erroring.
+// Setting a bogus HOME isolates the test from the developer's real
+// ~/.local/share/numista-pp-cli/data.db.
+func TestLoadCataloguesFromCacheMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	got, err := loadCataloguesFromCache()
+	if err != nil {
+		t.Fatalf("expected nil error on missing cache, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil slice on missing cache, got %d records", len(got))
+	}
+}
+
+// TestIntFromAny covers the JSON-numeric coercion contract. encoding/json
+// decodes numeric values as float64 through the generic map[string]any
+// path — the function must coerce that back to int, plus handle the
+// pre-existing int/int64/json.Number/string-of-digits edge cases the
+// loader may encounter as the schema evolves.
+func TestIntFromAny(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   any
+		want int
+		ok   bool
+	}{
+		{"float64 (json default)", float64(1856), 1856, true},
+		{"int", 1856, 1856, true},
+		{"int64", int64(1856), 1856, true},
+		{"string of digits", "1856", 1856, true},
+		{"empty string", "", 0, false},
+		{"nil", nil, 0, false},
+		{"bool", true, 0, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := intFromAny(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ok: got %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Errorf("value: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/library/other/numista/internal/cli/root.go
+++ b/library/other/numista/internal/cli/root.go
@@ -341,6 +341,13 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newUsersPromotedCmd(flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
+	// PATCH(amend-2026-05-18: catalogue-discovery): wire hand-written
+	// 'catalogues find' subcommand AFTER newCataloguesPromotedCmd has added
+	// the generated parent so the attach helper finds it. No-ops cleanly if
+	// a future regeneration removes the 'catalogues' command, so this is
+	// safe across generator versions.
+	attachCatalogueAmendments(rootCmd, flags)
+
 	return rootCmd
 }
 


### PR DESCRIPTION
## Summary

Closes pp-numista/AGENTS.md Priority 4 — the last open backlog item from the 2026-05-18 PCGS inventory enrichment retro. Two related changes:

1. **New `numista-pp-cli catalogues find <query>` subcommand** — local-only fuzzy search against the cached Numista reference catalogues (3,106 rows). Mirrors the `issuers find` pattern from PR #684.
2. **SKILL.md cookbook entry** — "If your input is a PCGS cert" — documents the direct PCGSNo → N# cross-walk via Numista catalogue id 1856 (PCGS CoinFacts).

## Why

The cookbook entry corrects a factual error I introduced during the AGENTS.md review in `pp-numista`. I had claimed PCGS was not one of Numista's reference catalogues based on a swagger-spec check, but the spec only describes the `/catalogues` endpoint shape, not the catalogue data itself. The actual catalogue data registers PCGS at id `1856`, code `PCGS`, title "PCGS CoinFacts", and the direct cross-walk works:

| PCGSNo | Numista cross-walk | Result |
|---|---|---|
| 7130 | `types search --catalogue 1856 --number 7130` | N#1492 "Morgan Dollar" (matches AGENTS.md's canonical mapping) |
| 7787 | `types search --catalogue 1856 --number 7787` | N#13432 "Coronet Head Quarter Eagle" |

The new `catalogues find` subcommand lets agents verify catalogue IDs locally without spending quota — `numista-pp-cli catalogues find pcgs` returns `id=1856` as the top hit, sourced from the local cache.

## Relationship to other open PRs

- **PR #684** contains an earlier draft of this same cookbook entry that says PCGS is *not* catalogued. This PR's text supersedes it. Reviewer can merge this after #684 and resolve the conflict in favor of this content, or drop the cookbook diff from #684 before merging.
- **PR #687** (pcgs-pp-cli reciprocal cookbook) was fixed in parallel with the same corrections (commit `e74ef141` on that branch).
- **PR #685** (numista quota stdout/stderr discipline) is independent of this PR.

## Implementation details

`catalogues_amend.go` follows the `issuers_amend.go` pattern from PR #684:

- `loadCataloguesFromCache()` reads `store.List("catalogues", limit)`. Returns `(nil, nil)` on empty cache so callers render a warm-the-cache message instead of auto-fetching — a typo on the error path must not silently spend a quota call.
- `scoreCatalogue()` ranks by exact-code → exact-title → code-prefix → title-word-prefix → substring (in code, title, author, or publisher), with alphabetical-code tiebreak for stable ordering.
- `fuzzyFindCatalogues()` returns top N (default 5).
- `attachCatalogueAmendments()` wires the `find` subcommand to the generated `catalogues` parent, no-oping cleanly if a future regeneration removes the parent.

The SKILL.md entry uses `--date` (Gregorian) for the year PCGS returns in the text-search fallback, not `--year` — Numista's `--year` is "as written on the item" (relevant for Hijri / Republican / other non-Gregorian dating on world coins; for US coins they coincide).

## Verification

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS |
| `TestFuzzyFindCatalogues` (9 sub-tests, incl. `pcgs_locks_to_id=1856`) | PASS |
| `printing-press publish validate` (11 checks) | PASS |
| Live: `catalogues find pcgs --agent` | id=1856 top hit, source=local (no API call) |
| Live: `types search --catalogue 1856 --number 7130 --agent` | N#1492 |

## Test plan

- [ ] `numista-pp-cli catalogues find pcgs` returns id=1856 as the top hit
- [ ] `numista-pp-cli catalogues find krause` returns id=3 (KM) as the top hit
- [ ] `numista-pp-cli catalogues find KM` exact-code match locks to id=3
- [ ] `numista-pp-cli catalogues find <anything>` against an empty cache prints "run `numista-pp-cli catalogues` to populate the cache" and exits non-zero
- [ ] `numista-pp-cli types search --catalogue 1856 --number 7130` returns N#1492 (live)
- [ ] SKILL.md "If your input is a PCGS cert" section renders intelligibly to an agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)