### PR TITLE
docs(surgegraph): reposition opener as AEO platform

### DIFF
--- a/library/ai/surgegraph/.goreleaser.yaml
+++ b/library/ai/surgegraph/.goreleaser.yaml
@@ -45,7 +45,7 @@ brews:
       owner: surgegraph
       name: homebrew-tap
     homepage: "https://github.com/mvanhorn/printing-press-library"
-    description: "Every SurgeGraph workflow — research, write, publish, monitor — from the terminal or any agent, with a local..."
+    description: "SurgeGraph is the Answer Engine Optimization (AEO) platform that tracks AI citations, scores pages for citation readiness, and one-click fixes the gaps — now every workflow runs from the terminal or any agent."
     install: |
       bin.install "surgegraph-pp-cli"
       bin.install "surgegraph-pp-mcp"

--- a/library/ai/surgegraph/README.md
+++ b/library/ai/surgegraph/README.md
@@ -1,6 +1,6 @@
 # SurgeGraph CLI
 
-**Every SurgeGraph workflow — research, write, publish, monitor — from the terminal or any agent, with a local SQLite that compounds week-over-week deltas the web app can't produce.**
+**SurgeGraph is the Answer Engine Optimization (AEO) platform that tracks AI citations, scores pages for citation readiness, and one-click fixes the gaps — now every workflow runs from the terminal or any agent.**
 
 SurgeGraph is an AI-search content operations cockpit. The web app shows point-in-time snapshots; this CLI keeps a local cache so you can run `visibility delta`, `prompts losers`, and `citation-domains rank-shift` over time. It compounds three split workflows — topic research, bulk writing, WordPress publishing — into a single `research gaps publish` pipeline, and ships every command as both CLI and MCP so the same agent that drafts an article can monitor the citations it generates.
 

--- a/library/ai/surgegraph/SKILL.md
+++ b/library/ai/surgegraph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-surgegraph
-description: "Every SurgeGraph workflow — research, write, publish, monitor — from the terminal or any agent, with a local... Trigger phrases: `what changed in SurgeGraph this week`, `AI Visibility for my project`, `which prompts lost AI citations`, `publish gap articles from a topic research`, `what knowledge libraries actually show up in citations`, `use surgegraph`, `run surgegraph`."
+description: "SurgeGraph is the Answer Engine Optimization (AEO) platform that tracks AI citations, scores pages for citation readiness, and one-click fixes the gaps — now every workflow runs from the terminal or any agent. Trigger phrases: `what changed in SurgeGraph this week`, `AI Visibility for my project`, `which prompts lost AI citations`, `publish gap articles from a topic research`, `what knowledge libraries actually show up in citations`, `use surgegraph`, `run surgegraph`."
 author: "SurgeGraph Team"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"


### PR DESCRIPTION
## Summary

- Reposition the SurgeGraph CLI opener as an **Answer Engine Optimization (AEO) platform** in three user-visible surfaces (README, SKILL.md frontmatter, homebrew tap one-liner). Markdown-only; no Go source or behavior change.

## Published CLI Metadata

**API:** `surgegraph` | **Category:** `ai` | **Press version:** `4.5.0`
**Spec:** `library/ai/surgegraph/spec.json` (openapi3, `sha256:7404117f6fe1c310e7c89b640be94157783ba4e1ccd1c1ac0467ca211abd02ff`)
**Required env:** `SURGEGRAPH_TOKEN` (OAuth 2.1 bearer; populated via `surgegraph-pp-cli auth login --browser`)

## What Changed

- `library/ai/surgegraph/README.md` — replaced the bold first-paragraph opener.
- `library/ai/surgegraph/SKILL.md` — replaced the frontmatter `description:` lead sentence (trigger phrases preserved).
- `library/ai/surgegraph/.goreleaser.yaml` — replaced the `brews.description` homebrew one-liner.

New copy (verbatim, applied to all three):

> SurgeGraph is the Answer Engine Optimization (AEO) platform that tracks AI citations, scores pages for citation readiness, and one-click fixes the gaps — now every workflow runs from the terminal or any agent.

## CLI Shape

```bash
$ surgegraph-pp-cli --help
SurgeGraph CLI — Every SurgeGraph workflow — research, write, publish, monitor — from the terminal or any agent, with a local SQLite tha…

Highlights (not in the official API docs):
  • visibility delta                       AI Visibility week-over-week diff
  • visibility prompts losers              Tracked prompts whose citation count or rank dropped
  • visibility citation-domains rank-shift Domains gaining/losing citation share over 30d
  • knowledge impact                       Rank knowledge libraries by citation appearance
  • research drift                         Topic-research map vs shipped writer_documents
  • research gaps publish                  Bulk-create + queue gap articles to WordPress
  • docs stale                             Writer/optimized docs unrefreshed in N days
  • research domain diff                   Competitor topic-tree set-diff vs your own
  • visibility portfolio                   Org-wide AI Visibility deltas
  • account burn                           Credit-exhaustion forecast
  • visibility traffic-citations           Tracked prompts that resolve to top-traffic pages
  • context bundle                         Agent-context JSON payload
  • search                                 Full-text search over local cache
  • sync diff                              Per-resource sync cursors + row counts

Agent mode: add --agent to any command for JSON output + non-interactive mode.
Health check: run 'surgegraph-pp-cli doctor' to verify auth and connectivity.

Usage:
  surgegraph-pp-cli [command]
```

(Header line of the `--help` output reflects the pre-change README opener; it's templated from `.printing-press.json:description` at generate time, not from README.md, and is intentionally not refreshed in this PR.)

## What This CLI Does

SurgeGraph is the Answer Engine Optimization (AEO) platform that tracks AI citations, scores pages for citation readiness, and one-click fixes the gaps — now every workflow runs from the terminal or any agent.

SurgeGraph is an AI-search content operations cockpit. The web app shows point-in-time snapshots; this CLI keeps a local cache so you can run `visibility delta`, `prompts losers`, and `citation-domains rank-shift` over time. It compounds three split workflows — topic research, bulk writing, WordPress publishing — into a single `research gaps publish` pipeline, and ships every command as both CLI and MCP so the same agent that drafts an article can monitor the citations it generates.

## Manuscripts

- [Research Brief](./library/ai/surgegraph/.manuscripts/20260512-171718/research/)
- [Shipcheck Results](./library/ai/surgegraph/.manuscripts/20260512-171718/proofs/)

## Validation

- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/ai/surgegraph/` — all checks passed
- [x] `go build ./...` from `library/ai/surgegraph/` — clean
- [x] `go vet ./...` from `library/ai/surgegraph/` — clean
- [x] `go test ./...` from `library/ai/surgegraph/` — all packages pass
- [x] `govulncheck ./...` from `library/ai/surgegraph/` — no vulnerabilities found
- [ ] `go run ./tools/generate-skills/main.go` — intentionally skipped; `cli-skills/pp-surgegraph/SKILL.md` is regenerated post-merge by `generate-skills.yml`, and `verify-library-conventions.yml` fails PRs that include it
- [x] `git diff --check` — clean

## Gaps / Follow-Up

- **`registry.json` description requires a maintainer push to `main`.** `verify-library-conventions.yml` strips/fails PRs that touch `registry.json`, and the generator preserves the prior `description` field as curated copy across regens (see `tools/generate-registry/main.go:311-317`). Refreshing the printingpress.dev card description follows the same pattern as commit `2fc12816` for `table-reservation-goat`: a one-line maintainer push to `main` updating the `surgegraph` entry's `"description"` to the new AEO copy above.
- The `--help` header is templated from `.printing-press.json:description` at generate time and still reflects the prior opener. Refreshing it is an upstream-generator concern (`cli-printing-press`), not a published-library hand-edit, so it's deliberately left for the next reprint.