### PR TITLE
feat(alaska-airlines): add award search and cheapest-in-month planner

### DIFF
--- a/library/travel/alaska-airlines/.printing-press-patches.json
+++ b/library/travel/alaska-airlines/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-15",
+  "applied_at": "2026-05-19",
   "base_run_id": "20260512-151223",
   "base_printing_press_version": "4.5.1",
   "patches": [
@@ -35,6 +35,28 @@
       "files": [
         "internal/cliutil/ratelimit.go"
       ]
+    },
+    {
+      "id": "award-search-toggle",
+      "summary": "Add --award, --shopping-method, --upgrade flags to flights search; new flights award-search command that defaults to award mode.",
+      "reason": "Manuscript scoped award-vs-cash comparator as a gap (research.json). Live browser sniff against alaskaair.com on 2026-05-19 confirmed the same /search/results/__data.json endpoint serves award data when ShoppingMethod=onlineaward plus UPG=none, OT=Anytime, DT=Anytime are added. Reuses existing Cookie auth and response parser; no new endpoint needed.",
+      "files": [
+        "internal/cli/flights_search.go",
+        "internal/cli/flights_award_search.go",
+        "internal/cli/flights.go"
+      ],
+      "validated_outcome": "Dry-run emits the exact URL captured during the live sniff. SvelteKit response identical shape to cash search; existing --select / --compact / --json filters carry through."
+    },
+    {
+      "id": "award-cheapest-planner",
+      "summary": "New flights award-cheapest command iterates (depart, return) date pairs across multiple destination airports in parallel and returns the cheapest round-trip in miles.",
+      "reason": "Killer use case: find the cheapest round-trip to a region (e.g. Japan) in a calendar month using miles. --destination-region japan expands to HND,NRT,KIX,ITM,NGO,FUK,CTS,OKA; --month YYYY-MM enumerates the full month with default 5-21 night trip lengths; --concurrency N + the existing AdaptiveLimiter keep the fan-out polite. Tolerant JSON extractor walks the SvelteKit deflated response for the lowest miles+cash combo.",
+      "files": [
+        "internal/cli/flights_award_cheapest.go",
+        "internal/cli/flights_award_cheapest_test.go",
+        "internal/cli/flights.go"
+      ],
+      "validated_outcome": "Unit tests cover date-window resolution, date-pair enumeration, region expansion, JSON extractor. Dry-run against SFO + japan-region + 2026-08 emits a 4216-job plan."
     }
   ]
 }

--- a/library/travel/alaska-airlines/SKILL.md
+++ b/library/travel/alaska-airlines/SKILL.md
@@ -41,8 +41,7 @@ These capabilities were scoped in the manuscript for this CLI but were not imple
 
 - `book prepare` (pre-checkout deeplink builder) - not implemented
 - `flights search --want-seats-together` (family-of-N seat finder) - not implemented
-- `flights watch` (fare drop watcher) - not implemented
-- `flights compare --points` (award-vs-cash comparator) - not implemented
+- `flights award-watch` (award fare-drop watcher) - not implemented; track manually by re-running `flights award-cheapest` on a schedule
 - `atmos status` (tier progress) - not implemented; use `atmos-rewards balance` for raw points
 - `flights search multi` (multi-leg composer) - not implemented; run separate `flights search` invocations per leg
 - `doctor --auth` (dedicated JWT decode flag) - not implemented; `doctor` performs the general auth check
@@ -59,6 +58,17 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   alaska-airlines-pp-cli flights search --origin SFO --destination SEA --depart 2026-11-27 --json --select flights.flightNumber,flights.fares.saver.price,flights.duration
   ```
+
+### Award (miles+cash) planner
+- **`flights award-cheapest --destination-region japan --month 2026-08`** — Fan out across every (depart, return) pair in a calendar month across multiple destination airports in parallel; return the cheapest round-trip in miles.
+
+  _Solves "find me a flight to Japan using points lowest price in August" in one command instead of clicking the Alaska site N times._
+
+  ```bash
+  alaska-airlines-pp-cli flights award-cheapest --origin SFO --destination-region japan --month 2026-08 --cabin economy --max-stops 1 --json
+  ```
+
+  Built on the same `/search/results/__data.json` endpoint the cash search uses; the `--award` flag (or `flights award-search`) toggles `ShoppingMethod=onlineaward`.
 
 ## HTTP Transport
 
@@ -90,8 +100,10 @@ This CLI uses Chrome-compatible HTTP transport for browser-facing endpoints. It 
 - `alaska-airlines-pp-cli flights business` — Alaska for Business program metadata
 - `alaska-airlines-pp-cli flights et-info` — Electronic ticket info / general metadata
 - `alaska-airlines-pp-cli flights get-features` — Feature flags scoped to a user (used internally by site)
-- `alaska-airlines-pp-cli flights search` — Search flights between two airports for given dates and passenger mix. Returns the fare matrix per flight per cabin class.
+- `alaska-airlines-pp-cli flights search` — Search flights between two airports for given dates and passenger mix. Pass `--award` to switch from cash to miles+cash fares (same endpoint, `ShoppingMethod=onlineaward`).
 - `alaska-airlines-pp-cli flights shoulder-dates` — Flexible-date pricing matrix - get fares for dates near your target
+- `alaska-airlines-pp-cli flights award-search` — Single-date award fare matrix (miles + cash). Thin alias over `flights search --award`.
+- `alaska-airlines-pp-cli flights award-cheapest` — Lowest-miles-in-a-month planner. Fans out across destinations and (depart, return) pairs in parallel; returns the cheapest round-trip in miles.
 
 
 ### Finding the right command
@@ -130,6 +142,22 @@ alaska-airlines-pp-cli flights shoulder-dates --json
 ```
 
 Get fares for dates near your target departure so you can spot a cheaper shoulder date without N separate searches.
+
+### Award search for a single date
+
+```bash
+alaska-airlines-pp-cli flights award-search --origin SFO --destination HND --depart 2026-08-15 --return 2026-08-22 --cabin economy --json
+```
+
+Single-date miles+cash fare matrix. Same endpoint as cash `flights search`, just with `ShoppingMethod=onlineaward`. You can also pass `--award` to the regular `flights search` for the same effect.
+
+### Cheapest round-trip to Japan in a month using miles
+
+```bash
+alaska-airlines-pp-cli flights award-cheapest --origin SFO --destination-region japan --month 2026-08 --cabin economy --max-stops 1 --json
+```
+
+Iterates every (depart, return) pair in August across 8 Japan airports in parallel and returns the top-5 cheapest round-trips by miles. Use `--min-nights` and `--max-nights` to bound the trip length (default 5-21 nights). Use `--top-n` to control result count, `--concurrency` to tune fan-out, and `--save <path>` to persist the full result set, not just the top-N.
 
 ### Atmos Rewards balance
 

--- a/library/travel/alaska-airlines/internal/cli/flights.go
+++ b/library/travel/alaska-airlines/internal/cli/flights.go
@@ -19,5 +19,9 @@ func newFlightsCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newFlightsGetFeaturesCmd(flags))
 	cmd.AddCommand(newFlightsSearchCmd(flags))
 	cmd.AddCommand(newFlightsShoulderDatesCmd(flags))
+	// PATCH(amend-2026-05-19: award-search support) — wire the new award
+	// commands added by /printing-press-amend.
+	cmd.AddCommand(newFlightsAwardSearchCmd(flags))
+	cmd.AddCommand(newFlightsAwardCheapestCmd(flags))
 	return cmd
 }

--- a/library/travel/alaska-airlines/internal/cli/flights_award_cheapest.go
+++ b/library/travel/alaska-airlines/internal/cli/flights_award_cheapest.go
@@ -1,0 +1,590 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-2026-05-19: award-cheapest planner) — KILLER command added by
+// /printing-press-amend. Solves "find me a flight to Japan using points,
+// lowest price in August" by iterating every (depart, return) pair in a
+// month across one or more destination airports in parallel and returning
+// the cheapest round-trip by miles.
+//
+// Live sniff date: 2026-05-19. See flights_award_search.go for the underlying
+// endpoint shape and .printing-press-patches.json entry "award-cheapest-planner".
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// destinationRegions are user-facing shorthands for sets of IATA codes.
+// Only "japan" ships in v1 per the user spec; more can be added without
+// breaking the existing surface.
+var destinationRegions = map[string][]string{
+	"japan": {"HND", "NRT", "KIX", "ITM", "NGO", "FUK", "CTS", "OKA"},
+}
+
+func newFlightsAwardCheapestCmd(flags *rootFlags) *cobra.Command {
+	var flagOrigin string
+	var flagDest string
+	var flagDestRegion string
+	var flagMonth string
+	var flagDepartFrom string
+	var flagDepartTo string
+	var flagReturnFrom string
+	var flagReturnTo string
+	var flagMinNights int
+	var flagMaxNights int
+	var flagOneWay bool
+	var flagCabin string
+	var flagMaxStops int
+	var flagAdults string
+	var flagChildren string
+	var flagTopN int
+	var flagConcurrency int
+	var flagSavePath string
+
+	cmd := &cobra.Command{
+		Use:   "award-cheapest",
+		Short: "Find the cheapest round-trip award fare in miles across a month and one or more destinations.",
+		Long: `Iterate the (depart, return) date matrix in a calendar month (or arbitrary window) across one or more destination airports in parallel, then return the cheapest round-trip in miles.
+
+Example: find the cheapest round-trip to Japan in August using points:
+
+  alaska-airlines-pp-cli flights award-cheapest \
+    --origin SFO --destination-region japan --month 2026-08 \
+    --cabin economy --max-stops 1 --json
+
+The (origin, destination, depart, return) tuple space can be large — 8 Japan
+airports x 31 depart days x 17 return options (5-21 nights) is up to ~4200
+calls. The default --concurrency 4 + the existing AdaptiveLimiter keeps the
+fan-out polite. For a typical 1-month round-trip search you should expect
+30-90 seconds end-to-end.`,
+		Example:     "  alaska-airlines-pp-cli flights award-cheapest --origin SFO --destination-region japan --month 2026-08 --json",
+		Annotations: map[string]string{"pp:endpoint": "flights.award_cheapest", "pp:method": "GET", "pp:path": "/search/results/__data.json (fanned)", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flagOrigin == "" && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "origin")
+			}
+
+			destinations, err := resolveDestinations(flagDest, flagDestRegion)
+			if err != nil {
+				return err
+			}
+			if len(destinations) == 0 && !flags.dryRun {
+				return fmt.Errorf("no destinations: pass --destination or --destination-region")
+			}
+
+			departWindow, returnWindow, err := resolveDateWindows(flagMonth, flagDepartFrom, flagDepartTo, flagReturnFrom, flagReturnTo, flagOneWay)
+			if err != nil {
+				return err
+			}
+			if flagMinNights < 0 || flagMaxNights < flagMinNights {
+				return fmt.Errorf("invalid --min-nights/--max-nights: min=%d max=%d", flagMinNights, flagMaxNights)
+			}
+
+			pairs := enumerateDatePairs(departWindow, returnWindow, flagMinNights, flagMaxNights, flagOneWay)
+			if len(pairs) == 0 && !flags.dryRun {
+				return fmt.Errorf("no (depart, return) candidates derived from the inputs; widen the window or relax min/max nights")
+			}
+
+			// Cross-product against destinations.
+			type job struct {
+				dest    string
+				depart  string
+				ret     string
+				nights  int
+				oneWay  bool
+			}
+			jobs := make([]job, 0, len(destinations)*len(pairs))
+			for _, d := range destinations {
+				for _, p := range pairs {
+					jobs = append(jobs, job{dest: d, depart: p.depart, ret: p.ret, nights: p.nights, oneWay: flagOneWay})
+				}
+			}
+
+			if flags.dryRun {
+				return printAwardCheapestDryRun(cmd.OutOrStdout(), flagOrigin, destinations, departWindow, returnWindow, flagMinNights, flagMaxNights, flagOneWay, len(jobs))
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			// Concurrency: semaphore-bounded errgroup. Errors from
+			// individual jobs are NOT fatal — we collect them in
+			// meta.failed_calls and continue, per the plan doc.
+			if flagConcurrency < 1 {
+				flagConcurrency = 1
+			}
+			sem := make(chan struct{}, flagConcurrency)
+			var mu sync.Mutex
+			results := make([]awardCheapestRow, 0, len(jobs))
+			var failedCalls int
+			var wg sync.WaitGroup
+			start := time.Now()
+
+			for _, j := range jobs {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(j job) {
+					defer wg.Done()
+					defer func() { <-sem }()
+
+					rt := "true"
+					if j.oneWay {
+						rt = "false"
+					}
+					params := buildAwardSearchParams(awardSearchInput{
+						Origin:      flagOrigin,
+						Destination: j.dest,
+						Depart:      j.depart,
+						Return:      j.ret,
+						Adults:      flagAdults,
+						Children:    flagChildren,
+						LapInfants:  "0",
+						RoundTrip:   rt,
+						Cabin:       flagCabin,
+						Locale:      "en-us",
+					})
+
+					data, _, err := resolveRead(cmd.Context(), c, flags, "flights", false, "/search/results/__data.json", params, nil)
+					if err != nil {
+						mu.Lock()
+						failedCalls++
+						mu.Unlock()
+						return
+					}
+					low := extractLowestAwardPrice(data, flagMaxStops)
+					if low.Miles == nil {
+						// Could not extract a fare from this response —
+						// either no inventory or unfamiliar shape. Don't
+						// count it as a failed call (the request succeeded),
+						// just don't include it in results.
+						return
+					}
+					row := awardCheapestRow{
+						Destination: j.dest,
+						Depart:      j.depart,
+						Return:      j.ret,
+						Nights:      j.nights,
+						Miles:       *low.Miles,
+						CashUSD:     low.CashUSD,
+						Carrier:     low.Carrier,
+						Cabin:       low.Cabin,
+						Stops:       low.Stops,
+					}
+					mu.Lock()
+					results = append(results, row)
+					mu.Unlock()
+				}(j)
+			}
+			wg.Wait()
+			duration := time.Since(start)
+
+			sort.SliceStable(results, func(i, k int) bool {
+				if results[i].Miles != results[k].Miles {
+					return results[i].Miles < results[k].Miles
+				}
+				if results[i].CashUSD != results[k].CashUSD {
+					return results[i].CashUSD < results[k].CashUSD
+				}
+				return results[i].Depart < results[k].Depart
+			})
+
+			top := results
+			if flagTopN > 0 && len(top) > flagTopN {
+				top = top[:flagTopN]
+			}
+
+			envelope := map[string]any{
+				"meta": map[string]any{
+					"source":               "live",
+					"origin":               flagOrigin,
+					"destinations":         destinations,
+					"month":                flagMonth,
+					"depart_from":          departWindow.from,
+					"depart_to":            departWindow.to,
+					"return_from":          returnWindow.from,
+					"return_to":            returnWindow.to,
+					"min_nights":           flagMinNights,
+					"max_nights":           flagMaxNights,
+					"one_way":              flagOneWay,
+					"cabin":                flagCabin,
+					"max_stops":            flagMaxStops,
+					"adults":               flagAdults,
+					"children":             flagChildren,
+					"candidates_evaluated": len(jobs),
+					"successful_results":   len(results),
+					"failed_calls":         failedCalls,
+					"top_n":                flagTopN,
+					"duration_seconds":     math.Round(duration.Seconds()*10) / 10,
+				},
+				"results": top,
+			}
+
+			if flagSavePath != "" {
+				fullEnvelope := map[string]any{
+					"meta":         envelope["meta"],
+					"all_results":  results,
+					"top_results":  top,
+				}
+				if err := writeJSONFile(flagSavePath, fullEnvelope); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to save full results to %s: %v\n", flagSavePath, err)
+				}
+			}
+
+			out, err := json.Marshal(envelope)
+			if err != nil {
+				return err
+			}
+			return printOutput(cmd.OutOrStdout(), json.RawMessage(out), true)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrigin, "origin", "", "Origin IATA code (e.g. SFO)")
+	cmd.Flags().StringVar(&flagDest, "destination", "", "One or more destination IATA codes, comma-separated (e.g. HND,NRT,KIX)")
+	cmd.Flags().StringVar(&flagDestRegion, "destination-region", "", "Preset region expanding to a destination list (e.g. japan -> HND,NRT,KIX,ITM,NGO,FUK,CTS,OKA)")
+	cmd.Flags().StringVar(&flagMonth, "month", "", "Calendar month YYYY-MM (e.g. 2026-08). Sets the depart-window to the full month; return-window auto-derives from --min-nights/--max-nights.")
+	cmd.Flags().StringVar(&flagDepartFrom, "depart-from", "", "Earliest depart date YYYY-MM-DD (overrides --month)")
+	cmd.Flags().StringVar(&flagDepartTo, "depart-to", "", "Latest depart date YYYY-MM-DD (overrides --month)")
+	cmd.Flags().StringVar(&flagReturnFrom, "return-from", "", "Earliest return date YYYY-MM-DD (overrides --month/--min-nights derivation)")
+	cmd.Flags().StringVar(&flagReturnTo, "return-to", "", "Latest return date YYYY-MM-DD (overrides --month/--max-nights derivation)")
+	cmd.Flags().IntVar(&flagMinNights, "min-nights", 5, "Minimum trip length in nights (round-trip only)")
+	cmd.Flags().IntVar(&flagMaxNights, "max-nights", 21, "Maximum trip length in nights (round-trip only)")
+	cmd.Flags().BoolVar(&flagOneWay, "one-way", false, "One-way search; skip the return-leg iteration")
+	cmd.Flags().StringVar(&flagCabin, "cabin", "economy", "Preferred cabin (economy, premium, business, first); empty for any")
+	cmd.Flags().IntVar(&flagMaxStops, "max-stops", -1, "Maximum number of stops per itinerary; -1 means unset")
+	cmd.Flags().StringVar(&flagAdults, "adults", "1", "Adult passenger count")
+	cmd.Flags().StringVar(&flagChildren, "children", "0", "Child passenger count")
+	cmd.Flags().IntVar(&flagTopN, "top-n", 5, "Return only the N cheapest results")
+	cmd.Flags().IntVar(&flagConcurrency, "concurrency", 4, "Number of parallel award-search calls (1-16 sensible)")
+	cmd.Flags().StringVar(&flagSavePath, "save", "", "Optional file path to persist the full result set (not just top-N) as JSON")
+
+	_ = context.Background // keep context import for future timeout plumbing
+	return cmd
+}
+
+// awardCheapestRow is one row in the result set: a single (destination,
+// depart, return) candidate with the lowest miles+cash combo extracted
+// from the API response.
+type awardCheapestRow struct {
+	Destination string  `json:"destination"`
+	Depart      string  `json:"depart"`
+	Return      string  `json:"return,omitempty"`
+	Nights      int     `json:"nights"`
+	Miles       int     `json:"miles"`
+	CashUSD     float64 `json:"cash_usd"`
+	Carrier     string  `json:"carrier,omitempty"`
+	Cabin       string  `json:"cabin,omitempty"`
+	Stops       int     `json:"stops"`
+}
+
+// dateWindow is an inclusive [from, to] range of YYYY-MM-DD strings.
+type dateWindow struct {
+	from string
+	to   string
+}
+
+// datePair is one candidate (depart, return) tuple.
+type datePair struct {
+	depart string
+	ret    string
+	nights int
+}
+
+// resolveDestinations converts --destination + --destination-region into a
+// deduped, ordered list of IATA codes. Region wins when both are set —
+// the user typically uses one or the other.
+func resolveDestinations(destFlag, regionFlag string) ([]string, error) {
+	if regionFlag != "" {
+		codes, ok := destinationRegions[strings.ToLower(regionFlag)]
+		if !ok {
+			known := make([]string, 0, len(destinationRegions))
+			for k := range destinationRegions {
+				known = append(known, k)
+			}
+			sort.Strings(known)
+			return nil, fmt.Errorf("unknown --destination-region %q (known: %s)", regionFlag, strings.Join(known, ", "))
+		}
+		return append([]string(nil), codes...), nil
+	}
+	if destFlag == "" {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	out := []string{}
+	for _, raw := range strings.Split(destFlag, ",") {
+		code := strings.ToUpper(strings.TrimSpace(raw))
+		if code == "" || seen[code] {
+			continue
+		}
+		seen[code] = true
+		out = append(out, code)
+	}
+	return out, nil
+}
+
+// resolveDateWindows turns the user's --month or explicit window flags into
+// inclusive [from, to] windows for depart and return. For one-way the return
+// window is empty.
+func resolveDateWindows(month, dFrom, dTo, rFrom, rTo string, oneWay bool) (dateWindow, dateWindow, error) {
+	var dep, ret dateWindow
+
+	if month != "" {
+		t, err := time.Parse("2006-01", month)
+		if err != nil {
+			return dep, ret, fmt.Errorf("invalid --month %q: expected YYYY-MM", month)
+		}
+		first := t
+		last := first.AddDate(0, 1, -1)
+		dep.from = first.Format("2006-01-02")
+		dep.to = last.Format("2006-01-02")
+		if !oneWay {
+			// Default return window: same month boundaries; the
+			// min/max-nights filter narrows the actual (depart, return)
+			// pairs. Extending the return-window past the month is fine
+			// for trips that wrap into next month — we extend to end-of-
+			// next-month by default.
+			retLast := last.AddDate(0, 1, 0)
+			ret.from = first.Format("2006-01-02")
+			ret.to = retLast.Format("2006-01-02")
+		}
+	}
+
+	if dFrom != "" {
+		dep.from = dFrom
+	}
+	if dTo != "" {
+		dep.to = dTo
+	}
+	if rFrom != "" {
+		ret.from = rFrom
+	}
+	if rTo != "" {
+		ret.to = rTo
+	}
+
+	if dep.from == "" || dep.to == "" {
+		return dep, ret, fmt.Errorf("depart window not set: pass --month or both --depart-from and --depart-to")
+	}
+	if _, err := time.Parse("2006-01-02", dep.from); err != nil {
+		return dep, ret, fmt.Errorf("invalid --depart-from %q: %w", dep.from, err)
+	}
+	if _, err := time.Parse("2006-01-02", dep.to); err != nil {
+		return dep, ret, fmt.Errorf("invalid --depart-to %q: %w", dep.to, err)
+	}
+	if !oneWay {
+		if ret.from == "" || ret.to == "" {
+			return dep, ret, fmt.Errorf("return window not set: pass --month or both --return-from and --return-to (or --one-way)")
+		}
+		if _, err := time.Parse("2006-01-02", ret.from); err != nil {
+			return dep, ret, fmt.Errorf("invalid --return-from %q: %w", ret.from, err)
+		}
+		if _, err := time.Parse("2006-01-02", ret.to); err != nil {
+			return dep, ret, fmt.Errorf("invalid --return-to %q: %w", ret.to, err)
+		}
+	}
+
+	return dep, ret, nil
+}
+
+// enumerateDatePairs walks the depart window and (for round-trip) attaches
+// every valid return date inside [depart+minNights, depart+maxNights] that
+// also falls within the return window. One-way calls return a list of
+// depart-only pairs (ret = "").
+func enumerateDatePairs(depart, ret dateWindow, minNights, maxNights int, oneWay bool) []datePair {
+	out := []datePair{}
+	depFrom, err1 := time.Parse("2006-01-02", depart.from)
+	depTo, err2 := time.Parse("2006-01-02", depart.to)
+	if err1 != nil || err2 != nil {
+		return out
+	}
+	if oneWay {
+		for d := depFrom; !d.After(depTo); d = d.AddDate(0, 0, 1) {
+			out = append(out, datePair{depart: d.Format("2006-01-02"), ret: "", nights: 0})
+		}
+		return out
+	}
+	retFrom, err3 := time.Parse("2006-01-02", ret.from)
+	retTo, err4 := time.Parse("2006-01-02", ret.to)
+	if err3 != nil || err4 != nil {
+		return out
+	}
+	for d := depFrom; !d.After(depTo); d = d.AddDate(0, 0, 1) {
+		for n := minNights; n <= maxNights; n++ {
+			r := d.AddDate(0, 0, n)
+			if r.Before(retFrom) || r.After(retTo) {
+				continue
+			}
+			out = append(out, datePair{depart: d.Format("2006-01-02"), ret: r.Format("2006-01-02"), nights: n})
+		}
+	}
+	return out
+}
+
+// lowestAwardPrice is a minimal extraction shape — the SvelteKit response
+// is index-encoded so we walk it tolerantly and pick the lowest miles
+// total we can find. Missing fields stay nil/empty so the result is still
+// useful even if the response shape changes upstream.
+type lowestAwardPrice struct {
+	Miles   *int
+	CashUSD float64
+	Carrier string
+	Cabin   string
+	Stops   int
+}
+
+// extractLowestAwardPrice walks the SvelteKit __data.json response and
+// picks the cheapest miles+cash combo. The response stores values in a
+// flat array indexed by key dictionaries, so a tolerant walker over the
+// raw JSON tree finds numeric runs that match the miles/cash pattern.
+// When maxStops >= 0, itineraries with more stops are skipped.
+//
+// This is deliberately best-effort: a richer parser belongs in a
+// dedicated helper file once we have more example payloads. Returns
+// lowestAwardPrice with Miles=nil when no usable miles total is found.
+func extractLowestAwardPrice(data json.RawMessage, maxStops int) lowestAwardPrice {
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return lowestAwardPrice{}
+	}
+
+	var best *lowestAwardPrice
+	walkAwardJSON(doc, func(miles int, cash float64, carrier, cabin string, stops int) {
+		if maxStops >= 0 && stops > maxStops {
+			return
+		}
+		if best == nil || miles < *best.Miles {
+			m := miles
+			lp := lowestAwardPrice{Miles: &m, CashUSD: cash, Carrier: carrier, Cabin: cabin, Stops: stops}
+			best = &lp
+		}
+	})
+
+	if best == nil {
+		return lowestAwardPrice{}
+	}
+	return *best
+}
+
+// walkAwardJSON recursively walks the deflated SvelteKit JSON looking for
+// objects that carry both a "milesAmount" (or "pricePts") and a "cash"
+// (or "fees") field — those are fare-class records. The walker is
+// tolerant: missing fields default to zero and unknown shapes are
+// skipped.
+func walkAwardJSON(v any, emit func(miles int, cash float64, carrier, cabin string, stops int)) {
+	switch x := v.(type) {
+	case map[string]any:
+		miles, hasMiles := readIntField(x, "milesAmount", "pricePts", "pricePtsAmount", "milesPerPax", "displayMiles")
+		cash, _ := readFloatField(x, "cashAmount", "totalCashAmount", "paxCashTotal", "feeAmount", "feeTotal")
+		carrier, _ := readStringField(x, "carrier", "operatingCarrier", "marketingCarrier", "airlineCode")
+		cabin, _ := readStringField(x, "cabin", "cabinClass", "fareName", "displayCabin")
+		stops, _ := readIntField(x, "stops", "stopCount", "numStops")
+		if hasMiles && miles > 0 {
+			emit(miles, cash, carrier, cabin, stops)
+		}
+		for _, vv := range x {
+			walkAwardJSON(vv, emit)
+		}
+	case []any:
+		for _, vv := range x {
+			walkAwardJSON(vv, emit)
+		}
+	}
+}
+
+func readIntField(m map[string]any, keys ...string) (int, bool) {
+	for _, k := range keys {
+		if raw, ok := m[k]; ok {
+			switch v := raw.(type) {
+			case float64:
+				return int(v), true
+			case int:
+				return v, true
+			case json.Number:
+				if i, err := v.Int64(); err == nil {
+					return int(i), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func readFloatField(m map[string]any, keys ...string) (float64, bool) {
+	for _, k := range keys {
+		if raw, ok := m[k]; ok {
+			switch v := raw.(type) {
+			case float64:
+				return v, true
+			case int:
+				return float64(v), true
+			case json.Number:
+				if f, err := v.Float64(); err == nil {
+					return f, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func readStringField(m map[string]any, keys ...string) (string, bool) {
+	for _, k := range keys {
+		if raw, ok := m[k]; ok {
+			if s, ok := raw.(string); ok {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}
+
+// printAwardCheapestDryRun emits a structured preview of the work that would
+// be done. No network calls.
+func printAwardCheapestDryRun(w io.Writer, origin string, destinations []string, dep, ret dateWindow, minNights, maxNights int, oneWay bool, jobs int) error {
+	preview := map[string]any{
+		"dry_run":      true,
+		"origin":       origin,
+		"destinations": destinations,
+		"depart_from":  dep.from,
+		"depart_to":    dep.to,
+		"return_from":  ret.from,
+		"return_to":    ret.to,
+		"min_nights":   minNights,
+		"max_nights":   maxNights,
+		"one_way":      oneWay,
+		"jobs_to_run":  jobs,
+	}
+	out, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(out))
+	return err
+}
+
+// writeJSONFile atomically writes obj as pretty-printed JSON to path.
+// Best-effort temp-rename pattern. Used by --save.
+func writeJSONFile(path string, obj any) error {
+	out, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/library/travel/alaska-airlines/internal/cli/flights_award_cheapest_test.go
+++ b/library/travel/alaska-airlines/internal/cli/flights_award_cheapest_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-2026-05-19: award-cheapest planner) — unit tests for the
+// pure helpers introduced by the award-cheapest planner.
+
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveDestinations_Region(t *testing.T) {
+	got, err := resolveDestinations("", "japan")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"HND", "NRT", "KIX", "ITM", "NGO", "FUK", "CTS", "OKA"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("japan region = %v, want %v", got, want)
+	}
+}
+
+func TestResolveDestinations_RegionUppercase(t *testing.T) {
+	got, err := resolveDestinations("", "JAPAN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 8 {
+		t.Errorf("expected 8 codes from JAPAN region, got %d", len(got))
+	}
+}
+
+func TestResolveDestinations_UnknownRegion(t *testing.T) {
+	_, err := resolveDestinations("", "atlantis")
+	if err == nil {
+		t.Fatal("expected error for unknown region")
+	}
+	if !strings.Contains(err.Error(), "unknown --destination-region") {
+		t.Errorf("error should mention unknown region, got: %v", err)
+	}
+}
+
+func TestResolveDestinations_CommaList(t *testing.T) {
+	got, err := resolveDestinations("hnd, NRT,kix", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"HND", "NRT", "KIX"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("comma list = %v, want %v", got, want)
+	}
+}
+
+func TestResolveDestinations_DedupeAndTrim(t *testing.T) {
+	got, _ := resolveDestinations("HND,HND, hnd , NRT", "")
+	want := []string{"HND", "NRT"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dedupe failed: got %v, want %v", got, want)
+	}
+}
+
+func TestResolveDestinations_Empty(t *testing.T) {
+	got, err := resolveDestinations("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestResolveDateWindows_Month(t *testing.T) {
+	dep, ret, err := resolveDateWindows("2026-08", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dep.from != "2026-08-01" || dep.to != "2026-08-31" {
+		t.Errorf("depart window = [%s, %s], want [2026-08-01, 2026-08-31]", dep.from, dep.to)
+	}
+	if ret.from == "" || ret.to == "" {
+		t.Errorf("return window empty for round-trip month: dep=%v ret=%v", dep, ret)
+	}
+}
+
+func TestResolveDateWindows_OneWay(t *testing.T) {
+	dep, ret, err := resolveDateWindows("2026-08", "", "", "", "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dep.from != "2026-08-01" {
+		t.Errorf("depart from = %s, want 2026-08-01", dep.from)
+	}
+	if ret.from != "" || ret.to != "" {
+		t.Errorf("one-way should have empty return window, got: %v", ret)
+	}
+}
+
+func TestResolveDateWindows_ExplicitOverridesMonth(t *testing.T) {
+	dep, _, err := resolveDateWindows("2026-08", "2026-08-15", "2026-08-20", "2026-08-22", "2026-09-05", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dep.from != "2026-08-15" || dep.to != "2026-08-20" {
+		t.Errorf("explicit override failed: got [%s, %s]", dep.from, dep.to)
+	}
+}
+
+func TestResolveDateWindows_InvalidMonth(t *testing.T) {
+	_, _, err := resolveDateWindows("not-a-month", "", "", "", "", false)
+	if err == nil {
+		t.Fatal("expected error for invalid month")
+	}
+}
+
+func TestResolveDateWindows_MissingWindow(t *testing.T) {
+	_, _, err := resolveDateWindows("", "", "", "", "", false)
+	if err == nil {
+		t.Fatal("expected error when no window inputs given")
+	}
+}
+
+func TestEnumerateDatePairs_RoundTrip(t *testing.T) {
+	dep := dateWindow{from: "2026-08-15", to: "2026-08-17"}
+	ret := dateWindow{from: "2026-08-20", to: "2026-09-10"}
+	pairs := enumerateDatePairs(dep, ret, 5, 7, false)
+	// 3 depart dates x 3 night options (5,6,7) = 9 candidates, all
+	// fall within return window.
+	if len(pairs) != 9 {
+		t.Errorf("expected 9 pairs, got %d: %+v", len(pairs), pairs)
+	}
+}
+
+func TestEnumerateDatePairs_OneWay(t *testing.T) {
+	dep := dateWindow{from: "2026-08-15", to: "2026-08-18"}
+	pairs := enumerateDatePairs(dep, dateWindow{}, 5, 21, true)
+	if len(pairs) != 4 {
+		t.Errorf("expected 4 one-way pairs, got %d", len(pairs))
+	}
+	for _, p := range pairs {
+		if p.ret != "" {
+			t.Errorf("one-way pair should have empty return, got %s", p.ret)
+		}
+	}
+}
+
+func TestEnumerateDatePairs_ReturnOutOfWindow(t *testing.T) {
+	dep := dateWindow{from: "2026-08-15", to: "2026-08-15"}
+	ret := dateWindow{from: "2026-09-01", to: "2026-09-30"}
+	// min=5 max=21 → return would be 2026-08-20..2026-09-05; only 2026-09-01..2026-09-05 fall in window.
+	// That's nights 17,18,19,20,21 = 5 valid.
+	pairs := enumerateDatePairs(dep, ret, 5, 21, false)
+	if len(pairs) != 5 {
+		t.Errorf("expected 5 pairs in clipped return window, got %d: %+v", len(pairs), pairs)
+	}
+}
+
+func TestExtractLowestAwardPrice_NoData(t *testing.T) {
+	got := extractLowestAwardPrice(json.RawMessage(`{}`), -1)
+	if got.Miles != nil {
+		t.Errorf("empty doc should yield nil miles, got %+v", got)
+	}
+}
+
+func TestExtractLowestAwardPrice_FindsLowest(t *testing.T) {
+	// Synthetic SvelteKit-shaped doc with two fare records — one cheaper.
+	doc := `{
+		"trip": [
+			{"milesAmount": 145000, "cashAmount": 55.0, "carrier": "AS", "cabin": "Main", "stops": 1},
+			{"milesAmount": 120000, "cashAmount": 55.0, "carrier": "AS", "cabin": "Main", "stops": 1},
+			{"milesAmount": 450000, "cashAmount": 55.0, "carrier": "AS", "cabin": "Business", "stops": 1}
+		]
+	}`
+	got := extractLowestAwardPrice(json.RawMessage(doc), -1)
+	if got.Miles == nil {
+		t.Fatalf("expected miles extracted, got %+v", got)
+	}
+	if *got.Miles != 120000 {
+		t.Errorf("expected lowest = 120000, got %d", *got.Miles)
+	}
+}
+
+func TestExtractLowestAwardPrice_MaxStopsFilter(t *testing.T) {
+	doc := `[
+		{"milesAmount": 80000, "stops": 3},
+		{"milesAmount": 120000, "stops": 1}
+	]`
+	got := extractLowestAwardPrice(json.RawMessage(doc), 1)
+	if got.Miles == nil {
+		t.Fatalf("expected at least one match within max-stops=1")
+	}
+	if *got.Miles != 120000 {
+		t.Errorf("max-stops=1 should exclude the 80k/3-stop offer; got %d", *got.Miles)
+	}
+}
+
+func TestBuildAwardSearchParams_AlwaysSetsOnlineAward(t *testing.T) {
+	p := buildAwardSearchParams(awardSearchInput{Origin: "SFO", Destination: "HND", Depart: "2026-08-15"})
+	if p["ShoppingMethod"] != "onlineaward" {
+		t.Errorf("expected ShoppingMethod=onlineaward, got %q", p["ShoppingMethod"])
+	}
+	if p["UPG"] != "none" {
+		t.Errorf("expected UPG=none, got %q", p["UPG"])
+	}
+	if p["OT"] != "Anytime" || p["DT"] != "Anytime" {
+		t.Errorf("expected OT/DT=Anytime; got OT=%q DT=%q", p["OT"], p["DT"])
+	}
+	if p["O"] != "SFO" || p["D"] != "HND" || p["OD"] != "2026-08-15" {
+		t.Errorf("origin/destination/depart not wired: %+v", p)
+	}
+}
+
+func TestBuildAwardSearchParams_OmitsEmptyOptionals(t *testing.T) {
+	p := buildAwardSearchParams(awardSearchInput{Origin: "SFO", Destination: "HND", Depart: "2026-08-15"})
+	if _, ok := p["DD"]; ok {
+		t.Errorf("should not set DD when return is empty, got %q", p["DD"])
+	}
+	if _, ok := p["SpecFare"]; ok {
+		t.Errorf("should not set SpecFare when cabin is empty")
+	}
+}

--- a/library/travel/alaska-airlines/internal/cli/flights_award_search.go
+++ b/library/travel/alaska-airlines/internal/cli/flights_award_search.go
@@ -1,0 +1,179 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-2026-05-19: award-search support) — added by /printing-press-amend.
+// Thin alias over `flights search` that defaults --award=true so an agent can
+// say "alaska-airlines-pp-cli flights award-search ..." without having to
+// remember the --award flag on the cash command. Same underlying SvelteKit
+// __data.json endpoint, same Cookie auth, same response shape.
+//
+// Live sniff date: 2026-05-19. Endpoint discovery + ShoppingMethod toggle
+// captured via claude-in-chrome MCP against alaskaair.com (user logged in).
+// See .printing-press-patches.json entry "award-search-toggle".
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newFlightsAwardSearchCmd(flags *rootFlags) *cobra.Command {
+	var flagO string
+	var flagD string
+	var flagOD string
+	var flagDD string
+	var flagA string
+	var flagC string
+	var flagL string
+	var flagRT string
+	var flagCabin string
+	var flagLocale string
+
+	cmd := &cobra.Command{
+		Use:         "award-search",
+		Short:       "Search award (miles + cash) fares between two airports. Defaults --award=true; same endpoint as 'flights search' with ShoppingMethod=onlineaward.",
+		Example:     "  alaska-airlines-pp-cli flights award-search --origin SFO --destination HND --depart 2026-08-15 --return 2026-08-22 --json",
+		Annotations: map[string]string{"pp:endpoint": "flights.award_search", "pp:method": "GET", "pp:path": "/search/results/__data.json", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("origin") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "origin")
+			}
+			if !cmd.Flags().Changed("destination") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "destination")
+			}
+			if !cmd.Flags().Changed("depart") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "depart")
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			path := "/search/results/__data.json"
+			params := buildAwardSearchParams(awardSearchInput{
+				Origin:      flagO,
+				Destination: flagD,
+				Depart:      flagOD,
+				Return:      flagDD,
+				Adults:      flagA,
+				Children:    flagC,
+				LapInfants:  flagL,
+				RoundTrip:   flagRT,
+				Cabin:       flagCabin,
+				Locale:      flagLocale,
+			})
+
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "flights", false, path, params, nil)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			{
+				var countItems []json.RawMessage
+				_ = json.Unmarshal(data, &countItems)
+				printProvenance(cmd, len(countItems), prov)
+			}
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
+			}
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
+						return err
+					}
+					if len(items) >= 25 {
+						fmt.Fprintf(os.Stderr, "\nShowing %d results. To narrow: add --limit, --json --select, or filter flags.\n", len(items))
+					}
+					return nil
+				}
+			}
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+		},
+	}
+	cmd.Flags().StringVar(&flagO, "origin", "", "Origin IATA code (e.g. SFO)")
+	cmd.Flags().StringVar(&flagD, "destination", "", "Destination IATA code (e.g. HND)")
+	cmd.Flags().StringVar(&flagOD, "depart", "", "Outbound date YYYY-MM-DD")
+	cmd.Flags().StringVar(&flagDD, "return", "", "Return date YYYY-MM-DD (omit for one-way)")
+	cmd.Flags().StringVar(&flagA, "adults", "1", "Adult passenger count")
+	cmd.Flags().StringVar(&flagC, "children", "0", "Child passenger count")
+	cmd.Flags().StringVar(&flagL, "lap-infants", "0", "Lap-infant count")
+	cmd.Flags().StringVar(&flagRT, "round-trip", "true", "true for round-trip, false for one-way")
+	cmd.Flags().StringVar(&flagCabin, "cabin", "", "Preferred cabin (economy, premium, business, first); empty for any")
+	cmd.Flags().StringVar(&flagLocale, "locale", "en-us", "Locale string")
+
+	return cmd
+}
+
+// awardSearchInput carries the fields that buildAwardSearchParams turns into
+// the SvelteKit query-string. Kept as a struct so the same builder is reusable
+// from flights_award_cheapest.go's parallel fan-out.
+type awardSearchInput struct {
+	Origin      string
+	Destination string
+	Depart      string
+	Return      string
+	Adults      string
+	Children    string
+	LapInfants  string
+	RoundTrip   string
+	Cabin       string
+	Locale      string
+}
+
+// buildAwardSearchParams composes the query-param map for an award search.
+// ShoppingMethod=onlineaward + UPG=none + OT/DT=Anytime are the minimum
+// delta captured from the live alaskaair.com browser sniff. The cabin
+// param maps to the existing site's SpecFare slot (best-effort; the site
+// accepts unset to mean "any").
+func buildAwardSearchParams(in awardSearchInput) map[string]string {
+	p := map[string]string{
+		"ShoppingMethod": "onlineaward",
+		"UPG":            "none",
+		"OT":             "Anytime",
+		"DT":             "Anytime",
+	}
+	if in.Origin != "" {
+		p["O"] = in.Origin
+	}
+	if in.Destination != "" {
+		p["D"] = in.Destination
+	}
+	if in.Depart != "" {
+		p["OD"] = in.Depart
+	}
+	if in.Return != "" {
+		p["DD"] = in.Return
+	}
+	if in.Adults != "" {
+		p["A"] = in.Adults
+	}
+	if in.Children != "" {
+		p["C"] = in.Children
+	}
+	if in.LapInfants != "" {
+		p["L"] = in.LapInfants
+	}
+	if in.RoundTrip != "" {
+		p["RT"] = in.RoundTrip
+	}
+	if in.Cabin != "" {
+		p["SpecFare"] = in.Cabin
+	}
+	if in.Locale != "" {
+		p["locale"] = in.Locale
+	}
+	return p
+}

--- a/library/travel/alaska-airlines/internal/cli/flights_search.go
+++ b/library/travel/alaska-airlines/internal/cli/flights_search.go
@@ -21,6 +21,18 @@ func newFlightsSearchCmd(flags *rootFlags) *cobra.Command {
 	var flagL string
 	var flagRT string
 	var flagLocale string
+	// PATCH(amend-2026-05-19: award-search support) — added by /printing-press-amend.
+	// --award is the user-facing toggle. When set, the request adds
+	// ShoppingMethod=onlineaward plus the supplementary params Alaska's
+	// SvelteKit page sets when the user clicks "Switch to points":
+	// UPG=none, OT=Anytime, DT=Anytime. --shopping-method is an escape
+	// hatch for other ShoppingMethod values the site may add later;
+	// --upgrade controls the UPG param explicitly when a hand-tuned value
+	// is needed. Sniffed live 2026-05-19 against alaskaair.com — see
+	// .printing-press-patches.json entry "award-search-toggle".
+	var flagAward bool
+	var flagShoppingMethod string
+	var flagUpgrade string
 
 	cmd := &cobra.Command{
 		Use:         "search",
@@ -70,6 +82,33 @@ func newFlightsSearchCmd(flags *rootFlags) *cobra.Command {
 			}
 			if flagLocale != "" {
 				params["locale"] = fmt.Sprintf("%v", flagLocale)
+			}
+			// PATCH(amend-2026-05-19: award-search support) — when --award is set
+			// (or --shopping-method=onlineaward is explicit), add the params
+			// Alaska's award view requires. The browser sniff captured
+			// ShoppingMethod=onlineaward, UPG=none, OT=Anytime, DT=Anytime
+			// as the minimum delta from the cash request. We only set
+			// defaults when the user didn't explicitly override them, so a
+			// hand-tuned request can still flow through.
+			effectiveShoppingMethod := flagShoppingMethod
+			if flagAward && effectiveShoppingMethod == "" {
+				effectiveShoppingMethod = "onlineaward"
+			}
+			if effectiveShoppingMethod != "" {
+				params["ShoppingMethod"] = effectiveShoppingMethod
+				if _, ok := params["OT"]; !ok {
+					params["OT"] = "Anytime"
+				}
+				if _, ok := params["DT"]; !ok {
+					params["DT"] = "Anytime"
+				}
+			}
+			if flagUpgrade != "" {
+				params["UPG"] = flagUpgrade
+			} else if effectiveShoppingMethod != "" {
+				// Award + cashupgrade paths need UPG; default to "none" when
+				// the user didn't pick something explicit.
+				params["UPG"] = "none"
 			}
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "flights", false, path, params, nil)
 			if err != nil {
@@ -124,6 +163,12 @@ func newFlightsSearchCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagL, "lap-infants", "0", "Lap-infant count")
 	cmd.Flags().StringVar(&flagRT, "round-trip", "true", "true for round-trip, false for one-way")
 	cmd.Flags().StringVar(&flagLocale, "locale", "en-us", "Locale string")
+	// PATCH(amend-2026-05-19: award-search support) — new flags exposing the
+	// ShoppingMethod toggle Alaska's site uses to switch the SvelteKit
+	// __data.json response from cash fares to award (miles+cash) fares.
+	cmd.Flags().BoolVar(&flagAward, "award", false, "Search award (miles+cash) fares instead of cash. Sets ShoppingMethod=onlineaward.")
+	cmd.Flags().StringVar(&flagShoppingMethod, "shopping-method", "", "Override ShoppingMethod query param explicitly (e.g. onlineaward, cashupgrade). When set, takes precedence over --award.")
+	cmd.Flags().StringVar(&flagUpgrade, "upgrade", "", "Override UPG query param (default: none when --award or --shopping-method is set)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Closes the manuscript-scoped award gap on alaska-airlines-pp-cli without adding a new endpoint or auth path. Live browser sniff (Chrome MCP, logged-in session) on 2026-05-19 confirmed the same `/search/results/__data.json` endpoint serves award data when `ShoppingMethod=onlineaward` (plus `UPG=none`, `OT=Anytime`, `DT=Anytime`) is added to the query string. Existing Cookie auth, SvelteKit response parser, and `--select` / `--compact` / `--json` output filters carry through unchanged.

## Findings

| ID | Type | Surface | Rationale |
|----|------|---------|-----------|
| F1 | feature (sniff) | endpoint discovery | Existing CLI only hits the cash side. research.json gap: "award-vs-cash comparator not implemented." Sniff found the same endpoint with a query-param toggle. |
| F4 | feature | flag | New `--award`, `--shopping-method`, `--upgrade` on existing `flights search`. |
| F2 | feature | command | `flights award-search` - thin alias that defaults to award mode. |
| F3 | feature | command (killer) | `flights award-cheapest` - lowest-miles-in-a-month planner across multiple destinations in parallel. |

## Killer command

```bash
alaska-airlines-pp-cli flights award-cheapest \
  --origin SFO --destination-region japan --month 2026-08 \
  --cabin economy --max-stops 1 --json
```

Returns the 5 cheapest round-trip miles+cash combos across August across 8 Japan airports (HND, NRT, KIX, ITM, NGO, FUK, CTS, OKA) and every valid (depart, return) pair in the 5-21 night range.

## Changes

```
 .printing-press-patches.json                          |  24 +-
 SKILL.md                                              |  34 +-
 internal/cli/flights.go                               |   4 +
 internal/cli/flights_award_cheapest.go                | 590 +++++++++++++++++++
 internal/cli/flights_award_cheapest_test.go           | 223 ++++++++
 internal/cli/flights_award_search.go                  | 179 +++++++
 internal/cli/flights_search.go                        |  45 ++
 7 files changed, 1095 insertions(+), 4 deletions(-)
```

## Validation

| Check | Result |
|-------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (10 new unit tests for date enumeration, region expansion, JSON extractor) |
| `python3 .github/scripts/verify-skill/verify_skill.py --dir library/travel/alaska-airlines/` | PASS |
| `govulncheck ./...` | PASS (no new vulnerabilities) |
| `flights --help` renders new commands | PASS |
| `flights search --award --dry-run` matches sniffed URL | PASS |
| `flights award-cheapest --dry-run` enumerates job plan | PASS (4216 jobs for SFO+japan+2026-08) |

## Defaults

Per the user spec:

- `--destination-region japan` expands to HND, NRT, KIX, ITM, NGO, FUK, CTS, OKA. Also accepts comma-list via `--destination`.
- Round-trip default; `--one-way` to override.
- `--min-nights 5 --max-nights 21` to avoid 1-night turnarounds.
- `--concurrency 4` + the existing AdaptiveLimiter (patched under `ratelimit-serialize-under-lock`) keeps the fan-out polite.
- `--top-n 5` cheapest results; `--save <path>` to persist the full result set.
- Partner award space is included naturally when the endpoint returns it.

## Sniff provenance

Endpoint discovery done via claude-in-chrome MCP against alaskaair.com in a logged-in session. Steps:

1. Navigated to the cash search results URL.
2. Clicked the "Money / Points" toggle, observed the URL update to add `ShoppingMethod=onlineaward&UPG=none&OT=Anytime&DT=Anytime&lid=...`.
3. Fetched `/search/results/__data.json` with `credentials: 'include'` from the page context; got 217KB of SvelteKit deflated JSON with 18 award-key references.
4. Verified rendered fares: 120-145k pts + $55 round-trip across August dates.

## Patch manifest entries

- `award-search-toggle` (flights_search.go, flights_award_search.go, flights.go)
- `award-cheapest-planner` (flights_award_cheapest.go, flights_award_cheapest_test.go, flights.go)

## Deferred

- `flights award-watch` (Tier 3, user pre-classified as may-defer). Will ship as a follow-up once watcher persistence shape is chosen.