### PR TITLE
fix(ci): overlay generate-registry tool from base in Verify

### DIFF
--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -93,9 +93,17 @@ jobs:
           # have since been relaxed and missing checks that have since
           # been added. It's also the right security default: fork PRs
           # shouldn't be able to ship their own modified verifier.
+          #
+          # tools/generate-registry is overlaid for the same reason: the
+          # "Validate registry source descriptions" step below runs it in
+          # --validate mode, so it is a verifier too. A PR branched before
+          # the --validate flag existed otherwise runs its own stale tool
+          # and dies with "flag provided but not defined: -validate"
+          # instead of a real validation message (or a pass).
           git checkout "${BASE_REMOTE_REF}" -- \
             .github/scripts/verify-attribution \
-            .github/scripts/verify-publish-package
+            .github/scripts/verify-publish-package \
+            tools/generate-registry
 
       - name: Fail on changes to generated artifacts
         if: github.event_name == 'pull_request'
@@ -225,6 +233,10 @@ jobs:
         # by walking up from the source file. The package-path form
         # (./tools/generate-registry) fails with "go.mod not found" from the
         # repo root. Matches the invocation in generate-registry.yml.
+        #
+        # The tool is overlaid from base in "Overlay verifier scripts from
+        # base" above, so this always runs the current validator even on a
+        # stale-base PR; only the library data being validated is the PR's.
         run: |
           set -euo pipefail
           go run ./tools/generate-registry/main.go --validate


### PR DESCRIPTION
## What

The `Verify` job's "Validate registry source descriptions" step runs `tools/generate-registry` in `--validate` mode, but unlike the other verifiers (`verify-attribution`, `verify-publish-package`) the tool was **not** overlaid from base in the "Overlay verifier scripts from base" step. So the `--validate` step runs whatever copy of the tool the PR was branched from.

## Why

The `--validate` flag landed in #674 (2026-05-18). A fork PR branched before that runs its own **stale** tool, which doesn't define `--validate`, and the step dies with:

```
flag provided but not defined: -validate
```

— a cryptic error that looks like the contributor's fault when it's purely branch staleness. Live case: #668 (already fixed by bringing it current with `main`).

## Change

Add `tools/generate-registry` to the base-overlay checkout. Now the step always compiles the **current** validator (from base) and runs it against the **PR's** library data. A stale-base PR then gets a real validation message (or a pass) instead of the flag error. This also matches the existing fork-PR security posture: a fork can't ship its own modified validator.

No behavior change for up-to-date PRs. YAML parse-checked locally.

## Note

This makes the failure *clearer*; it does not make stale-data PRs pass — a PR whose tree still carries CLIs that `main` has since fixed/removed will now surface a real `description is empty` message for those, which is the correct signal to bring the branch current.