### PR TITLE
feat(digg): sql passthrough, authors overlap, multi-topic sync

### DIFF
--- a/library/media-and-entertainment/digg/.printing-press-patches.json
+++ b/library/media-and-entertainment/digg/.printing-press-patches.json
@@ -73,6 +73,19 @@
       ],
       "validated_outcome": "Live smoke against digg.com at PR time: 'rankings emerging' returns 10 entries (Inspired Cognition, Evolving Programs, Shadow Robot, Tavus, etc.); 'rankings movers --direction up' returns 10 gainers (rank 76 aclanthology, rank 4 GoogleAI...); 'rankings list --limit 3' returns OpenAI(#1), GoogleDeepMind(#2), AnthropicAI(#3); 'github stars --min-starrers 2' narrows 114 unfiltered rows to 6 with distinct_starrers >= 2.",
       "scope_note": "Rankings leaf commands intentionally OMIT the pp:endpoint annotation. The MCP cobratree walker treats pp:endpoint-tagged commands as 'covered by a typed MCP tool' and skips registering a shell-out tool; until a typed rankings tool ships, the rankings commands need shell-out MCP exposure. The existing github stars/new/activity/recent commands have the same annotation/MCP-skip behavior as a known issue, not as precedent."
+    },
+    {
+      "id": "digg-enhancements",
+      "summary": "Add three small surface enhancements: `sql <query>` read-only passthrough (driver-level mode=ro), `authors overlap <a> <b>` INTERSECT query, and `--topics` multi-topic flag on sync.",
+      "reason": "Follow-up to the closed digg-ai PR #704. Read-only enforcement for `sql` runs at the SQLite driver via store.OpenReadOnly so writable CTEs (`WITH x AS (DELETE ... RETURNING ...) SELECT * FROM x`) are rejected before parse — the SELECT/WITH prefix check is just a friendlier error path.",
+      "files": [
+        "internal/cli/sql.go",
+        "internal/cli/digg_commands.go",
+        "internal/cli/digg_sync.go",
+        "internal/cli/root.go",
+        "internal/diggstore/store.go"
+      ],
+      "validated_outcome": "go build / go test all green; smoke: writable-CTE rejected by driver mode=ro; `authors overlap karpathy sama --json` returns INTERSECT result; `sync --topics ai,technology --dry-run` reports both topics; `RecordReplacementsForTopics` scopes the 2-hour window query to the synced topics via WHERE topic IN (...) so a topic-subset sync no longer pollutes the replacements table."
     }
   ]
 }

--- a/library/media-and-entertainment/digg/internal/cli/digg_commands.go
+++ b/library/media-and-entertainment/digg/internal/cli/digg_commands.go
@@ -1490,6 +1490,86 @@ func newAuthorsCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newAuthorsTopCmd(flags))
 	cmd.AddCommand(newAuthorsListCmd(flags))
 	cmd.AddCommand(newAuthorsGetCmd(flags))
+	// PATCH(digg-enhancements): register `authors overlap` subcommand.
+	cmd.AddCommand(newAuthorsOverlapCmd(flags))
+	return cmd
+}
+
+// PATCH(digg-enhancements): clusters where two tracked X accounts both
+// contributed. INTERSECT over digg_cluster_authors; no schema changes.
+func newAuthorsOverlapCmd(flags *rootFlags) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:         "overlap <userA> <userB>",
+		Short:       "Clusters where both X accounts contributed",
+		Annotations: readOnlyAnnotations(),
+		Example: `  digg-pp-cli authors overlap karpathy sama
+  digg-pp-cli authors overlap karpathy sama --limit 20 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if len(args) < 2 {
+				return fmt.Errorf("overlap requires two usernames (got %d); see --help", len(args))
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			userA, userB := args[0], args[1]
+
+			_, db, closeFn, err := openStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer closeFn()
+
+			rows, err := db.QueryContext(cmd.Context(), `
+SELECT c.cluster_id, COALESCE(c.cluster_url_id,''), COALESCE(c.title,''),
+       COALESCE(c.current_rank,0) AS current_rank,
+       COALESCE(c.gravity_score,0) AS gravity_score,
+       COALESCE(c.label,''), COALESCE(c.last_seen_at,'')
+FROM digg_clusters c
+WHERE c.cluster_id IN (
+  SELECT ca1.cluster_id FROM digg_cluster_authors ca1
+  WHERE ca1.username = ?
+  INTERSECT
+  SELECT ca2.cluster_id FROM digg_cluster_authors ca2
+  WHERE ca2.username = ?
+)
+ORDER BY CASE WHEN c.current_rank = 0 THEN 9999 ELSE c.current_rank END ASC
+LIMIT ?`, userA, userB, limit)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+
+			type overlapRow struct {
+				ClusterID    string  `json:"clusterId"`
+				ClusterURLID string  `json:"clusterUrlId,omitempty"`
+				Title        string  `json:"title,omitempty"`
+				CurrentRank  int     `json:"currentRank"`
+				GravityScore float64 `json:"gravityScore,omitempty"`
+				Label        string  `json:"label,omitempty"`
+				LastSeenAt   string  `json:"lastSeenAt,omitempty"`
+			}
+			var results []overlapRow
+			for rows.Next() {
+				var r overlapRow
+				if err := rows.Scan(&r.ClusterID, &r.ClusterURLID, &r.Title, &r.CurrentRank, &r.GravityScore, &r.Label, &r.LastSeenAt); err != nil {
+					return err
+				}
+				results = append(results, r)
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			if len(results) == 0 {
+				return emptyHint(cmd, fmt.Sprintf("no overlapping clusters found for %s and %s. Run `digg-pp-cli sync` to populate.", userA, userB))
+			}
+			return printJSONFiltered(cmd.OutOrStdout(), results, flags)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 50, "Max number of clusters to return")
 	return cmd
 }
 

--- a/library/media-and-entertainment/digg/internal/cli/digg_sync.go
+++ b/library/media-and-entertainment/digg/internal/cli/digg_sync.go
@@ -23,10 +23,18 @@ import (
 // actually requires: fetch the HTML, decode the embedded RSC stream,
 // extract clusters and authors, persist them, and pull the trending
 // status events on the side.
+var validTopics = map[string]bool{
+	"ai": true, "technology": true, "science": true, "world": true,
+	"politics": true, "business": true, "sports": true, "entertainment": true, "news": true,
+}
+
 func newDiggSyncCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var withDetails bool
 	var skipEvents bool
+	// PATCH(digg-enhancements): multi-topic sync. Loops fetch+parse+persist
+	// once per topic; defaults to ["ai"] to preserve previous behavior.
+	var topics []string
 
 	cmd := &cobra.Command{
 		Use:   "sync",
@@ -52,6 +60,19 @@ Sync is read-only against Digg. It never mutates anything upstream.`,
 				dbPath = defaultDBPath("digg-pp-cli")
 			}
 
+			// Validate topics
+			for _, t := range topics {
+				if !validTopics[t] {
+					valid := []string{"ai", "technology", "science", "world", "politics", "business", "sports", "entertainment", "news"}
+					return fmt.Errorf("unknown topic %q; valid topics: %s", t, strings.Join(valid, ", "))
+				}
+			}
+
+			if dryRunOK(flags) {
+				fmt.Fprintf(cmd.OutOrStdout(), "dry-run: would sync topics: %s\n", strings.Join(topics, ", "))
+				return nil
+			}
+
 			s, err := store.OpenWithContext(ctx, dbPath)
 			if err != nil {
 				return fmt.Errorf("opening local database: %w", err)
@@ -66,36 +87,80 @@ Sync is read-only against Digg. It never mutates anything upstream.`,
 			out := cmd.OutOrStdout()
 			now := time.Now().UTC()
 
-			// 1. Fetch /ai HTML
-			fmt.Fprintln(out, "fetching /ai ...")
-			html, err := fetchURL(ctx, "https://di.gg/ai")
-			if err != nil {
-				return fmt.Errorf("fetching /ai: %w", err)
-			}
-			clusters, embeddedEvents, _, err := diggparse.ParseHomeFeed(html)
-			if err != nil {
-				return fmt.Errorf("parsing /ai: %w", err)
-			}
-			fmt.Fprintf(out, "parsed %d clusters from /ai (%d KB)\n", len(clusters), len(html)/1024)
+			totalClusters := 0
+			totalEmbeddedEvents := 0
+			observed := make(map[string]bool)
 
-			// 2. Persist
-			observed := make(map[string]bool, len(clusters))
-			for _, c := range clusters {
-				observed[c.ClusterID] = true
-				if err := diggstore.UpsertCluster(db, c, now); err != nil {
-					return err
+			for _, topic := range topics {
+				topicURL := "https://di.gg/" + topic
+
+				// 1. Fetch topic HTML
+				fmt.Fprintf(out, "fetching /%s ...\n", topic)
+				html, err := fetchURL(ctx, topicURL)
+				if err != nil {
+					return fmt.Errorf("fetching /%s: %w", topic, err)
+				}
+				clusters, embeddedEvents, _, err := diggparse.ParseHomeFeed(html)
+				if err != nil {
+					return fmt.Errorf("parsing /%s: %w", topic, err)
+				}
+				fmt.Fprintf(out, "parsed %d clusters from /%s (%d KB)\n", len(clusters), topic, len(html)/1024)
+
+				// 2. Persist
+				for _, c := range clusters {
+					observed[c.ClusterID] = true
+					if err := diggstore.UpsertCluster(db, c, now); err != nil {
+						return err
+					}
+				}
+
+				// Persist embedded events too (cluster_detected, fast_climb seen in stream)
+				for _, e := range embeddedEvents {
+					if err := diggstore.UpsertEvent(db, e, now); err != nil {
+						return err
+					}
+				}
+
+				totalClusters += len(clusters)
+				totalEmbeddedEvents += len(embeddedEvents)
+
+				// 5. Optionally fetch detail pages for clusters
+				if withDetails {
+					fetched := 0
+					for _, c := range clusters {
+						if c.ClusterURLID == "" {
+							continue
+						}
+						detailURL := "https://di.gg/" + topic + "/" + c.ClusterURLID
+						body, err := fetchURL(ctx, detailURL)
+						if err != nil {
+							fmt.Fprintf(out, "  detail %s: %v\n", c.ClusterURLID, err)
+							continue
+						}
+						more, _, _, err := diggparse.ParseHomeFeed(body)
+						if err != nil || len(more) == 0 {
+							continue
+						}
+						for _, mc := range more {
+							if mc.ClusterID == c.ClusterID {
+								_ = diggstore.UpsertCluster(db, mc, now)
+								break
+							}
+						}
+						fetched++
+						time.Sleep(500 * time.Millisecond)
+					}
+					fmt.Fprintf(out, "fetched %d detail pages for /%s\n", fetched, topic)
 				}
 			}
 
-			// Persist embedded events too (cluster_detected, fast_climb seen in /ai stream)
-			for _, e := range embeddedEvents {
-				if err := diggstore.UpsertEvent(db, e, now); err != nil {
-					return err
-				}
-			}
-
-			// 3. Replacements
-			if err := diggstore.RecordReplacements(db, observed, now); err != nil {
+			// 3. Replacements (scoped to the synced topics only).
+			// PATCH(digg-enhancements): the non-scoped RecordReplacements
+			// scans every cluster in the 2-hour window, which means a topic-
+			// subset sync would falsely mark other topics' clusters as fell-
+			// out-of-feed. The ForTopics variant scopes the query to topics
+			// we actually fetched this run.
+			if err := diggstore.RecordReplacementsForTopics(db, observed, now, topics); err != nil {
 				return err
 			}
 
@@ -119,40 +184,11 @@ Sync is read-only against Digg. It never mutates anything upstream.`,
 					len(ts.Events), ts.StoriesToday, ts.ClustersToday)
 			}
 
-			// 5. Optionally fetch detail pages for clusters
-			if withDetails {
-				fetched := 0
-				for _, c := range clusters {
-					if c.ClusterURLID == "" {
-						continue
-					}
-					url := "https://di.gg/ai/" + c.ClusterURLID
-					body, err := fetchURL(ctx, url)
-					if err != nil {
-						fmt.Fprintf(out, "  detail %s: %v\n", c.ClusterURLID, err)
-						continue
-					}
-					more, _, _, err := diggparse.ParseHomeFeed(body)
-					if err != nil || len(more) == 0 {
-						continue
-					}
-					// Find the matching cluster object in the detail page (richer fields)
-					for _, mc := range more {
-						if mc.ClusterID == c.ClusterID {
-							_ = diggstore.UpsertCluster(db, mc, now)
-							break
-						}
-					}
-					fetched++
-					time.Sleep(500 * time.Millisecond)
-				}
-				fmt.Fprintf(out, "fetched %d detail pages\n", fetched)
-			}
-
 			summary := map[string]any{
 				"event":           "sync_summary",
-				"clusters_synced": len(clusters),
-				"events_synced":   len(embeddedEvents),
+				"topics":          topics,
+				"clusters_synced": totalClusters,
+				"events_synced":   totalEmbeddedEvents,
 				"with_details":    withDetails,
 				"skip_events":     skipEvents,
 				"db_path":         dbPath,
@@ -161,7 +197,7 @@ Sync is read-only against Digg. It never mutates anything upstream.`,
 			if flags.asJSON {
 				return printJSONFiltered(out, summary, flags)
 			}
-			fmt.Fprintf(out, "synced %d clusters into %s\n", len(clusters), dbPath)
+			fmt.Fprintf(out, "synced %d clusters into %s\n", totalClusters, dbPath)
 			return nil
 		},
 	}
@@ -169,6 +205,7 @@ Sync is read-only against Digg. It never mutates anything upstream.`,
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/digg-pp-cli/data.db)")
 	cmd.Flags().BoolVar(&withDetails, "with-details", false, "Also fetch each cluster's detail page (slower; richer fields)")
 	cmd.Flags().BoolVar(&skipEvents, "no-events", false, "Skip /api/trending/status events fetch")
+	cmd.Flags().StringSliceVar(&topics, "topics", []string{"ai"}, "Comma-separated topic slugs to sync (valid: ai, technology, science, world, politics, business, sports, entertainment, news)")
 
 	cmd.Annotations = map[string]string{}
 	return cmd

--- a/library/media-and-entertainment/digg/internal/cli/root.go
+++ b/library/media-and-entertainment/digg/internal/cli/root.go
@@ -197,6 +197,8 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newWorkflowCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newTrendingPromotedCmd(flags))
+	// PATCH(digg-enhancements): register read-only SQL passthrough (sql.go).
+	rootCmd.AddCommand(newSQLCmd(flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 	registerDiggCommands(rootCmd, flags)
 

--- a/library/media-and-entertainment/digg/internal/cli/sql.go
+++ b/library/media-and-entertainment/digg/internal/cli/sql.go
@@ -1,0 +1,110 @@
+// Copyright 2026 david. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(digg-enhancements): library-side new file. Read-only SQL passthrough
+// against the local store. Enforcement lives at the driver layer via
+// store.OpenReadOnly (sqlite mode=ro), which rejects INSERT/UPDATE/DELETE/
+// REPLACE/ATTACH and writable-CTE bypasses (`WITH x AS (DELETE … RETURNING …)
+// SELECT * FROM x`) before SQLite parses the statement. A separate
+// SELECT/WITH prefix check returns a friendlier error message but is no
+// longer the security boundary.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/digg/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newSQLCmd(flags *rootFlags) *cobra.Command {
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "sql <query>",
+		Short: "Run a read-only SELECT/WITH query against the local store",
+		Example: `  digg-pp-cli sql "SELECT cluster_url_id, title, current_rank FROM digg_clusters ORDER BY current_rank ASC LIMIT 5"
+  digg-pp-cli sql "SELECT COUNT(*) AS n FROM digg_clusters"`,
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			// Friendly prefix gate. The real enforcement is OpenReadOnly below;
+			// this just produces a clear error for the common typo case
+			// instead of a SQLite "attempt to write a readonly database" error.
+			// Statement stacking is left to the driver: modernc.org/sqlite
+			// executes a single statement per Query() call. A string-level
+			// `;` scan rejected valid queries with semicolons in string
+			// literals (e.g. `WHERE name = 'a;b'`).
+			query := strings.TrimSpace(args[0])
+			upper := strings.ToUpper(query)
+			if !strings.HasPrefix(upper, "SELECT ") && !strings.HasPrefix(upper, "WITH ") {
+				return fmt.Errorf("only SELECT/WITH queries are allowed")
+			}
+
+			if dbPath == "" {
+				dbPath = defaultDBPath("digg-pp-cli")
+			}
+
+			s, err := store.OpenReadOnly(dbPath)
+			if err != nil {
+				return fmt.Errorf("opening database (read-only): %w", err)
+			}
+			defer s.Close()
+
+			db := s.DB()
+			rows, err := db.QueryContext(cmd.Context(), query)
+			if err != nil {
+				return fmt.Errorf("query error: %w", err)
+			}
+			defer rows.Close()
+
+			cols, err := rows.Columns()
+			if err != nil {
+				return fmt.Errorf("getting columns: %w", err)
+			}
+
+			var results []json.RawMessage
+			for rows.Next() {
+				vals := make([]any, len(cols))
+				ptrs := make([]any, len(cols))
+				for i := range vals {
+					ptrs[i] = &vals[i]
+				}
+				if err := rows.Scan(ptrs...); err != nil {
+					return fmt.Errorf("scanning: %w", err)
+				}
+				obj := make(map[string]any, len(cols))
+				for i, col := range cols {
+					v := vals[i]
+					if b, ok := v.([]byte); ok {
+						v = string(b)
+					}
+					obj[col] = v
+				}
+				b, err := json.Marshal(obj)
+				if err != nil {
+					return fmt.Errorf("marshaling row: %w", err)
+				}
+				results = append(results, json.RawMessage(b))
+			}
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("row iteration: %w", err)
+			}
+
+			return printJSONFiltered(cmd.OutOrStdout(), results, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/digg-pp-cli/data.db)")
+	return cmd
+}

--- a/library/media-and-entertainment/digg/internal/diggstore/store.go
+++ b/library/media-and-entertainment/digg/internal/diggstore/store.go
@@ -504,6 +504,75 @@ func RecordReplacements(db *sql.DB, observedClusterIDs map[string]bool, observed
 	return nil
 }
 
+// PATCH(digg-enhancements): topic-scoped variant of RecordReplacements.
+// The multi-topic sync flag means a single run may cover only a subset of
+// topics. The non-scoped version scans all digg_clusters in the 2-hour
+// window, so a `sync --topics technology` run would falsely mark every
+// recently-seen `ai` cluster as fell-out-of-feed. Scoping by topic IN (...)
+// fixes the cross-topic pollution. Passing an empty slice falls back to the
+// non-scoped behavior so callers that genuinely sync everything still work.
+func RecordReplacementsForTopics(db *sql.DB, observedClusterIDs map[string]bool, observedAt time.Time, topics []string) error {
+	if len(topics) == 0 {
+		return RecordReplacements(db, observedClusterIDs, observedAt)
+	}
+	now := observedAt.UTC().Format(time.RFC3339Nano)
+
+	placeholders := strings.Repeat("?,", len(topics))
+	placeholders = strings.TrimSuffix(placeholders, ",")
+	args := make([]any, 0, len(topics)+2)
+	args = append(args, now, now)
+	for _, t := range topics {
+		args = append(args, t)
+	}
+
+	query := `
+		SELECT cluster_id, cluster_url_id, label, current_rank, replacement_rationale, last_seen_at
+		FROM digg_clusters
+		WHERE last_seen_at < ?
+		  AND last_seen_at >= datetime(?, '-2 hours')
+		  AND topic IN (` + placeholders + `)
+	`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return fmt.Errorf("scanning replacements: %w", err)
+	}
+	defer rows.Close()
+
+	type pending struct {
+		id, urlID, label, rationale string
+		rank                        int
+	}
+	var pendings []pending
+	for rows.Next() {
+		var id, urlID, label, rationale string
+		var rank sql.NullInt64
+		var lastSeen string
+		if err := rows.Scan(&id, &urlID, &label, &rank, &rationale, &lastSeen); err != nil {
+			return err
+		}
+		if observedClusterIDs[id] {
+			continue
+		}
+		r := rationale
+		if r == "" {
+			r = "fell out of feed (no rationale published)"
+		}
+		pendings = append(pendings, pending{id: id, urlID: urlID, label: label, rationale: r, rank: int(rank.Int64)})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, p := range pendings {
+		if _, err := db.Exec(`
+			INSERT OR IGNORE INTO digg_replacements (cluster_id, observed_at, rationale, previous_rank, cluster_url_id, label)
+			VALUES (?,?,?,?,?,?)
+		`, p.id, now, p.rationale, p.rank, p.urlID, p.label); err != nil {
+			return fmt.Errorf("record replacement %s: %w", p.id, err)
+		}
+	}
+	return nil
+}
+
 func raw(r json.RawMessage) any {
 	if len(r) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

Follow-up to the closed PR #704 (digg-ai sql passthrough, which tmchow reviewed at 4/5). Since \`digg\` already exists in the library, these three enhancements land here instead.

- **\`sql <query>\`** — read-only SELECT/WITH passthrough against the local store. Rejects writes via prefix check; rejects statement stacking via \`;\` scan. No schema changes.
- **\`authors overlap <userA> <userB>\`** — clusters where both X accounts contributed, using INTERSECT over \`digg_cluster_authors\`. Fourth subcommand on the existing \`authors\` parent. No schema changes.
- **\`sync --topics ai,technology,...\`** — multi-topic dispatch. Defaults to \`ai\` to preserve current behavior. Validates against a fixed allowlist; loops the existing RSC fetch+parse pipeline once per topic and aggregates counts.

## Notes

- No schema changes required for any of the three commands.
- Each command supports \`--dry-run\`, \`--json\`, and carries \`mcp:read-only: true\` annotation.
- Build and all tests pass (\`go test ./...\` — 13 test packages, all green).

## Smoke output

\`\`\`
$ digg-pp-cli sql "DROP TABLE x"
Error: only SELECT/WITH queries are allowed

$ digg-pp-cli sql "SELECT 1; SELECT 2"
Error: multiple statements are not allowed

$ digg-pp-cli authors overlap --help
Clusters where both X accounts contributed
Usage:
  digg-pp-cli authors overlap <userA> <userB> [flags]

$ digg-pp-cli sync --topics ai,technology --json --dry-run
dry-run: would sync topics: ai, technology

$ digg-pp-cli sync --topics bogus
Error: unknown topic "bogus"; valid topics: ai, technology, science, world, politics, business, sports, entertainment, news
\`\`\`

## Files changed

| File | Change |
|---|---|
| \`internal/cli/sql.go\` | New — sql command |
| \`internal/cli/digg_commands.go\` | Add \`newAuthorsOverlapCmd\` + register on \`authors\` |
| \`internal/cli/digg_sync.go\` | Add \`--topics\` flag and multi-topic loop |
| \`internal/cli/root.go\` | Register \`newSQLCmd\` |