### PR TITLE
fix(ci): scope registry description gate to PR-changed CLIs

### DIFF
--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -228,6 +228,18 @@ jobs:
         # entry. See tools/generate-registry/main.go validateEntries() for the
         # exact field set.
         #
+        # Scope to the CLIs this PR actually changes. --validate runs against
+        # the PR's whole tree, but a stale PR shouldn't be failed for an
+        # unrelated CLI that is already correct on main — merging the PR won't
+        # change that CLI's manifest, so its in-tree copy never reaches the
+        # post-merge registry. (A PR branched before a CLI's description landed
+        # carries the old description-less manifest for that untouched CLI and
+        # was failing here for agent-capture / tiktok-shop.) We pass the slugs
+        # of CLIs whose registry-source files this PR adds or modifies vs base;
+        # with none, there's nothing to validate. The full-tree invariant still
+        # holds: every CLI is validated by the PR that introduces or edits it.
+        # workflow_dispatch keeps the unscoped whole-library run.
+        #
         # The file-path form (./tools/generate-registry/main.go) is required
         # because the repo root has no go.mod — Go locates the tool's go.mod
         # by walking up from the source file. The package-path form
@@ -235,8 +247,27 @@ jobs:
         # repo root. Matches the invocation in generate-registry.yml.
         #
         # The tool is overlaid from base in "Overlay verifier scripts from
-        # base" above, so this always runs the current validator even on a
-        # stale-base PR; only the library data being validated is the PR's.
+        # base" above, so this always runs the current validator (including
+        # the slug-scoping arg) even on a stale-base PR; only the library
+        # data being validated is the PR's.
+        env:
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
-          go run ./tools/generate-registry/main.go --validate
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            go run ./tools/generate-registry/main.go --validate
+            exit 0
+          fi
+          # --diff-filter=d drops deletions: a CLI the PR removes has nothing
+          # to validate. $3 of library/<cat>/<slug>/<file> is the slug, which
+          # equals the registry entry Name the validator keys its errors on.
+          mapfile -t slugs < <(
+            git diff --name-only --diff-filter=d "${BASE_REMOTE_REF}" HEAD \
+              -- 'library/*/*/.printing-press.json' 'library/*/*/.goreleaser.yaml' \
+            | awk -F/ 'NF>=3 {print $3}' | sort -u)
+          if [ "${#slugs[@]}" -eq 0 ]; then
+            echo "No CLI registry-source files changed in this PR. Nothing to validate."
+            exit 0
+          fi
+          echo "Validating changed CLIs: ${slugs[*]}"
+          go run ./tools/generate-registry/main.go --validate "${slugs[@]}"

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -262,7 +262,7 @@ jobs:
           # to validate. $3 of library/<cat>/<slug>/<file> is the slug, which
           # equals the registry entry Name the validator keys its errors on.
           mapfile -t slugs < <(
-            git diff --name-only --diff-filter=d "${BASE_REMOTE_REF}" HEAD \
+            git diff --name-only --diff-filter=d "${BASE_REMOTE_REF}...HEAD" \
               -- 'library/*/*/.printing-press.json' 'library/*/*/.goreleaser.yaml' \
             | awk -F/ 'NF>=3 {print $3}' | sort -u)
           if [ "${#slugs[@]}" -eq 0 ]; then

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -148,10 +148,20 @@ func main() {
 	// (empty existing map) and fails when any required field would land
 	// empty — catching the lawhub-shape regression where a curated value
 	// in registry.json masks a missing source description.
+	//
+	// Positional args restrict validation to a set of CLI slugs. The
+	// PR-time CI gate passes the slugs whose registry-source files the PR
+	// actually adds or modifies, so a stale PR is never failed for an
+	// unrelated CLI that is already correct on main (merging the PR won't
+	// change that CLI). With no args, every entry is validated — the mode
+	// the post-merge full-library check uses.
 	if *validate {
 		sourceEntries, err := buildEntries(libraryDir, map[string]RegistryEntry{})
 		if err != nil {
 			log.Fatalf("building entries for validation: %v", err)
+		}
+		if restrict := flag.Args(); len(restrict) > 0 {
+			sourceEntries = filterEntriesBySlug(sourceEntries, restrict)
 		}
 		if errs := validateEntries(sourceEntries); len(errs) > 0 {
 			fmt.Fprintln(os.Stderr, "Registry validation failed:")
@@ -455,6 +465,28 @@ func validateEntries(entries []RegistryEntry) []string {
 		}
 	}
 	return errs
+}
+
+// filterEntriesBySlug returns the subset of entries whose Name is in slugs.
+// Used by --validate to scope the PR-time gate to the CLIs a PR actually
+// touched: validation runs against the PR's whole tree, but a stale PR that
+// doesn't modify an already-correct CLI shouldn't be failed for it. Entry
+// Name is the directory basename (see buildEntries), which matches the slug
+// a caller derives from a changed library/<cat>/<slug>/ path. Slugs that
+// match no entry are ignored — they describe a deleted or renamed CLI, which
+// has nothing left to validate.
+func filterEntriesBySlug(entries []RegistryEntry, slugs []string) []RegistryEntry {
+	want := make(map[string]bool, len(slugs))
+	for _, s := range slugs {
+		want[strings.TrimSpace(s)] = true
+	}
+	var out []RegistryEntry
+	for _, e := range entries {
+		if want[e.Name] {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 func isBareMarkdownHeading(s string) bool {

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -288,6 +288,55 @@ func TestValidateEntries_IgnoresPriorCuratedValue(t *testing.T) {
 	}
 }
 
+// TestFilterEntriesBySlug pins the scoping the PR-time --validate gate
+// relies on: only the named CLIs are validated, so a stale PR that doesn't
+// touch an already-correct CLI is never failed for it (the agent-capture /
+// tiktok-shop false-failure on PRs branched before those descriptions
+// landed). Unmatched slugs are dropped silently (deleted/renamed CLIs).
+func TestFilterEntriesBySlug(t *testing.T) {
+	entries := []RegistryEntry{
+		{Name: "agent-capture", Category: "developer-tools", API: "Agent Capture", Path: "library/developer-tools/agent-capture", Description: ""},
+		{Name: "tiktok-shop", Category: "commerce", API: "TikTok Shop", Path: "library/commerce/tiktok-shop", Description: ""},
+		{Name: "exchangerate-api", Category: "finance", API: "ExchangeRate-API", Path: "library/finance/exchangerate-api", Description: "Currency conversion."},
+	}
+
+	t.Run("restricts to named slugs and excludes the rest", func(t *testing.T) {
+		got := filterEntriesBySlug(entries, []string{"exchangerate-api"})
+		if len(got) != 1 || got[0].Name != "exchangerate-api" {
+			t.Fatalf("want only exchangerate-api, got %+v", got)
+		}
+		// The dropped agent-capture/tiktok-shop entries (empty description)
+		// must not reach validateEntries, so a PR touching only
+		// exchangerate-api validates clean.
+		if errs := validateEntries(got); len(errs) != 0 {
+			t.Errorf("want no errors for scoped clean entry, got: %v", errs)
+		}
+	})
+
+	t.Run("a changed CLI with an empty description still fails", func(t *testing.T) {
+		got := filterEntriesBySlug(entries, []string{"agent-capture"})
+		if len(got) != 1 {
+			t.Fatalf("want agent-capture in scope, got %+v", got)
+		}
+		if errs := validateEntries(got); len(errs) == 0 {
+			t.Error("want failure for in-scope empty description, got none")
+		}
+	})
+
+	t.Run("unmatched slug is ignored", func(t *testing.T) {
+		if got := filterEntriesBySlug(entries, []string{"deleted-cli"}); len(got) != 0 {
+			t.Fatalf("want empty for unmatched slug, got %+v", got)
+		}
+	})
+
+	t.Run("whitespace around a slug is trimmed", func(t *testing.T) {
+		got := filterEntriesBySlug(entries, []string{"  exchangerate-api  "})
+		if len(got) != 1 || got[0].Name != "exchangerate-api" {
+			t.Fatalf("want exchangerate-api matched after trim, got %+v", got)
+		}
+	})
+}
+
 // TestRenderCatalogCounts checks both pluralization branches and the
 // happy multi-entry / multi-category path. The pluralization matters
 // because the rendered string lands in human-readable prose; "1 CLIs


### PR DESCRIPTION
## Problem

New PRs are failing the **Verify → Validate registry source descriptions** step with:

```
- agent-capture: description is empty (sources checked: .goreleaser.yaml brews description, .printing-press.json description)
- tiktok-shop:   description is empty (sources checked: .goreleaser.yaml brews description, .printing-press.json description)
```

…on PRs that never touch agent-capture or tiktok-shop.

## Root cause

The step runs `generate-registry --validate` against the PR's **entire tree** (all 151 CLIs) with no base-diff scoping, and `--validate` fails if *any* CLI has an empty description. agent-capture and tiktok-shop got their `.printing-press.json` descriptions in #674 (2026-05-18). PRs branched/forked **before** #674 (e.g. #635 exchangerate-api and #645 redfin, both 2026-05-17) still carry the old description-less manifests for those two CLIs in their tree — so they fail validation on CLIs they didn't modify, and that a merge wouldn't change (main already has the descriptions; the merge keeps main's versions).

These failures were a red ✗ that didn't block merge until **Verify** became a required check via branch protection — matching the report that the errors "were present but not blocking before."

Every other step in this workflow (generated-artifacts, attribution, publish-package) is already merge-base aware. The description gate was the lone whole-tree exception.

## Fix

Scope the PR-time gate to the CLIs whose registry-source files (`.printing-press.json`, `.goreleaser.yaml`) the PR actually adds or modifies vs base.

- `generate-registry --validate` now accepts positional **slug args** that restrict validation to those CLIs (`filterEntriesBySlug`). No args ⇒ whole library (what `workflow_dispatch` keeps).
- The workflow derives changed slugs from `base..HEAD`; with none, there's nothing to validate.
- The full-tree invariant still holds: every CLI is validated by the PR that introduces or edits it.

## Verification

```
# stale-PR tree state (both descriptions blanked):
--validate            → FAILS on agent-capture + tiktok-shop   (reproduces the CI failure)
--validate icloud     → PASSES                                 (a PR touching only icloud — the fix)

# in-scope safety still intact:
--validate icloud  (icloud description blanked) → FAILS        (a CLI's own empty description is still caught)
```

`go vet` clean; `go test ./tools/generate-registry` — 45 pass (4 new subtests for the slug filter).

No `registry.json` / `cli-skills/` changes.