### PR TITLE
ci: run required checks on every PR

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,10 +11,6 @@ name: Govulncheck
 
 on:
   pull_request:
-    paths:
-      - 'library/**/*.go'
-      - 'library/**/go.mod'
-      - 'library/**/go.sum'
   workflow_dispatch:
     inputs:
       scope:
@@ -38,16 +34,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.3'
-          # This workflow may scan several unrelated standalone modules. There
-          # is no single dependency file that produces a useful setup-go cache.
-          cache: false
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-
       - name: Select library CLIs
         id: modules
         env:
@@ -69,7 +55,7 @@ jobs:
             if [ "$EVENT_NAME" = "pull_request" ]; then
               git diff --name-status "${PR_BASE_SHA}...HEAD" -- library > "$changed"
             else
-              git fetch origin main --depth=1
+              git fetch origin main
               base=$(git merge-base origin/main HEAD)
               git diff --name-status "${base}...HEAD" -- library > "$changed"
             fi
@@ -117,6 +103,19 @@ jobs:
           cat "$dirs"
 
           echo "dirs_path=${dirs}" >> "$GITHUB_OUTPUT"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v6
+        if: steps.modules.outputs.count != '0'
+        with:
+          go-version: '1.26.3'
+          # This workflow may scan several unrelated standalone modules. There
+          # is no single dependency file that produces a useful setup-go cache.
+          cache: false
+
+      - name: Install govulncheck
+        if: steps.modules.outputs.count != '0'
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: |

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -37,16 +37,6 @@ name: Verify library conventions
 
 on:
   pull_request:
-    paths:
-      - 'library/**'
-      - 'cli-skills/**'
-      - 'registry.json'
-      - 'tools/generate-registry/**'
-      - 'tools/generate-skills/**'
-      - 'tools/sweep-canonical/**'
-      - '.github/scripts/verify-attribution/**'
-      - '.github/scripts/verify-publish-package/**'
-      - '.github/workflows/verify-library-conventions.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify-skills.yml
+++ b/.github/workflows/verify-skills.yml
@@ -2,12 +2,6 @@ name: Verify SKILL.md
 
 on:
   pull_request:
-    paths:
-      - 'library/**/.printing-press.json'
-      - 'library/**/SKILL.md'
-      - 'library/**/internal/cli/**'
-      - '.github/workflows/verify-skills.yml'
-      - '.github/scripts/verify-skill/**'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- run globally required PR checks on every PR instead of path-filtering them out on docs-only or workflow-only changes
- keep Govulncheck scanning scoped to changed Go modules and skip Go setup/install when there is nothing to scan
- avoid shallow-fetching main in Govulncheck workflow_dispatch changed-scope runs before computing a merge-base

## Validation
- rtk actionlint .github/workflows/govulncheck.yml .github/workflows/verify-library-conventions.yml .github/workflows/verify-skills.yml
- git diff --check