### PR TITLE
fix(ci): harden MCPB manifest policy

### DIFF
--- a/.github/scripts/verify-binary-payload/verify_binary_payload.py
+++ b/.github/scripts/verify-binary-payload/verify_binary_payload.py
@@ -26,7 +26,7 @@ MAGIC_PREFIXES = {
     b"\x7fELF": "ELF executable/shared object",
     b"MZ": "Windows PE executable",
     b"PK\x03\x04": "ZIP/MCPB archive",
-    b"\xca\xfe\xba\xbe": "Mach-O universal binary",
+    b"\xca\xfe\xba\xbe": "Mach-O universal binary / Java class file",
     b"\xfe\xed\xfa\xce": "Mach-O executable",
     b"\xfe\xed\xfa\xcf": "Mach-O executable",
     b"\xce\xfa\xed\xfe": "Mach-O executable",
@@ -34,8 +34,24 @@ MAGIC_PREFIXES = {
 }
 
 
+def suffix_kind(path: Path) -> str | None:
+    name = path.name.lower()
+    for suffix in BINARY_SUFFIXES:
+        if name.endswith(suffix) or (suffix == ".so" and ".so." in name):
+            return f"{suffix} artifact"
+    return None
+
+
 def run(args: list[str]) -> str:
-    return subprocess.check_output(args, cwd=REPO_ROOT, text=True)
+    completed = subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return completed.stdout
 
 
 def changed_library_paths(base_ref: str) -> list[Path]:
@@ -54,12 +70,10 @@ def changed_library_paths(base_ref: str) -> list[Path]:
 
 
 def binary_kind(path: Path) -> str | None:
-    if path.suffix.lower() in BINARY_SUFFIXES:
-        return f"{path.suffix} artifact"
-    try:
-        prefix = path.read_bytes()[:4]
-    except OSError:
-        return None
+    if kind := suffix_kind(path):
+        return kind
+    with path.open("rb") as fh:
+        prefix = fh.read(4)
     for magic, label in MAGIC_PREFIXES.items():
         if prefix.startswith(magic):
             return label
@@ -75,13 +89,28 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    try:
+        paths = changed_library_paths(args.base_ref)
+    except subprocess.CalledProcessError as exc:
+        output = (exc.stderr or exc.output or "").strip()
+        detail = f": {output}" if output else ""
+        print(f"::error::Could not list changed library files (git exited {exc.returncode}){detail}")
+        return 1
+
     problems: list[str] = []
-    for path in changed_library_paths(args.base_ref):
+    for path in paths:
         if not path.is_file():
             continue
-        kind = binary_kind(path)
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            kind = binary_kind(path)
+        except OSError as exc:
+            problems.append(
+                f"::error file={rel}::Could not read changed library file to check for "
+                f"binary content: {exc}"
+            )
+            continue
         if kind:
-            rel = path.relative_to(REPO_ROOT)
             problems.append(
                 f"::error file={rel}::Do not commit {kind} payloads under library/. "
                 "MCPB and native binaries must be built from source in GitHub Actions before signing."

--- a/.github/scripts/verify-binary-payload/verify_binary_payload.py
+++ b/.github/scripts/verify-binary-payload/verify_binary_payload.py
@@ -44,7 +44,7 @@ def changed_library_paths(base_ref: str) -> list[Path]:
             "git",
             "diff",
             "--name-only",
-            "--diff-filter=AMR",
+            "--diff-filter=AMRC",
             f"{base_ref}...HEAD",
             "--",
             "library/",

--- a/.github/scripts/verify-binary-payload/verify_binary_payload.py
+++ b/.github/scripts/verify-binary-payload/verify_binary_payload.py
@@ -26,7 +26,6 @@ MAGIC_PREFIXES = {
     b"\x7fELF": "ELF executable/shared object",
     b"MZ": "Windows PE executable",
     b"\xca\xfe\xba\xbe": "Mach-O universal binary",
-    b"\xbe\xba\xfe\xca": "Mach-O universal binary",
     b"\xfe\xed\xfa\xce": "Mach-O executable",
     b"\xfe\xed\xfa\xcf": "Mach-O executable",
     b"\xce\xfa\xed\xfe": "Mach-O executable",

--- a/.github/scripts/verify-binary-payload/verify_binary_payload.py
+++ b/.github/scripts/verify-binary-payload/verify_binary_payload.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Block committed MCPB/native binary payloads under library/.
+
+Published CLI and MCPB release assets must be built from source in GitHub
+Actions. This guard catches PRs that add or modify prebuilt payloads in the
+catalog tree before those files can be signed or released.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+BINARY_SUFFIXES = {
+    ".mcpb",
+    ".dylib",
+    ".so",
+    ".dll",
+    ".exe",
+}
+
+MAGIC_PREFIXES = {
+    b"\x7fELF": "ELF executable/shared object",
+    b"MZ": "Windows PE executable",
+    b"\xca\xfe\xba\xbe": "Mach-O universal binary",
+    b"\xbe\xba\xfe\xca": "Mach-O universal binary",
+    b"\xfe\xed\xfa\xce": "Mach-O executable",
+    b"\xfe\xed\xfa\xcf": "Mach-O executable",
+    b"\xce\xfa\xed\xfe": "Mach-O executable",
+    b"\xcf\xfa\xed\xfe": "Mach-O executable",
+}
+
+
+def run(args: list[str]) -> str:
+    return subprocess.check_output(args, cwd=REPO_ROOT, text=True)
+
+
+def changed_library_paths(base_ref: str) -> list[Path]:
+    diff = run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            f"{base_ref}...HEAD",
+            "--",
+            "library/",
+        ]
+    )
+    return [REPO_ROOT / line for line in diff.splitlines() if line]
+
+
+def binary_kind(path: Path) -> str | None:
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return f"{path.suffix} artifact"
+    try:
+        prefix = path.read_bytes()[:4]
+    except OSError:
+        return None
+    for magic, label in MAGIC_PREFIXES.items():
+        if prefix.startswith(magic):
+            return label
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base git ref to compare against; defaults to origin/main.",
+    )
+    args = parser.parse_args()
+
+    problems: list[str] = []
+    for path in changed_library_paths(args.base_ref):
+        if not path.is_file():
+            continue
+        kind = binary_kind(path)
+        if kind:
+            rel = path.relative_to(REPO_ROOT)
+            problems.append(
+                f"::error file={rel}::Do not commit {kind} payloads under library/. "
+                "MCPB and native binaries must be built from source in GitHub Actions before signing."
+            )
+
+    if problems:
+        for problem in problems:
+            print(problem)
+        return 1
+
+    print("No newly added or modified MCPB/native binary payloads under library/.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/verify-binary-payload/verify_binary_payload.py
+++ b/.github/scripts/verify-binary-payload/verify_binary_payload.py
@@ -25,6 +25,7 @@ BINARY_SUFFIXES = {
 MAGIC_PREFIXES = {
     b"\x7fELF": "ELF executable/shared object",
     b"MZ": "Windows PE executable",
+    b"PK\x03\x04": "ZIP/MCPB archive",
     b"\xca\xfe\xba\xbe": "Mach-O universal binary",
     b"\xfe\xed\xfa\xce": "Mach-O executable",
     b"\xfe\xed\xfa\xcf": "Mach-O executable",

--- a/.github/scripts/verify-manifest/verify_manifest.py
+++ b/.github/scripts/verify-manifest/verify_manifest.py
@@ -109,7 +109,7 @@ def validate(cli_dir: Path) -> list[str]:
             problems.append(
                 f"server.mcp_config.env {env_name!r} references missing user_config key {expected_key!r}"
             )
-        if env_value != expected_ref:
+        elif env_value != expected_ref:
             problems.append(
                 f"server.mcp_config.env {env_name!r} should map to {expected_ref!r} (got {env_value!r})"
             )

--- a/.github/scripts/verify-manifest/verify_manifest.py
+++ b/.github/scripts/verify-manifest/verify_manifest.py
@@ -7,6 +7,8 @@ Per CLI:
 - has manifest_version="0.3", non-empty name, display_name, version, description
 - server.type="binary", server.entry_point references the bundled binary
 - server.mcp_config.command points at ${__dirname}/<entry_point>
+- server.mcp_config.args is empty for generated binary MCPBs
+- server.mcp_config.env maps each env var to its lower-case user_config key
 - user_config keys (when present) match auth_env_vars in .printing-press.json
 - cli_binary, when present, matches the CLI name from .printing-press.json
 - compatibility.platforms is a non-empty list
@@ -65,6 +67,11 @@ def validate(cli_dir: Path) -> list[str]:
     cmd = (server.get("mcp_config") or {}).get("command", "")
     if "${__dirname}" not in cmd:
         problems.append(f'server.mcp_config.command should contain ${{__dirname}} (got {cmd!r})')
+    args = (server.get("mcp_config") or {}).get("args")
+    if args not in ([], None):
+        problems.append(
+            f"server.mcp_config.args should be empty for generated binary MCPBs (got {args!r})"
+        )
 
     expected_mcp = pp.get("mcp_binary")
     if expected_mcp:
@@ -94,6 +101,18 @@ def validate(cli_dir: Path) -> list[str]:
         missing = declared_envs - uc_envs
         if missing:
             problems.append(f"user_config missing entries for {sorted(missing)}")
+    mcp_env = (server.get("mcp_config") or {}).get("env") or {}
+    for env_name, env_value in mcp_env.items():
+        expected_key = env_name.lower()
+        expected_ref = f"${{user_config.{expected_key}}}"
+        if expected_key not in user_config:
+            problems.append(
+                f"server.mcp_config.env {env_name!r} references missing user_config key {expected_key!r}"
+            )
+        if env_value != expected_ref:
+            problems.append(
+                f"server.mcp_config.env {env_name!r} should map to {expected_ref!r} (got {env_value!r})"
+            )
 
     # cli_binary should match .printing-press.json's cli_name when set.
     cli_binary = m.get("cli_binary")

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -34,6 +34,10 @@ name: Verify library conventions
 #    novel feature metadata, and MCP manifests when advertised. The
 #    publish-skill PR body sections are suggested from these artifacts,
 #    but artifact completeness remains the source of truth.
+#
+# 5. Prebuilt MCPB/native binary payloads must not be committed under
+#    library/. Release assets are built from source in GitHub Actions,
+#    then published from that workflow.
 
 on:
   pull_request:
@@ -90,10 +94,16 @@ jobs:
           # the --validate flag existed otherwise runs its own stale tool
           # and dies with "flag provided but not defined: -validate"
           # instead of a real validation message (or a pass).
-          git checkout "${BASE_REMOTE_REF}" -- \
+          for path in \
             .github/scripts/verify-attribution \
+            .github/scripts/verify-binary-payload \
             .github/scripts/verify-publish-package \
             tools/generate-registry
+          do
+            if git cat-file -e "${BASE_REMOTE_REF}:${path}" 2>/dev/null; then
+              git checkout "${BASE_REMOTE_REF}" -- "${path}"
+            fi
+          done
 
       - name: Fail on changes to generated artifacts
         if: github.event_name == 'pull_request'
@@ -183,6 +193,14 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref "${BASE_REMOTE_REF}"
+
+      - name: Block committed MCPB/native binary payloads
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify-binary-payload/verify_binary_payload.py --base-ref "${BASE_REMOTE_REF}"
 
       - name: go.mod module path matches directory
         run: |

--- a/library/developer-tools/posthog/manifest.json
+++ b/library/developer-tools/posthog/manifest.json
@@ -19,12 +19,12 @@
       "command": "${__dirname}/bin/posthog-pp-mcp",
       "args": [],
       "env": {
-        "POSTHOG_PERSONAL_APIKEY_AUTH": "${user_config.POSTHOG_PERSONAL_APIKEY_AUTH}"
+        "POSTHOG_PERSONAL_APIKEY_AUTH": "${user_config.posthog_personal_apikey_auth}"
       }
     }
   },
   "user_config": {
-    "POSTHOG_PERSONAL_APIKEY_AUTH": {
+    "posthog_personal_apikey_auth": {
       "type": "string",
       "description": "PostHog personal API key (phx_...). Get yours at https://app.posthog.com/settings/user-api-keys",
       "required": true,

--- a/library/sales-and-crm/conduyt-crm/manifest.json
+++ b/library/sales-and-crm/conduyt-crm/manifest.json
@@ -15,12 +15,12 @@
       "command": "${__dirname}/bin/conduyt-crm-pp-mcp",
       "args": [],
       "env": {
-        "CONDUYT_CRM_TOKEN": "${user_config.CONDUYT_CRM_TOKEN}"
+        "CONDUYT_CRM_TOKEN": "${user_config.conduyt_crm_token}"
       }
     }
   },
   "user_config": {
-    "CONDUYT_CRM_TOKEN": {
+    "conduyt_crm_token": {
       "type": "string",
       "title": "CONDUYT_CRM_TOKEN",
       "description": "Bearer token for authenticating with the Conduyt CRM API.",

--- a/library/travel/seats-aero/manifest.json
+++ b/library/travel/seats-aero/manifest.json
@@ -15,7 +15,7 @@
       "command": "${__dirname}/bin/seats-aero-pp-mcp",
       "args": [],
       "env": {
-        "SEATS_AERO_PARTNER_PARTNER_AUTHORIZATION": "${user_config.seats_aero_partner_partner_authorization}"
+        "SEATS_AERO_API_KEY": "${user_config.seats_aero_api_key}"
       }
     }
   },


### PR DESCRIPTION
## Summary

This replaces the stale draft in #285 with the MCPB-specific pieces that are still useful on current `main`.

It tightens `manifest.json` validation so generated binary MCPB manifests must keep empty `mcp_config.args` and map each env var to its lower-case `user_config` key. It also fixes the three current manifests exposed by that stricter check: Conduyt CRM, PostHog, and Seats Aero.

The PR also adds a PR-time library convention guard that blocks newly added or modified `.mcpb` and native binary payloads under `library/`. Release assets should be built from source in GitHub Actions before publishing, not committed into the catalog tree.

## Deliberately left out from #285

- `govulncheck`: superseded by the current scoped workflow on `main`.
- dependency review: still requires repo Dependency Graph enablement before it can pass.
- CodeQL / Dependabot: useful as separate repo-admin hardening work, but not part of this MCPB-focused repair.
- artifact attestations: the old draft granted `id-token: write` outside the current allowlist, conflicting with the newer supply-chain policy.

## Validation

- `python3 .github/scripts/verify-manifest/verify_manifest.py`
- `python3 .github/scripts/verify-binary-payload/verify_binary_payload.py --base-ref origin/main`
- `python3 -m py_compile .github/scripts/verify-manifest/verify_manifest.py .github/scripts/verify-binary-payload/verify_binary_payload.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify-library-conventions.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/verify-library-conventions.yml`
- `git diff --check`
