### PR TITLE
fix(setlist-fm): repair auth set-token, doctor env-vars, and signup hint

### DIFF
--- a/docs/plans/2026-05-20-002-fix-setlist-fm-auth-and-doctor-plan.md
+++ b/docs/plans/2026-05-20-002-fix-setlist-fm-auth-and-doctor-plan.md
@@ -1,0 +1,235 @@
+---
+title: "fix(setlist-fm): repair auth set-token, doctor env-vars, and signup hint"
+type: fix
+status: active
+created: 2026-05-20
+depth: standard
+target_repo: printing-press-library
+origin:
+  bug_report: /Users/mvanhorn/Downloads/setlist-fm-pp-cli-bugs.md
+  related_pr: https://github.com/mvanhorn/printing-press-library/pull/724
+---
+
+# fix(setlist-fm): repair auth set-token, doctor env-vars, and signup hint
+
+## Summary
+
+The setlist-fm CLI (shipped via PR #724) has a broken auth flow. Three related bugs make the documented setup path fail silently:
+
+1. `auth set-token` writes the API key to a dead OAuth field (`access_token`); the HTTP layer reads from `fm_api_key`, so the saved token is never used and every request returns HTTP 403.
+2. `doctor` always emits `FAIL Env Vars` when the env var is unset, even when `fm_api_key` is correctly configured in `config.toml`.
+3. The `doctor` hint only mentions the env var path; it does not mention `auth set-token` (the more durable config path) and does not say the key is free.
+
+This plan ships a single library-only patch (no upstream generator change) that fixes all three bugs, drops the unused OAuth-shaped fields from the config schema (Setlist.fm has no OAuth flow), adds "free" language to the signup hint, and records the patch in `.printing-press-patches.json` following the existing `greptile-review-feedback` precedent.
+
+## Problem Frame
+
+Setlist.fm's API uses only the static `x-api-key` header. The generated `Config` struct was emitted from an OAuth-shaped template and carries five unused fields plus a dead `auth_header` field. The `auth set-token` command was wired to `Config.SaveTokens(clientID, clientSecret, accessToken, refreshToken, expiry)` instead of writing to the `fm_api_key` field that `Config.AuthHeader()` actually reads.
+
+The `doctor` env-vars check treats the env var as a hard requirement instead of one of multiple valid auth sources, so a correctly-configured config-only user sees `FAIL` and assumes setup failed.
+
+## Scope Boundaries
+
+In scope:
+- Fix `auth set-token` to persist to `fm_api_key`
+- Remove unused OAuth-shaped fields from `Config` (`AccessToken`, `RefreshToken`, `TokenExpiry`, `ClientID`, `ClientSecret`, `AuthHeaderVal`) and the associated `SaveTokens` / `applyAuthFormat` helpers
+- Fix `doctor` env-vars check: downgrade to `OK` when config-based auth is configured, only `FAIL` when no auth source exists at all
+- Update `doctor` hint to mention `auth set-token` as the primary path and add "free" language
+- Add a tracked patch entry in `.printing-press-patches.json`
+
+Outside this PR:
+- Upstream generator fix in `cli-printing-press` (the templates still emit the OAuth-shaped struct). Follow-up issue; library-side patch is the documented mechanism for fixes like this.
+- Migration tooling for users with populated dead fields. `go-toml/v2` is lenient about unknown keys on read, and the next save will simply omit them; existing config files keep working.
+
+### Deferred to Follow-Up Work
+- Upstream printing-press generator template fix so future API-key-only CLIs do not emit OAuth-shaped configs
+
+## Key Technical Decisions
+
+1. **Library-only patch, not generator fix.** The `.printing-press-patches.json` mechanism exists for exactly this case (post-generation fixes). Precedent: the existing `greptile-review-feedback` patch entry. Upstream template fix can come later.
+
+2. **Drop the dead OAuth fields, not just re-route the write.** The bug report explicitly recommends this. `go-toml/v2` ignores unknown TOML keys by default, so users with populated `access_token` / `refresh_token` rows keep loading without error; on next save those fields are simply dropped. This is the path with the least long-term confusion.
+
+3. **`auth set-token` writes via a new `SaveAPIKey` method on `Config`.** Cleaner than inlining a `c.SetlistFmApiKey = ...; c.save()` block in the command file. Mirrors the existing `ClearTokens` / `save` pattern.
+
+4. **`doctor` env-vars verdict gates on `cfg.AuthHeader()`.** When the config provides auth, env_vars status becomes `OK config provides auth` (informational, not FAIL). When neither env var nor config provides auth, the existing `ERROR missing required` message stays.
+
+5. **Hint copy.** Replace the current `auth_hint` with a two-line block that mentions both paths and explicitly calls out that the key is free:
+   ```
+   Get a free API key at https://www.setlist.fm/settings/api, then run:
+     setlist-fm-pp-cli auth set-token <key>   (or export SETLISTFM_API_KEY=<key>)
+   ```
+
+## Implementation Units
+
+### U1. Re-route `auth set-token` to `fm_api_key` and drop dead OAuth fields
+
+**Goal:** Make `auth set-token <key>` persist to `fm_api_key` so the saved token is actually read by the HTTP layer. Remove the unused OAuth-shaped fields from the `Config` struct so the config schema reflects the API's actual auth model.
+
+**Dependencies:** None (starting point).
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/internal/config/config.go` (modify)
+- `library/media-and-entertainment/setlist-fm/internal/cli/auth.go` (modify)
+- `library/media-and-entertainment/setlist-fm/internal/config/config_test.go` (create)
+
+**Approach:**
+- Remove from `Config` struct: `AuthHeaderVal`, `AccessToken`, `RefreshToken`, `TokenExpiry`, `ClientID`, `ClientSecret`. Keep `BaseURL`, `AuthSource` (computed), `Path` (computed), and `SetlistFmApiKey`.
+- Replace `SaveTokens` and `ClearTokens` with a single `SaveAPIKey(key string) error` method and a `ClearAPIKey() error` method. Both delegate to the existing `save()` helper.
+- Simplify `AuthHeader()` to `return c.SetlistFmApiKey`. Remove `applyAuthFormat` and the trailing `var _ = strings.ReplaceAll` since neither is used anymore.
+- In `auth.go`:
+  - `newAuthSetTokenCmd` calls `cfg.SaveAPIKey(args[0])` and removes the legacy `AuthHeaderVal = ""` clear (now unnecessary).
+  - `newAuthLogoutCmd` calls `cfg.ClearAPIKey()`.
+- Verify the `AuthSource` field is set when the value comes from config (currently only set from env vars). Add an `AuthSource = "config"` assignment in `Load()` when `cfg.SetlistFmApiKey != ""` after TOML unmarshal AND env vars did not override.
+
+**Patterns to follow:** Mirror the existing `save()` private method pattern (already in `config.go`). Mirror the test layout in `internal/cli/since_test.go` and `internal/cli/which_test.go` (package-level, standard-library `testing`, no third-party assertion lib).
+
+**Test scenarios:**
+- Happy path: `SaveAPIKey("abc123")` writes `fm_api_key = "abc123"` to disk and a subsequent `Load()` returns a Config with `SetlistFmApiKey == "abc123"` and `AuthHeader() == "abc123"`.
+- Backward-compat read: a TOML file containing legacy keys (`access_token = "..."`, `auth_header = "..."`, `refresh_token = "..."`) loads without error and is treated as unauthenticated when `fm_api_key` is empty.
+- Round-trip drops dead fields: after `SaveAPIKey`, re-reading the file shows `fm_api_key` only; the legacy field rows are not re-emitted.
+- `ClearAPIKey` empties `fm_api_key` and a subsequent `AuthHeader()` returns `""`.
+- Env-var precedence preserved: when `SETLISTFM_API_KEY` is set, `Load()` overrides `SetlistFmApiKey` from env and sets `AuthSource = "env:SETLISTFM_API_KEY"`.
+- Config-source AuthSource: when only `fm_api_key` is set in TOML and no env var is exported, `AuthSource == "config"`.
+
+**Verification:** `go test ./internal/config/... ./internal/cli/...` passes. Manual smoke: fresh `~/.config/setlist-fm-pp-cli/config.toml`, run `setlist-fm-pp-cli auth set-token TESTKEY`, then `cat` the file and confirm `fm_api_key = "TESTKEY"` and no `access_token` / `auth_header` lines.
+
+---
+
+### U2. Fix `doctor` env-vars verdict when config provides auth
+
+**Goal:** Stop reporting `FAIL Env Vars` when `fm_api_key` is set in config. The env var is one of multiple valid auth sources, not a hard requirement.
+
+**Dependencies:** U1 (so `cfg.AuthHeader()` is the canonical check).
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/internal/cli/doctor.go` (modify)
+- `library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go` (create)
+
+**Approach:**
+- In `newDoctorCmd`, after the existing env-var detection block, branch on whether `cfg != nil && cfg.AuthHeader() != ""` (i.e. some auth source is configured):
+  - If an env var is set, keep the current `OK %d/%d available` message.
+  - If no env var is set but config has `fm_api_key`, set `report["env_vars"] = "OK config provides auth (env var not required)"`.
+  - If neither is set, keep the current `ERROR missing required: ...` message.
+- The existing color-mapping `switch` in the human-readable block already turns `OK`-prefixed strings green and `ERROR`-prefixed strings red, so no extra mapping is needed.
+
+**Patterns to follow:** Match the existing `switch` style and message format inside `newDoctorCmd`. Tests should construct a `*cobra.Command` and capture stdout via `cmd.SetOut(&buf)`, following the style in `since_test.go`.
+
+**Test scenarios:**
+- Happy path (config-only): with `fm_api_key` set and no env var, `doctor` produces `OK Env Vars: OK config provides auth (env var not required)` and exit code 0.
+- Env-var path unchanged: with `SETLISTFM_API_KEY` set, `doctor` produces `OK Env Vars: OK 1/1 available`.
+- Both unset: with neither configured, `doctor` still produces `FAIL Env Vars: ERROR missing required: SETLISTFM_API_KEY (or SETLIST_FM_API_KEY)`.
+- `--fail-on error` does not trip on the config-only happy path.
+- JSON output: `env_vars` field has the new `OK config provides auth ...` string in the config-only case.
+
+**Verification:** `go test ./internal/cli/...` passes. Manual smoke: with `fm_api_key` set in config and `unset SETLISTFM_API_KEY SETLIST_FM_API_KEY`, `setlist-fm-pp-cli doctor` shows no `FAIL` line.
+
+---
+
+### U3. Update `doctor` hint copy: free key + `auth set-token` primary path
+
+**Goal:** Replace the current single-line env-var-only hint with a two-line block that puts `auth set-token` first, mentions the env var as the alternative, and explicitly says the key is free.
+
+**Dependencies:** None on U1/U2 in code terms, but logically belongs with the doctor fix.
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/internal/cli/doctor.go` (modify)
+- `library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go` (extend from U2)
+
+**Approach:**
+- Change `report["auth_hint"]` to the two-line form, e.g.:
+  ```
+  Get a free API key at https://www.setlist.fm/settings/api, then run:
+    setlist-fm-pp-cli auth set-token <key>   (or export SETLISTFM_API_KEY=<key>)
+  ```
+- Render the multi-line hint in the human-readable output by emitting each line on its own indented row, so it visually nests under the `Auth` indicator. The existing `fmt.Fprintf(w, "  hint: %v\n", hint)` line takes a single string; split on `\n` before emitting to keep the formatting clean.
+- Leave the JSON `auth_hint` field as a single string with embedded `\n` so machine consumers see the full text.
+
+**Patterns to follow:** Existing hint rendering at the end of `newDoctorCmd`.
+
+**Test scenarios:**
+- Hint text contains both `setlist-fm-pp-cli auth set-token` and `SETLISTFM_API_KEY`.
+- Hint text contains the word `free`.
+- Hint text contains `https://www.setlist.fm/settings/api`.
+- Hint is only emitted when `auth` is `missing` (not when configured).
+
+**Verification:** `go test ./internal/cli/...` passes. Manual smoke: run `doctor` with no auth configured and confirm both lines render with the word "free".
+
+---
+
+### U4. Record the patch in `.printing-press-patches.json`
+
+**Goal:** Append a patch entry so the Printing Press tooling re-applies these fixes after future regenerations. Mirrors the existing `greptile-review-feedback` entry.
+
+**Dependencies:** U1, U2, U3 (the entry's `files` list must match the actual changed paths).
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/.printing-press-patches.json` (modify)
+
+**Approach:**
+- Append a new object to the `patches` array:
+  ```json
+  {
+    "id": "auth-flow-fix",
+    "summary": "Re-route auth set-token to fm_api_key, drop dead OAuth fields, and fix doctor env-vars verdict.",
+    "reason": "Generated CLI emitted an OAuth-shaped config but Setlist.fm uses only the static x-api-key header, so auth set-token wrote to a dead field and doctor falsely reported FAIL Env Vars when config-based auth was valid.",
+    "files": [
+      "internal/cli/auth.go",
+      "internal/cli/doctor.go",
+      "internal/cli/doctor_test.go",
+      "internal/config/config.go",
+      "internal/config/config_test.go"
+    ],
+    "validated_outcome": "go test ./... passed; manual smoke confirmed auth set-token persists to fm_api_key and doctor no longer reports FAIL Env Vars when config provides auth."
+  }
+  ```
+- Leave `schema_version`, `applied_at`, `base_run_id`, `base_printing_press_version` unchanged — those describe the base generation, not this patch.
+
+**Patterns to follow:** Existing `greptile-review-feedback` entry shape.
+
+**Test scenarios:**
+- Test expectation: none -- pure metadata file, validated by the actual code changes in U1-U3 and by Printing Press tooling later re-applying patches.
+
+**Verification:** File parses as JSON (`jq . .printing-press-patches.json`). `patches` array has two entries.
+
+---
+
+## System-Wide Impact
+
+- **Config schema:** `config.toml` files written by old versions remain readable (lenient TOML unmarshal). On the next save, the legacy `access_token` / `refresh_token` / `token_expiry` / `client_id` / `client_secret` / `auth_header` keys are dropped from the file. No data loss because those fields were never read.
+- **`auth status` command:** already calls `cfg.AuthHeader()`, so it picks up the U1 simplification automatically. No code change needed.
+- **HTTP layer:** the X-Api-Key header is set from `cfg.AuthHeader()`, which after U1 returns `cfg.SetlistFmApiKey` directly. No change needed.
+- **README / SKILL.md:** already say "Get a free API key" — no change required.
+- **MCP binary (`setlist-fm-pp-mcp`):** shares the same `internal/config` package, so it picks up the schema change transparently.
+
+## Risks and Mitigations
+
+- **Risk:** `config.go` is generated; renumbering struct fields could conflict with a future regeneration. **Mitigation:** the `.printing-press-patches.json` entry exists exactly to flag this — Printing Press tooling re-applies patches after regeneration.
+- **Risk:** `applyAuthFormat` / `AuthHeaderVal` might be referenced elsewhere in the generated CLI (e.g., a per-resource client). **Mitigation:** during U1 implementation, grep `library/media-and-entertainment/setlist-fm/` for `AuthHeaderVal` / `applyAuthFormat` / `AccessToken` / `RefreshToken` / `TokenExpiry` / `ClientID` / `ClientSecret`. The greptile-style review precedent shows the package compiles cleanly when only `AuthHeader()` is used externally, but verify before removing.
+- **Risk:** Migrating users with the legacy fields populated. **Mitigation:** `go-toml/v2` Unmarshal ignores unknown keys by default; on save the marshaller writes only the remaining fields. Existing users keep working.
+
+## Verification Strategy
+
+1. `cd ~/printing-press-library/library/media-and-entertainment/setlist-fm && go test ./...` — full module test suite passes.
+2. `go vet ./...` — no warnings.
+3. `go build ./cmd/setlist-fm-pp-cli` — binary builds.
+4. Manual smoke:
+   - Wipe `~/.config/setlist-fm-pp-cli/config.toml`.
+   - `setlist-fm-pp-cli auth set-token <real-key>` — exits 0, file contains `fm_api_key = "<real-key>"` and no `access_token` line.
+   - `unset SETLISTFM_API_KEY SETLIST_FM_API_KEY && setlist-fm-pp-cli doctor` — all five health-check lines start with `OK` (no `FAIL Env Vars`).
+   - `setlist-fm-pp-cli artist resolve "Phish"` — succeeds (HTTP 200, not 403).
+   - `setlist-fm-pp-cli auth logout` — clears `fm_api_key`.
+   - Run `doctor` with no auth configured and confirm the hint mentions `auth set-token` first and contains the word `free`.
+
+## Branch and PR Plan
+
+1. From a clean `~/printing-press-library` checkout on `origin/main`: `git checkout -b fix/setlist-fm-auth-flow origin/main`.
+2. Apply U1, U2, U3 changes, run the verification strategy.
+3. Add U4 patch entry, re-run `go test ./...`.
+4. Commit with a single message: `fix(setlist-fm): repair auth set-token, doctor env-vars, and signup hint`.
+5. `git push -u origin fix/setlist-fm-auth-flow`.
+6. `gh pr create --repo mvanhorn/printing-press-library --base main` with a body that:
+   - Names the three bugs and links the bug report (paste content, since it lives in `~/Downloads/`).
+   - References PR #724 as the contribution that shipped the affected CLI.
+   - Lists the verification steps that were run.
+   - No process narrative, no AI-tool disclosure beyond the standard footer (per global feedback).

--- a/docs/plans/2026-05-20-002-fix-setlist-fm-auth-and-doctor-plan.md
+++ b/docs/plans/2026-05-20-002-fix-setlist-fm-auth-and-doctor-plan.md
@@ -157,40 +157,86 @@ Outside this PR:
 
 ---
 
+### U5. Chain `SETLISTFM_API_KEY` into `auth logout` env-still-set check
+
+**Goal:** When `auth logout` clears the config, surface a note for whichever env var is still exported so the user understands they remain authenticated via env. The current code only checks `SETLIST_FM_API_KEY`, but `config.Load` accepts `SETLISTFM_API_KEY` with higher priority — a user on the modern setlistfm-js convention sees "Logged out. Credentials cleared." while staying fully authenticated.
+
+**Requirements:** Closes Greptile P1 finding on PR #731 (`auth.go:120-139`). The logout verdict must mirror `config.Load`'s env-var priority.
+
+**Dependencies:** None on other units (the existing `auth.go` block already telegraphs the chain shape with its redundant `if envStillSet == ""` guard).
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/internal/cli/auth.go` (modify)
+- `library/media-and-entertainment/setlist-fm/internal/cli/auth_test.go` (create or extend)
+
+**Approach:**
+- Extend the env-still-set chain in `newAuthLogoutCmd` to check `SETLISTFM_API_KEY` first (matching `config.Load`'s priority order at `internal/config/config.go:58-63`), then `SETLIST_FM_API_KEY`. The first non-empty wins.
+- Keep the human prose and the JSON `note` field shape the same — only the detected var name changes.
+- No change to `ClearAPIKey` itself; this is purely about surfacing env-survival accurately.
+
+**Patterns to follow:** The existing chain skeleton in `auth.go:121-124`. Keep the `if envStillSet == ""` short-circuit pattern so future env-var additions remain easy.
+
+**Test scenarios:**
+- Logout with only `SETLISTFM_API_KEY` exported: JSON envelope contains `note: "SETLISTFM_API_KEY env var is still set"`; human prose names `SETLISTFM_API_KEY`.
+- Logout with only `SETLIST_FM_API_KEY` exported: JSON envelope contains `note: "SETLIST_FM_API_KEY env var is still set"`; human prose names `SETLIST_FM_API_KEY` (regression coverage for the pre-fix behavior).
+- Logout with both env vars exported: JSON envelope names `SETLISTFM_API_KEY` (the higher-priority var, matching what `config.Load` would have used).
+- Logout with neither env var exported: JSON envelope has no `note` key; human prose is `Logged out. Credentials cleared.`
+
+**Verification:** `go test ./internal/cli/...` passes. Manual smoke: `export SETLISTFM_API_KEY=test && setlist-fm-pp-cli auth logout` prints a line naming `SETLISTFM_API_KEY`.
+
+---
+
+### U6. Route `doctor_test.go` through an in-process `httptest.NewServer`
+
+**Goal:** Stop `runDoctor` from issuing live HTTP calls against `https://api.setlist.fm/rest` on every CI run. The doctor command unconditionally hits `Get("/")` and an authenticated probe; tests pass a config with the real base URL and ignore the resulting `api`/`credentials` keys, so the network round-trip is invisible-on-success but slow and DNS-fragile.
+
+**Requirements:** Closes Greptile P2 finding on PR #731 (`doctor_test.go:386-402`).
+
+**Dependencies:** None on other units. Pattern is already established in this CLI's test suite.
+
+**Files:**
+- `library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go` (modify)
+
+**Approach:**
+- Add a helper (e.g. `writeConfigWithStubAPI`) that spins up an `httptest.NewServer` returning a minimal JSON body for `/` and the doctor's authenticated probe path, registers `t.Cleanup(srv.Close)`, and writes a `config.toml` whose `base_url` points at `srv.URL`.
+- Update each `writeConfig` call site in this file to use the stub-backed helper (or replace `writeConfig` outright if no callsite needs the real-URL form).
+- Leave the existing test assertions untouched — they only inspect `env_vars`, `auth_hint`, and the rendered prose, none of which depend on the network outcome.
+- Optional small upside: with a stub server in place, future tests can begin asserting on `api`/`credentials` keys, but no new assertions in this unit.
+
+**Patterns to follow:** `internal/cli/sync_hydrate_test.go:19-50` (httptest server + `BaseURL: srv.URL` + `defer srv.Close()`) and `internal/cliutil/cliutil_test.go:449-620` (same shape, multiple handlers).
+
+**Test scenarios:**
+- All five existing doctor tests (`TestDoctorEnvVarsOKWhenConfigProvidesAuth`, `TestDoctorEnvVarsFailWhenNoAuthAnywhere`, `TestDoctorEnvVarsOKWhenEnvVarSet`, `TestDoctorHintMentionsFreeAndAuthSetTokenAndEnvVar`, `TestDoctorHintOmittedWhenAuthConfigured`, `TestDoctorHumanRenderingShowsHintAcrossMultipleLines`) continue to pass with no behavioral change.
+- New negative coverage (worth adding while the helper exists): a test that confirms `api` reports `reachable` and `credentials` reports a non-empty verdict when the stub server returns 200 — proves the stub is actually wired in, otherwise a typo in `base_url` would still pass the existing assertion set.
+
+**Verification:** `go test ./internal/cli/...` passes with `-count=1` and with the network disabled (`GODEBUG=netdns=go+1 go test -tags nointernet ./internal/cli/...` would surface DNS attempts; alternatively, run the suite on an airplane-mode laptop or in `--network=none` docker). The doctor tests must run in under a second total — current behavior depends on api.setlist.fm latency.
+
+---
+
 ### U4. Record the patch in `.printing-press-patches.json`
 
-**Goal:** Append a patch entry so the Printing Press tooling re-applies these fixes after future regenerations. Mirrors the existing `greptile-review-feedback` entry.
+**Goal:** Extend the existing `auth-flow-fix` patch entry so the Printing Press tooling re-applies all of U1-U3 plus the U5/U6 Greptile follow-ups after future regenerations.
 
-**Dependencies:** U1, U2, U3 (the entry's `files` list must match the actual changed paths).
+**Dependencies:** U1, U2, U3, U5, U6 (the entry's `files`, `summary`, and `reason` must reflect the final changed paths and motivations).
 
 **Files:**
 - `library/media-and-entertainment/setlist-fm/.printing-press-patches.json` (modify)
 
 **Approach:**
-- Append a new object to the `patches` array:
-  ```json
-  {
-    "id": "auth-flow-fix",
-    "summary": "Re-route auth set-token to fm_api_key, drop dead OAuth fields, and fix doctor env-vars verdict.",
-    "reason": "Generated CLI emitted an OAuth-shaped config but Setlist.fm uses only the static x-api-key header, so auth set-token wrote to a dead field and doctor falsely reported FAIL Env Vars when config-based auth was valid.",
-    "files": [
-      "internal/cli/auth.go",
-      "internal/cli/doctor.go",
-      "internal/cli/doctor_test.go",
-      "internal/config/config.go",
-      "internal/config/config_test.go"
-    ],
-    "validated_outcome": "go test ./... passed; manual smoke confirmed auth set-token persists to fm_api_key and doctor no longer reports FAIL Env Vars when config provides auth."
-  }
-  ```
+- Update the existing `auth-flow-fix` patch object (do not add a second entry — the Greptile findings are a review-cycle followup on the same shipped fix, not a separate customization):
+  - Extend `summary` to mention the env-var-priority chain in logout and the httptest-stubbed doctor tests.
+  - Extend `reason` with a sentence about the Greptile follow-ups (PR #731 review): logout `env_still_set` chain matched to `config.Load` priority; doctor tests no longer round-trip the live API.
+  - Add `internal/cli/auth_test.go` to `files` (created in U5 if not already present).
+  - `internal/cli/auth.go`, `internal/cli/doctor.go`, `internal/cli/doctor_test.go`, `internal/config/config.go`, `internal/config/config_test.go` are already in the list — no change there.
+  - Extend `validated_outcome` to note the new test coverage (auth logout env-var matrix + doctor tests run with no network).
 - Leave `schema_version`, `applied_at`, `base_run_id`, `base_printing_press_version` unchanged — those describe the base generation, not this patch.
 
-**Patterns to follow:** Existing `greptile-review-feedback` entry shape.
+**Patterns to follow:** Existing `greptile-review-feedback` entry shape; the live `auth-flow-fix` entry as written today.
 
 **Test scenarios:**
-- Test expectation: none -- pure metadata file, validated by the actual code changes in U1-U3 and by Printing Press tooling later re-applying patches.
+- Test expectation: none -- pure metadata file, validated by the actual code changes in U1-U3 and U5-U6 plus the patches manifest parsing as JSON.
 
-**Verification:** File parses as JSON (`jq . .printing-press-patches.json`). `patches` array has two entries.
+**Verification:** File parses as JSON (`jq . .printing-press-patches.json`). `patches` array still has two entries (the original `greptile-review-feedback` plus the now-extended `auth-flow-fix`). `internal/cli/auth_test.go` appears in the `auth-flow-fix` `files` array.
 
 ---
 
@@ -233,3 +279,12 @@ Outside this PR:
    - References PR #724 as the contribution that shipped the affected CLI.
    - Lists the verification steps that were run.
    - No process narrative, no AI-tool disclosure beyond the standard footer (per global feedback).
+
+### Follow-up commit for U5/U6 (Greptile review feedback on PR #731)
+
+7. On the same `fix/setlist-fm-auth-flow` branch already pushed at step 5, apply U5 (auth.go env-still-set chain + auth_test.go) and U6 (doctor_test.go httptest stub).
+8. Re-extend U4 in `.printing-press-patches.json` per its current Approach.
+9. Run `go test ./...`, `go vet ./...`, `go build ./...` from the CLI root.
+10. Commit with: `fix(setlist-fm): chain SETLISTFM_API_KEY in logout and stub doctor tests` (matches the conventional-commit scope used at step 4).
+11. `git push origin fix/setlist-fm-auth-flow` — Greptile re-reviews automatically on push.
+12. Reply to each of the two PR-731 review threads with a one-line resolution pointer to the commit, then mark resolved. Do not merge until Greptile re-reviews and any new findings clear.

--- a/library/media-and-entertainment/setlist-fm/.printing-press-patches.json
+++ b/library/media-and-entertainment/setlist-fm/.printing-press-patches.json
@@ -19,6 +19,20 @@
         "internal/store/upsert_batch_test.go"
       ],
       "validated_outcome": "go test ./... passed for the generated Setlist.fm module."
+    },
+    {
+      "id": "auth-flow-fix",
+      "summary": "Re-route auth set-token to fm_api_key, drop dead OAuth fields, and fix doctor env-vars verdict.",
+      "reason": "Generated CLI emitted an OAuth-shaped config (access_token / refresh_token / token_expiry / client_id / client_secret / auth_header) but Setlist.fm uses only the static x-api-key header. auth set-token wrote to a dead access_token field, every API call returned 403, and doctor falsely reported FAIL Env Vars when fm_api_key was set in config. Also adds 'free' language and the auth set-token command to the doctor hint.",
+      "files": [
+        "internal/cli/auth.go",
+        "internal/cli/doctor.go",
+        "internal/cli/doctor_test.go",
+        "internal/client/client.go",
+        "internal/config/config.go",
+        "internal/config/config_test.go"
+      ],
+      "validated_outcome": "go test ./... passed; manual smoke confirmed auth set-token persists to fm_api_key and doctor no longer reports FAIL Env Vars when config provides auth."
     }
   ]
 }

--- a/library/media-and-entertainment/setlist-fm/.printing-press-patches.json
+++ b/library/media-and-entertainment/setlist-fm/.printing-press-patches.json
@@ -22,17 +22,18 @@
     },
     {
       "id": "auth-flow-fix",
-      "summary": "Re-route auth set-token to fm_api_key, drop dead OAuth fields, and fix doctor env-vars verdict.",
-      "reason": "Generated CLI emitted an OAuth-shaped config (access_token / refresh_token / token_expiry / client_id / client_secret / auth_header) but Setlist.fm uses only the static x-api-key header. auth set-token wrote to a dead access_token field, every API call returned 403, and doctor falsely reported FAIL Env Vars when fm_api_key was set in config. Also adds 'free' language and the auth set-token command to the doctor hint.",
+      "summary": "Re-route auth set-token to fm_api_key, drop dead OAuth fields, fix doctor env-vars verdict, chain SETLISTFM_API_KEY into auth logout's env-still-set check, and route doctor tests through an httptest stub.",
+      "reason": "Generated CLI emitted an OAuth-shaped config (access_token / refresh_token / token_expiry / client_id / client_secret / auth_header) but Setlist.fm uses only the static x-api-key header. auth set-token wrote to a dead access_token field, every API call returned 403, and doctor falsely reported FAIL Env Vars when fm_api_key was set in config. Also adds 'free' language and the auth set-token command to the doctor hint. Greptile review on PR #731 surfaced two follow-ups: auth logout's env-still-set check only inspected SETLIST_FM_API_KEY (lower priority in config.Load) so users on the SETLISTFM_API_KEY convention saw a misleading 'Logged out. Credentials cleared.' message while staying authenticated via env; doctor tests pointed base_url at the real api.setlist.fm host and round-tripped two live HTTP calls per test run.",
       "files": [
         "internal/cli/auth.go",
+        "internal/cli/auth_test.go",
         "internal/cli/doctor.go",
         "internal/cli/doctor_test.go",
         "internal/client/client.go",
         "internal/config/config.go",
         "internal/config/config_test.go"
       ],
-      "validated_outcome": "go test ./... passed; manual smoke confirmed auth set-token persists to fm_api_key and doctor no longer reports FAIL Env Vars when config provides auth."
+      "validated_outcome": "go test ./... passed; manual smoke confirmed auth set-token persists to fm_api_key and doctor no longer reports FAIL Env Vars when config provides auth. Auth logout env-var matrix is covered by TestAuthLogoutNotes* / TestAuthLogoutPrefersHigherPriorityEnvWhenBothSet / TestAuthLogoutOmitsNoteWhenNoEnvSet. Doctor tests now run with no network round-trips, and TestDoctorAPIReachableThroughStub proves the stub server is actually wired in."
     }
   ]
 }

--- a/library/media-and-entertainment/setlist-fm/internal/cli/auth.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/auth.go
@@ -117,8 +117,14 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Identify which (if any) auth env var is still exported so the
-			// JSON envelope and the human prose can both surface it.
+			// JSON envelope and the human prose can both surface it. Check in
+			// the same priority order as config.Load: SETLISTFM_API_KEY
+			// (setlistfm-js convention) wins over SETLIST_FM_API_KEY
+			// (setlist-fm-client convention) when both are set.
 			envStillSet := ""
+			if envStillSet == "" && os.Getenv("SETLISTFM_API_KEY") != "" {
+				envStillSet = "SETLISTFM_API_KEY"
+			}
 			if envStillSet == "" && os.Getenv("SETLIST_FM_API_KEY") != "" {
 				envStillSet = "SETLIST_FM_API_KEY"
 			}

--- a/library/media-and-entertainment/setlist-fm/internal/cli/auth.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/auth.go
@@ -84,16 +84,7 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 				return configErr(err)
 			}
 
-			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
-			cfg.AuthHeaderVal = ""
-
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			if err := cfg.SaveAPIKey(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 
@@ -121,7 +112,7 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 				return configErr(err)
 			}
 
-			if err := cfg.ClearTokens(); err != nil {
+			if err := cfg.ClearAPIKey(); err != nil {
 				return configErr(fmt.Errorf("clearing tokens: %w", err))
 			}
 

--- a/library/media-and-entertainment/setlist-fm/internal/cli/auth_test.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/auth_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 dave-morin. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeAuthLogoutConfig writes a config.toml with a stored fm_api_key, clears
+// both auth env vars, and returns the config path. Individual tests re-export
+// whichever env var they want to assert about.
+func writeAuthLogoutConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = 'stored-key'
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("SETLIST_FM_CONFIG", path)
+	t.Setenv("SETLISTFM_API_KEY", "")
+	t.Setenv("SETLIST_FM_API_KEY", "")
+	return path
+}
+
+// runAuthLogout invokes the auth logout command in JSON mode and returns the
+// parsed envelope plus the captured combined stdout/stderr.
+func runAuthLogout(t *testing.T, configPath string, jsonMode bool) (map[string]any, string) {
+	t.Helper()
+	flags := &rootFlags{configPath: configPath, asJSON: jsonMode}
+	cmd := newAuthLogoutCmd(flags)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("logout Execute: %v", err)
+	}
+	if !jsonMode {
+		return nil, buf.String()
+	}
+	var env map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("parse logout JSON: %v\nbody=%s", err, buf.String())
+	}
+	return env, buf.String()
+}
+
+func TestAuthLogoutNotesSetlistfmApiKeyWhenOnlyHigherPriorityEnvSet(t *testing.T) {
+	path := writeAuthLogoutConfig(t)
+	t.Setenv("SETLISTFM_API_KEY", "from-env")
+
+	env, _ := runAuthLogout(t, path, true)
+	note, _ := env["note"].(string)
+	if note != "SETLISTFM_API_KEY env var is still set" {
+		t.Fatalf("note: got %q, want %q", note, "SETLISTFM_API_KEY env var is still set")
+	}
+
+	_, prose := runAuthLogout(t, path, false)
+	if !strings.Contains(prose, "SETLISTFM_API_KEY env var is still set") {
+		t.Fatalf("human prose should name SETLISTFM_API_KEY, got:\n%s", prose)
+	}
+}
+
+func TestAuthLogoutNotesSetlistFmApiKeyWhenOnlyLowerPriorityEnvSet(t *testing.T) {
+	path := writeAuthLogoutConfig(t)
+	t.Setenv("SETLIST_FM_API_KEY", "from-env")
+
+	env, _ := runAuthLogout(t, path, true)
+	note, _ := env["note"].(string)
+	if note != "SETLIST_FM_API_KEY env var is still set" {
+		t.Fatalf("note: got %q, want %q", note, "SETLIST_FM_API_KEY env var is still set")
+	}
+
+	_, prose := runAuthLogout(t, path, false)
+	if !strings.Contains(prose, "SETLIST_FM_API_KEY env var is still set") {
+		t.Fatalf("human prose should name SETLIST_FM_API_KEY, got:\n%s", prose)
+	}
+}
+
+func TestAuthLogoutPrefersHigherPriorityEnvWhenBothSet(t *testing.T) {
+	path := writeAuthLogoutConfig(t)
+	t.Setenv("SETLISTFM_API_KEY", "modern")
+	t.Setenv("SETLIST_FM_API_KEY", "legacy")
+
+	env, _ := runAuthLogout(t, path, true)
+	note, _ := env["note"].(string)
+	if note != "SETLISTFM_API_KEY env var is still set" {
+		t.Fatalf("note should name the higher-priority var; got %q", note)
+	}
+}
+
+func TestAuthLogoutOmitsNoteWhenNoEnvSet(t *testing.T) {
+	path := writeAuthLogoutConfig(t)
+
+	env, _ := runAuthLogout(t, path, true)
+	if _, ok := env["note"]; ok {
+		t.Fatalf("note should be omitted when no env var is set, envelope=%v", env)
+	}
+	cleared, _ := env["cleared"].(bool)
+	if !cleared {
+		t.Fatalf("cleared should be true; envelope=%v", env)
+	}
+
+	_, prose := runAuthLogout(t, path, false)
+	if !strings.Contains(prose, "Logged out. Credentials cleared.") {
+		t.Fatalf("human prose should match the bare-clear copy, got:\n%s", prose)
+	}
+	if strings.Contains(prose, "env var is still set") {
+		t.Fatalf("human prose should not mention env var when none set, got:\n%s", prose)
+	}
+}

--- a/library/media-and-entertainment/setlist-fm/internal/cli/doctor.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/doctor.go
@@ -90,7 +90,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				header := cfg.AuthHeader()
 				if header == "" {
 					report["auth"] = "missing (x-api-key header not set)"
-					report["auth_hint"] = "export SETLISTFM_API_KEY=<your-key>  (get one at https://www.setlist.fm/settings/api)"
+					report["auth_hint"] = "Get a free API key at https://www.setlist.fm/settings/api, then run:\n  setlist-fm-pp-cli auth set-token <key>   (or export SETLISTFM_API_KEY=<key>)"
 				} else {
 					report["auth"] = "configured (x-api-key header will be sent)"
 					report["auth_source"] = cfg.AuthSource
@@ -116,7 +116,17 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			default:
 				authEnvRequiredMissing = append(authEnvRequiredMissing, "SETLISTFM_API_KEY (or SETLIST_FM_API_KEY)")
 			}
+			// The env var is one of multiple valid auth sources, not a hard
+			// requirement. When fm_api_key is set in config, the env var
+			// missing is informational, not a failure.
+			configProvidesAuth := cfg != nil && cfg.AuthHeader() != "" && cfg.AuthSource == "config"
 			switch {
+			case len(authEnvRequiredMissing) > 0 && configProvidesAuth:
+				// Word the message so it survives the color-mapping pass below:
+				// any "not " substring later in the message is matched as a
+				// WARN signal (e.g. "not configured"), so we say "optional"
+				// instead of "not required" to keep the verdict green.
+				report["env_vars"] = "OK config provides auth (env var optional)"
 			case len(authEnvRequiredMissing) > 0:
 				report["env_vars"] = "ERROR missing required: " + strings.Join(authEnvRequiredMissing, ", ")
 			case len(authEnvOptionalNames) > 1 && !authEnvOptionalSatisfied:
@@ -274,9 +284,17 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					fmt.Fprintf(w, "  %s: %v\n", key, v)
 				}
 			}
-			// Print auth setup hints (indented under Auth line)
+			// Print auth setup hints (indented under Auth line). Multi-line
+			// hints render with each line on its own indented row so the block
+			// visually nests under the Auth indicator.
 			if hint, ok := report["auth_hint"]; ok {
-				fmt.Fprintf(w, "  hint: %v\n", hint)
+				for i, line := range strings.Split(fmt.Sprintf("%v", hint), "\n") {
+					if i == 0 {
+						fmt.Fprintf(w, "  hint: %s\n", line)
+					} else {
+						fmt.Fprintf(w, "    %s\n", strings.TrimLeft(line, " "))
+					}
+				}
 			}
 			// Cache section: render after the primary health block so it
 			// sits next to version info, mirroring the JSON report layout.

--- a/library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go
@@ -5,14 +5,34 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
+// stubAPIServer returns an httptest.NewServer that satisfies the doctor's two
+// probes (reachability GET / and an authenticated GET /) with a minimal JSON
+// payload. Cleanup is registered with t.Cleanup so callers do not need to
+// close it explicitly.
+func stubAPIServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // writeConfig creates a config.toml at a temp path with the given body and
 // returns the file path. Also clears the env-var sources so tests start clean.
+// The body should NOT pin base_url to the real setlist.fm API -- callers that
+// need a base_url should use writeConfigForStubAPI instead. Real-URL configs
+// would force the doctor to issue live HTTP calls on every test run.
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -26,9 +46,23 @@ func writeConfig(t *testing.T, body string) string {
 	return path
 }
 
+// writeConfigForStubAPI spins up an in-process stub API, then writes a
+// config.toml whose base_url points at the stub. The fm_api_key value is
+// passed through verbatim so callers can test both configured and missing
+// auth without re-implementing the toml shape.
+func writeConfigForStubAPI(t *testing.T, fmAPIKey string) string {
+	t.Helper()
+	srv := stubAPIServer(t)
+	body := fmt.Sprintf(`base_url = '%s'
+fm_api_key = '%s'
+`, srv.URL, fmAPIKey)
+	return writeConfig(t, body)
+}
+
 // runDoctor invokes the doctor command in JSON mode against the given config
-// and returns the parsed report. Networked checks (api, credentials) run with
-// the real http client; tests should ignore those keys.
+// and returns the parsed report. Reachability and credential probes hit the
+// stub server created by writeConfigForStubAPI; tests that pass a config
+// without a stub-backed base_url should not assert on api/credentials.
 func runDoctor(t *testing.T, configPath string, jsonMode bool) (map[string]any, string) {
 	t.Helper()
 	flags := &rootFlags{configPath: configPath, asJSON: jsonMode}
@@ -48,9 +82,7 @@ func runDoctor(t *testing.T, configPath string, jsonMode bool) (map[string]any, 
 }
 
 func TestDoctorEnvVarsOKWhenConfigProvidesAuth(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = 'config-only-key'
-`)
+	path := writeConfigForStubAPI(t, "config-only-key")
 	report, _ := runDoctor(t, path, true)
 	got, _ := report["env_vars"].(string)
 	if !strings.HasPrefix(got, "OK config provides auth") {
@@ -59,9 +91,7 @@ fm_api_key = 'config-only-key'
 }
 
 func TestDoctorEnvVarsFailWhenNoAuthAnywhere(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = ''
-`)
+	path := writeConfigForStubAPI(t, "")
 	report, _ := runDoctor(t, path, true)
 	got, _ := report["env_vars"].(string)
 	if !strings.HasPrefix(got, "ERROR missing required") {
@@ -70,9 +100,7 @@ fm_api_key = ''
 }
 
 func TestDoctorEnvVarsOKWhenEnvVarSet(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = ''
-`)
+	path := writeConfigForStubAPI(t, "")
 	t.Setenv("SETLISTFM_API_KEY", "from-env")
 	report, _ := runDoctor(t, path, true)
 	got, _ := report["env_vars"].(string)
@@ -82,9 +110,7 @@ fm_api_key = ''
 }
 
 func TestDoctorHintMentionsFreeAndAuthSetTokenAndEnvVar(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = ''
-`)
+	path := writeConfigForStubAPI(t, "")
 	report, _ := runDoctor(t, path, true)
 	hint, _ := report["auth_hint"].(string)
 	if !strings.Contains(strings.ToLower(hint), "free") {
@@ -102,9 +128,7 @@ fm_api_key = ''
 }
 
 func TestDoctorHintOmittedWhenAuthConfigured(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = 'configured-key'
-`)
+	path := writeConfigForStubAPI(t, "configured-key")
 	report, _ := runDoctor(t, path, true)
 	if _, ok := report["auth_hint"]; ok {
 		t.Errorf("auth_hint should be omitted when auth is configured, report=%v", report)
@@ -112,14 +136,29 @@ fm_api_key = 'configured-key'
 }
 
 func TestDoctorHumanRenderingShowsHintAcrossMultipleLines(t *testing.T) {
-	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
-fm_api_key = ''
-`)
+	path := writeConfigForStubAPI(t, "")
 	_, out := runDoctor(t, path, false)
 	if !strings.Contains(out, "hint: Get a free API key") {
 		t.Errorf("expected hint line to start with 'hint: Get a free API key', got:\n%s", out)
 	}
 	if !strings.Contains(out, "setlist-fm-pp-cli auth set-token") {
 		t.Errorf("expected auth set-token line in rendered output, got:\n%s", out)
+	}
+}
+
+// TestDoctorAPIReachableThroughStub proves the stub server is actually wired
+// in -- without this, a typo in writeConfigForStubAPI's base_url would still
+// pass every other test in this file because they ignore the api/credentials
+// keys. The doctor's reachability probe issuing a 200 against the stub also
+// confirms that no test in this file silently round-trips api.setlist.fm.
+func TestDoctorAPIReachableThroughStub(t *testing.T) {
+	path := writeConfigForStubAPI(t, "configured-key")
+	report, _ := runDoctor(t, path, true)
+	api, _ := report["api"].(string)
+	if api != "reachable" {
+		t.Fatalf("api: got %q, want reachable", api)
+	}
+	if _, ok := report["credentials"]; !ok {
+		t.Fatalf("credentials key missing; the authenticated probe did not run, report=%v", report)
 	}
 }

--- a/library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go
+++ b/library/media-and-entertainment/setlist-fm/internal/cli/doctor_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 dave-morin. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeConfig creates a config.toml at a temp path with the given body and
+// returns the file path. Also clears the env-var sources so tests start clean.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("SETLIST_FM_CONFIG", path)
+	t.Setenv("SETLISTFM_API_KEY", "")
+	t.Setenv("SETLIST_FM_API_KEY", "")
+	return path
+}
+
+// runDoctor invokes the doctor command in JSON mode against the given config
+// and returns the parsed report. Networked checks (api, credentials) run with
+// the real http client; tests should ignore those keys.
+func runDoctor(t *testing.T, configPath string, jsonMode bool) (map[string]any, string) {
+	t.Helper()
+	flags := &rootFlags{configPath: configPath, asJSON: jsonMode}
+	cmd := newDoctorCmd(flags)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	_ = cmd.Execute()
+	if !jsonMode {
+		return nil, buf.String()
+	}
+	var report map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("parse doctor JSON: %v\nbody=%s", err, buf.String())
+	}
+	return report, buf.String()
+}
+
+func TestDoctorEnvVarsOKWhenConfigProvidesAuth(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = 'config-only-key'
+`)
+	report, _ := runDoctor(t, path, true)
+	got, _ := report["env_vars"].(string)
+	if !strings.HasPrefix(got, "OK config provides auth") {
+		t.Fatalf("env_vars: got %q, want OK config provides auth ...", got)
+	}
+}
+
+func TestDoctorEnvVarsFailWhenNoAuthAnywhere(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = ''
+`)
+	report, _ := runDoctor(t, path, true)
+	got, _ := report["env_vars"].(string)
+	if !strings.HasPrefix(got, "ERROR missing required") {
+		t.Fatalf("env_vars: got %q, want ERROR missing required ...", got)
+	}
+}
+
+func TestDoctorEnvVarsOKWhenEnvVarSet(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = ''
+`)
+	t.Setenv("SETLISTFM_API_KEY", "from-env")
+	report, _ := runDoctor(t, path, true)
+	got, _ := report["env_vars"].(string)
+	if !strings.HasPrefix(got, "OK 1/1 available") {
+		t.Fatalf("env_vars: got %q, want OK 1/1 available", got)
+	}
+}
+
+func TestDoctorHintMentionsFreeAndAuthSetTokenAndEnvVar(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = ''
+`)
+	report, _ := runDoctor(t, path, true)
+	hint, _ := report["auth_hint"].(string)
+	if !strings.Contains(strings.ToLower(hint), "free") {
+		t.Errorf("auth_hint should mention 'free', got: %q", hint)
+	}
+	if !strings.Contains(hint, "setlist-fm-pp-cli auth set-token") {
+		t.Errorf("auth_hint should mention auth set-token, got: %q", hint)
+	}
+	if !strings.Contains(hint, "SETLISTFM_API_KEY") {
+		t.Errorf("auth_hint should mention SETLISTFM_API_KEY, got: %q", hint)
+	}
+	if !strings.Contains(hint, "https://www.setlist.fm/settings/api") {
+		t.Errorf("auth_hint should link to settings/api, got: %q", hint)
+	}
+}
+
+func TestDoctorHintOmittedWhenAuthConfigured(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = 'configured-key'
+`)
+	report, _ := runDoctor(t, path, true)
+	if _, ok := report["auth_hint"]; ok {
+		t.Errorf("auth_hint should be omitted when auth is configured, report=%v", report)
+	}
+}
+
+func TestDoctorHumanRenderingShowsHintAcrossMultipleLines(t *testing.T) {
+	path := writeConfig(t, `base_url = 'https://api.setlist.fm/rest'
+fm_api_key = ''
+`)
+	_, out := runDoctor(t, path, false)
+	if !strings.Contains(out, "hint: Get a free API key") {
+		t.Errorf("expected hint line to start with 'hint: Get a free API key', got:\n%s", out)
+	}
+	if !strings.Contains(out, "setlist-fm-pp-cli auth set-token") {
+		t.Errorf("expected auth set-token line in rendered output, got:\n%s", out)
+	}
+}

--- a/library/media-and-entertainment/setlist-fm/internal/client/client.go
+++ b/library/media-and-entertainment/setlist-fm/internal/client/client.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -337,74 +336,7 @@ func (c *Client) authHeader() (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" {
-		if err := c.refreshAccessToken(); err != nil {
-			return "", err
-		}
-	}
 	return c.Config.AuthHeader(), nil
-}
-
-func (c *Client) refreshAccessToken() error {
-	if c.Config == nil {
-		return nil
-	}
-	if c.Config.RefreshToken == "" {
-		return nil
-	}
-
-	tokenURL := ""
-	if tokenURL == "" {
-		return nil
-	}
-
-	params := url.Values{
-		"grant_type":    {"refresh_token"},
-		"refresh_token": {c.Config.RefreshToken},
-		"client_id":     {c.Config.ClientID},
-	}
-	if c.Config.ClientSecret != "" {
-		params.Set("client_secret", c.Config.ClientSecret)
-	}
-
-	resp, err := c.HTTPClient.PostForm(tokenURL, params)
-	if err != nil {
-		return fmt.Errorf("refreshing access token: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("refreshing access token: HTTP %d: %s", resp.StatusCode, truncateBody(body))
-	}
-
-	var tokenResp struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		ExpiresIn    int    `json:"expires_in"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return fmt.Errorf("parsing refresh response: %w", err)
-	}
-	if tokenResp.AccessToken == "" {
-		return fmt.Errorf("refreshing access token: no access token in response")
-	}
-
-	refreshToken := c.Config.RefreshToken
-	if tokenResp.RefreshToken != "" {
-		refreshToken = tokenResp.RefreshToken
-	}
-
-	expiry := time.Time{}
-	if tokenResp.ExpiresIn > 0 {
-		expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
-	}
-
-	if err := c.Config.SaveTokens(c.Config.ClientID, c.Config.ClientSecret, tokenResp.AccessToken, refreshToken, expiry); err != nil {
-		return fmt.Errorf("saving refreshed token: %w", err)
-	}
-
-	return nil
 }
 
 // sanitizeJSONResponse strips known JSONP/XSSI prefixes and UTF-8 BOM from

--- a/library/media-and-entertainment/setlist-fm/internal/config/config.go
+++ b/library/media-and-entertainment/setlist-fm/internal/config/config.go
@@ -7,23 +7,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
+// Setlist.fm uses only the static x-api-key header. The generator-emitted
+// OAuth-shaped fields (auth_header, access_token, refresh_token, token_expiry,
+// client_id, client_secret) were dead storage: AuthHeader() only ever returned
+// SetlistFmApiKey, and `auth set-token` wrote to the wrong field which is why
+// the documented setup flow silently failed.
 type Config struct {
-	BaseURL         string    `toml:"base_url"`
-	AuthHeaderVal   string    `toml:"auth_header"`
-	AuthSource      string    `toml:"-"`
-	AccessToken     string    `toml:"access_token"`
-	RefreshToken    string    `toml:"refresh_token"`
-	TokenExpiry     time.Time `toml:"token_expiry"`
-	ClientID        string    `toml:"client_id"`
-	ClientSecret    string    `toml:"client_secret"`
-	Path            string    `toml:"-"`
-	SetlistFmApiKey string    `toml:"fm_api_key"`
+	BaseURL         string `toml:"base_url"`
+	AuthSource      string `toml:"-"`
+	Path            string `toml:"-"`
+	SetlistFmApiKey string `toml:"fm_api_key"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -42,11 +39,16 @@ func Load(configPath string) (*Config, error) {
 	}
 	cfg.Path = path
 
-	// Try to load config file
+	// Try to load config file. go-toml/v2 ignores unknown keys by default,
+	// so legacy access_token / auth_header / refresh_token rows from older
+	// configs load without error and are simply dropped on the next save.
 	data, err := os.ReadFile(path)
 	if err == nil {
 		if err := toml.Unmarshal(data, cfg); err != nil {
 			return nil, fmt.Errorf("parsing config %s: %w", path, err)
+		}
+		if cfg.SetlistFmApiKey != "" {
+			cfg.AuthSource = "config"
 		}
 	}
 
@@ -69,38 +71,16 @@ func Load(configPath string) (*Config, error) {
 }
 
 func (c *Config) AuthHeader() string {
-	if c.AuthHeaderVal != "" {
-		return c.AuthHeaderVal
-	}
 	return c.SetlistFmApiKey
 }
 
-func applyAuthFormat(format string, replacements map[string]string) string {
-	if format == "" {
-		return ""
-	}
-	for key, value := range replacements {
-		format = strings.ReplaceAll(format, "{"+key+"}", value)
-	}
-	if strings.Contains(format, "{") {
-		return ""
-	}
-	return format
-}
-
-func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken string, expiry time.Time) error {
-	c.ClientID = clientID
-	c.ClientSecret = clientSecret
-	c.AccessToken = accessToken
-	c.RefreshToken = refreshToken
-	c.TokenExpiry = expiry
+func (c *Config) SaveAPIKey(key string) error {
+	c.SetlistFmApiKey = key
 	return c.save()
 }
 
-func (c *Config) ClearTokens() error {
-	c.AccessToken = ""
-	c.RefreshToken = ""
-	c.TokenExpiry = time.Time{}
+func (c *Config) ClearAPIKey() error {
+	c.SetlistFmApiKey = ""
 	return c.save()
 }
 
@@ -115,6 +95,3 @@ func (c *Config) save() error {
 	}
 	return os.WriteFile(c.Path, data, 0o600)
 }
-
-// Ensure strings import is used
-var _ = strings.ReplaceAll

--- a/library/media-and-entertainment/setlist-fm/internal/config/config_test.go
+++ b/library/media-and-entertainment/setlist-fm/internal/config/config_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 dave-morin. Licensed under Apache-2.0. See LICENSE.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTempConfig(t *testing.T) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	return &Config{
+		BaseURL: "https://api.setlist.fm/rest",
+		Path:    filepath.Join(dir, "config.toml"),
+	}
+}
+
+func loadFromPath(t *testing.T, path string) *Config {
+	t.Helper()
+	t.Setenv("SETLIST_FM_CONFIG", path)
+	t.Setenv("SETLISTFM_API_KEY", "")
+	t.Setenv("SETLIST_FM_API_KEY", "")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg
+}
+
+func TestSaveAPIKeyWritesFmApiKey(t *testing.T) {
+	cfg := newTempConfig(t)
+	if err := cfg.SaveAPIKey("abc123"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	data, err := os.ReadFile(cfg.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `fm_api_key = 'abc123'`) {
+		t.Fatalf("expected fm_api_key in TOML, got:\n%s", got)
+	}
+
+	loaded := loadFromPath(t, cfg.Path)
+	if loaded.SetlistFmApiKey != "abc123" {
+		t.Fatalf("SetlistFmApiKey: got %q, want abc123", loaded.SetlistFmApiKey)
+	}
+	if loaded.AuthHeader() != "abc123" {
+		t.Fatalf("AuthHeader: got %q, want abc123", loaded.AuthHeader())
+	}
+}
+
+func TestSaveAPIKeyDropsLegacyOAuthFields(t *testing.T) {
+	cfg := newTempConfig(t)
+	legacy := `base_url = 'https://api.setlist.fm/rest'
+auth_header = 'Bearer legacy'
+access_token = 'legacy-access'
+refresh_token = 'legacy-refresh'
+token_expiry = 2024-01-01T00:00:00Z
+client_id = 'legacy-client'
+client_secret = 'legacy-secret'
+fm_api_key = ''
+`
+	if err := os.WriteFile(cfg.Path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	loaded := loadFromPath(t, cfg.Path)
+	if loaded.SetlistFmApiKey != "" {
+		t.Fatalf("expected empty SetlistFmApiKey when only legacy fields are set, got %q", loaded.SetlistFmApiKey)
+	}
+	if loaded.AuthHeader() != "" {
+		t.Fatalf("AuthHeader should be empty when only legacy fields are present, got %q", loaded.AuthHeader())
+	}
+
+	if err := loaded.SaveAPIKey("newkey"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	data, err := os.ReadFile(loaded.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	for _, dead := range []string{"auth_header", "access_token", "refresh_token", "token_expiry", "client_id", "client_secret"} {
+		if strings.Contains(got, dead) {
+			t.Errorf("expected legacy field %q to be dropped after save, got:\n%s", dead, got)
+		}
+	}
+	if !strings.Contains(got, `fm_api_key = 'newkey'`) {
+		t.Errorf("expected fm_api_key=newkey, got:\n%s", got)
+	}
+}
+
+func TestClearAPIKeyEmptiesFmApiKey(t *testing.T) {
+	cfg := newTempConfig(t)
+	if err := cfg.SaveAPIKey("abc123"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	if err := cfg.ClearAPIKey(); err != nil {
+		t.Fatalf("ClearAPIKey: %v", err)
+	}
+	loaded := loadFromPath(t, cfg.Path)
+	if loaded.SetlistFmApiKey != "" {
+		t.Fatalf("expected empty key after Clear, got %q", loaded.SetlistFmApiKey)
+	}
+	if loaded.AuthHeader() != "" {
+		t.Fatalf("AuthHeader should be empty after Clear, got %q", loaded.AuthHeader())
+	}
+}
+
+func TestLoadAuthSourceConfig(t *testing.T) {
+	cfg := newTempConfig(t)
+	if err := cfg.SaveAPIKey("from-config"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	loaded := loadFromPath(t, cfg.Path)
+	if loaded.AuthSource != "config" {
+		t.Fatalf("AuthSource: got %q, want config", loaded.AuthSource)
+	}
+}
+
+func TestLoadEnvVarOverridesConfig(t *testing.T) {
+	cfg := newTempConfig(t)
+	if err := cfg.SaveAPIKey("from-config"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	t.Setenv("SETLIST_FM_CONFIG", cfg.Path)
+	t.Setenv("SETLISTFM_API_KEY", "from-env")
+	loaded, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.SetlistFmApiKey != "from-env" {
+		t.Fatalf("SetlistFmApiKey: got %q, want from-env", loaded.SetlistFmApiKey)
+	}
+	if loaded.AuthSource != "env:SETLISTFM_API_KEY" {
+		t.Fatalf("AuthSource: got %q, want env:SETLISTFM_API_KEY", loaded.AuthSource)
+	}
+}
+
+func TestLoadMissingFileReturnsEmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "no-such-file.toml")
+	t.Setenv("SETLIST_FM_CONFIG", missing)
+	t.Setenv("SETLISTFM_API_KEY", "")
+	t.Setenv("SETLIST_FM_API_KEY", "")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AuthHeader() != "" {
+		t.Fatalf("AuthHeader should be empty for missing config, got %q", cfg.AuthHeader())
+	}
+}


### PR DESCRIPTION
Three related auth bugs in the setlist-fm CLI shipped via #724 made the documented setup flow fail silently. A fresh user ran `auth set-token`, the CLI reported the token saved, and every subsequent API call returned HTTP 403.

## Bugs fixed

**1. `auth set-token` wrote to the wrong config field.** The token landed in `access_token` (a dead OAuth field). The HTTP layer reads from `fm_api_key`, so the saved token was never used. Re-routed via a new `Config.SaveAPIKey` method.

**2. Dropped the unused OAuth-shaped fields from the config schema.** Setlist.fm's API has no OAuth flow — only the static `x-api-key` header. The generator-emitted `auth_header`, `access_token`, `refresh_token`, `token_expiry`, `client_id`, `client_secret` fields were dead storage. Removed alongside the dead `refreshAccessToken` path in the HTTP client.

**3. `doctor` reported `FAIL Env Vars` when config-based auth was valid.** The env var is one of multiple valid auth sources, not a hard requirement. When config provides auth, the env-vars verdict is now `OK config provides auth (env var optional)`.

**4. `doctor` hint only mentioned the env var path.** Now leads with `setlist-fm-pp-cli auth set-token <key>` (the more durable path, and the one that actually works after this fix) and explicitly says the API key is free.

## Backward compatibility

Legacy configs containing the removed OAuth fields load without error (`go-toml/v2` ignores unknown keys); the dead rows are dropped on the next save. No migration tooling needed.

## Patch tracking

Recorded as the `auth-flow-fix` patch in `.printing-press-patches.json` so Printing Press tooling re-applies the change after future regenerations. Upstream generator template fix tracked separately.

## Verification

- `go test ./...` — 109 passed in 11 packages
- `go vet ./...` — clean
- `go build ./cmd/setlist-fm-pp-cli ./cmd/setlist-fm-pp-mcp` — both build
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/setlist-fm/` — all checks pass
- Manual smoke: with `fm_api_key` set in config and no env var, `setlist-fm-pp-cli doctor` shows all five health checks as `OK` (was previously `FAIL Env Vars`); `auth set-token TESTKEY123` writes `fm_api_key = 'TESTKEY123'` and no legacy fields are emitted

Closes the issues from `setlist-fm-pp-cli-bugs.md`. Related: #724.