### PR TITLE
fix(ci): enforce MCPB user config injection

### DIFF
--- a/.github/scripts/verify-manifest/verify_manifest.py
+++ b/.github/scripts/verify-manifest/verify_manifest.py
@@ -8,7 +8,10 @@ Per CLI:
 - server.type="binary", server.entry_point references the bundled binary
 - server.mcp_config.command points at ${__dirname}/<entry_point>
 - server.mcp_config.args is empty for generated binary MCPBs
-- server.mcp_config.env maps each env var to its lower-case user_config key
+- server.mcp_config.env maps each env var to its lower-case user_config key,
+  or to an existing alias key when the lower-case env key is intentionally absent
+- every user_config key is injected through server.mcp_config.env
+- server.env is not used; generated binary MCPBs inject env through mcp_config.env
 - user_config keys (when present) match auth_env_vars in .printing-press.json
 - cli_binary, when present, matches the CLI name from .printing-press.json
 - compatibility.platforms is a non-empty list
@@ -96,22 +99,33 @@ def validate(cli_dir: Path) -> list[str]:
     declared_envs = set(pp.get("auth_env_vars") or [])
     user_config = m.get("user_config") or {}
     if declared_envs:
-        # user_config keys are lower-cased env var names; map back for comparison.
-        uc_envs = {k.upper() for k in user_config}
-        missing = declared_envs - uc_envs
+        mcp_env_keys = set(((server.get("mcp_config") or {}).get("env") or {}).keys())
+        missing = declared_envs - mcp_env_keys
         if missing:
-            problems.append(f"user_config missing entries for {sorted(missing)}")
+            problems.append(f"server.mcp_config.env missing entries for {sorted(missing)}")
     mcp_env = (server.get("mcp_config") or {}).get("env") or {}
+    if server.get("env"):
+        problems.append("server.env is unsupported for generated binary MCPBs; use server.mcp_config.env")
     for env_name, env_value in mcp_env.items():
         expected_key = env_name.lower()
         expected_ref = f"${{user_config.{expected_key}}}"
-        if expected_key not in user_config:
-            problems.append(
-                f"server.mcp_config.env {env_name!r} references missing user_config key {expected_key!r}"
-            )
-        elif env_value != expected_ref:
+        ref_key = None
+        if isinstance(env_value, str) and env_value.startswith("${user_config.") and env_value.endswith("}"):
+            ref_key = env_value[len("${user_config.") : -1]
+
+        if expected_key in user_config and env_value != expected_ref:
             problems.append(
                 f"server.mcp_config.env {env_name!r} should map to {expected_ref!r} (got {env_value!r})"
+            )
+        elif expected_key not in user_config and ref_key not in user_config:
+            problems.append(
+                f"server.mcp_config.env {env_name!r} references missing user_config key {ref_key or expected_key!r}"
+            )
+    for config_key in user_config:
+        expected_env = config_key.upper()
+        if expected_env not in mcp_env:
+            problems.append(
+                f"user_config key {config_key!r} is not injected through server.mcp_config.env {expected_env!r}"
             )
 
     # cli_binary should match .printing-press.json's cli_name when set.

--- a/.github/scripts/verify-manifest/verify_manifest_test.py
+++ b/.github/scripts/verify-manifest/verify_manifest_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_manifest as verifier
+
+
+class ManifestVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="verify-manifest-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+        self.cli_dir = self.tmp / "library" / "cloud" / "example"
+        self.cli_dir.mkdir(parents=True)
+        (self.cli_dir / "cmd" / "example-pp-mcp").mkdir(parents=True)
+
+    def write_pp(self, auth_env_vars: list[str] | None = None) -> None:
+        (self.cli_dir / ".printing-press.json").write_text(
+            json.dumps(
+                {
+                    "api_name": "example",
+                    "cli_name": "example-pp-cli",
+                    "mcp_binary": "example-pp-mcp",
+                    "auth_env_vars": auth_env_vars or ["EXAMPLE_TOKEN"],
+                }
+            )
+        )
+
+    def write_manifest(
+        self,
+        *,
+        server_env: dict[str, str] | None = None,
+        inject_token: bool = True,
+        extra_mcp_env: dict[str, str] | None = None,
+    ) -> None:
+        server = {
+            "type": "binary",
+            "entry_point": "bin/example-pp-mcp",
+            "mcp_config": {
+                "command": "${__dirname}/bin/example-pp-mcp",
+                "args": [],
+                "env": {},
+            },
+        }
+        if inject_token:
+            server["mcp_config"]["env"]["EXAMPLE_TOKEN"] = "${user_config.example_token}"
+        if extra_mcp_env:
+            server["mcp_config"]["env"].update(extra_mcp_env)
+        if server_env is not None:
+            server["env"] = server_env
+
+        (self.cli_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "manifest_version": "0.3",
+                    "name": "example-pp-mcp",
+                    "display_name": "Example",
+                    "version": "1.0.0",
+                    "description": "Example MCP bundle.",
+                    "server": server,
+                    "user_config": {
+                        "example_token": {
+                            "type": "string",
+                            "title": "EXAMPLE_TOKEN",
+                            "sensitive": True,
+                            "required": True,
+                        }
+                    },
+                    "cli_binary": "example-pp-cli",
+                    "compatibility": {"platforms": ["darwin", "linux", "win32"]},
+                }
+            )
+        )
+
+    def test_valid_manifest_passes(self) -> None:
+        self.write_pp()
+        self.write_manifest()
+
+        self.assertEqual([], verifier.validate(self.cli_dir))
+
+    def test_user_config_must_be_injected_through_mcp_env(self) -> None:
+        self.write_pp()
+        self.write_manifest(inject_token=False)
+
+        problems = verifier.validate(self.cli_dir)
+
+        self.assertTrue(
+            any("user_config key 'example_token' is not injected" in problem for problem in problems),
+            problems,
+        )
+
+    def test_server_env_is_rejected(self) -> None:
+        self.write_pp()
+        self.write_manifest(server_env={"EXAMPLE_TOKEN": "${user_config.example_token}"})
+
+        problems = verifier.validate(self.cli_dir)
+
+        self.assertTrue(
+            any("server.env is unsupported" in problem for problem in problems),
+            problems,
+        )
+
+    def test_server_env_does_not_count_as_user_config_injection(self) -> None:
+        self.write_pp()
+        self.write_manifest(
+            inject_token=False,
+            server_env={"EXAMPLE_TOKEN": "${user_config.example_token}"},
+        )
+
+        problems = verifier.validate(self.cli_dir)
+
+        self.assertTrue(
+            any("server.env is unsupported" in problem for problem in problems),
+            problems,
+        )
+        self.assertTrue(
+            any("user_config key 'example_token' is not injected" in problem for problem in problems),
+            problems,
+        )
+
+    def test_alias_env_can_share_one_user_config_prompt(self) -> None:
+        self.write_pp(["EXAMPLE_TOKEN", "EXAMPLE_TOKEN_ALIAS"])
+        self.write_manifest(
+            extra_mcp_env={"EXAMPLE_TOKEN_ALIAS": "${user_config.example_token}"}
+        )
+
+        self.assertEqual([], verifier.validate(self.cli_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/library/cloud/cf-domain/manifest.json
+++ b/library/cloud/cf-domain/manifest.json
@@ -15,7 +15,10 @@
       "command": "${__dirname}/bin/cf-domain-pp-mcp",
       "args": [],
       "env": {
-        "CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH": "${user_config.cloudflare_registrar_domains_bearer_auth}"
+        "CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH": "${user_config.cloudflare_registrar_domains_bearer_auth}",
+        "CLOUDFLARE_API_TOKEN": "${user_config.cloudflare_api_token}",
+        "ACCOUNT_ID": "${user_config.account_id}",
+        "CLOUDFLARE_ACCOUNT_ID": "${user_config.account_id}"
       }
     }
   },
@@ -40,13 +43,6 @@
       "description": "Cloudflare account ID used for Registrar requests.",
       "sensitive": false,
       "required": true
-    },
-    "cloudflare_account_id": {
-      "type": "string",
-      "title": "CLOUDFLARE_ACCOUNT_ID",
-      "description": "Cloudflare account ID fallback used for Registrar requests.",
-      "sensitive": false,
-      "required": false
     }
   },
   "compatibility": {

--- a/library/developer-tools/namecheap/manifest.json
+++ b/library/developer-tools/namecheap/manifest.json
@@ -17,11 +17,9 @@
       "env": {
         "NAMECHEAP_USERNAME": "${user_config.namecheap_username}",
         "NAMECHEAP_API_KEY": "${user_config.namecheap_api_key}",
-        "NAMECHEAP_CLIENT_IP": "${user_config.namecheap_client_ip}"
+        "NAMECHEAP_CLIENT_IP": "${user_config.namecheap_client_ip}",
+        "NAMECHEAP_SANDBOX": "${user_config.namecheap_sandbox}"
       }
-    },
-    "env": {
-      "NAMECHEAP_SANDBOX": "${user_config.namecheap_sandbox}"
     }
   },
   "user_config": {


### PR DESCRIPTION
## Summary

Follow-up to #729: enforce the deferred symmetric MCPB manifest rule now that the concrete catalog gaps are fixed.

This PR makes `verify_manifest.py` require every `user_config` prompt to be injected through `server.mcp_config.env`, and rejects the stray `server.env` shape for generated binary MCPBs. The audit found exactly two current catalog gaps:

- `cf-domain` prompted for Cloudflare token/account values but only injected `CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH`.
- `namecheap` put `NAMECHEAP_SANDBOX` under `server.env` instead of `server.mcp_config.env`.

## Validation

- `python3 .github/scripts/verify-manifest/verify_manifest.py`
- `python3 -m unittest verify_manifest_test` from `.github/scripts/verify-manifest`
- `python3 -m py_compile .github/scripts/verify-manifest/verify_manifest.py .github/scripts/verify-manifest/verify_manifest_test.py`
- `git diff --check origin/main...HEAD`
- targeted JSON audit: 0 remaining `user_config` keys missing from `server.mcp_config.env`, 0 remaining `server.env` users
