### PR TITLE
fix(npm): preserve printing-press-library bin

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -28,7 +28,7 @@
     "installer"
   ],
   "bin": {
-    "printing-press-library": "./bin/printing-press-library.mjs"
+    "printing-press-library": "bin/printing-press-library.mjs"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary

Normalize the npm bin path for `printing-press-library` so npm does not auto-correct the package by removing the executable during publish.

## Why

A local publish attempt for `@mvanhorn/printing-press-library@0.1.6` failed on provenance, but the dry-run also exposed a separate packaging warning: npm treated `./bin/printing-press-library.mjs` as an invalid bin script and removed the bin entry. That would publish a package without the CLI executable.

## Validation

- `npm publish --dry-run --access public --provenance=false` from `npm/`
- This ran `prepublishOnly`, including build and 54 passing tests, and no longer emitted the npm auto-correct warning.
