### PR TITLE
docs(npm): refresh package readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ Three to try first:
 - flight-goat (Kayak nonstop search plus sniffed Google Flights). _"Non-stop flights over 8 hours from Seattle for 4 people, Dec 24 to Jan 1, cheapest first."_ Two sources, one query.
 - sentry-pp-cli (local SQLite mirror, SQL across orgs and projects). _"Every issue first seen in the last release whose error rate is climbing across two projects."_ Compound queries the Sentry API can't answer.
 
-## Install
+## Discover and install
 
 The fastest way to start — install four hand-picked CLIs and skills in one command:
 
 ```bash
-npx -y @mvanhorn/printing-press install starter-pack
+npx -y @mvanhorn/printing-press-library install starter-pack
 ```
+
+The `-y` flag only tells `npx` to run the installer package without an interactive npm prompt; discovery commands like `list` and `search` do not install catalog CLIs.
 
 The starter pack: [`espn`](library/media-and-entertainment/espn/) (live sports), [`flight-goat`](library/travel/flightgoat/) (flight search), [`movie-goat`](library/media-and-entertainment/movie-goat/) (movie discovery), [`recipe-goat`](library/food-and-dining/recipe-goat/) (recipe ranking).
 
@@ -29,14 +31,14 @@ Every install pulls the Go binary **and** the focused skill in one shot. Pass `-
 One tool:
 
 ```bash
-npx -y @mvanhorn/printing-press install espn
+npx -y @mvanhorn/printing-press-library install espn
 ```
 
 Several at once (bundles and CLI names mix freely):
 
 ```bash
-npx -y @mvanhorn/printing-press install espn sentry dub
-npx -y @mvanhorn/printing-press install starter-pack cal-com
+npx -y @mvanhorn/printing-press-library install espn sentry dub
+npx -y @mvanhorn/printing-press-library install starter-pack cal-com
 ```
 
 Under the hood: the npm package is a thin orchestrator that reads the live catalog in `registry.json`, resolves each CLI's Go module path, runs `go install`, and installs the matching skill from `cli-skills/pp-<name>`.
@@ -44,15 +46,24 @@ Under the hood: the npm package is a thin orchestrator that reads the live catal
 Useful commands:
 
 ```bash
-npx -y @mvanhorn/printing-press search sports
-npx -y @mvanhorn/printing-press list
-npx -y @mvanhorn/printing-press update espn
-npx -y @mvanhorn/printing-press uninstall espn --yes
+npx -y @mvanhorn/printing-press-library list
+npx -y @mvanhorn/printing-press-library search flights
+npx -y @mvanhorn/printing-press-library list --category travel
+npx -y @mvanhorn/printing-press-library list --installed
+npx -y @mvanhorn/printing-press-library update espn
+npx -y @mvanhorn/printing-press-library uninstall espn --yes
 ```
 
-The npm installer package is being renamed to `@mvanhorn/printing-press-library` to avoid ambiguity with the generator repo. Until that package is published, this README keeps the currently published `@mvanhorn/printing-press` commands.
+`@mvanhorn/printing-press-library` replaces the older `@mvanhorn/printing-press` npm package. The unambiguous `printing-press-library` binary is the catalog installer: use it to browse available CLIs, search by keyword, install the matching Go binary plus focused agent skill, and keep installed tools fresh.
 
-While the catalog repository is private, live installer use requires `GITHUB_TOKEN` or `GH_TOKEN` for catalog and skill fetches, plus working private Go module access for `go install`.
+Install accepts catalog slugs and generated binary names, so both `airbnb` and `airbnb-pp-cli` resolve to the Airbnb tool.
+
+Discovery commands print human-readable cards by default and support `--json` for scripts and agents:
+
+```bash
+npx -y @mvanhorn/printing-press-library search flights --json
+npx -y @mvanhorn/printing-press-library list --category food-and-dining --json
+```
 
 ## Focused skills
 

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.7
+
+- Refresh the GitHub and npm README surfaces now that `@mvanhorn/printing-press-library` is live.
+- Document catalog discovery flows for `list`, `search`, category filtering, installed-only listing, and JSON output.
+- Normalize search punctuation and simple plurals so queries like `cal.com`, `cal-com`, and `hotels` find the expected catalog entries.
+- Add generated registry `search_terms` sourced from manifest descriptions, auth notes, and novel features so concise result descriptions can stay readable without weakening discovery.
+- Document the optional global uninstall step for the older `@mvanhorn/printing-press` package.
+- Show `npx -y @mvanhorn/printing-press-library install <name>` in discovery output so copy-paste installs work before the package is globally installed.
+
 ## 0.1.6
 
 - Rename the npm package and command to `@mvanhorn/printing-press-library` / `printing-press-library` so the public catalog installer is unambiguous and does not collide with the Printing Press generator concept.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,18 +1,65 @@
 # @mvanhorn/printing-press-library
 
-Installer and catalog CLI for [Printing Press](https://printingpress.dev)-generated CLIs. Each install pulls down a Go binary plus its focused agent skill — the skill lands in every supported agent on your machine (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents the upstream [`skills`](https://github.com/vercel-labs/skills) CLI detects).
+Browse, search, install, update, and remove [Printing Press](https://printingpress.dev)-generated CLIs. Each install pulls down a Go binary plus its focused agent skill — the skill lands in every supported agent on your machine (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents the upstream [`skills`](https://github.com/vercel-labs/skills) CLI detects).
 
 This package replaces the older `@mvanhorn/printing-press` npm package. Use the unambiguous `printing-press-library` command for catalog discovery and installs.
 
 ## Quick start
 
-The fastest way in is the starter pack — four hand-picked CLIs and skills installed in one command:
+Search the catalog, browse a category, then install the CLI you want:
+
+```bash
+npx -y @mvanhorn/printing-press-library search flights
+npx -y @mvanhorn/printing-press-library list --category travel
+npx -y @mvanhorn/printing-press-library install airbnb
+```
+
+The `-y` flag only tells `npx` to run this wrapper package without an interactive npm prompt; `list` and `search` do not install catalog CLIs.
+
+Or install the starter pack — four hand-picked CLIs and skills in one command:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install starter-pack
 ```
 
 The starter pack installs `espn` (live sports), `flight-goat` (flight search), `movie-goat` (movie discovery), and `recipe-goat` (recipe ranking).
+
+## Discover the catalog
+
+List every published CLI:
+
+```bash
+npx -y @mvanhorn/printing-press-library list
+```
+
+Filter to one category:
+
+```bash
+npx -y @mvanhorn/printing-press-library list --category travel
+```
+
+Search by keyword across names, categories, APIs, descriptions, binaries, and generated search metadata:
+
+```bash
+npx -y @mvanhorn/printing-press-library search flights
+npx -y @mvanhorn/printing-press-library search sports
+```
+
+Discovery commands print compact cards by default:
+
+```text
+airbnb (travel) - airbnb-pp-cli
+  Search Airbnb and VRBO, find the host's direct booking site, and report the cheapest
+  of three sources side-by-side.
+  install: npx -y @mvanhorn/printing-press-library install airbnb
+```
+
+Use `--json` when another tool or agent is reading the output:
+
+```bash
+npx -y @mvanhorn/printing-press-library search flights --json
+npx -y @mvanhorn/printing-press-library list --category travel --json
+```
 
 ## Installing CLIs and skills
 
@@ -22,6 +69,7 @@ One tool:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install espn
+npx -y @mvanhorn/printing-press-library install airbnb-pp-cli
 ```
 
 Several at once (bundles and CLI names mix freely):
@@ -33,6 +81,8 @@ npx -y @mvanhorn/printing-press-library install starter-pack cal-com
 
 Under the hood: the installer reads the live catalog at [`registry.json`](https://github.com/mvanhorn/printing-press-library/blob/main/registry.json), resolves the CLI's Go module path, runs `go install`, and installs the matching focused skill from `cli-skills/pp-<name>` via `npx skills@latest`.
 
+Names are forgiving: use the catalog slug (`airbnb`), generated binary name (`airbnb-pp-cli`), or API-ish name (`Airbnb Vrbo`) and the installer normalizes it to the right catalog entry.
+
 ## Other commands
 
 ```bash
@@ -43,6 +93,8 @@ npx -y @mvanhorn/printing-press-library list --installed
 npx -y @mvanhorn/printing-press-library update espn
 npx -y @mvanhorn/printing-press-library uninstall espn --yes
 ```
+
+`list` shows the public catalog by default. Use `list --installed` when you only want CLIs already present on your machine.
 
 ## Options
 
@@ -59,6 +111,8 @@ npx -y @mvanhorn/printing-press-library install espn --agent claude-code
 
 # Machine-readable output
 npx -y @mvanhorn/printing-press-library install espn --json
+npx -y @mvanhorn/printing-press-library search sports --json
+npx -y @mvanhorn/printing-press-library list --installed --json
 
 # Pin to an alternate catalog (mainly for testing)
 npx -y @mvanhorn/printing-press-library search sports --registry-url https://example.com/registry.json
@@ -80,4 +134,23 @@ More bundles will be added over time. To suggest one, open an issue at the [prin
 - Go 1.26.3 or newer (for `go install`)
 - `$(go env GOPATH)/bin` on `$PATH` (usually `$HOME/go/bin`) so installed CLIs are runnable
 
-While the catalog repository is private, also set `GITHUB_TOKEN` or `GH_TOKEN` for catalog and skill fetches, and ensure Go can read private `github.com/mvanhorn/*` modules.
+## Migration from @mvanhorn/printing-press
+
+The old package name was ambiguous with the generator repo. If you installed it globally, remove the old package first:
+
+```bash
+npm uninstall -g @mvanhorn/printing-press
+```
+
+New installs should use:
+
+```bash
+npx -y @mvanhorn/printing-press-library <command>
+```
+
+The command name is also `printing-press-library`, so global installs are explicit:
+
+```bash
+npm install -g @mvanhorn/printing-press-library
+printing-press-library search flights
+```

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "printing-press-library": "bin/printing-press-library.mjs"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/commands/list.ts
+++ b/npm/src/commands/list.ts
@@ -7,6 +7,7 @@ import {
   type RegistryEntry,
 } from "../registry.js";
 import { renderCatalogEntries, renderInstalledEntries } from "../format.js";
+import { NPX_COMMAND_PREFIX } from "../constants.js";
 
 interface ListDeps {
   fetchRegistry: (url: string) => Promise<Registry>;
@@ -78,7 +79,7 @@ export function createListCommand(overrides: Partial<ListDeps> = {}) {
 
     if (installed.length === 0) {
       const suffix = options.category ? ` in category "${options.category}"` : "";
-      deps.stdout(`No Printing Press CLIs installed${suffix}. Try \`printing-press-library search <query>\` or \`printing-press-library install <name>\`.`);
+      deps.stdout(`No Printing Press CLIs installed${suffix}. Try \`${NPX_COMMAND_PREFIX} search <query>\` or \`${NPX_COMMAND_PREFIX} install <name>\`.`);
       return 0;
     }
 

--- a/npm/src/commands/search.ts
+++ b/npm/src/commands/search.ts
@@ -1,4 +1,10 @@
-import { DEFAULT_REGISTRY_URL, fetchRegistry, type Registry, type RegistryEntry } from "../registry.js";
+import {
+  DEFAULT_REGISTRY_URL,
+  cliBinaryName,
+  fetchRegistry,
+  type Registry,
+  type RegistryEntry,
+} from "../registry.js";
 import { renderCatalogEntries } from "../format.js";
 
 interface SearchDeps {
@@ -46,25 +52,64 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
 export const searchCommand = createSearchCommand();
 
 export function searchRegistry(entries: RegistryEntry[], query: string): RegistryEntry[] {
-  const q = query.toLowerCase();
+  const terms = searchTerms(query);
   return entries
-    .map((entry) => ({ entry, score: scoreEntry(entry, q) }))
+    .map((entry) => ({ entry, score: scoreEntry(entry, terms) }))
     .filter((result) => result.score > 0)
     .sort((a, b) => b.score - a.score || a.entry.name.localeCompare(b.entry.name))
     .map((result) => result.entry);
 }
 
-function scoreEntry(entry: RegistryEntry, query: string): number {
-  const name = entry.name.toLowerCase();
-  const api = entry.api.toLowerCase();
-  const category = entry.category.toLowerCase();
-  const description = entry.description.toLowerCase();
-  if (name === query || api === query) return 100;
-  if (name.includes(query)) return 80;
-  if (api.includes(query)) return 70;
-  if (category.includes(query)) return 50;
-  if (description.includes(query)) return 30;
+function scoreEntry(entry: RegistryEntry, terms: string[]): number {
+  const name = normalizeSearchText(entry.name);
+  const binary = normalizeSearchText(cliBinaryName(entry));
+  const api = normalizeSearchText(entry.api);
+  const category = normalizeSearchText(entry.category);
+  const description = normalizeSearchText(entry.description);
+  const indexText = normalizeSearchText(entry.search_terms?.join(" ") ?? "");
+  if (terms.some((term) => name === term || api === term)) return 100;
+  if (matchesAnyTerm(name, terms)) return 80;
+  if (matchesAnyTerm(binary, terms)) return 80;
+  if (matchesAnyTerm(api, terms)) return 70;
+  if (matchesAnyTerm(category, terms)) return 50;
+  if (matchesAnyTerm(description, terms)) return 30;
+  if (matchesAnyTerm(indexText, terms)) return 25;
   return 0;
+}
+
+function matchesAnyTerm(value: string, terms: string[]): boolean {
+  return terms.some((term) => value.includes(term));
+}
+
+function searchTerms(query: string): string[] {
+  const normalized = normalizeSearchText(query);
+  if (normalized === "") {
+    return [];
+  }
+
+  const terms = new Set([normalized]);
+  const singular = normalized
+    .split(" ")
+    .map((token) => singularizeToken(token))
+    .join(" ");
+  if (singular !== normalized) {
+    terms.add(singular);
+  }
+  return [...terms];
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function singularizeToken(token: string): string {
+  return token.length > 3 && token.endsWith("s") && !token.endsWith("ss")
+    ? token.slice(0, -1)
+    : token;
 }
 
 function parseSearchArgs(args: string[]):

--- a/npm/src/constants.ts
+++ b/npm/src/constants.ts
@@ -1,1 +1,3 @@
 export const CLI_COMMAND_NAME = "printing-press-library";
+export const NPM_PACKAGE_NAME = "@mvanhorn/printing-press-library";
+export const NPX_COMMAND_PREFIX = `npx -y ${NPM_PACKAGE_NAME}`;

--- a/npm/src/format.ts
+++ b/npm/src/format.ts
@@ -1,5 +1,5 @@
 import { cliBinaryName, type RegistryEntry } from "./registry.js";
-import { CLI_COMMAND_NAME } from "./constants.js";
+import { NPX_COMMAND_PREFIX } from "./constants.js";
 
 const DEFAULT_WIDTH = 88;
 const BODY_INDENT = "  ";
@@ -9,7 +9,7 @@ export function renderCatalogEntries(entries: RegistryEntry[]): string[] {
     const lines = [
       `${entry.name} (${entry.category}) - ${cliBinaryName(entry)}`,
       ...wrapText(entry.description, DEFAULT_WIDTH, BODY_INDENT),
-      `${BODY_INDENT}install: ${CLI_COMMAND_NAME} install ${entry.name}`,
+      `${BODY_INDENT}install: ${NPX_COMMAND_PREFIX} install ${entry.name}`,
     ];
     return index === entries.length - 1 ? lines : [...lines, ""];
   });

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -16,6 +16,7 @@ export interface RegistryEntry {
   category: string;
   api: string;
   description: string;
+  search_terms?: string[];
   path: string;
   mcp?: MCPBlock;
 }
@@ -149,6 +150,7 @@ function parseRegistryEntry(value: unknown): RegistryEntry {
     category: requiredString(value, "category"),
     api: requiredString(value, "api"),
     description: requiredString(value, "description"),
+    search_terms: optionalStringArray(value, "search_terms"),
     path: requiredString(value, "path"),
   };
 
@@ -200,6 +202,24 @@ function requiredStringArray(value: Record<string, unknown>, key: string): strin
     out.push(item);
   }
   return out;
+}
+
+function optionalStringArray(value: Record<string, unknown>, key: string): string[] | undefined {
+  const raw = value[key];
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error(`registry entry has non-array field: ${key}`);
+  }
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string" || item.trim() === "") {
+      throw new Error(`registry entry has non-string value in array field: ${key}`);
+    }
+    out.push(item);
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -24,6 +24,28 @@ const registry: Registry = {
       description: "Pizza ordering",
       path: "library/commerce/dominos",
     },
+    {
+      name: "hotel-tonight",
+      category: "travel",
+      api: "HotelTonight",
+      description: "Last-minute hotel deals",
+      path: "library/travel/hotel-tonight",
+    },
+    {
+      name: "cal-com",
+      category: "productivity",
+      api: "Cal.com",
+      description: "Scheduling and booking links",
+      path: "library/productivity/cal-com",
+    },
+    {
+      name: "booking-com",
+      category: "travel",
+      api: "Booking.com",
+      description: "Every Booking.com workflow",
+      search_terms: ["Search Booking.com hotels, scrape details and reviews, watch prices over time."],
+      path: "library/travel/booking-com",
+    },
   ],
 };
 
@@ -39,6 +61,7 @@ test("list command reports catalog CLIs by default", async () => {
   assert.equal(await command([]), 0);
   assert.match(stdout.join("\n"), /espn-pp-cli/);
   assert.match(stdout.join("\n"), /dominos-pp-cli/);
+  assert.match(stdout.join("\n"), /install: npx -y @mvanhorn\/printing-press-library install espn/);
 });
 
 test("list command can filter catalog CLIs by category", async () => {
@@ -86,6 +109,19 @@ test("list command can filter installed CLIs by category", async () => {
   assert.doesNotMatch(stdout.join("\n"), /dominos/);
 });
 
+test("list command suggests npx commands when no installed CLIs are detected", async () => {
+  const stdout: string[] = [];
+  const command = createListCommand({
+    fetchRegistry: async () => registry,
+    commandOnPath: async () => null,
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command(["--installed"]), 0);
+  assert.match(stdout.join("\n"), /npx -y @mvanhorn\/printing-press-library search <query>/);
+  assert.match(stdout.join("\n"), /npx -y @mvanhorn\/printing-press-library install <name>/);
+});
+
 test("search command ranks registry matches", async () => {
   const stdout: string[] = [];
   const command = createSearchCommand({
@@ -95,6 +131,23 @@ test("search command ranks registry matches", async () => {
 
   assert.equal(await command(["pizza"]), 0);
   assert.match(stdout.join("\n"), /dominos-pp-cli/);
+  assert.match(stdout.join("\n"), /install: npx -y @mvanhorn\/printing-press-library install dominos-pp-cli/);
+});
+
+test("search command normalizes punctuation and plural queries", async () => {
+  const stdout: string[] = [];
+  const command = createSearchCommand({
+    fetchRegistry: async () => registry,
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command(["hotels"]), 0);
+  assert.match(stdout.join("\n"), /hotel-tonight-pp-cli/);
+  assert.match(stdout.join("\n"), /booking-com-pp-cli/);
+
+  stdout.length = 0;
+  assert.equal(await command(["cal.com"]), 0);
+  assert.match(stdout.join("\n"), /cal-com-pp-cli/);
 });
 
 test("update command refreshes detected installed CLIs", async () => {

--- a/npm/tests/registry.test.ts
+++ b/npm/tests/registry.test.ts
@@ -19,6 +19,7 @@ test("parseRegistry validates and returns registry entries", () => {
         category: "sports",
         api: "ESPN",
         description: "Sports scores",
+        search_terms: ["NBA scores", "sports standings"],
         path: "library/sports/espn",
       },
     ],
@@ -26,6 +27,26 @@ test("parseRegistry validates and returns registry entries", () => {
 
   assert.equal(registry.entries.length, 1);
   assert.equal(registry.entries[0]?.name, "espn");
+  assert.deepEqual(registry.entries[0]?.search_terms, ["NBA scores", "sports standings"]);
+});
+
+test("parseRegistry treats null optional search_terms as absent", () => {
+  const registry = parseRegistry({
+    schema_version: 2,
+    entries: [
+      {
+        name: "espn",
+        category: "sports",
+        api: "ESPN",
+        description: "Sports scores",
+        search_terms: null,
+        path: "library/sports/espn",
+      },
+    ],
+  });
+
+  assert.equal(registry.entries.length, 1);
+  assert.equal(registry.entries[0]?.search_terms, undefined);
 });
 
 test("lookupByName matches normalized CLI and API names", () => {

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -66,11 +66,12 @@ type Registry struct {
 }
 
 type RegistryEntry struct {
-	Name        string `json:"name"`
-	Category    string `json:"category"`
-	API         string `json:"api"`
-	Description string `json:"description"`
-	Path        string `json:"path"`
+	Name        string   `json:"name"`
+	Category    string   `json:"category"`
+	API         string   `json:"api"`
+	Description string   `json:"description"`
+	SearchTerms []string `json:"search_terms,omitempty"`
+	Path        string   `json:"path"`
 	// Printer is the GitHub @handle of the human who originally ran the
 	// press for this CLI. Sourced verbatim from .printing-press.json's
 	// `printer` field; never derived from operator git config or curated
@@ -119,6 +120,8 @@ type printingPressManifest struct {
 	Description        string   `json:"description"`
 	Printer            string   `json:"printer"`
 	PrinterName        string   `json:"printer_name"`
+	CLIName            string   `json:"cli_name"`
+	AuthDescription    string   `json:"auth_description"`
 	MCPBinary          string   `json:"mcp_binary"`
 	MCPToolCount       int      `json:"mcp_tool_count"`
 	MCPPublicToolCount *int     `json:"mcp_public_tool_count"`
@@ -126,6 +129,12 @@ type printingPressManifest struct {
 	AuthType           string   `json:"auth_type"`
 	AuthEnvVars        []string `json:"auth_env_vars"`
 	SpecFormat         string   `json:"spec_format"`
+	NovelFeatures      []struct {
+		Name        string `json:"name"`
+		Command     string `json:"command"`
+		Description string `json:"description"`
+		Rationale   string `json:"rationale"`
+	} `json:"novel_features"`
 }
 
 // brewsDescriptionRE matches a `description:` line nested under `brews:` in
@@ -363,6 +372,7 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 		readGoreleaserDescription(filepath.Join(dir, ".goreleaser.yaml")),
 		pp.Description,
 	)
+	entry.SearchTerms = searchTerms(pp)
 
 	// MCP block preference: derive from .printing-press.json when it
 	// declares mcp_binary (the modern, authoritative source) > preserve
@@ -405,6 +415,46 @@ func registryDescription(prior, goreleaser, ppDescription string) string {
 		return goreleaser
 	}
 	return ppDescription
+}
+
+func searchTerms(pp printingPressManifest) []string {
+	var terms []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			terms = append(terms, value)
+		}
+	}
+
+	add(pp.APIName)
+	add(pp.DisplayName)
+	add(pp.CLIName)
+	add(pp.Description)
+	add(pp.AuthDescription)
+	for _, feature := range pp.NovelFeatures {
+		add(feature.Name)
+		add(feature.Command)
+		add(feature.Description)
+		add(feature.Rationale)
+	}
+	return dedupeStrings(terms)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	var out []string
+	for _, value := range values {
+		key := strings.ToLower(strings.TrimSpace(value))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 // validateEntries returns one human-readable error per missing required

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -67,11 +67,11 @@ func TestFormatDescription(t *testing.T) {
 
 func TestRegistryDescription(t *testing.T) {
 	cases := []struct {
-		name           string
-		prior          string
-		goreleaser     string
-		ppDescription  string
-		want           string
+		name          string
+		prior         string
+		goreleaser    string
+		ppDescription string
+		want          string
 	}{
 		{
 			name:          "curated copy wins over both fallbacks",
@@ -123,6 +123,44 @@ func TestRegistryDescription(t *testing.T) {
 					tc.prior, tc.goreleaser, tc.ppDescription, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSearchTerms(t *testing.T) {
+	got := searchTerms(printingPressManifest{
+		APIName:         "booking-com",
+		DisplayName:     "Booking.com",
+		CLIName:         "booking-com-pp-cli",
+		Description:     "Search Booking.com hotels, scrape details and reviews.",
+		AuthDescription: "Authenticated trips use cookie import.",
+		NovelFeatures: []struct {
+			Name        string `json:"name"`
+			Command     string `json:"command"`
+			Description string `json:"description"`
+			Rationale   string `json:"rationale"`
+		}{
+			{
+				Name:        "Compare two hotels side-by-side",
+				Command:     "compare",
+				Description: "Fetches detail and reviews for two hotels in parallel.",
+				Rationale:   "Useful for lodging decisions.",
+			},
+		},
+	})
+
+	want := []string{
+		"booking-com",
+		"Booking.com",
+		"booking-com-pp-cli",
+		"Search Booking.com hotels, scrape details and reviews.",
+		"Authenticated trips use cookie import.",
+		"Compare two hotels side-by-side",
+		"compare",
+		"Fetches detail and reviews for two hotels in parallel.",
+		"Useful for lodging decisions.",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("searchTerms mismatch\nwant: %#v\ngot:  %#v", want, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Switch the root README installer examples to the live `@mvanhorn/printing-press-library` package
- Expand the npm README with discovery flows for `list`, `search`, category filters, installed-only listing, forgiving names, and JSON output
- Bump the npm package to `0.1.7` so the npmjs README refreshes on publish
- Add generated registry `search_terms` plus npm-side punctuation/plural normalization so queries like `cal.com` and `hotels` find the expected CLIs
- Show `npx -y @mvanhorn/printing-press-library install <name>` in discovery result install hints so copy-paste installs work before a global install
- Treat `search_terms: null` as absent when parsing registries instead of dropping the whole entry

## Validation

- `npm test`
- `npm publish --dry-run --access public`
- `GO111MODULE=off go test ./tools/generate-registry`
- Generated-registry smoke: `searchRegistry(..., "hotels")` returns `hotel-tonight` and `booking-com`
- Executable smoke: `node bin/printing-press-library.mjs search hotels` prints the npx install hint for `hotel-tonight`

## Notes

- The catalog repository is public now, so the old `GITHUB_TOKEN` / `GH_TOKEN` prerequisite for private catalog fetches is intentionally not restored.
- The old `@mvanhorn/printing-press` package still needs an npm deprecation pass. I attempted it locally, but npm required OTP/browser authentication before applying the registry change.
