### PR TITLE
fix(npm): avoid pp-cli suffix search wildcards

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.8
+
+- Avoid treating one-character queries or the shared `-pp-cli` binary suffix as searchable content, so queries like `a`, `t`, `pp`, or `cli` no longer match broad slices of the catalog while full binary-name queries still resolve to the intended CLI.
+
 ## 0.1.7
 
 - Refresh the GitHub and npm README surfaces now that `@mvanhorn/printing-press-library` is live.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "bin": {
         "printing-press-library": "bin/printing-press-library.mjs"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/commands/search.ts
+++ b/npm/src/commands/search.ts
@@ -51,6 +51,9 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
 
 export const searchCommand = createSearchCommand();
 
+const MIN_MEANINGFUL_QUERY_LENGTH = 2;
+const IGNORED_SEARCH_TERMS = new Set(["pp", "cli"]);
+
 export function searchRegistry(entries: RegistryEntry[], query: string): RegistryEntry[] {
   const terms = searchTerms(query);
   return entries
@@ -61,8 +64,8 @@ export function searchRegistry(entries: RegistryEntry[], query: string): Registr
 }
 
 function scoreEntry(entry: RegistryEntry, terms: string[]): number {
-  const name = normalizeSearchText(entry.name);
-  const binary = normalizeSearchText(cliBinaryName(entry));
+  const name = normalizeCatalogIdentifier(entry.name);
+  const binary = normalizeCatalogIdentifier(cliBinaryName(entry));
   const api = normalizeSearchText(entry.api);
   const category = normalizeSearchText(entry.category);
   const description = normalizeSearchText(entry.description);
@@ -83,19 +86,32 @@ function matchesAnyTerm(value: string, terms: string[]): boolean {
 
 function searchTerms(query: string): string[] {
   const normalized = normalizeSearchText(query);
-  if (normalized === "") {
-    return [];
+  const terms = new Set<string>();
+  addSearchTerm(terms, normalized);
+  return [...terms];
+}
+
+function isMeaningfulSearchTerm(value: string): boolean {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  return tokens.some((token) => token.length >= MIN_MEANINGFUL_QUERY_LENGTH) && !IGNORED_SEARCH_TERMS.has(value);
+}
+
+function addSearchTerm(terms: Set<string>, term: string): void {
+  if (!isMeaningfulSearchTerm(term) || terms.has(term)) {
+    return;
   }
 
-  const terms = new Set([normalized]);
-  const singular = normalized
-    .split(" ")
-    .map((token) => singularizeToken(token))
-    .join(" ");
-  if (singular !== normalized) {
-    terms.add(singular);
+  terms.add(term);
+
+  const identifier = stripCommonBinarySuffix(term);
+  if (identifier !== term) {
+    addSearchTerm(terms, identifier);
   }
-  return [...terms];
+
+  const singular = singularizeTerm(term);
+  if (singular !== term) {
+    addSearchTerm(terms, singular);
+  }
 }
 
 function normalizeSearchText(value: string): string {
@@ -106,10 +122,30 @@ function normalizeSearchText(value: string): string {
     .replace(/\s+/g, " ");
 }
 
+function normalizeCatalogIdentifier(value: string): string {
+  return stripCommonBinarySuffix(normalizeSearchText(value));
+}
+
+function stripCommonBinarySuffix(value: string): string {
+  const suffix = " pp cli";
+  if (!value.endsWith(suffix)) {
+    return value;
+  }
+  const stripped = value.slice(0, -suffix.length).trim();
+  return stripped || value;
+}
+
 function singularizeToken(token: string): string {
   return token.length > 3 && token.endsWith("s") && !token.endsWith("ss")
     ? token.slice(0, -1)
     : token;
+}
+
+function singularizeTerm(term: string): string {
+  return term
+    .split(" ")
+    .map((token) => singularizeToken(token))
+    .join(" ");
 }
 
 function parseSearchArgs(args: string[]):

--- a/npm/src/commands/search.ts
+++ b/npm/src/commands/search.ts
@@ -52,7 +52,7 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
 export const searchCommand = createSearchCommand();
 
 const MIN_MEANINGFUL_QUERY_LENGTH = 2;
-const IGNORED_SEARCH_TERMS = new Set(["pp", "cli"]);
+const IGNORED_SEARCH_TERMS = new Set(["pp", "cli", "pp cli"]);
 
 export function searchRegistry(entries: RegistryEntry[], query: string): RegistryEntry[] {
   const terms = searchTerms(query);

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -156,6 +156,7 @@ test("search command ignores shared pp-cli binary suffix tokens", async () => {
   assert.deepEqual(searchRegistry(registry.entries, "t"), []);
   assert.deepEqual(searchRegistry(registry.entries, "cli"), []);
   assert.deepEqual(searchRegistry(registry.entries, "pp"), []);
+  assert.deepEqual(searchRegistry(registry.entries, "pp-cli"), []);
   assert.equal(searchRegistry(registry.entries, "cal")[0]?.name, "cal-com");
   assert.equal(searchRegistry(registry.entries, "dominos-pp-cli")[0]?.name, "dominos-pp-cli");
   assert.equal(searchRegistry(registry.entries, "hotels-pp-cli")[0]?.name, "hotel-tonight");

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createListCommand } from "../src/commands/list.js";
-import { createSearchCommand } from "../src/commands/search.js";
+import { createSearchCommand, searchRegistry } from "../src/commands/search.js";
 import { createUninstallCommand } from "../src/commands/uninstall.js";
 import { createUpdateCommand } from "../src/commands/update.js";
 import type { RunResult } from "../src/process.js";
@@ -148,6 +148,17 @@ test("search command normalizes punctuation and plural queries", async () => {
   stdout.length = 0;
   assert.equal(await command(["cal.com"]), 0);
   assert.match(stdout.join("\n"), /cal-com-pp-cli/);
+});
+
+test("search command ignores shared pp-cli binary suffix tokens", async () => {
+  assert.deepEqual(searchRegistry(registry.entries, "a"), []);
+  assert.deepEqual(searchRegistry(registry.entries, "a-b"), []);
+  assert.deepEqual(searchRegistry(registry.entries, "t"), []);
+  assert.deepEqual(searchRegistry(registry.entries, "cli"), []);
+  assert.deepEqual(searchRegistry(registry.entries, "pp"), []);
+  assert.equal(searchRegistry(registry.entries, "cal")[0]?.name, "cal-com");
+  assert.equal(searchRegistry(registry.entries, "dominos-pp-cli")[0]?.name, "dominos-pp-cli");
+  assert.equal(searchRegistry(registry.entries, "hotels-pp-cli")[0]?.name, "hotel-tonight");
 });
 
 test("update command refreshes detected installed CLIs", async () => {


### PR DESCRIPTION
## Summary

- Ignore one-character search queries and structural `pp` / `cli` terms so broad noise queries do not match large slices of the catalog
- Strip the shared `-pp-cli` suffix before scoring catalog identifiers while keeping full binary-name searches like `dominos-pp-cli` working
- Bump the npm package to `0.1.8` so the runtime fix publishes after merge

## Validation

- `npm test`
- `npm publish --dry-run --access public`
