### PR TITLE
fix(ci): dispatch npm publish after auto-tag

### DIFF
--- a/.github/workflows/auto-tag-npm.yml
+++ b/.github/workflows/auto-tag-npm.yml
@@ -1,13 +1,14 @@
 name: Auto-tag npm release on version bump
 
 # When npm/package.json's "version" field changes on main, push a matching
-# `npm-v<version>` tag. The existing npm-publish.yml workflow listens for that
-# tag and publishes via OIDC.
+# `npm-v<version>` tag, then explicitly dispatch npm-publish.yml for that tag.
+# Tag pushes made with GITHUB_TOKEN do not trigger another workflow run, so the
+# dispatch step is the part that actually starts the trusted publishing flow.
 #
 # This means the entire release rhythm is:
 #   1. Bump npm/package.json version in a PR (alongside any code change).
 #   2. Merge the PR.
-#   3. This workflow tags. npm-publish.yml publishes. Done.
+#   3. This workflow tags and dispatches npm-publish.yml. Done.
 #
 # Things that intentionally do NOT trigger a release:
 #   - Library / SKILL.md / registry.json / cli-skills changes (sourced live by
@@ -27,6 +28,7 @@ on:
       - 'npm/package.json'
 
 permissions:
+  actions: write    # needs to dispatch npm-publish.yml
   contents: write   # needs to push the tag
 
 jobs:
@@ -63,4 +65,14 @@ jobs:
           tag="npm-v${{ steps.check.outputs.new }}"
           git tag "$tag"
           git push origin "$tag"
-          echo "Pushed tag $tag — npm-publish.yml will run on the tag event."
+          echo "Pushed tag $tag."
+
+      - name: Dispatch npm publish workflow
+        if: steps.check.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="npm-v${{ steps.check.outputs.new }}"
+          gh workflow run npm-publish.yml --ref "$tag"
+          echo "Dispatched npm-publish.yml for $tag."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,9 +265,10 @@ Single rule: **bump `npm/package.json`'s `version` field in your release PR.** E
 When a PR that bumps the version merges to `main`:
 
 1. `.github/workflows/auto-tag-npm.yml` detects the version change and pushes a matching `npm-v<version>` tag.
-2. `.github/workflows/npm-publish.yml` triggers on the tag push, runs tests + build, and publishes via OIDC Trusted Publishing with a provenance attestation.
+2. The same auto-tag workflow dispatches `.github/workflows/npm-publish.yml` for that tag. Tag pushes made by `GITHUB_TOKEN` do not trigger a second workflow run by themselves, so the explicit dispatch is the release handoff.
+3. `.github/workflows/npm-publish.yml` runs tests + build, and publishes via OIDC Trusted Publishing with a provenance attestation.
 
-End-to-end: PR → review → merge → tag → publish, with no manual steps after merge.
+End-to-end: PR → review → merge → tag → dispatched publish, with no manual steps after merge.
 
 **What does NOT trigger a release:**
 


### PR DESCRIPTION
## Summary

- Update the npm auto-tag workflow to explicitly dispatch `npm-publish.yml` after creating an `npm-v*` tag
- Keep `npm-publish.yml` as the trusted-publisher workflow while avoiding the broken assumption that `GITHUB_TOKEN` tag pushes trigger follow-up workflows
- Update release docs in `AGENTS.md` to describe the actual tag-to-publish handoff

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/auto-tag-npm.yml"); YAML.load_file(".github/workflows/npm-publish.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/auto-tag-npm.yml .github/workflows/npm-publish.yml`
- `git diff --check`
