### PR TITLE
fix(ci): require cli-printing-press 4.10 for new CLIs

### DIFF
--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -89,10 +89,17 @@ def parse_semver(value: object) -> tuple[int, int, int] | None:
 
 
 def upgrade_message(actual: object) -> str:
-    actual_display = actual if isinstance(actual, str) and actual else "missing"
+    if actual is None:
+        version_clause = "printing_press_version is not set"
+    elif not isinstance(actual, str) or not actual:
+        version_clause = f"printing_press_version {actual!r} is not a valid version"
+    else:
+        version_clause = (
+            f"printing_press_version {actual!r} is below the required "
+            f"cli-printing-press version v{MIN_PRESS_VERSION}"
+        )
     return (
-        f"printing_press_version {actual_display!r} is below the required cli-printing-press "
-        f"version v{MIN_PRESS_VERSION}. Upgrade the generator checkout and installed tooling, then "
+        f"{version_clause}. Upgrade the generator checkout and installed tooling, then "
         "re-run the print/publish step so this manifest records the new version. Required steps: "
         "git -C <cli-printing-press checkout> pull --ff-only; "
         "go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest; "

--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -93,6 +93,8 @@ def upgrade_message(actual: object) -> str:
         version_clause = "printing_press_version is not set"
     elif not isinstance(actual, str) or not actual:
         version_clause = f"printing_press_version {actual!r} is not a valid version"
+    elif parse_semver(actual) is None:
+        version_clause = f"printing_press_version {actual!r} is not a valid version string"
     else:
         version_clause = (
             f"printing_press_version {actual!r} is below the required "

--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Require newly published library CLIs to come from a current cli-printing-press."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIN_PRESS_VERSION = "4.10.0"
+MIN_VERSION_PARTS = (4, 10, 0)
+
+
+@dataclass(frozen=True)
+class Problem:
+    file: Path | None
+    message: str
+
+
+def annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_error(problem: Problem) -> None:
+    message = annotation_escape(problem.message)
+    if problem.file is None:
+        print(f"::error::{message}")
+        return
+    print(f"::error file={rel(problem.file)}::{message}")
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def library_cli_dir_for(path: str) -> Path | None:
+    parts = PurePosixPath(path).parts
+    if len(parts) < 3 or parts[0] != "library":
+        return None
+    return REPO_ROOT / parts[0] / parts[1] / parts[2]
+
+
+def changed_cli_dirs(base_ref: str) -> list[Path]:
+    result = run_git(["diff", "--name-only", "--diff-filter=d", f"{base_ref}...HEAD", "--", "library"])
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+    dirs: set[Path] = set()
+    for path in result.stdout.splitlines():
+        cli_dir = library_cli_dir_for(path)
+        if cli_dir is not None and cli_dir.is_dir():
+            dirs.add(cli_dir)
+    return sorted(dirs, key=rel)
+
+
+def git_exists(base_ref: str, path: Path) -> bool:
+    result = run_git(["cat-file", "-e", f"{base_ref}:{rel(path)}"])
+    return result.returncode == 0
+
+
+def is_new_cli(base_ref: str, cli_dir: Path) -> bool:
+    return not git_exists(base_ref, cli_dir / ".printing-press.json")
+
+
+def parse_semver(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, str):
+        return None
+    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$", value.strip())
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def upgrade_message(actual: object) -> str:
+    actual_display = actual if isinstance(actual, str) and actual else "missing"
+    return (
+        f"printing_press_version {actual_display!r} is below the required cli-printing-press "
+        f"version v{MIN_PRESS_VERSION}. Upgrade the generator checkout and installed tooling, then "
+        "re-run the print/publish step so this manifest records the new version. Required steps: "
+        "git -C <cli-printing-press checkout> pull --ff-only; "
+        "go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest; "
+        "cli-printing-press --version; "
+        "install/update the latest cli-printing-press skills from mvanhorn/cli-printing-press; "
+        "then re-run /printing-press or /printing-press-publish."
+    )
+
+
+def validate_cli_dir(cli_dir: Path) -> list[Problem]:
+    manifest_path = cli_dir / ".printing-press.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except FileNotFoundError:
+        return [Problem(manifest_path, "touched library CLI is missing .printing-press.json")]
+    except json.JSONDecodeError as exc:
+        return [Problem(manifest_path, f".printing-press.json is not valid JSON: {exc}")]
+
+    if not isinstance(manifest, dict):
+        return [Problem(manifest_path, ".printing-press.json must contain a JSON object")]
+
+    raw_version = manifest.get("printing_press_version")
+    parsed = parse_semver(raw_version)
+    if parsed is None or parsed < MIN_VERSION_PARTS:
+        return [Problem(manifest_path, upgrade_message(raw_version))]
+
+    return []
+
+
+def run(base_ref: str) -> int:
+    problems: list[Problem] = []
+    for cli_dir in changed_cli_dirs(base_ref):
+        if not is_new_cli(base_ref, cli_dir):
+            continue
+        problems.extend(validate_cli_dir(cli_dir))
+
+    if not problems:
+        print(f"All newly added library CLIs declare cli-printing-press >= v{MIN_PRESS_VERSION}.")
+        return 0
+
+    for problem in problems:
+        emit_error(problem)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-ref", required=True, help="Base git ref to compare against")
+    args = parser.parse_args(argv)
+    return run(args.base_ref)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify-press-version/verify_press_version.py
+++ b/.github/scripts/verify-press-version/verify_press_version.py
@@ -13,7 +13,7 @@ from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MIN_PRESS_VERSION = "4.10.0"
-MIN_VERSION_PARTS = (4, 10, 0)
+MIN_VERSION_PARTS = tuple(int(part) for part in MIN_PRESS_VERSION.split("."))
 
 
 @dataclass(frozen=True)
@@ -98,7 +98,7 @@ def upgrade_message(actual: object) -> str:
         "go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest; "
         "cli-printing-press --version; "
         "install/update the latest cli-printing-press skills from mvanhorn/cli-printing-press; "
-        "then re-run /printing-press or /printing-press-publish."
+        "then re-run /cli-printing-press or /cli-printing-press-publish."
     )
 
 

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -93,7 +93,7 @@ class PressVersionVerifierTest(unittest.TestCase):
 
         self.assertEqual(1, self.run_quiet(base))
 
-    def test_touched_cli_with_current_press_version_passes(self) -> None:
+    def test_new_cli_with_current_press_version_passes(self) -> None:
         base = self.commit_base()
         self.git("switch", "-c", "feature")
         self.write_manifest("library/cloud/new", "4.10.0")
@@ -122,6 +122,15 @@ class PressVersionVerifierTest(unittest.TestCase):
         self.assertEqual(1, len(problems))
         self.assertIn("go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest", problems[0].message)
         self.assertIn("/cli-printing-press-publish", problems[0].message)
+
+    def test_absent_version_key_reports_not_set(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "missing-key"
+        self.write("library/cloud/missing-key/.printing-press.json", json.dumps({"api_name": "missing-key"}))
+
+        problems = verifier.validate_cli_dir(cli_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("printing_press_version is not set", problems[0].message)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -132,6 +132,15 @@ class PressVersionVerifierTest(unittest.TestCase):
         self.assertEqual(1, len(problems))
         self.assertIn("printing_press_version is not set", problems[0].message)
 
+    def test_unparseable_version_reports_invalid_string(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "bad-version"
+        self.write_manifest("library/cloud/bad-version", "4.10")
+
+        problems = verifier.validate_cli_dir(cli_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("printing_press_version '4.10' is not a valid version string", problems[0].message)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -121,7 +121,7 @@ class PressVersionVerifierTest(unittest.TestCase):
 
         self.assertEqual(1, len(problems))
         self.assertIn("go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest", problems[0].message)
-        self.assertIn("/printing-press-publish", problems[0].message)
+        self.assertIn("/cli-printing-press-publish", problems[0].message)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify-press-version/verify_press_version_test.py
+++ b/.github/scripts/verify-press-version/verify_press_version_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import verify_press_version as verifier
+
+
+class PressVersionVerifierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="verify-press-version-"))
+        self.addCleanup(lambda: shutil.rmtree(self.tmp))
+        self.old_root = verifier.REPO_ROOT
+        verifier.REPO_ROOT = self.tmp
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.com")
+        self.git("config", "user.name", "Test User")
+
+    def tearDown(self) -> None:
+        verifier.REPO_ROOT = self.old_root
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.tmp,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, rel: str, content: str) -> None:
+        path = self.tmp / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def write_manifest(self, root: str, version: object) -> None:
+        self.write(
+            f"{root}/.printing-press.json",
+            json.dumps(
+                {
+                    "api_name": Path(root).name,
+                    "cli_name": f"{Path(root).name}-pp-cli",
+                    "printing_press_version": version,
+                }
+            ),
+        )
+
+    def run_quiet(self, base: str) -> int:
+        with redirect_stdout(StringIO()):
+            return verifier.run(base)
+
+    def commit_base(self) -> str:
+        self.write_manifest("library/cloud/old", "4.0.0")
+        self.write("library/cloud/old/README.md", "# Old\n")
+        self.write("README.md", "# Repo\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "base")
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def test_non_library_pr_ignores_old_baseline_manifests(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write(".github/workflows/verify-library-conventions.yml", "name: Verify\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "update workflow")
+
+        self.assertEqual(0, self.run_quiet(base))
+
+    def test_touched_existing_cli_with_old_press_version_passes(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write("library/cloud/old/README.md", "# Updated\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "update old cli")
+
+        self.assertEqual(0, self.run_quiet(base))
+
+    def test_new_cli_with_old_press_version_fails(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write_manifest("library/cloud/new", "4.9.9")
+        self.write("library/cloud/new/README.md", "# New\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add stale cli")
+
+        self.assertEqual(1, self.run_quiet(base))
+
+    def test_touched_cli_with_current_press_version_passes(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write_manifest("library/cloud/new", "4.10.0")
+        self.write("library/cloud/new/README.md", "# New\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add current cli")
+
+        self.assertEqual(0, self.run_quiet(base))
+
+    def test_v_prefixed_newer_version_passes(self) -> None:
+        base = self.commit_base()
+        self.git("switch", "-c", "feature")
+        self.write_manifest("library/cloud/newer", "v4.11.0")
+        self.write("library/cloud/newer/README.md", "# Newer\n")
+        self.git("add", ".")
+        self.git("commit", "-m", "add newer cli")
+
+        self.assertEqual(0, self.run_quiet(base))
+
+    def test_missing_version_fails_with_upgrade_guidance(self) -> None:
+        cli_dir = self.tmp / "library" / "cloud" / "missing"
+        self.write_manifest("library/cloud/missing", "")
+
+        problems = verifier.validate_cli_dir(cli_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest", problems[0].message)
+        self.assertIn("/printing-press-publish", problems[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -14,7 +14,7 @@ name: Build CLI release artifacts
 #
 # Auth: requires GENERATOR_READ_TOKEN (fine-grained PAT with Contents:read on
 # mvanhorn/cli-printing-press) so the bundle job can `go install` the
-# printing-press generator from a private repo. The build-cli job doesn't
+# cli-printing-press generator from a private repo. The build-cli job doesn't
 # need it — printed CLIs only depend on public Go modules.
 
 on:
@@ -165,12 +165,12 @@ jobs:
             exit 1
           fi
           git config --global url."https://oauth2:${TOKEN}@github.com/".insteadOf "https://github.com/"
-      - name: Install printing-press
+      - name: Install cli-printing-press
         env:
           GOPRIVATE: github.com/mvanhorn/*
         run: |
-          go install github.com/mvanhorn/cli-printing-press/v3/cmd/printing-press@latest
-          printing-press --version
+          go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
+          cli-printing-press --version
       - name: Bundle MCPB
         env:
           CLI_TARGET: ${{ matrix.target }}
@@ -194,7 +194,7 @@ jobs:
           fi
           out="${RUNNER_TEMP}/out/${slug}-pp-mcp-${os}-${arch}.mcpb"
           mkdir -p "$(dirname "$out")"
-          printing-press bundle "$cli_dir" --platform "${PLATFORM}" --output "$out"
+          cli-printing-press bundle "$cli_dir" --platform "${PLATFORM}" --output "$out"
           ls -lh "$out"
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v6
@@ -387,6 +387,7 @@ jobs:
             echo "No artifacts to publish for ${SLUG}; skipping release."
             exit 0
           fi
+          # shellcheck disable=SC2016
           notes=$(printf 'Auto-built artifacts for **%s** at commit %s.\n\n**Claude Desktop:** download the matching `.mcpb` file and double-click to install.\n\n**Terminal CLI:** download the binary matching your platform. On macOS you may need to clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, `chmod +x <binary>`.\n\n_This is a moving tag — it always points at the latest build._' "${CLI_TARGET}" "${GITHUB_SHA}")
           if gh release view "${tag}" >/dev/null 2>&1; then
             echo "Updating existing release ${tag}"

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -45,12 +45,12 @@ jobs:
             exit 1
           fi
           git config --global url."https://oauth2:${TOKEN}@github.com/".insteadOf "https://github.com/"
-      - name: Install printing-press
+      - name: Install cli-printing-press
         env:
           GOPRIVATE: github.com/mvanhorn/*
         run: |
-          go install github.com/mvanhorn/cli-printing-press/v3/cmd/printing-press@latest
-          printing-press --version
+          go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
+          cli-printing-press --version
       - name: Run audit
         id: audit
         run: |
@@ -83,7 +83,7 @@ jobs:
             fi
 
             tmp_out="${RUNNER_TEMP}/${slug}.mcpb"
-            if printing-press bundle "$cli_dir" --output "$tmp_out" >/tmp/bundle.log 2>&1; then
+            if cli-printing-press bundle "$cli_dir" --output "$tmp_out" >/tmp/bundle.log 2>&1; then
               size=$(du -h "$tmp_out" 2>/dev/null | awk '{print $1}')
               echo "| ✅ ok | \`${target}\` | ${pp_version:-?} | ${size:-?} |" >> "$report"
               ok=$((ok+1))

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -38,6 +38,14 @@ name: Verify library conventions
 # 5. Prebuilt MCPB/native binary payloads must not be committed under
 #    library/. Release assets are built from source in GitHub Actions,
 #    then published from that workflow.
+#
+# 6. Newly added library CLIs must have been printed by cli-printing-press
+#    v4.10.0 or newer. That release renamed the generator binary from
+#    `printing-press` to `cli-printing-press`; stale local generator
+#    checkouts and skill installs should fail with direct upgrade
+#    instructions instead of publishing ambiguous old artifacts. Existing
+#    published CLIs can still receive narrow bugfixes even when their
+#    historical manifest records an older Printing Press version.
 
 on:
   pull_request:
@@ -97,6 +105,7 @@ jobs:
           for path in \
             .github/scripts/verify-attribution \
             .github/scripts/verify-binary-payload \
+            .github/scripts/verify-press-version \
             .github/scripts/verify-publish-package \
             tools/generate-registry
           do
@@ -201,6 +210,14 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/verify-binary-payload/verify_binary_payload.py --base-ref "${BASE_REMOTE_REF}"
+
+      - name: Require current cli-printing-press for new CLIs
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REMOTE_REF: ${{ steps.base.outputs.ref }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref "${BASE_REMOTE_REF}"
 
       - name: go.mod module path matches directory
         run: |


### PR DESCRIPTION
## Summary

New library additions now fail CI when they were printed with cli-printing-press before v4.10.0, giving agents the exact upgrade path for the renamed `cli-printing-press` binary before they publish ambiguous old artifacts.

The gate is intentionally limited to newly added CLI directories. Existing published CLIs can still receive narrow bugfixes even if their historical `.printing-press.json` records an older Printing Press version.

## Validation

- `python3 -m py_compile verify_press_version.py verify_press_version_test.py`
- `python3 -m unittest verify_press_version_test.py`
- `python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref origin/main`
- `actionlint .github/workflows/verify-library-conventions.yml .github/workflows/build-mcpb.yml .github/workflows/bundle-audit.yml`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
