### PR TITLE
fix(npm): prefer installed command in catalog hints

### DIFF
--- a/npm/src/commands/list.ts
+++ b/npm/src/commands/list.ts
@@ -7,7 +7,7 @@ import {
   type RegistryEntry,
 } from "../registry.js";
 import { renderCatalogEntries, renderInstalledEntries } from "../format.js";
-import { NPX_COMMAND_PREFIX } from "../constants.js";
+import { commandPrefixForInvocation } from "../constants.js";
 
 interface ListDeps {
   fetchRegistry: (url: string) => Promise<Registry>;
@@ -15,6 +15,7 @@ interface ListDeps {
   runner: Runner;
   stdout: (message: string) => void;
   stderr: (message: string) => void;
+  commandPrefix: string;
 }
 
 interface InstalledEntry {
@@ -31,6 +32,7 @@ export function createListCommand(overrides: Partial<ListDeps> = {}) {
     runner: execFileRunner,
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
+    commandPrefix: commandPrefixForInvocation(),
     ...overrides,
   };
 
@@ -55,7 +57,7 @@ export function createListCommand(overrides: Partial<ListDeps> = {}) {
         return 0;
       }
 
-      for (const line of renderCatalogEntries(entries)) {
+      for (const line of renderCatalogEntries(entries, deps.commandPrefix)) {
         deps.stdout(line);
       }
       return 0;
@@ -79,7 +81,7 @@ export function createListCommand(overrides: Partial<ListDeps> = {}) {
 
     if (installed.length === 0) {
       const suffix = options.category ? ` in category "${options.category}"` : "";
-      deps.stdout(`No Printing Press CLIs installed${suffix}. Try \`${NPX_COMMAND_PREFIX} search <query>\` or \`${NPX_COMMAND_PREFIX} install <name>\`.`);
+      deps.stdout(`No Printing Press CLIs installed${suffix}. Try \`${deps.commandPrefix} search <query>\` or \`${deps.commandPrefix} install <name>\`.`);
       return 0;
     }
 

--- a/npm/src/commands/search.ts
+++ b/npm/src/commands/search.ts
@@ -6,11 +6,13 @@ import {
   type RegistryEntry,
 } from "../registry.js";
 import { renderCatalogEntries } from "../format.js";
+import { commandPrefixForInvocation } from "../constants.js";
 
 interface SearchDeps {
   fetchRegistry: (url: string) => Promise<Registry>;
   stdout: (message: string) => void;
   stderr: (message: string) => void;
+  commandPrefix: string;
 }
 
 export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
@@ -18,6 +20,7 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
     fetchRegistry: (url) => fetchRegistry(url),
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
+    commandPrefix: commandPrefixForInvocation(),
     ...overrides,
   };
 
@@ -42,7 +45,7 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
       return 0;
     }
 
-    for (const line of renderCatalogEntries(matches)) {
+    for (const line of renderCatalogEntries(matches, deps.commandPrefix)) {
       deps.stdout(line);
     }
     return 0;

--- a/npm/src/commands/search.ts
+++ b/npm/src/commands/search.ts
@@ -28,7 +28,7 @@ export function createSearchCommand(overrides: Partial<SearchDeps> = {}) {
     const parsed = parseSearchArgs(args);
     if ("error" in parsed) {
       deps.stderr(parsed.error);
-      deps.stderr("Usage: printing-press-library search <query> [--json]");
+      deps.stderr(`Usage: ${deps.commandPrefix} search <query> [--json]`);
       return 1;
     }
 

--- a/npm/src/constants.ts
+++ b/npm/src/constants.ts
@@ -1,3 +1,20 @@
 export const CLI_COMMAND_NAME = "printing-press-library";
 export const NPM_PACKAGE_NAME = "@mvanhorn/printing-press-library";
 export const NPX_COMMAND_PREFIX = `npx -y ${NPM_PACKAGE_NAME}`;
+
+export function commandPrefixForInvocation(
+  scriptPath = process.argv[1] ?? "",
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (isNpxInvocation(scriptPath, env)) {
+    return NPX_COMMAND_PREFIX;
+  }
+  return CLI_COMMAND_NAME;
+}
+
+function isNpxInvocation(scriptPath: string, env: NodeJS.ProcessEnv): boolean {
+  if (env.npm_command === "exec") {
+    return true;
+  }
+  return /(^|[/\\])_npx([/\\]|$)/.test(scriptPath);
+}

--- a/npm/src/format.ts
+++ b/npm/src/format.ts
@@ -1,15 +1,14 @@
 import { cliBinaryName, type RegistryEntry } from "./registry.js";
-import { NPX_COMMAND_PREFIX } from "./constants.js";
 
 const DEFAULT_WIDTH = 88;
 const BODY_INDENT = "  ";
 
-export function renderCatalogEntries(entries: RegistryEntry[]): string[] {
+export function renderCatalogEntries(entries: RegistryEntry[], commandPrefix: string): string[] {
   return entries.flatMap((entry, index) => {
     const lines = [
       `${entry.name} (${entry.category}) - ${cliBinaryName(entry)}`,
       ...wrapText(entry.description, DEFAULT_WIDTH, BODY_INDENT),
-      `${BODY_INDENT}install: ${NPX_COMMAND_PREFIX} install ${entry.name}`,
+      `${BODY_INDENT}install: ${commandPrefix} install ${entry.name}`,
     ];
     return index === entries.length - 1 ? lines : [...lines, ""];
   });

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -4,6 +4,7 @@ import { createListCommand } from "../src/commands/list.js";
 import { createSearchCommand, searchRegistry } from "../src/commands/search.js";
 import { createUninstallCommand } from "../src/commands/uninstall.js";
 import { createUpdateCommand } from "../src/commands/update.js";
+import { commandPrefixForInvocation, NPX_COMMAND_PREFIX } from "../src/constants.js";
 import type { RunResult } from "../src/process.js";
 import type { Registry } from "../src/registry.js";
 
@@ -61,7 +62,7 @@ test("list command reports catalog CLIs by default", async () => {
   assert.equal(await command([]), 0);
   assert.match(stdout.join("\n"), /espn-pp-cli/);
   assert.match(stdout.join("\n"), /dominos-pp-cli/);
-  assert.match(stdout.join("\n"), /install: npx -y @mvanhorn\/printing-press-library install espn/);
+  assert.match(stdout.join("\n"), /install: printing-press-library install espn/);
 });
 
 test("list command can filter catalog CLIs by category", async () => {
@@ -109,7 +110,7 @@ test("list command can filter installed CLIs by category", async () => {
   assert.doesNotMatch(stdout.join("\n"), /dominos/);
 });
 
-test("list command suggests npx commands when no installed CLIs are detected", async () => {
+test("list command suggests the current wrapper command when no installed CLIs are detected", async () => {
   const stdout: string[] = [];
   const command = createListCommand({
     fetchRegistry: async () => registry,
@@ -118,8 +119,8 @@ test("list command suggests npx commands when no installed CLIs are detected", a
   });
 
   assert.equal(await command(["--installed"]), 0);
-  assert.match(stdout.join("\n"), /npx -y @mvanhorn\/printing-press-library search <query>/);
-  assert.match(stdout.join("\n"), /npx -y @mvanhorn\/printing-press-library install <name>/);
+  assert.match(stdout.join("\n"), /printing-press-library search <query>/);
+  assert.match(stdout.join("\n"), /printing-press-library install <name>/);
 });
 
 test("search command ranks registry matches", async () => {
@@ -131,7 +132,28 @@ test("search command ranks registry matches", async () => {
 
   assert.equal(await command(["pizza"]), 0);
   assert.match(stdout.join("\n"), /dominos-pp-cli/);
+  assert.match(stdout.join("\n"), /install: printing-press-library install dominos-pp-cli/);
+});
+
+test("catalog hints preserve npx when the wrapper is running through npx", async () => {
+  const stdout: string[] = [];
+  const command = createSearchCommand({
+    commandPrefix: NPX_COMMAND_PREFIX,
+    fetchRegistry: async () => registry,
+    stdout: (message) => stdout.push(message),
+  });
+
+  assert.equal(await command(["pizza"]), 0);
   assert.match(stdout.join("\n"), /install: npx -y @mvanhorn\/printing-press-library install dominos-pp-cli/);
+});
+
+test("command prefix follows the invocation source", () => {
+  assert.equal(commandPrefixForInvocation("/opt/homebrew/bin/printing-press-library", {}), "printing-press-library");
+  assert.equal(
+    commandPrefixForInvocation("/Users/me/.npm/_npx/123/node_modules/.bin/printing-press-library", {}),
+    NPX_COMMAND_PREFIX,
+  );
+  assert.equal(commandPrefixForInvocation("/tmp/printing-press-library", { npm_command: "exec" }), NPX_COMMAND_PREFIX);
 });
 
 test("search command normalizes punctuation and plural queries", async () => {

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -4,7 +4,7 @@ import { createListCommand } from "../src/commands/list.js";
 import { createSearchCommand, searchRegistry } from "../src/commands/search.js";
 import { createUninstallCommand } from "../src/commands/uninstall.js";
 import { createUpdateCommand } from "../src/commands/update.js";
-import { commandPrefixForInvocation, NPX_COMMAND_PREFIX } from "../src/constants.js";
+import { CLI_COMMAND_NAME, commandPrefixForInvocation, NPX_COMMAND_PREFIX } from "../src/constants.js";
 import type { RunResult } from "../src/process.js";
 import type { Registry } from "../src/registry.js";
 
@@ -55,6 +55,7 @@ const ok = (stdout = ""): RunResult => ({ code: 0, stdout, stderr: "" });
 test("list command reports catalog CLIs by default", async () => {
   const stdout: string[] = [];
   const command = createListCommand({
+    commandPrefix: CLI_COMMAND_NAME,
     fetchRegistry: async () => registry,
     stdout: (message) => stdout.push(message),
   });
@@ -113,6 +114,7 @@ test("list command can filter installed CLIs by category", async () => {
 test("list command suggests the current wrapper command when no installed CLIs are detected", async () => {
   const stdout: string[] = [];
   const command = createListCommand({
+    commandPrefix: CLI_COMMAND_NAME,
     fetchRegistry: async () => registry,
     commandOnPath: async () => null,
     stdout: (message) => stdout.push(message),
@@ -126,6 +128,7 @@ test("list command suggests the current wrapper command when no installed CLIs a
 test("search command ranks registry matches", async () => {
   const stdout: string[] = [];
   const command = createSearchCommand({
+    commandPrefix: CLI_COMMAND_NAME,
     fetchRegistry: async () => registry,
     stdout: (message) => stdout.push(message),
   });
@@ -145,6 +148,17 @@ test("catalog hints preserve npx when the wrapper is running through npx", async
 
   assert.equal(await command(["pizza"]), 0);
   assert.match(stdout.join("\n"), /install: npx -y @mvanhorn\/printing-press-library install dominos-pp-cli/);
+});
+
+test("search usage follows the current wrapper command", async () => {
+  const stderr: string[] = [];
+  const command = createSearchCommand({
+    commandPrefix: NPX_COMMAND_PREFIX,
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command([]), 1);
+  assert.match(stderr.join("\n"), /Usage: npx -y @mvanhorn\/printing-press-library search <query> \[--json\]/);
 });
 
 test("command prefix follows the invocation source", () => {


### PR DESCRIPTION
## Summary

Catalog search and list output now matches how the wrapper was invoked: globally installed users see `printing-press-library install ...`, while npx users still get copy-pasteable `npx -y @mvanhorn/printing-press-library install ...` hints.

The command prefix is resolved once per invocation and shared by the catalog renderers, so installing the wrapper globally no longer sends users back through npx for the next command.

## Testing

- `npm test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
