### PR TITLE
feat(google-search-console): add crawl-stats command tree (URL samples, time-series, totals)

### DIFF
--- a/library/marketing/google-search-console/.printing-press-patches.json
+++ b/library/marketing/google-search-console/.printing-press-patches.json
@@ -67,11 +67,24 @@
         "internal/config/config.go",
         "README.md",
         ".printing-press.json",
-        ".printing-press-patches.json"
+        ".printing-press-patches.json",
+        "internal/store/crawl_stats_test.go"
       ],
-      "findings_addressed": ["F1", "F2", "F3", "F4", "F6", "F7", "F8", "F9", "F10"],
+      "findings_addressed": [
+        "F1",
+        "F2",
+        "F3",
+        "F4",
+        "F6",
+        "F7",
+        "F8",
+        "F9",
+        "F10",
+        "Greptile-P1-top-before-persist",
+        "Greptile-P1-union-latest-row"
+      ],
       "patch_count": 12,
-      "validated_outcome": "go build ./..., go vet ./... clean. New `client/sapisidhash_test.go` passes against canonical SHA1 reference value. `crawl-stats by-type ... --dry-run --json` prints the constructed batchexecute payload matching the discovery-report shape byte-for-byte (file_type=css yields filter code 5 at envelope index 8). `auth status --json` reports the new `crawl_stats_cookie_jar` + `crawl_stats_cookie_jar_status` fields. `cli-printing-press publish validate` PASSES every check except (a) `verify-skill` SKILL.md install-section drift, which is pre-existing on main (verified by re-running the same check on a clean main checkout — fails identically). Live testing is deferred to post-merge since it requires the user's authenticated Google session cookies."
+      "validated_outcome": "go build ./..., go vet ./... clean. New `client/sapisidhash_test.go` passes against canonical SHA1 reference value. `crawl-stats by-type ... --dry-run --json` prints the constructed batchexecute payload matching the discovery-report shape byte-for-byte (file_type=css yields filter code 5 at envelope index 8). `auth status --json` reports the new `crawl_stats_cookie_jar` + `crawl_stats_cookie_jar_status` fields. `cli-printing-press publish validate` PASSES every check except (a) `verify-skill` SKILL.md install-section drift, which is pre-existing on main (verified by re-running the same check on a clean main checkout \u2014 fails identically). Live testing is deferred to post-merge since it requires the user's authenticated Google session cookies. Follow-up PR review sweep: `go test ./internal/store` passes for latest-row crawl-stats union regression; `gofmt` and `git diff --check` pass."
     }
   ]
 }

--- a/library/marketing/google-search-console/.printing-press-patches.json
+++ b/library/marketing/google-search-console/.printing-press-patches.json
@@ -85,6 +85,20 @@
       ],
       "patch_count": 12,
       "validated_outcome": "go build ./..., go vet ./... clean. New `client/sapisidhash_test.go` passes against canonical SHA1 reference value. `crawl-stats by-type ... --dry-run --json` prints the constructed batchexecute payload matching the discovery-report shape byte-for-byte (file_type=css yields filter code 5 at envelope index 8). `auth status --json` reports the new `crawl_stats_cookie_jar` + `crawl_stats_cookie_jar_status` fields. `cli-printing-press publish validate` PASSES every check except (a) `verify-skill` SKILL.md install-section drift, which is pre-existing on main (verified by re-running the same check on a clean main checkout \u2014 fails identically). Live testing is deferred to post-merge since it requires the user's authenticated Google session cookies. Follow-up PR review sweep: `go test ./internal/store` passes for latest-row crawl-stats union regression; `gofmt` and `git diff --check` pass."
+    },
+    {
+      "id": "crawl-stats-sample-metadata",
+      "date": "2026-05-22",
+      "summary": "Best-effort decode Crawl Stats sample metadata from the private GSC UI payload.",
+      "reason": "The crawl-stats client previously emitted only URLs, leaving fetched_at, response_code, size_bytes, and response_ms at zero in persisted union output.",
+      "files": [
+        "internal/client/crawlstats.go",
+        "internal/client/crawlstats_test.go"
+      ],
+      "findings_addressed": [
+        "Greptile-P1-extract-samples-metadata"
+      ],
+      "validated_outcome": "gofmt; git diff --check; go test ./internal/client; go test ./internal/store; go test ./..."
     }
   ]
 }

--- a/library/marketing/google-search-console/.printing-press-patches.json
+++ b/library/marketing/google-search-console/.printing-press-patches.json
@@ -46,6 +46,32 @@
         "internal/client/client.go"
       ],
       "validated_outcome": "After fix: 21-day sync persists 23,250 rows, quick-wins/cliff/compare/historical all return real data. Response cache .json files now live in `~/.cache/<cli>/responses/` while store.db lives at `~/.cache/<cli>/store.db`. POST requests safely invalidate only response JSON."
+    },
+    {
+      "id": "crawl-stats",
+      "date": "2026-05-21",
+      "amend_run_id": "amend-2026-05-21T1402",
+      "summary": "Add the `crawl-stats` command tree wrapping Google Search Console's Crawl Stats UI (URL samples, time-series, totals). Calls the private SearchConsoleAggReportUi.batchexecute endpoint reverse-engineered via chrome-MCP capture; not in the public Search Console v1 API.",
+      "reason": "The Crawl Stats UI under Settings > Crawl stats exposes per-URL sample lists, time-series, and totals that are NOT in the public Search Console v1 API. The endpoint behind that UI is reachable from outside the browser as long as the caller supplies the seven Google web session cookies plus the SAPISIDHASH header. This patch adds: a Cobra command tree (list/by-type/by-response/by-googlebot/by-purpose/union); an HTTP client that builds the batchexecute payload from typed dimension+code inputs; a SAPISIDHASH primitive and a Netscape cookie-jar reader; SQLite tables for samples/totals/time-series so the user can union URL samples across multiple ~1000-cap polls; an `auth login --chrome` setup path that prints export instructions and persists the jar path; cookie-jar surface state surfaced via `auth status`. The two auth surfaces (existing OAuth bearer token + new cookie jar) coexist.",
+      "files": [
+        "internal/cli/crawl_stats.go",
+        "internal/cli/root.go",
+        "internal/cli/auth.go",
+        "internal/cli/auth_login.go",
+        "internal/client/crawlstats.go",
+        "internal/client/sapisidhash.go",
+        "internal/client/sapisidhash_test.go",
+        "internal/client/cookiejar.go",
+        "internal/store/crawl_stats.go",
+        "internal/store/store.go",
+        "internal/config/config.go",
+        "README.md",
+        ".printing-press.json",
+        ".printing-press-patches.json"
+      ],
+      "findings_addressed": ["F1", "F2", "F3", "F4", "F6", "F7", "F8", "F9", "F10"],
+      "patch_count": 12,
+      "validated_outcome": "go build ./..., go vet ./... clean. New `client/sapisidhash_test.go` passes against canonical SHA1 reference value. `crawl-stats by-type ... --dry-run --json` prints the constructed batchexecute payload matching the discovery-report shape byte-for-byte (file_type=css yields filter code 5 at envelope index 8). `auth status --json` reports the new `crawl_stats_cookie_jar` + `crawl_stats_cookie_jar_status` fields. `cli-printing-press publish validate` PASSES every check except (a) `verify-skill` SKILL.md install-section drift, which is pre-existing on main (verified by re-running the same check on a clean main checkout — fails identically). Live testing is deferred to post-merge since it requires the user's authenticated Google session cookies."
     }
   ]
 }

--- a/library/marketing/google-search-console/.printing-press.json
+++ b/library/marketing/google-search-console/.printing-press.json
@@ -65,6 +65,11 @@
       "name": "New queries arriving",
       "command": "new-queries",
       "description": "Queries that started showing up with impressions in the last N days but didn't exist in the corpus before -- emerging demand."
+    },
+    {
+      "name": "Crawl Stats (URL samples + drill-down)",
+      "command": "crawl-stats",
+      "description": "Pull URL samples, time-series, and totals from the GSC Crawl Stats UI (Settings > Crawl stats) -- not in the public Search Console v1 API. Drill down by file type, response code, Googlebot crawler, or purpose; union samples across multiple polls in local SQLite to escape the ~1000-sample-per-poll cap."
     }
   ],
   "printer": "bossriceshark",

--- a/library/marketing/google-search-console/README.md
+++ b/library/marketing/google-search-console/README.md
@@ -277,6 +277,41 @@ These capabilities aren't available in any other tool for this API.
   google-search-console-pp-cli new-queries sc-domain:example.com --since 28d --min-imps 50 --top 100 --json
   ```
 
+### Crawl Stats (URL samples, time-series, totals)
+
+The Crawl Stats report (Settings > Crawl stats in the GSC web UI) exposes
+per-URL sample lists, time-series, and aggregate stats broken down by
+file type, response code, Googlebot crawler, and purpose. **None of this is
+in the public Search Console v1 API** — the CLI calls a private internal
+`batchexecute` endpoint reverse-engineered from a logged-in Chrome session.
+
+Auth is **separate** from the OAuth flow used by every other command in
+this CLI. You point the CLI at a Netscape-format cookie jar exported from
+your Chrome profile. Run `auth login --chrome` for export instructions.
+
+- **`crawl-stats list`** — overview view (no drill-down filter).
+- **`crawl-stats by-type --file-type <html|css|js|image|video|pdf|other|unknown>`** — drill down by file type.
+- **`crawl-stats by-response --response-code <ok|not-found|server-error|...>`** — drill down by Googlebot response code (18 values).
+- **`crawl-stats by-googlebot --googlebot <smartphone|desktop|image|adsbot|...>`** — drill down by crawler type.
+- **`crawl-stats by-purpose --purpose <discovery|refresh>`** — drill down by purpose.
+- **`crawl-stats union`** — read the deduplicated union of all polled samples from the local SQLite store. Each live poll caps at ~1000 URLs (Google's limit), so unioning across polls is the only way to build a larger corpus.
+
+  ```bash
+  # One-time setup
+  google-search-console-pp-cli auth login --chrome --cookie-jar-path ~/gsc-cookies.txt
+  export GSC_XSRF_TOKEN=<the `at=` field from a GSC batchexecute POST>
+
+  # Poll CSS samples and persist to local store
+  google-search-console-pp-cli crawl-stats by-type sc-domain:example.com \
+    --file-type css --json --top 1000
+
+  # Read the unioned set across all polls (no network call)
+  google-search-console-pp-cli crawl-stats union sc-domain:example.com --file-type css --json
+  ```
+
+  Cookies typically expire every ~2 weeks. When a crawl-stats command
+  returns HTTP 401/403, re-export the jar and re-point `GSC_COOKIE_JAR`.
+
 ## Cookbook
 
 End-to-end recipes that combine multiple commands. Every flag below is verified against the running CLI -- no guessed names.

--- a/library/marketing/google-search-console/internal/cli/auth.go
+++ b/library/marketing/google-search-console/internal/cli/auth.go
@@ -10,11 +10,20 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/internal/config"
 	"github.com/spf13/cobra"
 )
+
+// PATCH(crawl-stats): one-line shim so the auth-status cookie-jar helper
+// doesn't need to import the client package directly at every call site.
+// Kept here (not in helpers.go) because it's auth-surface-specific.
+func clientLoadJar(path string) (*client.CookieJarFile, error) {
+	return client.LoadNetscapeCookieJar(path)
+}
 
 func newAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
@@ -63,6 +72,25 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 
+			// PATCH(crawl-stats): surface cookie-jar state alongside the OAuth
+			// state so users can tell at a glance whether the crawl-stats
+			// surface is configured. The two paths are independent.
+			cookieJarPath := cfg.CrawlStatsCookieJar
+			cookieJarStatus := "not configured"
+			cookieJarMissing := []string{}
+			if cookieJarPath != "" {
+				if jar, jerr := loadCrawlStatsCookieJarStatus(cookieJarPath); jerr == nil {
+					cookieJarMissing = jar
+					if len(jar) == 0 {
+						cookieJarStatus = "complete"
+					} else {
+						cookieJarStatus = fmt.Sprintf("incomplete (%d cookies missing)", len(jar))
+					}
+				} else {
+					cookieJarStatus = "unreadable: " + jerr.Error()
+				}
+			}
+
 			if flags.asJSON {
 				out := map[string]any{
 					"authenticated":       authed,
@@ -72,6 +100,13 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 					"has_refresh_token":   cfg.RefreshToken != "",
 					"access_token_expiry": expiryStr,
 					"expires_in":          expiresIn,
+					// PATCH(crawl-stats): independent auth surface for the
+					// Crawl Stats UI endpoints. OAuth is sufficient for the
+					// public Search Console v1 API, but the private Crawl
+					// Stats endpoints need cookie-jar auth instead.
+					"crawl_stats_cookie_jar":         cookieJarPath,
+					"crawl_stats_cookie_jar_status":  cookieJarStatus,
+					"crawl_stats_cookie_jar_missing": cookieJarMissing,
 				}
 				if printErr := printJSONFiltered(w, out, flags); printErr != nil {
 					return printErr
@@ -101,6 +136,20 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			if expiryStr != "" {
 				fmt.Fprintf(w, "  Token expiry:     %s (%s)\n", expiryStr, expiresIn)
 			}
+			// PATCH(crawl-stats): render the separate cookie-jar surface so
+			// users immediately know whether Crawl Stats commands will work.
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, bold("Crawl Stats cookie-jar surface (separate from OAuth):"))
+			if cookieJarPath == "" {
+				fmt.Fprintln(w, "  Path:             "+yellow("not configured"))
+				fmt.Fprintln(w, "  Status:           run `auth login --chrome` to set up")
+			} else {
+				fmt.Fprintf(w, "  Path:             %s\n", cookieJarPath)
+				fmt.Fprintf(w, "  Status:           %s\n", cookieJarStatus)
+				if len(cookieJarMissing) > 0 {
+					fmt.Fprintf(w, "  Missing cookies:  %s\n", strings.Join(cookieJarMissing, ", "))
+				}
+			}
 			if cfg.AuthSource == "env:GSC_ACCESS_TOKEN" && cfg.RefreshToken == "" {
 				fmt.Fprintln(w, "")
 				fmt.Fprintln(w, yellow("Note: GSC_ACCESS_TOKEN is set but there's no refresh token, so the next call will fail when this token expires."))
@@ -109,6 +158,18 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// PATCH(crawl-stats): helper that loads a cookie jar and returns the list of
+// missing required cookies (empty when the jar is complete). Returns an error
+// when the jar file is unreadable. Used by `auth status` to summarize the
+// crawl-stats auth surface without printing cookie values themselves.
+func loadCrawlStatsCookieJarStatus(path string) ([]string, error) {
+	jar, err := clientLoadJar(path)
+	if err != nil {
+		return nil, err
+	}
+	return jar.MissingCookies(), nil
 }
 
 func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {

--- a/library/marketing/google-search-console/internal/cli/auth_login.go
+++ b/library/marketing/google-search-console/internal/cli/auth_login.go
@@ -181,9 +181,6 @@ func runAuthLoginChrome(cmd *cobra.Command, flags *rootFlags, cookieJarPath stri
 	if cfg.CrawlStatsCookieJar != "" {
 		fmt.Fprintf(w, "\nCurrent cookie jar path in config: %s\n", cfg.CrawlStatsCookieJar)
 	}
-	// strings is imported elsewhere in this file; reference it so the
-	// unused-import linter doesn't complain if it's only used by login proper.
-	_ = strings.ToLower
 	return nil
 }
 

--- a/library/marketing/google-search-console/internal/cli/auth_login.go
+++ b/library/marketing/google-search-console/internal/cli/auth_login.go
@@ -50,9 +50,11 @@ const loginTimeout = 5 * time.Minute
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var (
-		scope     string
-		noBrowser bool
-		port      int
+		scope         string
+		noBrowser     bool
+		port          int
+		chromeMode    bool
+		cookieJarPath string
 	)
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -67,7 +69,12 @@ when it expires.
 
 Prerequisite: run ` + "`gsc auth set-client <client_id> <client_secret>`" + ` once
 to register your Google Cloud OAuth client. See README.md for the 5-minute
-Google Cloud Console setup walkthrough.`,
+Google Cloud Console setup walkthrough.
+
+CRAWL STATS NOTE: the OAuth flow above does NOT authenticate against the
+private Crawl Stats endpoints (Settings > Crawl stats). Those need Google
+web session cookies. Run ` + "`auth login --chrome`" + ` to set up that path —
+the OAuth surface and the cookie-jar surface coexist; you can run both.`,
 		Example: `  # Default (readonly scope)
   google-search-console-pp-cli auth login
 
@@ -75,15 +82,109 @@ Google Cloud Console setup walkthrough.`,
   google-search-console-pp-cli auth login --scope write
 
   # SSH/headless: print URL, don't try to open a browser
-  google-search-console-pp-cli auth login --no-browser`,
+  google-search-console-pp-cli auth login --no-browser
+
+  # Crawl Stats cookie-jar setup (prints export instructions)
+  google-search-console-pp-cli auth login --chrome
+
+  # Crawl Stats cookie-jar setup (record a jar path you already exported)
+  google-search-console-pp-cli auth login --chrome --cookie-jar-path ~/cookies.txt`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// PATCH(crawl-stats): --chrome flag short-circuits the OAuth flow
+			// and configures the cookie-jar path used by the crawl-stats
+			// command surface. The two auth paths are independent — calling
+			// `auth login` later with no flags still runs OAuth as before.
+			if chromeMode {
+				return runAuthLoginChrome(cmd, flags, cookieJarPath)
+			}
 			return runAuthLogin(cmd, flags, scope, noBrowser, port)
 		},
 	}
 	cmd.Flags().StringVar(&scope, "scope", "readonly", "Scope to request: readonly | write")
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Don't try to open the browser — print the URL only")
 	cmd.Flags().IntVar(&port, "port", 0, "Loopback port (0 = OS-assigned, recommended)")
+	// PATCH(crawl-stats): chrome cookie-jar setup mode (separate auth surface).
+	cmd.Flags().BoolVar(&chromeMode, "chrome", false, "Set up cookie-jar auth for the Crawl Stats surface (prints export instructions; pair with --cookie-jar-path to persist a jar path)")
+	cmd.Flags().StringVar(&cookieJarPath, "cookie-jar-path", "", "Path to a Netscape-format cookie jar (used with --chrome to persist the path in config)")
 	return cmd
+}
+
+// PATCH(crawl-stats): runAuthLoginChrome configures the cookie-jar auth path
+// used by the `crawl-stats` command tree. The OAuth flow does NOT
+// authenticate against the private SearchConsoleAggReportUi endpoints; this
+// command documents the manual cookie export from Chrome and (optionally)
+// persists a jar path to config. Manual capture is required for v0.2;
+// in-process Chrome driving is deferred to v0.3.
+func runAuthLoginChrome(cmd *cobra.Command, flags *rootFlags, cookieJarPath string) error {
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return configErr(err)
+	}
+
+	if cookieJarPath != "" {
+		cfg.CrawlStatsCookieJar = cookieJarPath
+		if err := cfg.SaveClient(cfg.ClientID, cfg.ClientSecret); err != nil {
+			// SaveClient just writes the entire config; the OAuth-flavored
+			// name is incidental. Use it as the simplest persistence path.
+			return configErr(fmt.Errorf("persisting cookie jar path to config: %w", err))
+		}
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"Cookie jar path saved to %s.\n  crawl_stats_cookie_jar = %q\n\n"+
+				"Verify with: google-search-console-pp-cli auth status\n",
+			cfg.Path, cookieJarPath)
+		return nil
+	}
+
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "Crawl Stats cookie-jar auth setup (manual capture, v0.2)")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "The public Search Console v1 API does NOT expose the Crawl Stats")
+	fmt.Fprintln(w, "report's URL samples. The CLI calls Google's private internal")
+	fmt.Fprintln(w, "endpoint at search.google.com/_/SearchConsoleAggReportUi/data/batchexecute,")
+	fmt.Fprintln(w, "which requires the seven Google web session cookies:")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  SAPISID, __Secure-1PSID, __Secure-3PSID,")
+	fmt.Fprintln(w, "  SID, HSID, SSID, APISID")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "How to capture them (one-time, takes ~2 minutes):")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  1. In Chrome, install the \"Get cookies.txt LOCALLY\" extension")
+	fmt.Fprintln(w, "     (or any Netscape-format cookie exporter you trust).")
+	fmt.Fprintln(w, "  2. Sign in to https://search.google.com/search-console with the")
+	fmt.Fprintln(w, "     Google account that owns the property you want crawl-stats for.")
+	fmt.Fprintln(w, "  3. With that tab focused, click the extension and export cookies")
+	fmt.Fprintln(w, "     filtered to .google.com to a file (e.g. ~/gsc-cookies.txt).")
+	fmt.Fprintln(w, "  4. Tell the CLI where the file lives:")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "       google-search-console-pp-cli auth login --chrome \\")
+	fmt.Fprintln(w, "         --cookie-jar-path ~/gsc-cookies.txt")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "     ...or set GSC_COOKIE_JAR=~/gsc-cookies.txt in your shell.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  5. You also need the XSRF token (the `at=` form field) from the")
+	fmt.Fprintln(w, "     GSC HTML on first call. Open DevTools > Network > any")
+	fmt.Fprintln(w, "     batchexecute POST > Payload, copy the `at` value, then:")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "       export GSC_XSRF_TOKEN=<value>")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  6. Verify with:")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "       google-search-console-pp-cli crawl-stats list \\")
+	fmt.Fprintln(w, "         sc-domain:your-property.com --dry-run")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Cookies expire roughly every ~2 weeks; you'll know they're stale")
+	fmt.Fprintln(w, "when a crawl-stats command returns HTTP 401/403. Re-export and")
+	fmt.Fprintln(w, "re-point GSC_COOKIE_JAR at the new file.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Automated cookie capture (Chrome-driven) is on the roadmap for")
+	fmt.Fprintln(w, "v0.3 of this CLI.")
+	if cfg.CrawlStatsCookieJar != "" {
+		fmt.Fprintf(w, "\nCurrent cookie jar path in config: %s\n", cfg.CrawlStatsCookieJar)
+	}
+	// strings is imported elsewhere in this file; reference it so the
+	// unused-import linter doesn't complain if it's only used by login proper.
+	_ = strings.ToLower
+	return nil
 }
 
 func runAuthLogin(cmd *cobra.Command, flags *rootFlags, scopeArg string, noBrowser bool, port int) error {

--- a/library/marketing/google-search-console/internal/cli/crawl_stats.go
+++ b/library/marketing/google-search-console/internal/cli/crawl_stats.go
@@ -37,24 +37,24 @@ var fileTypeCodes = map[string]int{
 // responseCodes maps --response-code values to integer codes (1-7, 9-13,
 // 15-20 per the discovery report; 8 and 14 are not valid).
 var responseCodes = map[string]int{
-	"ok":                  1,
-	"not-found":           2,
-	"unauthorized":        3,
-	"other-4xx":           4,
-	"dns-error":           5,
-	"fetch-error":         6,
-	"robots-blocked":      7,
-	"server-error":        9,
-	"dns-unresponsive":    10,
-	"robots-unavailable":  11,
-	"page-unreachable":    12,
-	"page-timeout":        13,
-	"redirect-error":      15,
-	"other-fetch-error":   16,
-	"moved-permanently":   17,
-	"moved-temporarily":   18,
-	"moved-other":         19,
-	"not-modified":        20,
+	"ok":                 1,
+	"not-found":          2,
+	"unauthorized":       3,
+	"other-4xx":          4,
+	"dns-error":          5,
+	"fetch-error":        6,
+	"robots-blocked":     7,
+	"server-error":       9,
+	"dns-unresponsive":   10,
+	"robots-unavailable": 11,
+	"page-unreachable":   12,
+	"page-timeout":       13,
+	"redirect-error":     15,
+	"other-fetch-error":  16,
+	"moved-permanently":  17,
+	"moved-temporarily":  18,
+	"moved-other":        19,
+	"not-modified":       20,
 }
 
 // googlebotCodes maps --googlebot values to integer codes (1-9).
@@ -130,13 +130,13 @@ SQLite store to give you the unioned URL set across every poll.`,
 
 // crawlStatsCommonFlags carries the flag set every subcommand reuses.
 type crawlStatsCommonFlags struct {
-	top         int
-	noPersist   bool
-	xsrfToken   string
-	buildLabel  string
-	sessionID   string
-	cookieJar   string
-	requestSeq  int
+	top        int
+	noPersist  bool
+	xsrfToken  string
+	buildLabel string
+	sessionID  string
+	cookieJar  string
+	requestSeq int
 }
 
 func attachCommonCrawlStatsFlags(c *cobra.Command, f *crawlStatsCommonFlags) {
@@ -355,12 +355,6 @@ the only way to build a corpus larger than any single snapshot.`,
 // subcommands. dimLabel is the human-readable filter value (e.g. "css") used
 // for SQLite persistence and JSON output; pass "" when dim is DimensionNone.
 func runCrawlStats(cobraCmd *cobra.Command, flags *rootFlags, common *crawlStatsCommonFlags, property string, dim client.Dimension, filterCode int, dimLabel string) error {
-	if dryRunOK(flags) {
-		// dryRunOK short-circuits when --dry-run is set; the client itself
-		// still builds the full request and returns the wire body for
-		// preview. Fall through so the user sees that body.
-	}
-
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return configErr(err)
@@ -493,13 +487,13 @@ func persistCrawlStatsPoll(ctx context.Context, resp *client.CrawlStatsResponse,
 	// Samples — encode dim into the row so subsequent --file-type/--googlebot
 	// filters on `union` work without re-derivation.
 	sampleRows := make([]store.CrawlStatsSampleRow, 0, len(resp.Samples))
-	for _, s := range resp.Samples {
+	for _, sample := range resp.Samples {
 		row := store.CrawlStatsSampleRow{
 			SiteURL:    resp.Property,
-			SampleURL:  s.URL,
-			FetchedAt:  s.FetchedAt,
-			SizeBytes:  s.SizeBytes,
-			ResponseMs: s.ResponseMs,
+			SampleURL:  sample.URL,
+			FetchedAt:  sample.FetchedAt,
+			SizeBytes:  sample.SizeBytes,
+			ResponseMs: sample.ResponseMs,
 			PollAt:     pollAt,
 		}
 		switch dim {
@@ -510,11 +504,11 @@ func persistCrawlStatsPoll(ctx context.Context, resp *client.CrawlStatsResponse,
 		case client.DimensionGooglebotType:
 			row.GooglebotType = dimLabel
 		}
-		if s.ResponseCode > 0 {
-			row.ResponseCode = s.ResponseCode
+		if sample.ResponseCode > 0 {
+			row.ResponseCode = sample.ResponseCode
 		}
 		// Best-effort raw payload preservation.
-		if b, err := json.Marshal(s); err == nil {
+		if b, err := json.Marshal(sample); err == nil {
 			row.RawJSON = string(b)
 		}
 		sampleRows = append(sampleRows, row)

--- a/library/marketing/google-search-console/internal/cli/crawl_stats.go
+++ b/library/marketing/google-search-console/internal/cli/crawl_stats.go
@@ -407,16 +407,19 @@ func runCrawlStats(cobraCmd *cobra.Command, flags *rootFlags, common *crawlStats
 		return apiErr(err)
 	}
 
-	// Apply --top to the in-memory sample list before printing / persisting.
-	if common.top > 0 && len(resp.Samples) > common.top {
-		resp.Samples = resp.Samples[:common.top]
-	}
-
 	// Best-effort persistence. --no-persist or --dry-run suppresses.
+	// PATCH: Persist the full crawl-stats sample corpus before display-only --top truncation.
 	if !common.noPersist && !flags.dryRun {
 		if err := persistCrawlStatsPoll(ctx, resp, dim, filterCode, dimLabel); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: persisting crawl-stats poll to local store failed: %v\n", err)
 		}
+	}
+
+	// Apply --top only to printed / JSON output. Persistence above keeps the full
+	// sample list so multi-poll union commands can accumulate every URL returned
+	// by Google, not just the user's display cap.
+	if common.top > 0 && len(resp.Samples) > common.top {
+		resp.Samples = resp.Samples[:common.top]
 	}
 
 	return emitCrawlStats(cobraCmd, flags, resp, dimLabel)

--- a/library/marketing/google-search-console/internal/cli/crawl_stats.go
+++ b/library/marketing/google-search-console/internal/cli/crawl_stats.go
@@ -1,0 +1,619 @@
+// PATCH(crawl-stats: cobra command tree for the GSC Crawl Stats UI surface).
+// The Crawl Stats report is NOT in the public Search Console v1 API; this
+// command tree calls the private SearchConsoleAggReportUi.batchexecute
+// endpoint reverse-engineered via chrome-MCP. See
+// internal/client/crawlstats.go for the HTTP client and the discovery report
+// at manuscripts/google-search-console/amend-2026-05-21T1402/.
+//
+// Auth: cookie-jar, NOT the OAuth bearer token. Two paths:
+//   1. `auth login --chrome`  (prints manual capture instructions for v0.2)
+//   2. `GSC_COOKIE_JAR=<path>` env var pointing at a Netscape cookie jar
+//
+// All subcommands honor --json (root), --dry-run (root), and --no-persist.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/internal/config"
+	"github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/internal/store"
+	"github.com/spf13/cobra"
+)
+
+// fileTypeCodes maps the human label expected on --file-type to the integer
+// code Google uses internally. Pulled directly from the discovery report.
+var fileTypeCodes = map[string]int{
+	"html": 1, "image": 2, "video": 3, "js": 4, "javascript": 4,
+	"css": 5, "pdf": 6, "other": 7, "unknown": 9,
+}
+
+// responseCodes maps --response-code values to integer codes (1-7, 9-13,
+// 15-20 per the discovery report; 8 and 14 are not valid).
+var responseCodes = map[string]int{
+	"ok":                  1,
+	"not-found":           2,
+	"unauthorized":        3,
+	"other-4xx":           4,
+	"dns-error":           5,
+	"fetch-error":         6,
+	"robots-blocked":      7,
+	"server-error":        9,
+	"dns-unresponsive":    10,
+	"robots-unavailable":  11,
+	"page-unreachable":    12,
+	"page-timeout":        13,
+	"redirect-error":      15,
+	"other-fetch-error":   16,
+	"moved-permanently":   17,
+	"moved-temporarily":   18,
+	"moved-other":         19,
+	"not-modified":        20,
+}
+
+// googlebotCodes maps --googlebot values to integer codes (1-9).
+var googlebotCodes = map[string]int{
+	"smartphone":    1,
+	"desktop":       2,
+	"image":         3,
+	"video":         4,
+	"page-resource": 5,
+	"other":         6,
+	"adsbot":        7,
+	"storebot":      8,
+	"amp":           9,
+}
+
+// purposeCodes maps --purpose values to integer codes (1-2).
+var purposeCodes = map[string]int{
+	"discovery": 1,
+	"refresh":   2,
+}
+
+func newCrawlStatsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "crawl-stats",
+		Short: "Pull Crawl Stats reports (URL samples, time-series, totals) from GSC",
+		Long: `Pull Crawl Stats reports from Google Search Console.
+
+The Crawl Stats UI (Settings > Crawl stats) exposes data that is NOT in the
+public Search Console v1 API: per-URL sample lists, time-series, and
+aggregate totals broken down by file type, response code, Googlebot type,
+and purpose.
+
+This command tree authenticates against Google's private internal RPC
+endpoint using a cookie-jar export from your logged-in Chrome session.
+The standard ` + "`auth login`" + ` OAuth flow does NOT authenticate against this
+surface — you need to point the CLI at a cookie jar via GSC_COOKIE_JAR or
+the cookies field in config.toml.
+
+Run ` + "`google-search-console-pp-cli auth login --chrome`" + ` for instructions on
+exporting cookies from Chrome.
+
+Each poll caps at ~1000 sample URLs (Google's limit, no pagination). The
+` + "`crawl-stats union`" + ` subcommand reads all polled samples from the local
+SQLite store to give you the unioned URL set across every poll.`,
+		Example: `  # Top-level list (overview — no drill-down filter)
+  google-search-console-pp-cli crawl-stats list sc-domain:example.com --json
+
+  # Drill-down by file type
+  google-search-console-pp-cli crawl-stats by-type sc-domain:example.com --file-type css --top 500
+
+  # Drill-down by response code
+  google-search-console-pp-cli crawl-stats by-response sc-domain:example.com --response-code not-found --json
+
+  # Drill-down by Googlebot crawler type
+  google-search-console-pp-cli crawl-stats by-googlebot sc-domain:example.com --googlebot smartphone
+
+  # Drill-down by purpose
+  google-search-console-pp-cli crawl-stats by-purpose sc-domain:example.com --purpose discovery
+
+  # Read the unioned sample URL set across all polls (no network call)
+  google-search-console-pp-cli crawl-stats union sc-domain:example.com --file-type html`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+	}
+
+	cmd.AddCommand(newCrawlStatsListCmd(flags))
+	cmd.AddCommand(newCrawlStatsByTypeCmd(flags))
+	cmd.AddCommand(newCrawlStatsByResponseCmd(flags))
+	cmd.AddCommand(newCrawlStatsByGooglebotCmd(flags))
+	cmd.AddCommand(newCrawlStatsByPurposeCmd(flags))
+	cmd.AddCommand(newCrawlStatsUnionCmd(flags))
+	return cmd
+}
+
+// crawlStatsCommonFlags carries the flag set every subcommand reuses.
+type crawlStatsCommonFlags struct {
+	top         int
+	noPersist   bool
+	xsrfToken   string
+	buildLabel  string
+	sessionID   string
+	cookieJar   string
+	requestSeq  int
+}
+
+func attachCommonCrawlStatsFlags(c *cobra.Command, f *crawlStatsCommonFlags) {
+	c.Flags().IntVar(&f.top, "top", 100, "Max samples to return (Google caps at ~1000)")
+	c.Flags().BoolVar(&f.noPersist, "no-persist", false, "Skip writing this poll to the local SQLite store")
+	c.Flags().StringVar(&f.xsrfToken, "xsrf-token", "", "XSRF token (the `at=` form field from GSC HTML); falls back to GSC_XSRF_TOKEN env")
+	c.Flags().StringVar(&f.buildLabel, "build-label", "", "Override the bl= GSC web build label (defaults to a recent pinned value)")
+	c.Flags().StringVar(&f.sessionID, "session-id", "", "Optional f.sid= query parameter")
+	c.Flags().StringVar(&f.cookieJar, "cookie-jar", "", "Path to Netscape cookie jar (overrides config + GSC_COOKIE_JAR env)")
+	c.Flags().IntVar(&f.requestSeq, "request-seq", 1, "Monotonic _reqid= counter (auto-increments across multiple calls in one process)")
+}
+
+func newCrawlStatsListCmd(flags *rootFlags) *cobra.Command {
+	common := &crawlStatsCommonFlags{}
+	cmd := &cobra.Command{
+		Use:         "list <property>",
+		Short:       "Pull the Crawl Stats overview (no drill-down filter)",
+		Long:        "Pull totals + time-series + URL samples for the overview view at GSC Settings > Crawl stats. No drill-down dimension applied.",
+		Example:     "  google-search-console-pp-cli crawl-stats list sc-domain:example.com --json",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			return runCrawlStats(c, flags, common, args[0], client.DimensionNone, 0, "")
+		},
+	}
+	attachCommonCrawlStatsFlags(cmd, common)
+	return cmd
+}
+
+func newCrawlStatsByTypeCmd(flags *rootFlags) *cobra.Command {
+	common := &crawlStatsCommonFlags{}
+	var fileType string
+	cmd := &cobra.Command{
+		Use:         "by-type <property>",
+		Short:       "Pull Crawl Stats drill-down filtered by file type",
+		Long:        "Drill-down by file type. Valid values: html, image, video, js (alias javascript), css, pdf, other, unknown.",
+		Example:     "  google-search-console-pp-cli crawl-stats by-type sc-domain:example.com --file-type css --json",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			code, err := lookupCode(fileTypeCodes, fileType, "--file-type", fileTypeKeys())
+			if err != nil {
+				return usageErr(err)
+			}
+			return runCrawlStats(c, flags, common, args[0], client.DimensionFileType, code, fileType)
+		},
+	}
+	cmd.Flags().StringVar(&fileType, "file-type", "", "File type filter (required)")
+	_ = cmd.MarkFlagRequired("file-type")
+	attachCommonCrawlStatsFlags(cmd, common)
+	return cmd
+}
+
+func newCrawlStatsByResponseCmd(flags *rootFlags) *cobra.Command {
+	common := &crawlStatsCommonFlags{}
+	var responseCode string
+	cmd := &cobra.Command{
+		Use:         "by-response <property>",
+		Short:       "Pull Crawl Stats drill-down filtered by response code",
+		Long:        "Drill-down by Googlebot response code. Valid values: ok, not-found, unauthorized, other-4xx, dns-error, fetch-error, robots-blocked, server-error, dns-unresponsive, robots-unavailable, page-unreachable, page-timeout, redirect-error, other-fetch-error, moved-permanently, moved-temporarily, moved-other, not-modified.",
+		Example:     "  google-search-console-pp-cli crawl-stats by-response sc-domain:example.com --response-code not-found",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			code, err := lookupCode(responseCodes, responseCode, "--response-code", responseKeys())
+			if err != nil {
+				return usageErr(err)
+			}
+			return runCrawlStats(c, flags, common, args[0], client.DimensionResponseCode, code, responseCode)
+		},
+	}
+	cmd.Flags().StringVar(&responseCode, "response-code", "", "Response code filter (required)")
+	_ = cmd.MarkFlagRequired("response-code")
+	attachCommonCrawlStatsFlags(cmd, common)
+	return cmd
+}
+
+func newCrawlStatsByGooglebotCmd(flags *rootFlags) *cobra.Command {
+	common := &crawlStatsCommonFlags{}
+	var googlebot string
+	cmd := &cobra.Command{
+		Use:         "by-googlebot <property>",
+		Short:       "Pull Crawl Stats drill-down filtered by Googlebot crawler type",
+		Long:        "Drill-down by Googlebot crawler type. Valid values: smartphone, desktop, image, video, page-resource, other, adsbot, storebot, amp.",
+		Example:     "  google-search-console-pp-cli crawl-stats by-googlebot sc-domain:example.com --googlebot smartphone",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			code, err := lookupCode(googlebotCodes, googlebot, "--googlebot", googlebotKeys())
+			if err != nil {
+				return usageErr(err)
+			}
+			return runCrawlStats(c, flags, common, args[0], client.DimensionGooglebotType, code, googlebot)
+		},
+	}
+	cmd.Flags().StringVar(&googlebot, "googlebot", "", "Googlebot crawler type (required)")
+	_ = cmd.MarkFlagRequired("googlebot")
+	attachCommonCrawlStatsFlags(cmd, common)
+	return cmd
+}
+
+func newCrawlStatsByPurposeCmd(flags *rootFlags) *cobra.Command {
+	common := &crawlStatsCommonFlags{}
+	var purpose string
+	cmd := &cobra.Command{
+		Use:         "by-purpose <property>",
+		Short:       "Pull Crawl Stats drill-down filtered by purpose",
+		Long:        "Drill-down by Googlebot purpose. Valid values: discovery, refresh.",
+		Example:     "  google-search-console-pp-cli crawl-stats by-purpose sc-domain:example.com --purpose discovery",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			code, err := lookupCode(purposeCodes, purpose, "--purpose", purposeKeys())
+			if err != nil {
+				return usageErr(err)
+			}
+			return runCrawlStats(c, flags, common, args[0], client.DimensionPurpose, code, purpose)
+		},
+	}
+	cmd.Flags().StringVar(&purpose, "purpose", "", "Purpose filter (required)")
+	_ = cmd.MarkFlagRequired("purpose")
+	attachCommonCrawlStatsFlags(cmd, common)
+	return cmd
+}
+
+func newCrawlStatsUnionCmd(flags *rootFlags) *cobra.Command {
+	var (
+		fileType   string
+		googlebot  string
+		responseCd string
+		limit      int
+	)
+	cmd := &cobra.Command{
+		Use:   "union <property>",
+		Short: "Read the unioned sample-URL set across all polls (offline; no network)",
+		Long: `Returns the deduplicated union of every URL ever polled for this property,
+read from the local SQLite store. Optionally narrow with the same filter
+flags as the live drill-down commands.
+
+Each live poll caps at ~1000 URL samples; unioning across multiple polls is
+the only way to build a corpus larger than any single snapshot.`,
+		Example:     "  google-search-console-pp-cli crawl-stats union sc-domain:example.com --file-type html",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return c.Help()
+			}
+			site := args[0]
+			ctx := context.Background()
+			s, err := openStore(ctx)
+			if err != nil {
+				return configErr(err)
+			}
+			defer s.Close()
+
+			var responseInt int
+			if responseCd != "" {
+				v, err := lookupCode(responseCodes, responseCd, "--response-code", responseKeys())
+				if err != nil {
+					return usageErr(err)
+				}
+				responseInt = v
+			}
+			fileTypeCanon := canonFileType(fileType)
+			googlebotCanon := canonGooglebot(googlebot)
+
+			rows, err := s.QueryCrawlStatsSamplesUnion(ctx, site, fileTypeCanon, googlebotCanon, responseInt, limit)
+			if err != nil {
+				return apiErr(err)
+			}
+			if len(rows) == 0 {
+				count, _ := s.CountCrawlStatsSamples(ctx, site)
+				if count == 0 {
+					return fmt.Errorf("local store has no crawl-stats polls for %q; run `crawl-stats list %s` (or a drill-down) at least once first", site, site)
+				}
+				return fmt.Errorf("no rows match the requested filters; %d total samples for %q", count, site)
+			}
+
+			out := []map[string]any{}
+			for _, r := range rows {
+				row := map[string]any{
+					"url":            r.SampleURL,
+					"file_type":      r.FileType,
+					"response_code":  r.ResponseCode,
+					"googlebot_type": r.GooglebotType,
+					"size_bytes":     r.SizeBytes,
+					"response_ms":    r.ResponseMs,
+					"last_poll_at":   r.PollAt.Format(time.RFC3339),
+				}
+				if !r.FetchedAt.IsZero() {
+					row["fetched_at"] = r.FetchedAt.Format(time.RFC3339)
+				}
+				out = append(out, row)
+			}
+			return printJSONFiltered(c.OutOrStdout(), out, flags)
+		},
+	}
+	cmd.Flags().StringVar(&fileType, "file-type", "", "Filter union by file type (e.g. html, css)")
+	cmd.Flags().StringVar(&googlebot, "googlebot", "", "Filter union by Googlebot crawler type")
+	cmd.Flags().StringVar(&responseCd, "response-code", "", "Filter union by response code")
+	cmd.Flags().IntVar(&limit, "top", 0, "Max rows to return (0 = no limit)")
+	return cmd
+}
+
+// runCrawlStats is the shared execution path for the five live drill-down
+// subcommands. dimLabel is the human-readable filter value (e.g. "css") used
+// for SQLite persistence and JSON output; pass "" when dim is DimensionNone.
+func runCrawlStats(cobraCmd *cobra.Command, flags *rootFlags, common *crawlStatsCommonFlags, property string, dim client.Dimension, filterCode int, dimLabel string) error {
+	if dryRunOK(flags) {
+		// dryRunOK short-circuits when --dry-run is set; the client itself
+		// still builds the full request and returns the wire body for
+		// preview. Fall through so the user sees that body.
+	}
+
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return configErr(err)
+	}
+	jarPath := common.cookieJar
+	if jarPath == "" {
+		jarPath = cfg.CrawlStatsCookieJar
+	}
+	if jarPath == "" {
+		return authErr(fmt.Errorf("crawl-stats requires a Google session cookie jar; set GSC_COOKIE_JAR=<path>, pass --cookie-jar <path>, or run `google-search-console-pp-cli auth login --chrome` for export instructions"))
+	}
+	jar, err := client.LoadNetscapeCookieJar(jarPath)
+	if err != nil {
+		return authErr(err)
+	}
+	if missing := jar.MissingCookies(); len(missing) > 0 {
+		return authErr(fmt.Errorf("cookie jar %s is missing %d Google session cookie(s): %s", jarPath, len(missing), strings.Join(missing, ", ")))
+	}
+
+	csClient, err := client.NewCrawlStatsClient(jar, flags.timeout)
+	if err != nil {
+		return authErr(err)
+	}
+	csClient.DryRun = flags.dryRun
+
+	xsrf := common.xsrfToken
+	if xsrf == "" {
+		xsrf = os.Getenv("GSC_XSRF_TOKEN")
+	}
+	if xsrf == "" && !flags.dryRun {
+		return authErr(fmt.Errorf("crawl-stats requires an XSRF token (the `at=` form field from the GSC HTML); pass --xsrf-token <value> or set GSC_XSRF_TOKEN"))
+	}
+	if xsrf == "" {
+		xsrf = "DRY-RUN-PLACEHOLDER"
+	}
+
+	ctx := context.Background()
+	req := client.CrawlStatsRequest{
+		Property:   property,
+		Dimension:  dim,
+		FilterCode: filterCode,
+		XSRFToken:  xsrf,
+		BuildLabel: common.buildLabel,
+		SessionID:  common.sessionID,
+		RequestSeq: common.requestSeq,
+	}
+
+	resp, err := csClient.Fetch(ctx, req)
+	if err != nil {
+		return apiErr(err)
+	}
+
+	// Apply --top to the in-memory sample list before printing / persisting.
+	if common.top > 0 && len(resp.Samples) > common.top {
+		resp.Samples = resp.Samples[:common.top]
+	}
+
+	// Best-effort persistence. --no-persist or --dry-run suppresses.
+	if !common.noPersist && !flags.dryRun {
+		if err := persistCrawlStatsPoll(ctx, resp, dim, filterCode, dimLabel); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: persisting crawl-stats poll to local store failed: %v\n", err)
+		}
+	}
+
+	return emitCrawlStats(cobraCmd, flags, resp, dimLabel)
+}
+
+func emitCrawlStats(c *cobra.Command, flags *rootFlags, resp *client.CrawlStatsResponse, dimLabel string) error {
+	if flags.asJSON {
+		out := map[string]any{
+			"property":         resp.Property,
+			"filter_dimension": string(resp.Dimension),
+			"filter_value":     dimLabel,
+			"filter_code":      resp.FilterCode,
+			"captured_at":      resp.CapturedAt.Format(time.RFC3339),
+			"totals":           resp.Totals,
+			"time_series":      resp.TimeSeries,
+			"samples":          resp.Samples,
+		}
+		if len(resp.RawResponses) > 0 {
+			out["raw"] = resp.RawResponses
+		}
+		return printJSONFiltered(c.OutOrStdout(), out, flags)
+	}
+
+	// Human-friendly table output.
+	w := c.OutOrStdout()
+	fmt.Fprintf(w, "Property: %s\n", resp.Property)
+	if dimLabel != "" {
+		fmt.Fprintf(w, "Filter:   %s = %s (code %d)\n", resp.Dimension, dimLabel, resp.FilterCode)
+	}
+	fmt.Fprintf(w, "Captured: %s\n", resp.CapturedAt.Format(time.RFC3339))
+	if resp.Totals != nil {
+		fmt.Fprintf(w, "\nTotals:\n  crawl_requests=%d  download_size=%d  avg_response_ms=%d\n",
+			resp.Totals.CrawlRequests, resp.Totals.DownloadSizeBytes, resp.Totals.AvgResponseMs)
+	}
+	if len(resp.TimeSeries) > 0 {
+		fmt.Fprintf(w, "\nTime series (%d points):\n", len(resp.TimeSeries))
+		for _, p := range resp.TimeSeries {
+			fmt.Fprintf(w, "  %s  %d\n", p.Date, p.CrawlRequests)
+		}
+	}
+	if len(resp.Samples) > 0 {
+		fmt.Fprintf(w, "\nSamples (%d URLs):\n", len(resp.Samples))
+		for _, s := range resp.Samples {
+			fmt.Fprintln(w, "  "+s.URL)
+		}
+	}
+	if len(resp.RawResponses) > 0 {
+		fmt.Fprintf(w, "\n(raw response shards available via --json)\n")
+	}
+	return nil
+}
+
+func persistCrawlStatsPoll(ctx context.Context, resp *client.CrawlStatsResponse, dim client.Dimension, filterCode int, dimLabel string) error {
+	if resp == nil {
+		return nil
+	}
+	s, err := openStore(ctx)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	pollAt := resp.CapturedAt
+	if pollAt.IsZero() {
+		pollAt = time.Now().UTC()
+	}
+
+	// Samples — encode dim into the row so subsequent --file-type/--googlebot
+	// filters on `union` work without re-derivation.
+	sampleRows := make([]store.CrawlStatsSampleRow, 0, len(resp.Samples))
+	for _, s := range resp.Samples {
+		row := store.CrawlStatsSampleRow{
+			SiteURL:    resp.Property,
+			SampleURL:  s.URL,
+			FetchedAt:  s.FetchedAt,
+			SizeBytes:  s.SizeBytes,
+			ResponseMs: s.ResponseMs,
+			PollAt:     pollAt,
+		}
+		switch dim {
+		case client.DimensionFileType:
+			row.FileType = dimLabel
+		case client.DimensionResponseCode:
+			row.ResponseCode = filterCode
+		case client.DimensionGooglebotType:
+			row.GooglebotType = dimLabel
+		}
+		if s.ResponseCode > 0 {
+			row.ResponseCode = s.ResponseCode
+		}
+		// Best-effort raw payload preservation.
+		if b, err := json.Marshal(s); err == nil {
+			row.RawJSON = string(b)
+		}
+		sampleRows = append(sampleRows, row)
+	}
+	if err := s.UpsertCrawlStatsSamples(ctx, sampleRows); err != nil {
+		return err
+	}
+
+	if resp.Totals != nil {
+		if err := s.UpsertCrawlStatsTotals(ctx, store.CrawlStatsTotalsRow{
+			SiteURL:           resp.Property,
+			FilterDim:         string(dim),
+			FilterCode:        filterCode,
+			PollAt:            pollAt,
+			CrawlRequests:     resp.Totals.CrawlRequests,
+			DownloadSizeBytes: resp.Totals.DownloadSizeBytes,
+			AvgResponseMs:     resp.Totals.AvgResponseMs,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if len(resp.TimeSeries) > 0 {
+		tsRows := make([]store.CrawlStatsTimeSeriesRow, 0, len(resp.TimeSeries))
+		for _, p := range resp.TimeSeries {
+			tsRows = append(tsRows, store.CrawlStatsTimeSeriesRow{
+				SiteURL:       resp.Property,
+				FilterDim:     string(dim),
+				FilterCode:    filterCode,
+				Date:          p.Date,
+				CrawlRequests: p.CrawlRequests,
+				PollAt:        pollAt,
+			})
+		}
+		if err := s.UpsertCrawlStatsTimeSeries(ctx, tsRows); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Helpers — enum lookup with friendly error messaging.
+
+func lookupCode(table map[string]int, val, flag string, valid []string) (int, error) {
+	v := strings.ToLower(strings.TrimSpace(val))
+	if v == "" {
+		return 0, fmt.Errorf("%s is required", flag)
+	}
+	if code, ok := table[v]; ok {
+		return code, nil
+	}
+	return 0, fmt.Errorf("unknown %s %q; valid values: %s", flag, val, strings.Join(valid, ", "))
+}
+
+// fileTypeKeys returns the canonical list of valid --file-type values for
+// error messages. Skips the `javascript` alias.
+func fileTypeKeys() []string {
+	return []string{"html", "image", "video", "js", "css", "pdf", "other", "unknown"}
+}
+
+func responseKeys() []string {
+	return []string{
+		"ok", "not-found", "unauthorized", "other-4xx", "dns-error",
+		"fetch-error", "robots-blocked", "server-error", "dns-unresponsive",
+		"robots-unavailable", "page-unreachable", "page-timeout",
+		"redirect-error", "other-fetch-error", "moved-permanently",
+		"moved-temporarily", "moved-other", "not-modified",
+	}
+}
+
+func googlebotKeys() []string {
+	return []string{
+		"smartphone", "desktop", "image", "video", "page-resource",
+		"other", "adsbot", "storebot", "amp",
+	}
+}
+
+func purposeKeys() []string {
+	return []string{"discovery", "refresh"}
+}
+
+// canonFileType normalizes a free-form input ("HTML", "Css") to the canonical
+// lowercase form used as the SQLite column value. Returns the alias-resolved
+// canonical name (e.g. "javascript" -> "js").
+func canonFileType(s string) string {
+	v := strings.ToLower(strings.TrimSpace(s))
+	if v == "" {
+		return ""
+	}
+	if v == "javascript" {
+		return "js"
+	}
+	if _, ok := fileTypeCodes[v]; ok {
+		return v
+	}
+	return v
+}
+
+func canonGooglebot(s string) string {
+	v := strings.ToLower(strings.TrimSpace(s))
+	return v
+}

--- a/library/marketing/google-search-console/internal/cli/root.go
+++ b/library/marketing/google-search-console/internal/cli/root.go
@@ -215,6 +215,12 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newDecayingCmd(flags))
 	rootCmd.AddCommand(newNewQueriesCmd(flags))
 
+	// PATCH(crawl-stats): private GSC Crawl Stats UI surface (URL samples,
+	// time series, totals broken down by file_type / response / googlebot /
+	// purpose). Calls the SearchConsoleAggReportUi.batchexecute endpoint
+	// reverse-engineered via chrome-MCP. See internal/cli/crawl_stats.go.
+	rootCmd.AddCommand(newCrawlStatsCmd(flags))
+
 	return rootCmd
 }
 

--- a/library/marketing/google-search-console/internal/client/cookiejar.go
+++ b/library/marketing/google-search-console/internal/client/cookiejar.go
@@ -1,0 +1,163 @@
+// PATCH(crawl-stats: read Google session cookies from a Netscape-format
+// cookie jar). The Crawl Stats batchexecute endpoint requires the seven
+// Google web session cookies (SAPISID, __Secure-1PSID, __Secure-3PSID, SID,
+// HSID, SSID, APISID). Users export them from Chrome via an extension and
+// point the CLI at the jar via GSC_COOKIE_JAR or the `auth login --chrome`
+// flow. See .printing-press-patches.json patch id: crawl-stats.
+
+package client
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// requiredCrawlStatsCookies lists the seven cookies the batchexecute endpoint
+// requires. SAPISID is special — its value is also fed into SAPISIDHash().
+var requiredCrawlStatsCookies = []string{
+	"SAPISID",
+	"__Secure-1PSID",
+	"__Secure-3PSID",
+	"SID",
+	"HSID",
+	"SSID",
+	"APISID",
+}
+
+// CookieJarFile carries parsed Google session cookies plus a marker for
+// which ones came from the jar (so the client can fail-fast with a clear
+// "missing cookies" error rather than silently posting an unauthenticated
+// request that gets 401-back-redirected to the login page).
+type CookieJarFile struct {
+	Path    string
+	Cookies map[string]*http.Cookie
+}
+
+// LoadNetscapeCookieJar reads a Netscape-format cookie jar (the .cookies.txt
+// shape Chrome/Firefox/curl all share) and returns the subset matching
+// requiredCrawlStatsCookies. Format reference:
+//
+//	# Netscape HTTP Cookie File
+//	# domain	include_subdomains	path	secure	expiry	name	value
+//	.google.com	TRUE	/	TRUE	0	SAPISID	xxxxx
+//
+// Lines starting with '#' (and blank lines) are skipped. Fields are
+// tab-separated. Cookies whose names aren't in requiredCrawlStatsCookies are
+// ignored to keep the in-memory map lean.
+func LoadNetscapeCookieJar(path string) (*CookieJarFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening cookie jar %s: %w", path, err)
+	}
+	defer f.Close()
+
+	required := make(map[string]bool, len(requiredCrawlStatsCookies))
+	for _, name := range requiredCrawlStatsCookies {
+		required[name] = true
+	}
+
+	out := &CookieJarFile{
+		Path:    path,
+		Cookies: make(map[string]*http.Cookie),
+	}
+
+	scan := bufio.NewScanner(f)
+	// Cookie values can exceed bufio's default 64 KiB line cap for some
+	// browsers' session cookies; raise to 1 MiB which is well beyond any
+	// realistic cookie size.
+	scan.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scan.Scan() {
+		line := scan.Text()
+		// Allow optional "#HttpOnly_" prefix (Firefox/curl convention) on the
+		// domain field so HttpOnly cookies parse identically to non-HttpOnly.
+		raw := strings.TrimPrefix(line, "#HttpOnly_")
+		if strings.HasPrefix(raw, "#") || strings.TrimSpace(raw) == "" {
+			continue
+		}
+		fields := strings.Split(raw, "\t")
+		if len(fields) < 7 {
+			continue
+		}
+		domain := fields[0]
+		path := fields[2]
+		secure := strings.EqualFold(fields[3], "TRUE")
+		expiry, _ := strconv.ParseInt(fields[4], 10, 64)
+		name := fields[5]
+		value := fields[6]
+
+		if !required[name] {
+			continue
+		}
+
+		c := &http.Cookie{
+			Name:   name,
+			Value:  value,
+			Domain: strings.TrimPrefix(domain, "."),
+			Path:   path,
+			Secure: secure,
+		}
+		if expiry > 0 {
+			c.Expires = time.Unix(expiry, 0)
+		}
+		// Take the first occurrence per name. Cookie jars sometimes contain
+		// duplicates (different domains / paths); the first-write-wins
+		// behavior keeps the parse deterministic.
+		if _, exists := out.Cookies[name]; !exists {
+			out.Cookies[name] = c
+		}
+	}
+	if err := scan.Err(); err != nil {
+		return nil, fmt.Errorf("scanning cookie jar %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// MissingCookies returns the subset of requiredCrawlStatsCookies absent from
+// the jar. An empty slice means the jar is fully populated and ready for
+// crawl-stats requests.
+func (j *CookieJarFile) MissingCookies() []string {
+	if j == nil {
+		return append([]string{}, requiredCrawlStatsCookies...)
+	}
+	missing := []string{}
+	for _, name := range requiredCrawlStatsCookies {
+		if _, ok := j.Cookies[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// SAPISIDValue returns the SAPISID cookie value (needed for SAPISIDHash) or
+// an empty string when missing.
+func (j *CookieJarFile) SAPISIDValue() string {
+	if j == nil {
+		return ""
+	}
+	if c, ok := j.Cookies["SAPISID"]; ok {
+		return c.Value
+	}
+	return ""
+}
+
+// CookieHeader formats the seven cookies as a single "Cookie:" header value
+// (name1=value1; name2=value2; ...). Order is stable
+// (requiredCrawlStatsCookies order) so the header value is deterministic
+// across calls — useful for tests and for any future request-signing layer.
+func (j *CookieJarFile) CookieHeader() string {
+	if j == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(requiredCrawlStatsCookies))
+	for _, name := range requiredCrawlStatsCookies {
+		if c, ok := j.Cookies[name]; ok {
+			parts = append(parts, c.Name+"="+c.Value)
+		}
+	}
+	return strings.Join(parts, "; ")
+}

--- a/library/marketing/google-search-console/internal/client/crawlstats.go
+++ b/library/marketing/google-search-console/internal/client/crawlstats.go
@@ -56,9 +56,9 @@ const (
 
 // rpcDef is one rpc entry in the outer batchexecute payload.
 type rpcDef struct {
-	rpcID     string
+	rpcID      string
 	reportKind int
-	index     string // string-encoded request index
+	index      string // string-encoded request index
 }
 
 // canonicalRPCSet is the three-rpc set Crawl Stats fires for each drill-down
@@ -82,25 +82,25 @@ const (
 
 // CrawlStatsRequest carries the inputs for a single batchexecute call.
 type CrawlStatsRequest struct {
-	Property    string    // e.g. "sc-domain:example.com"
-	Dimension   Dimension // empty for the no-drill-down overview
-	FilterCode  int       // integer code from the discovery report (file_type 1-9, etc.)
-	XSRFToken   string    // `at=` body field — extracted from GSC HTML on first call
-	BuildLabel  string    // bl= query param; empty uses defaultBuildLabel
-	SessionID   string    // f.sid= query param; empty omits
-	RequestSeq  int       // _reqid= query param; monotonic counter; 0 -> use 1
+	Property   string    // e.g. "sc-domain:example.com"
+	Dimension  Dimension // empty for the no-drill-down overview
+	FilterCode int       // integer code from the discovery report (file_type 1-9, etc.)
+	XSRFToken  string    // `at=` body field — extracted from GSC HTML on first call
+	BuildLabel string    // bl= query param; empty uses defaultBuildLabel
+	SessionID  string    // f.sid= query param; empty omits
+	RequestSeq int       // _reqid= query param; monotonic counter; 0 -> use 1
 }
 
 // CrawlStatsResponse is the decoded payload from one canonical-three-rpc set.
 type CrawlStatsResponse struct {
-	Property      string                  `json:"property"`
-	Dimension     Dimension               `json:"filter_dimension,omitempty"`
-	FilterCode    int                     `json:"filter_code,omitempty"`
-	CapturedAt    time.Time               `json:"captured_at"`
-	Totals        *CrawlStatsTotals       `json:"totals,omitempty"`
-	TimeSeries    []CrawlStatsTimePoint   `json:"time_series,omitempty"`
-	Samples       []CrawlStatsSample      `json:"samples,omitempty"`
-	RawResponses  map[string]json.RawMessage `json:"raw,omitempty"` // present only when --raw set
+	Property     string                     `json:"property"`
+	Dimension    Dimension                  `json:"filter_dimension,omitempty"`
+	FilterCode   int                        `json:"filter_code,omitempty"`
+	CapturedAt   time.Time                  `json:"captured_at"`
+	Totals       *CrawlStatsTotals          `json:"totals,omitempty"`
+	TimeSeries   []CrawlStatsTimePoint      `json:"time_series,omitempty"`
+	Samples      []CrawlStatsSample         `json:"samples,omitempty"`
+	RawResponses map[string]json.RawMessage `json:"raw,omitempty"` // present only when --raw set
 }
 
 // CrawlStatsTotals are the aggregate stats (rpcid czrWJf, report_kind 35).
@@ -455,10 +455,68 @@ func extractSamples(payload json.RawMessage) []CrawlStatsSample {
 		}
 		var rawURL string
 		if err := json.Unmarshal(inner[0], &rawURL); err == nil && rawURL != "" {
-			out = append(out, CrawlStatsSample{URL: rawURL})
+			// PATCH(crawl-stats): preserve metadata from the sparse GSC sample array.
+			// The private UI payload has shifted field positions across captures, so keep
+			// URL decoding strict while best-effort extracting the remaining scalar values.
+			out = append(out, crawlStatsSampleFromInner(rawURL, inner[1:]))
 		}
 	}
 	return out
+}
+
+func crawlStatsSampleFromInner(rawURL string, fields []json.RawMessage) CrawlStatsSample {
+	sample := CrawlStatsSample{URL: rawURL}
+	for _, field := range fields {
+		if sample.FetchedAt.IsZero() {
+			if t, ok := crawlStatsTime(field); ok {
+				sample.FetchedAt = t
+				continue
+			}
+		}
+
+		if n, ok := crawlStatsInt64(field); ok {
+			switch {
+			case sample.ResponseCode == 0 && n >= 100 && n <= 599:
+				sample.ResponseCode = int(n)
+			case sample.SizeBytes == 0 && n > 0:
+				sample.SizeBytes = n
+			case sample.ResponseMs == 0 && n > 0 && n <= 600000:
+				sample.ResponseMs = int(n)
+			}
+		}
+	}
+	return sample
+}
+
+func crawlStatsInt64(raw json.RawMessage) (int64, bool) {
+	var n int64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n, true
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return int64(f), true
+	}
+	return 0, false
+}
+
+func crawlStatsTime(raw json.RawMessage) (time.Time, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+			if t, err := time.Parse(layout, s); err == nil {
+				return t.UTC(), true
+			}
+		}
+	}
+	if n, ok := crawlStatsInt64(raw); ok {
+		// Treat large UI timestamps as milliseconds since epoch; smaller values are
+		// left for response-code/size/latency extraction.
+		if n > 946684800000 {
+			return time.UnixMilli(n).UTC(), true
+		}
+	}
+	return time.Time{}, false
 }
 
 // extractTimeSeries walks the OLiH4d payload. The series is a list of

--- a/library/marketing/google-search-console/internal/client/crawlstats.go
+++ b/library/marketing/google-search-console/internal/client/crawlstats.go
@@ -1,0 +1,532 @@
+// PATCH(crawl-stats: HTTP client for the SearchConsoleAggReportUi.batchexecute
+// endpoint that powers the GSC Crawl Stats UI). The public Search Console v1
+// API does NOT expose the Crawl Stats report's sample URLs. This client wires
+// the three rpcids — nDAfwb (URL samples), OLiH4d (time-series), czrWJf
+// (aggregate stats) — discovered by chrome-MCP capture against the user's
+// authenticated GSC session on 2026-05-21. See the discovery report at
+// manuscripts/google-search-console/amend-2026-05-21T1402/discovery/.
+//
+// Endpoint: POST https://search.google.com/_/SearchConsoleAggReportUi/data/batchexecute
+//
+// This client uses cookie-based auth (SAPISIDHASH + 7 session cookies), not
+// the OAuth bearer token used by the rest of this CLI. The two auth surfaces
+// coexist; the OAuth flow is unaffected by this patch.
+
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// crawlStatsEndpoint is the private batchexecute endpoint discovered via
+	// chrome-MCP capture against the GSC Crawl Stats UI on 2026-05-21.
+	crawlStatsEndpoint = "https://search.google.com/_/SearchConsoleAggReportUi/data/batchexecute"
+
+	// crawlStatsOrigin is the origin used as the third component of the
+	// SAPISIDHASH payload. Must match the Origin/Referer the GSC web UI
+	// would send.
+	crawlStatsOrigin = "https://search.google.com"
+
+	// defaultBuildLabel is a recent GSC build label observed during chrome-MCP
+	// capture. The build label rotates whenever Google deploys GSC; the CLI
+	// accepts an override via --build-label, and v0.3 will auto-scrape this
+	// value from the GSC HTML at first call. Hardcoded fallback is safe
+	// because Google appears to accept stale build labels (request still
+	// succeeds; only the response renderer differs).
+	defaultBuildLabel = "boq_searchconsoleserver_20260520.03_p0"
+)
+
+// Drill-down report kinds (the second element of the inner rpc jsonArgs).
+const (
+	reportKindURLSamples = 69
+	reportKindTimeSeries = 49
+	reportKindAggregate  = 35
+)
+
+// rpcDef is one rpc entry in the outer batchexecute payload.
+type rpcDef struct {
+	rpcID     string
+	reportKind int
+	index     string // string-encoded request index
+}
+
+// canonicalRPCSet is the three-rpc set Crawl Stats fires for each drill-down
+// view (one URL-sample list, one time-series, one aggregate stats block).
+var canonicalRPCSet = []rpcDef{
+	{rpcID: "nDAfwb", reportKind: reportKindURLSamples, index: "1"},
+	{rpcID: "OLiH4d", reportKind: reportKindTimeSeries, index: "2"},
+	{rpcID: "czrWJf", reportKind: reportKindAggregate, index: "8"},
+}
+
+// Dimension is a filter dimension for crawl-stats drill-downs.
+type Dimension string
+
+const (
+	DimensionNone          Dimension = ""
+	DimensionFileType      Dimension = "file_type"
+	DimensionResponseCode  Dimension = "response"
+	DimensionGooglebotType Dimension = "googlebot_type"
+	DimensionPurpose       Dimension = "purpose"
+)
+
+// CrawlStatsRequest carries the inputs for a single batchexecute call.
+type CrawlStatsRequest struct {
+	Property    string    // e.g. "sc-domain:example.com"
+	Dimension   Dimension // empty for the no-drill-down overview
+	FilterCode  int       // integer code from the discovery report (file_type 1-9, etc.)
+	XSRFToken   string    // `at=` body field — extracted from GSC HTML on first call
+	BuildLabel  string    // bl= query param; empty uses defaultBuildLabel
+	SessionID   string    // f.sid= query param; empty omits
+	RequestSeq  int       // _reqid= query param; monotonic counter; 0 -> use 1
+}
+
+// CrawlStatsResponse is the decoded payload from one canonical-three-rpc set.
+type CrawlStatsResponse struct {
+	Property      string                  `json:"property"`
+	Dimension     Dimension               `json:"filter_dimension,omitempty"`
+	FilterCode    int                     `json:"filter_code,omitempty"`
+	CapturedAt    time.Time               `json:"captured_at"`
+	Totals        *CrawlStatsTotals       `json:"totals,omitempty"`
+	TimeSeries    []CrawlStatsTimePoint   `json:"time_series,omitempty"`
+	Samples       []CrawlStatsSample      `json:"samples,omitempty"`
+	RawResponses  map[string]json.RawMessage `json:"raw,omitempty"` // present only when --raw set
+}
+
+// CrawlStatsTotals are the aggregate stats (rpcid czrWJf, report_kind 35).
+type CrawlStatsTotals struct {
+	CrawlRequests     int64 `json:"crawl_requests"`
+	DownloadSizeBytes int64 `json:"download_size_bytes"`
+	AvgResponseMs     int64 `json:"avg_response_ms"`
+}
+
+// CrawlStatsTimePoint is one point on the time-series line graph.
+type CrawlStatsTimePoint struct {
+	Date          string `json:"date"`
+	CrawlRequests int64  `json:"crawl_requests"`
+}
+
+// CrawlStatsSample is one URL sample from rpcid nDAfwb.
+type CrawlStatsSample struct {
+	URL          string    `json:"url"`
+	FetchedAt    time.Time `json:"fetched_at,omitempty"`
+	ResponseCode int       `json:"response_code,omitempty"`
+	SizeBytes    int64     `json:"size_bytes,omitempty"`
+	ResponseMs   int       `json:"response_ms,omitempty"`
+}
+
+// CrawlStatsClient calls the private batchexecute endpoint. It does NOT share
+// the cache/limiter of the main Client because the cache key shape and rate
+// limits are different (the batchexecute endpoint is not rate-limited the
+// same way the public API is).
+type CrawlStatsClient struct {
+	HTTPClient *http.Client
+	Jar        *CookieJarFile
+	BuildLabel string
+	DryRun     bool
+
+	// AuthUser is the X-Goog-AuthUser header value. Defaults to "0" (the
+	// primary signed-in Google account); override if the user has multi-login
+	// and wants a non-primary account.
+	AuthUser string
+
+	// nowFunc is overridable for tests; production callers leave it nil.
+	nowFunc func() time.Time
+}
+
+// NewCrawlStatsClient builds a client around an already-loaded cookie jar.
+// Returns an error when the jar is missing any required cookie.
+func NewCrawlStatsClient(jar *CookieJarFile, timeout time.Duration) (*CrawlStatsClient, error) {
+	if jar == nil {
+		return nil, fmt.Errorf("crawl-stats: cookie jar is nil — set GSC_COOKIE_JAR or run `auth login --chrome`")
+	}
+	if missing := jar.MissingCookies(); len(missing) > 0 {
+		return nil, fmt.Errorf("crawl-stats: cookie jar at %s is missing %d Google session cookie(s): %s — re-export your jar (see README.md crawl-stats section)", jar.Path, len(missing), strings.Join(missing, ", "))
+	}
+	return &CrawlStatsClient{
+		HTTPClient: &http.Client{Timeout: timeout},
+		Jar:        jar,
+		BuildLabel: defaultBuildLabel,
+		AuthUser:   "0",
+	}, nil
+}
+
+// now returns the current time, honoring nowFunc when set (for tests).
+func (c *CrawlStatsClient) now() time.Time {
+	if c.nowFunc != nil {
+		return c.nowFunc()
+	}
+	return time.Now().UTC()
+}
+
+// Fetch dispatches one canonical-three-rpc batchexecute call and parses the
+// response into a CrawlStatsResponse. When DryRun is true, builds the request
+// up to the wire and returns a synthetic response with the request body in
+// RawResponses["dry_run_body"].
+func (c *CrawlStatsClient) Fetch(ctx context.Context, req CrawlStatsRequest) (*CrawlStatsResponse, error) {
+	if req.Property == "" {
+		return nil, fmt.Errorf("crawl-stats: Property required (e.g. sc-domain:example.com)")
+	}
+	if req.XSRFToken == "" {
+		return nil, fmt.Errorf("crawl-stats: XSRFToken required (read from the `at=` form field in the GSC HTML; pass via --xsrf-token or GSC_XSRF_TOKEN)")
+	}
+
+	buildLabel := req.BuildLabel
+	if buildLabel == "" {
+		buildLabel = c.BuildLabel
+	}
+	if buildLabel == "" {
+		buildLabel = defaultBuildLabel
+	}
+
+	// Compose the f.req payload — see discovery report for the shape.
+	fReq, err := encodeBatchExecuteFReq(req.Property, req.Dimension, req.FilterCode)
+	if err != nil {
+		return nil, err
+	}
+
+	body := url.Values{}
+	body.Set("f.req", fReq)
+	body.Set("at", req.XSRFToken)
+	bodyEncoded := body.Encode()
+
+	// Compose the query string.
+	q := url.Values{}
+	q.Set("rpcids", "nDAfwb,OLiH4d,czrWJf")
+	q.Set("source-path", "/search-console/settings/crawl-stats")
+	if req.SessionID != "" {
+		q.Set("f.sid", req.SessionID)
+	}
+	q.Set("bl", buildLabel)
+	q.Set("hl", "en")
+	reqid := req.RequestSeq
+	if reqid <= 0 {
+		reqid = 1
+	}
+	q.Set("_reqid", strconv.Itoa(reqid))
+	q.Set("rt", "c")
+
+	endpoint := crawlStatsEndpoint + "?" + q.Encode()
+
+	if c.DryRun {
+		return &CrawlStatsResponse{
+			Property:   req.Property,
+			Dimension:  req.Dimension,
+			FilterCode: req.FilterCode,
+			CapturedAt: c.now(),
+			RawResponses: map[string]json.RawMessage{
+				"dry_run_endpoint": json.RawMessage(`"` + endpoint + `"`),
+				"dry_run_body":     json.RawMessage(`"` + jsonEscape(bodyEncoded) + `"`),
+			},
+		}, nil
+	}
+
+	hr, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(bodyEncoded))
+	if err != nil {
+		return nil, fmt.Errorf("crawl-stats: building request: %w", err)
+	}
+	hr.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+	hr.Header.Set("Cookie", c.Jar.CookieHeader())
+	hr.Header.Set("Authorization", SAPISIDHash(c.Jar.SAPISIDValue(), crawlStatsOrigin, c.now()))
+	hr.Header.Set("X-Goog-AuthUser", c.AuthUser)
+	hr.Header.Set("X-Same-Domain", "1")
+	hr.Header.Set("Origin", crawlStatsOrigin)
+	hr.Header.Set("Referer", crawlStatsOrigin+"/search-console/settings/crawl-stats")
+	hr.Header.Set("User-Agent", "google-search-console-pp-cli/1.0.0 (+crawl-stats)")
+
+	resp, err := c.HTTPClient.Do(hr)
+	if err != nil {
+		return nil, fmt.Errorf("crawl-stats: POST %s: %w", crawlStatsEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("crawl-stats: HTTP %d — cookies likely stale; re-export your cookie jar (try `google-search-console-pp-cli auth login --chrome` for instructions)", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("crawl-stats: HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+
+	parsed, raw, err := decodeBatchExecuteChunks(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("crawl-stats: decoding response chunks: %w", err)
+	}
+
+	out := &CrawlStatsResponse{
+		Property:     req.Property,
+		Dimension:    req.Dimension,
+		FilterCode:   req.FilterCode,
+		CapturedAt:   c.now(),
+		RawResponses: raw,
+	}
+	if samples, ok := parsed["nDAfwb"]; ok {
+		out.Samples = extractSamples(samples)
+	}
+	if ts, ok := parsed["OLiH4d"]; ok {
+		out.TimeSeries = extractTimeSeries(ts)
+	}
+	if agg, ok := parsed["czrWJf"]; ok {
+		out.Totals = extractTotals(agg)
+	}
+	return out, nil
+}
+
+// encodeBatchExecuteFReq builds the f.req body field. The outer shape is:
+//
+//	[[
+//	  ["nDAfwb", "[<property>, 69, <filter_envelope>]", null, "1"],
+//	  ["OLiH4d", "[<property>, 49, <filter_envelope>]", null, "2"],
+//	  ["czrWJf", "[<property>, 35, <filter_value_or_default>]", null, "8"]
+//	]]
+//
+// The filter_envelope for nDAfwb/OLiH4d is
+// `[[22,""],[23,null,null,null,null,null,null,null,<filter_code>]]`; the
+// czrWJf rpc takes a bare integer instead of the envelope (see discovery
+// report).
+func encodeBatchExecuteFReq(property string, dim Dimension, filterCode int) (string, error) {
+	// Build filter envelope for nDAfwb / OLiH4d (URL samples + time series).
+	// Index 8 of the inner [23,...] array holds the filter value. When
+	// dim==DimensionNone we still send the envelope with a null at index 8
+	// (matches the GSC web UI's overview call shape).
+	var filterIndex8 any
+	if dim != DimensionNone {
+		filterIndex8 = filterCode
+	}
+	envelope := []any{
+		[]any{22, ""},
+		[]any{23, nil, nil, nil, nil, nil, nil, nil, filterIndex8},
+	}
+
+	rpcs := make([]any, 0, 3)
+	for _, rpc := range canonicalRPCSet {
+		var argsAny any
+		if rpc.rpcID == "czrWJf" {
+			// Aggregate rpc takes (property, report_kind, filter_code_or_2)
+			// per the discovery report. When no drill-down dimension, the
+			// observed value at this position is 2.
+			third := 2
+			if dim != DimensionNone {
+				third = filterCode
+			}
+			argsAny = []any{property, rpc.reportKind, third}
+		} else {
+			argsAny = []any{property, rpc.reportKind, envelope}
+		}
+		argsJSON, err := json.Marshal(argsAny)
+		if err != nil {
+			return "", err
+		}
+		rpcs = append(rpcs, []any{rpc.rpcID, string(argsJSON), nil, rpc.index})
+	}
+	outer := []any{rpcs}
+	b, err := json.Marshal(outer)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// decodeBatchExecuteChunks parses the chunked response. Each chunk is
+// `<decimal_length>\n<json_array>\n`, where the json_array carries one
+// `["wrb.fr","<rpcId>","<json_string_of_payload>",null,null,"<requestIndex>"]`
+// entry. The `<json_string_of_payload>` itself is a JSON-encoded string and
+// must be parsed twice to reach the actual payload.
+//
+// Returns: rpcID -> decoded inner payload (the second parse) and rpcID -> the
+// raw inner string (preserved for --raw output mode).
+func decodeBatchExecuteChunks(body io.Reader) (map[string]json.RawMessage, map[string]json.RawMessage, error) {
+	scan := bufio.NewReader(body)
+	parsed := make(map[string]json.RawMessage)
+	raw := make(map[string]json.RawMessage)
+
+	// Strip the )]}'  XSSI prefix.
+	prefix := make([]byte, 4)
+	if _, err := io.ReadFull(scan, prefix); err != nil {
+		return nil, nil, fmt.Errorf("reading XSSI prefix: %w", err)
+	}
+	if !bytes.Equal(prefix, []byte(")]}'")) {
+		return nil, nil, fmt.Errorf("missing )]}'  XSSI prefix (got %q)", string(prefix))
+	}
+	// Drain to next newline after the prefix.
+	if _, err := scan.ReadString('\n'); err != nil && err != io.EOF {
+		return nil, nil, err
+	}
+
+	for {
+		lenLine, err := scan.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		lenLine = strings.TrimSpace(lenLine)
+		if lenLine == "" {
+			continue
+		}
+		n, err := strconv.Atoi(lenLine)
+		if err != nil {
+			// Some chunks emit a trailing checksum / empty marker;
+			// non-decimal line ends the stream.
+			break
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(scan, buf); err != nil {
+			return nil, nil, fmt.Errorf("reading chunk body: %w", err)
+		}
+
+		// Parse the outer wrapper array.
+		var outer [][]any
+		if err := json.Unmarshal(buf, &outer); err != nil {
+			// Some chunks are control frames (e.g. ["di",...]); skip silently.
+			continue
+		}
+		for _, row := range outer {
+			if len(row) < 3 {
+				continue
+			}
+			tag, _ := row[0].(string)
+			if tag != "wrb.fr" {
+				continue
+			}
+			rpcID, _ := row[1].(string)
+			innerStr, _ := row[2].(string)
+			raw[rpcID] = json.RawMessage(strconvQuote(innerStr))
+			var inner json.RawMessage
+			if innerStr != "" {
+				if err := json.Unmarshal([]byte(innerStr), &inner); err == nil {
+					parsed[rpcID] = inner
+				}
+			}
+		}
+	}
+	return parsed, raw, nil
+}
+
+// extractSamples walks the nDAfwb payload structure to pull (URL, optional
+// metadata) per sample. The full URL position within the 43-element inner
+// array varies; this implementation reads element 0 as the URL (most common
+// position observed in chrome-MCP capture) and best-efforts the rest.
+//
+// The walker is defensive: never panics on unexpected shape, returns the
+// samples it could decode and skips malformed entries.
+func extractSamples(payload json.RawMessage) []CrawlStatsSample {
+	var top []json.RawMessage
+	if err := json.Unmarshal(payload, &top); err != nil {
+		return nil
+	}
+	// The nDAfwb payload shape from the discovery report:
+	//   [<echo of request args>, [<N samples>], ...]
+	// We want index 1 — the primary URL list.
+	if len(top) < 2 {
+		return nil
+	}
+	var samples []json.RawMessage
+	if err := json.Unmarshal(top[1], &samples); err != nil {
+		return nil
+	}
+	out := make([]CrawlStatsSample, 0, len(samples))
+	for _, s := range samples {
+		var sampleOuter []json.RawMessage
+		if err := json.Unmarshal(s, &sampleOuter); err != nil {
+			continue
+		}
+		if len(sampleOuter) == 0 {
+			continue
+		}
+		// First element is the 43-element sparse array.
+		var inner []json.RawMessage
+		if err := json.Unmarshal(sampleOuter[0], &inner); err != nil {
+			continue
+		}
+		if len(inner) == 0 {
+			continue
+		}
+		var rawURL string
+		if err := json.Unmarshal(inner[0], &rawURL); err == nil && rawURL != "" {
+			out = append(out, CrawlStatsSample{URL: rawURL})
+		}
+	}
+	return out
+}
+
+// extractTimeSeries walks the OLiH4d payload. The series is a list of
+// [date_string, crawl_requests] pairs in the inner array. Defensive walking
+// matches extractSamples — unknown shapes return an empty slice.
+func extractTimeSeries(payload json.RawMessage) []CrawlStatsTimePoint {
+	var top []json.RawMessage
+	if err := json.Unmarshal(payload, &top); err != nil {
+		return nil
+	}
+	if len(top) < 2 {
+		return nil
+	}
+	var series []json.RawMessage
+	if err := json.Unmarshal(top[1], &series); err != nil {
+		return nil
+	}
+	out := make([]CrawlStatsTimePoint, 0, len(series))
+	for _, p := range series {
+		var pair []json.RawMessage
+		if err := json.Unmarshal(p, &pair); err != nil {
+			continue
+		}
+		if len(pair) < 2 {
+			continue
+		}
+		var date string
+		var requests int64
+		_ = json.Unmarshal(pair[0], &date)
+		_ = json.Unmarshal(pair[1], &requests)
+		if date != "" {
+			out = append(out, CrawlStatsTimePoint{Date: date, CrawlRequests: requests})
+		}
+	}
+	return out
+}
+
+// extractTotals walks the czrWJf payload. The aggregate stats live at
+// indices 0, 1, 2 of the inner array (crawl_requests, download_size_bytes,
+// avg_response_ms) per chrome-MCP capture.
+func extractTotals(payload json.RawMessage) *CrawlStatsTotals {
+	var top []json.RawMessage
+	if err := json.Unmarshal(payload, &top); err != nil {
+		return nil
+	}
+	if len(top) < 3 {
+		return nil
+	}
+	out := &CrawlStatsTotals{}
+	_ = json.Unmarshal(top[0], &out.CrawlRequests)
+	_ = json.Unmarshal(top[1], &out.DownloadSizeBytes)
+	_ = json.Unmarshal(top[2], &out.AvgResponseMs)
+	return out
+}
+
+// strconvQuote wraps a Go string in JSON-quoted form so it can be stored
+// as a json.RawMessage for round-trippable --raw output.
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// jsonEscape returns the JSON-string-escaped form of s, without surrounding
+// quotes — used for synthesizing dry-run output structures.
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	if len(b) >= 2 {
+		return string(b[1 : len(b)-1])
+	}
+	return s
+}

--- a/library/marketing/google-search-console/internal/client/crawlstats_test.go
+++ b/library/marketing/google-search-console/internal/client/crawlstats_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestExtractSamplesPreservesMetadata(t *testing.T) {
+	fetchedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	payload, err := json.Marshal([]any{
+		[]any{"request echo"},
+		[]any{
+			[]any{[]any{"https://example.com/page", fetchedAt.Format(time.RFC3339), 200, 12345, 67}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	samples := extractSamples(payload)
+	if len(samples) != 1 {
+		t.Fatalf("expected one sample, got %d", len(samples))
+	}
+	got := samples[0]
+	if got.URL != "https://example.com/page" {
+		t.Fatalf("unexpected URL: %q", got.URL)
+	}
+	if !got.FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("expected fetched_at %s, got %s", fetchedAt, got.FetchedAt)
+	}
+	if got.ResponseCode != 200 || got.SizeBytes != 12345 || got.ResponseMs != 67 {
+		t.Fatalf("metadata was not preserved: %+v", got)
+	}
+}
+
+func TestExtractSamplesPreservesEpochMillisTimestamp(t *testing.T) {
+	fetchedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	payload, err := json.Marshal([]any{
+		[]any{"request echo"},
+		[]any{
+			[]any{[]any{"https://example.com/epoch", fetchedAt.UnixMilli(), 304, 9000, 12}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	samples := extractSamples(payload)
+	if len(samples) != 1 {
+		t.Fatalf("expected one sample, got %d", len(samples))
+	}
+	got := samples[0]
+	if !got.FetchedAt.Equal(fetchedAt) || got.ResponseCode != 304 || got.SizeBytes != 9000 || got.ResponseMs != 12 {
+		t.Fatalf("metadata was not preserved: %+v", got)
+	}
+}

--- a/library/marketing/google-search-console/internal/client/sapisidhash.go
+++ b/library/marketing/google-search-console/internal/client/sapisidhash.go
@@ -1,0 +1,35 @@
+// PATCH(crawl-stats: SAPISIDHASH compute for the Crawl Stats batchexecute
+// endpoint). The public Search Console v1 API uses OAuth bearer tokens, but
+// the private SearchConsoleAggReportUi.batchexecute endpoint that powers the
+// Crawl Stats UI requires a Google-web SAPISIDHASH header. The hash is
+// deterministic from (unix_ts, SAPISID cookie value, origin). See
+// .printing-press-patches.json patch id: crawl-stats and the discovery report
+// at manuscripts/google-search-console/amend-2026-05-21T1402/.
+
+package client
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// SAPISIDHash returns the value for the Authorization header expected by
+// Google's logged-in web endpoints (search.google.com, mail.google.com, etc.).
+//
+// Format: "SAPISIDHASH <ts>_<sha1hex(ts + " " + sapisid + " " + origin)>"
+//
+// `ts` is the current Unix timestamp in seconds. `sapisid` is the value of
+// the user's SAPISID cookie. `origin` is the scheme+host of the page making
+// the request — for Crawl Stats this is "https://search.google.com".
+//
+// The Authorization header MUST be paired with the seven Google session
+// cookies (SAPISID, __Secure-1PSID, __Secure-3PSID, SID, HSID, SSID, APISID)
+// for the request to authenticate.
+func SAPISIDHash(sapisid, origin string, now time.Time) string {
+	ts := fmt.Sprintf("%d", now.Unix())
+	payload := ts + " " + sapisid + " " + origin
+	sum := sha1.Sum([]byte(payload))
+	return "SAPISIDHASH " + ts + "_" + hex.EncodeToString(sum[:])
+}

--- a/library/marketing/google-search-console/internal/client/sapisidhash_test.go
+++ b/library/marketing/google-search-console/internal/client/sapisidhash_test.go
@@ -1,0 +1,49 @@
+// PATCH(crawl-stats: SAPISIDHASH unit test — deterministic, no network).
+
+package client
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSAPISIDHashDeterministic(t *testing.T) {
+	// Fixed inputs produce a fixed output. The reference value below was
+	// computed by hand from the canonical formula (ts=1716300000,
+	// sapisid="abcd1234", origin="https://search.google.com"):
+	//   payload  = "1716300000 abcd1234 https://search.google.com"
+	//   sha1hex  = sha1(payload).hexdigest()
+	//   result   = "SAPISIDHASH 1716300000_" + sha1hex
+	got := SAPISIDHash("abcd1234", "https://search.google.com", time.Unix(1716300000, 0))
+	want := "SAPISIDHASH 1716300000_30892117018aea8395c713cc7094b86ef72e54d7"
+	if got != want {
+		t.Errorf("SAPISIDHash mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestSAPISIDHashShape(t *testing.T) {
+	// Two consecutive calls with the same inputs and different timestamps
+	// must differ in the ts prefix. Header format must always carry the
+	// "SAPISIDHASH " prefix and an underscore-joined ts/hash pair.
+	now1 := time.Unix(1700000000, 0)
+	now2 := time.Unix(1700000060, 0)
+	h1 := SAPISIDHash("sapisid-val", "https://search.google.com", now1)
+	h2 := SAPISIDHash("sapisid-val", "https://search.google.com", now2)
+	if h1 == h2 {
+		t.Fatal("hashes must differ when ts differs")
+	}
+	for _, h := range []string{h1, h2} {
+		if !strings.HasPrefix(h, "SAPISIDHASH ") {
+			t.Errorf("missing SAPISIDHASH prefix: %s", h)
+		}
+		body := strings.TrimPrefix(h, "SAPISIDHASH ")
+		parts := strings.SplitN(body, "_", 2)
+		if len(parts) != 2 {
+			t.Errorf("missing underscore separator: %s", h)
+		}
+		if len(parts[1]) != 40 {
+			t.Errorf("hash component must be 40-char sha1 hex, got %d: %s", len(parts[1]), parts[1])
+		}
+	}
+}

--- a/library/marketing/google-search-console/internal/config/config.go
+++ b/library/marketing/google-search-console/internal/config/config.go
@@ -25,6 +25,13 @@ type Config struct {
 	ClientID      string            `toml:"client_id"`
 	ClientSecret  string            `toml:"client_secret"`
 	Path          string            `toml:"-"`
+
+	// PATCH(crawl-stats): path to a Netscape-format cookie jar carrying
+	// the seven Google session cookies needed by the private
+	// SearchConsoleAggReportUi.batchexecute endpoint. The Crawl Stats
+	// surface auth-checks against cookies, not the OAuth bearer token;
+	// the two surfaces coexist. Override via GSC_COOKIE_JAR env var.
+	CrawlStatsCookieJar string `toml:"crawl_stats_cookie_jar"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -77,6 +84,13 @@ func Load(configPath string) (*Config, error) {
 	// Base URL override (used by printing-press verify to point at mock/test servers)
 	if v := os.Getenv("GOOGLE_SEARCH_CONSOLE_BASE_URL"); v != "" {
 		cfg.BaseURL = v
+	}
+
+	// PATCH(crawl-stats): env override for the cookie-jar path. Env wins so
+	// CI/agent environments can drop a jar at /tmp/cookies.txt without
+	// touching the persisted config file.
+	if v := os.Getenv("GSC_COOKIE_JAR"); v != "" {
+		cfg.CrawlStatsCookieJar = v
 	}
 	return cfg, nil
 }

--- a/library/marketing/google-search-console/internal/store/crawl_stats.go
+++ b/library/marketing/google-search-console/internal/store/crawl_stats.go
@@ -1,0 +1,276 @@
+// PATCH(crawl-stats: SQLite tables + upserts for crawl-stats poll samples).
+// Each poll caps at ~1000 URL samples; unioning across polls is the only way
+// to get full URL coverage. The tables here back the `crawl-stats union`
+// subcommand. See .printing-press-patches.json patch id: crawl-stats and the
+// discovery report under manuscripts/google-search-console/amend-2026-05-21T1402.
+
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// CrawlStatsSampleRow is one row in crawl_stats_samples.
+type CrawlStatsSampleRow struct {
+	SiteURL       string
+	SampleURL     string
+	FileType      string    // empty when not from a by-type poll
+	ResponseCode  int       // 0 when not observed
+	GooglebotType string    // empty when not from a by-googlebot poll
+	FetchedAt     time.Time // when GSC says the sample was crawled
+	SizeBytes     int64
+	ResponseMs    int
+	PollAt        time.Time // wall-clock time of this poll
+	RawJSON       string    // best-effort raw shard (for forensics)
+}
+
+// CrawlStatsTotalsRow is one row in crawl_stats_totals.
+type CrawlStatsTotalsRow struct {
+	SiteURL           string
+	FilterDim         string // "" (overview), "file_type", "response", "googlebot_type", "purpose"
+	FilterCode        int
+	PollAt            time.Time
+	CrawlRequests     int64
+	DownloadSizeBytes int64
+	AvgResponseMs     int64
+}
+
+// CrawlStatsTimeSeriesRow is one row in crawl_stats_time_series.
+type CrawlStatsTimeSeriesRow struct {
+	SiteURL       string
+	FilterDim     string
+	FilterCode    int
+	Date          string // YYYY-MM-DD
+	CrawlRequests int64
+	PollAt        time.Time
+}
+
+// migrateCrawlStats creates the three crawl-stats tables. Called from the
+// main migrate() loop. Separate function to keep migrate() readable.
+func (s *Store) migrateCrawlStats(ctx context.Context) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS crawl_stats_samples (
+			site_url TEXT NOT NULL,
+			sample_url TEXT NOT NULL,
+			file_type TEXT NOT NULL DEFAULT '',
+			response_code INTEGER NOT NULL DEFAULT 0,
+			googlebot_type TEXT NOT NULL DEFAULT '',
+			fetched_at TEXT NOT NULL DEFAULT '',
+			size_bytes INTEGER NOT NULL DEFAULT 0,
+			response_ms INTEGER NOT NULL DEFAULT 0,
+			poll_at TEXT NOT NULL,
+			raw_json TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (site_url, sample_url, fetched_at, poll_at)
+		)`,
+		`CREATE INDEX IF NOT EXISTS crawl_stats_samples_site ON crawl_stats_samples(site_url, poll_at)`,
+		`CREATE INDEX IF NOT EXISTS crawl_stats_samples_filters ON crawl_stats_samples(site_url, file_type, response_code, googlebot_type)`,
+
+		`CREATE TABLE IF NOT EXISTS crawl_stats_totals (
+			site_url TEXT NOT NULL,
+			filter_dim TEXT NOT NULL DEFAULT '',
+			filter_code INTEGER NOT NULL DEFAULT 0,
+			poll_at TEXT NOT NULL,
+			crawl_requests INTEGER NOT NULL DEFAULT 0,
+			download_size_bytes INTEGER NOT NULL DEFAULT 0,
+			avg_response_ms INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (site_url, filter_dim, filter_code, poll_at)
+		)`,
+		`CREATE INDEX IF NOT EXISTS crawl_stats_totals_site ON crawl_stats_totals(site_url, poll_at)`,
+
+		`CREATE TABLE IF NOT EXISTS crawl_stats_time_series (
+			site_url TEXT NOT NULL,
+			filter_dim TEXT NOT NULL DEFAULT '',
+			filter_code INTEGER NOT NULL DEFAULT 0,
+			date TEXT NOT NULL,
+			crawl_requests INTEGER NOT NULL DEFAULT 0,
+			poll_at TEXT NOT NULL,
+			PRIMARY KEY (site_url, filter_dim, filter_code, date, poll_at)
+		)`,
+		`CREATE INDEX IF NOT EXISTS crawl_stats_time_series_site ON crawl_stats_time_series(site_url, poll_at)`,
+	}
+	for _, q := range stmts {
+		if _, err := s.db.ExecContext(ctx, q); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpsertCrawlStatsSamples bulk-inserts a batch of sample rows in one
+// transaction. Conflicts on the natural primary key are no-ops (first-write-
+// wins) — a re-poll on the same (site, sample_url, fetched_at, poll_at)
+// shouldn't happen in practice but we don't want a dupe to error the call.
+func (s *Store) UpsertCrawlStatsSamples(ctx context.Context, rows []CrawlStatsSampleRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO crawl_stats_samples (
+			site_url, sample_url, file_type, response_code, googlebot_type,
+			fetched_at, size_bytes, response_ms, poll_at, raw_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(site_url, sample_url, fetched_at, poll_at) DO NOTHING`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, r := range rows {
+		if r.SiteURL == "" || r.SampleURL == "" {
+			continue
+		}
+		fetchedAt := ""
+		if !r.FetchedAt.IsZero() {
+			fetchedAt = r.FetchedAt.Format(time.RFC3339)
+		}
+		pollAt := r.PollAt
+		if pollAt.IsZero() {
+			pollAt = time.Now().UTC()
+		}
+		if _, err := stmt.ExecContext(ctx,
+			r.SiteURL, r.SampleURL, r.FileType, r.ResponseCode, r.GooglebotType,
+			fetchedAt, r.SizeBytes, r.ResponseMs, pollAt.Format(time.RFC3339), r.RawJSON,
+		); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// UpsertCrawlStatsTotals writes one totals row per poll.
+func (s *Store) UpsertCrawlStatsTotals(ctx context.Context, row CrawlStatsTotalsRow) error {
+	if row.SiteURL == "" {
+		return errors.New("UpsertCrawlStatsTotals: SiteURL required")
+	}
+	if row.PollAt.IsZero() {
+		row.PollAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO crawl_stats_totals (
+			site_url, filter_dim, filter_code, poll_at,
+			crawl_requests, download_size_bytes, avg_response_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(site_url, filter_dim, filter_code, poll_at) DO UPDATE SET
+			crawl_requests = excluded.crawl_requests,
+			download_size_bytes = excluded.download_size_bytes,
+			avg_response_ms = excluded.avg_response_ms`,
+		row.SiteURL, row.FilterDim, row.FilterCode, row.PollAt.Format(time.RFC3339),
+		row.CrawlRequests, row.DownloadSizeBytes, row.AvgResponseMs)
+	return err
+}
+
+// UpsertCrawlStatsTimeSeries writes a batch of time-series points in one tx.
+func (s *Store) UpsertCrawlStatsTimeSeries(ctx context.Context, rows []CrawlStatsTimeSeriesRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO crawl_stats_time_series (
+			site_url, filter_dim, filter_code, date, crawl_requests, poll_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(site_url, filter_dim, filter_code, date, poll_at) DO UPDATE SET
+			crawl_requests = excluded.crawl_requests`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, r := range rows {
+		if r.SiteURL == "" || r.Date == "" {
+			continue
+		}
+		pollAt := r.PollAt
+		if pollAt.IsZero() {
+			pollAt = time.Now().UTC()
+		}
+		if _, err := stmt.ExecContext(ctx,
+			r.SiteURL, r.FilterDim, r.FilterCode, r.Date, r.CrawlRequests,
+			pollAt.Format(time.RFC3339),
+		); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// QueryCrawlStatsSamplesUnion returns the deduplicated union of all sample
+// URLs ever polled for a site, optionally filtered by dimension. Unioning
+// across polls is the entire reason the SQLite layer exists for crawl-stats
+// (each individual poll caps at ~1000 URLs).
+func (s *Store) QueryCrawlStatsSamplesUnion(ctx context.Context, siteURL, fileType, googlebotType string, responseCode int, limit int) ([]CrawlStatsSampleRow, error) {
+	if siteURL == "" {
+		return nil, errors.New("QueryCrawlStatsSamplesUnion: SiteURL required")
+	}
+	q := `SELECT site_url, sample_url, file_type, response_code, googlebot_type,
+		  fetched_at, size_bytes, response_ms, poll_at, raw_json
+	      FROM crawl_stats_samples
+	      WHERE site_url = ?`
+	args := []any{siteURL}
+	if fileType != "" {
+		q += ` AND file_type = ?`
+		args = append(args, fileType)
+	}
+	if googlebotType != "" {
+		q += ` AND googlebot_type = ?`
+		args = append(args, googlebotType)
+	}
+	if responseCode > 0 {
+		q += ` AND response_code = ?`
+		args = append(args, responseCode)
+	}
+	q += ` GROUP BY sample_url ORDER BY MAX(poll_at) DESC`
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []CrawlStatsSampleRow{}
+	for rows.Next() {
+		var r CrawlStatsSampleRow
+		var fetchedAtStr, pollAtStr string
+		if err := rows.Scan(
+			&r.SiteURL, &r.SampleURL, &r.FileType, &r.ResponseCode, &r.GooglebotType,
+			&fetchedAtStr, &r.SizeBytes, &r.ResponseMs, &pollAtStr, &r.RawJSON,
+		); err != nil {
+			return nil, err
+		}
+		if fetchedAtStr != "" {
+			if t, err := time.Parse(time.RFC3339, fetchedAtStr); err == nil {
+				r.FetchedAt = t
+			}
+		}
+		if pollAtStr != "" {
+			if t, err := time.Parse(time.RFC3339, pollAtStr); err == nil {
+				r.PollAt = t
+			}
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// CountCrawlStatsSamples returns the number of unique sample URLs for a site.
+func (s *Store) CountCrawlStatsSamples(ctx context.Context, siteURL string) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT sample_url) FROM crawl_stats_samples WHERE site_url = ?`,
+		siteURL).Scan(&n)
+	return n, err
+}

--- a/library/marketing/google-search-console/internal/store/crawl_stats.go
+++ b/library/marketing/google-search-console/internal/store/crawl_stats.go
@@ -213,10 +213,16 @@ func (s *Store) QueryCrawlStatsSamplesUnion(ctx context.Context, siteURL, fileTy
 	if siteURL == "" {
 		return nil, errors.New("QueryCrawlStatsSamplesUnion: SiteURL required")
 	}
+	// PATCH: Use a ranked subquery so union metadata comes from the newest poll
+	// for each URL instead of SQLite's arbitrary non-aggregated GROUP BY row.
 	q := `SELECT site_url, sample_url, file_type, response_code, googlebot_type,
 		  fetched_at, size_bytes, response_ms, poll_at, raw_json
-	      FROM crawl_stats_samples
-	      WHERE site_url = ?`
+	      FROM (
+	        SELECT site_url, sample_url, file_type, response_code, googlebot_type,
+		       fetched_at, size_bytes, response_ms, poll_at, raw_json,
+		       ROW_NUMBER() OVER (PARTITION BY sample_url ORDER BY poll_at DESC) AS rn
+	        FROM crawl_stats_samples
+	        WHERE site_url = ?`
 	args := []any{siteURL}
 	if fileType != "" {
 		q += ` AND file_type = ?`
@@ -230,7 +236,10 @@ func (s *Store) QueryCrawlStatsSamplesUnion(ctx context.Context, siteURL, fileTy
 		q += ` AND response_code = ?`
 		args = append(args, responseCode)
 	}
-	q += ` GROUP BY sample_url ORDER BY MAX(poll_at) DESC`
+	q += `
+	      )
+	      WHERE rn = 1
+	      ORDER BY poll_at DESC`
 	if limit > 0 {
 		q += ` LIMIT ?`
 		args = append(args, limit)

--- a/library/marketing/google-search-console/internal/store/crawl_stats_test.go
+++ b/library/marketing/google-search-console/internal/store/crawl_stats_test.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestQueryCrawlStatsSamplesUnionReturnsLatestMetadata(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	olderPoll := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	newerPoll := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	if err := st.UpsertCrawlStatsSamples(ctx, []CrawlStatsSampleRow{
+		{
+			SiteURL:       "sc-domain:example.com",
+			SampleURL:     "https://example.com/page",
+			FileType:      "html",
+			ResponseCode:  200,
+			GooglebotType: "smartphone",
+			FetchedAt:     olderPoll.Add(-time.Hour),
+			SizeBytes:     100,
+			ResponseMs:    50,
+			PollAt:        olderPoll,
+			RawJSON:       `{"poll":"older"}`,
+		},
+		{
+			SiteURL:       "sc-domain:example.com",
+			SampleURL:     "https://example.com/page",
+			FileType:      "html",
+			ResponseCode:  304,
+			GooglebotType: "desktop",
+			FetchedAt:     newerPoll.Add(-time.Hour),
+			SizeBytes:     250,
+			ResponseMs:    25,
+			PollAt:        newerPoll,
+			RawJSON:       `{"poll":"newer"}`,
+		},
+	}); err != nil {
+		t.Fatalf("upsert samples: %v", err)
+	}
+
+	rows, err := st.QueryCrawlStatsSamplesUnion(ctx, "sc-domain:example.com", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("query union: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one deduplicated URL, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.ResponseCode != 304 || got.GooglebotType != "desktop" || got.SizeBytes != 250 || got.RawJSON != `{"poll":"newer"}` {
+		t.Fatalf("union returned stale metadata: %+v", got)
+	}
+	if !got.PollAt.Equal(newerPoll) {
+		t.Fatalf("expected newest poll %s, got %s", newerPoll, got.PollAt)
+	}
+}

--- a/library/marketing/google-search-console/internal/store/store.go
+++ b/library/marketing/google-search-console/internal/store/store.go
@@ -216,6 +216,13 @@ func (s *Store) migrate(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, ftsStmt); err == nil {
 		s.fts = true
 	}
+
+	// PATCH(crawl-stats): migrate the three crawl_stats_* tables. Lives in a
+	// separate file (crawl_stats.go) so the new schema isn't tangled with the
+	// generated migrate() loop above.
+	if err := s.migrateCrawlStats(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Adds a new `crawl-stats` command tree to the `google-search-console-pp-cli`,
exposing the GSC Crawl Stats UI (Settings > Crawl stats) — URL samples,
time-series, and totals broken down by file type, response code, Googlebot
crawler, and purpose. None of this is in the public Search Console v1 API;
the CLI calls the private `SearchConsoleAggReportUi.batchexecute` endpoint,
which I reverse-engineered via chrome-MCP capture against a live
authenticated GSC session.

The new surface ships with its own auth path (cookie-jar + SAPISIDHASH)
that coexists with — does not replace — the existing OAuth bearer-token
flow. The existing `auth login` is unaffected; the new `auth login --chrome`
prints export instructions and (optionally) persists a jar path to config.

Each live poll caps at ~1000 URL samples (Google's hard limit). A new
SQLite table set persists every poll so the `crawl-stats union` subcommand
returns the deduplicated union across all polls — the only way to build a
corpus larger than any single snapshot.

## Findings

| ID  | Category         | Type     | Rationale |
|-----|------------------|----------|-----------|
| F1  | command-surface  | feature  | Add `crawl-stats list/by-type/by-response/by-googlebot/by-purpose` subcommands |
| F2  | filter-flags     | feature  | Wire `--file-type / --response-code / --googlebot / --purpose` enums onto the drill-down subcommands |
| F3  | json-export      | feature  | Root `--json` flag works on every crawl-stats subcommand with a documented payload shape |
| F4  | sqlite-persistence | feature | Persist samples + totals + time-series across polls so `crawl-stats union` can return a multi-poll URL union |
| F6  | endpoint (sniff) | feature  | `nDAfwb` rpcid (URL samples, report_kind=69) wired |
| F7  | endpoint (sniff) | feature  | `OLiH4d` rpcid (time-series, report_kind=49) wired |
| F8  | endpoint (sniff) | feature  | `czrWJf` rpcid (aggregate stats, report_kind=35) wired |
| F9  | endpoint (sniff) | feature  | `SAPISIDHASH` auth header + cookie jar reader implemented |
| F10 | endpoint (sniff) | feature  | XSRF `at=` body field surfaced as `--xsrf-token` flag and `GSC_XSRF_TOKEN` env var |

## Changes

```
 .printing-press-patches.json            |  26 +
 .printing-press.json                    |   5 +
 README.md                               |  35 ++
 internal/cli/auth.go                    |  61 ++
 internal/cli/auth_login.go              | 111 +++-
 internal/cli/crawl_stats.go             | 619 +++++++++++++++++++++
 internal/cli/root.go                    |   6 +
 internal/client/cookiejar.go            | 163 ++++++
 internal/client/crawlstats.go           | 532 ++++++++++++++++++
 internal/client/sapisidhash.go          |  35 ++
 internal/client/sapisidhash_test.go     |  49 ++
 internal/config/config.go               |  14 +
 internal/store/crawl_stats.go           | 276 +++++++++
 internal/store/store.go                 |   7 +
 14 files changed, 1934 insertions(+), 5 deletions(-)
```

No new dependencies. All new code uses the existing `modernc.org/sqlite`
(no cgo) store and the stdlib HTTP client.

## Verification

- Build: **PASS** (`go build ./...` clean)
- Vet: **PASS** (`go vet ./...` clean)
- Tests: **PASS** for the new `internal/client/sapisidhash_test.go` —
  deterministic SHA1 reference value + structural shape assertions.
- Pre-existing test `TestSaveTokensAtomicallyAndRoundtrips` in
  `internal/config/config_atomic_test.go` fails on Windows for both
  `main` and this branch (it asserts Unix file mode 0600; unrelated to
  this patch).
- `cli-printing-press publish validate --dir <CLI_DIR> --json`: **PASS**
  on every check except `verify-skill` (canonical SKILL.md install-section
  drift). That drift is **pre-existing on `main`** — same check fails
  identically on a clean `main` checkout. Not a blocker introduced by this
  PR.
- Dogfood: **N/A** for this run. This is direct-input amend mode (user-
  asks, not session-transcript friction). Live testing of `crawl-stats`
  is deferred to post-merge since it requires the user's authenticated
  Google session cookies — the discovery work for the underlying endpoint
  shape was driven against a live property and the dry-run path against
  this PR's branch produces a request body byte-identical to the captured
  shape.
- Patch contract: 12 `// PATCH(crawl-stats: ...)` source comments,
  `.printing-press-patches.json` declares `patch_count: 12`. Parity check
  passes.
- Smoke dry-run (no network):
  ```
  $ google-search-console-pp-cli crawl-stats by-type sc-domain:example.com \
      --file-type css --dry-run --xsrf-token <stub> \
      --cookie-jar <synth-jar> --json
  ```
  emits a body containing
  `["sc-domain:example.com",69,[[22,""],[23,null,null,null,null,null,null,null,5]]]`
  for the `nDAfwb` rpc — file_type code 5 (CSS) at envelope index 8,
  matching the captured shape exactly.

## Evidence

- Patch record: `.printing-press-patches.json` entry `id: crawl-stats`,
  amend_run_id `amend-2026-05-21T1402`, with the full file list and
  validated_outcome.
- Per-finding rationale: see Findings table above; verbatim user asks
  are preserved in the local plan doc (intentionally not in the PR; PII-
  scrubbed local artifact at the run's manuscripts path).
- Discovery report (the chrome-MCP reverse-engineering output that
  documents the endpoint shape, rpcids, enum mappings, auth strategy, and
  reliability notes) is a LOCAL artifact under the run's manuscripts
  directory — NOT in the PR. The technical content is summarized in
  `internal/client/crawlstats.go` and `internal/client/cookiejar.go`
  top-of-file comments so reviewers don't need the report to understand
  the patch.

## Known limitations (deferred to v0.3)

- Overview-panel RPCs (`mKtLlc`, `pPDvCb`) for the four breakdown panels
  are not wired. Drill-down works; overview panel breakdowns deferred.
- Hosts table and Insights tab RPCs are out of scope.
- Automated Chrome-driven cookie capture deferred. v0.2 documents the
  manual extension-based export path; the CLI accepts the resulting
  Netscape-format jar via `GSC_COOKIE_JAR`, `--cookie-jar`, or
  `auth login --chrome --cookie-jar-path`.
- Build-label drift (`bl=` query param): v0.2 pins a recent observed
  value and exposes `--build-label` for override. v0.3 will auto-scrape
  the live label from the GSC HTML `WIZ_global_data` blob.
- This is a private Google endpoint and may change without notice. The
  patch is robust to defensive walking of the protobuf-style sparse
  arrays (returns partial decode rather than panicking), but the project
  should expect breakage on Google deploys.

## Why this can't use the existing OAuth surface

The public Search Console v1 API
(`https://searchconsole.googleapis.com/v1`) does NOT expose Crawl Stats
sample URLs. The `SearchConsoleAggReportUi.batchexecute` endpoint at
`search.google.com` rejects the OAuth bearer token with HTTP 401 — it
auth-checks against Google web session cookies (SAPISID + the family) and
an `SAPISIDHASH <ts>_<sha1(ts+" "+SAPISID+" "+origin)>` Authorization
header. This patch adds the second auth surface alongside the first; both
flows persist independently to the same `config.toml`, and `auth status`
reports both states.

Closes #750
