### PR TITLE
fix(ci): require npm version bumps for package changes

### DIFF
--- a/.github/workflows/verify-npm-version-bump.yml
+++ b/.github/workflows/verify-npm-version-bump.yml
@@ -1,0 +1,72 @@
+name: Verify npm version bump
+
+# The npm publish workflow only runs after npm/package.json's version changes on
+# main. This PR-time guard catches package-code/docs changes that would
+# otherwise merge without ever reaching npmjs.com.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/verify-npm-version-bump.yml'
+      - 'npm/**'
+      - '!npm/tests/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-npm-version-bump-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify npm version bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify npm package version bump
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git remote add pr "https://github.com/${HEAD_REPO}.git" 2>/dev/null || git remote set-url pr "https://github.com/${HEAD_REPO}.git"
+          git fetch --no-tags pr "${HEAD_SHA}"
+          merge_base=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
+
+          changed=$(git diff --name-only --diff-filter=ACMRD "${merge_base}" "${HEAD_SHA}" -- npm)
+          release_relevant=$(printf '%s\n' "${changed}" | awk '
+            /^npm\/(CHANGELOG\.md|LICENSE|README\.md|package-lock\.json|package\.json|tsconfig\.json)$/ { print; next }
+            /^npm\/(bin|src)\// { print }
+          ')
+
+          if [ -z "${release_relevant}" ]; then
+            echo "No npm package release-relevant files changed. OK."
+            exit 0
+          fi
+
+          base_version=$(git show "${merge_base}:npm/package.json" | jq -er '.version | strings')
+          head_version=$(git show "${HEAD_SHA}:npm/package.json" | jq -er '.version | strings')
+
+          if [ "${base_version}" != "${head_version}" ]; then
+            echo "npm package release-relevant files changed and version changed (${base_version} -> ${head_version}). OK."
+            exit 0
+          fi
+
+          echo "::error::This PR changes files that ship in, build, or document the npm package, but npm/package.json's version did not change."
+          echo "::error::Bump npm/package.json's version in this PR so merge triggers npm publish."
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            echo "::error file=${file}::requires an npm/package.json version bump"
+          done <<< "${release_relevant}"
+          echo "Tests-only npm changes under npm/tests/ do not require a version bump."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,8 @@ The repo is public, the package is published, and `npx -y @mvanhorn/printing-pre
 
 Single rule: **bump `npm/package.json`'s `version` field in your release PR.** Everything else is automated.
 
+An npm version bump is required for any PR that changes files that ship in, build, or document the npm package: `npm/src/**`, `npm/bin/**`, `npm/package.json`, `npm/package-lock.json`, `npm/README.md`, `npm/CHANGELOG.md`, `npm/LICENSE`, or `npm/tsconfig.json`. Tests-only changes under `npm/tests/**` do not need a bump. The `verify-npm-version-bump.yml` workflow enforces this at PR time so npm package behavior does not merge to `main` without a publishable version change.
+
 When a PR that bumps the version merges to `main`:
 
 1. `.github/workflows/auto-tag-npm.yml` detects the version change and pushes a matching `npm-v<version>` tag.
@@ -279,7 +281,7 @@ End-to-end: PR → review → merge → tag → dispatched publish, with no manu
 | `registry.json` | Fetched live by the installer; auto-regenerated post-merge with `[skip ci]` |
 | Root `README.md` / `AGENTS.md` / `CONTRIBUTING.md` | Repo docs, not in the npm tarball |
 | `.github/workflows/**` | CI infra, not in the tarball |
-| `npm/README.md` alone (no version bump) | The npmjs.com page only refreshes on republish; bump a patch version intentionally if you want it updated |
+| `npm/tests/**` only | Test coverage for the npm package, not published package behavior |
 | Bot regen commits with `[skip ci]` | Skipped by GitHub Actions |
 
 The single source of truth is `npm/package.json`'s `version`. If it didn't change in the merge to `main`, nothing publishes.


### PR DESCRIPTION
## Summary

Npm package behavior can no longer merge without a publishable version change: PRs that touch npm package inputs now fail unless `npm/package.json`'s version changes too.

The guard is intentionally lightweight: one workflow step diffs the PR, filters package code, bin shims, npm package docs, package metadata, lockfile, and TypeScript build config, then compares the base/head package versions. Tests-only npm PRs skip the workflow entirely, and deleted npm package files are treated as release-relevant. AGENTS.md now states the same rule beside the existing auto-tag and publish workflow contract.

## Testing

- `actionlint .github/workflows/verify-npm-version-bump.yml`
- local shell simulation of the no-release-relevant-change path
- local shell simulation against PR #749's merge commit proving npm source changes without a bump are caught
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
