### PR TITLE
fix(craigslist): repair site-scoped search URLs

### DIFF
--- a/library/commerce/craigslist/.printing-press-patches.json
+++ b/library/commerce/craigslist/.printing-press-patches.json
@@ -1,7 +1,22 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-08",
+  "applied_at": "2026-05-21",
   "base_run_id": "20260502-152300",
   "base_printing_press_version": "3.6.0",
-  "patches": []
+  "patches": [
+    {
+      "id": "craigslist-site-scoped-search-urls",
+      "summary": "Make craigslist search honor --site and emit real listing URLs and posting IDs.",
+      "reason": "The SAPI wrapper was tagging results with the requested site without anchoring the request geographically, and it treated Craigslist's compact posting-id offset as the final posting id.",
+      "files": [
+        "internal/source/craigslist/client.go",
+        "internal/source/craigslist/reference.go",
+        "internal/source/craigslist/sapi.go",
+        "internal/source/craigslist/sapi_test.go",
+        "internal/cli/promoted_postings.go"
+      ],
+      "validated_outcome": "Regression tests cover posting-id expansion, scalar empty-search decode, lat/lon query params, and canonical URL construction.",
+      "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/1773"
+    }
+  ]
 }

--- a/library/commerce/craigslist/internal/cli/promoted_postings.go
+++ b/library/commerce/craigslist/internal/cli/promoted_postings.go
@@ -12,6 +12,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type stringParams map[string]string
+
+func (p stringParams) Get(key string) string {
+	return p[key]
+}
+
+func (p stringParams) Set(key, value string) {
+	p[key] = value
+}
+
 func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 	var flagQuery string
 	var flagSearchPath string
@@ -40,7 +50,7 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/postings/search/full"
-			params := map[string]string{}
+			params := stringParams{}
 			if flagQuery != "" {
 				params["query"] = fmt.Sprintf("%v", flagQuery)
 			}
@@ -71,18 +81,10 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flagSearchDistance != 0 {
 				params["search_distance"] = fmt.Sprintf("%v", flagSearchDistance)
 			}
-			if flagSite != "" && flagPostal == "" {
-				area, ok, err := craigslist.New(1.0).ResolveArea(cmd.Context(), flagSite)
+			if flagSite != "" {
+				_, err := craigslist.New(1.0).ApplySiteScopeParams(cmd.Context(), flagSite, params)
 				if err != nil {
-					return fmt.Errorf("resolve craigslist site %q: %w", flagSite, err)
-				}
-				if !ok {
-					return fmt.Errorf("unknown craigslist site %q", flagSite)
-				}
-				params["lat"] = fmt.Sprintf("%v", area.Latitude)
-				params["lon"] = fmt.Sprintf("%v", area.Longitude)
-				if _, ok := params["search_distance"]; !ok {
-					params["search_distance"] = "60"
+					return err
 				}
 			}
 			if flagSrchType != "" {
@@ -91,7 +93,7 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			if flagSort != "" {
 				params["sort"] = fmt.Sprintf("%v", flagSort)
 			}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "postings", false, path, params, nil)
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "postings", false, path, map[string]string(params), nil)
 			if err != nil {
 				return classifyAPIError(err)
 			}

--- a/library/commerce/craigslist/internal/cli/promoted_postings.go
+++ b/library/commerce/craigslist/internal/cli/promoted_postings.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mvanhorn/printing-press-library/library/commerce/craigslist/internal/source/craigslist"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 	var flagHasPic int
 	var flagPostal string
 	var flagSearchDistance int
+	var flagSite string
 	var flagSrchType string
 	var flagSort string
 
@@ -68,6 +70,20 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 			if flagSearchDistance != 0 {
 				params["search_distance"] = fmt.Sprintf("%v", flagSearchDistance)
+			}
+			if flagSite != "" && flagPostal == "" {
+				area, ok, err := craigslist.New(1.0).ResolveArea(cmd.Context(), flagSite)
+				if err != nil {
+					return fmt.Errorf("resolve craigslist site %q: %w", flagSite, err)
+				}
+				if !ok {
+					return fmt.Errorf("unknown craigslist site %q", flagSite)
+				}
+				params["lat"] = fmt.Sprintf("%v", area.Latitude)
+				params["lon"] = fmt.Sprintf("%v", area.Longitude)
+				if _, ok := params["search_distance"]; !ok {
+					params["search_distance"] = "60"
+				}
 			}
 			if flagSrchType != "" {
 				params["srchType"] = fmt.Sprintf("%v", flagSrchType)
@@ -137,6 +153,7 @@ func newPostingsPromotedCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&flagHasPic, "has-pic", 0, "Set to 1 to require listings with a picture")
 	cmd.Flags().StringVar(&flagPostal, "postal", "", "ZIP / postal code to anchor distance filtering")
 	cmd.Flags().IntVar(&flagSearchDistance, "search-distance", 0, "Distance in miles from postal code")
+	cmd.Flags().StringVar(&flagSite, "site", "", "Craigslist site hostname or abbreviation to anchor the search")
 	cmd.Flags().StringVar(&flagSrchType, "srch-type", "", "Set to T to search titles only")
 	cmd.Flags().StringVar(&flagSort, "sort", "", "Sort order: date, rel, priceasc, pricedsc")
 

--- a/library/commerce/craigslist/internal/source/craigslist/client.go
+++ b/library/commerce/craigslist/internal/source/craigslist/client.go
@@ -51,7 +51,7 @@ type Client struct {
 
 	cacheMu          sync.Mutex
 	areasLoaded      bool
-	areas            []Area
+	areaByKey        map[string]Area
 	categoriesLoaded bool
 	categoryAbbrs    map[int]string
 }

--- a/library/commerce/craigslist/internal/source/craigslist/client.go
+++ b/library/commerce/craigslist/internal/source/craigslist/client.go
@@ -16,6 +16,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/commerce/craigslist/internal/cliutil"
@@ -47,6 +48,12 @@ type Client struct {
 	HTTP      *http.Client
 	UserAgent string
 	limiter   *cliutil.AdaptiveLimiter
+
+	cacheMu          sync.Mutex
+	areasLoaded      bool
+	areas            []Area
+	categoriesLoaded bool
+	categoryAbbrs    map[int]string
 }
 
 // New returns a fresh Client. ratePerSec=0 disables rate limiting; the polite

--- a/library/commerce/craigslist/internal/source/craigslist/reference.go
+++ b/library/commerce/craigslist/internal/source/craigslist/reference.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Category is one entry from reference.craigslist.org/Categories. 178 entries as of 2026.
@@ -45,6 +46,30 @@ func (c *Client) GetCategories(ctx context.Context) ([]Category, error) {
 		})
 	}
 	return out, nil
+}
+
+func (c *Client) cachedCategoryAbbrs(ctx context.Context) (map[int]string, error) {
+	c.cacheMu.Lock()
+	if c.categoriesLoaded {
+		defer c.cacheMu.Unlock()
+		return c.categoryAbbrs, nil
+	}
+	c.cacheMu.Unlock()
+
+	cats, err := c.GetCategories(ctx)
+	if err != nil {
+		return nil, err
+	}
+	abbrs := make(map[int]string, len(cats))
+	for _, cat := range cats {
+		abbrs[cat.CategoryID] = cat.Abbreviation
+	}
+
+	c.cacheMu.Lock()
+	c.categoryAbbrs = abbrs
+	c.categoriesLoaded = true
+	c.cacheMu.Unlock()
+	return abbrs, nil
 }
 
 // Area is one entry from reference.craigslist.org/Areas. 707 entries as of 2026.
@@ -127,4 +152,52 @@ func (c *Client) GetAreas(ctx context.Context) ([]Area, error) {
 		out = append(out, a)
 	}
 	return out, nil
+}
+
+func (c *Client) cachedAreas(ctx context.Context) ([]Area, error) {
+	c.cacheMu.Lock()
+	if c.areasLoaded {
+		defer c.cacheMu.Unlock()
+		return c.areas, nil
+	}
+	c.cacheMu.Unlock()
+
+	areas, err := c.GetAreas(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cacheMu.Lock()
+	c.areas = areas
+	c.areasLoaded = true
+	c.cacheMu.Unlock()
+	return areas, nil
+}
+
+// ResolveArea finds a Craigslist area by hostname or abbreviation. Common user
+// inputs include hostnames ("sfbay", "portland") and abbreviations ("nyc").
+func (c *Client) ResolveArea(ctx context.Context, site string) (Area, bool, error) {
+	key := normalizeSiteKey(site)
+	if key == "" {
+		return Area{}, false, nil
+	}
+	areas, err := c.cachedAreas(ctx)
+	if err != nil {
+		return Area{}, false, err
+	}
+	for _, area := range areas {
+		if normalizeSiteKey(area.Hostname) == key || strings.ToLower(area.Abbreviation) == key {
+			return area, true, nil
+		}
+	}
+	return Area{}, false, nil
+}
+
+func normalizeSiteKey(site string) string {
+	key := strings.ToLower(strings.TrimSpace(site))
+	key = strings.TrimPrefix(key, "https://")
+	key = strings.TrimPrefix(key, "http://")
+	key = strings.TrimSuffix(key, "/")
+	key = strings.TrimSuffix(key, ".craigslist.org")
+	return key
 }

--- a/library/commerce/craigslist/internal/source/craigslist/reference.go
+++ b/library/commerce/craigslist/internal/source/craigslist/reference.go
@@ -51,13 +51,13 @@ func (c *Client) GetCategories(ctx context.Context) ([]Category, error) {
 func (c *Client) cachedCategoryAbbrs(ctx context.Context) (map[int]string, error) {
 	c.cacheMu.Lock()
 	if c.categoriesLoaded {
-		defer c.cacheMu.Unlock()
-		return c.categoryAbbrs, nil
+		abbrs := c.categoryAbbrs
+		c.cacheMu.Unlock()
+		return abbrs, nil
 	}
-	c.cacheMu.Unlock()
-
 	cats, err := c.GetCategories(ctx)
 	if err != nil {
+		c.cacheMu.Unlock()
 		return nil, err
 	}
 	abbrs := make(map[int]string, len(cats))
@@ -65,7 +65,6 @@ func (c *Client) cachedCategoryAbbrs(ctx context.Context) (map[int]string, error
 		abbrs[cat.CategoryID] = cat.Abbreviation
 	}
 
-	c.cacheMu.Lock()
 	c.categoryAbbrs = abbrs
 	c.categoriesLoaded = true
 	c.cacheMu.Unlock()
@@ -154,24 +153,28 @@ func (c *Client) GetAreas(ctx context.Context) ([]Area, error) {
 	return out, nil
 }
 
-func (c *Client) cachedAreas(ctx context.Context) ([]Area, error) {
+func (c *Client) cachedAreaIndex(ctx context.Context) (map[string]Area, error) {
 	c.cacheMu.Lock()
 	if c.areasLoaded {
-		defer c.cacheMu.Unlock()
-		return c.areas, nil
+		areaByKey := c.areaByKey
+		c.cacheMu.Unlock()
+		return areaByKey, nil
 	}
-	c.cacheMu.Unlock()
-
 	areas, err := c.GetAreas(ctx)
 	if err != nil {
+		c.cacheMu.Unlock()
 		return nil, err
 	}
+	areaByKey := make(map[string]Area, len(areas)*2)
+	for _, area := range areas {
+		areaByKey[normalizeSiteKey(area.Hostname)] = area
+		areaByKey[strings.ToLower(area.Abbreviation)] = area
+	}
 
-	c.cacheMu.Lock()
-	c.areas = areas
+	c.areaByKey = areaByKey
 	c.areasLoaded = true
 	c.cacheMu.Unlock()
-	return areas, nil
+	return areaByKey, nil
 }
 
 // ResolveArea finds a Craigslist area by hostname or abbreviation. Common user
@@ -181,16 +184,15 @@ func (c *Client) ResolveArea(ctx context.Context, site string) (Area, bool, erro
 	if key == "" {
 		return Area{}, false, nil
 	}
-	areas, err := c.cachedAreas(ctx)
+	areaByKey, err := c.cachedAreaIndex(ctx)
 	if err != nil {
 		return Area{}, false, err
 	}
-	for _, area := range areas {
-		if normalizeSiteKey(area.Hostname) == key || strings.ToLower(area.Abbreviation) == key {
-			return area, true, nil
-		}
+	area, ok := areaByKey[key]
+	if !ok {
+		return Area{}, false, nil
 	}
-	return Area{}, false, nil
+	return area, true, nil
 }
 
 func normalizeSiteKey(site string) string {

--- a/library/commerce/craigslist/internal/source/craigslist/sapi.go
+++ b/library/commerce/craigslist/internal/source/craigslist/sapi.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const defaultSiteSearchDistanceMi = 60
+
 // SearchResults is the typed shape we extract from a sapi response. The wire format
 // is positional arrays plus shared decode tables; we expand into these structs so
 // commands and the local store work with named fields.
@@ -79,17 +81,41 @@ type rawDecode struct {
 	MinPostingID         int64             `json:"minPostingId"`
 }
 
+func (d *rawDecode) UnmarshalJSON(body []byte) error {
+	if len(body) == 0 || string(body) == "null" || body[0] != '{' {
+		*d = rawDecode{}
+		return nil
+	}
+	type rawDecodeAlias rawDecode
+	var alias rawDecodeAlias
+	if err := json.Unmarshal(body, &alias); err != nil {
+		return err
+	}
+	*d = rawDecode(alias)
+	return nil
+}
+
 // Search hits sapi.craigslist.org/web/v8/postings/search/full and returns typed results.
-// host is the area hostname (e.g. "sfbay", "nyc"); the actual API host is always sapi.craigslist.org
-// but Craigslist scopes responses by the `cc` and area-context query params plus the request's
-// implied geo. We pass site through so callers can drive cross-city fan-out.
+// site is the area hostname or abbreviation (e.g. "sfbay", "portland", "nyc").
 func (c *Client) Search(ctx context.Context, site string, q SearchQuery) (*SearchResults, error) {
+	var err error
+	q, site, err = c.applySiteScope(ctx, site, q)
+	if err != nil {
+		return nil, err
+	}
 	params := q.values()
 	body, err := c.RawGet(ctx, HostSAPI, "/postings/search/full", params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeSearchBody(body, site)
+	results, err := decodeSearchBody(body, site)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.enrichSearchURLs(ctx, results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 // SearchQuery is the typed input. Cross-city callers re-use the same query against multiple sites.
@@ -104,6 +130,8 @@ type SearchQuery struct {
 	HasPic         bool
 	Postal         string
 	SearchDistance int
+	Latitude       float64
+	Longitude      float64
 	TitleOnly      bool
 	Sort           string // date|rel|priceasc|pricedsc; default rel
 	BatchSize      int    // default 360
@@ -145,6 +173,10 @@ func (q SearchQuery) values() url.Values {
 	if q.Postal != "" {
 		v.Set("postal", q.Postal)
 	}
+	if q.Latitude != 0 && q.Longitude != 0 {
+		v.Set("lat", strconv.FormatFloat(q.Latitude, 'f', -1, 64))
+		v.Set("lon", strconv.FormatFloat(q.Longitude, 'f', -1, 64))
+	}
 	if q.SearchDistance > 0 {
 		v.Set("search_distance", strconv.Itoa(q.SearchDistance))
 	}
@@ -155,6 +187,28 @@ func (q SearchQuery) values() url.Values {
 		v.Set("sort", q.Sort)
 	}
 	return v
+}
+
+func (c *Client) applySiteScope(ctx context.Context, site string, q SearchQuery) (SearchQuery, string, error) {
+	site = strings.TrimSpace(site)
+	if site == "" {
+		return q, site, nil
+	}
+	area, ok, err := c.ResolveArea(ctx, site)
+	if err != nil {
+		return q, site, fmt.Errorf("resolve craigslist site %q: %w", site, err)
+	}
+	if !ok {
+		return q, site, fmt.Errorf("unknown craigslist site %q", site)
+	}
+	if q.Postal == "" && q.Latitude == 0 && q.Longitude == 0 {
+		q.Latitude = area.Latitude
+		q.Longitude = area.Longitude
+		if q.SearchDistance == 0 {
+			q.SearchDistance = defaultSiteSearchDistanceMi
+		}
+	}
+	return q, area.Hostname, nil
 }
 
 func decodeSearchBody(body []byte, site string) (*SearchResults, error) {
@@ -177,6 +231,7 @@ func decodeSearchBody(body []byte, site string) (*SearchResults, error) {
 		locationDescs: raw.Data.Decode.LocationDescriptions,
 		neighborhoods: raw.Data.Decode.Neighborhoods,
 		maxPostedDate: raw.Data.Decode.MaxPostedDate,
+		minPostingID:  raw.Data.Decode.MinPostingID,
 	}
 	out.Items = make([]Listing, 0, len(raw.Data.Items))
 	for _, item := range raw.Data.Items {
@@ -186,12 +241,6 @@ func decodeSearchBody(body []byte, site string) (*SearchResults, error) {
 			continue
 		}
 		l.Site = site
-		// Compose canonical URL when we know enough.
-		if l.UUID != "" && l.Slug != "" && l.PostingID > 0 {
-			// Without subarea/category abbreviation prefix we can't reconstruct the full HTML URL,
-			// but `<host>/d/<slug>/<id>.html` is also valid and redirects to the canonical form.
-			l.CanonicalURL = fmt.Sprintf("https://%s.craigslist.org/d/%s/%d.html", site, l.Slug, l.PostingID)
-		}
 		out.Items = append(out.Items, l)
 	}
 	return out, nil
@@ -202,6 +251,7 @@ type raw0Decode struct {
 	locationDescs []json.RawMessage
 	neighborhoods []json.RawMessage
 	maxPostedDate int64
+	minPostingID  int64
 }
 
 // decodeItem expands one positional-array item into a typed Listing.
@@ -227,8 +277,13 @@ func decodeItem(raw json.RawMessage, decode *raw0Decode) (Listing, error) {
 		return Listing{}, fmt.Errorf("item has %d fields, need at least 7", len(arr))
 	}
 	var l Listing
-	if err := json.Unmarshal(arr[0], &l.PostingID); err != nil {
+	var postingOffset int64
+	if err := json.Unmarshal(arr[0], &postingOffset); err != nil {
 		return Listing{}, fmt.Errorf("postingId: %w", err)
+	}
+	l.PostingID = postingOffset
+	if decode.minPostingID > 0 {
+		l.PostingID = decode.minPostingID + postingOffset
 	}
 	_ = json.Unmarshal(arr[1], &l.PostedDelta)
 	_ = json.Unmarshal(arr[2], &l.CategoryID)
@@ -288,6 +343,36 @@ func decodeItem(raw json.RawMessage, decode *raw0Decode) (Listing, error) {
 		}
 	}
 	return l, nil
+}
+
+func (c *Client) enrichSearchURLs(ctx context.Context, results *SearchResults) error {
+	categories, err := c.cachedCategoryAbbrs(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve craigslist categories: %w", err)
+	}
+	enrichSearchURLsWithCategories(results, categories)
+	return nil
+}
+
+func enrichSearchURLsWithCategories(results *SearchResults, categories map[int]string) {
+	if results == nil {
+		return
+	}
+	for i := range results.Items {
+		item := &results.Items[i]
+		category := categories[item.CategoryID]
+		item.CanonicalURL = listingURL(item.Site, item.Subarea, category, item.Slug, item.PostingID)
+	}
+}
+
+func listingURL(site, subarea, category, slug string, postingID int64) string {
+	if site == "" || category == "" || slug == "" || postingID <= 0 {
+		return ""
+	}
+	if subarea != "" {
+		return fmt.Sprintf("https://%s.craigslist.org/%s/%s/d/%s/%d.html", site, subarea, category, slug, postingID)
+	}
+	return fmt.Sprintf("https://%s.craigslist.org/%s/d/%s/%d.html", site, category, slug, postingID)
 }
 
 // parseLocation extracts subarea+neighborhood+lat+lng from "<areaIdx>:<subIdx>:<nbhIdx>~<lat>~<lng>".

--- a/library/commerce/craigslist/internal/source/craigslist/sapi.go
+++ b/library/commerce/craigslist/internal/source/craigslist/sapi.go
@@ -11,6 +11,13 @@ import (
 
 const defaultSiteSearchDistanceMi = 60
 
+// QueryParams is the small query-parameter surface needed to apply Craigslist
+// site scoping to both url.Values and generated command parameter maps.
+type QueryParams interface {
+	Get(string) string
+	Set(string, string)
+}
+
 // SearchResults is the typed shape we extract from a sapi response. The wire format
 // is positional arrays plus shared decode tables; we expand into these structs so
 // commands and the local store work with named fields.
@@ -98,12 +105,12 @@ func (d *rawDecode) UnmarshalJSON(body []byte) error {
 // Search hits sapi.craigslist.org/web/v8/postings/search/full and returns typed results.
 // site is the area hostname or abbreviation (e.g. "sfbay", "portland", "nyc").
 func (c *Client) Search(ctx context.Context, site string, q SearchQuery) (*SearchResults, error) {
+	params := q.values()
 	var err error
-	q, site, err = c.applySiteScope(ctx, site, q)
+	site, err = c.ApplySiteScopeParams(ctx, site, params)
 	if err != nil {
 		return nil, err
 	}
-	params := q.values()
 	body, err := c.RawGet(ctx, HostSAPI, "/postings/search/full", params)
 	if err != nil {
 		return nil, err
@@ -189,26 +196,26 @@ func (q SearchQuery) values() url.Values {
 	return v
 }
 
-func (c *Client) applySiteScope(ctx context.Context, site string, q SearchQuery) (SearchQuery, string, error) {
+func (c *Client) ApplySiteScopeParams(ctx context.Context, site string, params QueryParams) (string, error) {
 	site = strings.TrimSpace(site)
 	if site == "" {
-		return q, site, nil
+		return site, nil
 	}
 	area, ok, err := c.ResolveArea(ctx, site)
 	if err != nil {
-		return q, site, fmt.Errorf("resolve craigslist site %q: %w", site, err)
+		return site, fmt.Errorf("resolve craigslist site %q: %w", site, err)
 	}
 	if !ok {
-		return q, site, fmt.Errorf("unknown craigslist site %q", site)
+		return site, fmt.Errorf("unknown craigslist site %q", site)
 	}
-	if q.Postal == "" && q.Latitude == 0 && q.Longitude == 0 {
-		q.Latitude = area.Latitude
-		q.Longitude = area.Longitude
-		if q.SearchDistance == 0 {
-			q.SearchDistance = defaultSiteSearchDistanceMi
+	if params.Get("postal") == "" && (params.Get("lat") == "" || params.Get("lon") == "") {
+		params.Set("lat", strconv.FormatFloat(area.Latitude, 'f', -1, 64))
+		params.Set("lon", strconv.FormatFloat(area.Longitude, 'f', -1, 64))
+		if params.Get("search_distance") == "" {
+			params.Set("search_distance", strconv.Itoa(defaultSiteSearchDistanceMi))
 		}
 	}
-	return q, area.Hostname, nil
+	return area.Hostname, nil
 }
 
 func decodeSearchBody(body []byte, site string) (*SearchResults, error) {

--- a/library/commerce/craigslist/internal/source/craigslist/sapi_test.go
+++ b/library/commerce/craigslist/internal/source/craigslist/sapi_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -46,8 +45,13 @@ func TestDecodeSearchBody_ipadFixture(t *testing.T) {
 	if first.PostingID == 0 {
 		t.Error("first item PostingID zero")
 	}
-	if first.CanonicalURL == "" || !strings.HasPrefix(first.CanonicalURL, "https://sfbay.craigslist.org/") {
-		t.Errorf("first item CanonicalURL unexpected: %q", first.CanonicalURL)
+	if got, want := first.PostingID, int64(7915891289); got != want {
+		t.Errorf("first item PostingID: got %d, want %d", got, want)
+	}
+	enrichSearchURLsWithCategories(results, map[int]string{first.CategoryID: "ele"})
+	first = results.Items[0]
+	if got, want := first.CanonicalURL, "https://sfbay.craigslist.org/sfc/ele/d/san-francisco-apple-smart-folio-for/7915891289.html"; got != want {
+		t.Errorf("first item CanonicalURL: got %q, want %q", got, want)
 	}
 	// Most listings should have at least one image.
 	withImages := 0
@@ -58,6 +62,17 @@ func TestDecodeSearchBody_ipadFixture(t *testing.T) {
 	}
 	if withImages < len(results.Items)/2 {
 		t.Errorf("expected >50%% of items to have images, got %d/%d", withImages, len(results.Items))
+	}
+}
+
+func TestDecodeSearchBody_emptyScalarDecode(t *testing.T) {
+	body := []byte(`{"apiVersion":8,"data":{"apiVersion":8,"categoryAbbr":"sss","canonicalUrl":"//sfbay.craigslist.org/search/sss?query=missing","decode":0,"items":[],"totalResultCount":0},"errors":[]}`)
+	results, err := decodeSearchBody(body, "sfbay")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results.Items) != 0 {
+		t.Fatalf("items: got %d, want 0", len(results.Items))
 	}
 }
 
@@ -90,6 +105,8 @@ func TestSearchQueryValues_filters(t *testing.T) {
 		HasPic:         true,
 		Postal:         "94110",
 		SearchDistance: 25,
+		Latitude:       37.7749,
+		Longitude:      -122.4194,
 		TitleOnly:      true,
 		Sort:           "date",
 		Page:           2,
@@ -110,6 +127,9 @@ func TestSearchQueryValues_filters(t *testing.T) {
 	if v.Get("postal") != "94110" {
 		t.Errorf("postal: %q", v.Get("postal"))
 	}
+	if v.Get("lat") != "37.7749" || v.Get("lon") != "-122.4194" {
+		t.Errorf("lat/lon: %q/%q", v.Get("lat"), v.Get("lon"))
+	}
 	if v.Get("search_distance") != "25" {
 		t.Errorf("search_distance: %q", v.Get("search_distance"))
 	}
@@ -118,6 +138,14 @@ func TestSearchQueryValues_filters(t *testing.T) {
 	}
 	if v.Get("batch") != "2-0-360-0-0" {
 		t.Errorf("batch on page 2: %q", v.Get("batch"))
+	}
+}
+
+func TestListingURL(t *testing.T) {
+	got := listingURL("portland", "mlt", "vgm", "portland-nintendo-switch", 7930350012)
+	want := "https://portland.craigslist.org/mlt/vgm/d/portland-nintendo-switch/7930350012.html"
+	if got != want {
+		t.Fatalf("listingURL: got %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Craigslist search now returns listings from the requested site instead of silently falling back to SF Bay results, and search output now carries the real posting IDs and canonical listing URLs that users can open directly.

The fix anchors SAPI searches to the resolved Craigslist area's coordinates, expands Craigslist's compact posting ID offsets, and builds listing URLs with the real site, subarea, category, slug, and posting ID. `listing get-by-pid` now works with IDs emitted by `search`, while stale short IDs fail as not found rather than tripping the SAPI decoder. The generated `postings` shortcut also accepts `--site` so callers can scope it the same way as `search`.

This is the published-library repair for mvanhorn/cli-printing-press#1773.

## Validation

- `go test ./...` in `library/commerce/craigslist`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/commerce/craigslist`
- `git diff --check`
- Live smoke: `craigslist-pp-cli search "nintendo switch" --site portland --json --limit 1` returned `postingId: 7930350012`, `subarea: mlt`, `lat: 45.5581`, and `https://portland.craigslist.org/mlt/vgm/d/portland-donkey-kong-bananza-nintendo/7930350012.html`
- Live URL check: that Portland URL returned HTTP 200
- Live PID check: `listing get-by-pid 7930350012 --site portland --json` returned the same canonical URL

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
