### PR TITLE
chore(npm): bump package to 0.1.9

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "bin": {
         "printing-press-library": "bin/printing-press-library.mjs"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump the npm installer package from `0.1.8` to `0.1.9` so the already-merged npm runtime fix from #749 is published to npmjs.

## Why

PR #749 changed npm package behavior but merged without a version bump, so `auto-tag-npm.yml` correctly did not create a new release tag. This PR provides the missing patch release input now that #752 enforces the requirement for future npm package changes.

## Validation

- `npm test` from `npm/` passes (61 tests)
- `git diff --check` passes
