### PR TITLE
docs(library): sweep installer package name

### DIFF
--- a/library/ai/elevenlabs/README.md
+++ b/library/ai/elevenlabs/README.md
@@ -11,26 +11,26 @@ Printed by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
 The recommended path installs both the `elevenlabs-pp-cli` binary and the `pp-elevenlabs` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install elevenlabs
+npx -y @mvanhorn/printing-press-library install elevenlabs
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install elevenlabs --cli-only
+npx -y @mvanhorn/printing-press-library install elevenlabs --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install elevenlabs --skill-only
+npx -y @mvanhorn/printing-press-library install elevenlabs --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install elevenlabs --agent claude-code
-npx -y @mvanhorn/printing-press install elevenlabs --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install elevenlabs --agent claude-code
+npx -y @mvanhorn/printing-press-library install elevenlabs --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/ai/elevenlabs/SKILL.md
+++ b/library/ai/elevenlabs/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `elevenlabs-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install elevenlabs --cli-only
+   npx -y @mvanhorn/printing-press-library install elevenlabs --cli-only
    ```
 2. Verify: `elevenlabs-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/ai/elevenlabs/cmd/
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This is the documentation for the ElevenLabs API. You can use this API to use our service programmatically, this is done by using your API key. You can find your API key in the dashboard at https://elevenlabs.io/app/settings/api-keys.
 
 ## Unique Capabilities
 

--- a/library/ai/openrouter/README.md
+++ b/library/ai/openrouter/README.md
@@ -11,26 +11,26 @@ Learn more at [OpenRouter](https://openrouter.ai/docs).
 The recommended path installs both the `openrouter-pp-cli` binary and the `pp-openrouter` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install openrouter
+npx -y @mvanhorn/printing-press-library install openrouter
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openrouter --cli-only
+npx -y @mvanhorn/printing-press-library install openrouter --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openrouter --skill-only
+npx -y @mvanhorn/printing-press-library install openrouter --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install openrouter --agent claude-code
-npx -y @mvanhorn/printing-press install openrouter --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install openrouter --agent claude-code
+npx -y @mvanhorn/printing-press-library install openrouter --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/ai/openrouter/SKILL.md
+++ b/library/ai/openrouter/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `openrouter-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install openrouter --cli-only
+   npx -y @mvanhorn/printing-press-library install openrouter --cli-only
    ```
 2. Verify: `openrouter-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/ai/openrouter/cmd/
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Other OpenRouter CLIs are chat REPLs. This one is built for the cron job and the AI agent calling out to `Bash`. Absorbed introspection commands (`credits`, `models`, `key`, `generation`, `providers`) honor the global `--agent` flag (sets --json --compact --no-input). Eight novel commands (`usage cost-by`, `models query`, `key eta`, `providers degraded`, `generation explain`, `usage anomaly`, `endpoints failover`, `budget`) ship a `--llm` mode that returns under 200 tokens of key:value output. A local SQLite catalog lets you query the 400+ model list with `models query "tools=true cost.completion<1"` instead of pasting 425KB of JSON into context.
 
 ## When to Use This CLI
 

--- a/library/ai/surgegraph/README.md
+++ b/library/ai/surgegraph/README.md
@@ -11,26 +11,26 @@ Printed by [@ng-plentisoft](https://github.com/ng-plentisoft) (SurgeGraph Team).
 The recommended path installs both the `surgegraph-pp-cli` binary and the `pp-surgegraph` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install surgegraph
+npx -y @mvanhorn/printing-press-library install surgegraph
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install surgegraph --cli-only
+npx -y @mvanhorn/printing-press-library install surgegraph --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install surgegraph --skill-only
+npx -y @mvanhorn/printing-press-library install surgegraph --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install surgegraph --agent claude-code
-npx -y @mvanhorn/printing-press install surgegraph --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install surgegraph --agent claude-code
+npx -y @mvanhorn/printing-press-library install surgegraph --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/ai/surgegraph/SKILL.md
+++ b/library/ai/surgegraph/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `surgegraph-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install surgegraph --cli-only
+   npx -y @mvanhorn/printing-press-library install surgegraph --cli-only
    ```
 2. Verify: `surgegraph-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/ai/surgegraph/cmd/surgegraph-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-SurgeGraph is an AI-search content operations cockpit. The web app shows point-in-time snapshots; this CLI keeps a local cache so you can run `visibility delta`, `prompts losers`, and `citation-domains rank-shift` over time. It compounds three split workflows — topic research, bulk writing, WordPress publishing — into a single `research gaps publish` pipeline, and ships every command as both CLI and MCP so the same agent that drafts an article can monitor the citations it generates.
 
 ## When to Use This CLI
 

--- a/library/cloud/cf-domain/README.md
+++ b/library/cloud/cf-domain/README.md
@@ -7,26 +7,26 @@ Agent-native CLI for Cloudflare Registrar domain search, check, and registration
 The recommended path installs both the `cf-domain-pp-cli` binary and the `pp-cf-domain` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install cf-domain
+npx -y @mvanhorn/printing-press-library install cf-domain
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cf-domain --cli-only
+npx -y @mvanhorn/printing-press-library install cf-domain --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cf-domain --skill-only
+npx -y @mvanhorn/printing-press-library install cf-domain --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install cf-domain --agent claude-code
-npx -y @mvanhorn/printing-press install cf-domain --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install cf-domain --agent claude-code
+npx -y @mvanhorn/printing-press-library install cf-domain --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/cloud/cf-domain/SKILL.md
+++ b/library/cloud/cf-domain/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `cf-domain-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install cf-domain --cli-only
+   npx -y @mvanhorn/printing-press-library install cf-domain --cli-only
    ```
 2. Verify: `cf-domain-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/cloud/cf-domain/cm
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Agent-native CLI for Cloudflare Registrar domain search, check, and registration.
 
 ## Command Reference
 

--- a/library/cloud/cloud-run-admin/README.md
+++ b/library/cloud/cloud-run-admin/README.md
@@ -11,26 +11,26 @@ Learn more at [Google Cloud Run](https://google.com).
 The recommended path installs both the `cloud-run-admin-pp-cli` binary and the `pp-cloud-run-admin` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install cloud-run-admin
+npx -y @mvanhorn/printing-press-library install cloud-run-admin
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cloud-run-admin --cli-only
+npx -y @mvanhorn/printing-press-library install cloud-run-admin --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cloud-run-admin --skill-only
+npx -y @mvanhorn/printing-press-library install cloud-run-admin --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install cloud-run-admin --agent claude-code
-npx -y @mvanhorn/printing-press install cloud-run-admin --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install cloud-run-admin --agent claude-code
+npx -y @mvanhorn/printing-press-library install cloud-run-admin --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/cloud/cloud-run-admin/SKILL.md
+++ b/library/cloud/cloud-run-admin/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `cloud-run-admin-pp-cli` binary. **You must verify the CLI
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install cloud-run-admin --cli-only
+   npx -y @mvanhorn/printing-press-library install cloud-run-admin --cli-only
    ```
 2. Verify: `cloud-run-admin-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.25+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/cloud/cloud-run-admin/cmd/cloud-run-admin-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI wraps the Cloud Run Admin API directly for services, jobs, executions, tasks, operations, revisions, and IAM helpers. It complements gcloud by giving agents a smaller API-shaped surface with JSON-first output, field selection, local sync, search, analytics, and workflow commands.
 
 ## When to Use This CLI
 

--- a/library/cloud/digitalocean/README.md
+++ b/library/cloud/digitalocean/README.md
@@ -7,26 +7,26 @@ Learn more at [Digitalocean](https://docs.digitalocean.com/reference/api).
 The recommended path installs both the `digitalocean-pp-cli` binary and the `pp-digitalocean` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install digitalocean
+npx -y @mvanhorn/printing-press-library install digitalocean
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install digitalocean --cli-only
+npx -y @mvanhorn/printing-press-library install digitalocean --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install digitalocean --skill-only
+npx -y @mvanhorn/printing-press-library install digitalocean --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install digitalocean --agent claude-code
-npx -y @mvanhorn/printing-press install digitalocean --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install digitalocean --agent claude-code
+npx -y @mvanhorn/printing-press-library install digitalocean --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/cloud/digitalocean/SKILL.md
+++ b/library/cloud/digitalocean/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `digitalocean-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install digitalocean --cli-only
+   npx -y @mvanhorn/printing-press-library install digitalocean --cli-only
    ```
 2. Verify: `digitalocean-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/cloud/render/README.md
+++ b/library/cloud/render/README.md
@@ -11,26 +11,26 @@ Learn more at [Render](https://community.render.com).
 The recommended path installs both the `render-pp-cli` binary and the `pp-render` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install render
+npx -y @mvanhorn/printing-press-library install render
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install render --cli-only
+npx -y @mvanhorn/printing-press-library install render --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install render --skill-only
+npx -y @mvanhorn/printing-press-library install render --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install render --agent claude-code
-npx -y @mvanhorn/printing-press install render --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install render --agent claude-code
+npx -y @mvanhorn/printing-press-library install render --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/cloud/render/SKILL.md
+++ b/library/cloud/render/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `render-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install render --cli-only
+   npx -y @mvanhorn/printing-press-library install render --cli-only
    ```
 2. Verify: `render-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,7 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/cloud/render/cmd/r
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
 
 ## When to Use This CLI
 

--- a/library/commerce/amazon-orders/README.md
+++ b/library/commerce/amazon-orders/README.md
@@ -8,18 +8,30 @@ Learn more at [Amazon Orders](https://www.amazon.com).
 
 ## Install
 
-The recommended path installs both the `amazon-orders-pp-cli` binary and the `pp-amazon-orders` agent skill in one shot:
+The recommended path installs both the `amazon-orders-pp-cli` binary and the `pp-amazon-orders` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-orders
+npx -y @mvanhorn/printing-press-library install amazon-orders
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-orders --cli-only
+npx -y @mvanhorn/printing-press-library install amazon-orders --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install amazon-orders --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install amazon-orders --agent claude-code
+npx -y @mvanhorn/printing-press-library install amazon-orders --agent claude-code --agent codex
+```
 
 ### Without Node (Go fallback)
 
@@ -58,6 +70,47 @@ Tell your OpenClaw agent (copy this):
 Install the pp-amazon-orders skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-orders. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+The bundle reuses your local browser session — set it up first if you haven't:
+
+```bash
+amazon-orders-pp-cli auth login --chrome
+```
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/amazon-orders-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/cmd/amazon-orders-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "amazon-orders": {
+      "command": "amazon-orders-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Amazon publishes no buyer API. The CLI imports cookies from your logged-in Chrome / Firefox / Safari / Brave session via `auth login --chrome`. Those cookies persist locally, refresh automatically, and authenticate every subsequent fetch — no API key, no OAuth, no resident browser at runtime.
@@ -82,18 +135,14 @@ The exported JSON shape is `amazon-orders-session/v1`. `auth import` also accept
 # Import cookies from your logged-in browser session — required for any authenticated fetch.
 amazon-orders-pp-cli auth login --chrome
 
-
 # Walk the last 3 months of orders into the local store, including per-order item detail.
 amazon-orders-pp-cli sync --since 90d --concurrency 1
-
 
 # See every in-flight package with current status and ETA.
 amazon-orders-pp-cli where-is-my-stuff --json
 
-
 # Roll up your 2026 Amazon spending by month.
 amazon-orders-pp-cli spend --by month --year 2026 --json
-
 
 # Find every order containing 'usb-c cable' — FTS5-backed, instant, offline.
 amazon-orders-pp-cli find 'usb-c cable' --json
@@ -196,7 +245,6 @@ Charges and refunds across all orders, recurring services, and Prime.
 
 - **`amazon-orders-pp-cli transactions list`** - First page of your transactions list, grouped by date. Each row has payment method, last-4, signed amount, and (when applicable) the linked order ID.
 
-
 ## Output Formats
 
 ```bash
@@ -244,78 +292,6 @@ Covered command paths:
 - `amazon-orders-pp-cli transactions`
 
 JSON outputs that use the generated provenance envelope include freshness metadata at `meta.freshness`. This metadata describes the freshness decision for the covered command path; it does not claim full historical backfill or API-specific enrichment.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-amazon-orders -g
-```
-
-Then invoke `/pp-amazon-orders <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/cmd/amazon-orders-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-# Some tools work without auth. For full access, set up auth first:
-amazon-orders-pp-cli auth login --chrome
-
-claude mcp add amazon-orders amazon-orders-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-The bundle reuses your local browser session — set it up first if you haven't:
-
-```bash
-amazon-orders-pp-cli auth login --chrome
-```
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/amazon-orders-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/cmd/amazon-orders-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "amazon-orders": {
-      "command": "amazon-orders-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `amazon-orders-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install amazon-orders --cli-only
+   npx -y @mvanhorn/printing-press-library install amazon-orders --cli-only
    ```
 2. Verify: `amazon-orders-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-or
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Sync once and ask cross-cutting questions forever. Where is my stuff right now, what did I spend last quarter, which deliveries are slipping, when did I order that thing — answered in milliseconds without re-hitting the live site or burning agent context on full HTML pages.
 
 ## When to Use This CLI
 

--- a/library/commerce/amazon-seller/README.md
+++ b/library/commerce/amazon-seller/README.md
@@ -9,26 +9,26 @@ Learn more at [Amazon Seller](https://developer-docs.amazon.com/sp-api/).
 The recommended path installs both the `amazon-seller-pp-cli` binary and the `pp-amazon-seller` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-seller
+npx -y @mvanhorn/printing-press-library install amazon-seller
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-seller --cli-only
+npx -y @mvanhorn/printing-press-library install amazon-seller --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-seller --skill-only
+npx -y @mvanhorn/printing-press-library install amazon-seller --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install amazon-seller --agent claude-code
-npx -y @mvanhorn/printing-press install amazon-seller --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install amazon-seller --agent claude-code
+npx -y @mvanhorn/printing-press-library install amazon-seller --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/amazon-seller/SKILL.md
+++ b/library/commerce/amazon-seller/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `amazon-seller-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install amazon-seller --cli-only
+   npx -y @mvanhorn/printing-press-library install amazon-seller --cli-only
    ```
 2. Verify: `amazon-seller-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/craigslist/README.md
+++ b/library/commerce/craigslist/README.md
@@ -11,26 +11,26 @@ Learn more at [Craigslist](https://www.craigslist.org).
 The recommended path installs both the `craigslist-pp-cli` binary and the `pp-craigslist` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install craigslist
+npx -y @mvanhorn/printing-press-library install craigslist
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install craigslist --cli-only
+npx -y @mvanhorn/printing-press-library install craigslist --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install craigslist --skill-only
+npx -y @mvanhorn/printing-press-library install craigslist --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install craigslist --agent claude-code
-npx -y @mvanhorn/printing-press install craigslist --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install craigslist --agent claude-code
+npx -y @mvanhorn/printing-press-library install craigslist --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/craigslist/SKILL.md
+++ b/library/commerce/craigslist/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `craigslist-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install craigslist --cli-only
+   npx -y @mvanhorn/printing-press-library install craigslist --cli-only
    ```
 2. Verify: `craigslist-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/ebay/README.md
+++ b/library/commerce/ebay/README.md
@@ -26,26 +26,26 @@ See [Known Limitations](#known-limitations) for what doesn't work today.
 The recommended path installs both the `ebay-pp-cli` binary and the `pp-ebay` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ebay
+npx -y @mvanhorn/printing-press-library install ebay
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ebay --cli-only
+npx -y @mvanhorn/printing-press-library install ebay --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ebay --skill-only
+npx -y @mvanhorn/printing-press-library install ebay --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install ebay --agent claude-code
-npx -y @mvanhorn/printing-press install ebay --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install ebay --agent claude-code
+npx -y @mvanhorn/printing-press-library install ebay --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/ebay/SKILL.md
+++ b/library/commerce/ebay/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `ebay-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ebay --cli-only
+   npx -y @mvanhorn/printing-press-library install ebay --cli-only
    ```
 2. Verify: `ebay-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/facebook-marketplace/README.md
+++ b/library/commerce/facebook-marketplace/README.md
@@ -8,22 +8,40 @@ Learn more at [Facebook Marketplace](https://www.facebook.com).
 
 ## Install
 
-The recommended path installs both the `facebook-marketplace-pp-cli` binary and the `pp-facebook-marketplace` agent skill in one shot:
+The recommended path installs both the `facebook-marketplace-pp-cli` binary and the `pp-facebook-marketplace` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install facebook-marketplace
+npx -y @mvanhorn/printing-press-library install facebook-marketplace
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install facebook-marketplace --cli-only
+npx -y @mvanhorn/printing-press-library install facebook-marketplace --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install facebook-marketplace --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install facebook-marketplace --agent claude-code
+npx -y @mvanhorn/printing-press-library install facebook-marketplace --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/facebook-marketplace/cmd/facebook-marketplace-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,6 +70,45 @@ Tell your OpenClaw agent (copy this):
 Install the pp-facebook-marketplace skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-facebook-marketplace. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+The bundle reuses your local browser session — set it up first if you haven't:
+
+```bash
+facebook-marketplace-pp-cli auth login --chrome
+```
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/facebook-marketplace-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "facebook-marketplace": {
+      "command": "facebook-marketplace-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Run `facebook-marketplace-pp-cli auth login --chrome` while logged in to Facebook in Chrome. The captured browser session is the credential; do not store session material in the Dropbox project workspace.
@@ -62,10 +119,8 @@ Run `facebook-marketplace-pp-cli auth login --chrome` while logged in to Faceboo
 # Capture the local Facebook browser session before any live command.
 facebook-marketplace-pp-cli doctor
 
-
 # Confirm the session still reaches Marketplace.
 facebook-marketplace-pp-cli doctor
-
 
 # Run the captured search operation with a realistic variable payload.
 facebook-marketplace-pp-cli marketplace-search content --json
@@ -165,7 +220,6 @@ Marketplace search operations.
 
 - **`facebook-marketplace-pp-cli marketplace_search content`** - Search Marketplace listings.
 
-
 ## Output Formats
 
 ```bash
@@ -199,74 +253,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-facebook-marketplace -g
-```
-
-Then invoke `/pp-facebook-marketplace <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-# Some tools work without auth. For full access, set up auth first:
-facebook-marketplace-pp-cli auth login --chrome
-
-claude mcp add facebook-marketplace facebook-marketplace-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-The bundle reuses your local browser session — set it up first if you haven't:
-
-```bash
-facebook-marketplace-pp-cli auth login --chrome
-```
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/facebook-marketplace-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "facebook-marketplace": {
-      "command": "facebook-marketplace-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/commerce/facebook-marketplace/SKILL.md
+++ b/library/commerce/facebook-marketplace/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `facebook-marketplace-pp-cli` binary. **You must verify th
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install facebook-marketplace --cli-only
+   npx -y @mvanhorn/printing-press-library install facebook-marketplace --cli-only
    ```
 2. Verify: `facebook-marketplace-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/commerce/facebook-
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Facebook Marketplace is an authenticated browser surface, so this CLI treats the browser session as the credential and keeps writes opt-in. It turns captured Marketplace GraphQL traffic into repeatable commands, then layers local watches, matches, stale listing checks, and seller drafting on top.
 
 ## When to Use This CLI
 

--- a/library/commerce/fedex/README.md
+++ b/library/commerce/fedex/README.md
@@ -11,26 +11,26 @@ Learn more at [FedEx](https://developer.fedex.com).
 The recommended path installs both the `fedex-pp-cli` binary and the `pp-fedex` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install fedex
+npx -y @mvanhorn/printing-press-library install fedex
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fedex --cli-only
+npx -y @mvanhorn/printing-press-library install fedex --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fedex --skill-only
+npx -y @mvanhorn/printing-press-library install fedex --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install fedex --agent claude-code
-npx -y @mvanhorn/printing-press install fedex --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install fedex --agent claude-code
+npx -y @mvanhorn/printing-press-library install fedex --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/fedex/SKILL.md
+++ b/library/commerce/fedex/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `fedex-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install fedex --cli-only
+   npx -y @mvanhorn/printing-press-library install fedex --cli-only
    ```
 2. Verify: `fedex-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/gumroad/README.md
+++ b/library/commerce/gumroad/README.md
@@ -11,26 +11,26 @@ Printed by [@bheemreddy181](https://github.com/bheemreddy181) (Bheem Reddy).
 The recommended path installs both the `gumroad-pp-cli` binary and the `pp-gumroad` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install gumroad
+npx -y @mvanhorn/printing-press-library install gumroad
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gumroad --cli-only
+npx -y @mvanhorn/printing-press-library install gumroad --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gumroad --skill-only
+npx -y @mvanhorn/printing-press-library install gumroad --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install gumroad --agent claude-code
-npx -y @mvanhorn/printing-press install gumroad --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install gumroad --agent claude-code
+npx -y @mvanhorn/printing-press-library install gumroad --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/gumroad/SKILL.md
+++ b/library/commerce/gumroad/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `gumroad-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install gumroad --cli-only
+   npx -y @mvanhorn/printing-press-library install gumroad --cli-only
    ```
 2. Verify: `gumroad-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/gumroad/cmd/gumroad-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This tool wraps Gumroad's documented OAuth API for products, files, covers, variants, offer codes, custom fields, resource subscriptions, sales, subscribers, licenses, payouts, tax forms, and earnings. It also adds the Printing Press local sync/search/analytics layer so agents can answer seller questions from a consistent local snapshot instead of repeatedly walking paginated endpoints.
 
 ## When to Use This CLI
 

--- a/library/commerce/harris-teeter/README.md
+++ b/library/commerce/harris-teeter/README.md
@@ -6,21 +6,34 @@ Learn more at [Harris Teeter](https://www.harristeeter.com).
 
 ## Install
 
-The recommended path installs both the `harris-teeter-pp-cli` binary and the `pp-harris-teeter` agent skill in one shot:
+The recommended path installs both the `harris-teeter-pp-cli` binary and the `pp-harris-teeter` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install harris-teeter
+npx -y @mvanhorn/printing-press-library install harris-teeter
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install harris-teeter --cli-only
+npx -y @mvanhorn/printing-press-library install harris-teeter --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install harris-teeter --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install harris-teeter --agent claude-code
+npx -y @mvanhorn/printing-press-library install harris-teeter --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.25+):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-cli@latest
@@ -54,6 +67,46 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-harris-teeter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-harris-teeter. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+The bundle reuses your local browser session — set it up first if you haven't:
+
+```bash
+harris-teeter-pp-cli auth login --chrome
+```
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/harris-teeter-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "harris-teeter": {
+      "command": "harris-teeter-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -195,7 +248,6 @@ Find Harris Teeter stores and store metadata.
 
 - **`harris-teeter-pp-cli stores`** - Find stores by ZIP code, city, state, or address text.
 
-
 ## Output Formats
 
 ```bash
@@ -228,76 +280,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-harris-teeter -g
-```
-
-Then invoke `/pp-harris-teeter <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-# Some tools work without auth. For full access, set up auth first:
-harris-teeter-pp-cli auth login --chrome
-
-claude mcp add harris-teeter harris-teeter-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-The bundle reuses your local browser session — set it up first if you haven't:
-
-```bash
-harris-teeter-pp-cli auth login --chrome
-```
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/harris-teeter-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "harris-teeter": {
-      "command": "harris-teeter-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/commerce/harris-teeter/SKILL.md
+++ b/library/commerce/harris-teeter/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `harris-teeter-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install harris-teeter --cli-only
+   npx -y @mvanhorn/printing-press-library install harris-teeter --cli-only
    ```
 2. Verify: `harris-teeter-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.25+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Harris Teeter grocery shopping API discovered from the logged-in web app
 
 ## When Not to Use This CLI
 

--- a/library/commerce/instacart/README.md
+++ b/library/commerce/instacart/README.md
@@ -279,26 +279,26 @@ available for offline reads.
 The recommended path installs both the `instacart-pp-cli` binary and the `pp-instacart` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install instacart
+npx -y @mvanhorn/printing-press-library install instacart
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install instacart --cli-only
+npx -y @mvanhorn/printing-press-library install instacart --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install instacart --skill-only
+npx -y @mvanhorn/printing-press-library install instacart --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install instacart --agent claude-code
-npx -y @mvanhorn/printing-press install instacart --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install instacart --agent claude-code
+npx -y @mvanhorn/printing-press-library install instacart --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `instacart-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install instacart --cli-only
+   npx -y @mvanhorn/printing-press-library install instacart --cli-only
    ```
 2. Verify: `instacart-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/loopnet/README.md
+++ b/library/commerce/loopnet/README.md
@@ -13,31 +13,37 @@ Printed by [@melanson633](https://github.com/melanson633).
 The recommended path installs both the `loopnet-pp-cli` binary and the `pp-loopnet` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install loopnet
+npx -y @mvanhorn/printing-press-library install loopnet
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install loopnet --cli-only
+npx -y @mvanhorn/printing-press-library install loopnet --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install loopnet --skill-only
+npx -y @mvanhorn/printing-press-library install loopnet --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install loopnet --agent claude-code
-npx -y @mvanhorn/printing-press install loopnet --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install loopnet --agent claude-code
+npx -y @mvanhorn/printing-press-library install loopnet --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/loopnet/cmd/loopnet-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -109,18 +115,14 @@ LoopNet's data pages are protected by Akamai Bot Manager, which blocks plain HTT
 # Mint Akamai clearance cookies (briefly opens a browser). Required before any live fetch.
 loopnet-pp-cli auth refresh
 
-
 # Live search — confirm cookies work and listings parse.
 loopnet-pp-cli inventory worcester-ma --type industrial --listing for-sale --json
-
 
 # Pull the submarket into the local store (fetches are paced ~10s for Akamai).
 loopnet-pp-cli sync worcester-ma --type industrial --listing for-sale
 
-
 # Cap-rate and yield distribution, computed offline from the store.
 loopnet-pp-cli caprate worcester-ma --type industrial --agent
-
 
 # After a later sync, see which listings dropped their asking price.
 loopnet-pp-cli price-cuts worcester-ma --agent
@@ -210,7 +212,6 @@ Search LoopNet commercial real estate inventory by location, property type, and 
 Fetch the full detail record for a single LoopNet listing.
 
 - **`loopnet-pp-cli property <id>`** - Fetch one LoopNet listing's detail page. The page carries a schema.org RealEstateListing/Product JSON-LD block plus a property-facts table (price, cap rate, building class, zoning, year built, parcel numbers, tax assessments).
-
 
 ## Output Formats
 

--- a/library/commerce/loopnet/SKILL.md
+++ b/library/commerce/loopnet/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `loopnet-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install loopnet --cli-only
+   npx -y @mvanhorn/printing-press-library install loopnet --cli-only
    ```
 2. Verify: `loopnet-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/loopnet/cmd/loopnet-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-A SQLite-backed, agent-native CLI for LoopNet, the largest US commercial real estate marketplace. Search inventory and pull full listing detail like any scraper — then sync a submarket on a schedule and the local store accumulates the time series LoopNet hides. price-cuts finds every drop, dom computes true days-on-market, velocity tracks absorption, distress surfaces motivated sellers. Built to feed CRE market-intelligence pipelines: every command emits clean JSON or CSV.
 
 ## When to Use This CLI
 

--- a/library/commerce/shopify/README.md
+++ b/library/commerce/shopify/README.md
@@ -9,26 +9,26 @@ Learn more at [Shopify](https://shopify.dev/docs/api/admin-graphql).
 The recommended path installs both the `shopify-pp-cli` binary and the `pp-shopify` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install shopify
+npx -y @mvanhorn/printing-press-library install shopify
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install shopify --cli-only
+npx -y @mvanhorn/printing-press-library install shopify --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install shopify --skill-only
+npx -y @mvanhorn/printing-press-library install shopify --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install shopify --agent claude-code
-npx -y @mvanhorn/printing-press install shopify --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install shopify --agent claude-code
+npx -y @mvanhorn/printing-press-library install shopify --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/shopify/SKILL.md
+++ b/library/commerce/shopify/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `shopify-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install shopify --cli-only
+   npx -y @mvanhorn/printing-press-library install shopify --cli-only
    ```
 2. Verify: `shopify-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/slickdeals/README.md
+++ b/library/commerce/slickdeals/README.md
@@ -24,26 +24,26 @@ Learn more at [Slickdeals](https://slickdeals.net).
 The recommended path installs both the `slickdeals-pp-cli` binary and the `pp-slickdeals` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install slickdeals
+npx -y @mvanhorn/printing-press-library install slickdeals
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install slickdeals --cli-only
+npx -y @mvanhorn/printing-press-library install slickdeals --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install slickdeals --skill-only
+npx -y @mvanhorn/printing-press-library install slickdeals --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install slickdeals --agent claude-code
-npx -y @mvanhorn/printing-press install slickdeals --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install slickdeals --agent claude-code
+npx -y @mvanhorn/printing-press-library install slickdeals --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/slickdeals/SKILL.md
+++ b/library/commerce/slickdeals/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `slickdeals-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install slickdeals --cli-only
+   npx -y @mvanhorn/printing-press-library install slickdeals --cli-only
    ```
 2. Verify: `slickdeals-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/slickdeals/cmd/slickdeals-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-v0.2 release. Wraps Slickdeals' live RSS feed and Nuxt JSON endpoints in a Go CLI with agent-native --json output, local SQLite snapshot store for deal-tracking across time, and a companion MCP server. v0.2 is the read surface + local transcendence release: live RSS commands (hot/frontpage-fresh/search/category/coupons) feed the watch+digest+deals+analytics pipeline for compound queries and merchant analytics. Authenticated write features (vote/comment/submit/DM) are deferred to v0.3.
 
 ## When to Use This CLI
 

--- a/library/commerce/squarespace/README.md
+++ b/library/commerce/squarespace/README.md
@@ -2,26 +2,42 @@
 
 Squarespace Commerce API coverage plus browser-backed account dashboard reads for domains, DNS records, email forwarding, Google Workspace pricing, and domain billing metadata.
 
-
-
 ## Install
 
-The recommended path installs both the `squarespace-pp-cli` binary and the `pp-squarespace` agent skill in one shot:
+The recommended path installs both the `squarespace-pp-cli` binary and the `pp-squarespace` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install squarespace
+npx -y @mvanhorn/printing-press-library install squarespace
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install squarespace --cli-only
+npx -y @mvanhorn/printing-press-library install squarespace --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install squarespace --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install squarespace --agent claude-code
+npx -y @mvanhorn/printing-press-library install squarespace --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/squarespace/cmd/squarespace-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -49,6 +65,43 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-squarespace skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-squarespace. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/squarespace-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `COMMERCE_AUTHORIZATION` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "squarespace": {
+      "command": "squarespace-pp-mcp",
+      "env": {
+        "COMMERCE_AUTHORIZATION": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -177,7 +230,6 @@ Manage customer contacts and address book entries for a website: create, read, u
 - **`squarespace-pp-cli contacts patch`** - Updates a contact using JSON merge patch. Requires OAuth website scope WEBSITE_CONTACTS or WEBSITE_PROFILES (read/write).
 - **`squarespace-pp-cli contacts query`** - Returns a paginated list of contacts matching filters and sort options in the request body. Requires OAuth website scope WEBSITE_CONTACTS_READ, WEBSITE_CONTACTS, WEBSITE_PROFILES_READ, or WEBSITE_PROFILES.
 
-
 ## Output Formats
 
 ```bash
@@ -212,69 +264,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-squarespace -g
-```
-
-Then invoke `/pp-squarespace <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add squarespace squarespace-pp-mcp -e COMMERCE_AUTHORIZATION=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/squarespace-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `COMMERCE_AUTHORIZATION` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "squarespace": {
-      "command": "squarespace-pp-mcp",
-      "env": {
-        "COMMERCE_AUTHORIZATION": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/commerce/squarespace/SKILL.md
+++ b/library/commerce/squarespace/SKILL.md
@@ -14,20 +14,22 @@ metadata:
 
 # Squarespace — Printing Press CLI
 
-Use this skill for the public Squarespace Commerce API and for read-only account dashboard inspection through a logged-in browser session cookie.
-
 ## Prerequisites: Install the CLI
 
 This skill drives the `squarespace-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install squarespace --cli-only
+   npx -y @mvanhorn/printing-press-library install squarespace --cli-only
    ```
 2. Verify: `squarespace-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/squarespace/cmd/squarespace-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
 

--- a/library/commerce/tiktok-shop/README.md
+++ b/library/commerce/tiktok-shop/README.md
@@ -9,26 +9,26 @@ This package intentionally exposes a conservative surface based only on official
 The recommended path installs both the `tiktok-shop-pp-cli` binary and the `pp-tiktok-shop` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install tiktok-shop
+npx -y @mvanhorn/printing-press-library install tiktok-shop
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tiktok-shop --cli-only
+npx -y @mvanhorn/printing-press-library install tiktok-shop --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tiktok-shop --skill-only
+npx -y @mvanhorn/printing-press-library install tiktok-shop --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install tiktok-shop --agent claude-code
-npx -y @mvanhorn/printing-press install tiktok-shop --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install tiktok-shop --agent claude-code
+npx -y @mvanhorn/printing-press-library install tiktok-shop --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/tiktok-shop/SKILL.md
+++ b/library/commerce/tiktok-shop/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `tiktok-shop-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install tiktok-shop --cli-only
+   npx -y @mvanhorn/printing-press-library install tiktok-shop --cli-only
    ```
 2. Verify: `tiktok-shop-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/commerce/yahoo-finance/README.md
+++ b/library/commerce/yahoo-finance/README.md
@@ -29,26 +29,26 @@ This CLI combines:
 The recommended path installs both the `yahoo-finance-pp-cli` binary and the `pp-yahoo-finance` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install yahoo-finance
+npx -y @mvanhorn/printing-press-library install yahoo-finance
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install yahoo-finance --cli-only
+npx -y @mvanhorn/printing-press-library install yahoo-finance --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install yahoo-finance --skill-only
+npx -y @mvanhorn/printing-press-library install yahoo-finance --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install yahoo-finance --agent claude-code
-npx -y @mvanhorn/printing-press install yahoo-finance --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install yahoo-finance --agent claude-code
+npx -y @mvanhorn/printing-press-library install yahoo-finance --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/commerce/yahoo-finance/SKILL.md
+++ b/library/commerce/yahoo-finance/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `yahoo-finance-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install yahoo-finance --cli-only
+   npx -y @mvanhorn/printing-press-library install yahoo-finance --cli-only
    ```
 2. Verify: `yahoo-finance-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/agent-capture/SKILL.md
+++ b/library/developer-tools/agent-capture/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `agent-capture-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install agent-capture --cli-only
+   npx -y @mvanhorn/printing-press-library install agent-capture --cli-only
    ```
 2. Verify: `agent-capture-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/airframe/README.md
+++ b/library/developer-tools/airframe/README.md
@@ -175,26 +175,26 @@ NTSB only publishes their accident database in Microsoft Access binary format. T
 The recommended path installs both the `airframe-pp-cli` binary and the `pp-airframe` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install airframe
+npx -y @mvanhorn/printing-press-library install airframe
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install airframe --cli-only
+npx -y @mvanhorn/printing-press-library install airframe --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install airframe --skill-only
+npx -y @mvanhorn/printing-press-library install airframe --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install airframe --agent claude-code
-npx -y @mvanhorn/printing-press install airframe --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install airframe --agent claude-code
+npx -y @mvanhorn/printing-press-library install airframe --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/airframe/SKILL.md
+++ b/library/developer-tools/airframe/SKILL.md
@@ -18,15 +18,13 @@ metadata:
 
 # airframe — Printing Press CLI
 
-Aircraft forensics from open public data. **Two distinct data tiers — understand which one the user's question needs before doing anything.**
-
 ## Prerequisites: Install the CLI
 
 This skill drives the `airframe-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install airframe --cli-only
+   npx -y @mvanhorn/printing-press-library install airframe --cli-only
    ```
 2. Verify: `airframe-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -38,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/ai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-For Tier 2 (NTSB accident data) you'll also need the `mdbtools` package — `airframe-pp-cli doctor` reports whether it's detected and gives the install command for your OS. Tier 1 (FAA registry) works without it.
 
 ## The two-tier model (read this first, every invocation)
 

--- a/library/developer-tools/apify/README.md
+++ b/library/developer-tools/apify/README.md
@@ -11,31 +11,37 @@ Printed by [@kjmagnan1s](https://github.com/kjmagnan1s) (Kevin Magnan).
 The recommended path installs both the `apify-pp-cli` binary and the `pp-apify` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install apify
+npx -y @mvanhorn/printing-press-library install apify
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install apify --cli-only
+npx -y @mvanhorn/printing-press-library install apify --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install apify --skill-only
+npx -y @mvanhorn/printing-press-library install apify --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install apify --agent claude-code
-npx -y @mvanhorn/printing-press install apify --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install apify --agent claude-code
+npx -y @mvanhorn/printing-press-library install apify --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/apify/cmd/apify-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,22 +117,17 @@ Set `APIFY_TOKEN` (from Apify Console → Settings → Integrations) or run `api
 # Verify token, API reachability, and quota status.
 apify-pp doctor
 
-
 # Find an Actor in the public store.
 apify-pp store search 'twitter scraper' --json --select name,username,stats.totalUsers7Days
-
 
 # Run an Actor and block until terminal state.
 apify-pp run apidojo/twitter-scraper-lite --input @input.json --wait --json
 
-
 # Pull items from the run's default dataset.
 apify-pp datasets items <dataset-id> --format json --limit 100
 
-
 # Hydrate local store, then full-text search across every cached dataset.
 apify-pp sync --since 7d && apify-pp search 'AI' --since 7d --agent
-
 
 # Render a newsletter-ready markdown digest from the local store.
 apify-pp digest --topic AI --since 24h --template default --agent
@@ -788,7 +789,6 @@ header!
 When providing your API authentication token, we recommend using the
 request's `Authorization` header, rather than the URL. ([More
 info](#/introduction/authentication)).
-
 
 ## Output Formats
 

--- a/library/developer-tools/apify/SKILL.md
+++ b/library/developer-tools/apify/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `apify-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install apify --cli-only
+   npx -y @mvanhorn/printing-press-library install apify --cli-only
    ```
 2. Verify: `apify-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/apify/cmd/apify-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI is the operator-side interface to the Apify platform — agent-native JSON across every endpoint, plus a layer of features built on top of a local store that the official CLI, SDKs, and MCP can't reach: cross-Actor full-text search (`search items`), novel-only runs (`run --only-new`), per-run cost ledger (`cost report`), and templated newsletter digests (`digest`).
 
 ## When to Use This CLI
 

--- a/library/developer-tools/company-goat/README.md
+++ b/library/developer-tools/company-goat/README.md
@@ -54,26 +54,26 @@ company-goat-pp-cli funding --domain junelife.com --json
 The recommended path installs both the `company-goat-pp-cli` binary and the `pp-company-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install company-goat
+npx -y @mvanhorn/printing-press-library install company-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install company-goat --cli-only
+npx -y @mvanhorn/printing-press-library install company-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install company-goat --skill-only
+npx -y @mvanhorn/printing-press-library install company-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install company-goat --agent claude-code
-npx -y @mvanhorn/printing-press install company-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install company-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install company-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/company-goat/SKILL.md
+++ b/library/developer-tools/company-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `company-goat-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install company-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install company-goat --cli-only
    ```
 2. Verify: `company-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/docker-hub/README.md
+++ b/library/developer-tools/docker-hub/README.md
@@ -9,26 +9,26 @@ No authentication required for public repositories (rate limited to ~18 req/min)
 The recommended path installs both the `docker-hub-pp-cli` binary and the `pp-docker-hub` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install docker-hub
+npx -y @mvanhorn/printing-press-library install docker-hub
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install docker-hub --cli-only
+npx -y @mvanhorn/printing-press-library install docker-hub --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install docker-hub --skill-only
+npx -y @mvanhorn/printing-press-library install docker-hub --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install docker-hub --agent claude-code
-npx -y @mvanhorn/printing-press install docker-hub --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install docker-hub --agent claude-code
+npx -y @mvanhorn/printing-press-library install docker-hub --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/docker-hub/SKILL.md
+++ b/library/developer-tools/docker-hub/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `docker-hub-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install docker-hub --cli-only
+   npx -y @mvanhorn/printing-press-library install docker-hub --cli-only
    ```
 2. Verify: `docker-hub-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/domain-goat/README.md
+++ b/library/developer-tools/domain-goat/README.md
@@ -9,26 +9,26 @@ domain-goat absorbs everything dnstwist, openrdap, whois, and the abandoned doma
 The recommended path installs both the `domain-goat-pp-cli` binary and the `pp-domain-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install domain-goat
+npx -y @mvanhorn/printing-press-library install domain-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install domain-goat --cli-only
+npx -y @mvanhorn/printing-press-library install domain-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install domain-goat --skill-only
+npx -y @mvanhorn/printing-press-library install domain-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install domain-goat --agent claude-code
-npx -y @mvanhorn/printing-press install domain-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install domain-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install domain-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/domain-goat/SKILL.md
+++ b/library/developer-tools/domain-goat/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `domain-goat-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install domain-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install domain-goat --cli-only
    ```
 2. Verify: `domain-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/domain-goat/cmd/domain-goat-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-domain-goat absorbs everything dnstwist, openrdap, whois, and the abandoned domainr-cli ever did, then transcends with a local SQLite shortlist that knows your scores, your notes, your watch list, and 5-year renewal cost for every TLD — so you can find domains worth registering instead of just typing names into instant-domain-search.com five at a time.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/firecrawl/README.md
+++ b/library/developer-tools/firecrawl/README.md
@@ -9,26 +9,26 @@ Learn more at [Firecrawl](https://firecrawl.dev/support).
 The recommended path installs both the `firecrawl-pp-cli` binary and the `pp-firecrawl` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install firecrawl
+npx -y @mvanhorn/printing-press-library install firecrawl
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install firecrawl --cli-only
+npx -y @mvanhorn/printing-press-library install firecrawl --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install firecrawl --skill-only
+npx -y @mvanhorn/printing-press-library install firecrawl --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install firecrawl --agent claude-code
-npx -y @mvanhorn/printing-press install firecrawl --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install firecrawl --agent claude-code
+npx -y @mvanhorn/printing-press-library install firecrawl --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/firecrawl/SKILL.md
+++ b/library/developer-tools/firecrawl/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `firecrawl-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install firecrawl --cli-only
+   npx -y @mvanhorn/printing-press-library install firecrawl --cli-only
    ```
 2. Verify: `firecrawl-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/namecheap/README.md
+++ b/library/developer-tools/namecheap/README.md
@@ -11,26 +11,26 @@ by the Namecheap printed CLI patch layer.
 The recommended path installs both the `namecheap-pp-cli` binary and the `pp-namecheap` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install namecheap
+npx -y @mvanhorn/printing-press-library install namecheap
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install namecheap --cli-only
+npx -y @mvanhorn/printing-press-library install namecheap --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install namecheap --skill-only
+npx -y @mvanhorn/printing-press-library install namecheap --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install namecheap --agent claude-code
-npx -y @mvanhorn/printing-press install namecheap --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install namecheap --agent claude-code
+npx -y @mvanhorn/printing-press-library install namecheap --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/namecheap/SKILL.md
+++ b/library/developer-tools/namecheap/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `namecheap-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install namecheap --cli-only
+   npx -y @mvanhorn/printing-press-library install namecheap --cli-only
    ```
 2. Verify: `namecheap-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,12 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/na
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Curated OpenAPI description for Namecheap's XML API. The real API uses a single
-endpoint (`/xml.response`) with a `Command` query parameter plus Namecheap's
-query-string authentication parameters (`ApiUser`, `ApiKey`, `UserName`, `ClientIp`).
-Generation uses command-shaped pseudo paths that are normalized back to `/xml.response`
-by the Namecheap printed CLI patch layer.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/nse-india/README.md
+++ b/library/developer-tools/nse-india/README.md
@@ -9,26 +9,26 @@ nse-india-pp-cli fetches real-time NSE equity quotes, index constituents, corpor
 The recommended path installs both the `nse-india-pp-cli` binary and the `pp-nse-india` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install nse-india
+npx -y @mvanhorn/printing-press-library install nse-india
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nse-india --cli-only
+npx -y @mvanhorn/printing-press-library install nse-india --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nse-india --skill-only
+npx -y @mvanhorn/printing-press-library install nse-india --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install nse-india --agent claude-code
-npx -y @mvanhorn/printing-press install nse-india --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install nse-india --agent claude-code
+npx -y @mvanhorn/printing-press-library install nse-india --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/nse-india/SKILL.md
+++ b/library/developer-tools/nse-india/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `nse-india-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install nse-india --cli-only
+   npx -y @mvanhorn/printing-press-library install nse-india --cli-only
    ```
 2. Verify: `nse-india-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/nse-india/cmd/nse-india-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-nse-india-pp-cli fetches real-time NSE equity quotes, index constituents, corporate filings, and market status with just browser headers — no API key, no Python runtime, no setup friction. After sync, the local SQLite store powers cross-symbol analysis that is invisible in any single API call: delivery spikes, sector breadth, portfolio margin health, and index attribution.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/nvd/README.md
+++ b/library/developer-tools/nvd/README.md
@@ -9,26 +9,26 @@ affected versions, references, and severity ratings. No API key required (option
 The recommended path installs both the `nvd-pp-cli` binary and the `pp-nvd` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install nvd
+npx -y @mvanhorn/printing-press-library install nvd
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nvd --cli-only
+npx -y @mvanhorn/printing-press-library install nvd --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nvd --skill-only
+npx -y @mvanhorn/printing-press-library install nvd --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install nvd --agent claude-code
-npx -y @mvanhorn/printing-press install nvd --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install nvd --agent claude-code
+npx -y @mvanhorn/printing-press-library install nvd --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/nvd/SKILL.md
+++ b/library/developer-tools/nvd/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `nvd-pp-cli` binary. **You must verify the CLI is installe
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install nvd --cli-only
+   npx -y @mvanhorn/printing-press-library install nvd --cli-only
    ```
 2. Verify: `nvd-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/openfda/README.md
+++ b/library/developer-tools/openfda/README.md
@@ -7,26 +7,26 @@ The FDA safety data terminal. Every drug adverse event, device recall, food cont
 The recommended path installs both the `openfda-pp-cli` binary and the `pp-openfda` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install openfda
+npx -y @mvanhorn/printing-press-library install openfda
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openfda --cli-only
+npx -y @mvanhorn/printing-press-library install openfda --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openfda --skill-only
+npx -y @mvanhorn/printing-press-library install openfda --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install openfda --agent claude-code
-npx -y @mvanhorn/printing-press install openfda --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install openfda --agent claude-code
+npx -y @mvanhorn/printing-press-library install openfda --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/openfda/SKILL.md
+++ b/library/developer-tools/openfda/SKILL.md
@@ -20,17 +20,18 @@ This skill drives the `openfda-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install openfda --cli-only
+   npx -y @mvanhorn/printing-press-library install openfda --cli-only
    ```
 2. Verify: `openfda-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/openfda/cmd/openfda-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The FDA safety data terminal. Every drug adverse event, device recall, food contamination, and product label the FDA publishes — synced locally, searchable offline, with trend analysis no other tool offers.
-
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/openipa/README.md
+++ b/library/developer-tools/openipa/README.md
@@ -61,22 +61,40 @@ openipa-pp-cli uo list --codice agid --json
 
 ## Install
 
-The recommended path installs both the `openipa-pp-cli` binary and the `pp-openipa` agent skill in one shot:
+The recommended path installs both the `openipa-pp-cli` binary and the `pp-openipa` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install openipa
+npx -y @mvanhorn/printing-press-library install openipa
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openipa --cli-only
+npx -y @mvanhorn/printing-press-library install openipa --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install openipa --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install openipa --agent claude-code
+npx -y @mvanhorn/printing-press-library install openipa --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/openipa/cmd/openipa-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -105,6 +123,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-openipa skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-openipa. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/openipa-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `IPA_auth_id` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "openipa": {
+      "command": "openipa-pp-mcp",
+      "env": {
+        "IPA_auth_id": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Richiede un AUTH_ID gratuito da registrare su indicepa.gov.it (rilasciato immediatamente). Salvalo come variabile d'ambiente IPA_auth_id o in ~/.config/openipa/config.toml.
@@ -115,18 +170,14 @@ Richiede un AUTH_ID gratuito da registrare su indicepa.gov.it (rilasciato immedi
 # Trova il codice IPA di un ente per nome
 openipa-pp-cli enti cerca 'comune di Roma'
 
-
 # Dati anagrafici completi di un ente per codice IPA
 openipa-pp-cli enti get c_h501 --json
-
 
 # Codice destinatario SDI (cod_uni_ou) per fatturazione elettronica
 openipa-pp-cli fatturazione cf 80012000826 --json
 
-
 # Tutti i canali PA (FE + NSO + domicilio digitale) in un colpo solo
 openipa-pp-cli cf 97735020584 --json
-
 
 # Sync offline e lista enti per regione
 openipa-pp-cli sync && openipa-pp-cli enti list --regione Lazio --json
@@ -315,7 +366,6 @@ Responsabile Transizione Digitale (portale IPA — non disponibile via API pubbl
 
 Filtri disponibili: `--nominativo`, `--ente`, `--codice-ente`, `--area`, `--categoria`.
 
-
 ## Output Formats
 
 ```bash
@@ -349,69 +399,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-openipa -g
-```
-
-Then invoke `/pp-openipa <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add openipa openipa-pp-mcp -e IPA_auth_id=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/openipa-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `IPA_auth_id` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "openipa": {
-      "command": "openipa-pp-mcp",
-      "env": {
-        "IPA_auth_id": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/developer-tools/openipa/SKILL.md
+++ b/library/developer-tools/openipa/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `openipa-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install openipa --cli-only
+   npx -y @mvanhorn/printing-press-library install openipa --cli-only
    ```
 2. Verify: `openipa-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/op
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-openipa porta sul terminale le 22 API web service di IPA che gli sviluppatori usano copia-incollando curl. Con un singolo comando `openipa cf <CF>` ottieni uffici FE, nodi NSO e domicilio digitale in parallelo — tre roundtrip in uno.
 
 ## Perché openipa?
 

--- a/library/developer-tools/pdok-location/README.md
+++ b/library/developer-tools/pdok-location/README.md
@@ -26,31 +26,37 @@ Printed by [@markvandeven](https://github.com/markvandeven) (markvandeven).
 The recommended path installs both the `pdok-location-pp-cli` binary and the `pp-pdok-location` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pdok-location
+npx -y @mvanhorn/printing-press-library install pdok-location
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pdok-location --cli-only
+npx -y @mvanhorn/printing-press-library install pdok-location --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pdok-location --skill-only
+npx -y @mvanhorn/printing-press-library install pdok-location --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pdok-location --agent claude-code
-npx -y @mvanhorn/printing-press install pdok-location --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pdok-location --agent claude-code
+npx -y @mvanhorn/printing-press-library install pdok-location --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/pdok-location/cmd/pdok-location-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -122,18 +128,14 @@ Both PDOK Location services are free, open, and require no authentication or API
 # Verify the API is reachable with a real Dutch address — should return one match with lat/lon and RD coords.
 pdok-location-pp-cli free --q 'Hertog Aalbrechtweg 5 1823DL Alkmaar' --rows 1 --json
 
-
 # Demonstrate the suggest→lookup chain returning full GeoJSON geometry for the canonical match.
 pdok-location-pp-cli resolve 'Damrak Amsterdam' --geojson
-
 
 # Seed the local gazetteer (342 gemeenten, 12 provincies) so offline lookups work immediately.
 pdok-location-pp-cli sync
 
-
 # Show that gemeente lookups are now served from the local cache.
 pdok-location-pp-cli gemeente get amsterdam --json
-
 
 # Cross-source reverse geocode — nearest address, parcel, hectometer marker, and gemeente in one call.
 pdok-location-pp-cli nearest --lat 52.3731 --lon 4.8922 --json
@@ -302,7 +304,6 @@ Manage suggest
 
 - **`pdok-location-pp-cli suggest`** - De Suggest API biedt de mogelijkheid om een (gedeelte van een) zoekopdracht op
 te voeren, waarnaar er suggesties teruggegeven worden.
-
 
 ## Output Formats
 

--- a/library/developer-tools/pdok-location/SKILL.md
+++ b/library/developer-tools/pdok-location/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `pdok-location-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pdok-location --cli-only
+   npx -y @mvanhorn/printing-press-library install pdok-location --cli-only
    ```
 2. Verify: `pdok-location-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/pd
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-PDOK Location wraps both Dutch government location services in one CLI: the Solr-based Locatieserver for text geocoding and the OGC Kadaster Location API for full-geometry features. Local SQLite caches every lookup so repeats are free, and Dutch identity features like RD coordinate conversion and the suggest→lookup chain ship as one command.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/posthog/README.md
+++ b/library/developer-tools/posthog/README.md
@@ -6,22 +6,40 @@ posthog-pp-cli syncs your flags, insights, experiments, persons, errors, and LLM
 
 ## Install
 
-The recommended path installs both the `posthog-pp-cli` binary and the `pp-posthog` agent skill in one shot:
+The recommended path installs both the `posthog-pp-cli` binary and the `pp-posthog` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install posthog
+npx -y @mvanhorn/printing-press-library install posthog
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install posthog --cli-only
+npx -y @mvanhorn/printing-press-library install posthog --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install posthog --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install posthog --agent claude-code
+npx -y @mvanhorn/printing-press-library install posthog --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/posthog/cmd/posthog-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,6 +68,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-posthog skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-posthog. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/posthog-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `POSTHOG_PERSONAL_APIKEY_AUTH` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "command": "posthog-pp-mcp",
+      "env": {
+        "POSTHOG_PERSONAL_APIKEY_AUTH": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Uses your PostHog personal API key (phx_...). Set POSTHOG_API_KEY or run `posthog-pp-cli auth set-token`. Supports both US (app.posthog.com) and EU (eu.posthog.com) instances via POSTHOG_HOST.
@@ -60,18 +115,14 @@ Uses your PostHog personal API key (phx_...). Set POSTHOG_API_KEY or run `postho
 # Connect to your PostHog instance with your personal API key
 posthog-pp-cli auth set-token
 
-
 # Sync flags, insights, experiments, persons, and errors to local store
 posthog-pp-cli sync --full
-
 
 # List all feature flags with rollout rules
 posthog-pp-cli flags list --json
 
-
 # Run HogQL to see your top events
 posthog-pp-cli query run --sql "SELECT event, count() FROM events WHERE timestamp > now() - INTERVAL 7 DAY GROUP BY event ORDER BY count() DESC LIMIT 20"
-
 
 # Find everything that references a flag before archiving
 posthog-pp-cli flags blast-radius my-checkout-v2
@@ -213,7 +264,6 @@ Manage code
 
 Manage environments
 
-
 ### organizations
 
 Manage organizations
@@ -228,7 +278,6 @@ Manage organizations
 ### projects
 
 Manage projects
-
 
 ### public-hog-function-templates
 
@@ -255,7 +304,6 @@ Manage users
 - **`posthog-pp-cli users retrieve`** - Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user; non-staff callers may only access their own account.
 - **`posthog-pp-cli users update`** - Replace the authenticated user's profile and settings. Pass `@me` as the UUID to update the authenticated user. Prefer the PATCH endpoint for partial updates — PUT requires every writable field to be provided.
 - **`posthog-pp-cli users verify-email-create`** - Verify email create
-
 
 ## Output Formats
 
@@ -291,69 +339,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-posthog -g
-```
-
-Then invoke `/pp-posthog <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add posthog posthog-pp-mcp -e POSTHOG_PERSONAL_APIKEY_AUTH=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/posthog-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `POSTHOG_PERSONAL_APIKEY_AUTH` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "posthog": {
-      "command": "posthog-pp-mcp",
-      "env": {
-        "POSTHOG_PERSONAL_APIKEY_AUTH": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/developer-tools/posthog/SKILL.md
+++ b/library/developer-tools/posthog/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `posthog-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install posthog --cli-only
+   npx -y @mvanhorn/printing-press-library install posthog --cli-only
    ```
 2. Verify: `posthog-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/po
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-posthog-pp-cli sync your flags, insights, experiments, persons, errors, and LLM traces to a local SQLite store. Query anything offline, run compound analytics across resources the UI keeps separate, and pipe results directly to agents or scripts.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/postman-explore/README.md
+++ b/library/developer-tools/postman-explore/README.md
@@ -11,26 +11,26 @@ Learn more at [Postman Explore](https://www.postman.com/explore).
 The recommended path installs both the `postman-explore-pp-cli` binary and the `pp-postman-explore` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install postman-explore
+npx -y @mvanhorn/printing-press-library install postman-explore
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install postman-explore --cli-only
+npx -y @mvanhorn/printing-press-library install postman-explore --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install postman-explore --skill-only
+npx -y @mvanhorn/printing-press-library install postman-explore --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install postman-explore --agent claude-code
-npx -y @mvanhorn/printing-press install postman-explore --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install postman-explore --agent claude-code
+npx -y @mvanhorn/printing-press-library install postman-explore --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/postman-explore/SKILL.md
+++ b/library/developer-tools/postman-explore/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `postman-explore-pp-cli` binary. **You must verify the CLI
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install postman-explore --cli-only
+   npx -y @mvanhorn/printing-press-library install postman-explore --cli-only
    ```
 2. Verify: `postman-explore-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/pypi/README.md
+++ b/library/developer-tools/pypi/README.md
@@ -9,26 +9,26 @@ No authentication required — all endpoints are public.
 The recommended path installs both the `pypi-pp-cli` binary and the `pp-pypi` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pypi
+npx -y @mvanhorn/printing-press-library install pypi
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pypi --cli-only
+npx -y @mvanhorn/printing-press-library install pypi --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pypi --skill-only
+npx -y @mvanhorn/printing-press-library install pypi --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pypi --agent claude-code
-npx -y @mvanhorn/printing-press install pypi --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pypi --agent claude-code
+npx -y @mvanhorn/printing-press-library install pypi --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/pypi/SKILL.md
+++ b/library/developer-tools/pypi/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `pypi-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pypi --cli-only
+   npx -y @mvanhorn/printing-press-library install pypi --cli-only
    ```
 2. Verify: `pypi-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/scrape-creators/README.md
+++ b/library/developer-tools/scrape-creators/README.md
@@ -11,26 +11,26 @@ Learn more at [Scrape Creators](https://scrapecreators.com).
 The recommended path installs both the `scrape-creators-pp-cli` binary and the `pp-scrape-creators` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install scrape-creators
+npx -y @mvanhorn/printing-press-library install scrape-creators
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install scrape-creators --cli-only
+npx -y @mvanhorn/printing-press-library install scrape-creators --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install scrape-creators --skill-only
+npx -y @mvanhorn/printing-press-library install scrape-creators --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install scrape-creators --agent claude-code
-npx -y @mvanhorn/printing-press install scrape-creators --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install scrape-creators --agent claude-code
+npx -y @mvanhorn/printing-press-library install scrape-creators --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/scrape-creators/SKILL.md
+++ b/library/developer-tools/scrape-creators/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `scrape-creators-pp-cli` binary. **You must verify the CLI
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install scrape-creators --cli-only
+   npx -y @mvanhorn/printing-press-library install scrape-creators --cli-only
    ```
 2. Verify: `scrape-creators-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/developer-tools/sec-edgar/README.md
+++ b/library/developer-tools/sec-edgar/README.md
@@ -9,26 +9,26 @@ An agent-native CLI for the entire SEC EDGAR surface — data.sec.gov XBRL, efts
 The recommended path installs both the `sec-edgar-pp-cli` binary and the `pp-sec-edgar` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install sec-edgar
+npx -y @mvanhorn/printing-press-library install sec-edgar
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sec-edgar --cli-only
+npx -y @mvanhorn/printing-press-library install sec-edgar --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sec-edgar --skill-only
+npx -y @mvanhorn/printing-press-library install sec-edgar --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install sec-edgar --agent claude-code
-npx -y @mvanhorn/printing-press install sec-edgar --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install sec-edgar --agent claude-code
+npx -y @mvanhorn/printing-press-library install sec-edgar --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/sec-edgar/SKILL.md
+++ b/library/developer-tools/sec-edgar/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `sec-edgar-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install sec-edgar --cli-only
+   npx -y @mvanhorn/printing-press-library install sec-edgar --cli-only
    ```
 2. Verify: `sec-edgar-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/se
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-An agent-native CLI for the entire SEC EDGAR surface — data.sec.gov XBRL, efts.sec.gov full-text search, and the live Atom feed. The synced SQLite store enables joins no single SEC endpoint supports: insider-cluster detection across issuers, XBRL peer-group benchmarks by SIC, 13F holdings deltas across quarters, and live filing watches with multi-dimensional filters. All free — SEC provides no API key, just a mandatory User-Agent header.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/supabase/README.md
+++ b/library/developer-tools/supabase/README.md
@@ -14,26 +14,26 @@ Printed by [@giacaglia](https://github.com/giacaglia) (Giuliano Giacaglia).
 The recommended path installs both the `supabase-pp-cli` binary and the `pp-supabase` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install supabase
+npx -y @mvanhorn/printing-press-library install supabase
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install supabase --cli-only
+npx -y @mvanhorn/printing-press-library install supabase --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install supabase --skill-only
+npx -y @mvanhorn/printing-press-library install supabase --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install supabase --agent claude-code
-npx -y @mvanhorn/printing-press install supabase --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install supabase --agent claude-code
+npx -y @mvanhorn/printing-press-library install supabase --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/supabase/SKILL.md
+++ b/library/developer-tools/supabase/SKILL.md
@@ -21,16 +21,18 @@ This skill drives the `supabase-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install supabase --cli-only
+   npx -y @mvanhorn/printing-press-library install supabase --cli-only
    ```
 2. Verify: `supabase-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/cmd/supabase-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The official supabase CLI is local-dev tooling (Docker, migrations, types). This CLI is the runtime API surface it omits, with `--json --select --dry-run` consistency across every command. The local store enables cross-project queries (`secrets where-name STRIPE_KEY`, `branches drift --older-than 7d`, `functions inventory --org acme`) that no single live API call answers.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/trigger-dev/README.md
+++ b/library/developer-tools/trigger-dev/README.md
@@ -11,26 +11,26 @@ Learn more at [Trigger.dev](https://trigger.dev).
 The recommended path installs both the `trigger-dev-pp-cli` binary and the `pp-trigger-dev` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install trigger-dev
+npx -y @mvanhorn/printing-press-library install trigger-dev
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install trigger-dev --cli-only
+npx -y @mvanhorn/printing-press-library install trigger-dev --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install trigger-dev --skill-only
+npx -y @mvanhorn/printing-press-library install trigger-dev --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install trigger-dev --agent claude-code
-npx -y @mvanhorn/printing-press install trigger-dev --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install trigger-dev --agent claude-code
+npx -y @mvanhorn/printing-press-library install trigger-dev --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/developer-tools/trigger-dev/SKILL.md
+++ b/library/developer-tools/trigger-dev/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `trigger-dev-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install trigger-dev
+   npx -y @mvanhorn/printing-press-library install trigger-dev --cli-only
    ```
 2. Verify: `trigger-dev-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/developer-tools/tr
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-trigger-dev-pp-cli wraps the full v3 management API (47 endpoints across runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL queries) and adds the cross-run aggregations the dashboard hides one click deep — LLM span cost rollups, recurring-failure patterns, real-time failure watch with desktop notifications, env-var diffs across environments, and substring grep over cached run errors.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/uspto-tsdr/README.md
+++ b/library/developer-tools/uspto-tsdr/README.md
@@ -8,22 +8,40 @@ Beginning on October 2, 2020, you will need an API key to access the TSDR REST A
 
 ## Install
 
-The recommended path installs both the `uspto-tsdr-pp-cli` binary and the `pp-uspto-tsdr` agent skill in one shot:
+The recommended path installs both the `uspto-tsdr-pp-cli` binary and the `pp-uspto-tsdr` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install uspto-tsdr
+npx -y @mvanhorn/printing-press-library install uspto-tsdr
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install uspto-tsdr --cli-only
+npx -y @mvanhorn/printing-press-library install uspto-tsdr --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install uspto-tsdr --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install uspto-tsdr --agent claude-code
+npx -y @mvanhorn/printing-press-library install uspto-tsdr --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/uspto-tsdr/cmd/uspto-tsdr-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -51,6 +69,43 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-uspto-tsdr skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-uspto-tsdr. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/uspto-tsdr-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `TSDR_APIKEY_HEADER` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "uspto-tsdr": {
+      "command": "uspto-tsdr-pp-mcp",
+      "env": {
+        "TSDR_APIKEY_HEADER": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -148,7 +203,6 @@ Manage case multi status
 
 Manage casedoc
 
-
 ### casedocs
 
 Manage casedocs
@@ -167,13 +221,11 @@ Note: only one parameter can be specified, like sn in the example
 
 Manage casestatus
 
-
 ### raw-image
 
 Manage raw image
 
 - **`uspto-tsdr-pp-cli raw-image get-image`** - Parameter is the digits only of the serial number, no leading sn. Example: https://tsdrapi.uspto.gov/ts/cd/rawImage/78787878
-
 
 ## Output Formats
 
@@ -207,69 +259,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-uspto-tsdr -g
-```
-
-Then invoke `/pp-uspto-tsdr <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add uspto-tsdr uspto-tsdr-pp-mcp -e TSDR_APIKEY_HEADER=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/uspto-tsdr-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `TSDR_APIKEY_HEADER` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "uspto-tsdr": {
-      "command": "uspto-tsdr-pp-mcp",
-      "env": {
-        "TSDR_APIKEY_HEADER": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/developer-tools/uspto-tsdr/SKILL.md
+++ b/library/developer-tools/uspto-tsdr/SKILL.md
@@ -20,20 +20,18 @@ This skill drives the `uspto-tsdr-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install uspto-tsdr --cli-only
+   npx -y @mvanhorn/printing-press-library install uspto-tsdr --cli-only
    ```
 2. Verify: `uspto-tsdr-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/uspto-tsdr/cmd/uspto-tsdr-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Beginning on October 2, 2020, you will need an API key to access the TSDR REST API See https://account.uspto.gov/api-manager and the uspto's TSDR Data API webpage for more information on retrieving bulk data.
-
- Click on the Authorize box and enter your api key.  It is required and will be sent on all requests.
-
- This uses the uspto's swagger object with a number of changes.  The uspto's api does not allow browser request (CORS issues) so requests from this page will not actually work.  The generated curl commands will work and the modified swagger object can be imported into postman.
 
 ## When Not to Use This CLI
 

--- a/library/devices/adminbyrequest/README.md
+++ b/library/devices/adminbyrequest/README.md
@@ -6,22 +6,40 @@ Pull audit log, events, inventory and requests into a local store with one sync,
 
 ## Install
 
-The recommended path installs both the `adminbyrequest-pp-cli` binary and the `pp-adminbyrequest` agent skill in one shot:
+The recommended path installs both the `adminbyrequest-pp-cli` binary and the `pp-adminbyrequest` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install adminbyrequest
+npx -y @mvanhorn/printing-press-library install adminbyrequest
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install adminbyrequest --cli-only
+npx -y @mvanhorn/printing-press-library install adminbyrequest --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install adminbyrequest --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install adminbyrequest --agent claude-code
+npx -y @mvanhorn/printing-press-library install adminbyrequest --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/adminbyrequest/cmd/adminbyrequest-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,6 +68,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-adminbyrequest skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-adminbyrequest. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/adminbyrequest-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `ADMINBYREQUEST_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "adminbyrequest": {
+      "command": "adminbyrequest-pp-mcp",
+      "env": {
+        "ADMINBYREQUEST_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Set ADMINBYREQUEST_API_KEY in your environment. The CLI sends it via the apikey header. AbR enforces a 100,000-call daily quota per tenant; the CLI tracks calls locally and warns you before exhaustion via quota forecast.
@@ -60,18 +115,14 @@ Set ADMINBYREQUEST_API_KEY in your environment. The CLI sends it via the apikey 
 # Confirm key works and detect which AbR data center your tenant lives on.
 adminbyrequest-pp-cli doctor
 
-
 # Pull audit log, events, inventory and requests into the local SQLite store.
 adminbyrequest-pp-cli sync --full
-
 
 # Surface pending elevation requests to approve or deny.
 adminbyrequest-pp-cli requests list --status pending --json
 
-
 # Identify users repeatedly requesting elevation over the last 30 days.
 adminbyrequest-pp-cli requests repeat-offenders --window 30d --json
-
 
 # Check whether the current API usage pace will exceed the 100k daily quota.
 adminbyrequest-pp-cli quota forecast --json
@@ -173,7 +224,6 @@ Pending, approved, and denied elevation requests
 - **`adminbyrequest-pp-cli requests deny`** - Deny a pending elevation request.
 - **`adminbyrequest-pp-cli requests list`** - List elevation requests filtered by status.
 
-
 ## Output Formats
 
 ```bash
@@ -208,69 +258,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-adminbyrequest -g
-```
-
-Then invoke `/pp-adminbyrequest <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add adminbyrequest adminbyrequest-pp-mcp -e ADMINBYREQUEST_API_KEY=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/adminbyrequest-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `ADMINBYREQUEST_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "adminbyrequest": {
-      "command": "adminbyrequest-pp-mcp",
-      "env": {
-        "ADMINBYREQUEST_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/devices/adminbyrequest/SKILL.md
+++ b/library/devices/adminbyrequest/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `adminbyrequest-pp-cli` binary. **You must verify the CLI 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install adminbyrequest --cli-only
+   npx -y @mvanhorn/printing-press-library install adminbyrequest --cli-only
    ```
 2. Verify: `adminbyrequest-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/adminbyrequest/cmd/adminbyrequest-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Pull audit log, events, inventory and requests into a local store with one sync, then approve or deny elevations, generate offline PIN codes, and answer cross-resource questions (repeat requestors, agent-version drift, audit/event correlation) the portal does not surface.
 
 ## When to Use This CLI
 

--- a/library/devices/dreo/README.md
+++ b/library/devices/dreo/README.md
@@ -11,31 +11,37 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `dreo-pp-cli` binary and the `pp-dreo` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install dreo
+npx -y @mvanhorn/printing-press-library install dreo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dreo --cli-only
+npx -y @mvanhorn/printing-press-library install dreo --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dreo --skill-only
+npx -y @mvanhorn/printing-press-library install dreo --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install dreo --agent claude-code
-npx -y @mvanhorn/printing-press install dreo --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install dreo --agent claude-code
+npx -y @mvanhorn/printing-press-library install dreo --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/dreo/cmd/dreo-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -144,18 +150,14 @@ Treat the file as sensitive: don't commit it to a public repo, don't share it, a
 # Verify credentials and login round-trip against the live API
 dreo-pp-cli doctor
 
-
 # See every device on your Dreo account with model, room, and online status
 dreo-pp-cli devices list
-
 
 # Whole-house temperature, humidity, and PM2.5 in one shot
 dreo-pp-cli sensors --json
 
-
 # Turn off every tower fan in one command — the bedtime ritual
 dreo-pp-cli bulk --action off --type tower-fan
-
 
 # Live WebSocket state stream as JSON lines — the realtime debug surface no other Dreo tool exposes
 dreo-pp-cli watch --all
@@ -253,7 +255,6 @@ Read and write persistent per-device settings
 
 - **`dreo-pp-cli settings get`** - Get persistent settings for a device
 - **`dreo-pp-cli settings update`** - Update persistent settings for a device
-
 
 ## Output Formats
 

--- a/library/devices/dreo/SKILL.md
+++ b/library/devices/dreo/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `dreo-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install dreo --cli-only
+   npx -y @mvanhorn/printing-press-library install dreo --cli-only
    ```
 2. Verify: `dreo-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/dreo/cmd/dreo-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every existing Dreo client is bundled inside Home Assistant or Homebridge; this is the first general-purpose CLI. It speaks the same WebSocket control protocol the reverse-engineered clients use, plus it keeps a local SQLite cache so bulk fan-out, cross-device sensor snapshots, sensor history, scenes, and alerts work even when the cloud is slow.
 
 ## When to Use This CLI
 

--- a/library/devices/hayward-omnilogic/README.md
+++ b/library/devices/hayward-omnilogic/README.md
@@ -9,26 +9,26 @@ Drives the same partner API the Hayward mobile app and Home Assistant integratio
 The recommended path installs both the `hayward-omnilogic-pp-cli` binary and the `pp-hayward-omnilogic` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install hayward-omnilogic
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hayward-omnilogic --cli-only
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hayward-omnilogic --skill-only
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install hayward-omnilogic --agent claude-code
-npx -y @mvanhorn/printing-press install hayward-omnilogic --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic --agent claude-code
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/devices/hayward-omnilogic/SKILL.md
+++ b/library/devices/hayward-omnilogic/SKILL.md
@@ -14,27 +14,24 @@ metadata:
 
 # Hayward OmniLogic — Printing Press CLI
 
-> ## Write-command status
->
-> The Hayward `.ashx` handler overloads the `IsOn` parameter on `SetUIEquipmentCmd`: it expects `dataType="int"` 0-100 for variable-speed pumps, `dataType="bool"` `True`/`False` for everything else. This was reverse-engineered via a side-by-side packet capture against the canonical Python wrapper (`djtimca/omnilogic-api` 0.6.1).
->
-> **Verified working against the live API** (turn the pump on at 50%, observe `filterSpeed: 50` in telemetry, turn it off, observe `filterSpeed: 0`):
-> - `pump set-speed <name> --bow Pool --speed N` — VSP control 0-100. Speed=0 stops the pump.
-> - `equipment on <name> --bow Pool` — for VSPs, routes through `SetPumpSpeed(speed=100)`. For non-VSP equipment (relays, valves, single-speed accessory pumps) sends `IsOn=bool`.
-> - `equipment off <name> --bow Pool` — same routing; speed=0 for VSPs, `IsOn=False` for non-VSPs.
->
-> **Probably working but not yet verified end-to-end** (the operations use different XML shapes that didn't hit the IsOn overload trap, so they should work, but treat with care until exercised):
-> - `heater enable`, `heater disable`, `heater set-temp` (different op: `SetHeaterEnable` / `SetUIHeaterCmd`, uses `Enabled` and `Temp` params)
-> - `spillover set` (`SetUISpilloverCmd`, uses `Speed` param)
-> - `superchlor on`, `superchlor off` (`SetUISuperCHLORCmd`, uses `IsOn=bool` which is the non-overloaded form)
-> - `light show` (`SetStandAloneLightShow`, uses `Show` param)
-> - `chlorinator set-params` (`SetCHLORParams`, uses ordered fixed-format builder)
-> - `ready-by` (chains `SetHeaterEnable` + `SetUIHeaterCmd`; depends on the heater operations above)
->
-> **Always working** (read-only commands, exhaustively tested against the live API):
-> `sites list`, `config get`, `alarms list`, `telemetry get`, `chemistry get`, `status`, `sweep`, `sync`, `search`, `sql`, `command-log`, `runtime`, `schedule diff`, `chemistry log`, `chemistry drift`, `auth login/logout/status`, `doctor`, `capabilities get/set/clear`.
->
-> Cloud propagation lag is 10-15 seconds — after a successful write, `telemetry get` may show the prior state until the cloud catches up. The CLI's command response (`{"status":"ok"}`) returns as soon as Hayward accepts the request.
+## Prerequisites: Install the CLI
+
+This skill drives the `hayward-omnilogic-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
+
+1. Install via the Printing Press installer:
+   ```bash
+   npx -y @mvanhorn/printing-press-library install hayward-omnilogic --cli-only
+   ```
+2. Verify: `hayward-omnilogic-pp-cli --version`
+3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/hayward-omnilogic/cmd/hayward-omnilogic-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Pool sensor capabilities — configure once per site
 
@@ -60,24 +57,6 @@ hayward-omnilogic-pp-cli capabilities get --json
 Stored in the local SQLite store per `MspSystemID`. After configuration: `status` correctly excludes the missing sensors from its verdict, `chemistry get` returns `not_equipped` instead of `unknown` for sensors that don't exist, and `water_temp = -1` while the pump is idle is reported as `"n/a (pump off)"` instead of "sensor offline".
 
 **Agents seeing `setup_hint` in CLI output should surface the suggested `capabilities set` command to the user as a one-time setup step before relying on chemistry/temp verdicts.**
-
-## Prerequisites: Install the CLI
-
-This skill drives the `hayward-omnilogic-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
-
-1. Install via the Printing Press installer:
-   ```bash
-   npx -y @mvanhorn/printing-press install hayward-omnilogic --cli-only
-   ```
-2. Verify: `hayward-omnilogic-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
-
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
-
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Drives the same partner API the Hayward mobile app and Home Assistant integration use, but adds the historical chemistry log, the equipment diagnostic the cloud refuses to compute, the schedule-change detector for service techs, and the multi-site alarm sweep pool-service businesses ask for. Agent-native JSON throughout, with a local SQLite store that turns single-shot cloud reads into compound answers.
-
 ## When to Use This CLI
 
 Pick this CLI when an agent needs to read or control a Hayward OmniLogic pool/spa system over the partner cloud API: pool owners managing one pool, integrators wiring OmniLogic into agentic workflows, and pool-service businesses managing many sites. The CLI replaces ad-hoc Python scripts on top of `omnilogic-api`, the Hayward mobile app for diagnostics and trends, and the per-site click-through pool-service operators do every morning.

--- a/library/devices/whoop/README.md
+++ b/library/devices/whoop/README.md
@@ -7,26 +7,26 @@ Printed by [@gregvanhorn](https://github.com/gregvanhorn) (Greg Van Horn).
 The recommended path installs both the `whoop-pp-cli` binary and the `pp-whoop` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install whoop
+npx -y @mvanhorn/printing-press-library install whoop
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install whoop --cli-only
+npx -y @mvanhorn/printing-press-library install whoop --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install whoop --skill-only
+npx -y @mvanhorn/printing-press-library install whoop --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install whoop --agent claude-code
-npx -y @mvanhorn/printing-press install whoop --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install whoop --agent claude-code
+npx -y @mvanhorn/printing-press-library install whoop --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/devices/whoop/SKILL.md
+++ b/library/devices/whoop/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `whoop-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install whoop --cli-only
+   npx -y @mvanhorn/printing-press-library install whoop --cli-only
    ```
 2. Verify: `whoop-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/whoop/cmd/whoop-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-
 
 ## Command Reference
 

--- a/library/education/lawhub/README.md
+++ b/library/education/lawhub/README.md
@@ -35,24 +35,66 @@ Use `review open` to view official content in LawHub.
 
 ## Install
 
-Once published in the Printing Press library:
+The recommended path installs both the `lawhub-pp-cli` binary and the `pp-lawhub` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+
+```bash
+npx -y @mvanhorn/printing-press-library install lawhub
+```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install lawhub --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install lawhub --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install lawhub --agent claude-code
+npx -y @mvanhorn/printing-press-library install lawhub --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/education/lawhub/cmd/lawhub-pp-cli@latest
 ```
 
-Verify:
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/lawhub-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
 
 ```bash
-lawhub-pp-cli version --agent
-lawhub-pp-cli doctor --agent
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-lawhub --force
 ```
 
-Local development:
+Inside a Hermes chat session:
 
 ```bash
-make build VERSION=0.1.0-dev
-./bin/lawhub-pp-cli-go version --agent
+/skills install mvanhorn/printing-press-library/cli-skills/pp-lawhub --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-lawhub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-lawhub. The skill defines how its required CLI can be installed.
 ```
 
 ## Authentication

--- a/library/education/lawhub/SKILL.md
+++ b/library/education/lawhub/SKILL.md
@@ -18,6 +18,25 @@ metadata:
 
 # LawHub — Printing Press CLI
 
+## Prerequisites: Install the CLI
+
+This skill drives the `lawhub-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
+
+1. Install via the Printing Press installer:
+   ```bash
+   npx -y @mvanhorn/printing-press-library install lawhub --cli-only
+   ```
+2. Verify: `lawhub-pp-cli --version`
+3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/education/lawhub/cmd/lawhub-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+
 ## Prerequisites
 
 Verify the CLI is installed before use:

--- a/library/food-and-dining/allrecipes/README.md
+++ b/library/food-and-dining/allrecipes/README.md
@@ -11,26 +11,26 @@ Learn more at [Allrecipes](https://www.allrecipes.com).
 The recommended path installs both the `allrecipes-pp-cli` binary and the `pp-allrecipes` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install allrecipes
+npx -y @mvanhorn/printing-press-library install allrecipes
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install allrecipes --cli-only
+npx -y @mvanhorn/printing-press-library install allrecipes --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install allrecipes --skill-only
+npx -y @mvanhorn/printing-press-library install allrecipes --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install allrecipes --agent claude-code
-npx -y @mvanhorn/printing-press install allrecipes --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install allrecipes --agent claude-code
+npx -y @mvanhorn/printing-press-library install allrecipes --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/allrecipes/SKILL.md
+++ b/library/food-and-dining/allrecipes/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `allrecipes-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install allrecipes --cli-only
+   npx -y @mvanhorn/printing-press-library install allrecipes --cli-only
    ```
 2. Verify: `allrecipes-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/food-and-dining/anylist/README.md
+++ b/library/food-and-dining/anylist/README.md
@@ -6,22 +6,40 @@ The CLI syncs your shopping lists, recipes, and meal plan to a local SQLite data
 
 ## Install
 
-The recommended path installs both the `anylist-pp-cli` binary and the `pp-anylist` agent skill in one shot:
+The recommended path installs both the `anylist-pp-cli` binary and the `pp-anylist` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install anylist
+npx -y @mvanhorn/printing-press-library install anylist
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install anylist --cli-only
+npx -y @mvanhorn/printing-press-library install anylist --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install anylist --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install anylist --agent claude-code
+npx -y @mvanhorn/printing-press-library install anylist --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/food-and-dining/anylist/cmd/anylist-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,6 +68,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-anylist skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-anylist. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/anylist-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `ANYLIST_ACCESS_TOKEN` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "anylist": {
+      "command": "anylist-pp-mcp",
+      "env": {
+        "ANYLIST_ACCESS_TOKEN": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 AnyList uses email + password authentication returning a short-lived access_token and a refresh_token. The CLI stores these in ~/.config/anylist-pp-cli/config.toml and transparently refreshes on 401 responses. All requests require two additional headers: X-AnyLeaf-API-Version: 3 and a stable X-AnyLeaf-Client-Identifier (a 32-char hex UUID generated once per device and reused).
@@ -60,22 +115,17 @@ AnyList uses email + password authentication returning a short-lived access_toke
 # Authenticate with your AnyList email and password
 anylist-pp-cli auth login
 
-
 # Pull all your lists, recipes, and meal plan into the local SQLite cache
 anylist-pp-cli sync
-
 
 # See all your shopping lists
 anylist-pp-cli lists list
 
-
 # Pipe unchecked items to jq for scripting
 anylist-pp-cli items list --list Groceries --unchecked --json | jq '.[].name'
 
-
 # View this week's meal plan as a Mon-Sun grid
 anylist-pp-cli meal summary --week
-
 
 # Preview adding this week's recipe ingredients to your grocery list
 anylist-pp-cli meal add-to-list --week --list Groceries --dry-run
@@ -261,7 +311,6 @@ View and manage stores and store filters
 
 - **`anylist-pp-cli stores`** - List all stores and store filters
 
-
 ## Output Formats
 
 ```bash
@@ -295,69 +344,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-anylist -g
-```
-
-Then invoke `/pp-anylist <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add anylist anylist-pp-mcp -e ANYLIST_ACCESS_TOKEN=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/anylist-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `ANYLIST_ACCESS_TOKEN` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "anylist": {
-      "command": "anylist-pp-mcp",
-      "env": {
-        "ANYLIST_ACCESS_TOKEN": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/food-and-dining/anylist/SKILL.md
+++ b/library/food-and-dining/anylist/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `anylist-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install anylist --cli-only
+   npx -y @mvanhorn/printing-press-library install anylist --cli-only
    ```
 2. Verify: `anylist-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/food-and-dining/an
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The CLI syncs your shopping lists, recipes, and meal plan to a local SQLite database, then lets you query and automate everything from the shell. Search recipes by ingredient, split shopping lists by store, and build this week's grocery list from your meal plan — all scriptable, JSON-outputting, and safe to run on a schedule.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/coffee-goat/README.md
+++ b/library/food-and-dining/coffee-goat/README.md
@@ -17,26 +17,26 @@ Printed by [@justinwfu](https://github.com/justinwfu) (Justin Fu).
 The recommended path installs both the `coffee-goat-pp-cli` binary and the `pp-coffee-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install coffee-goat
+npx -y @mvanhorn/printing-press-library install coffee-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install coffee-goat --cli-only
+npx -y @mvanhorn/printing-press-library install coffee-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install coffee-goat --skill-only
+npx -y @mvanhorn/printing-press-library install coffee-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install coffee-goat --agent claude-code
-npx -y @mvanhorn/printing-press install coffee-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install coffee-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install coffee-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -121,22 +121,17 @@ No API key required. All shipped sources are no-auth: roaster storefronts via pu
 # Confirm youtube-pp-cli is on PATH and the representative roaster (Onyx) is reachable
 coffee-goat doctor
 
-
 # Pull catalogs from Shopify roasters, Coffee Review, and the Hoffmann + Hedrick YouTube channels into the local store
 coffee-goat sync
-
 
 # Cross-roaster origin/process search — every Ethiopian natural under $25 ($25.00 = 2500 cents) across the global shelf
 coffee-goat search "ethiopia natural" --in-stock --price-lt 2500 --agent
 
-
 # Find the closest current match across roasters for a bean you loved (use any synced roaster_products handle)
 coffee-goat twin sey-banko-gotiti --top 5 --agent
 
-
 # Show every Hoffmann/Hedrick clip mentioning Onyx with transcript excerpts
 coffee-goat creator-review onyx --agent
-
 
 # Integrates shelf + brews + Coffee Review + creator transcripts into one brew-now and one buy-next pick (works against fixture data; cellar/brew CLI is Phase 3 follow-up)
 coffee-goat god-cup --method espresso --agent
@@ -377,7 +372,6 @@ Run `coffee-goat-pp-cli --help` for the full command reference and flag list.
 Unified roaster product corpus synced from 24 specialty coffee roasters
 
 - **`coffee-goat-pp-cli products`** - List synced roaster products with structured filters
-
 
 ## Output Formats
 

--- a/library/food-and-dining/coffee-goat/SKILL.md
+++ b/library/food-and-dining/coffee-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `coffee-goat-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install coffee-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install coffee-goat --cli-only
    ```
 2. Verify: `coffee-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/food-and-dining/co
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-coffee-goat aggregates the global specialty-coffee shelf via Shopify-backed roaster storefronts, Coffee Review scores, and James Hoffmann + Lance Hedrick YouTube transcripts (via the youtube-pp-cli sibling) into one no-auth local SQLite corpus — then joins it with your personal brew log. Cross-roaster search, restock watch, closest-twin replacement, creator-clip lookup, SCA flavor-wheel palate mapping, friend-pick recommendations, and the eponymous `god-cup` recommender that integrates shelf freshness + brew history + Coffee Review + creator coverage into one brew-now and one buy-next pick. (Champion recipes, cafe finder, drift diagnostics, and 11 other commands documented in the absorb manifest are Phase 3 follow-up.)
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/dominos/README.md
+++ b/library/food-and-dining/dominos/README.md
@@ -9,26 +9,26 @@ Every Domino's feature you would expect — store locator, menu browse, build ca
 The recommended path installs both the `dominos-pp-cli` binary and the `pp-dominos` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install dominos
+npx -y @mvanhorn/printing-press-library install dominos
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dominos --cli-only
+npx -y @mvanhorn/printing-press-library install dominos --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dominos --skill-only
+npx -y @mvanhorn/printing-press-library install dominos --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install dominos --agent claude-code
-npx -y @mvanhorn/printing-press install dominos --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install dominos --agent claude-code
+npx -y @mvanhorn/printing-press-library install dominos --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/dominos/SKILL.md
+++ b/library/food-and-dining/dominos/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `dominos-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install dominos --cli-only
+   npx -y @mvanhorn/printing-press-library install dominos --cli-only
    ```
 2. Verify: `dominos-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/food-and-dining/food52/README.md
+++ b/library/food-and-dining/food52/README.md
@@ -11,26 +11,26 @@ Learn more at [Food52](https://food52.com).
 The recommended path installs both the `food52-pp-cli` binary and the `pp-food52` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install food52
+npx -y @mvanhorn/printing-press-library install food52
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install food52 --cli-only
+npx -y @mvanhorn/printing-press-library install food52 --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install food52 --skill-only
+npx -y @mvanhorn/printing-press-library install food52 --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install food52 --agent claude-code
-npx -y @mvanhorn/printing-press install food52 --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install food52 --agent claude-code
+npx -y @mvanhorn/printing-press-library install food52 --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/food52/SKILL.md
+++ b/library/food-and-dining/food52/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `food52-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install food52 --cli-only
+   npx -y @mvanhorn/printing-press-library install food52 --cli-only
    ```
 2. Verify: `food52-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/food-and-dining/jimmy-johns/README.md
+++ b/library/food-and-dining/jimmy-johns/README.md
@@ -11,26 +11,26 @@ Learn more at [Jimmy John's](https://www.jimmyjohns.com).
 The recommended path installs both the `jimmy-johns-pp-cli` binary and the `pp-jimmy-johns` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install jimmy-johns
+npx -y @mvanhorn/printing-press-library install jimmy-johns
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jimmy-johns --cli-only
+npx -y @mvanhorn/printing-press-library install jimmy-johns --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jimmy-johns --skill-only
+npx -y @mvanhorn/printing-press-library install jimmy-johns --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install jimmy-johns --agent claude-code
-npx -y @mvanhorn/printing-press install jimmy-johns --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install jimmy-johns --agent claude-code
+npx -y @mvanhorn/printing-press-library install jimmy-johns --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/jimmy-johns/SKILL.md
+++ b/library/food-and-dining/jimmy-johns/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `jimmy-johns-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install jimmy-johns --cli-only
+   npx -y @mvanhorn/printing-press-library install jimmy-johns --cli-only
    ```
 2. Verify: `jimmy-johns-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/food-and-dining/jimmy-johns/cmd/jimmy-johns-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Browse stores and menus, build carts, view rewards, and one-shot reorders from the terminal. The Unwich converter computes lettuce-wrap modifier deltas locally so agents can build no-bread orders without an extra API round trip.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/ordertogo/README.md
+++ b/library/food-and-dining/ordertogo/README.md
@@ -11,26 +11,26 @@ Learn more at [OrderToGo](https://www.ordertogo.com).
 The recommended path installs both the `ordertogo-pp-cli` binary and the `pp-ordertogo` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ordertogo
+npx -y @mvanhorn/printing-press-library install ordertogo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ordertogo --cli-only
+npx -y @mvanhorn/printing-press-library install ordertogo --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ordertogo --skill-only
+npx -y @mvanhorn/printing-press-library install ordertogo --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install ordertogo --agent claude-code
-npx -y @mvanhorn/printing-press install ordertogo --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install ordertogo --agent claude-code
+npx -y @mvanhorn/printing-press-library install ordertogo --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/ordertogo/SKILL.md
+++ b/library/food-and-dining/ordertogo/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `ordertogo-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ordertogo --cli-only
+   npx -y @mvanhorn/printing-press-library install ordertogo --cli-only
    ```
 2. Verify: `ordertogo-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/food-and-dining/or
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-OrderToGo.com is a multi-tenant pickup ordering platform that powers small chains across multiple US metros. There is no CLI, MCP, or SDK presence anywhere for it. This CLI gives an agent every read endpoint, a safe `order plan` that composes a cart locally and validates against a `--max` cap, and an `order place` that drives a headless Chrome through Braintree DropIn to actually submit. Everything is offline-cacheable, agent-callable, and verify-env safe by construction.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/pagliacci/README.md
+++ b/library/food-and-dining/pagliacci/README.md
@@ -9,26 +9,26 @@ First and only CLI for the Pagliacci API. Browse menus and slice availability ac
 The recommended path installs both the `pagliacci-pp-cli` binary and the `pp-pagliacci` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pagliacci
+npx -y @mvanhorn/printing-press-library install pagliacci
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pagliacci --cli-only
+npx -y @mvanhorn/printing-press-library install pagliacci --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pagliacci --skill-only
+npx -y @mvanhorn/printing-press-library install pagliacci --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pagliacci --agent claude-code
-npx -y @mvanhorn/printing-press install pagliacci --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pagliacci --agent claude-code
+npx -y @mvanhorn/printing-press-library install pagliacci --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/pagliacci/SKILL.md
+++ b/library/food-and-dining/pagliacci/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `pagliacci-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pagliacci --cli-only
+   npx -y @mvanhorn/printing-press-library install pagliacci --cli-only
    ```
 2. Verify: `pagliacci-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/food-and-dining/rappi/README.md
+++ b/library/food-and-dining/rappi/README.md
@@ -10,22 +10,40 @@ Printed by [@bobeglz](https://github.com/bobeglz) (bobe).
 
 ## Install
 
-The recommended path installs both the `rappi-pp-cli` binary and the `pp-rappi` agent skill in one shot:
+The recommended path installs both the `rappi-pp-cli` binary and the `pp-rappi` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install rappi
+npx -y @mvanhorn/printing-press-library install rappi
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install rappi --cli-only
+npx -y @mvanhorn/printing-press-library install rappi --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install rappi --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install rappi --agent claude-code
+npx -y @mvanhorn/printing-press-library install rappi --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/food-and-dining/rappi/cmd/rappi-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,6 +72,39 @@ Tell your OpenClaw agent (copy this):
 Install the pp-rappi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-rappi. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/rappi-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "rappi": {
+      "command": "rappi-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 No login or API key required. The CLI reads only public catalog pages (restaurants, stores, categories, promotions). Cart, orders, and account features are out of scope by design and not exposed in this CLI.
@@ -64,18 +115,14 @@ No login or API key required. The CLI reads only public catalog pages (restauran
 # Confirm the CLI can reach rappi.com.mx and write to its config path.
 rappi-pp-cli doctor
 
-
 # Snapshot the CDMX restaurant + store catalog into the local SQLite store. Takes about a minute.
 rappi-pp-cli sync
-
 
 # The listicle-grade filter Rappi UI hides — pick top-rated burgers with a real review-count floor.
 rappi-pp-cli restaurants top --city ciudad-de-mexico --category hamburguesas --min-rating 4.5 --min-reviews 100 --limit 10 --agent
 
-
 # Cross-city coverage matrix across all five store types — the analyst view Rappi has no UI for.
 rappi-pp-cli stores coverage --cities ciudad-de-mexico,guadalajara,monterrey --agent
-
 
 # FTS5 search across the synced catalog with field selection for narrow agent output.
 rappi-pp-cli search "sushi roma" --agent --select id,name,rating,address
@@ -192,7 +239,6 @@ Supermarket, pharmacy, liquor, and convenience store catalog
 
 - **`rappi-pp-cli stores get`** - Fetch a store detail page (name, type, address, branding)
 - **`rappi-pp-cli stores list-by-type`** - List stores by type (market for supermarkets, farmatodo for pharmacy, liquor, express, rappimall-parent)
-
 
 ## Output Formats
 
@@ -312,65 +358,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-rappi -g
-```
-
-Then invoke `/pp-rappi <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add rappi rappi-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/rappi-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "rappi": {
-      "command": "rappi-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/food-and-dining/rappi/SKILL.md
+++ b/library/food-and-dining/rappi/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `rappi-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install rappi --cli-only
+   npx -y @mvanhorn/printing-press-library install rappi --cli-only
    ```
 2. Verify: `rappi-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/food-and-dining/ra
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Browse restaurants and stores across every Mexican city Rappi serves, snapshot the catalog to a local SQLite database, then ask questions the Rappi UI cannot answer — like "which sushi spots opened in Roma Norte this month," "top-rated burgers with 100+ reviews," or "pharmacies within 1km of a supermarket." All read-only and proxy-free.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/recipe-goat/README.md
+++ b/library/food-and-dining/recipe-goat/README.md
@@ -7,26 +7,26 @@ Recipe GOAT — find the best version of any recipe across 37 trusted sites, wit
 The recommended path installs both the `recipe-goat-pp-cli` binary and the `pp-recipe-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install recipe-goat
+npx -y @mvanhorn/printing-press-library install recipe-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install recipe-goat --cli-only
+npx -y @mvanhorn/printing-press-library install recipe-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install recipe-goat --skill-only
+npx -y @mvanhorn/printing-press-library install recipe-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install recipe-goat --agent claude-code
-npx -y @mvanhorn/printing-press install recipe-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install recipe-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install recipe-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `recipe-goat-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install recipe-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install recipe-goat --cli-only
    ```
 2. Verify: `recipe-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/food-and-dining/table-reservation-goat/README.md
+++ b/library/food-and-dining/table-reservation-goat/README.md
@@ -9,26 +9,26 @@ OpenTable, Tock, and Resy split the US fine-dining world between them and share 
 The recommended path installs both the `table-reservation-goat-pp-cli` binary and the `pp-table-reservation-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install table-reservation-goat
+npx -y @mvanhorn/printing-press-library install table-reservation-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install table-reservation-goat --cli-only
+npx -y @mvanhorn/printing-press-library install table-reservation-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install table-reservation-goat --skill-only
+npx -y @mvanhorn/printing-press-library install table-reservation-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install table-reservation-goat --agent claude-code
-npx -y @mvanhorn/printing-press install table-reservation-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install table-reservation-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install table-reservation-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/food-and-dining/table-reservation-goat/SKILL.md
+++ b/library/food-and-dining/table-reservation-goat/SKILL.md
@@ -20,23 +20,18 @@ This skill drives the `table-reservation-goat-pp-cli` binary. **You must verify 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install table-reservation-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install table-reservation-goat --cli-only
    ```
 2. Verify: `table-reservation-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/cmd/table-reservation-goat-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-OpenTable, Tock, and Resy split the US fine-dining world between them and share zero data. This CLI unifies them: `goat` searches all three at once, `watch` polls each network for cancellations, `earliest` composes availability across all three, and `drift` surfaces what changed at a venue since your last look.
-
-**Authentication** is two commands, each run once:
-
-- `auth login --chrome` imports OpenTable + Tock session cookies from your local Chrome profile.
-- `auth login --resy --email <you@example.com>` exchanges Resy email + password for a long-lived API token; the password is consumed and never persisted.
-
-**Network-prefixed addressing.** Resy venues are addressed by numeric id (`resy:1387`); OpenTable by numeric id or URL slug (`opentable:le-bernardin`); Tock by domain-name slug (`tock:alinea`).
 
 ## When to Use This CLI
 

--- a/library/marketing/ahrefs/README.md
+++ b/library/marketing/ahrefs/README.md
@@ -9,26 +9,26 @@ Learn more at [Ahrefs](https://docs.ahrefs.com/docs/api/reference/introduction).
 The recommended path installs both the `ahrefs-pp-cli` binary and the `pp-ahrefs` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ahrefs
+npx -y @mvanhorn/printing-press-library install ahrefs
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ahrefs --cli-only
+npx -y @mvanhorn/printing-press-library install ahrefs --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ahrefs --skill-only
+npx -y @mvanhorn/printing-press-library install ahrefs --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install ahrefs --agent claude-code
-npx -y @mvanhorn/printing-press install ahrefs --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install ahrefs --agent claude-code
+npx -y @mvanhorn/printing-press-library install ahrefs --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/ahrefs/SKILL.md
+++ b/library/marketing/ahrefs/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `ahrefs-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ahrefs --cli-only
+   npx -y @mvanhorn/printing-press-library install ahrefs --cli-only
    ```
 2. Verify: `ahrefs-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/beehiiv/README.md
+++ b/library/marketing/beehiiv/README.md
@@ -5,26 +5,26 @@
 The recommended path installs both the `beehiiv-pp-cli` binary and the `pp-beehiiv` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install beehiiv
+npx -y @mvanhorn/printing-press-library install beehiiv
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install beehiiv --cli-only
+npx -y @mvanhorn/printing-press-library install beehiiv --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install beehiiv --skill-only
+npx -y @mvanhorn/printing-press-library install beehiiv --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install beehiiv --agent claude-code
-npx -y @mvanhorn/printing-press install beehiiv --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install beehiiv --agent claude-code
+npx -y @mvanhorn/printing-press-library install beehiiv --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/beehiiv/SKILL.md
+++ b/library/marketing/beehiiv/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `beehiiv-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install beehiiv --cli-only
+   npx -y @mvanhorn/printing-press-library install beehiiv --cli-only
    ```
 2. Verify: `beehiiv-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/clarity/README.md
+++ b/library/marketing/clarity/README.md
@@ -11,26 +11,26 @@ Learn more at [PP Clarity](https://clarity.microsoft.com).
 The recommended path installs both the `clarity-pp-cli` binary and the `pp-clarity` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install clarity
+npx -y @mvanhorn/printing-press-library install clarity
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install clarity --cli-only
+npx -y @mvanhorn/printing-press-library install clarity --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install clarity --skill-only
+npx -y @mvanhorn/printing-press-library install clarity --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install clarity --agent claude-code
-npx -y @mvanhorn/printing-press install clarity --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install clarity --agent claude-code
+npx -y @mvanhorn/printing-press-library install clarity --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/clarity/SKILL.md
+++ b/library/marketing/clarity/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `clarity-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install clarity --cli-only
+   npx -y @mvanhorn/printing-press-library install clarity --cli-only
    ```
 2. Verify: `clarity-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/clarity/cmd/clarity-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/marketing/clarity/cmd/clarity-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Microsoft Clarity's client API is made of JavaScript calls and HTML attributes, so this CLI treats it as an instrumentation assistant instead of a fake REST wrapper. It can fetch the public tag script, render copy-safe snippets, and audit local HTML for the calls Microsoft documents.
 
 ## When to Use This CLI
 

--- a/library/marketing/customer-io/README.md
+++ b/library/marketing/customer-io/README.md
@@ -9,26 +9,26 @@ The official customerio/cli exposes the API as raw passthrough. This CLI gives y
 The recommended path installs both the `customer-io-pp-cli` binary and the `pp-customer-io` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install customer-io
+npx -y @mvanhorn/printing-press-library install customer-io
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install customer-io --cli-only
+npx -y @mvanhorn/printing-press-library install customer-io --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install customer-io --skill-only
+npx -y @mvanhorn/printing-press-library install customer-io --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install customer-io --agent claude-code
-npx -y @mvanhorn/printing-press install customer-io --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install customer-io --agent claude-code
+npx -y @mvanhorn/printing-press-library install customer-io --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/customer-io/SKILL.md
+++ b/library/marketing/customer-io/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `customer-io-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install customer-io --cli-only
+   npx -y @mvanhorn/printing-press-library install customer-io --cli-only
    ```
 2. Verify: `customer-io-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,12 +32,10 @@ This skill drives the `customer-io-pp-cli` binary. **You must verify the CLI is 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/customer-io/cmd/customer-io-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/marketing/customer-io/cmd/customer-io-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The official customerio/cli exposes the API as raw passthrough. This CLI gives you typed commands for every meaningful workflow, plus eight commands no other tool has — journey funnels cross-cut by segment, multi-segment overlap, customer 360 timelines, broadcast pre-flight, suppression audit trails, Reverse-ETL health, bulk suppress with provenance, and incident-ready delivery triage bundles. It is also the only Customer.io tool that ships an MCP server.
 
 ## When to Use This CLI
 

--- a/library/marketing/dub/README.md
+++ b/library/marketing/dub/README.md
@@ -11,26 +11,26 @@ Learn more at [Dub](https://dub.co/support).
 The recommended path installs both the `dub-pp-cli` binary and the `pp-dub` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install dub
+npx -y @mvanhorn/printing-press-library install dub
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dub --cli-only
+npx -y @mvanhorn/printing-press-library install dub --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install dub --skill-only
+npx -y @mvanhorn/printing-press-library install dub --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install dub --agent claude-code
-npx -y @mvanhorn/printing-press install dub --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install dub --agent claude-code
+npx -y @mvanhorn/printing-press-library install dub --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/dub/SKILL.md
+++ b/library/marketing/dub/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `dub-pp-cli` binary. **You must verify the CLI is installe
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install dub --cli-only
+   npx -y @mvanhorn/printing-press-library install dub --cli-only
    ```
 2. Verify: `dub-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/emailoctopus/README.md
+++ b/library/marketing/emailoctopus/README.md
@@ -11,31 +11,37 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `emailoctopus-pp-cli` binary and the `pp-emailoctopus` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install emailoctopus
+npx -y @mvanhorn/printing-press-library install emailoctopus
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install emailoctopus --cli-only
+npx -y @mvanhorn/printing-press-library install emailoctopus --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install emailoctopus --skill-only
+npx -y @mvanhorn/printing-press-library install emailoctopus --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install emailoctopus --agent claude-code
-npx -y @mvanhorn/printing-press install emailoctopus --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install emailoctopus --agent claude-code
+npx -y @mvanhorn/printing-press-library install emailoctopus --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/emailoctopus/cmd/emailoctopus-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,18 +117,14 @@ Generate a v2 key at https://api.emailoctopus.com/developer/api-keys/create and 
 # Verify auth and reachability before doing anything else.
 emailoctopus-pp-cli doctor
 
-
 # Inventory your lists and grab the list_id you'll use below.
 emailoctopus-pp-cli lists list --json
-
 
 # Pull every list, contact, tag, field, and campaign into the local SQLite store.
 emailoctopus-pp-cli sync --full
 
-
 # Surface cold subscribers — the API has no equivalent.
 emailoctopus-pp-cli contacts engagement --list <list_id> --inactive-since 90d --json
-
 
 # Paste-ready campaign report in one command.
 emailoctopus-pp-cli campaigns digest 071f24b2-51cd-11f1-a3ce-11fd783017da --md
@@ -208,7 +210,6 @@ Run `emailoctopus-pp-cli --help` for the full command reference and flag list.
 An automation is a sequence of automated steps triggered by an event, such as when a contact subscribes to a list or is tagged.
 Automations allow you to automatically send emails, update fields, apply tags and more.
 
-
 ### campaigns
 
 A campaign is generally used to send a one-off, timely email to some or all of your subscribers. For example you may use a campaign to send the latest edition of your weekly newsletter, or to announce a new feature in your product.
@@ -225,7 +226,6 @@ A list is a collection of contacts. Every one of your contacts will exist inside
 - **`emailoctopus-pp-cli lists id-get`** - Get list
 - **`emailoctopus-pp-cli lists id-put`** - Update list
 - **`emailoctopus-pp-cli lists post`** - Create list
-
 
 ## Output Formats
 

--- a/library/marketing/emailoctopus/SKILL.md
+++ b/library/marketing/emailoctopus/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `emailoctopus-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install emailoctopus --cli-only
+   npx -y @mvanhorn/printing-press-library install emailoctopus --cli-only
    ```
 2. Verify: `emailoctopus-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/emailoctopus/cmd/emailoctopus-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-EmailOctopus is the only major email-marketing platform whose free tier includes API access — but until now no maintained v2 CLI or SDK existed. This CLI ships all 25 endpoints with --json, --select, --csv, --dry-run, plus a local SQLite store that powers cross-list dedupe, per-contact engagement scoring, list churn diffs over time, and rate-budgeted bulk delete.
 
 ## When to Use This CLI
 

--- a/library/marketing/google-ads/README.md
+++ b/library/marketing/google-ads/README.md
@@ -9,26 +9,26 @@ Learn more at [Google Ads](https://developers.google.com/google-ads/api/).
 The recommended path installs both the `google-ads-pp-cli` binary and the `pp-google-ads` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install google-ads
+npx -y @mvanhorn/printing-press-library install google-ads
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-ads --cli-only
+npx -y @mvanhorn/printing-press-library install google-ads --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-ads --skill-only
+npx -y @mvanhorn/printing-press-library install google-ads --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-ads --agent claude-code
-npx -y @mvanhorn/printing-press install google-ads --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install google-ads --agent claude-code
+npx -y @mvanhorn/printing-press-library install google-ads --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/google-ads/SKILL.md
+++ b/library/marketing/google-ads/SKILL.md
@@ -1,24 +1,14 @@
 ---
 name: pp-google-ads
 description: "Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations. Trigger phrases: `pull a Google Ads report`, `GAQL query`, `check campaign performance`, `use google-ads`."
+license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
 metadata:
   openclaw:
     requires:
-      env: ["GOOGLE_ADS_ACCESS_TOKEN", "GOOGLE_ADS_DEVELOPER_TOKEN"]
       bins:
         - google-ads-pp-cli
-    envVars:
-      - name: GOOGLE_ADS_ACCESS_TOKEN
-        required: true
-        description: "OAuth2 access token with the https://www.googleapis.com/auth/adwords scope."
-      - name: GOOGLE_ADS_DEVELOPER_TOKEN
-        required: true
-        description: "Google Ads developer token sent as the developer-token header."
-      - name: GOOGLE_ADS_LOGIN_CUSTOMER_ID
-        required: false
-        description: "Optional manager account ID sent as the login-customer-id header."
     install:
       - kind: go
         bins: [google-ads-pp-cli]
@@ -27,7 +17,24 @@ metadata:
 
 # Google Ads — Printing Press CLI
 
-Google Ads API for account discovery, GAQL reporting, campaigns, budgets, assets, conversions, audiences, planning, and billing operations.
+## Prerequisites: Install the CLI
+
+This skill drives the `google-ads-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
+
+1. Install via the Printing Press installer:
+   ```bash
+   npx -y @mvanhorn/printing-press-library install google-ads --cli-only
+   ```
+2. Verify: `google-ads-pp-cli --version`
+3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/google-ads/cmd/google-ads-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 
@@ -607,19 +614,8 @@ Use async submission without `--wait` when you want to fire-and-forget; use `--w
 Parse `$ARGUMENTS`:
 
 1. **Empty, `help`, or `--help`** → show `google-ads-pp-cli --help` output
-2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → CLI installation
+2. **Starts with `install`** → ends with `mcp` → MCP installation; otherwise → see Prerequisites above
 3. **Anything else** → Direct Use (execute as CLI command with `--agent`)
-
-## CLI Installation
-
-1. Check Go is installed: `go version` (requires Go 1.26.3 or newer)
-2. Install:
-   ```bash
-   go install github.com/mvanhorn/printing-press-library/library/marketing/google-ads/cmd/google-ads-pp-cli@latest
-   ```
-3. Verify: `google-ads-pp-cli --version`
-4. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
-
 ## MCP Server Installation
 
 1. Install the MCP server:
@@ -635,7 +631,7 @@ Parse `$ARGUMENTS`:
 ## Direct Use
 
 1. Check if installed: `which google-ads-pp-cli`
-   If not found, offer to install (see CLI Installation above).
+   If not found, offer to install (see Prerequisites at the top of this skill).
 2. Match the user query to the best command from the Unique Capabilities and Command Reference above.
 3. Execute with the `--agent` flag:
    ```bash

--- a/library/marketing/google-search-console/README.md
+++ b/library/marketing/google-search-console/README.md
@@ -9,26 +9,26 @@ A single binary covering search analytics, URL inspection, sitemaps, and site ma
 The recommended path installs both the `google-search-console-pp-cli` binary and the `pp-google-search-console` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install google-search-console
+npx -y @mvanhorn/printing-press-library install google-search-console
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-search-console --cli-only
+npx -y @mvanhorn/printing-press-library install google-search-console --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-search-console --skill-only
+npx -y @mvanhorn/printing-press-library install google-search-console --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-search-console --agent claude-code
-npx -y @mvanhorn/printing-press install google-search-console --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install google-search-console --agent claude-code
+npx -y @mvanhorn/printing-press-library install google-search-console --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/google-search-console/SKILL.md
+++ b/library/marketing/google-search-console/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `google-search-console-pp-cli` binary. **You must verify t
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install google-search-console --cli-only
+   npx -y @mvanhorn/printing-press-library install google-search-console --cli-only
    ```
 2. Verify: `google-search-console-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/marketing/google-s
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-A single binary covering search analytics, URL inspection, sitemaps, and site management -- with the agent-native JSON and CSV outputs, --dry-run, exit codes, and offline search every other GSC tool half-implements. The transcendence layer (compare, quick-wins, cannibalization, historical, decaying, outliers, cliff, roll-up, coverage-drift, sitemap-watch, new-queries) runs entirely from the local SQLite store, so the workflows the API can't answer in one call are answered in one command.
 
 ## When to Use This CLI
 

--- a/library/marketing/kit/README.md
+++ b/library/marketing/kit/README.md
@@ -11,26 +11,26 @@ Printed by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
 The recommended path installs both the `kit-pp-cli` binary and the `pp-kit` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install kit
+npx -y @mvanhorn/printing-press-library install kit
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install kit --cli-only
+npx -y @mvanhorn/printing-press-library install kit --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install kit --skill-only
+npx -y @mvanhorn/printing-press-library install kit --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install kit --agent claude-code
-npx -y @mvanhorn/printing-press install kit --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install kit --agent claude-code
+npx -y @mvanhorn/printing-press-library install kit --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -437,7 +437,6 @@ Kit-specific compound workflows for agents. These call real Kit v4 endpoints and
 - **`kit-pp-cli workflow audience-health`** - Subscriber status counts, growth stats, and largest tags by subscriber count.
 - **`kit-pp-cli workflow content-inventory`** - Sequences, sequence emails, snippets, forms, email templates, and recent broadcast stats.
 - **`kit-pp-cli workflow subscriber-lookup --email <email>`** - Subscriber profile, custom fields, tags, attribution, and email stats for support or personalization checks.
-
 
 ## Output Formats
 

--- a/library/marketing/kit/SKILL.md
+++ b/library/marketing/kit/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `kit-pp-cli` binary. **You must verify the CLI is installe
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install kit --cli-only
+   npx -y @mvanhorn/printing-press-library install kit --cli-only
    ```
 2. Verify: `kit-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/marketing/kit/cmd/
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-
 
 ## Agentic Kit Workflows
 

--- a/library/marketing/klaviyo/README.md
+++ b/library/marketing/klaviyo/README.md
@@ -11,26 +11,26 @@ Learn more at [Klaviyo](https://developers.klaviyo.com).
 The recommended path installs both the `klaviyo-pp-cli` binary and the `pp-klaviyo` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install klaviyo
+npx -y @mvanhorn/printing-press-library install klaviyo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install klaviyo --cli-only
+npx -y @mvanhorn/printing-press-library install klaviyo --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install klaviyo --skill-only
+npx -y @mvanhorn/printing-press-library install klaviyo --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install klaviyo --agent claude-code
-npx -y @mvanhorn/printing-press install klaviyo --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install klaviyo --agent claude-code
+npx -y @mvanhorn/printing-press-library install klaviyo --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/klaviyo/SKILL.md
+++ b/library/marketing/klaviyo/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `klaviyo-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install klaviyo --cli-only
+   npx -y @mvanhorn/printing-press-library install klaviyo --cli-only
    ```
 2. Verify: `klaviyo-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/mailchimp/README.md
+++ b/library/marketing/mailchimp/README.md
@@ -13,31 +13,37 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `mailchimp-pp-cli` binary and the `pp-mailchimp` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install mailchimp
+npx -y @mvanhorn/printing-press-library install mailchimp
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install mailchimp --cli-only
+npx -y @mvanhorn/printing-press-library install mailchimp --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install mailchimp --skill-only
+npx -y @mvanhorn/printing-press-library install mailchimp --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install mailchimp --agent claude-code
-npx -y @mvanhorn/printing-press install mailchimp --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install mailchimp --agent claude-code
+npx -y @mvanhorn/printing-press-library install mailchimp --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/mailchimp/cmd/mailchimp-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -113,22 +119,17 @@ Mailchimp encodes the datacenter in the API key suffix. The key 'abc...xyz-us6' 
 # datacenter encoded in the suffix; the CLI parses it
 export MAILCHIMP_API_KEY=your-key-us6
 
-
 # verify auth, dc routing, and API reach
 mailchimp-pp-cli doctor
-
 
 # pull a local copy so search and sql work offline
 mailchimp-pp-cli sync --resources lists,members,campaigns,reports
 
-
 # one-shot upsert with tags, no MD5 dance
 mailchimp-pp-cli subscribe alice@example.com --list LIST_ID --tags vip,newsletter
 
-
 # the four-endpoint join the dashboard buries
 mailchimp-pp-cli digest CAMPAIGN_ID --json --select campaign_id,open_rate,click_rate,top_links
-
 
 # offline FTS over synced audiences, members, campaigns
 mailchimp-pp-cli search 'newsletter' --json
@@ -493,7 +494,6 @@ Manage verified domains
 - **`mailchimp-pp-cli verified-domains delete`** - Delete a verified domain from the account.
 - **`mailchimp-pp-cli verified-domains get`** - Get all of the sending domains on the account.
 - **`mailchimp-pp-cli verified-domains get-verifieddomains`** - Get the details for a single domain on the account.
-
 
 ## Output Formats
 

--- a/library/marketing/mailchimp/SKILL.md
+++ b/library/marketing/mailchimp/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `mailchimp-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install mailchimp --cli-only
+   npx -y @mvanhorn/printing-press-library install mailchimp --cli-only
    ```
 2. Verify: `mailchimp-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/mailchimp/cmd/mailchimp-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Mailchimp's REST API has 291 endpoints and an SDK in every language, but composes nothing — subscribing a contact with tags takes three calls and an MD5 hash; checking whether a campaign worked takes four endpoints joined by hand; bulk imports require decoding tar.gz JSONL from a 10-minute expiring URL. This CLI ships every endpoint as a typed command plus eight novel workflow commands that compose the API the way humans and agents actually use it: subscribe-with-tags in one call, CSV bulk subscribe with batch decode, single and multi-campaign digests with --md for pasting into weekly review docs, head-to-head campaign comparison, segment health audit, send-checklist CI gate, e-commerce attribution, and per-domain deliverability rollup. A local SQLite cache makes every audience SQL-queryable, and the MCP surface uses code orchestration so an agent loads the whole API in ~1K tokens.
 
 ## When to Use This CLI
 

--- a/library/marketing/producthunt/README.md
+++ b/library/marketing/producthunt/README.md
@@ -11,26 +11,26 @@ Learn more at [Product Hunt](https://www.producthunt.com).
 The recommended path installs both the `producthunt-pp-cli` binary and the `pp-producthunt` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install producthunt
+npx -y @mvanhorn/printing-press-library install producthunt
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install producthunt --cli-only
+npx -y @mvanhorn/printing-press-library install producthunt --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install producthunt --skill-only
+npx -y @mvanhorn/printing-press-library install producthunt --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install producthunt --agent claude-code
-npx -y @mvanhorn/printing-press install producthunt --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install producthunt --agent claude-code
+npx -y @mvanhorn/printing-press-library install producthunt --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/marketing/producthunt/SKILL.md
+++ b/library/marketing/producthunt/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `producthunt-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install producthunt --cli-only
+   npx -y @mvanhorn/printing-press-library install producthunt --cli-only
    ```
 2. Verify: `producthunt-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/marketing/trendhunter/README.md
+++ b/library/marketing/trendhunter/README.md
@@ -10,18 +10,30 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
-The recommended path installs both the `trendhunter-pp-cli` binary and the `pp-trendhunter` agent skill in one shot:
+The recommended path installs both the `trendhunter-pp-cli` binary and the `pp-trendhunter` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install trendhunter
+npx -y @mvanhorn/printing-press-library install trendhunter
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install trendhunter --cli-only
+npx -y @mvanhorn/printing-press-library install trendhunter --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install trendhunter --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install trendhunter --agent claude-code
+npx -y @mvanhorn/printing-press-library install trendhunter --agent claude-code --agent codex
+```
 
 ### Without Node (Go fallback)
 
@@ -60,24 +72,55 @@ Tell your OpenClaw agent (copy this):
 Install the pp-trendhunter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trendhunter. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trendhunter-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/trendhunter/cmd/trendhunter-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "trendhunter": {
+      "command": "trendhunter-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Quick Start
 
 ```bash
 # Pull the latest 30 trends + sitemap and write them to the local store.
 trendhunter-pp-cli sync
 
-
 # Search the local corpus first, with a flag to fan-out live.
 trendhunter-pp-cli search "AI clone" --json
-
 
 # Week-over-week digest with new vs repeat split.
 trendhunter-pp-cli digest --since 7d --category eco --json
 
-
 # Pull the FAQ JSON-LD from any /trends/<slug> page.
 trendhunter-pp-cli faq ai-clone --json
-
 
 # One-shot agent brief: ranked trends with FAQ Q&A.
 trendhunter-pp-cli brief --category ai --top 10 --format markdown
@@ -217,7 +260,6 @@ Individual trend pages with full metadata, FAQ Q&A, related trends, author, cate
 
 - **`trendhunter-pp-cli trends get`** - Fetch the full trend page HTML for a slug. The CLI's 'trend show <slug>' parses this; users should use that instead of calling this directly.
 
-
 ## Output Formats
 
 ```bash
@@ -250,69 +292,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-trendhunter -g
-```
-
-Then invoke `/pp-trendhunter <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/marketing/trendhunter/cmd/trendhunter-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-claude mcp add trendhunter trendhunter-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trendhunter-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/marketing/trendhunter/cmd/trendhunter-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "trendhunter": {
-      "command": "trendhunter-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/marketing/trendhunter/SKILL.md
+++ b/library/marketing/trendhunter/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `trendhunter-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install trendhunter --cli-only
+   npx -y @mvanhorn/printing-press-library install trendhunter --cli-only
    ```
 2. Verify: `trendhunter-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/marketing/trendhun
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-trendhunter-pp-cli scrapes the free public TrendHunter surface (RSS feed, sitemap, category and trend pages, search results) into a local SQLite store, then exposes corpus-diff, rising-keyword clusters, time-windowed author velocity, FAQ Q&A extraction, and a category-watch feed the site itself can't provide. No API key. No login. Stdlib HTTP transport - no headless browser.
 
 ## When to Use This CLI
 

--- a/library/marketing/trustpilot/README.md
+++ b/library/marketing/trustpilot/README.md
@@ -10,22 +10,40 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
-The recommended path installs both the `trustpilot-pp-cli` binary and the `pp-trustpilot` agent skill in one shot:
+The recommended path installs both the `trustpilot-pp-cli` binary and the `pp-trustpilot` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install trustpilot
+npx -y @mvanhorn/printing-press-library install trustpilot
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install trustpilot --cli-only
+npx -y @mvanhorn/printing-press-library install trustpilot --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install trustpilot --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install trustpilot --agent claude-code
+npx -y @mvanhorn/printing-press-library install trustpilot --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/trustpilot/cmd/trustpilot-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,6 +72,39 @@ Tell your OpenClaw agent (copy this):
 Install the pp-trustpilot skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trustpilot. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trustpilot-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "trustpilot": {
+      "command": "trustpilot-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Trustpilot is fronted by AWS WAF, so plain HTTP is blocked. Run `trustpilot-pp-cli auth login --chrome` once to harvest the `aws-waf-token` cookie via a one-shot headless Chrome; the CLI persists it locally and refreshes automatically when it expires (every 5-15 minutes). No paid API subscription required.
@@ -64,22 +115,17 @@ Trustpilot is fronted by AWS WAF, so plain HTTP is blocked. Run `trustpilot-pp-c
 # One-time cookie harvest via headless Chrome; clears the AWS WAF challenge.
 trustpilot-pp-cli auth login --chrome
 
-
 # Resolve a company name to its canonical Trustpilot domain (e.g. www.thriftbooks.com).
 trustpilot-pp-cli search 'thriftbooks'
-
 
 # TrustScore, total reviews, rating histogram, and Trustpilot's own AI summary.
 trustpilot-pp-cli info www.thriftbooks.com --json
 
-
 # Balanced recent slice — the headline command for agent integrations.
 trustpilot-pp-cli top-recent www.thriftbooks.com --window 30d --good 5 --bad 5 --json
 
-
 # Pull up to 500 recent reviews into the local SQLite store for offline analysis.
 trustpilot-pp-cli sync-trustpilot www.thriftbooks.com --max-pages 25
-
 
 # FTS5 grep on synced reviews — no remote call once sync is current.
 trustpilot-pp-cli search-reviews www.thriftbooks.com 'refund' --stars 1 --window 90d
@@ -198,7 +244,6 @@ Fetch Trustpilot reviews for a company
 
 - **`trustpilot-pp-cli reviews list`** - Fetch a page of reviews for a company by domain (use 'reviews fetch <domain>' from the CLI). Authenticated via aws-waf-token cookie harvested with auth login.
 
-
 ## Output Formats
 
 ```bash
@@ -231,65 +276,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-trustpilot -g
-```
-
-Then invoke `/pp-trustpilot <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add trustpilot trustpilot-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/trustpilot-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "trustpilot": {
-      "command": "trustpilot-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/marketing/trustpilot/SKILL.md
+++ b/library/marketing/trustpilot/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `trustpilot-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install trustpilot --cli-only
+   npx -y @mvanhorn/printing-press-library install trustpilot --cli-only
    ```
 2. Verify: `trustpilot-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/trustpilot/cmd/trustpilot-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Pulls public Trustpilot reviews into a local SQLite store with FTS5 over titles, bodies, and business replies. Designed to pair with research agents like last30days: one call returns a balanced good-and-bad sample for an entity along with TrustScore, Trustpilot's own AI summary, and the rating histogram.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/archive-is/README.md
+++ b/library/media-and-entertainment/archive-is/README.md
@@ -11,26 +11,26 @@ Bypass paywalls and look up web archives via archive.today. Looks up existing sn
 The recommended path installs both the `archive-is-pp-cli` binary and the `pp-archive-is` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install archive-is
+npx -y @mvanhorn/printing-press-library install archive-is
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install archive-is --cli-only
+npx -y @mvanhorn/printing-press-library install archive-is --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install archive-is --skill-only
+npx -y @mvanhorn/printing-press-library install archive-is --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install archive-is --agent claude-code
-npx -y @mvanhorn/printing-press install archive-is --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install archive-is --agent claude-code
+npx -y @mvanhorn/printing-press-library install archive-is --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/archive-is/SKILL.md
+++ b/library/media-and-entertainment/archive-is/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `archive-is-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install archive-is --cli-only
+   npx -y @mvanhorn/printing-press-library install archive-is --cli-only
    ```
 2. Verify: `archive-is-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/bandsintown/README.md
+++ b/library/media-and-entertainment/bandsintown/README.md
@@ -11,26 +11,26 @@ Learn more at [Bandsintown](https://bandsintown.com/).
 The recommended path installs both the `bandsintown-pp-cli` binary and the `pp-bandsintown` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install bandsintown
+npx -y @mvanhorn/printing-press-library install bandsintown
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install bandsintown --cli-only
+npx -y @mvanhorn/printing-press-library install bandsintown --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install bandsintown --skill-only
+npx -y @mvanhorn/printing-press-library install bandsintown --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install bandsintown --agent claude-code
-npx -y @mvanhorn/printing-press install bandsintown --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install bandsintown --agent claude-code
+npx -y @mvanhorn/printing-press-library install bandsintown --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/bandsintown/SKILL.md
+++ b/library/media-and-entertainment/bandsintown/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `bandsintown-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install bandsintown --cli-only
+   npx -y @mvanhorn/printing-press-library install bandsintown --cli-only
    ```
 2. Verify: `bandsintown-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every existing Bandsintown wrapper is a 10-year-old language binding for the same two API endpoints. This CLI absorbs all of them and adds the queries promoters and tour routers actually need: feasibility-ranked routing candidates for a target city and date, empty windows in an artist's calendar, co-bill patterns across past festivals, and tracker_count trends over time. Local SQLite store, FTS search, agent-native --json output, and MCP exposure are standard.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/blu-ray/README.md
+++ b/library/media-and-entertainment/blu-ray/README.md
@@ -13,26 +13,26 @@ Printed by [@vinnyp](https://github.com/vinnyp) (Vinny Pasceri).
 The recommended path installs both the `blu-ray-pp-cli` binary and the `pp-blu-ray` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install blu-ray
+npx -y @mvanhorn/printing-press-library install blu-ray
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install blu-ray --cli-only
+npx -y @mvanhorn/printing-press-library install blu-ray --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install blu-ray --skill-only
+npx -y @mvanhorn/printing-press-library install blu-ray --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install blu-ray --agent claude-code
-npx -y @mvanhorn/printing-press install blu-ray --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install blu-ray --agent claude-code
+npx -y @mvanhorn/printing-press-library install blu-ray --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -117,18 +117,14 @@ No account, no API key, no OAuth — Blu-ray.com is read from its published HTML
 # Pull the public sitemap into a local SQLite + FTS5 index (~400k+ Blu-ray releases). Run weekly.
 blu-ray-pp-cli sync
 
-
 # Offline title search — instant, regex-capable, no round-trip.
 blu-ray-pp-cli search 'fight club' --format 4k --json
-
 
 # Fetch one release in full (specs, ratings, audio, subtitles, packaging) — cached locally.
 blu-ray-pp-cli releases get Fight-Club-4K-Blu-ray 406956 --json
 
-
 # Live 4K UHD deals at 30%+ off, narrowed to the columns an agent cares about.
 blu-ray-pp-cli deals --country USA --format 4k --min-discount 30 --json --select title,sale_price,percent_off
-
 
 # Add a release to the local watchlist, then rescan deals and alert when the target is hit.
 blu-ray-pp-cli watch add 406956 --target-price 14.99 && blu-ray-pp-cli watch check
@@ -268,7 +264,6 @@ Public XML sitemaps. Used by `sync` to enumerate every release id; safe to fetch
 - **`blu-ray-pp-cli sitemap bluraymovies`** - One of nine gzipped Blu-ray release shards (50,000 URLs each). Pull all nine for the full Blu-ray catalog.
 - **`blu-ray-pp-cli sitemap index`** - Sitemap index — points at gzipped sub-sitemaps for main, news, bluraymovies (9 shards), dvdmovies (7), itunesmovies (5), digitalmovies (2), cast (11), ma, games, other.
 - **`blu-ray-pp-cli sitemap news`** - Compressed news sitemap — each entry has title + publication_date inline (no per-story fetch needed for enumeration).
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/blu-ray/SKILL.md
+++ b/library/media-and-entertainment/blu-ray/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `blu-ray-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install blu-ray --cli-only
+   npx -y @mvanhorn/printing-press-library install blu-ray --cli-only
    ```
 2. Verify: `blu-ray-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Sync the public Blu-ray.com sitemap into a local SQLite + FTS5 index and search ~400,000 releases without a network round-trip. Track prices with a local watchlist that pings you on new historical lows. Pipe everything as JSON.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/digg/README.md
+++ b/library/media-and-entertainment/digg/README.md
@@ -9,26 +9,26 @@ Digg is a curated AI-news leaderboard powered by tracked accounts on X and a par
 The recommended path installs both the `digg-pp-cli` binary and the `pp-digg` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install digg
+npx -y @mvanhorn/printing-press-library install digg
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install digg --cli-only
+npx -y @mvanhorn/printing-press-library install digg --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install digg --skill-only
+npx -y @mvanhorn/printing-press-library install digg --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install digg --agent claude-code
-npx -y @mvanhorn/printing-press install digg --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install digg --agent claude-code
+npx -y @mvanhorn/printing-press-library install digg --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -120,10 +120,8 @@ digg-pp-cli events --since 1h --type fast_climb
 # What got knocked out of the rankings overnight and Digg's own rationale for each
 digg-pp-cli replaced --since 24h
 
-
 # Top influencers tracked by Digg, ranked by Digg's score
 digg-pp-cli authors top --by influence --limit 25
-
 
 # Top AI repos by starring activity from Digg-tracked accounts
 digg-pp-cli github stars --limit 10 --json
@@ -131,10 +129,8 @@ digg-pp-cli github stars --limit 10 --json
 # Smart-money convergence — repos starred by >= 2 distinct AI-builder accounts
 digg-pp-cli github stars --min-starrers 2 --json
 
-
 # Live GitHub activity feed: who starred / committed / opened issues, in real time
 digg-pp-cli github recent --limit 20 --json
-
 
 # Curated emerging AI companies from the /ai/x/rankings/companies snapshot
 digg-pp-cli rankings emerging --json

--- a/library/media-and-entertainment/digg/SKILL.md
+++ b/library/media-and-entertainment/digg/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `digg-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install digg --cli-only
+   npx -y @mvanhorn/printing-press-library install digg --cli-only
    ```
 2. Verify: `digg-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/digg/cmd/digg-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Digg is a curated AI-news leaderboard powered by tracked accounts on X and a parallel GitHub feed (stars / new / activity / recent). The web UI shows you today's snapshot. This CLI tails the pipeline events, keeps a local rank-history that survives daily overwrites, exposes Digg's own replacement rationale and gravity components, and surfaces the four GitHub feeds — so an agent can answer 'why this story?', 'what got dropped overnight?', and 'what AI repos are Digg-tracked accounts starring right now?' with one binary.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/espn/README.md
+++ b/library/media-and-entertainment/espn/README.md
@@ -7,26 +7,26 @@ Live scores, standings, news, and game history across 17 sports from ESPN
 The recommended path installs both the `espn-pp-cli` binary and the `pp-espn` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install espn
+npx -y @mvanhorn/printing-press-library install espn
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install espn --cli-only
+npx -y @mvanhorn/printing-press-library install espn --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install espn --skill-only
+npx -y @mvanhorn/printing-press-library install espn --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install espn --agent claude-code
-npx -y @mvanhorn/printing-press install espn --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install espn --agent claude-code
+npx -y @mvanhorn/printing-press-library install espn --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/espn/SKILL.md
+++ b/library/media-and-entertainment/espn/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `espn-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install espn --cli-only
+   npx -y @mvanhorn/printing-press-library install espn --cli-only
    ```
 2. Verify: `espn-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/google-photos/README.md
+++ b/library/media-and-entertainment/google-photos/README.md
@@ -9,26 +9,26 @@ Learn more at [Google Photos](https://developers.google.com/photos).
 The recommended path installs both the `google-photos-pp-cli` binary and the `pp-google-photos` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install google-photos
+npx -y @mvanhorn/printing-press-library install google-photos
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-photos --cli-only
+npx -y @mvanhorn/printing-press-library install google-photos --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-photos --skill-only
+npx -y @mvanhorn/printing-press-library install google-photos --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install google-photos --agent claude-code
-npx -y @mvanhorn/printing-press install google-photos --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install google-photos --agent claude-code
+npx -y @mvanhorn/printing-press-library install google-photos --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/google-photos/SKILL.md
+++ b/library/media-and-entertainment/google-photos/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `google-photos-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install google-photos --cli-only
+   npx -y @mvanhorn/printing-press-library install google-photos --cli-only
    ```
 2. Verify: `google-photos-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/hackernews/README.md
+++ b/library/media-and-entertainment/hackernews/README.md
@@ -11,26 +11,26 @@ Learn more at [Hacker News](https://news.ycombinator.com).
 The recommended path installs both the `hackernews-pp-cli` binary and the `pp-hackernews` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install hackernews
+npx -y @mvanhorn/printing-press-library install hackernews
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hackernews --cli-only
+npx -y @mvanhorn/printing-press-library install hackernews --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hackernews --skill-only
+npx -y @mvanhorn/printing-press-library install hackernews --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install hackernews --agent claude-code
-npx -y @mvanhorn/printing-press install hackernews --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install hackernews --agent claude-code
+npx -y @mvanhorn/printing-press-library install hackernews --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/hackernews/SKILL.md
+++ b/library/media-and-entertainment/hackernews/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `hackernews-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install hackernews --cli-only
+   npx -y @mvanhorn/printing-press-library install hackernews --cli-only
    ```
 2. Verify: `hackernews-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/icloud/README.md
+++ b/library/media-and-entertainment/icloud/README.md
@@ -9,19 +9,67 @@ directly — no Photos.app launch, no API token, no network calls.
 
 ## Install
 
-```bash
-go install github.com/matysanchez/icloudcli/cmd/icloud-pp-cli@latest
-```
-
-Or via [Printing Press](https://github.com/mvanhorn/printing-press-library):
+The recommended path installs both the `icloud-pp-cli` binary and the `pp-icloud` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install icloud
+npx -y @mvanhorn/printing-press-library install icloud
 ```
 
-**Requires:** macOS (Sonoma / Sequoia), Go 1.23+
+For CLI only (no skill):
 
----
+```bash
+npx -y @mvanhorn/printing-press-library install icloud --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install icloud --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install icloud --agent claude-code
+npx -y @mvanhorn/printing-press-library install icloud --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/icloud/cmd/icloud-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/icloud-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-icloud --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-icloud --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-icloud skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-icloud. The skill defines how its required CLI can be installed.
+```
 
 ## Quick start
 

--- a/library/media-and-entertainment/icloud/SKILL.md
+++ b/library/media-and-entertainment/icloud/SKILL.md
@@ -20,19 +20,22 @@ metadata:
 
 ## Prerequisites: Install the CLI
 
-This skill drives the `icloud-pp-cli` binary. **Verify it is installed before running any command.**
+This skill drives the `icloud-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-Install via Go (requires Go 1.23+):
+1. Install via the Printing Press installer:
+   ```bash
+   npx -y @mvanhorn/printing-press-library install icloud --cli-only
+   ```
+2. Verify: `icloud-pp-cli --version`
+3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/matysanchez/icloudcli/cmd/icloud-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/icloud/cmd/icloud-pp-cli@latest
 ```
 
-Verify: `icloud-pp-cli --version`
-
-Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
-
-**macOS only.** The CLI reads local iCloud SQLite databases and uses AppleScript for deletion — it does not run on Linux or Windows.
+If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Pre-flight Check
 

--- a/library/media-and-entertainment/marginalrevolution/README.md
+++ b/library/media-and-entertainment/marginalrevolution/README.md
@@ -9,26 +9,26 @@ This CLI was regenerated with CLI Printing Press 4.2.1. It keeps the generated v
 The recommended path installs both the `marginalrevolution-pp-cli` binary and the `pp-marginalrevolution` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install marginalrevolution
+npx -y @mvanhorn/printing-press-library install marginalrevolution
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install marginalrevolution --cli-only
+npx -y @mvanhorn/printing-press-library install marginalrevolution --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install marginalrevolution --skill-only
+npx -y @mvanhorn/printing-press-library install marginalrevolution --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install marginalrevolution --agent claude-code
-npx -y @mvanhorn/printing-press install marginalrevolution --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install marginalrevolution --agent claude-code
+npx -y @mvanhorn/printing-press-library install marginalrevolution --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/marginalrevolution/SKILL.md
+++ b/library/media-and-entertainment/marginalrevolution/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `marginalrevolution-pp-cli` binary. **You must verify the 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install marginalrevolution --cli-only
+   npx -y @mvanhorn/printing-press-library install marginalrevolution --cli-only
    ```
 2. Verify: `marginalrevolution-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Use this CLI for recent Marginal Revolution posts in structured form, including author/category filtering, recent-feed search, post text, comment counts, and outbound links. It was regenerated with CLI Printing Press 4.2.1 and keeps the generated v4.2 agent/MCP scaffolding while adding RSS-native helper commands.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/movie-goat/README.md
+++ b/library/media-and-entertainment/movie-goat/README.md
@@ -11,26 +11,26 @@ Learn more at [Movie Goat](https://www.themoviedb.org).
 The recommended path installs both the `movie-goat-pp-cli` binary and the `pp-movie-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install movie-goat
+npx -y @mvanhorn/printing-press-library install movie-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install movie-goat --cli-only
+npx -y @mvanhorn/printing-press-library install movie-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install movie-goat --skill-only
+npx -y @mvanhorn/printing-press-library install movie-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install movie-goat --agent claude-code
-npx -y @mvanhorn/printing-press install movie-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install movie-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install movie-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/movie-goat/SKILL.md
+++ b/library/media-and-entertainment/movie-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `movie-goat-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install movie-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install movie-goat --cli-only
    ```
 2. Verify: `movie-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/nasa-images/README.md
+++ b/library/media-and-entertainment/nasa-images/README.md
@@ -11,31 +11,37 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `nasa-images-pp-cli` binary and the `pp-nasa-images` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install nasa-images
+npx -y @mvanhorn/printing-press-library install nasa-images
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nasa-images --cli-only
+npx -y @mvanhorn/printing-press-library install nasa-images --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nasa-images --skill-only
+npx -y @mvanhorn/printing-press-library install nasa-images --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install nasa-images --agent claude-code
-npx -y @mvanhorn/printing-press install nasa-images --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install nasa-images --agent claude-code
+npx -y @mvanhorn/printing-press-library install nasa-images --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/nasa-images/cmd/nasa-images-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -103,22 +109,17 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # search the live API with all the filters NASA exposes
 nasa-images-pp-cli media --q "perseverance rover" --media-type image --year-start 2024 --json
 
-
 # get exactly one URL for the best variant under a size cap — no manifest parsing
 nasa-images-pp-cli assets best PIA26345 --prefer orig,large --max-bytes 5000000
-
 
 # bulk-download a curated album with byte-range resume; re-runs pick up where they left off
 nasa-images-pp-cli download album Mars-Perseverance --variant orig --resume --out ./mars
 
-
 # populate the local SQLite mirror for offline FTS search and timeline queries
 nasa-images-pp-cli mirror search --q "webb" --year-start 2022
 
-
 # chronologically-sorted FTS search NASA's upstream API doesn't offer
 nasa-images-pp-cli recent --q "deep field" --sort date-desc --limit 10
-
 
 # actual caption text, not the .srt URL every other wrapper stops at
 nasa-images-pp-cli captions fetch jsc2022m000123 --format text
@@ -235,7 +236,6 @@ Search the NASA Image and Video Library catalog by free text and filters
 Retrieve the location URL of an asset's metadata.json sidecar (AVAIL editorial + ExifTool fields)
 
 - **`nasa-images-pp-cli metadata <nasa_id>`** - Return the location URL of the metadata.json sidecar for an asset. Use `metadata fetch` (novel command) to follow the indirection and fetch the cleaned metadata content.
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/nasa-images/SKILL.md
+++ b/library/media-and-entertainment/nasa-images/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `nasa-images-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install nasa-images --cli-only
+   npx -y @mvanhorn/printing-press-library install nasa-images --cli-only
    ```
 2. Verify: `nasa-images-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/nasa-images/cmd/nasa-images-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The official NASA Image and Video Library exposes five endpoints but no Go CLI covers all of them, and none of the existing wrappers go past returning JSON. nasa-images-pp-cli adds a local SQLite mirror with FTS5 search, byte-range resumable album downloads, caption text extraction (not just URLs), deterministic best-variant picking for agents, and a typed MCP server — every command works offline once synced, and every command pipes cleanly to jq.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/podcast-goat/README.md
+++ b/library/media-and-entertainment/podcast-goat/README.md
@@ -11,31 +11,37 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `podcast-goat-pp-cli` binary and the `pp-podcast-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install podcast-goat
+npx -y @mvanhorn/printing-press-library install podcast-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install podcast-goat --cli-only
+npx -y @mvanhorn/printing-press-library install podcast-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install podcast-goat --skill-only
+npx -y @mvanhorn/printing-press-library install podcast-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install podcast-goat --agent claude-code
-npx -y @mvanhorn/printing-press install podcast-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install podcast-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install podcast-goat --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/podcast-goat/cmd/podcast-goat-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -113,18 +119,14 @@ Three auth surfaces, in cost order. (1) `auth login-service --service <huberman|
 # Confirm yt-dlp present, RSS reachability, cookie freshness
 podcast-goat-pp-cli doctor
 
-
 # Free path; canonical markdown straight to cache
 podcast-goat-pp-cli episode get https://www.dwarkesh.com/p/andrej-karpathy
-
 
 # One-time cookie capture from your logged-in Chrome
 podcast-goat-pp-cli auth login-service --service huberman
 
-
 # Cookie path; free because you subscribe
 podcast-goat-pp-cli episode get https://www.hubermanlab.com/episode/<your-premium-slug>
-
 
 # Bundle cached transcripts into one prompt-shaped file
 podcast-goat-pp-cli magic 'AI chip supply chain' --out chips.md
@@ -228,7 +230,6 @@ Pull, search, and inspect podcast episode transcripts
 
 - **`podcast-goat-pp-cli episode get`** - Fetch one transcript by URL via the cookie -> free -> paid dispatch chain
 - **`podcast-goat-pp-cli episode latest`** - Pull the most recent episode for a subscribed feed
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/podcast-goat/SKILL.md
+++ b/library/media-and-entertainment/podcast-goat/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `podcast-goat-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install podcast-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install podcast-goat --cli-only
    ```
 2. Verify: `podcast-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Built for agentic users who already pay for Huberman, Acquired, Founders, and Peter Attia and want to feed those transcripts into Claude or Hermes without copy-pasting. Walks a cookie -> free -> paid dispatch chain across 10 sources, normalizes everything to the same `**Speaker** (MM:SS)` markdown shape, caches to a local FTS5 store, and ships an MCP wrapper so agents can drive the whole thing.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/podscan/README.md
+++ b/library/media-and-entertainment/podscan/README.md
@@ -12,26 +12,26 @@ Printed by [@gregvanhorn](https://github.com/gregvanhorn) (Greg Van Horn).
 The recommended path installs both the `podscan-pp-cli` binary and the `pp-podscan` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install podscan
+npx -y @mvanhorn/printing-press-library install podscan
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install podscan --cli-only
+npx -y @mvanhorn/printing-press-library install podscan --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install podscan --skill-only
+npx -y @mvanhorn/printing-press-library install podscan --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install podscan --agent claude-code
-npx -y @mvanhorn/printing-press install podscan --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install podscan --agent claude-code
+npx -y @mvanhorn/printing-press-library install podscan --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/podscan/SKILL.md
+++ b/library/media-and-entertainment/podscan/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `podscan-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install podscan --cli-only
+   npx -y @mvanhorn/printing-press-library install podscan --cli-only
    ```
 2. Verify: `podscan-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,9 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Podscan REST API — search 51M+ podcast episodes and 4.4M+ podcasts.
-Full transcripts, AI-extracted entities, mentions, brand-safety analysis.
 
 ## Command Reference
 

--- a/library/media-and-entertainment/pokeapi/README.md
+++ b/library/media-and-entertainment/pokeapi/README.md
@@ -11,26 +11,26 @@ Learn more at [PokéAPI](https://pokeapi.co/docs/v2).
 The recommended path installs both the `pokeapi-pp-cli` binary and the `pp-pokeapi` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pokeapi
+npx -y @mvanhorn/printing-press-library install pokeapi
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pokeapi --cli-only
+npx -y @mvanhorn/printing-press-library install pokeapi --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pokeapi --skill-only
+npx -y @mvanhorn/printing-press-library install pokeapi --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pokeapi --agent claude-code
-npx -y @mvanhorn/printing-press install pokeapi --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pokeapi --agent claude-code
+npx -y @mvanhorn/printing-press-library install pokeapi --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/pokeapi/SKILL.md
+++ b/library/media-and-entertainment/pokeapi/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `pokeapi-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pokeapi --cli-only
+   npx -y @mvanhorn/printing-press-library install pokeapi --cli-only
    ```
 2. Verify: `pokeapi-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/setlist-fm/README.md
+++ b/library/media-and-entertainment/setlist-fm/README.md
@@ -6,24 +6,37 @@ Setlist.fm rate-limits to 2 requests per second and 1,440 per day, which makes a
 
 ## Install
 
-The recommended path installs both the `setlist-fm-pp-cli` binary and the `pp-setlist-fm` agent skill in one shot:
+The recommended path installs both the `setlist-fm-pp-cli` binary and the `pp-setlist-fm` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install setlist-fm
+npx -y @mvanhorn/printing-press-library install setlist-fm
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install setlist-fm --cli-only
+npx -y @mvanhorn/printing-press-library install setlist-fm --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install setlist-fm --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install setlist-fm --agent claude-code
+npx -y @mvanhorn/printing-press-library install setlist-fm --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.23+):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/setlist-fm/cmd/setlist-fm-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/setlist-fm/cmd/setlist-fm-pp-cli@latest
 ```
 
 This installs the CLI only — no skill.
@@ -54,6 +67,44 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-setlist-fm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-setlist-fm. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/setlist-fm-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `SETLIST_FM_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/setlist-fm/cmd/setlist-fm-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "setlist-fm": {
+      "command": "setlist-fm-pp-mcp",
+      "env": {
+        "SETLIST_FM_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ## Authentication
 
@@ -304,71 +355,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-setlist-fm -g
-```
-
-Then invoke `/pp-setlist-fm <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/other/setlist-fm/cmd/setlist-fm-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-claude mcp add setlist-fm setlist-fm-pp-mcp -e SETLIST_FM_API_KEY=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/setlist-fm-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `SETLIST_FM_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/other/setlist-fm/cmd/setlist-fm-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "setlist-fm": {
-      "command": "setlist-fm-pp-mcp",
-      "env": {
-        "SETLIST_FM_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Cookbook
 

--- a/library/media-and-entertainment/setlist-fm/SKILL.md
+++ b/library/media-and-entertainment/setlist-fm/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `setlist-fm-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install setlist-fm --cli-only
+   npx -y @mvanhorn/printing-press-library install setlist-fm --cli-only
    ```
 2. Verify: `setlist-fm-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/setlist-fm/cmd/setlist-fm-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Setlist.fm rate-limits to 2 requests per second and 1,440 per day, which makes any real analytics workflow impossible against the live API. This CLI syncs an artist's full setlist history to a local SQLite store once, then runs every transcendence query — predict, overdue, tour shape, song gap, covers, attended stats — instantly and offline. Six SDK wrappers exist across five languages; none of them store anything. This one does.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/skool/README.md
+++ b/library/media-and-entertainment/skool/README.md
@@ -9,26 +9,26 @@ Pulls every post, comment, member, course, lesson, and calendar event into a loc
 The recommended path installs both the `skool-pp-cli` binary and the `pp-skool` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install skool
+npx -y @mvanhorn/printing-press-library install skool
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install skool --cli-only
+npx -y @mvanhorn/printing-press-library install skool --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install skool --skill-only
+npx -y @mvanhorn/printing-press-library install skool --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install skool --agent claude-code
-npx -y @mvanhorn/printing-press install skool --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install skool --agent claude-code
+npx -y @mvanhorn/printing-press-library install skool --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/skool/SKILL.md
+++ b/library/media-and-entertainment/skool/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `skool-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install skool --cli-only
+   npx -y @mvanhorn/printing-press-library install skool --cli-only
    ```
 2. Verify: `skool-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/skool/cmd/skool-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Community + course platform (skool.com). No public API — reverse-engineered from www.skool.com Next.js data routes (reads) and api2.skool.com REST (writes), authenticated via the auth_token JWT cookie.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/spotify/README.md
+++ b/library/media-and-entertainment/spotify/README.md
@@ -13,26 +13,26 @@ Printed by [@rob-coco](https://github.com/rob-coco) (Rob Zehner).
 The recommended path installs both the `spotify-pp-cli` binary and the `pp-spotify` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install spotify
+npx -y @mvanhorn/printing-press-library install spotify
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install spotify --cli-only
+npx -y @mvanhorn/printing-press-library install spotify --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install spotify --skill-only
+npx -y @mvanhorn/printing-press-library install spotify --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install spotify --agent claude-code
-npx -y @mvanhorn/printing-press install spotify --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install spotify --agent claude-code
+npx -y @mvanhorn/printing-press-library install spotify --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/spotify/SKILL.md
+++ b/library/media-and-entertainment/spotify/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `spotify-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install spotify --cli-only
+   npx -y @mvanhorn/printing-press-library install spotify --cli-only
    ```
 2. Verify: `spotify-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/spotify/cmd/spotify-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every Spotify Web API endpoint is reachable from one static binary with --json and --select everywhere and a built-in MCP server, so an agent can drive playback, search, and library curation with the same surface a human uses. A local SQLite store captures top-tracks/top-artists snapshots, snapshot-keyed playlist tracks, and extended play history beyond Spotify's 50-event cap, enabling one-shot queries like 'which tracks dropped out of medium-term but stayed in long-term' that no existing CLI can answer. Endpoints Spotify removed for new apps on 2024-11-27 ship as honest deprecation-aware stubs with a --legacy-app opt-in.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/steam-web/README.md
+++ b/library/media-and-entertainment/steam-web/README.md
@@ -11,26 +11,26 @@ Learn more at [Steam Web](https://store.steampowered.com).
 The recommended path installs both the `steam-web-pp-cli` binary and the `pp-steam-web` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install steam-web
+npx -y @mvanhorn/printing-press-library install steam-web
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install steam-web --cli-only
+npx -y @mvanhorn/printing-press-library install steam-web --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install steam-web --skill-only
+npx -y @mvanhorn/printing-press-library install steam-web --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install steam-web --agent claude-code
-npx -y @mvanhorn/printing-press install steam-web --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install steam-web --agent claude-code
+npx -y @mvanhorn/printing-press-library install steam-web --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/steam-web/SKILL.md
+++ b/library/media-and-entertainment/steam-web/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `steam-web-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install steam-web --cli-only
+   npx -y @mvanhorn/printing-press-library install steam-web --cli-only
    ```
 2. Verify: `steam-web-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,12 +32,10 @@ This skill drives the `steam-web-pp-cli` binary. **You must verify the CLI is in
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/steam-web/cmd/steam-web-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Mirrors all 169 documented Steam Web API endpoints (and the undocumented store endpoints every wrapper picks one of) with rate-limit-aware throttling for the post-2025 25 req/s budget. Adds a local SQLite layer with FTS5 over apps, news, and achievements so cross-library queries — `next-achievement`, `friends compare`, `library audit`, `achievement-leaderboard` — run as one command instead of an N+1 fanout app rewrite. Ships an MCP server with both stdio and HTTP streamable transport plus a code-orchestration pair (`steam_web_search` + `steam_web_execute`) so the full surface is reachable without flooding your agent's tool catalog.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/substack-creator/README.md
+++ b/library/media-and-entertainment/substack-creator/README.md
@@ -6,26 +6,44 @@ Manage every Substack you own from one terminal. Sync posts, drafts, notes, comm
 
 ## Install
 
-The recommended path installs both the `substack-creator-pp-cli` binary and the `pp-substack-creator` agent skill in one shot:
+The recommended path installs both the `substack-creator-pp-cli` binary and the `pp-substack-creator` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install substack
+npx -y @mvanhorn/printing-press-library install substack-creator
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install substack --cli-only
+npx -y @mvanhorn/printing-press-library install substack-creator --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install substack-creator --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install substack-creator --agent claude-code
+npx -y @mvanhorn/printing-press-library install substack-creator --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack-creator/cmd/substack-creator-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
-Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/substack-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/substack-creator-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
@@ -50,6 +68,45 @@ Tell your OpenClaw agent (copy this):
 Install the pp-substack-creator skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-substack-creator. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+The bundle reuses your local browser session — set it up first if you haven't:
+
+```bash
+substack-creator-pp-cli auth login --chrome
+```
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/substack-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "substack": {
+      "command": "substack-creator-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Substack has no API tokens. The CLI reads your `connect.sid` and `substack.sid` cookies from a logged-in Chrome session: run `auth login --chrome` once, and the cookies are saved to `~/.config/substack-creator-pp-cli/config.toml`. When the session expires (every few weeks), log into Substack in your browser and rerun the command. No password, no OTP, no scraped credentials.
@@ -60,22 +117,17 @@ Substack has no API tokens. The CLI reads your `connect.sid` and `substack.sid` 
 # Import the connect.sid + substack.sid cookies from your logged-in Chrome session
 substack-creator-pp-cli auth login --chrome
 
-
 # Verify the session works end-to-end against /api/v1/profile
 substack-creator-pp-cli doctor
-
 
 # First-time full sync: posts, drafts, notes, comments, subscribers for every publication you own
 substack-creator-pp-cli sync --full
 
-
 # Cross-publication snapshot — the command the web UI cannot produce
 substack-creator-pp-cli portfolio --json
 
-
 # Named delta of who joined, left, upgraded, downgraded since last sync
 substack-creator-pp-cli subscribers churn --since 7d --json
-
 
 # FTS5 over years of posts + notes + comments
 substack-creator-pp-cli grep "yield curve" --scope all --since 2024-01-01
@@ -255,7 +307,6 @@ Manage your publication's subscribers.
 - **`substack-creator-pp-cli subscribers export_paid`** - Export paid subscribers as CSV.
 - **`substack-creator-pp-cli subscribers list`** - List subscribers for a publication you own.
 
-
 ## Output Formats
 
 ```bash
@@ -290,74 +341,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-substack-creator -g
-```
-
-Then invoke `/pp-substack-creator <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-# Some tools work without auth. For full access, set up auth first:
-substack-creator-pp-cli auth login --chrome
-
-claude mcp add substack substack-creator-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-The bundle reuses your local browser session — set it up first if you haven't:
-
-```bash
-substack-creator-pp-cli auth login --chrome
-```
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/substack-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "substack": {
-      "command": "substack-creator-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/media-and-entertainment/substack-creator/SKILL.md
+++ b/library/media-and-entertainment/substack-creator/SKILL.md
@@ -22,7 +22,7 @@ This skill drives the `substack-creator-pp-cli` binary. **You must verify the CL
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install substack-creator --cli-only
+   npx -y @mvanhorn/printing-press-library install substack-creator --cli-only
    ```
 2. Verify: `substack-creator-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -34,8 +34,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Manage every Substack you own from one terminal. Sync posts, drafts, notes, comments, and subscribers into a local SQLite store; FTS-search them offline; diff subscriber lists for honest churn reports; spot cross-sell candidates by joining paid and free lists across publications; and twin published posts into a sibling publication as drafts. Built for owners of multiple Substacks — bilingual writers, paid+free tier creators, anyone with more than one newsletter.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/substack/README.md
+++ b/library/media-and-entertainment/substack/README.md
@@ -9,26 +9,26 @@ Substack has no public API and the closed-source tools that work around it (Writ
 The recommended path installs both the `substack-pp-cli` binary and the `pp-substack` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install substack
+npx -y @mvanhorn/printing-press-library install substack
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install substack --cli-only
+npx -y @mvanhorn/printing-press-library install substack --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install substack --skill-only
+npx -y @mvanhorn/printing-press-library install substack --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install substack --agent claude-code
-npx -y @mvanhorn/printing-press install substack --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install substack --agent claude-code
+npx -y @mvanhorn/printing-press-library install substack --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/substack/SKILL.md
+++ b/library/media-and-entertainment/substack/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `substack-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install substack --cli-only
+   npx -y @mvanhorn/printing-press-library install substack --cli-only
    ```
 2. Verify: `substack-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Substack has no public API and the closed-source tools that work around it (WriteStack, StackSweller) stop at Notes scheduling and a heatmap. This CLI absorbs every endpoint the community has reverse-engineered across 8 wrappers, then transcends with local-SQLite analytics: per-Note subscriber attribution (`growth attribution`), engagement reciprocity tracking (`engage reciprocity`), and a goal-aware best-time recommender (`growth best-time`). Every command is MCP-callable so an agent can drive the full publish → engage → measure → swap loop.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/suno/README.md
+++ b/library/media-and-entertainment/suno/README.md
@@ -13,26 +13,26 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `suno-pp-cli` binary and the `pp-suno` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install suno
+npx -y @mvanhorn/printing-press-library install suno
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install suno --cli-only
+npx -y @mvanhorn/printing-press-library install suno --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install suno --skill-only
+npx -y @mvanhorn/printing-press-library install suno --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install suno --agent claude-code
-npx -y @mvanhorn/printing-press install suno --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install suno --agent claude-code
+npx -y @mvanhorn/printing-press-library install suno --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/suno/SKILL.md
+++ b/library/media-and-entertainment/suno/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `suno-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install suno --cli-only
+   npx -y @mvanhorn/printing-press-library install suno --cli-only
    ```
 2. Verify: `suno-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/cmd/suno-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every Suno workflow lands in a single Go binary: generate from a prompt, extend, concat, remaster, download with embedded lyrics and cover art. On top of that, every clip you generate syncs to a local SQLite store so you can list your library offline, run cross-table SQL queries, build vibe recipes that compound across sessions, and watch your credit burn by tag or persona. Built-in MCP server exposes the whole surface (stdio and HTTP) so agents reach Suno through one orchestration pair instead of 30 raw tools.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/tella/README.md
+++ b/library/media-and-entertainment/tella/README.md
@@ -8,28 +8,46 @@ Printed by [@gregce](https://github.com/gregce) (Greg Ceccarelli).
 
 ## Install
 
-The recommended path installs both the `tella-pp-cli` binary and the `pp-tella` agent skill in one shot:
+The recommended path installs both the `tella-pp-cli` binary and the `pp-tella` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install tella
+npx -y @mvanhorn/printing-press-library install tella
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tella --cli-only
+npx -y @mvanhorn/printing-press-library install tella --cli-only
 ```
 
-### Without Node
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+```bash
+npx -y @mvanhorn/printing-press-library install tella --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install tella --agent claude-code
+npx -y @mvanhorn/printing-press-library install tella --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/tella/cmd/tella-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/tella-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 <!-- pp-hermes-install-anchor -->
-
 ## Install for Hermes
 
 From the Hermes CLI:
@@ -52,6 +70,42 @@ Tell your OpenClaw agent (copy this):
 Install the pp-tella skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tella. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/tella-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `TELLA_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "tella": {
+      "command": "tella-pp-mcp",
+      "env": {
+        "TELLA_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Set TELLA_API_KEY to your Tella account API key (Account → Settings → API). Sent as Authorization: Bearer on every call. No OAuth, no refresh — it's a single static token.
@@ -62,22 +116,17 @@ Set TELLA_API_KEY to your Tella account API key (Account → Settings → API). 
 # Save your Tella API key to local config; used by every command.
 tella-pp-cli auth set-token
 
-
 # Verify token + reachability before doing anything else.
 tella-pp-cli doctor
-
 
 # Sanity-check that you can see your workspace.
 tella-pp-cli videos list --json --limit 5
 
-
 # Populate the local SQLite store; required for transcript search and milestone digest.
 tella-pp-cli sync
 
-
 # Offline FTS5 search across every cached transcript.
 tella-pp-cli transcripts search "pricing" --json
-
 
 # Stream new webhook events to stdout; useful during integration development.
 tella-pp-cli webhooks tail --follow
@@ -252,67 +301,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-tella -g
-```
-
-Then invoke `/pp-tella <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add tella tella-pp-mcp -e TELLA_API_KEY=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/tella-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `TELLA_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "tella": {
-      "command": "tella-pp-mcp",
-      "env": {
-        "TELLA_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/media-and-entertainment/tella/SKILL.md
+++ b/library/media-and-entertainment/tella/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `tella-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install tella --cli-only
+   npx -y @mvanhorn/printing-press-library install tella --cli-only
    ```
 2. Verify: `tella-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/tella/cmd/tella-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Tella ships an API and an official MCP server; this CLI gives you both surfaces in one binary, plus a local-first store that makes cross-video transcript search, view-milestone rollups, and webhook replay actually fast. Every endpoint is a Cobra command, every command emits structured JSON, and every mutation supports --dry-run.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/ticketmaster/README.md
+++ b/library/media-and-entertainment/ticketmaster/README.md
@@ -13,26 +13,26 @@ Printed by [@omarshahine](https://github.com/omarshahine) (Omar Shahine).
 The recommended path installs both the `ticketmaster-pp-cli` binary and the `pp-ticketmaster` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ticketmaster
+npx -y @mvanhorn/printing-press-library install ticketmaster
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ticketmaster --cli-only
+npx -y @mvanhorn/printing-press-library install ticketmaster --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ticketmaster --skill-only
+npx -y @mvanhorn/printing-press-library install ticketmaster --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install ticketmaster --agent claude-code
-npx -y @mvanhorn/printing-press install ticketmaster --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install ticketmaster --agent claude-code
+npx -y @mvanhorn/printing-press-library install ticketmaster --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/ticketmaster/SKILL.md
+++ b/library/media-and-entertainment/ticketmaster/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `ticketmaster-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ticketmaster --cli-only
+   npx -y @mvanhorn/printing-press-library install ticketmaster --cli-only
    ```
 2. Verify: `ticketmaster-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/media-and-entertai
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI is the first single-binary tool for the Ticketmaster Discovery API. It absorbs the full read-only surface (events, venues, attractions, classifications, suggest) and adds a local SQLite store with FTS search, named watchlists, residency collapse, tour-view with on-sale flags, and markdown briefs — the workflows real users built scripts to handle.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/wikipedia/README.md
+++ b/library/media-and-entertainment/wikipedia/README.md
@@ -9,26 +9,26 @@ Uses a polite User-Agent header.
 The recommended path installs both the `wikipedia-pp-cli` binary and the `pp-wikipedia` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install wikipedia
+npx -y @mvanhorn/printing-press-library install wikipedia
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install wikipedia --cli-only
+npx -y @mvanhorn/printing-press-library install wikipedia --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install wikipedia --skill-only
+npx -y @mvanhorn/printing-press-library install wikipedia --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install wikipedia --agent claude-code
-npx -y @mvanhorn/printing-press install wikipedia --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install wikipedia --agent claude-code
+npx -y @mvanhorn/printing-press-library install wikipedia --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/media-and-entertainment/wikipedia/SKILL.md
+++ b/library/media-and-entertainment/wikipedia/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `wikipedia-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install wikipedia --cli-only
+   npx -y @mvanhorn/printing-press-library install wikipedia --cli-only
    ```
 2. Verify: `wikipedia-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/media-and-entertainment/youtube/README.md
+++ b/library/media-and-entertainment/youtube/README.md
@@ -12,22 +12,40 @@ Printed by [@justinwfu](https://github.com/justinwfu) (Justin).
 
 ## Install
 
-The recommended path installs both the `youtube-pp-cli` binary and the `pp-youtube` agent skill in one shot:
+The recommended path installs both the `youtube-pp-cli` binary and the `pp-youtube` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install youtube
+npx -y @mvanhorn/printing-press-library install youtube
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install youtube --cli-only
+npx -y @mvanhorn/printing-press-library install youtube --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install youtube --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install youtube --agent claude-code
+npx -y @mvanhorn/printing-press-library install youtube --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/youtube/cmd/youtube-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -56,6 +74,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-youtube skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-youtube. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/youtube-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `YOUTUBE_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "youtube": {
+      "command": "youtube-pp-mcp",
+      "env": {
+        "YOUTUBE_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 API-key only — set `YOUTUBE_API_KEY` and you're done. Read-only public-data operations only (10,000 quota units/day default). Write operations are not configured; this CLI is for discovery and research, not channel management.
@@ -66,22 +121,17 @@ API-key only — set `YOUTUBE_API_KEY` and you're done. Read-only public-data op
 # Verify the API key and reachability.
 youtube-pp-cli doctor
 
-
 # Single-term search.
 youtube-pp-cli youtube search-list --q "sourdough scoring" --max-results 5 --json
-
 
 # Bulk search from positional args — the photo-keywords -> videos shape (use --stdin to read from a file/pipe instead).
 youtube-pp-cli youtube search-bulk "sourdough scoring" "latte art" --top 3 --json
 
-
 # Fetch the transcript to verify topic relevance before picking the video.
 youtube-pp-cli youtube videos-transcript dQw4w9WgXcQ --lang en
 
-
 # Get a markdown embed snippet for the blog draft.
 youtube-pp-cli youtube videos-embed dQw4w9WgXcQ --format markdown
-
 
 # Find more candidates similar to a video you've already picked.
 youtube-pp-cli youtube videos-related dQw4w9WgXcQ --limit 5
@@ -170,7 +220,6 @@ Run `youtube-pp-cli --help` for the full command reference and flag list.
 - **`youtube-pp-cli youtube videos-comments`** - Top comments on a video, ranked locally by likeCount.
 - **`youtube-pp-cli youtube channel-uploads`** - List a channel's most recent uploads in one call (resolves `@handle` → uploads playlist).
 
-
 ## Output Formats
 
 ```bash
@@ -203,69 +252,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-youtube -g
-```
-
-Then invoke `/pp-youtube <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add youtube youtube-pp-mcp -e YOUTUBE_API_KEY=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/youtube-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `YOUTUBE_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "youtube": {
-      "command": "youtube-pp-mcp",
-      "env": {
-        "YOUTUBE_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/media-and-entertainment/youtube/SKILL.md
+++ b/library/media-and-entertainment/youtube/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `youtube-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install youtube --cli-only
+   npx -y @mvanhorn/printing-press-library install youtube --cli-only
    ```
 2. Verify: `youtube-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/youtube/cmd/youtube-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-A trimmed read-only YouTube Data API v3 CLI built for local research workflows. Bulk search from stdin, transcript fetching via timedtext (no OAuth needed), embed snippet generation, and a heuristic-based `videos related` that still works despite the 2023 deprecation.
 
 ## When to Use This CLI
 

--- a/library/monitoring/sentry/README.md
+++ b/library/monitoring/sentry/README.md
@@ -11,26 +11,26 @@ Learn more at [Sentry](https://sentry.io).
 The recommended path installs both the `sentry-pp-cli` binary and the `pp-sentry` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install sentry
+npx -y @mvanhorn/printing-press-library install sentry
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sentry --cli-only
+npx -y @mvanhorn/printing-press-library install sentry --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sentry --skill-only
+npx -y @mvanhorn/printing-press-library install sentry --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install sentry --agent claude-code
-npx -y @mvanhorn/printing-press install sentry --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install sentry --agent claude-code
+npx -y @mvanhorn/printing-press-library install sentry --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/monitoring/sentry/SKILL.md
+++ b/library/monitoring/sentry/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `sentry-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install sentry --cli-only
+   npx -y @mvanhorn/printing-press-library install sentry --cli-only
    ```
 2. Verify: `sentry-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/american-reindustrialization/README.md
+++ b/library/other/american-reindustrialization/README.md
@@ -11,31 +11,37 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `american-reindustrialization-pp-cli` binary and the `pp-american-reindustrialization` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install american-reindustrialization
+npx -y @mvanhorn/printing-press-library install american-reindustrialization
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install american-reindustrialization --cli-only
+npx -y @mvanhorn/printing-press-library install american-reindustrialization --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install american-reindustrialization --skill-only
+npx -y @mvanhorn/printing-press-library install american-reindustrialization --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install american-reindustrialization --agent claude-code
-npx -y @mvanhorn/printing-press install american-reindustrialization --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install american-reindustrialization --agent claude-code
+npx -y @mvanhorn/printing-press-library install american-reindustrialization --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/american-reindustrialization/cmd/american-reindustrialization-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -103,18 +109,14 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # Pull every company, job, category, and tag into local SQLite; all subsequent commands run offline.
 american-reindustrialization-pp-cli sync
 
-
 # Cached list of California companies with full agent-native output.
 american-reindustrialization-pp-cli companies list --state CA --json
-
 
 # Composed multi-axis filter no website view exposes.
 american-reindustrialization-pp-cli openings find --work-mode remote --experience senior --salary-min 150000
 
-
 # Sector × state crosstab weighted by job openings — pure local SQL.
 american-reindustrialization-pp-cli analytics sector-heatmap --weight jobs
-
 
 # Diff against the prior sync snapshot — companies and jobs that appeared or changed.
 american-reindustrialization-pp-cli whats-new --since 2026-05-12
@@ -242,7 +244,6 @@ Typed tags (tag_type = tech, sector, focus area, etc.)
 - **`american-reindustrialization-pp-cli tags get`** - Get one tag by slug
 - **`american-reindustrialization-pp-cli tags list`** - List every tag (bare array)
 - **`american-reindustrialization-pp-cli tags search`** - Search tags by query string
-
 
 ## Output Formats
 

--- a/library/other/american-reindustrialization/SKILL.md
+++ b/library/other/american-reindustrialization/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `american-reindustrialization-pp-cli` binary. **You must v
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install american-reindustrialization --cli-only
+   npx -y @mvanhorn/printing-press-library install american-reindustrialization --cli-only
    ```
 2. Verify: `american-reindustrialization-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/american-reindustrialization/cmd/american-reindustrialization-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-A read-only CLI for the company directory and jobs board at americanreindustrialization.com. Sync once, then run cross-entity queries (jobs at robotics companies in TX, sector × state heatmaps, funding × sector crosstabs, week-over-week diffs) entirely offline, with agent-native JSON and a local SQLite surface no view on the website exposes.
 
 ## When to Use This CLI
 

--- a/library/other/apartments/README.md
+++ b/library/other/apartments/README.md
@@ -11,26 +11,26 @@ Learn more at [Apartments.com](https://www.apartments.com).
 The recommended path installs both the `apartments-pp-cli` binary and the `pp-apartments` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install apartments
+npx -y @mvanhorn/printing-press-library install apartments
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install apartments --cli-only
+npx -y @mvanhorn/printing-press-library install apartments --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install apartments --skill-only
+npx -y @mvanhorn/printing-press-library install apartments --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install apartments --agent claude-code
-npx -y @mvanhorn/printing-press install apartments --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install apartments --agent claude-code
+npx -y @mvanhorn/printing-press-library install apartments --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/apartments/SKILL.md
+++ b/library/other/apartments/SKILL.md
@@ -16,7 +16,7 @@ This skill drives the `apartments-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install apartments --cli-only
+   npx -y @mvanhorn/printing-press-library install apartments --cli-only
    ```
 2. Verify: `apartments-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/arxiv/README.md
+++ b/library/other/arxiv/README.md
@@ -9,26 +9,26 @@ Printed by [@hiten-shah](https://github.com/hiten-shah) (Hiten Shah).
 The recommended path installs both the `arxiv-pp-cli` binary and the `pp-arxiv` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install arxiv
+npx -y @mvanhorn/printing-press-library install arxiv
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install arxiv --cli-only
+npx -y @mvanhorn/printing-press-library install arxiv --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install arxiv --skill-only
+npx -y @mvanhorn/printing-press-library install arxiv --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install arxiv --agent claude-code
-npx -y @mvanhorn/printing-press install arxiv --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install arxiv --agent claude-code
+npx -y @mvanhorn/printing-press-library install arxiv --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/arxiv/SKILL.md
+++ b/library/other/arxiv/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `arxiv-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install arxiv --cli-only
+   npx -y @mvanhorn/printing-press-library install arxiv --cli-only
    ```
 2. Verify: `arxiv-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/edgar/README.md
+++ b/library/other/edgar/README.md
@@ -9,26 +9,26 @@ Built for a Claude Code agent doing conviction research on public-company filing
 The recommended path installs both the `edgar-pp-cli` binary and the `pp-edgar` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install edgar
+npx -y @mvanhorn/printing-press-library install edgar
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install edgar --cli-only
+npx -y @mvanhorn/printing-press-library install edgar --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install edgar --skill-only
+npx -y @mvanhorn/printing-press-library install edgar --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install edgar --agent claude-code
-npx -y @mvanhorn/printing-press install edgar --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install edgar --agent claude-code
+npx -y @mvanhorn/printing-press-library install edgar --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/edgar/SKILL.md
+++ b/library/other/edgar/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `edgar-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install edgar --cli-only
+   npx -y @mvanhorn/printing-press-library install edgar --cli-only
    ```
 2. Verify: `edgar-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/edgar/cmd/edgar-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Built for a Claude Code agent doing conviction research on public-company filings. Compound commands collapse a ticker's full primary-source pull into one structured response; insider-summary distinguishes discretionary code-S sales from RSU-tax code-F noise and flags senior officers separately. Local SQLite cache with tiered TTLs makes re-reads near-free; FTS5 over cached bodies eliminates re-hitting EDGAR for the same query.
 
 ## When to Use This CLI
 

--- a/library/other/greatclips/README.md
+++ b/library/other/greatclips/README.md
@@ -45,26 +45,26 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `greatclips-pp-cli` binary and the `pp-greatclips` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install greatclips
+npx -y @mvanhorn/printing-press-library install greatclips
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install greatclips --cli-only
+npx -y @mvanhorn/printing-press-library install greatclips --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install greatclips --skill-only
+npx -y @mvanhorn/printing-press-library install greatclips --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install greatclips --agent claude-code
-npx -y @mvanhorn/printing-press install greatclips --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install greatclips --agent claude-code
+npx -y @mvanhorn/printing-press-library install greatclips --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/greatclips/SKILL.md
+++ b/library/other/greatclips/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `greatclips-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install greatclips --cli-only
+   npx -y @mvanhorn/printing-press-library install greatclips --cli-only
    ```
 2. Verify: `greatclips-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/other/greatclips/c
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Drives the Great Clips Online Check-In API (webservices.greatclips.com) and the ICS Net Check-In wait/check-in service (www.stylewaretouch.net) from one Go binary. v0.1 ships every endpoint with --dry-run and --json so an agent can build flows on top; live calls require pasting cookies from a logged-in Chrome session (documented v0.2 gap).
 
 ## When to Use This CLI
 

--- a/library/other/numista/README.md
+++ b/library/other/numista/README.md
@@ -11,31 +11,37 @@ Printed by [@vinnyp](https://github.com/vinnyp) (Vinny Pasceri).
 The recommended path installs both the `numista-pp-cli` binary and the `pp-numista` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install numista
+npx -y @mvanhorn/printing-press-library install numista
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install numista --cli-only
+npx -y @mvanhorn/printing-press-library install numista --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install numista --skill-only
+npx -y @mvanhorn/printing-press-library install numista --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install numista --agent claude-code
-npx -y @mvanhorn/printing-press install numista --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install numista --agent claude-code
+npx -y @mvanhorn/printing-press-library install numista --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/numista/cmd/numista-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,22 +117,17 @@ Set `NUMISTA_API_KEY` in your environment (request one at https://en.numista.com
 # Confirm the API key is set, the network is reachable, and the local store is initialized.
 numista-pp-cli doctor
 
-
 # Local SQL view over the lookup_log table: every API call you have made this month, grouped by endpoint. Zero API cost. Pair with the root `--quota` flag (e.g. `numista-pp-cli --quota`) to see this month's used/remaining.
 numista-pp-cli audit --by-endpoint --json
-
 
 # Find a type by free-text search; one API call, result cached.
 numista-pp-cli types search --q 'Australia 3 pence George VI' --json
 
-
 # Fetch full type details; cached on subsequent runs.
 numista-pp-cli types get 11013 --json
 
-
 # Pull every year of issue + every grade's price for one type in one quota-aware fan-out.
 numista-pp-cli types series 11013 --json
-
 
 # Grant the CLI access to your own collection; needed once for user-scoped commands.
 numista-pp-cli oauth-token --grant-type client_credentials --scope view_collection
@@ -245,9 +246,7 @@ Manage oauth token
 - **`numista-pp-cli oauth-token`** - In order to access the data of a Numista user, you will need to authenticate using the OAuth 2.0 protocol.
 See the section "Authentication" above.
 
-
 Two types of authentications are available: authorization code and client credentials.
-
 
 For the "authoriation code" flow, call the endpoint `/oauth_token` with the following parameters:
 - `grant_type` is "authorization_code".
@@ -255,7 +254,6 @@ For the "authoriation code" flow, call the endpoint `/oauth_token` with the foll
 - `client_id` is the client ID which was assigned to your application and provided together with your API key.
 - `client_secret` is your API key.
 - `redirect_uri` is the redirection URI you specified for the step described above.
-
 
 For the "client credentials" flow, call the endpoint `/oauth_token` with the following parameters:
 - `grant_type` is "client_credentials".
@@ -265,7 +263,6 @@ You may use the resulting access token for all subsequent API calls which need u
 The access token should be provided in the HTTP header of the subsequent API calls according the following model:
 
 `Authorization: Bearer {access_token}`
-
 
 The access token has a limited validity period. The lifetime of the access token is indicated in the response of the API.
 
@@ -287,7 +284,6 @@ Manage types
 The API endpoints in this section allow to access data about the Numista users and their collection.
 
 - **`numista-pp-cli users <user_id>`** - Get details about a user
-
 
 ## Output Formats
 

--- a/library/other/numista/SKILL.md
+++ b/library/other/numista/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `numista-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install numista --cli-only
+   npx -y @mvanhorn/printing-press-library install numista --cli-only
    ```
 2. Verify: `numista-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/numista/cmd/numista-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI wraps the Numista REST API in a Go single binary, persists every type, issuer, mint, catalogue, and collected item into a local SQLite store, and tracks the 2000-call monthly free-plan quota client-side so batches never run blind. Commands like `types series`, `collection value`, and `crawl issuer` only exist because the local cache lets the CLI compose dozens of calls into one quota-aware operation.
 
 ## When to Use This CLI
 

--- a/library/other/open-meteo/README.md
+++ b/library/other/open-meteo/README.md
@@ -9,26 +9,26 @@ Comprehensive coverage of Open-Meteo's free, no-API-key tier across all 11 endpo
 The recommended path installs both the `open-meteo-pp-cli` binary and the `pp-open-meteo` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install open-meteo
+npx -y @mvanhorn/printing-press-library install open-meteo
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install open-meteo --cli-only
+npx -y @mvanhorn/printing-press-library install open-meteo --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install open-meteo --skill-only
+npx -y @mvanhorn/printing-press-library install open-meteo --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install open-meteo --agent claude-code
-npx -y @mvanhorn/printing-press install open-meteo --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install open-meteo --agent claude-code
+npx -y @mvanhorn/printing-press-library install open-meteo --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/open-meteo/SKILL.md
+++ b/library/other/open-meteo/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `open-meteo-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install open-meteo --cli-only
+   npx -y @mvanhorn/printing-press-library install open-meteo --cli-only
    ```
 2. Verify: `open-meteo-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/openalex/README.md
+++ b/library/other/openalex/README.md
@@ -11,26 +11,26 @@ Printed by [@hiten-shah](https://github.com/hiten-shah) (Hiten Shah).
 The recommended path installs both the `openalex-pp-cli` binary and the `pp-openalex` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install openalex
+npx -y @mvanhorn/printing-press-library install openalex
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openalex --cli-only
+npx -y @mvanhorn/printing-press-library install openalex --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install openalex --skill-only
+npx -y @mvanhorn/printing-press-library install openalex --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install openalex --agent claude-code
-npx -y @mvanhorn/printing-press install openalex --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install openalex --agent claude-code
+npx -y @mvanhorn/printing-press-library install openalex --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/openalex/SKILL.md
+++ b/library/other/openalex/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `openalex-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install openalex --cli-only
+   npx -y @mvanhorn/printing-press-library install openalex --cli-only
    ```
 2. Verify: `openalex-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/other/pcgs/README.md
+++ b/library/other/pcgs/README.md
@@ -11,31 +11,37 @@ Printed by [@vinnyp](https://github.com/vinnyp) (Vinny Pasceri).
 The recommended path installs both the `pcgs-pp-cli` binary and the `pp-pcgs` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pcgs
+npx -y @mvanhorn/printing-press-library install pcgs
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pcgs --cli-only
+npx -y @mvanhorn/printing-press-library install pcgs --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pcgs --skill-only
+npx -y @mvanhorn/printing-press-library install pcgs --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pcgs --agent claude-code
-npx -y @mvanhorn/printing-press install pcgs --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pcgs --agent claude-code
+npx -y @mvanhorn/printing-press-library install pcgs --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/pcgs/cmd/pcgs-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,22 +117,17 @@ Set `PCGS_AUTH_TOKEN` to the bearer token generated at https://www.pcgs.com/publ
 # Confirm the token is set and the API is reachable before spending quota.
 pcgs-pp-cli doctor --json
 
-
 # See today's used / remaining / reset before any batch.
 pcgs-pp-cli --quota --json
-
 
 # Single-cert verification + full CoinFacts extraction (IsValidRequest = true iff the cert is legit).
 pcgs-pp-cli coin facts-cert 53972744 --json
 
-
 # Forecast batch cost against remaining quota with zero live calls.
 pcgs-pp-cli coin batch --file examples-pcgs-coin-list.csv --dry-run --json
 
-
 # Real batch ingest, resumable across UTC days if the file is larger than the daily budget.
 pcgs-pp-cli coin batch --file examples-pcgs-coin-list.csv --resumable --checkpoint pcgs.ckpt --json
-
 
 # Refresh only Population / PriceGuide / Auction / Images / CoinFactsNotes — never overwrite cert identity.
 pcgs-pp-cli refresh --all --older 7d --json
@@ -217,7 +218,6 @@ PCGS submission and order lookups for submitters.
 
 - **`pcgs-pp-cli order range`** - Orders within a date window (paginated).
 - **`pcgs-pp-cli order submission`** - Orders associated with one PCGS submission number.
-
 
 ## Output Formats
 

--- a/library/other/pcgs/SKILL.md
+++ b/library/other/pcgs/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `pcgs-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pcgs --cli-only
+   npx -y @mvanhorn/printing-press-library install pcgs --cli-only
    ```
 2. Verify: `pcgs-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/other/pcgs/cmd/pcg
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-PCGS gives you 1,000 API calls per day per token. This CLI tracks every call locally, forecasts batch cost before you spend a single one, syncs only mutable market fields on refresh, and ingests CSV / JSON / JSONL / plain-text cert lists straight into a local SQLite cache. No community wrapper exists. This is the only PCGS CLI.
 
 ## When to Use This CLI
 

--- a/library/other/pvgis/README.md
+++ b/library/other/pvgis/README.md
@@ -11,31 +11,37 @@ Printed by [@robertobissanti](https://github.com/robertobissanti) (Roberto Bissa
 The recommended path installs both the `pvgis-pp-cli` binary and the `pp-pvgis` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pvgis
+npx -y @mvanhorn/printing-press-library install pvgis
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pvgis --cli-only
+npx -y @mvanhorn/printing-press-library install pvgis --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pvgis --skill-only
+npx -y @mvanhorn/printing-press-library install pvgis --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pvgis --agent claude-code
-npx -y @mvanhorn/printing-press install pvgis --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pvgis --agent claude-code
+npx -y @mvanhorn/printing-press-library install pvgis --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/pvgis/cmd/pvgis-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -103,18 +109,14 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # Confirm the JRC API is reachable from this machine.
 pvgis-pp-cli doctor
 
-
 # Monthly irradiance for a Milano-area site, fixed tilt 30 south.
 pvgis-pp-cli radiation monthly --lat 45.0 --lon 9.0 --tilt 30 --azimuth 0 --json
-
 
 # Annual yield for a 5 kWp crystSi system at the same spot.
 pvgis-pp-cli production monthly --lat 45.0 --lon 9.0 --pnom 5 --system-loss 14 --tilt 30 --azimuth 0 --json
 
-
 # Sweep tilt 0-60 to find the production peak for a south-facing system.
 pvgis-pp-cli production optimal-tilt --lat 45.0 --lon 9.0 --azimuth 0 --json
-
 
 # Pull the full 8760-hour TMY; pipe through jq or save for downstream tools.
 pvgis-pp-cli weather tmy --lat 45.0 --lon 9.0 --json --select outputs.tmy_hourly
@@ -194,7 +196,6 @@ Solar radiation queries — monthly irradiance on horizontal, tilted, or optimal
 Typical Meteorological Year (TMY) weather data — 8760-hour synthetic year representative of long-term climate.
 
 - **`pvgis-pp-cli weather`** - Typical Meteorological Year for a site. Returns 8760 hourly rows with air temperature T2m, relative humidity, global horizontal irradiance G(h), beam normal Gb(n), diffuse Gd(h), longwave IR(h), wind speed WS10m, wind direction WD10m, surface pressure SP. Constructed from the long-term record so it represents climate, not a specific year.
-
 
 ## Output Formats
 

--- a/library/other/pvgis/SKILL.md
+++ b/library/other/pvgis/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `pvgis-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pvgis --cli-only
+   npx -y @mvanhorn/printing-press-library install pvgis --cli-only
    ```
 2. Verify: `pvgis-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/pvgis/cmd/pvgis-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Estimates monthly and hourly PV production, downloads Typical Meteorological Year (TMY) weather, fetches DEM-derived horizon profiles, and finds optimal tilt for any point covered by PVGIS-SARAH3, PVGIS-NSRDB, or PVGIS-ERA5. Adds offline SQLite caching, multi-site fan-out (`sites rank`), and a local 2D tilt/azimuth heatmap (`production sweep`) that no PVGIS endpoint returns directly.
 
 ## When to Use This CLI
 

--- a/library/other/redfin/README.md
+++ b/library/other/redfin/README.md
@@ -11,26 +11,26 @@ Learn more at [Redfin](https://www.redfin.com).
 The recommended path installs both the `redfin-pp-cli` binary and the `pp-redfin` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install redfin
+npx -y @mvanhorn/printing-press-library install redfin
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install redfin --cli-only
+npx -y @mvanhorn/printing-press-library install redfin --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install redfin --skill-only
+npx -y @mvanhorn/printing-press-library install redfin --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install redfin --agent claude-code
-npx -y @mvanhorn/printing-press install redfin --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install redfin --agent claude-code
+npx -y @mvanhorn/printing-press-library install redfin --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/redfin/SKILL.md
+++ b/library/other/redfin/SKILL.md
@@ -16,7 +16,7 @@ This skill drives the `redfin-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install redfin --cli-only
+   npx -y @mvanhorn/printing-press-library install redfin --cli-only
    ```
 2. Verify: `redfin-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -28,8 +28,6 @@ go install github.com/mvanhorn/printing-press-library/library/other/redfin/cmd/r
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Search homes for sale via Redfin's internal Stingray endpoints from the terminal, sync results to a local SQLite store, and run the workflows the website never built: diff a saved search week-over-week with `watch`, rank by $/sqft net of HOA with `rank`, pull sold comps for a subject property with `comps`, surface price drops or stale listings with `drops`, and overlay market trends across multiple cities with `trends`. Every command is `--json` / `--select`-shaped so an agent can pipe the output without burning context.
 
 ## When to Use This CLI
 

--- a/library/other/ufo-goat/README.md
+++ b/library/other/ufo-goat/README.md
@@ -9,26 +9,26 @@ The first CLI for the War.gov/UFO declassified files portal. Search across all f
 The recommended path installs both the `ufo-goat-pp-cli` binary and the `pp-ufo-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo-goat
+npx -y @mvanhorn/printing-press-library install ufo-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo-goat --cli-only
+npx -y @mvanhorn/printing-press-library install ufo-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo-goat --skill-only
+npx -y @mvanhorn/printing-press-library install ufo-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install ufo-goat --agent claude-code
-npx -y @mvanhorn/printing-press install ufo-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install ufo-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install ufo-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/ufo-goat/SKILL.md
+++ b/library/other/ufo-goat/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `ufo-goat-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install ufo-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install ufo-goat --cli-only
    ```
 2. Verify: `ufo-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/other/ufo-goat/cmd/ufo-goat-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The first CLI for the War.gov/UFO declassified files portal. Search across all four agencies (DoW, FBI, NASA, State), download files with resume support, track new release tranches, and discover video-PDF pairings — all from a single binary with offline SQLite storage.
 
 ## When to Use This CLI
 

--- a/library/other/usgs-earthquakes/README.md
+++ b/library/other/usgs-earthquakes/README.md
@@ -13,26 +13,26 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `usgs-earthquakes-pp-cli` binary and the `pp-usgs-earthquakes` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install usgs-earthquakes
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install usgs-earthquakes --cli-only
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install usgs-earthquakes --skill-only
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install usgs-earthquakes --agent claude-code
-npx -y @mvanhorn/printing-press install usgs-earthquakes --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes --agent claude-code
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -117,22 +117,17 @@ No authentication required. USGS earthquake services are fully public; doctor ve
 # List M4.5+ earthquakes in the last 24h. Default for newsroom triage.
 usgs-earthquakes-pp-cli recent --min-magnitude 4.5 --json
 
-
 # Pull the pre-built 'past week, significant' summary feed once.
 usgs-earthquakes-pp-cli feeds get significant_week --json
-
 
 # Populate the local SQLite cache (30 days, M2.5+) so search/sql/aftershocks/top/changes work offline.
 usgs-earthquakes-pp-cli sync
 
-
 # Rank recent events by composite editorial score (sig × alert × felt × tsunami).
 usgs-earthquakes-pp-cli top --window 24h --limit 10 --json
 
-
 # Get a one-event briefing with PAGER, DYFI, tsunami, ShakeMap MMI, and product inventory.
 usgs-earthquakes-pp-cli brief us7000abcd --format markdown
-
 
 # Investigate a mainshock's aftershock sequence from the local store.
 usgs-earthquakes-pp-cli aftershocks us7000abcd --radius-km 100 --days 30 --json
@@ -244,7 +239,6 @@ Pre-built GeoJSON earthquake summary feeds (updated every minute by USGS)
 FDSN Event service metadata: enumerated values for every parameter
 
 - **`usgs-earthquakes-pp-cli metadata`** - Show enum dictionaries for catalogs, contributors, event types, product types, and magnitude types
-
 
 ## Output Formats
 

--- a/library/other/usgs-earthquakes/SKILL.md
+++ b/library/other/usgs-earthquakes/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `usgs-earthquakes-pp-cli` binary. **You must verify the CL
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install usgs-earthquakes --cli-only
+   npx -y @mvanhorn/printing-press-library install usgs-earthquakes --cli-only
    ```
 2. Verify: `usgs-earthquakes-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/other/usgs-earthqu
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Wraps the full USGS FDSN Event Service and all 20 GeoJSON summary feeds in a single binary. Adds a 30-day rolling local SQLite cache so search, sql, aftershocks, swarm-detect, top, and changes run instantly without the network. Built for seismologists, journalists, emergency managers, and agents that need to reason about earthquake activity programmatically.
 
 ## When to Use This CLI
 

--- a/library/other/weather-goat/README.md
+++ b/library/other/weather-goat/README.md
@@ -9,26 +9,26 @@ Powered by Open-Meteo (global forecasts, 80 years of history, air quality) and N
 The recommended path installs both the `weather-goat-pp-cli` binary and the `pp-weather-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install weather-goat
+npx -y @mvanhorn/printing-press-library install weather-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install weather-goat --cli-only
+npx -y @mvanhorn/printing-press-library install weather-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install weather-goat --skill-only
+npx -y @mvanhorn/printing-press-library install weather-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install weather-goat --agent claude-code
-npx -y @mvanhorn/printing-press install weather-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install weather-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install weather-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/other/weather-goat/SKILL.md
+++ b/library/other/weather-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `weather-goat-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install weather-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install weather-goat --cli-only
    ```
 2. Verify: `weather-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/coingecko/README.md
+++ b/library/payments/coingecko/README.md
@@ -9,26 +9,26 @@ Learn more at [Coingecko](https://www.coingecko.com).
 The recommended path installs both the `coingecko-pp-cli` binary and the `pp-coingecko` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install coingecko
+npx -y @mvanhorn/printing-press-library install coingecko
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install coingecko --cli-only
+npx -y @mvanhorn/printing-press-library install coingecko --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install coingecko --skill-only
+npx -y @mvanhorn/printing-press-library install coingecko --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install coingecko --agent claude-code
-npx -y @mvanhorn/printing-press install coingecko --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install coingecko --agent claude-code
+npx -y @mvanhorn/printing-press-library install coingecko --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/payments/coingecko/SKILL.md
+++ b/library/payments/coingecko/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `coingecko-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install coingecko --cli-only
+   npx -y @mvanhorn/printing-press-library install coingecko --cli-only
    ```
 2. Verify: `coingecko-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/exchangerate-api/README.md
+++ b/library/payments/exchangerate-api/README.md
@@ -11,31 +11,37 @@ Printed by [@vinnyp](https://github.com/vinnyp) (Vinny Pasceri).
 The recommended path installs both the `exchangerate-api-pp-cli` binary and the `pp-exchangerate-api` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install exchangerate-api
+npx -y @mvanhorn/printing-press-library install exchangerate-api
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install exchangerate-api --cli-only
+npx -y @mvanhorn/printing-press-library install exchangerate-api --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install exchangerate-api --skill-only
+npx -y @mvanhorn/printing-press-library install exchangerate-api --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install exchangerate-api --agent claude-code
-npx -y @mvanhorn/printing-press install exchangerate-api --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install exchangerate-api --agent claude-code
+npx -y @mvanhorn/printing-press-library install exchangerate-api --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/payments/exchangerate-api/cmd/exchangerate-api-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,22 +117,17 @@ Set `EXCHANGERATE_API_KEY` from your ExchangeRate-API dashboard (https://app.exc
 # Confirms key works and the API is reachable
 exchangerate-api-pp-cli doctor
 
-
 # Pulls latest rates and seeds local snapshots; foundation for offline + history features
 exchangerate-api-pp-cli sync-rates --base USD
-
 
 # Single-pair lookup, the most common request
 exchangerate-api-pp-cli rates pair USD EUR
 
-
 # Multi-target conversion with one API call
 exchangerate-api-pp-cli convert 250 USD EUR,GBP,JPY --json
 
-
 # Cross-rate matrix — N² rates, 1 quota tick
 exchangerate-api-pp-cli matrix USD,EUR,GBP,JPY --base USD --json
-
 
 # How fast you're burning the monthly 1500-call quota
 exchangerate-api-pp-cli quota burn --json
@@ -267,7 +268,6 @@ Live exchange rates and conversions
 - **`exchangerate-api-pp-cli doctor`** - Verify credentials and API reachability
 - **`exchangerate-api-pp-cli open`** - Keyless `open.er-api.com` lookup (rate-limited, attribution required)
 - **`exchangerate-api-pp-cli mcp serve`** - Run as an MCP server for AI agents
-
 
 ## Output Formats
 

--- a/library/payments/exchangerate-api/SKILL.md
+++ b/library/payments/exchangerate-api/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `exchangerate-api-pp-cli` binary. **You must verify the CL
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install exchangerate-api --cli-only
+   npx -y @mvanhorn/printing-press-library install exchangerate-api --cli-only
    ```
 2. Verify: `exchangerate-api-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/payments/exchangerate-api/cmd/exchangerate-api-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI exposes every ExchangeRate-API endpoint (latest, pair, codes, quota, enriched, history) as typed commands and layers on offline-first features the API can't provide: local snapshots in SQLite, watchlists with drift alerts, quota burn projection, N×N cross-rate matrices from a single API call, and an MCP server for AI agents. Free-tier users get time travel from their own captured history without paying for /history access.
 
 ## When to Use This CLI
 

--- a/library/payments/kalshi/README.md
+++ b/library/payments/kalshi/README.md
@@ -9,26 +9,26 @@ Every Kalshi feature, plus a local SQLite store that records market prices on ev
 The recommended path installs both the `kalshi-pp-cli` binary and the `pp-kalshi` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install kalshi
+npx -y @mvanhorn/printing-press-library install kalshi
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install kalshi --cli-only
+npx -y @mvanhorn/printing-press-library install kalshi --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install kalshi --skill-only
+npx -y @mvanhorn/printing-press-library install kalshi --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install kalshi --agent claude-code
-npx -y @mvanhorn/printing-press install kalshi --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install kalshi --agent claude-code
+npx -y @mvanhorn/printing-press-library install kalshi --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/payments/kalshi/SKILL.md
+++ b/library/payments/kalshi/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `kalshi-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install kalshi --cli-only
+   npx -y @mvanhorn/printing-press-library install kalshi --cli-only
    ```
 2. Verify: `kalshi-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/lunch-money/README.md
+++ b/library/payments/lunch-money/README.md
@@ -6,22 +6,40 @@ Built on Lunch Money's published v2 alpha spec for forward compatibility — eve
 
 ## Install
 
-The recommended path installs both the `lunch-money-pp-cli` binary and the `pp-lunch-money` agent skill in one shot:
+The recommended path installs both the `lunch-money-pp-cli` binary and the `pp-lunch-money` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install lunch-money
+npx -y @mvanhorn/printing-press-library install lunch-money
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install lunch-money --cli-only
+npx -y @mvanhorn/printing-press-library install lunch-money --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install lunch-money --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install lunch-money --agent claude-code
+npx -y @mvanhorn/printing-press-library install lunch-money --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/payments/lunch-money/cmd/lunch-money-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,6 +68,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-lunch-money skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-lunch-money. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/lunch-money-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `LUNCHMONEY_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "lunch-money": {
+      "command": "lunch-money-pp-mcp",
+      "env": {
+        "LUNCHMONEY_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 **Public API** (`api.lunchmoney.dev/v2`) — covers every top-level command. Get a bearer token from https://my.lunchmoney.app/developers and set it as `LUNCHMONEY_API_KEY`:
@@ -74,22 +129,17 @@ The value IS the bearer token — the CLI prepends `Authorization: Bearer ` for 
 # Paste your token from my.lunchmoney.app/developers; the CLI writes it to config and points doctor at the live API.
 lunch-money-pp-cli auth set-token YOUR_TOKEN_HERE
 
-
 # Confirm the token is valid, the API is reachable, and the local store is initialized — before any sync.
 lunch-money-pp-cli doctor
-
 
 # Full pull of categories, tags, accounts, recurring items, and transactions into the local SQLite store with rate-limit-aware backoff.
 lunch-money-pp-cli sync
 
-
 # See unreviewed transactions with suggested categories computed from your own historical categorizations.
 lunch-money-pp-cli triage --limit 20
 
-
 # Preview a bulk retag before letting the bulk PUT /transactions endpoint apply it.
 lunch-money-pp-cli transactions retag --match '^AMZN' --category-id 73 --dry-run
-
 
 # Mid-month per-category burn-down with end-of-period projection — pipe into an agent or dashboard.
 lunch-money-pp-cli budgets burn --period 2026-05 --json
@@ -375,7 +425,6 @@ You may submit the response from a `GET /transactions/{id}` as the request body,
 Transactions that have been previously split or grouped may not be modified by this endpoint. Therefore the `is_split_parent`, `split_parent_id`, `is_group_parent`, `group_parent_id`, and `children` properties are also ignored when provided in the request body.<br><br>
 It is also possible to provide only the properties to be updated in the request body, as long as the request includes at least one of the properties that is not listed above. For example a request body that contains only an `category_id` attribute is valid.
 
-
 ## Output Formats
 
 ```bash
@@ -410,69 +459,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-lunch-money -g
-```
-
-Then invoke `/pp-lunch-money <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add lunch-money lunch-money-pp-mcp -e LUNCHMONEY_API_KEY=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/lunch-money-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `LUNCHMONEY_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "lunch-money": {
-      "command": "lunch-money-pp-mcp",
-      "env": {
-        "LUNCHMONEY_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/payments/lunch-money/SKILL.md
+++ b/library/payments/lunch-money/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `lunch-money-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install lunch-money --cli-only
+   npx -y @mvanhorn/printing-press-library install lunch-money --cli-only
    ```
 2. Verify: `lunch-money-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/payments/lunch-mon
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Built on Lunch Money's published v2 alpha spec for forward compatibility — every endpoint exposed as a Cobra subcommand with --json, --select dotted-paths, --csv, --dry-run, and typed exit codes. Local SQLite store powers offline search, history queries, and joins (net worth at any date, stale balance audit, duplicate detection, subscription detective) that single API calls can't answer. A companion `lunch-money-pp-mcp` binary ships alongside for Claude Desktop / Claude Code MCP integration.
 
 ## When to Use This CLI
 

--- a/library/payments/mercury/README.md
+++ b/library/payments/mercury/README.md
@@ -9,26 +9,26 @@ Learn more at [Mercury](https://docs.mercury.com/reference).
 The recommended path installs both the `mercury-pp-cli` binary and the `pp-mercury` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install mercury
+npx -y @mvanhorn/printing-press-library install mercury
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install mercury --cli-only
+npx -y @mvanhorn/printing-press-library install mercury --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install mercury --skill-only
+npx -y @mvanhorn/printing-press-library install mercury --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install mercury --agent claude-code
-npx -y @mvanhorn/printing-press install mercury --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install mercury --agent claude-code
+npx -y @mvanhorn/printing-press-library install mercury --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/payments/mercury/SKILL.md
+++ b/library/payments/mercury/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `mercury-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install mercury --cli-only
+   npx -y @mvanhorn/printing-press-library install mercury --cli-only
    ```
 2. Verify: `mercury-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/monarch-money/README.md
+++ b/library/payments/monarch-money/README.md
@@ -6,27 +6,67 @@ This CLI wraps Monarch's browser API/GraphQL interface for practical terminal an
 
 ## Install
 
-The recommended path installs both the `monarch-money-pp-cli` binary and the `pp-monarch-money` agent skill in one shot:
+The recommended path installs both the `monarch-money-pp-cli` binary and the `pp-monarch-money` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install monarch-money
+npx -y @mvanhorn/printing-press-library install monarch-money
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install monarch-money --cli-only
+npx -y @mvanhorn/printing-press-library install monarch-money --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install monarch-money --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install monarch-money --agent claude-code
+npx -y @mvanhorn/printing-press-library install monarch-money --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
 
-If `npx` isn't available, install the CLI directly via Go (requires Go 1.26.3 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/payments/monarch-money/cmd/monarch-money-pp-cli@latest
 ```
 
-This installs the CLI only -- no skill.
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/monarch-money-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-monarch-money --force
+```
+
+Inside a Hermes chat session:
+
+```bash
+/skills install mvanhorn/printing-press-library/cli-skills/pp-monarch-money --force
+```
+
+## Install for OpenClaw
+
+Tell your OpenClaw agent (copy this):
+
+```
+Install the pp-monarch-money skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-monarch-money. The skill defines how its required CLI can be installed.
+```
 
 ## Authentication
 

--- a/library/payments/monarch-money/SKILL.md
+++ b/library/payments/monarch-money/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `monarch-money-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install monarch-money --cli-only
+   npx -y @mvanhorn/printing-press-library install monarch-money --cli-only
    ```
 2. Verify: `monarch-money-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/payments/pop/README.md
+++ b/library/payments/pop/README.md
@@ -31,26 +31,26 @@ Printed by [@mircobabini](https://github.com/mircobabini) (Mirco Babini).
 The recommended path installs both the `pop-pp-cli` binary and the `pp-pop` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pop
+npx -y @mvanhorn/printing-press-library install pop
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pop --cli-only
+npx -y @mvanhorn/printing-press-library install pop --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pop --skill-only
+npx -y @mvanhorn/printing-press-library install pop --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pop --agent claude-code
-npx -y @mvanhorn/printing-press install pop --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pop --agent claude-code
+npx -y @mvanhorn/printing-press-library install pop --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -200,7 +200,6 @@ Manage SdI document workflows
 - **`pop-pp-cli sdi get-sdi-document`** - Retrieve a stored SdI document by UUID.
 - **`pop-pp-cli sdi preserve-sdi-document`** - Archive an accepted SdI document in POP's long-term storage.
 - **`pop-pp-cli sdi verify-sdi-document`** - Validate a Base64-encoded SdI XML document before submission.
-
 
 ## Output Formats
 

--- a/library/payments/pop/SKILL.md
+++ b/library/payments/pop/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `pop-pp-cli` binary. **You must verify the CLI is installe
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pop --cli-only
+   npx -y @mvanhorn/printing-press-library install pop --cli-only
    ```
 2. Verify: `pop-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,28 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/payments/pop/cmd/p
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-POP API for European electronic invoicing workflows.
-
-This Printing Press blueprint intentionally exposes only the documented
-8-operation surface used by the POP MCP README at
-`getpopapi/pop-mcp@07a4a19ad5e657fa94d16fe617b8288e5046c489`:
-
-  - create-xml
-  - create-ubl
-  - create-pdf
-  - sdi-via-pop/document-notifications
-  - peppol/document-get
-  - sdi-via-pop/document-get
-  - sdi-via-pop/document-verify
-  - sdi-via-pop/document-preserve
-
-The `data` payloads are intentionally modeled as free-form JSON objects so
-the CLI can pass through the full POP invoice structure without freezing a
-brittle nested schema in this catalog spec.
-
-Upstream POP MCP changes should be reviewed periodically and intentionally
-synced into this print when the documented public surface evolves.
 
 ## Command Reference
 

--- a/library/payments/stripe/README.md
+++ b/library/payments/stripe/README.md
@@ -11,26 +11,26 @@ Learn more at [Stripe](https://stripe.com).
 The recommended path installs both the `stripe-pp-cli` binary and the `pp-stripe` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install stripe
+npx -y @mvanhorn/printing-press-library install stripe
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install stripe --cli-only
+npx -y @mvanhorn/printing-press-library install stripe --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install stripe --skill-only
+npx -y @mvanhorn/printing-press-library install stripe --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install stripe --agent claude-code
-npx -y @mvanhorn/printing-press install stripe --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install stripe --agent claude-code
+npx -y @mvanhorn/printing-press-library install stripe --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/payments/stripe/SKILL.md
+++ b/library/payments/stripe/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `stripe-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install stripe --cli-only
+   npx -y @mvanhorn/printing-press-library install stripe --cli-only
    ```
 2. Verify: `stripe-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/payments/stripe/cm
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-stripe-pp-cli matches the official stripe-cli verb-for-verb and adds what it deliberately omits: a local mirror of customers, subscriptions, invoices, charges, payouts, and events with FTS5 search; cross-entity SQL queries (`sql`); and dossier commands (`health`, `dunning-queue`, `customer-360`, `subs-at-risk`, `payout-reconcile`). Built for agents — every command is one-shot, one-shot, and emits structured output.
 
 ## When to Use This CLI
 

--- a/library/productivity/cal-com/README.md
+++ b/library/productivity/cal-com/README.md
@@ -11,26 +11,26 @@ Learn more at [Cal.com](https://cal.com).
 The recommended path installs both the `cal-com-pp-cli` binary and the `pp-cal-com` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install cal-com
+npx -y @mvanhorn/printing-press-library install cal-com
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cal-com --cli-only
+npx -y @mvanhorn/printing-press-library install cal-com --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install cal-com --skill-only
+npx -y @mvanhorn/printing-press-library install cal-com --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install cal-com --agent claude-code
-npx -y @mvanhorn/printing-press install cal-com --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install cal-com --agent claude-code
+npx -y @mvanhorn/printing-press-library install cal-com --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/cal-com/SKILL.md
+++ b/library/productivity/cal-com/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `cal-com-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install cal-com --cli-only
+   npx -y @mvanhorn/printing-press-library install cal-com --cli-only
    ```
 2. Verify: `cal-com-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/productivity/etherpad/README.md
+++ b/library/productivity/etherpad/README.md
@@ -8,22 +8,40 @@ Printed by [@JohnMcLear](https://github.com/JohnMcLear) (John McLear).
 
 ## Install
 
-The recommended path installs both the `etherpad-pp-cli` binary and the `pp-etherpad` agent skill in one shot:
+The recommended path installs both the `etherpad-pp-cli` binary and the `pp-etherpad` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install etherpad
+npx -y @mvanhorn/printing-press-library install etherpad
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install etherpad --cli-only
+npx -y @mvanhorn/printing-press-library install etherpad --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install etherpad --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install etherpad --agent claude-code
+npx -y @mvanhorn/printing-press-library install etherpad --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/etherpad/cmd/etherpad-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -51,6 +69,43 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-etherpad skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-etherpad. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/etherpad-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `ETHERPAD_OPENID` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "etherpad": {
+      "command": "etherpad-pp-mcp",
+      "env": {
+        "ETHERPAD_OPENID": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -392,7 +447,6 @@ Manage set text
 
 - **`etherpad-pp-cli set-text using-post`** - sets the text of a pad
 
-
 ## Output Formats
 
 ```bash
@@ -427,69 +481,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-etherpad -g
-```
-
-Then invoke `/pp-etherpad <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add etherpad etherpad-pp-mcp -e ETHERPAD_OPENID=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/etherpad-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `ETHERPAD_OPENID` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "etherpad": {
-      "command": "etherpad-pp-mcp",
-      "env": {
-        "ETHERPAD_OPENID": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/productivity/etherpad/SKILL.md
+++ b/library/productivity/etherpad/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `etherpad-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install etherpad --cli-only
+   npx -y @mvanhorn/printing-press-library install etherpad --cli-only
    ```
 2. Verify: `etherpad-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/ether
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Etherpad is a real-time collaborative editor scalable to thousands of simultaneous real time users. It provides full data export capabilities, and runs on your server, under your control.
 
 ## Command Reference
 

--- a/library/productivity/fathom/README.md
+++ b/library/productivity/fathom/README.md
@@ -9,26 +9,26 @@ fathom-pp-cli pulls every meeting, transcript, summary, and action item into a l
 The recommended path installs both the `fathom-pp-cli` binary and the `pp-fathom` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install fathom
+npx -y @mvanhorn/printing-press-library install fathom
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fathom --cli-only
+npx -y @mvanhorn/printing-press-library install fathom --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fathom --skill-only
+npx -y @mvanhorn/printing-press-library install fathom --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install fathom --agent claude-code
-npx -y @mvanhorn/printing-press install fathom --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install fathom --agent claude-code
+npx -y @mvanhorn/printing-press-library install fathom --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/fathom/SKILL.md
+++ b/library/productivity/fathom/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `fathom-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install fathom --cli-only
+   npx -y @mvanhorn/printing-press-library install fathom --cli-only
    ```
 2. Verify: `fathom-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/fatho
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-fathom-pp-cli pulls every meeting, transcript, summary, and action item into a local SQLite store, then unlocks cross-meeting intelligence no MCP server or web UI can provide: commitment tracking across all your calls, topic trend analysis over weeks, pre-call account briefs, pipeline velocity detection, and team meeting-load audits.
 
 ## When to Use This CLI
 

--- a/library/productivity/figma/README.md
+++ b/library/productivity/figma/README.md
@@ -13,26 +13,26 @@ Printed by [@giacaglia](https://github.com/giacaglia) (Giuliano Giacaglia).
 The recommended path installs both the `figma-pp-cli` binary and the `pp-figma` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install figma
+npx -y @mvanhorn/printing-press-library install figma
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install figma --cli-only
+npx -y @mvanhorn/printing-press-library install figma --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install figma --skill-only
+npx -y @mvanhorn/printing-press-library install figma --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install figma --agent claude-code
-npx -y @mvanhorn/printing-press install figma --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install figma --agent claude-code
+npx -y @mvanhorn/printing-press-library install figma --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/figma/SKILL.md
+++ b/library/productivity/figma/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `figma-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install figma --cli-only
+   npx -y @mvanhorn/printing-press-library install figma --cli-only
    ```
 2. Verify: `figma-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,7 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/figma
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
 
 ## When to Use This CLI
 

--- a/library/productivity/fireflies/README.md
+++ b/library/productivity/fireflies/README.md
@@ -9,26 +9,26 @@ Sync your entire meeting history once, then search, analyze, and correlate acros
 The recommended path installs both the `fireflies-pp-cli` binary and the `pp-fireflies` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install fireflies
+npx -y @mvanhorn/printing-press-library install fireflies
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fireflies --cli-only
+npx -y @mvanhorn/printing-press-library install fireflies --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install fireflies --skill-only
+npx -y @mvanhorn/printing-press-library install fireflies --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install fireflies --agent claude-code
-npx -y @mvanhorn/printing-press install fireflies --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install fireflies --agent claude-code
+npx -y @mvanhorn/printing-press-library install fireflies --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/fireflies/SKILL.md
+++ b/library/productivity/fireflies/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `fireflies-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install fireflies --cli-only
+   npx -y @mvanhorn/printing-press-library install fireflies --cli-only
    ```
 2. Verify: `fireflies-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/firef
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Sync your entire meeting history once, then search, analyze, and correlate across every conversation without touching the API. Find stale action items, track topic escalation over weeks, reconstruct the full history with any person or account — all offline, all composable with jq and SQL.
 
 ## When to Use This CLI
 

--- a/library/productivity/freshservice/README.md
+++ b/library/productivity/freshservice/README.md
@@ -9,26 +9,26 @@ freshservice-pp-cli is the first general-purpose terminal CLI for Freshservice �
 The recommended path installs both the `freshservice-pp-cli` binary and the `pp-freshservice` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install freshservice
+npx -y @mvanhorn/printing-press-library install freshservice
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install freshservice --cli-only
+npx -y @mvanhorn/printing-press-library install freshservice --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install freshservice --skill-only
+npx -y @mvanhorn/printing-press-library install freshservice --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install freshservice --agent claude-code
-npx -y @mvanhorn/printing-press install freshservice --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install freshservice --agent claude-code
+npx -y @mvanhorn/printing-press-library install freshservice --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/freshservice/SKILL.md
+++ b/library/productivity/freshservice/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `freshservice-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install freshservice --cli-only
+   npx -y @mvanhorn/printing-press-library install freshservice --cli-only
    ```
 2. Verify: `freshservice-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/freshservice/cmd/freshservice-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This is the first general-purpose terminal CLI for Freshservice — the jira-cli equivalent for ITSM. It covers tickets, changes, assets, users, and knowledge base with full CRUD, local SQLite sync, FTS across all entity types, and novel analytics commands that would require three dashboards and a spreadsheet to replicate manually.
 
 ## When to Use This CLI
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -11,26 +11,26 @@ Printed by [@dstevens](https://github.com/dstevens) (Damien Stevens).
 The recommended path installs both the `granola-pp-cli` binary and the `pp-granola` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install granola
+npx -y @mvanhorn/printing-press-library install granola
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install granola --cli-only
+npx -y @mvanhorn/printing-press-library install granola --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install granola --skill-only
+npx -y @mvanhorn/printing-press-library install granola --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install granola --agent claude-code
-npx -y @mvanhorn/printing-press install granola --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install granola --agent claude-code
+npx -y @mvanhorn/printing-press-library install granola --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -25,16 +25,18 @@ This skill drives the `granola-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install granola --cli-only
+   npx -y @mvanhorn/printing-press-library install granola --cli-only
    ```
 2. Verify: `granola-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/granola/cmd/granola-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI reads Granola’s local cache directly and adds the queries Granola.ai’s web app and existing community CLIs cannot answer. Cache-first, then internal API, then public API — transparent fallthrough. memo run, memo queue, attendee timeline, recipes coverage, calendar overlay, and talktime are local-data joins no per-meeting tool produces. Works offline; agent-native JSON by default.
 
 ## When to Use This CLI
 

--- a/library/productivity/marianatek/README.md
+++ b/library/productivity/marianatek/README.md
@@ -9,26 +9,26 @@ marianatek is the first CLI and MCP server for the Mariana Tek booking platform 
 The recommended path installs both the `marianatek-pp-cli` binary and the `pp-marianatek` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install marianatek
+npx -y @mvanhorn/printing-press-library install marianatek
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install marianatek --cli-only
+npx -y @mvanhorn/printing-press-library install marianatek --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install marianatek --skill-only
+npx -y @mvanhorn/printing-press-library install marianatek --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install marianatek --agent claude-code
-npx -y @mvanhorn/printing-press install marianatek --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install marianatek --agent claude-code
+npx -y @mvanhorn/printing-press-library install marianatek --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/marianatek/SKILL.md
+++ b/library/productivity/marianatek/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `marianatek-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install marianatek --cli-only
+   npx -y @mvanhorn/printing-press-library install marianatek --cli-only
    ```
 2. Verify: `marianatek-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/maria
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-marianatek is the first CLI and MCP server for the Mariana Tek booking platform that powers hundreds of boutique-fitness, yoga, sauna, and wellness studios. Beyond mirroring every Customer API endpoint, it adds a local SQLite catalog, FTS5 search across class sessions, cancellation watching (the API exposes no waitlist signal), and joins across tenants that the per-studio iframe widget can't perform.
 
 ## When to Use This CLI
 

--- a/library/productivity/myfitnesspal/README.md
+++ b/library/productivity/myfitnesspal/README.md
@@ -11,26 +11,26 @@ Learn more at [MyFitnessPal](https://www.myfitnesspal.com).
 The recommended path installs both the `myfitnesspal-pp-cli` binary and the `pp-myfitnesspal` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install myfitnesspal
+npx -y @mvanhorn/printing-press-library install myfitnesspal
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install myfitnesspal --cli-only
+npx -y @mvanhorn/printing-press-library install myfitnesspal --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install myfitnesspal --skill-only
+npx -y @mvanhorn/printing-press-library install myfitnesspal --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install myfitnesspal --agent claude-code
-npx -y @mvanhorn/printing-press install myfitnesspal --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install myfitnesspal --agent claude-code
+npx -y @mvanhorn/printing-press-library install myfitnesspal --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/myfitnesspal/SKILL.md
+++ b/library/productivity/myfitnesspal/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `myfitnesspal-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install myfitnesspal --cli-only
+   npx -y @mvanhorn/printing-press-library install myfitnesspal --cli-only
    ```
 2. Verify: `myfitnesspal-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,12 +32,10 @@ This skill drives the `myfitnesspal-pp-cli` binary. **You must verify the CLI is
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/myfitnesspal/cmd/myfitnesspal-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/productivity/myfitnesspal/cmd/myfitnesspal-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-MyFitnessPal closed their API, gates per-food export behind premium, and ships per-meal rows even there. This CLI imports your browser session, syncs your diary to local SQLite, and answers questions the official UI never can: which 5 foods drove 80% of your protein this quarter, what's your weekly weight slope vs your deficit, what changed since last sync. Built with agent-native output (`--json`, `--select`, `context`) so Claude can reason over your last 14 days in one tool call.
 
 ## When to Use This CLI
 

--- a/library/productivity/notion/README.md
+++ b/library/productivity/notion/README.md
@@ -9,26 +9,26 @@ notion-pp-cli syncs your Notion workspace into a local SQLite store and exposes 
 The recommended path installs both the `notion-pp-cli` binary and the `pp-notion` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install notion
+npx -y @mvanhorn/printing-press-library install notion
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install notion --cli-only
+npx -y @mvanhorn/printing-press-library install notion --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install notion --skill-only
+npx -y @mvanhorn/printing-press-library install notion --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install notion --agent claude-code
-npx -y @mvanhorn/printing-press install notion --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install notion --agent claude-code
+npx -y @mvanhorn/printing-press-library install notion --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/notion/SKILL.md
+++ b/library/productivity/notion/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `notion-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install notion --cli-only
+   npx -y @mvanhorn/printing-press-library install notion --cli-only
    ```
 2. Verify: `notion-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/notio
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-notion-pp-cli syncs your Notion workspace into a local SQLite store and exposes commands for page and block management, stale page detection, and change tracking. Works offline and ships a full MCP server.
 
 ## When to Use This CLI
 

--- a/library/productivity/nylas/README.md
+++ b/library/productivity/nylas/README.md
@@ -13,31 +13,37 @@ Printed by [@natekettles](https://github.com/natekettles) (Nathan Kettles).
 The recommended path installs both the `nylas-pp-cli` binary and the `pp-nylas` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install nylas
+npx -y @mvanhorn/printing-press-library install nylas
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nylas --cli-only
+npx -y @mvanhorn/printing-press-library install nylas --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install nylas --skill-only
+npx -y @mvanhorn/printing-press-library install nylas --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install nylas --agent claude-code
-npx -y @mvanhorn/printing-press install nylas --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install nylas --agent claude-code
+npx -y @mvanhorn/printing-press-library install nylas --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/nylas/cmd/nylas-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -113,22 +119,17 @@ Nylas V3 uses a bearer API key (Authorization: Bearer <NYLAS_API_KEY>) for appli
 # store the Nylas API key locally (or set NYLAS_API_KEY)
 nylas-pp-cli auth set-token <TOKEN>
 
-
 # verify auth + reachability before any sync
 nylas-pp-cli doctor --agent
-
 
 # list every connected mailbox under your application
 nylas-pp-cli grants get-all --agent
 
-
 # build the local mirror for the last day across every grant
 nylas-pp-cli sync --resources messages,events --since 24h
 
-
 # now answer 'what changed' instantly without an API call
 nylas-pp-cli since 2h --resource messages --agent --select id,subject,from,grant_id
-
 
 # FTS5 search across every grant in one shot
 nylas-pp-cli search "invoice overdue" --type messages --agent
@@ -490,7 +491,6 @@ included in your request. For more information, see
 ### domains
 
 Manage domains
-
 
 ### grants
 
@@ -936,7 +936,6 @@ set. If you don't set any filters, Nylas considers all grants.
 - **`nylas-pp-cli workspaces get-all`** - Returns all workspaces in your Nylas application. The application queried is determined based on
 the API key you use to authorize your request.
 - **`nylas-pp-cli workspaces update`** - Updates the specified workspace.
-
 
 ## Output Formats
 

--- a/library/productivity/nylas/SKILL.md
+++ b/library/productivity/nylas/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `nylas-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install nylas --cli-only
+   npx -y @mvanhorn/printing-press-library install nylas --cli-only
    ```
 2. Verify: `nylas-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/nylas/cmd/nylas-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The official nylas-cli is stateless and single-grant. nylas-pp-cli adds a local store of messages, events, threads, and contacts across every connected grant, FTS5 search, a SQL escape hatch, response-time and contact-gravity analytics, persisted webhook replay, and confirm-by-hash sending. Every Nylas v3 endpoint is exposed as a typed command; the local-store commands answer questions the live API cannot.
 
 ## When to Use This CLI
 

--- a/library/productivity/obsidian/README.md
+++ b/library/productivity/obsidian/README.md
@@ -15,26 +15,26 @@ Printed by [@DrDriftwood](https://github.com/DrDriftwood) (Angelo Pullen).
 The recommended path installs both the `obsidian-pp-cli` binary and the `pp-obsidian` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install obsidian
+npx -y @mvanhorn/printing-press-library install obsidian
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install obsidian --cli-only
+npx -y @mvanhorn/printing-press-library install obsidian --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install obsidian --skill-only
+npx -y @mvanhorn/printing-press-library install obsidian --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install obsidian --agent claude-code
-npx -y @mvanhorn/printing-press install obsidian --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install obsidian --agent claude-code
+npx -y @mvanhorn/printing-press-library install obsidian --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -172,7 +172,6 @@ Mirror-backed commands check whether the local SQLite copy is older than 24h. If
 ### V2 (not in V1)
 
 Write commands (create, delete, append, prepend, move, property:set) are intentionally absent in V1. They wait on the upstream `markdown-patch` frontmatter-corruption fix. Skipping them in V1 means zero corruption exposure — V1 reads from the live binary or a SQLite copy of your vault, and never writes back. Multi-vault and non-macOS platforms are also V2.
-
 
 ## Output Formats
 

--- a/library/productivity/obsidian/SKILL.md
+++ b/library/productivity/obsidian/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `obsidian-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install obsidian --cli-only
+   npx -y @mvanhorn/printing-press-library install obsidian --cli-only
    ```
 2. Verify: `obsidian-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,11 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/obsid
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-SYNTHETIC OpenAPI 3.0 spec mapping Obsidian's official command-line interface (v1.12+) to virtual REST endpoints. NOT a real HTTP API. It is a structural description the Printing Press factory consumes to generate a Go CLI scaffold (Cobra + MCP server + agent-native flags + golden fixtures). During the build, the generated HTTP client in internal/client/ is replaced with exec.Command("obsidian", ...) subprocess dispatch, annotated // pp:client-call.
-SCOPE: V1 is READ-ONLY (14 endpoints). Zero write operations — this dodges the upstream markdown-patch frontmatter-corruption bug entirely (three corruption paths confirmed in Phase A eval 2026-05-19, all in the write path). The 6 write commands (create, delete, append, prepend, move, property:set) are DEFERRED to V2, gated on the upstream markdown-patch fix. The full ~95-command surface is also V2.
-Param convention in the Obsidian CLI: commands take ARG=value pairs, not POSIX flags. `file=<name>` resolves wikilink-style; `path=<rel>` is exact. Both are optional alternates on most commands — modeled here as the {name} path parameter (file) plus an optional `path` query parameter (exact).
-Source command surface: projects/morpheus/research/obsidian-cli-command-surface-2026-05-19.md
 
 ## When Not to Use This CLI
 

--- a/library/productivity/opensnow/README.md
+++ b/library/productivity/opensnow/README.md
@@ -9,26 +9,26 @@ The OpenSnow CLI puts the same hyper-local mountain forecasts trusted by million
 The recommended path installs both the `opensnow-pp-cli` binary and the `pp-opensnow` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install opensnow
+npx -y @mvanhorn/printing-press-library install opensnow
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install opensnow --cli-only
+npx -y @mvanhorn/printing-press-library install opensnow --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install opensnow --skill-only
+npx -y @mvanhorn/printing-press-library install opensnow --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install opensnow --agent claude-code
-npx -y @mvanhorn/printing-press install opensnow --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install opensnow --agent claude-code
+npx -y @mvanhorn/printing-press-library install opensnow --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/opensnow/SKILL.md
+++ b/library/productivity/opensnow/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `opensnow-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install opensnow --cli-only
+   npx -y @mvanhorn/printing-press-library install opensnow --cli-only
    ```
 2. Verify: `opensnow-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/productivity/opensnow/cmd/opensnow-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The OpenSnow CLI puts the same hyper-local mountain forecasts trusted by millions of skiers directly into your terminal. Sync resort data to a local SQLite store, then score powder days, rank resorts, and track storms offline. The Daily Snow digest brings expert meteorologist forecasts to your terminal without opening a browser.
 
 ## When to Use This CLI
 

--- a/library/productivity/outlook-calendar/README.md
+++ b/library/productivity/outlook-calendar/README.md
@@ -9,26 +9,26 @@ Drives your personal Microsoft 365 calendar from scripts and agents. OAuth 2.0 d
 The recommended path installs both the `outlook-calendar-pp-cli` binary and the `pp-outlook-calendar` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-calendar
+npx -y @mvanhorn/printing-press-library install outlook-calendar
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-calendar --cli-only
+npx -y @mvanhorn/printing-press-library install outlook-calendar --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-calendar --skill-only
+npx -y @mvanhorn/printing-press-library install outlook-calendar --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-calendar --agent claude-code
-npx -y @mvanhorn/printing-press install outlook-calendar --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install outlook-calendar --agent claude-code
+npx -y @mvanhorn/printing-press-library install outlook-calendar --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/outlook-calendar/SKILL.md
+++ b/library/productivity/outlook-calendar/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `outlook-calendar-pp-cli` binary. **You must verify the CL
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install outlook-calendar --cli-only
+   npx -y @mvanhorn/printing-press-library install outlook-calendar --cli-only
    ```
 2. Verify: `outlook-calendar-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/outlook-calendar/cmd/outlook-calendar-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Drives your personal Microsoft 365 calendar from scripts and agents. OAuth 2.0 device-code flow against the /common tenant, so personal MSAs work alongside work accounts. A local SQLite store synced through events/delta unlocks `conflicts`, `freetime`, `review`, `pending`, `recurring-drift`, and `prep` — workflows no other Outlook CLI exposes because they require persisted state.
 
 ## When to Use This CLI
 

--- a/library/productivity/outlook-email/README.md
+++ b/library/productivity/outlook-email/README.md
@@ -11,26 +11,26 @@ Printed by [@brennaman](https://github.com/brennaman) (Paul Brennaman).
 The recommended path installs both the `outlook-email-pp-cli` binary and the `pp-outlook-email` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-email
+npx -y @mvanhorn/printing-press-library install outlook-email
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-email --cli-only
+npx -y @mvanhorn/printing-press-library install outlook-email --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-email --skill-only
+npx -y @mvanhorn/printing-press-library install outlook-email --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install outlook-email --agent claude-code
-npx -y @mvanhorn/printing-press install outlook-email --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install outlook-email --agent claude-code
+npx -y @mvanhorn/printing-press-library install outlook-email --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/outlook-email/SKILL.md
+++ b/library/productivity/outlook-email/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `outlook-email-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install outlook-email --cli-only
+   npx -y @mvanhorn/printing-press-library install outlook-email --cli-only
    ```
 2. Verify: `outlook-email-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/outlo
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Personal MSA support via OAuth 2.0 device-code against /common. A local SQLite store synced through messages/delta unlocks `followup`, `senders`, `since`, `waiting`, `digest`, `stale-unread`, and `bulk-archive` — workflows no other Outlook CLI exposes because they require persisted state. Companion to outlook-calendar with the same auth playbook.
 
 ## When to Use This CLI
 

--- a/library/productivity/resend/README.md
+++ b/library/productivity/resend/README.md
@@ -11,26 +11,26 @@ Printed by [@giacaglia](https://github.com/giacaglia) (Giuliano Giacaglia).
 The recommended path installs both the `resend-pp-cli` binary and the `pp-resend` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install resend
+npx -y @mvanhorn/printing-press-library install resend
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install resend --cli-only
+npx -y @mvanhorn/printing-press-library install resend --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install resend --skill-only
+npx -y @mvanhorn/printing-press-library install resend --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install resend --agent claude-code
-npx -y @mvanhorn/printing-press install resend --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install resend --agent claude-code
+npx -y @mvanhorn/printing-press-library install resend --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/resend/SKILL.md
+++ b/library/productivity/resend/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `resend-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install resend --cli-only
+   npx -y @mvanhorn/printing-press-library install resend --cli-only
    ```
 2. Verify: `resend-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/resen
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The official Resend CLI is fast and one-shot per command; this CLI is the agent-native companion with --json --select --dry-run consistency, FTS5 search over sent emails, and rollups (audiences inventory, broadcasts performance, deliverability summary, contacts where, emails to <recipient>) that exist only because every Resend resource is mirrored locally.
 
 ## When to Use This CLI
 

--- a/library/productivity/roam/README.md
+++ b/library/productivity/roam/README.md
@@ -9,26 +9,26 @@ Roam HQ ships a remote MCP but no CLI. roam-pp-cli unifies all five Roam HQ APIs
 The recommended path installs both the `roam-pp-cli` binary and the `pp-roam` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install roam
+npx -y @mvanhorn/printing-press-library install roam
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install roam --cli-only
+npx -y @mvanhorn/printing-press-library install roam --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install roam --skill-only
+npx -y @mvanhorn/printing-press-library install roam --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install roam --agent claude-code
-npx -y @mvanhorn/printing-press install roam --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install roam --agent claude-code
+npx -y @mvanhorn/printing-press-library install roam --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/roam/SKILL.md
+++ b/library/productivity/roam/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `roam-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install roam --cli-only
+   npx -y @mvanhorn/printing-press-library install roam --cli-only
    ```
 2. Verify: `roam-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/productivity/roam/
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Roam HQ ships a remote MCP but no CLI. roam-pp-cli unifies all five Roam HQ APIs (HQ, On-Air, Chat, SCIM, Webhooks) into a single binary with a local SQLite cache and FTS5 search across messages and transcripts. Cron-friendly chat relay, decision extraction, attendance drift, and SCIM roster diff are built-in.
 
 ## When to Use This CLI
 

--- a/library/productivity/sendgrid/README.md
+++ b/library/productivity/sendgrid/README.md
@@ -13,31 +13,37 @@ Printed by [@natekettles](https://github.com/natekettles) (Nathan Kettles).
 The recommended path installs both the `sendgrid-pp-cli` binary and the `pp-sendgrid` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install sendgrid
+npx -y @mvanhorn/printing-press-library install sendgrid
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sendgrid --cli-only
+npx -y @mvanhorn/printing-press-library install sendgrid --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sendgrid --skill-only
+npx -y @mvanhorn/printing-press-library install sendgrid --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install sendgrid --agent claude-code
-npx -y @mvanhorn/printing-press install sendgrid --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install sendgrid --agent claude-code
+npx -y @mvanhorn/printing-press-library install sendgrid --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/sendgrid/cmd/sendgrid-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -113,18 +119,14 @@ sendgrid-pp-cli reads SENDGRID_API_KEY (Bearer token) from the environment. Use 
 # Verify auth and reachability
 sendgrid-pp-cli doctor
 
-
 # Mirror suppressions locally so diffs and joins are instant
 sendgrid-pp-cli sync suppressions
-
 
 # Audit drift between your CRM and SendGrid
 sendgrid-pp-cli suppression diff bounces --against crm.csv --json
 
-
 # Get a real time-series view without writing SQL
 sendgrid-pp-cli stats rollup --by week --metric opens,clicks --window 30d --json
-
 
 # Catch missing template variables before you send
 sendgrid-pp-cli templates lint d-abc123 --against '{"first_name":"Sam"}' --json
@@ -389,7 +391,6 @@ Adds existing recipients to a list, passing in the recipient IDs to add. Recipie
 **You can create up to 120 custom fields.**
 - **`sendgrid-pp-cli contactdb create-segment`** - **This endpoint allows you to create a new segment.**
 
-
   Valid operators for create and update depend on the type of the field for which you are searching.
 
 **Dates**
@@ -419,10 +420,8 @@ Adds existing recipients to a list, passing in the recipient IDs to add. Recipie
 
 All field values must be a string.
 
-
 Conditions using "eq" or "ne" for email clicks and opens should provide a "field" of either `clicks.campaign_identifier` or `opens.campaign_identifier`.
 The condition value should be a string containing the id of a completed campaign.
-
 
 The conditions list may contain multiple conditions, joined by an "and" or "or" in the "and_or" field.
 
@@ -713,12 +712,10 @@ Manage mail
 
 - **`sendgrid-pp-cli mail create-batch`** - **This operation allows you to generate a new mail batch ID.**
 
-
 Once a batch ID is created, you can associate it with a mail send by passing
 it in the request body of the [Mail Send operation](https://docs.sendgrid.com/api-reference/mail-send/mail-send).
 This makes it possible to group multiple requests to the Mail Send operation
 by assigning them the same batch ID.
-
 
 A batch ID that's associated with a mail send can be used to access and modify the associated send. For example, you can pause or cancel a send using its batch ID. See the [Scheduled Sends API](https://www.twilio.com/docs/sendgrid/api-reference/cancel-scheduled-sends) for more information about pausing and cancelling a mail send.
 - **`sendgrid-pp-cli mail get-batch`** - **This operation allows you to validate a mail batch ID.**
@@ -1059,7 +1056,6 @@ A `400` status code is returned if any searched addresses are invalid.
 
 Twilio SendGrid recommends exporting your contacts regularly as a backup to avoid issues or lost data.
 - **`sendgrid-pp-cli marketing list-contact-count`** - **This endpoint returns the total number of contacts you have stored.**
-
 
 Twilio SendGrid recommends exporting your contacts regularly as a backup to avoid issues or lost data.
 - **`sendgrid-pp-cli marketing list-contact-count-lists`** - **This endpoint returns the number of contacts on a specific list.**
@@ -1518,7 +1514,6 @@ Click Tracking overrides all the links and URLs in your emails and points them t
 Click tracking helps you understand how users are engaging with your communications. SendGrid can track up to 1000 links per email
 - **`sendgrid-pp-cli tracking-settings list-google-analytics`** - **This endpoint allows you to retrieve your current setting for Google Analytics.**
 
-
 Google Analytics helps you understand how users got to your site and what they're doing there. For more information about using Google Analytics, please refer to [Google’s URL Builder](https://support.google.com/analytics/answer/1033867?hl=en) and their article on ["Best Practices for Campaign Building"](https://support.google.com/analytics/answer/1037445).
 
 We default the settings to Google’s recommendations. For more information, see [Google Analytics Demystified](https://sendgrid.com/docs/ui/analytics-and-reporting/google-analytics/).
@@ -1812,16 +1807,12 @@ Link branding can be associated with subusers from the parent account. This func
 - **`sendgrid-pp-cli whitelabel associate-subuser-with-domain`** - **This endpoint allows you to associate a specific authenticated domain with a subuser.**
 Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.
 
-
 [You can associate more than one domain with a subuser using the `v3/whitelabel/domains/{domain_id}/subuser:add` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple).
 - **`sendgrid-pp-cli whitelabel associate-subuser-with-domain-multiple`** - **This endpoint allows you to associate a specific authenticated domain with a subuser. It can be used to associate up to five authenticated domains.**
 
-
 This functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.
 
-
 A subuser can have up to five associated authenticated domains. To see the domains that have already been associated with this user, you can [use the API to list the domains currently associated with the subuser](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple).
-
 
 When selecting a domain to send email from, SendGrid checks for domains in the following order and chooses the first one that appears in the hierarchy: 
 1. Domain assigned by the subuser that matches the email's `From` address domain. 
@@ -1855,7 +1846,6 @@ You can retrieve the IDs associated with all your reverse DNS records using the 
 
 Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.
 
-
 Note that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple) to add multiple domains to the subuser, you should use the [`/v3/whitelabel/domains/{domain_id}/subuser` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/disassociate-an-authenticated-domain-from-a-subuser-multiple) to disassociate those domains.
 - **`sendgrid-pp-cli whitelabel disassociate-branded-link-from-subuser`** - **This endpoint allows you to take a branded link away from a subuser.**
 
@@ -1863,7 +1853,6 @@ Link branding can be associated with subusers from the parent account. This func
 
 Your request will receive a response with a 204 status code if the disassociation was successful.
 - **`sendgrid-pp-cli whitelabel disassociate-subuser-from-domain`** - **This endpoint allows you to disassociate a specific authenticated domain from a subuser, for users with up to five associated domains.**
-
 
 This functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers kknt, and a subuser can have up to five associated authenticated domains. 
 
@@ -1886,11 +1875,9 @@ You can submit this request as one of your subusers if you include their ID in t
 You can retrieve the IDs associated with all your reverse DNS records using the "Retrieve all reverse DNS records" endpoint.
 - **`sendgrid-pp-cli whitelabel list-all-authenticated-domain-with-user`** - **This endpoint allows you to retrieve all of the authenticated domains that have been assigned to a specific subuser.**
 
-
 This functionality allows subusers to send mail using their parent's domain. Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account, and a subuser can have up to five associated domains. 
 
 To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.
-
 
 When selecting a domain to send email from, SendGrid checks for domains in the following order and chooses the first one that appears in the hierarchy: 
 1. Domain assigned by the subuser that matches the email's `From` address domain. 
@@ -1904,7 +1891,6 @@ You can use the `limit` query parameter to set the page size. If your list conta
 - **`sendgrid-pp-cli whitelabel list-authenticated-domain-with-user`** - **This endpoint allows you to retrieve all of the authenticated domains that have been assigned to a specific subuser.**
 
 Authenticated domains can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's domain. To associate an authenticated domain with a subuser, the parent account must first authenticate and validate the domain. The parent may then associate the authenticated domain via the subuser management tools.
-
 
 Note that if you used the [`/v3/whitelabel/domains/{domain_id}/subuser:add` endpoint]( https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/associate-an-authenticated-domain-with-a-subuser-multiple) to add multiple domains to the subuser, you can use the [`/v3/whitelabel/domains/subuser/all` endpoint](https://www.twilio.com/docs/sendgrid/api-reference/domain-authentication/list-the-authenticated-domain-associated-with-a-subuser-multiple) to list those associated domains.
 - **`sendgrid-pp-cli whitelabel list-branded-link`** - **This endpoint allows you to retrieve all branded links**.
@@ -1948,7 +1934,6 @@ Always check the `valid` property of the response’s `validation_results.a_reco
 If validity couldn’t be determined, you can check the value of `validation_results.a_record.reason` to find out why.
 
 You can retrieve the IDs associated with all your reverse DNS records using the "Retrieve all reverse DNS records" endpoint.
-
 
 ## Output Formats
 

--- a/library/productivity/sendgrid/SKILL.md
+++ b/library/productivity/sendgrid/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `sendgrid-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install sendgrid --cli-only
+   npx -y @mvanhorn/printing-press-library install sendgrid --cli-only
    ```
 2. Verify: `sendgrid-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/sendgrid/cmd/sendgrid-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Built from the official twilio/sendgrid-oai spec, sendgrid-pp-cli mirrors the full v3 surface (mail send, marketing, suppressions, stats, templates, subusers, IPs, webhooks) with offline SQLite, agent-native --json/--select/--csv output, and eight novel commands the existing SendGrid CLIs and MCP servers do not have. Suppression sync collapses the API's per-type format inconsistency into one table; templates lint catches silently-empty Handlebars variables before send; stats rollup turns flat API buckets into proper time-series.
 
 ## When to Use This CLI
 

--- a/library/productivity/slack/README.md
+++ b/library/productivity/slack/README.md
@@ -7,26 +7,26 @@ Send messages, search conversations, monitor channels, and manage your Slack wor
 The recommended path installs both the `slack-pp-cli` binary and the `pp-slack` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install slack
+npx -y @mvanhorn/printing-press-library install slack
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install slack --cli-only
+npx -y @mvanhorn/printing-press-library install slack --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install slack --skill-only
+npx -y @mvanhorn/printing-press-library install slack --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install slack --agent claude-code
-npx -y @mvanhorn/printing-press install slack --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install slack --agent claude-code
+npx -y @mvanhorn/printing-press-library install slack --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/slack/SKILL.md
+++ b/library/productivity/slack/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `slack-pp-cli` binary. **You must verify the CLI is instal
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install slack --cli-only
+   npx -y @mvanhorn/printing-press-library install slack --cli-only
    ```
 2. Verify: `slack-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/productivity/techmeme/README.md
+++ b/library/productivity/techmeme/README.md
@@ -9,26 +9,26 @@ The Techmeme CLI puts the tech industry's most trusted news curation into your t
 The recommended path installs both the `techmeme-pp-cli` binary and the `pp-techmeme` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install techmeme
+npx -y @mvanhorn/printing-press-library install techmeme
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install techmeme --cli-only
+npx -y @mvanhorn/printing-press-library install techmeme --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install techmeme --skill-only
+npx -y @mvanhorn/printing-press-library install techmeme --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install techmeme --agent claude-code
-npx -y @mvanhorn/printing-press install techmeme --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install techmeme --agent claude-code
+npx -y @mvanhorn/printing-press-library install techmeme --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/productivity/techmeme/SKILL.md
+++ b/library/productivity/techmeme/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `techmeme-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install techmeme --cli-only
+   npx -y @mvanhorn/printing-press-library install techmeme --cli-only
    ```
 2. Verify: `techmeme-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.25+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/productivity/techmeme/cmd/techmeme-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The Techmeme CLI puts the tech industry's most trusted news curation into your terminal. Sync headlines to a local SQLite store, then search, filter by time, track topics, and analyze which stories and sources are dominating. The 'since' command answers the question every tech professional asks: 'what did I miss?'
 
 ## When to Use This CLI
 

--- a/library/productivity/zoom/README.md
+++ b/library/productivity/zoom/README.md
@@ -13,31 +13,37 @@ Printed by [@Holajack](https://github.com/Holajack) (Jacken).
 The recommended path installs both the `zoom-pp-cli` binary and the `pp-zoom` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install zoom
+npx -y @mvanhorn/printing-press-library install zoom
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install zoom --cli-only
+npx -y @mvanhorn/printing-press-library install zoom --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install zoom --skill-only
+npx -y @mvanhorn/printing-press-library install zoom --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install zoom --agent claude-code
-npx -y @mvanhorn/printing-press install zoom --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install zoom --agent claude-code
+npx -y @mvanhorn/printing-press-library install zoom --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/zoom/cmd/zoom-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -109,26 +115,20 @@ Local commands (start, join, mute, leave, recordings local, search) require no Z
 # Confirms the Zoom app is installed, the URL handler is registered, ~/Documents/Zoom exists, and surfaces macOS accessibility-permission gaps before they bite.
 zoom-pp-cli doctor
 
-
 # Walks ~/Documents/Zoom/, parses every VTT transcript into a local FTS5 index — usually a few seconds.
 zoom-pp-cli recordings local sync
-
 
 # The killer command: searches every local and cloud transcript at once with speaker filter and clickable timestamps.
 zoom-pp-cli find "q2 pricing" --source both --json
 
-
 # Composes your cloud calendar, saved bookmarks, and today's local recordings into one view with conflict detection.
 zoom-pp-cli today --with-recordings --json
-
 
 # Pastes any Zoom URL, opens it directly in the desktop app — no browser interstitial. --dry-run prints the zoommtg:// URL it would launch.
 zoom-pp-cli join "https://zoom.us/j/85123456789?pwd=abc" --dry-run
 
-
 # macOS only — flips mute via the running Zoom app's Meeting menu. Safe no-op if not in a meeting.
 zoom-pp-cli mute toggle
-
 
 # The My Notes pipeline: drop in an exported PDF/DOCX from zoom.us/notes, then extract action items across the last week.
 zoom-pp-cli notes ingest ~/Downloads/zoom-notes-2026-05-12.pdf && zoom-pp-cli notes todos --since 7d --json
@@ -333,7 +333,6 @@ Manage past meetings
 
 Manage past webinars
 
-
 ### report
 
 Report operations
@@ -399,7 +398,6 @@ Webinar operations
 - **`zoom-pp-cli webinars delete`** - Delete a webinar
 - **`zoom-pp-cli webinars update`** - Update a webinar
 - **`zoom-pp-cli webinars webinar`** - Retrieve a webinar
-
 
 ## Output Formats
 

--- a/library/productivity/zoom/SKILL.md
+++ b/library/productivity/zoom/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `zoom-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install zoom --cli-only
+   npx -y @mvanhorn/printing-press-library install zoom --cli-only
    ```
 2. Verify: `zoom-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/zoom/cmd/zoom-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Start and join meetings via the desktop URL scheme (no browser interstitial), search every transcript you've ever recorded locally or in the cloud with one query, drive mute/unmute/video/leave from the command line on macOS, and run the full Zoom REST API (users, meetings, webinars, recordings, reports, dashboards) when your Server-to-Server OAuth credentials are configured. SQLite-backed; --json, --select, --dry-run on every command; works offline for the local surface and on-disk recordings.
 
 ## When to Use This CLI
 

--- a/library/project-management/clickup/README.md
+++ b/library/project-management/clickup/README.md
@@ -8,22 +8,40 @@ Printed by [@kjmagnan1s](https://github.com/kjmagnan1s) (Kevin Magnan).
 
 ## Install
 
-The recommended path installs both the `clickup-pp-cli` binary and the `pp-clickup` agent skill in one shot:
+The recommended path installs both the `clickup-pp-cli` binary and the `pp-clickup` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install clickup
+npx -y @mvanhorn/printing-press-library install clickup
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install clickup --cli-only
+npx -y @mvanhorn/printing-press-library install clickup --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install clickup --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install clickup --agent claude-code
+npx -y @mvanhorn/printing-press-library install clickup --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/project-management/clickup/cmd/clickup-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,6 +70,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-clickup skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-clickup. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/clickup-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `CLICKUP_AUTHORIZATION_TOKEN` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "clickup": {
+      "command": "clickup-pp-mcp",
+      "env": {
+        "CLICKUP_AUTHORIZATION_TOKEN": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 ClickUp accepts both personal API tokens (pk_...) and OAuth bearer tokens via the Authorization header. Set CLICKUP_AUTHORIZATION_TOKEN in your shell or in ~/.config/clickup-pp-cli/config.toml. Run `clickup-pp-cli doctor` to verify auth and API reachability.
@@ -62,18 +117,14 @@ ClickUp accepts both personal API tokens (pk_...) and OAuth bearer tokens via th
 # Confirm auth, API reachability, and config path before any command.
 clickup-pp-cli doctor
 
-
 # List your workspaces. v2 calls these "teams" for legacy reasons.
 clickup-pp-cli team --json
-
 
 # Hydrate the local SQLite store with the full hierarchy. Parent-ID traversal walks teams → spaces → folders → lists → tasks plus teams → docs and teams → channels in one command.
 clickup-pp-cli sync --json --profile default
 
-
 # Full-text search across every synced record, no API call required.
 clickup-pp-cli search "sprint planning" --profile default --data-source local
-
 
 # Use the v3 docs alias instead of the spec-derived `workspaces docs search-public`.
 clickup-pp-cli docs search <team_id> --json --profile default
@@ -255,8 +306,6 @@ Manage webhook
 
 Manage workspaces
 
-
-
 ## Output Formats
 
 ```bash
@@ -291,69 +340,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-clickup -g
-```
-
-Then invoke `/pp-clickup <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add clickup clickup-pp-mcp -e CLICKUP_AUTHORIZATION_TOKEN=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/clickup-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `CLICKUP_AUTHORIZATION_TOKEN` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "clickup": {
-      "command": "clickup-pp-mcp",
-      "env": {
-        "CLICKUP_AUTHORIZATION_TOKEN": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/project-management/clickup/SKILL.md
+++ b/library/project-management/clickup/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `clickup-pp-cli` binary. **You must verify the CLI is inst
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install clickup --cli-only
+   npx -y @mvanhorn/printing-press-library install clickup --cli-only
    ```
 2. Verify: `clickup-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/project-management/clickup/cmd/clickup-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-172 endpoints across the v2 reference (Tasks, Spaces, Folders, Lists, Goals, Time Tracking, Webhooks, Comments, Custom Fields, Members, Templates, Views) and the v3 public API (Chat, Docs, Audit Logs, ACLs). Hierarchical sync walks the full workspace tree into local SQLite for offline search and analytics. Top-level `docs` and `chat` commands give you idiomatic verbs without remembering the workspaces/<verb>-public spec path.
 
 ## When to Use This CLI
 

--- a/library/project-management/jira/README.md
+++ b/library/project-management/jira/README.md
@@ -9,26 +9,26 @@ Learn more at [Jira Cloud Platform](http://www.atlassian.com).
 The recommended path installs both the `jira-pp-cli` binary and the `pp-jira` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install jira
+npx -y @mvanhorn/printing-press-library install jira
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jira --cli-only
+npx -y @mvanhorn/printing-press-library install jira --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jira --skill-only
+npx -y @mvanhorn/printing-press-library install jira --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install jira --agent claude-code
-npx -y @mvanhorn/printing-press install jira --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install jira --agent claude-code
+npx -y @mvanhorn/printing-press-library install jira --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/project-management/jira/SKILL.md
+++ b/library/project-management/jira/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `jira-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install jira --cli-only
+   npx -y @mvanhorn/printing-press-library install jira --cli-only
    ```
 2. Verify: `jira-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/project-management
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Jira Cloud Platform REST API documentation
 
 ## Command Reference
 

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -11,31 +11,37 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `linear-pp-cli` binary and the `pp-linear` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install linear
+npx -y @mvanhorn/printing-press-library install linear
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install linear --cli-only
+npx -y @mvanhorn/printing-press-library install linear --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install linear --skill-only
+npx -y @mvanhorn/printing-press-library install linear --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install linear --agent claude-code
-npx -y @mvanhorn/printing-press install linear --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install linear --agent claude-code
+npx -y @mvanhorn/printing-press-library install linear --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,22 +117,17 @@ Linear personal API keys go in the `Authorization` header verbatim — no `Beare
 # Save your Linear personal API key (or export LINEAR_API_KEY)
 linear-pp-cli auth set-token <your-key>
 
-
 # Burn your workspace into the local SQLite store for offline + transcendent queries
 linear-pp-cli sync --full
-
 
 # Your ranked work queue for today across every team
 linear-pp-cli today --json
 
-
 # Pre-sprint-planning overload + blocked-count signal for one team
 linear-pp-cli bottleneck --team ENG
 
-
 # Project landing date from regressed velocity, not the static target someone typed in
 linear-pp-cli projects burndown PROJ_ID --weeks 8
-
 
 # Archive only the test issues this CLI created in this session
 linear-pp-cli pp-cleanup
@@ -404,7 +405,6 @@ Manage user-settingses
 Manage users
 
 - **`linear-pp-cli users`** - Get a single user
-
 
 ## Output Formats
 

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `linear-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install linear --cli-only
+   npx -y @mvanhorn/printing-press-library install linear --cli-only
    ```
 2. Verify: `linear-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Pulls your workspace into a local SQLite store with FTS5 search and runs compound queries that no live API call can answer in one round-trip — today view, bottleneck detection, project burndown, cycle comparison. Ships a thin linear_search + linear_execute MCP orchestration pair (with named multi-step intents for triage, standup, sprint plan, weekly update, and grooming) so agents reach the full surface in ~1K tokens instead of enumerating 60+ endpoint mirrors.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/conduyt-crm/README.md
+++ b/library/sales-and-crm/conduyt-crm/README.md
@@ -75,22 +75,40 @@ Learn more at [Conduyt Crm](https://conduyt.app).
 
 ## Install
 
-The recommended path installs both the `conduyt-crm-pp-cli` binary and the `pp-conduyt-crm` agent skill in one shot:
+The recommended path installs both the `conduyt-crm-pp-cli` binary and the `pp-conduyt-crm` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install conduyt-crm
+npx -y @mvanhorn/printing-press-library install conduyt-crm
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install conduyt-crm --cli-only
+npx -y @mvanhorn/printing-press-library install conduyt-crm --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install conduyt-crm --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install conduyt-crm --agent claude-code
+npx -y @mvanhorn/printing-press-library install conduyt-crm --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/conduyt-crm/cmd/conduyt-crm-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -118,6 +136,43 @@ Tell your OpenClaw agent (copy this):
 ```
 Install the pp-conduyt-crm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-conduyt-crm. The skill defines how its required CLI can be installed.
 ```
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/conduyt-crm-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `CONDUYT_BEARER_AUTH` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "conduyt-crm": {
+      "command": "conduyt-crm-pp-mcp",
+      "env": {
+        "CONDUYT_BEARER_AUTH": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -716,7 +771,6 @@ Simple trigger-action workflows
 - **`conduyt-crm-pp-cli workflows list`** - List workflows
 - **`conduyt-crm-pp-cli workflows update`** - Update a workflow
 
-
 ## Output Formats
 
 ```bash
@@ -751,69 +805,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-conduyt-crm -g
-```
-
-Then invoke `/pp-conduyt-crm <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add conduyt-crm conduyt-crm-pp-mcp -e CONDUYT_BEARER_AUTH=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/conduyt-crm-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `CONDUYT_BEARER_AUTH` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "conduyt-crm": {
-      "command": "conduyt-crm-pp-mcp",
-      "env": {
-        "CONDUYT_BEARER_AUTH": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/sales-and-crm/conduyt-crm/SKILL.md
+++ b/library/sales-and-crm/conduyt-crm/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `conduyt-crm-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install conduyt-crm --cli-only
+   npx -y @mvanhorn/printing-press-library install conduyt-crm --cli-only
    ```
 2. Verify: `conduyt-crm-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,10 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/cond
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The Conduyt CRM API provides programmatic access to your CRM data including
-contacts, companies, deals, pipelines, tasks, notes, automations, invoices,
-email sequences, and more.
 
 ## Authentication
 

--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -8,26 +8,26 @@ across LinkedIn, Happenstance, and Deepline from one SQLite-backed CLI.
 The recommended path installs both the `contact-goat-pp-cli` binary and the `pp-contact-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install contact-goat
+npx -y @mvanhorn/printing-press-library install contact-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install contact-goat --cli-only
+npx -y @mvanhorn/printing-press-library install contact-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install contact-goat --skill-only
+npx -y @mvanhorn/printing-press-library install contact-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install contact-goat --agent claude-code
-npx -y @mvanhorn/printing-press install contact-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install contact-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install contact-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `contact-goat-pp-cli` binary. **You must verify the CLI is
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install contact-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install contact-goat --cli-only
    ```
 2. Verify: `contact-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/sales-and-crm/eu-tenders/README.md
+++ b/library/sales-and-crm/eu-tenders/README.md
@@ -6,16 +6,29 @@ TED publishes every significant EU public contract (€676K notices/year) but th
 
 ## Install
 
-The recommended path installs both the `eu-tenders-pp-cli` binary and the `pp-eu-tenders` agent skill in one shot:
+The recommended path installs both the `eu-tenders-pp-cli` binary and the `pp-eu-tenders` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install eu-tenders
+npx -y @mvanhorn/printing-press-library install eu-tenders
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install eu-tenders --cli-only
+npx -y @mvanhorn/printing-press-library install eu-tenders --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install eu-tenders --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install eu-tenders --agent claude-code
+npx -y @mvanhorn/printing-press-library install eu-tenders --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -55,28 +68,57 @@ Tell your OpenClaw agent (copy this):
 Install the pp-eu-tenders skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-eu-tenders. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/eu-tenders-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/eu-tenders/cmd/eu-tenders-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "eu-tenders": {
+      "command": "eu-tenders-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ## Quick Start
 
 ```bash
 # Find recent construction contract winners who might need rented machinery
 eu-tenders-pp-cli leads --cpv 45 --country DEU --min-value 500000 --days 30
 
-
 # Find open IT contracts in Germany
 eu-tenders-pp-cli notices search --country DEU --cpv 72000000 --scope ACTIVE --limit 10
-
 
 # Pull matching notices into local SQLite for offline analysis
 eu-tenders-pp-cli sync --country DEU --cpv 72000000 --since 2023-01-01
 
-
 # Rank open opportunities by urgency, value, and fit
 eu-tenders-pp-cli score --keywords "cloud migration" --country DEU --max-days 30
 
-
 # Morning briefing: highest-priority expiring tenders
 eu-tenders-pp-cli deadline-heat --country DEU --cpv 72 --days 14
-
 
 # Is this market open? See incumbent repeat rates before writing a proposal
 eu-tenders-pp-cli win-rate --cpv 72000000 --country DEU --min-calls 5
@@ -170,7 +212,6 @@ Manage notices
 
 - **`eu-tenders-pp-cli notices search`** - Search for notices using expert search query. More information about the query format and field names can be found on [this page](https://ted.europa.eu/en/search/expert-search))
 
-
 ## Output Formats
 
 ```bash
@@ -202,67 +243,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-eu-tenders -g
-```
-
-Then invoke `/pp-eu-tenders <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/eu-tenders/cmd/eu-tenders-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-claude mcp add eu-tenders eu-tenders-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/eu-tenders-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/eu-tenders/cmd/eu-tenders-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "eu-tenders": {
-      "command": "eu-tenders-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/sales-and-crm/eu-tenders/SKILL.md
+++ b/library/sales-and-crm/eu-tenders/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `eu-tenders-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install eu-tenders --cli-only
+   npx -y @mvanhorn/printing-press-library install eu-tenders --cli-only
    ```
 2. Verify: `eu-tenders-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/eu-t
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-TED publishes every significant EU public contract (€676K notices/year) but the web interface makes analysis nearly impossible. This CLI syncs the corpus to SQLite, then layers market intelligence nobody else offers: win rates, concentration scores, dark-buyer detection, and opportunity scoring — free, composable, agent-native.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/gohighlevel/README.md
+++ b/library/sales-and-crm/gohighlevel/README.md
@@ -11,31 +11,37 @@ Printed by [@jenwilliams-eng](https://github.com/jenwilliams-eng).
 The recommended path installs both the `gohighlevel-pp-cli` binary and the `pp-gohighlevel` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install gohighlevel
+npx -y @mvanhorn/printing-press-library install gohighlevel
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gohighlevel --cli-only
+npx -y @mvanhorn/printing-press-library install gohighlevel --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gohighlevel --skill-only
+npx -y @mvanhorn/printing-press-library install gohighlevel --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install gohighlevel --agent claude-code
-npx -y @mvanhorn/printing-press install gohighlevel --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install gohighlevel --agent claude-code
+npx -y @mvanhorn/printing-press-library install gohighlevel --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/gohighlevel/cmd/gohighlevel-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,18 +117,14 @@ GoHighLevel uses Private Integration Tokens (PIT). Set GHL_PIT_TOKEN in your env
 # verify your PIT token works and the API is reachable
 gohighlevel-pp-cli doctor
 
-
 # pull contacts, opportunities, pipelines, custom fields, and tags into the local SQLite cache
 gohighlevel-pp-cli sync
-
 
 # stage-by-stage opportunity counts, ready to paste into a Looker sheet
 gohighlevel-pp-cli opp funnel --pipeline "Non-KW" --tsv
 
-
 # opportunities that have not moved in 30 days, derived from local stage-transition history
 gohighlevel-pp-cli opp stale --pipeline "Non-KW" --days 30 --json
-
 
 # any cross-entity query becomes one SQL statement
 gohighlevel-pp-cli sql "SELECT firstName, lastName, email FROM contacts WHERE tags LIKE '%recruit%' LIMIT 20" --json
@@ -295,7 +297,6 @@ Manage users
 Manage workflows
 
 - **`gohighlevel-pp-cli workflows`** - List workflows for a location
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/gohighlevel/SKILL.md
+++ b/library/sales-and-crm/gohighlevel/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `gohighlevel-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install gohighlevel --cli-only
+   npx -y @mvanhorn/printing-press-library install gohighlevel --cli-only
    ```
 2. Verify: `gohighlevel-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/gohighlevel/cmd/gohighlevel-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every GHL feature, plus a local SQLite mirror, name->ID resolution, SQL over your contacts and opportunities, and proper handling of the lowercase-pit footgun. The first GoHighLevel CLI — built for operators who run real-estate brokerages and digital agencies and want to stop hand-rolling retry logic and stage-history scripts.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/servicetitan-pricebook/README.md
+++ b/library/sales-and-crm/servicetitan-pricebook/README.md
@@ -6,22 +6,40 @@ This CLI (servicetitan-pricebook-pp-cli) mirrors every ServiceTitan Pricebook v2
 
 ## Install
 
-The recommended path installs both the `servicetitan-pricebook-pp-cli` binary and the `pp-servicetitan-pricebook` agent skill in one shot:
+The recommended path installs both the `servicetitan-pricebook-pp-cli` binary and the `pp-servicetitan-pricebook` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install servicetitan-pricebook
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install servicetitan-pricebook --cli-only
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --agent claude-code
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/servicetitan-pricebook/cmd/servicetitan-pricebook-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,6 +68,43 @@ Tell your OpenClaw agent (copy this):
 Install the pp-servicetitan-pricebook skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-servicetitan-pricebook. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/servicetitan-pricebook-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `ST_CLIENT_ID` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "servicetitan-pricebook": {
+      "command": "servicetitan-pricebook-pp-mcp",
+      "env": {
+        "ST_CLIENT_ID": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 ServiceTitan uses composed auth: a static ST-App-Key header (set ST_APP_KEY) plus an OAuth2 client-credentials bearer token (set ST_CLIENT_ID and ST_CLIENT_SECRET). Run servicetitan-pricebook-pp-cli auth login to walk the credential setup, then set the three credentials plus ST_TENANT_ID (your numeric tenant ID) in your environment. The client mints and refreshes the bearer token automatically and attaches both headers to every call. Whitespace is stripped defensively from credentials — a known JKA gotcha where a trailing newline in an env file produced opaque invalid_client 400s.
@@ -60,18 +115,14 @@ ServiceTitan uses composed auth: a static ST-App-Key header (set ST_APP_KEY) plu
 # Confirm ST_APP_KEY, bearer token, ST_TENANT_ID, and base URL before anything else.
 servicetitan-pricebook-pp-cli doctor
 
-
 # Pull materials, equipment, services, categories, markup tiers, and rate sheets into the local store and snapshot cost/price history.
 servicetitan-pricebook-pp-cli sync
-
 
 # See markup-drift, vendor-part-gap, warranty, cost-drift, and orphan counts in one rollup.
 servicetitan-pricebook-pp-cli health --agent
 
-
 # Drill into the SKUs whose markup has drifted off the tier ladder.
 servicetitan-pricebook-pp-cli markup-audit --tolerance 5
-
 
 # Diff a vendor quote against current pricebook costs before writing anything back.
 servicetitan-pricebook-pp-cli quote-reconcile ./2m-quote.csv
@@ -271,7 +322,6 @@ Manage services
 - **`servicetitan-pricebook-pp-cli services get-list`** - Get data on all of the services in the pricebook. Supports optional search filtering.
 - **`servicetitan-pricebook-pp-cli services update`** - Edit an existing item in your pricebook
 
-
 ## Output Formats
 
 ```bash
@@ -306,69 +356,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-servicetitan-pricebook -g
-```
-
-Then invoke `/pp-servicetitan-pricebook <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add servicetitan-pricebook servicetitan-pricebook-pp-mcp -e ST_CLIENT_ID=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/servicetitan-pricebook-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `ST_CLIENT_ID` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "servicetitan-pricebook": {
-      "command": "servicetitan-pricebook-pp-mcp",
-      "env": {
-        "ST_CLIENT_ID": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/sales-and-crm/servicetitan-pricebook/SKILL.md
+++ b/library/sales-and-crm/servicetitan-pricebook/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `servicetitan-pricebook-pp-cli` binary. **You must verify 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install servicetitan-pricebook --cli-only
+   npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --cli-only
    ```
 2. Verify: `servicetitan-pricebook-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/servicetitan-pricebook/cmd/servicetitan-pricebook-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI (servicetitan-pricebook-pp-cli) mirrors every ServiceTitan Pricebook v2 endpoint (categories, client-specific pricing, discounts & fees, equipment, materials, materials markup, bulk operations, images, services, export feeds) and adds twelve novel commands that join across them in a local SQLite store. It snapshots cost and price history on every sync, so markup-audit, cost-drift, and reprice become one-shot. It is part of a per-module ST CLI family (servicetitan-crm, servicetitan-dispatch, servicetitan-inventory, servicetitan-jpm, servicetitan-pricebook) designed to replace the heavy 600+-tool general ServiceTitan MCP with focused, agent-native binaries.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/smartlead/README.md
+++ b/library/sales-and-crm/smartlead/README.md
@@ -11,31 +11,37 @@ Printed by [@bossriceshark](https://github.com/bossriceshark) (bossriceshark).
 The recommended path installs both the `smartlead-pp-cli` binary and the `pp-smartlead` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install smartlead
+npx -y @mvanhorn/printing-press-library install smartlead
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install smartlead --cli-only
+npx -y @mvanhorn/printing-press-library install smartlead --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install smartlead --skill-only
+npx -y @mvanhorn/printing-press-library install smartlead --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install smartlead --agent claude-code
-npx -y @mvanhorn/printing-press install smartlead --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install smartlead --agent claude-code
+npx -y @mvanhorn/printing-press-library install smartlead --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/smartlead/cmd/smartlead-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -111,18 +117,14 @@ SmartLead authenticates with an API key passed as the api_key query parameter. S
 # Confirm the API key is set and SmartLead is reachable before anything else.
 smartlead-pp-cli doctor
 
-
 # Mirror campaigns, leads, email accounts, and statistics into the local SQLite store.
 smartlead-pp-cli sync
-
 
 # List every campaign now served instantly from the local mirror.
 smartlead-pp-cli campaigns list --json
 
-
 # Get the bounce/reply/silent-lead scorecard across all campaigns at once.
 smartlead-pp-cli health --json
-
 
 # Check whether a domain is already pitched before adding new leads.
 smartlead-pp-cli dupes --domain example.com --json
@@ -281,7 +283,6 @@ Run `smartlead-pp-cli --help` for the full command reference and flag list.
 | `which` | Find the command that implements a capability |
 | `profile` | Named sets of flags saved for reuse |
 | `agent-context` | Emit structured JSON describing this CLI for agents |
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/smartlead/SKILL.md
+++ b/library/sales-and-crm/smartlead/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `smartlead-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install smartlead --cli-only
+   npx -y @mvanhorn/printing-press-library install smartlead --cli-only
    ```
 2. Verify: `smartlead-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/smartlead/cmd/smartlead-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Beyond wrapping all 41 SmartLead REST endpoints with JSON-first, agent-native output, this CLI adds a local SQLite mirror no other SmartLead tool has. Sync once, then run health, silent, dupes, sender-health, warmup-gate, and drift offline — cross-campaign questions that otherwise cost a multi-call API loop per answer.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/tenderned/README.md
+++ b/library/sales-and-crm/tenderned/README.md
@@ -11,31 +11,37 @@ Printed by [@markvandeven](https://github.com/markvandeven) (markvandeven).
 The recommended path installs both the `tenderned-pp-cli` binary and the `pp-tenderned` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install tenderned
+npx -y @mvanhorn/printing-press-library install tenderned
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tenderned --cli-only
+npx -y @mvanhorn/printing-press-library install tenderned --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tenderned --skill-only
+npx -y @mvanhorn/printing-press-library install tenderned --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install tenderned --agent claude-code
-npx -y @mvanhorn/printing-press install tenderned --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install tenderned --agent claude-code
+npx -y @mvanhorn/printing-press-library install tenderned --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned/cmd/tenderned-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -107,18 +113,14 @@ Most of TenderNed (search, list, document download, RSS) is unauthenticated and 
 # List the past two weeks of public-works tenders as JSON
 tenderned-pp-cli notices list --agent
 
-
 # Populate the local SQLite store so offline queries and novel commands work
 tenderned-pp-cli sync
-
 
 # Compute a full procurement profile for one contracting authority
 tenderned-pp-cli buyer dossier "Gemeente Rotterdam" --since 2025-01-01 --agent
 
-
 # Find sub-threshold construction tenders that never reach EU TED
 tenderned-pp-cli leads --national --max-value 200000 --cpv 45000000-7 --since 2026-04-01 --agent
-
 
 # Triage what's closing in the next two weeks
 tenderned-pp-cli deadline --within 14 --agent
@@ -250,7 +252,6 @@ Search, list and fetch tender notices (aankondigingen) from TenderNed — mirror
 
 - **`tenderned-pp-cli notices get`** - Fetch full structured metadata for one publication
 - **`tenderned-pp-cli notices list`** - Search and list tender publications with rich filters (CPV, dates, buyer, procedure, scope)
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/tenderned/SKILL.md
+++ b/library/sales-and-crm/tenderned/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `tenderned-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install tenderned --cli-only
+   npx -y @mvanhorn/printing-press-library install tenderned --cli-only
    ```
 2. Verify: `tenderned-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned/cmd/tenderned-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-TenderNed is the central Dutch national procurement platform; all 143,000+ live notices are CC-0 licensed and freely accessible. This CLI puts every publication, every contracting authority, and every attached bestek into a local SQLite store you can grep, join, and aggregate offline. The novel commands — buyer dossier, sub-threshold leads, closing-deadline view, CPV drift over time, tender-thread reconcile — are workflows the official web UI cannot do.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/bird/README.md
+++ b/library/social-and-messaging/bird/README.md
@@ -10,18 +10,30 @@ Printed by [@CleverAI-ZH](https://github.com/CleverAI-ZH) (Stephan Stoeber).
 
 ## Install
 
-The recommended path installs both the `bird-pp-cli` binary and the `pp-bird` agent skill in one shot:
+The recommended path installs both the `bird-pp-cli` binary and the `pp-bird` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install bird
+npx -y @mvanhorn/printing-press-library install bird
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install bird --cli-only
+npx -y @mvanhorn/printing-press-library install bird --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install bird --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install bird --agent claude-code
+npx -y @mvanhorn/printing-press-library install bird --agent claude-code --agent codex
+```
 
 ### Without Node (Go fallback)
 
@@ -60,6 +72,46 @@ Tell your OpenClaw agent (copy this):
 Install the pp-bird skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-bird. The skill defines how its required CLI can be installed.
 ```
 
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/bird-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `BIRD_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/bird/cmd/bird-pp-mcp@latest
+```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "bird": {
+      "command": "bird-pp-mcp",
+      "env": {
+        "BIRD_WORKSPACE_ID": "<workspace_id>",
+        "BIRD_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ## Authentication
 
 Authentication uses Bird's `Authorization: AccessKey <key>` header. Set BIRD_API_KEY plus BIRD_WORKSPACE_ID (every Bird endpoint is workspace-scoped) before calling any command. An optional BIRD_CHANNEL_ID provides a default for SMS commands so you don't have to pass --channel-id every time.
@@ -70,14 +122,11 @@ Authentication uses Bird's `Authorization: AccessKey <key>` header. Set BIRD_API
 # Check that BIRD_API_KEY and BIRD_WORKSPACE_ID resolve and the API is reachable.
 bird-pp-cli doctor
 
-
 # Verify your SMS tenant is ready: channels, anti-spam, compliance keywords, and messageability all probed in one shot.
 bird-pp-cli tenant doctor --json
 
-
 # Inspect the request without sending; drop --dry-run to actually fire.
 bird-pp-cli sms send --to +31612345678 --body "Hello from bird-pp-cli" --dry-run
-
 
 # Find the most recent OTP-shaped SMS sent to that recipient. Works offline once 'bird-pp-cli sync' has populated the local store.
 bird-pp-cli sms search "otp" --to +31612345678 --json
@@ -190,7 +239,6 @@ SMS channels available in the workspace
 
 Channel compliance keyword routing (HELP/STOP/START)
 
-
 ### conversations
 
 Manage Bird conversation threads (cross-channel customer interactions)
@@ -232,8 +280,6 @@ Programmable SMS send (the headline command)
 ### workspace
 
 Workspace-level configuration: anti-spam and allow/block rules
-
-
 
 ## Output Formats
 
@@ -278,74 +324,6 @@ Endpoint environment variables:
 - `BIRD_WORKSPACE_ID` resolves `{workspace_id}`
 
 Base URL: `https://api.bird.com/workspaces/{workspace_id}`
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-bird -g
-```
-
-Then invoke `/pp-bird <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/bird/cmd/bird-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-claude mcp add bird bird-pp-mcp -e BIRD_WORKSPACE_ID=<workspace_id> -e BIRD_API_KEY=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/bird-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `BIRD_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/bird/cmd/bird-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "bird": {
-      "command": "bird-pp-mcp",
-      "env": {
-        "BIRD_WORKSPACE_ID": "<workspace_id>",
-        "BIRD_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/social-and-messaging/bird/SKILL.md
+++ b/library/social-and-messaging/bird/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `bird-pp-cli` binary. **You must verify the CLI is install
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install bird --cli-only
+   npx -y @mvanhorn/printing-press-library install bird --cli-only
    ```
 2. Verify: `bird-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/social-and-messagi
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-bird-pp-cli wraps every Conversations endpoint plus the SMS-relevant pieces of Bird's Channels API, then layers on what the SDKs miss: send/reconcile pairs with idempotency keys, FTS5 over message bodies, a delivery audit that exits non-zero on failure, and a tenant-readiness checklist that replaces the 12-curl onboarding flow.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/multimail/README.md
+++ b/library/social-and-messaging/multimail/README.md
@@ -7,26 +7,26 @@ CLI for [MultiMail](https://multimail.dev) — verifiable identity and graduated
 The recommended path installs both the `multimail-pp-cli` binary and the `pp-multimail` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install multimail
+npx -y @mvanhorn/printing-press-library install multimail
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install multimail --cli-only
+npx -y @mvanhorn/printing-press-library install multimail --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install multimail --skill-only
+npx -y @mvanhorn/printing-press-library install multimail --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install multimail --agent claude-code
-npx -y @mvanhorn/printing-press install multimail --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install multimail --agent claude-code
+npx -y @mvanhorn/printing-press-library install multimail --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/social-and-messaging/multimail/SKILL.md
+++ b/library/social-and-messaging/multimail/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `multimail-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install multimail --cli-only
+   npx -y @mvanhorn/printing-press-library install multimail --cli-only
    ```
 2. Verify: `multimail-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -32,8 +32,6 @@ go install github.com/mvanhorn/printing-press-library/library/social-and-messagi
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Email-as-a-Service for AI agents. Inbound email converted to markdown, outbound markdown converted to HTML. Built on Cloudflare Workers.
 
 ## Command Reference
 

--- a/library/social-and-messaging/pushover/README.md
+++ b/library/social-and-messaging/pushover/README.md
@@ -11,26 +11,26 @@ Printed by [@twidtwid](https://github.com/twidtwid) (Todd Dailey).
 The recommended path installs both the `pushover-pp-cli` binary and the `pp-pushover` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pushover
+npx -y @mvanhorn/printing-press-library install pushover
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pushover --cli-only
+npx -y @mvanhorn/printing-press-library install pushover --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pushover --skill-only
+npx -y @mvanhorn/printing-press-library install pushover --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pushover --agent claude-code
-npx -y @mvanhorn/printing-press install pushover --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pushover --agent claude-code
+npx -y @mvanhorn/printing-press-library install pushover --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/social-and-messaging/pushover/SKILL.md
+++ b/library/social-and-messaging/pushover/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `pushover-pp-cli` binary. **You must verify the CLI is ins
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pushover --cli-only
+   npx -y @mvanhorn/printing-press-library install pushover --cli-only
    ```
 2. Verify: `pushover-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/pushover/cmd/pushover-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI covers the full official API instead of stopping at send-message. It adds agent-safe env defaults, receipt lifecycle tools, quota preflight, and local history so alerts are auditable.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/twilio/README.md
+++ b/library/social-and-messaging/twilio/README.md
@@ -11,26 +11,26 @@ Learn more at [Twilio](https://support.twilio.com).
 The recommended path installs both the `twilio-pp-cli` binary and the `pp-twilio` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install twilio
+npx -y @mvanhorn/printing-press-library install twilio
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install twilio --cli-only
+npx -y @mvanhorn/printing-press-library install twilio --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install twilio --skill-only
+npx -y @mvanhorn/printing-press-library install twilio --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install twilio --agent claude-code
-npx -y @mvanhorn/printing-press install twilio --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install twilio --agent claude-code
+npx -y @mvanhorn/printing-press-library install twilio --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/social-and-messaging/twilio/SKILL.md
+++ b/library/social-and-messaging/twilio/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `twilio-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install twilio --cli-only
+   npx -y @mvanhorn/printing-press-library install twilio --cli-only
    ```
 2. Verify: `twilio-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/social-and-messagi
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Twilio's official CLI is a thin Node wrapper with 1–3 second cold start and no local cache. This CLI syncs your Messages, Calls, Recordings, UsageRecords, and IncomingPhoneNumbers into a local SQLite store you can grep, SQL, and aggregate offline. It ships every v2010 endpoint as a typed Cobra command, plus 12 novel features the Twilio ecosystem does not have: delivery-failure breakdowns, subaccount spend matrices, call-trace stitches, TCPA opt-out checks, idle-number reclamation, webhook-orphan audits, and more.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/x-twitter/README.md
+++ b/library/social-and-messaging/x-twitter/README.md
@@ -9,26 +9,26 @@ Learn more at [X](https://docs.x.com/x-api).
 The recommended path installs both the `x-twitter-pp-cli` binary and the `pp-x-twitter` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install x-twitter
+npx -y @mvanhorn/printing-press-library install x-twitter
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install x-twitter --cli-only
+npx -y @mvanhorn/printing-press-library install x-twitter --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install x-twitter --skill-only
+npx -y @mvanhorn/printing-press-library install x-twitter --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install x-twitter --agent claude-code
-npx -y @mvanhorn/printing-press install x-twitter --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install x-twitter --agent claude-code
+npx -y @mvanhorn/printing-press-library install x-twitter --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/social-and-messaging/x-twitter/SKILL.md
+++ b/library/social-and-messaging/x-twitter/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `x-twitter-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install x-twitter --cli-only
+   npx -y @mvanhorn/printing-press-library install x-twitter --cli-only
    ```
 2. Verify: `x-twitter-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/social-and-messagi
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Combined CLI for multiple API services
 
 ## HTTP Transport
 

--- a/library/travel/airbnb/README.md
+++ b/library/travel/airbnb/README.md
@@ -13,26 +13,26 @@ Search Airbnb from the terminal, run cheapest on a listing to extract the host's
 The recommended path installs both the `airbnb-pp-cli` binary and the `pp-airbnb` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install airbnb
+npx -y @mvanhorn/printing-press-library install airbnb
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install airbnb --cli-only
+npx -y @mvanhorn/printing-press-library install airbnb --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install airbnb --skill-only
+npx -y @mvanhorn/printing-press-library install airbnb --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install airbnb --agent claude-code
-npx -y @mvanhorn/printing-press install airbnb --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install airbnb --agent claude-code
+npx -y @mvanhorn/printing-press-library install airbnb --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/airbnb/SKILL.md
+++ b/library/travel/airbnb/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `airbnb-pp-cli` binary. **You must verify the CLI is insta
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install airbnb --cli-only
+   npx -y @mvanhorn/printing-press-library install airbnb --cli-only
    ```
 2. Verify: `airbnb-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/travel/alaska-airlines/README.md
+++ b/library/travel/alaska-airlines/README.md
@@ -11,26 +11,26 @@ Learn more at [Alaska Airlines](https://www.alaskaair.com).
 The recommended path installs both the `alaska-airlines-pp-cli` binary and the `pp-alaska-airlines` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install alaska-airlines
+npx -y @mvanhorn/printing-press-library install alaska-airlines
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install alaska-airlines --cli-only
+npx -y @mvanhorn/printing-press-library install alaska-airlines --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install alaska-airlines --skill-only
+npx -y @mvanhorn/printing-press-library install alaska-airlines --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install alaska-airlines --agent claude-code
-npx -y @mvanhorn/printing-press install alaska-airlines --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install alaska-airlines --agent claude-code
+npx -y @mvanhorn/printing-press-library install alaska-airlines --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/alaska-airlines/SKILL.md
+++ b/library/travel/alaska-airlines/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `alaska-airlines-pp-cli` binary. **You must verify the CLI
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install alaska-airlines --cli-only
+   npx -y @mvanhorn/printing-press-library install alaska-airlines --cli-only
    ```
 2. Verify: `alaska-airlines-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/alaska-airlines/cmd/alaska-airlines-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Single static binary that talks to alaskaair.com's SvelteKit endpoints over a Chrome-fingerprinted HTTP transport. Offline SQLite cache for the airport catalog. Cookie-import auth via your logged-in Chrome session for endpoints that need a guestsession JWT. This CLI is read-only; it does not attempt the final pay POST.
 
 ## When to Use This CLI
 

--- a/library/travel/booking-com/README.md
+++ b/library/travel/booking-com/README.md
@@ -13,31 +13,37 @@ Printed by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `booking-com-pp-cli` binary and the `pp-booking-com` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install booking-com
+npx -y @mvanhorn/printing-press-library install booking-com
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install booking-com --cli-only
+npx -y @mvanhorn/printing-press-library install booking-com --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install booking-com --skill-only
+npx -y @mvanhorn/printing-press-library install booking-com --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install booking-com --agent claude-code
-npx -y @mvanhorn/printing-press install booking-com --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install booking-com --agent claude-code
+npx -y @mvanhorn/printing-press-library install booking-com --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/booking-com/cmd/booking-com-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -115,22 +121,17 @@ Public search, hotel detail, reviews, destinations, and map markers run anonymou
 # Headline hotel search — 25 SSR-extracted property cards with --select narrowing the response shape.
 booking-com-pp-cli hotels list --query Paris --checkin 2026-06-20 --checkout 2026-06-23 --adults 2 --json --select '[].name,[].price,[].review_score,[].url'
 
-
 # Drill into a property: amenities, address, geo, rating from the JSON-LD Hotel schema.
 booking-com-pp-cli hotels get fr auliviaopera --checkin 2026-06-20 --checkout 2026-06-23 --json
-
 
 # Local price_history sweep — answers 'when is this hotel cheapest in summer?' in one call.
 booking-com-pp-cli prices cheapest --slug auliviaopera --country fr --window 2026-06-01..2026-08-31 --nights 3 --agent
 
-
 # Verify auth + reachability before authenticated commands. Run 'booking-com-pp-cli auth login --chrome' first if doctor reports missing cookies.
 booking-com-pp-cli doctor --json
 
-
 # Weekly digest of wishlist items whose price dropped at least 5 percent in the last 7 days.
 booking-com-pp-cli wishlist drops --since 168h --min-pct 5 --agent
-
 
 # Monday-morning alarm: upcoming trips whose free-cancellation deadline is within 7 days.
 booking-com-pp-cli trips deadlines --within 168h --agent
@@ -311,7 +312,6 @@ Authenticated `My Trips` page at `secure.booking.com/mytrips.html`. Lists upcomi
 Authenticated `Saved` wishlist at `www.booking.com/mywishlist.html?wl_id=<id>`. The user's wishlist id is server-resolved from the session cookie. Returns the saved properties with last-seen price snapshots.
 
 - **`booking-com-pp-cli wishlist`** - Fetch the authenticated user's wishlist. Returns each saved property's name, slug, country, last-seen price, and the date it was added.
-
 
 ## Output Formats
 

--- a/library/travel/booking-com/SKILL.md
+++ b/library/travel/booking-com/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `booking-com-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install booking-com --cli-only
+   npx -y @mvanhorn/printing-press-library install booking-com --cli-only
    ```
 2. Verify: `booking-com-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/booking-com/cmd/booking-com-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Search Booking.com, scrape hotel detail and reviews, watch prices over time, and read your trips, wishlist, and Genius rewards via a Chrome cookie import. Local SQLite price_history powers cheapest-date sweeps, price-drop watch, wishlist diff, and seasonal price-band rollups that the booking.com UI cannot answer.
 
 ## When to Use This CLI
 

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -50,26 +50,26 @@ provides a quick and easy way to test the delivery of customized alerts via Aero
 The recommended path installs both the `flight-goat-pp-cli` binary and the `pp-flight-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install flight-goat
+npx -y @mvanhorn/printing-press-library install flight-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install flight-goat --cli-only
+npx -y @mvanhorn/printing-press-library install flight-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install flight-goat --skill-only
+npx -y @mvanhorn/printing-press-library install flight-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install flight-goat --agent claude-code
-npx -y @mvanhorn/printing-press install flight-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install flight-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install flight-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `flight-goat-pp-cli` binary. **You must verify the CLI is 
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install flight-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install flight-goat --cli-only
    ```
 2. Verify: `flight-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/travel/hotel-tonight/README.md
+++ b/library/travel/hotel-tonight/README.md
@@ -11,26 +11,26 @@ Printed by [@tmchow](https://github.com/tmchow) (Trevin Chow).
 The recommended path installs both the `hotel-tonight-pp-cli` binary and the `pp-hotel-tonight` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install hotel-tonight
+npx -y @mvanhorn/printing-press-library install hotel-tonight
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hotel-tonight --cli-only
+npx -y @mvanhorn/printing-press-library install hotel-tonight --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install hotel-tonight --skill-only
+npx -y @mvanhorn/printing-press-library install hotel-tonight --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install hotel-tonight --agent claude-code
-npx -y @mvanhorn/printing-press install hotel-tonight --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install hotel-tonight --agent claude-code
+npx -y @mvanhorn/printing-press-library install hotel-tonight --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -115,10 +115,8 @@ No account or API key. HotelTonight's consumer endpoints are reachable anonymous
 # See HotelTonight's major markets and their ids (1 = San Francisco, 72 = Austin).
 hotel-tonight-pp-cli markets list
 
-
 # Pull tonight's deals near a location ranked by % off; this also records a price snapshot so history and watch have data to work with.
 hotel-tonight-pp-cli deals --lat 37.7749 --lng -122.4194 --sort discount
-
 
 # Flag rooms under $150 or that dropped since the last snapshot.
 hotel-tonight-pp-cli watch --lat 37.7749 --lng -122.4194 --when tonight --below 150
@@ -196,7 +194,6 @@ HotelTonight markets (cities where deals are offered)
 - **`hotel-tonight-pp-cli markets get`** - Get a single market by its numeric id
 - **`hotel-tonight-pp-cli markets list`** - List HotelTonight's major markets with location, slug, and category prices
 - **`hotel-tonight-pp-cli markets nearby`** - List popular/nearby markets for a given market id
-
 
 ## Output Formats
 

--- a/library/travel/hotel-tonight/SKILL.md
+++ b/library/travel/hotel-tonight/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `hotel-tonight-pp-cli` binary. **You must verify the CLI i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install hotel-tonight --cli-only
+   npx -y @mvanhorn/printing-press-library install hotel-tonight --cli-only
    ```
 2. Verify: `hotel-tonight-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
@@ -36,8 +36,6 @@ go install github.com/mvanhorn/printing-press-library/library/travel/hotel-tonig
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-HotelTonight's deals are deliberately ephemeral and geo-local: they appear, drop, and vanish, and you only ever see now, here. This CLI syncs the anonymous deal feed into a local SQLite store and snapshots prices over time, so you (or an agent) can watch a city for drops, see a hotel's real price history, and get an objective cheap/typical/expensive verdict — none of which the app supports.
 
 ## When to Use This CLI
 

--- a/library/travel/pointhound/README.md
+++ b/library/travel/pointhound/README.md
@@ -11,26 +11,26 @@ Learn more at [Pointhound](https://www.pointhound.com).
 The recommended path installs both the `pointhound-pp-cli` binary and the `pp-pointhound` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install pointhound
+npx -y @mvanhorn/printing-press-library install pointhound
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pointhound --cli-only
+npx -y @mvanhorn/printing-press-library install pointhound --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install pointhound --skill-only
+npx -y @mvanhorn/printing-press-library install pointhound --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install pointhound --agent claude-code
-npx -y @mvanhorn/printing-press install pointhound --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install pointhound --agent claude-code
+npx -y @mvanhorn/printing-press-library install pointhound --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/pointhound/SKILL.md
+++ b/library/travel/pointhound/SKILL.md
@@ -20,16 +20,18 @@ This skill drives the `pointhound-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install pointhound --cli-only
+   npx -y @mvanhorn/printing-press-library install pointhound --cli-only
    ```
 2. Verify: `pointhound-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/pointhound/cmd/pointhound-pp-cli@latest
+```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Pointhound's web search is great for one-off lookups but doesn't compound. This CLI lets you batch search 20 routes overnight, ask 'where can I go with the points I actually have' in one call, watch a route and exit-code-2 when a new deal appears, and pivot every snapshot through agent-native --json output.
 
 ## When to Use This CLI
 

--- a/library/travel/seats-aero/README.md
+++ b/library/travel/seats-aero/README.md
@@ -7,26 +7,26 @@ Seats.aero Partner API for award travel availability, cached search, route lists
 The recommended path installs both the `seats-aero-pp-cli` binary and the `pp-seats-aero` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install seats-aero
+npx -y @mvanhorn/printing-press-library install seats-aero
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install seats-aero --cli-only
+npx -y @mvanhorn/printing-press-library install seats-aero --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install seats-aero --skill-only
+npx -y @mvanhorn/printing-press-library install seats-aero --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install seats-aero --agent claude-code
-npx -y @mvanhorn/printing-press install seats-aero --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install seats-aero --agent claude-code
+npx -y @mvanhorn/printing-press-library install seats-aero --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/seats-aero/SKILL.md
+++ b/library/travel/seats-aero/SKILL.md
@@ -24,7 +24,7 @@ This skill drives the `seats-aero-pp-cli` binary. **You must verify the CLI is i
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install seats-aero --cli-only
+   npx -y @mvanhorn/printing-press-library install seats-aero --cli-only
    ```
 2. Verify: `seats-aero-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/library/travel/wanderlust-goat/README.md
+++ b/library/travel/wanderlust-goat/README.md
@@ -9,26 +9,26 @@ Two-stage funnel: seed candidates from Google Places, then deep-research each ag
 The recommended path installs both the `wanderlust-goat-pp-cli` binary and the `pp-wanderlust-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install wanderlust-goat
+npx -y @mvanhorn/printing-press-library install wanderlust-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install wanderlust-goat --cli-only
+npx -y @mvanhorn/printing-press-library install wanderlust-goat --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install wanderlust-goat --skill-only
+npx -y @mvanhorn/printing-press-library install wanderlust-goat --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install wanderlust-goat --agent claude-code
-npx -y @mvanhorn/printing-press install wanderlust-goat --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install wanderlust-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install wanderlust-goat --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)

--- a/library/travel/wanderlust-goat/SKILL.md
+++ b/library/travel/wanderlust-goat/SKILL.md
@@ -24,20 +24,18 @@ This skill drives the `wanderlust-goat-pp-cli` binary. **You must verify the CLI
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install wanderlust-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install wanderlust-goat --cli-only
    ```
 2. Verify: `wanderlust-goat-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.23+):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/travel/wanderlust-goat/cmd/wanderlust-goat-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Two-stage funnel: seed candidates from Google Places, then deep-research each against locale-aware sources (Tabelog/Naver/Le Fooding for the country you're in), trust-weight by source authority, kill-gate anything that's permanently closed, and return the 3-5 amazing things — not the comprehensive 40-row dump.
 
 ## When to Use This CLI
 

--- a/tools/sweep-canonical/main.go
+++ b/tools/sweep-canonical/main.go
@@ -35,7 +35,7 @@
 // README.md:
 //   - Rewrites the `## Install` section (with its `### Binary` /
 //     `### Go` subsections) to lead with the `npx -y
-//     @mvanhorn/printing-press install <api>` installer (CLI + agent
+//     @mvanhorn/printing-press-library install <api>` installer (CLI + agent
 //     skill), with `--cli-only` and a Go fallback below. Mirrors the
 //     upstream readme.md.tmpl change.
 //   - Inserts `## Install via Hermes` and `## Install via OpenClaw`
@@ -391,10 +391,11 @@ func sweepCLI(cliDir, ownerName string, readmeOnly bool) (sweepStatus, error) {
 }
 
 type patchSkillCtx struct {
-	CLIName    string // e.g. "shopify-pp-cli"
-	APIName    string // e.g. "shopify"
-	Category   string // e.g. "commerce"
-	AuthorName string // display name, e.g. "Trevin Chow"
+	CLIName           string // e.g. "shopify-pp-cli"
+	APIName           string // e.g. "shopify"
+	Category          string // e.g. "commerce"
+	AuthorName        string // display name, e.g. "Trevin Chow"
+	FillMissingAuthor bool   // opt in only for dedicated attribution sweeps
 }
 
 // patchSkill applies the canonical Hermes/OpenClaw shape to a SKILL.md
@@ -504,13 +505,11 @@ func leadingSpaces(s string) int {
 // the canonical "after description" position. Both are stripped first
 // and re-inserted as a contiguous block, so:
 //
-//   - Author preserves any existing non-placeholder value already in
-//     the frontmatter. Only when the existing author is missing or the
-//     known generator-fallback placeholder "user" does the sweep fill
-//     in `ctx.AuthorName` (resolved upstream through cliAuthorByAPIName
-//     → manifest owner_name → operator git config). This makes the
-//     sweep safe to run from any workspace — it never silently flips a
-//     real author to the operator's `git config user.name`.
+//   - Author preserves any existing value already in the frontmatter,
+//     including the old generator-fallback placeholder "user". Missing
+//     authors are filled only when ctx.FillMissingAuthor is true, so a
+//     docs-shape sweep cannot accidentally bundle attribution changes
+//     with unrelated README/SKILL surface edits.
 //   - License is always "Apache-2.0" — the constant for every printed
 //     CLI per LICENSE.tmpl.
 //
@@ -522,18 +521,20 @@ func leadingSpaces(s string) int {
 // same ctx produces the same output.
 func ensureFrontmatterTopLevelFields(fm string, ctx patchSkillCtx) string {
 	existingAuthor := extractTopLevelFieldValue(fm, "author")
+	hasAuthor := topLevelFieldRe("author").FindStringIndex(fm) != nil
 
 	fm = stripTopLevelField(fm, "version")
 	fm = stripTopLevelField(fm, "author")
 	fm = stripTopLevelField(fm, "license")
 
-	author := ctx.AuthorName
-	if existingAuthor != "" && existingAuthor != "user" {
-		author = existingAuthor
+	var b strings.Builder
+	if hasAuthor {
+		fmt.Fprintf(&b, "author: %q\n", existingAuthor)
+	} else if ctx.FillMissingAuthor && ctx.AuthorName != "" {
+		fmt.Fprintf(&b, "author: %q\n", ctx.AuthorName)
 	}
-
-	block := fmt.Sprintf("author: %q\nlicense: %q\n",
-		author, "Apache-2.0")
+	fmt.Fprintf(&b, "license: %q\n", "Apache-2.0")
+	block := b.String()
 
 	descRe := regexp.MustCompile(`(?m)^description: ".*"\n`)
 	return descRe.ReplaceAllStringFunc(fm, func(match string) string {
@@ -649,7 +650,7 @@ This skill drives the `+"`%s`"+` binary. **You must verify the CLI is installed 
 
 1. Install via the Printing Press installer:
    `+"```bash"+`
-   npx -y @mvanhorn/printing-press install %s --cli-only
+   npx -y @mvanhorn/printing-press-library install %s --cli-only
    `+"```"+`
 2. Verify: `+"`%s --version`"+`
 3. Ensure `+"`$GOPATH/bin`"+` (or `+"`$HOME/go/bin`"+`) is on `+"`$PATH`"+`.
@@ -733,7 +734,7 @@ type patchReadmeCtx struct {
 
 // patchReadme applies the canonical README shape:
 //  1. Rewrites the `## Install` section to lead with the `npx -y
-//     @mvanhorn/printing-press install <api>` installer (CLI + agent
+//     @mvanhorn/printing-press-library install <api>` installer (CLI + agent
 //     skill), with `--cli-only` and a Go fallback below. Mirrors the
 //     upstream readme.md.tmpl shape.
 //  2. Inserts the `## Install via Hermes` and `## Install via
@@ -794,26 +795,26 @@ func buildReadmeInstallSection(ctx patchReadmeCtx) string {
 The recommended path installs both the `+"`%s`"+` binary and the `+"`pp-%s`"+` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`+"`skills`"+`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 `+"```bash"+`
-npx -y @mvanhorn/printing-press install %s
+npx -y @mvanhorn/printing-press-library install %s
 `+"```"+`
 
 For CLI only (no skill):
 
 `+"```bash"+`
-npx -y @mvanhorn/printing-press install %s --cli-only
+npx -y @mvanhorn/printing-press-library install %s --cli-only
 `+"```"+`
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 `+"```bash"+`
-npx -y @mvanhorn/printing-press install %s --skill-only
+npx -y @mvanhorn/printing-press-library install %s --skill-only
 `+"```"+`
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`+"`skills`"+`](https://github.com/vercel-labs/skills) CLI):
 
 `+"```bash"+`
-npx -y @mvanhorn/printing-press install %s --agent claude-code
-npx -y @mvanhorn/printing-press install %s --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install %s --agent claude-code
+npx -y @mvanhorn/printing-press-library install %s --agent claude-code --agent codex
 `+"```"+`
 
 ### Without Node (Go fallback)
@@ -831,16 +832,16 @@ This installs the CLI only — no skill.
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/%s-current). On macOS, clear the Gatekeeper quarantine: `+"`xattr -d com.apple.quarantine <binary>`"+`. On Unix, mark it executable: `+"`chmod +x <binary>`"+`.
 
 `,
-		ctx.CLIName,  // binary name in headline
-		ctx.APIName,  // skill name in headline
-		ctx.APIName,  // bundled install slug
-		ctx.APIName,  // --cli-only slug
-		ctx.APIName,  // --skill-only slug
-		ctx.APIName,  // --agent single slug
-		ctx.APIName,  // --agent multi slug
+		ctx.CLIName, // binary name in headline
+		ctx.APIName, // skill name in headline
+		ctx.APIName, // bundled install slug
+		ctx.APIName, // --cli-only slug
+		ctx.APIName, // --skill-only slug
+		ctx.APIName, // --agent single slug
+		ctx.APIName, // --agent multi slug
 		minimumGoVersion,
-		module,       // Go fallback module
-		ctx.APIName,  // pre-built release tag
+		module,      // Go fallback module
+		ctx.APIName, // pre-built release tag
 	)
 }
 

--- a/tools/sweep-canonical/main_test.go
+++ b/tools/sweep-canonical/main_test.go
@@ -115,7 +115,23 @@ metadata:
 func TestEnsureFrontmatterTopLevelFields(t *testing.T) {
 	ctx := patchSkillCtx{AuthorName: "Trevin Chow"}
 
-	t.Run("inserts after description when fields absent", func(t *testing.T) {
+	t.Run("leaves author absent by default", func(t *testing.T) {
+		in := `name: pp-test
+description: "a CLI"
+argument-hint: "..."
+`
+		want := `name: pp-test
+description: "a CLI"
+license: "Apache-2.0"
+argument-hint: "..."
+`
+		if got := ensureFrontmatterTopLevelFields(in, ctx); got != want {
+			t.Errorf("\nwant: %q\ngot:  %q", want, got)
+		}
+	})
+
+	t.Run("can fill author when explicitly requested", func(t *testing.T) {
+		ctxFill := patchSkillCtx{AuthorName: "Trevin Chow", FillMissingAuthor: true}
 		in := `name: pp-test
 description: "a CLI"
 argument-hint: "..."
@@ -126,7 +142,7 @@ author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "..."
 `
-		if got := ensureFrontmatterTopLevelFields(in, ctx); got != want {
+		if got := ensureFrontmatterTopLevelFields(in, ctxFill); got != want {
 			t.Errorf("\nwant: %q\ngot:  %q", want, got)
 		}
 	})
@@ -163,22 +179,17 @@ license: "Apache-2.0"
 		}
 	})
 
-	t.Run("overrides placeholder \"user\" with ctx value", func(t *testing.T) {
-		// `user` is the known generator-fallback placeholder that means
-		// "no real author was captured at print time." The sweep is
-		// allowed to fill in the ctx-resolved author (which itself
-		// comes from cliAuthorByAPIName → manifest owner_name → git
-		// config) only in this specific case.
+	t.Run("preserves placeholder \"user\" by default", func(t *testing.T) {
 		in := `description: "a CLI"
 author: "user"
 license: "Apache-2.0"
 `
 		want := `description: "a CLI"
-author: "Trevin Chow"
+author: "user"
 license: "Apache-2.0"
 `
 		if got := ensureFrontmatterTopLevelFields(in, ctx); got != want {
-			t.Errorf("expected placeholder author overridden;\nwant: %q\ngot:  %q", want, got)
+			t.Errorf("expected placeholder author preserved;\nwant: %q\ngot:  %q", want, got)
 		}
 	})
 
@@ -201,7 +212,7 @@ license: "Apache-2.0"
 	})
 
 	t.Run("escapes special characters via fmt %q", func(t *testing.T) {
-		ctxQuoted := patchSkillCtx{AuthorName: `Trevin "Quoted" Chow`}
+		ctxQuoted := patchSkillCtx{AuthorName: `Trevin "Quoted" Chow`, FillMissingAuthor: true}
 		in := `description: "a CLI"
 `
 		got := ensureFrontmatterTopLevelFields(in, ctxQuoted)
@@ -239,7 +250,7 @@ stuff.
 	if strings.Contains(got, "STALE INSTALL CONTENT") {
 		t.Errorf("stale Prerequisites content not removed:\n%s", got)
 	}
-	if !strings.Contains(got, "npx -y @mvanhorn/printing-press install x --cli-only") {
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --cli-only") {
 		t.Errorf("canonical npx install line not present:\n%s", got)
 	}
 	if strings.Count(got, "## Prerequisites: Install the CLI") != 1 {
@@ -602,14 +613,14 @@ stuff.
 		t.Errorf("legacy ### Binary subsection still present:\n%s", got)
 	}
 	// Canonical npx install line present.
-	if !strings.Contains(got, "npx -y @mvanhorn/printing-press install x\n") {
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x\n") {
 		t.Errorf("canonical npx install line not present:\n%s", got)
 	}
-	if !strings.Contains(got, "npx -y @mvanhorn/printing-press install x --cli-only") {
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --cli-only") {
 		t.Errorf("--cli-only variant not present:\n%s", got)
 	}
 	// --skill-only variant is documented for skill-only installs / updates.
-	if !strings.Contains(got, "npx -y @mvanhorn/printing-press install x --skill-only") {
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --skill-only") {
 		t.Errorf("--skill-only variant not present:\n%s", got)
 	}
 	// --agent flag is documented for constraining the skill install to one


### PR DESCRIPTION
## Summary
- update `tools/sweep-canonical` to emit `@mvanhorn/printing-press-library` in README install blocks and SKILL prerequisites
- run the canonical sweep across published library CLIs so existing README/SKILL install commands match fresh generator output
- leave generated `cli-skills/` and `registry.json` untouched; they regenerate post-merge

## Coordination
- Generator-side template PR: https://github.com/mvanhorn/cli-printing-press/pull/1850

Closes #760

## Verification
- `cd tools/sweep-canonical && GO111MODULE=off /opt/homebrew/bin/go test .`
- `GO111MODULE=off /opt/homebrew/bin/go run ./tools/sweep-canonical` → `0 patched, 165 already up-to-date, 0 errored`
- `rg -n "@mvanhorn/printing-press(\\s|$)" library tools/sweep-canonical -g 'README.md' -g 'SKILL.md' -g '*.go'` → no matches
- `git diff --check`
- changed SKILL verifier loop over 165 changed `library/**/SKILL.md` files
- `python3 .github/scripts/verify-attribution/verify_attribution.py --base origin/main`
- `python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref origin/main`
- `python3 .github/scripts/verify-binary-payload/verify_binary_payload.py --base-ref origin/main`
- `python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref origin/main`