### PR TITLE
fix(registry): refresh stale catalog copy from sources

### DIFF
--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -398,23 +398,47 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 
 // registryDescription picks the final description for a registry entry from
 // three tiers in preference order: prior curated value > goreleaser brews
-// description > .printing-press.json description. The bare-markdown-heading
-// exception applies only to the prior tier — that's the only tier with the
-// legacy "# Introduction" bug history. The two source tiers are author-written
-// one-liners and don't need the exception.
+// description > .printing-press.json description. Prior values that match
+// known generated-junk shapes (boilerplate, raw HTML, truncation, oversized
+// prose blobs) are not treated as curated; the current source one-liner repairs
+// them on the next regen. The bare-markdown-heading exception applies only to
+// the prior tier — that's the only tier with the legacy "# Introduction" bug
+// history. The two source tiers are author-written one-liners and don't need
+// the exception.
 //
 // Returns "" only when every tier is empty. The --validate mode treats that
 // as a fail-stop; the regular write path lets it through so first-time runs
 // of new CLIs that intentionally have no description can complete (validation
 // is a separate concern from generation).
 func registryDescription(prior, goreleaser, ppDescription string) string {
+	source := firstNonEmpty(goreleaser, ppDescription)
+	if source != "" && isStaleRegistryDescription(prior) {
+		return source
+	}
 	if prior != "" && !isBareMarkdownHeading(prior) {
 		return prior
 	}
-	if goreleaser != "" {
-		return goreleaser
+	return source
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
 	}
-	return ppDescription
+	return ""
+}
+
+func isStaleRegistryDescription(prior string) bool {
+	trimmed := strings.TrimSpace(prior)
+	if trimmed == "" || isBareMarkdownHeading(trimmed) {
+		return false
+	}
+	return strings.HasPrefix(trimmed, "<") ||
+		strings.HasPrefix(trimmed, "Printing Press CLI for ") ||
+		strings.HasSuffix(trimmed, "...") ||
+		len(trimmed) > 240
 }
 
 func searchTerms(pp printingPressManifest) []string {
@@ -551,15 +575,20 @@ func isBareMarkdownHeading(s string) bool {
 // apiDisplayName picks the best human-facing name for the registry's
 // `api` field. Preference order:
 //
-//  1. The current registry.json's existing `api` value, when it differs
+//  1. .printing-press.json's display_name when the prior registry value
+//     matches a known stale generated shape: bare slug echo, naive title-cased
+//     slug ("Setlist Fm"), a long description accidentally stored in `api`, or
+//     a generic suffix such as "Pricebook" when the manifest has the parent
+//     product ("ServiceTitan Pricebook").
+//  2. The current registry.json's existing `api` value, when it differs
 //     from the slug — registry api values are hand-curated (e.g.,
 //     "PokéAPI", "Cal.com", "Product Hunt") and frequently better than
 //     what .printing-press.json's display_name auto-derives. Treating
 //     prior == slug as "not curated" lets the generator replace bare
 //     slug echoes with a proper display name when one shows up.
-//  2. .printing-press.json's display_name (modern-generator best guess).
-//  3. .printing-press.json's api_name (machine slug fallback).
-//  4. The slug itself, last resort.
+//  3. .printing-press.json's display_name (modern-generator best guess).
+//  4. .printing-press.json's api_name (machine slug fallback).
+//  5. The slug itself, last resort.
 //
 // Choosing prior over pp.DisplayName here is deliberate. Several
 // existing registry entries have curated names (PokéAPI, Product Hunt)
@@ -569,6 +598,9 @@ func isBareMarkdownHeading(s string) bool {
 // curated value also won't regress. A future cleanup could lift
 // curated api values back into .printing-press.json explicitly.
 func apiDisplayName(pp printingPressManifest, prior RegistryEntry, slug string) string {
+	if pp.DisplayName != "" && isStaleAPIValue(prior.API, pp.DisplayName, slug) {
+		return pp.DisplayName
+	}
 	if prior.API != "" && prior.API != slug {
 		return prior.API
 	}
@@ -579,6 +611,37 @@ func apiDisplayName(pp printingPressManifest, prior RegistryEntry, slug string) 
 		return pp.APIName
 	}
 	return slug
+}
+
+func isStaleAPIValue(prior, displayName, slug string) bool {
+	prior = strings.TrimSpace(prior)
+	displayName = strings.TrimSpace(displayName)
+	if prior == "" || prior == slug || displayName == "" || prior == displayName {
+		return false
+	}
+	if len(prior) > 80 {
+		return true
+	}
+	if prior == titleCaseSlug(slug) {
+		return true
+	}
+	if strings.HasSuffix(displayName, " "+prior) && !strings.Contains(prior, " ") {
+		return true
+	}
+	return false
+}
+
+func titleCaseSlug(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
 }
 
 // buildMCPBlock constructs an MCP block from a CLI's .printing-press.json

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -412,10 +412,11 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 // is a separate concern from generation).
 func registryDescription(prior, goreleaser, ppDescription string) string {
 	source := firstNonEmpty(goreleaser, ppDescription)
-	if source != "" && isStaleRegistryDescription(prior) {
+	stalePrior := isStaleRegistryDescription(prior)
+	if source != "" && stalePrior {
 		return source
 	}
-	if prior != "" && !isBareMarkdownHeading(prior) {
+	if prior != "" && !isBareMarkdownHeading(prior) && !stalePrior {
 		return prior
 	}
 	return source
@@ -639,7 +640,8 @@ func titleCaseSlug(slug string) string {
 		if part == "" {
 			continue
 		}
-		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+		runes := []rune(part)
+		parts[i] = strings.ToUpper(string(runes[:1])) + strings.ToLower(string(runes[1:]))
 	}
 	return strings.Join(parts, " ")
 }

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -81,6 +81,34 @@ func TestRegistryDescription(t *testing.T) {
 			want:          "Curated catalog copy.",
 		},
 		{
+			name:          "boilerplate prior falls through to goreleaser",
+			prior:         "Printing Press CLI for Whoop.",
+			goreleaser:    "Fetch WHOOP recovery, strain, sleep, workout, cycle, profile, and body-measurement data with OAuth-backed API access.",
+			ppDescription: "Manifest copy.",
+			want:          "Fetch WHOOP recovery, strain, sleep, workout, cycle, profile, and body-measurement data with OAuth-backed API access.",
+		},
+		{
+			name:          "raw-html prior falls through to goreleaser",
+			prior:         "<p>",
+			goreleaser:    "Search setlist.fm artists, setlists, venues, cities, and concert histories through the setlist.fm API.",
+			ppDescription: "Manifest copy.",
+			want:          "Search setlist.fm artists, setlists, venues, cities, and concert histories through the setlist.fm API.",
+		},
+		{
+			name:          "truncated prior falls through to goreleaser",
+			prior:         "Every EmailOctopus v2 endpoint, plus the cross-list joins, churn diffs, and rate-budgeted bulk operations the API...",
+			goreleaser:    "Manage EmailOctopus lists, contacts, campaigns, automations, reports, and cross-list cleanup workflows from the terminal.",
+			ppDescription: "Manifest copy.",
+			want:          "Manage EmailOctopus lists, contacts, campaigns, automations, reports, and cross-list cleanup workflows from the terminal.",
+		},
+		{
+			name:          "oversized prior falls through to goreleaser",
+			prior:         strings.Repeat("Recipe catalog copy ", 20),
+			goreleaser:    "Search trusted recipe sites, rank results, save a local cookbook, and enrich nutrition data with USDA FoodData Central.",
+			ppDescription: "Manifest copy.",
+			want:          "Search trusted recipe sites, rank results, save a local cookbook, and enrich nutrition data with USDA FoodData Central.",
+		},
+		{
 			name:          "bare-heading prior falls through to goreleaser",
 			prior:         "# Introduction",
 			goreleaser:    "Real catalog copy.",
@@ -121,6 +149,73 @@ func TestRegistryDescription(t *testing.T) {
 			if got := registryDescription(tc.prior, tc.goreleaser, tc.ppDescription); got != tc.want {
 				t.Errorf("registryDescription(%q, %q, %q) = %q, want %q",
 					tc.prior, tc.goreleaser, tc.ppDescription, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAPIDisplayName(t *testing.T) {
+	cases := []struct {
+		name  string
+		pp    printingPressManifest
+		prior RegistryEntry
+		slug  string
+		want  string
+	}{
+		{
+			name:  "curated punctuation wins over auto display",
+			pp:    printingPressManifest{APIName: "cal-com", DisplayName: "Cal Com"},
+			prior: RegistryEntry{API: "Cal.com"},
+			slug:  "cal-com",
+			want:  "Cal.com",
+		},
+		{
+			name:  "curated spacing wins over naive display",
+			pp:    printingPressManifest{APIName: "producthunt", DisplayName: "Producthunt"},
+			prior: RegistryEntry{API: "Product Hunt"},
+			slug:  "producthunt",
+			want:  "Product Hunt",
+		},
+		{
+			name:  "long description prior falls through to manifest display",
+			pp:    printingPressManifest{APIName: "recipe-goat", DisplayName: "Recipe GOAT"},
+			prior: RegistryEntry{API: "Cross-site recipe aggregator (37 trusted sites: King Arthur, Serious Eats, Smitten Kitchen, AllRecipes, Food52, BBC Food, EatingWell, Food Network, and 29 more) + USDA FoodData Central"},
+			slug:  "recipe-goat",
+			want:  "Recipe GOAT",
+		},
+		{
+			name:  "title-cased slug falls through to brand casing",
+			pp:    printingPressManifest{APIName: "setlist-fm", DisplayName: "setlist.fm"},
+			prior: RegistryEntry{API: "Setlist Fm"},
+			slug:  "setlist-fm",
+			want:  "setlist.fm",
+		},
+		{
+			name:  "internal capitalization replaces title-cased slug",
+			pp:    printingPressManifest{APIName: "coingecko", DisplayName: "CoinGecko"},
+			prior: RegistryEntry{API: "Coingecko"},
+			slug:  "coingecko",
+			want:  "CoinGecko",
+		},
+		{
+			name:  "lowercase brand replaces title-cased slug",
+			pp:    printingPressManifest{APIName: "beehiiv", DisplayName: "beehiiv"},
+			prior: RegistryEntry{API: "Beehiiv"},
+			slug:  "beehiiv",
+			want:  "beehiiv",
+		},
+		{
+			name:  "generic suffix falls through to full parent product",
+			pp:    printingPressManifest{APIName: "servicetitan-pricebook", DisplayName: "ServiceTitan Pricebook"},
+			prior: RegistryEntry{API: "Pricebook"},
+			slug:  "servicetitan-pricebook",
+			want:  "ServiceTitan Pricebook",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := apiDisplayName(tc.pp, tc.prior, tc.slug); got != tc.want {
+				t.Errorf("apiDisplayName(%+v, %+v, %q) = %q, want %q", tc.pp, tc.prior, tc.slug, got, tc.want)
 			}
 		})
 	}

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -109,6 +109,20 @@ func TestRegistryDescription(t *testing.T) {
 			want:          "Search trusted recipe sites, rank results, save a local cookbook, and enrich nutrition data with USDA FoodData Central.",
 		},
 		{
+			name:          "boilerplate prior with no source returns empty for validation",
+			prior:         "Printing Press CLI for Missing.",
+			goreleaser:    "",
+			ppDescription: "",
+			want:          "",
+		},
+		{
+			name:          "raw-html prior with no source returns empty for validation",
+			prior:         "<p>",
+			goreleaser:    "",
+			ppDescription: "",
+			want:          "",
+		},
+		{
 			name:          "bare-heading prior falls through to goreleaser",
 			prior:         "# Introduction",
 			goreleaser:    "Real catalog copy.",
@@ -216,6 +230,20 @@ func TestAPIDisplayName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := apiDisplayName(tc.pp, tc.prior, tc.slug); got != tc.want {
 				t.Errorf("apiDisplayName(%+v, %+v, %q) = %q, want %q", tc.pp, tc.prior, tc.slug, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTitleCaseSlug(t *testing.T) {
+	cases := map[string]string{
+		"setlist-fm": "Setlist Fm",
+		"éclair-api": "Éclair Api",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := titleCaseSlug(in); got != want {
+				t.Errorf("titleCaseSlug(%q) = %q, want %q", in, got, want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

PR #763 fixed the source metadata, but the post-merge registry regeneration still preserved stale `registry.json` titles/descriptions as if they were curated catalog copy. This updates `tools/generate-registry` so recognizable generated junk falls through to the current `.goreleaser.yaml` / `.printing-press.json` source values.

The generator still preserves real curated registry names like `Cal.com` and `Product Hunt`; it only bypasses prior values that match known stale shapes such as raw HTML (`<p>`), `Printing Press CLI for X.` boilerplate, truncated/oversized descriptions, title-cased slugs (`Setlist Fm`, `Coingecko`), long description text in `api`, or generic suffixes like `Pricebook` when the manifest has `ServiceTitan Pricebook`.

`registry.json` is intentionally not included in this PR. It should be regenerated post-merge by the catalog workflow.

## Preview

```text
recipe-goat              Recipe GOAT                 Search trusted recipe sites, rank results, save a local cookbook, and enrich nutrition data with USDA FoodData Central.
setlist-fm               setlist.fm                  Search setlist.fm artists, setlists, venues, cities, and concert histories through the setlist.fm API.
beehiiv                  beehiiv                     Manage beehiiv publications, subscribers, segments, posts, automations, and newsletter analytics from the terminal.
digitalocean             DigitalOcean                Manage DigitalOcean Droplets, Kubernetes, databases, firewalls, networking, billing, and other cloud resources from the terminal.
kit                      Kit                         Manage Kit subscribers, tags, forms, sequences, broadcasts, purchases, and email marketing automation data from the terminal.
whoop                    WHOOP                       Fetch WHOOP recovery, strain, sleep, workout, cycle, profile, and body-measurement data with OAuth-backed API access.
adminbyrequest           Admin By Request            Sync Admin By Request audit, event, inventory, and elevation-request data for approvals, quota checks, and admin-risk reports.
coingecko                CoinGecko                   CoinGecko public API for cryptocurrency data. Free tier, no API key required for basic endpoints.
emailoctopus             EmailOctopus                Manage EmailOctopus lists, contacts, campaigns, automations, reports, and cross-list cleanup workflows from the terminal.
gohighlevel              GoHighLevel                 Sync GoHighLevel CRM data for contacts, opportunities, pipelines, custom fields, tags, bulk operations, and funnel reports.
greatclips               Great Clips                 Check Great Clips salon wait times, prepare Online Check-In requests, inspect route shapes, and track local wait history.
servicetitan-pricebook   ServiceTitan Pricebook      Sync ServiceTitan Pricebook services, materials, equipment, vendors, markups, warranties, and cost-drift audits.
```

Note: `allrecipes` remains `Allrecipes` because that is the current source display name and product spelling in the library metadata.

## Validation

```bash
/opt/homebrew/bin/gofmt -w tools/generate-registry/main.go tools/generate-registry/main_test.go && git diff --check
/opt/homebrew/bin/go test . # from tools/generate-registry
/opt/homebrew/bin/go run ./tools/generate-registry/main.go --validate recipe-goat setlist-fm beehiiv digitalocean kit whoop adminbyrequest allrecipes coingecko emailoctopus gohighlevel greatclips servicetitan-pricebook
/opt/homebrew/bin/go run ./tools/generate-registry/main.go --print | jq -r '...preview query...'
```