### PR TITLE
feat(icloud): add messages command group

### DIFF
--- a/docs/plans/2026-05-23-001-fix-icloud-messages-decoder-and-pr-followups-plan.md
+++ b/docs/plans/2026-05-23-001-fix-icloud-messages-decoder-and-pr-followups-plan.md
@@ -1,8 +1,9 @@
 ---
 title: Fix iCloud Messages typedstream decoder + PR #766 review follow-ups
-status: active
+status: completed
 type: fix
 created: 2026-05-23
+completed: 2026-05-23
 plan_depth: standard
 target_repo: printing-press-library
 target_branch: feat/icloud-messages

--- a/docs/plans/2026-05-23-001-fix-icloud-messages-decoder-and-pr-followups-plan.md
+++ b/docs/plans/2026-05-23-001-fix-icloud-messages-decoder-and-pr-followups-plan.md
@@ -1,0 +1,321 @@
+---
+title: Fix iCloud Messages typedstream decoder + PR #766 review follow-ups
+status: active
+type: fix
+created: 2026-05-23
+plan_depth: standard
+target_repo: printing-press-library
+target_branch: feat/icloud-messages
+target_pr: 766
+---
+
+# Fix iCloud Messages typedstream decoder + PR #766 review follow-ups
+
+## Problem Frame
+
+The `feat/icloud-messages` branch (PR #766) ships a vendored typedstream heuristic decoder for the `attributedBody` column of macOS `~/Library/Messages/chat.db`. The decoder's fast-path prefix check rejects every real-world blob, so the `decoded` text-source path is effectively dead in production. The catastrophic failure mode is masked by a green test suite because the fixtures build synthetic blobs that do not match the canonical typedstream shape Apple emits.
+
+Independently, Greptile's automated review on PR #766 flagged four other defects across SQL filters, flag scoping, doctor schema probes, and the decoder's control-byte ratio. Per `AGENTS.md` the PR cannot merge with unresolved Greptile findings, so this plan bundles all six fixes into a single sweep against the same branch.
+
+### Decoder prefix bug (the new finding)
+
+`messages_decode.go` (current `feat/icloud-messages` HEAD) bails out when `bytes.HasPrefix(blob, []byte("streamtyped"))` is false. Per Sardegna's "Reverse Engineering Apple's typedstream Format" (cited in the file header), every NSArchiver typedstream begins with a 2-byte header `\x04\x0B` — a version byte (4) and a length byte (11) — followed by the literal ASCII `streamtyped`. So real blobs start with `\x04\x0Bstreamtyped...`, not `streamtyped...`, and the prefix check rejects 100% of them at the function entry point. The string-tag scan loop downstream is correct; it just never runs.
+
+The unit tests pass because `buildSimpleBlob` in `messages_decode_test.go` writes `[]byte("streamtyped")` directly without the leading version/length pair. The fixtures validate the decoder against synthetic input that does not match what chat.db actually stores, so all eight decoder tests are green while the production code path is unreachable.
+
+### Greptile-flagged issues on PR #766
+
+Greptile confidence score 3/5 with five inline findings (severity tags not surfaced in the summary; treat as blocking per repo convention):
+
+- **G1 (`messages_db.go:299-302`)**: `--since` filter on `list-chats` is a silent no-op on modern macOS — `MAX(m.date)` returns nanoseconds-since-Cocoa-epoch while the comparison threshold is seconds. The condition is always true. `searchMessages` (line 462) and `statsByYear` already handle the unit conversion correctly; `list-chats` is the outlier.
+- **G2 (`messages_db.go:473-474`)**: `escapeLike` writes `\%` and `\_` into LIKE patterns but the SQL string carries no `ESCAPE '\'` clause. SQLite treats `\` as literal, so escaping never fires and queries containing `%` in the literal search term silently miss matching rows in the SQL phase. The Go re-filter cannot recover them because they were never returned.
+- **G3 (`messages.go:17-18`)**: `--messages-db` is registered on the `messages` persistent-flag set, so it is invisible to the sibling `doctor` command. `doctor --messages-db /some/path` exits with `unknown flag`, but the doctor body reads `f.messagesDBPath` and `AGENTS.md` documents `--messages-db` as a path override at the root level.
+- **G4 (`messages_decode.go:202-204`)**: control-byte ratio compares `control` (counted per-rune) against `len(s)` (byte length). On emoji or CJK messages, multi-byte runes inflate the denominator and slacken the 25% rejection threshold below intent.
+- **G5 (`doctor.go:194-205`)**: `checkMessagesSchema` probes `message`, `chat`, `handle` but not `chat_message_join` or `message_attachment_join`, which every real query joins. A stripped/old db can report "schema valid" then fail at first query time.
+
+## Scope Boundaries
+
+### In scope
+
+- Permissive substring scan for the typedstream marker in the first ~20 bytes of `attributedBody` (replaces the broken `HasPrefix` check).
+- Rune-count denominator for the control-byte ratio.
+- A synthetic real-world-shape test fixture: a blob constructed to match the canonical `\x04\x0Bstreamtyped` format, with synthetic non-PII content, validating that the production code path actually decodes.
+- The four non-decoder Greptile findings (G1, G2, G3, G5) on the same branch.
+- Patch manifest entry for `messages-attributedbody-heuristic` updated to reflect the fixed shape.
+
+### Out of scope
+
+- Full typedstream graph walk or NSArchiver Foundation class registry. The vendored decoder remains a heuristic; this plan corrects its entry condition, not its scope.
+- Recovery of message rows whose `attributedBody` is absent or uses formats that genuinely fall outside the typedstream heuristic (e.g., balloon-payload-only rich content rows). Those continue to return `unrecoverable` and that is correct.
+- Photos-side commands and the existing photos test suite.
+- Real-world blob fixtures captured from any actual chat.db on disk. All test data is synthesized from the canonical format spec to keep private message content out of a public repo.
+
+### Deferred to Follow-Up Work
+
+- Coverage telemetry beyond the existing `text_source` field (e.g., a `messages stats --coverage` flag that reports decoded/text-column/unrecoverable ratios). Useful for tracking regressions but not required for the current bug fix.
+- Tapback / associated-message-type rendering (`associated_message_type=2001` and friends). Currently exported with empty text; semantically separate from the decoder fix.
+
+## Key Technical Decisions
+
+### KD1. Permissive prefix scan over format-aware parse
+
+Replace `bytes.HasPrefix(blob, []byte("streamtyped"))` with a substring scan of the first ~20 bytes. Rationale:
+
+- Robust to undocumented variations (e.g., if Apple changes the version byte from 4 to 5 in a future macOS, the scan still finds the marker).
+- Matches the heuristic posture already cited in the file header — this is a heuristic decoder, not a faithful NSArchiver parser.
+- One-line fix; minimal diff for reviewers.
+- The existing string-tag scan downstream is the actual safety check — if the blob isn't a typedstream, the tag scan finds no valid string-tag candidate and the function still returns `unrecoverable`.
+
+The format-aware alternative (parse `\x04\x0B` explicitly, verify length byte matches `"streamtyped"` length) was considered and rejected for diff churn and future-fragility.
+
+### KD2. Synthetic blob fixtures, not captured chat.db rows
+
+All test fixtures are constructed in code from the canonical format spec: `\x04\x0B` + `"streamtyped"` + intervening typedstream metadata + UTF-8 string tag + length-prefixed text. Synthetic message content (`"hello world"`, `"test message"`, etc.) — no real captured content from any developer's chat.db. Rationale:
+
+- The repo is public; committing real `attributedBody` hex from any contributor's chat would leak private messages.
+- The decoder is a format check, not a corpus check — synthesizing canonical-shape inputs covers the bug surface as effectively as captured blobs would.
+- `buildSimpleBlob` is updated to write the canonical 2-byte header; an extended `buildCanonicalBlob` adds the intervening NSArchiver class-table bytes for higher-fidelity coverage.
+
+### KD3. Bundle Greptile findings with the decoder fix
+
+The repo's `AGENTS.md` makes every Greptile finding blocking before merge. Bundling all six fixes in this plan keeps the PR's review surface contained and prevents a second review cycle on the same branch. Each fix lands as its own commit so reviewers can isolate any one if needed.
+
+### KD4. Use `utf8.RuneCountInString` for the control-byte ratio (G4)
+
+Aligns numerator (counted per-rune via `for _, r := range s`) and denominator (was byte length, now rune count). The 25% threshold then means "25% of characters are control" rather than "25% of bytes are control after multi-byte rune inflation."
+
+### KD5. Move `--messages-db` to root persistent flags (G3)
+
+Cleaner than duplicating on `doctor`. Photos commands already accept `--library` at the root level for the equivalent override; symmetric placement matches existing conventions.
+
+## Implementation Units
+
+### U1. Fix typedstream prefix check in attributedBody decoder
+
+**Goal**: Replace `HasPrefix("streamtyped")` with a permissive substring scan over the first ~20 bytes so real `\x04\x0Bstreamtyped`-prefixed blobs reach the existing string-tag scan loop.
+
+**Requirements**: Resolves the catastrophic decoder failure; the `decoded` `text_source` path becomes reachable in production for the first time.
+
+**Dependencies**: None — entry-point fix.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages_decode.go`
+
+**Approach**:
+- Replace lines 71-73 (`if !bytes.HasPrefix(...) { return ..., textSourceUnrecoverable }`) with a scan over `blob[:min(20, len(blob))]` looking for `"streamtyped"` via `bytes.Index`. If absent, return unrecoverable.
+- Keep the empty-blob guard at line 63 unchanged.
+- Keep the downstream tag-scan loop unchanged — it remains the authoritative validity check.
+- Update the function godoc at line 56 to describe the permissive entry condition.
+
+**Patterns to follow**: Match the existing godoc style (intent, returns, panic safety).
+
+**Test scenarios**:
+- Happy path: synthetic blob with canonical `\x04\x0Bstreamtyped` header + valid string tag + direct-length-prefixed ASCII text decodes to the expected text with `text_source=decoded`.
+- Backward compatibility: synthetic blob starting with bare `"streamtyped"` (the old test fixture shape) still decodes — the permissive scan finds the marker at offset 0.
+- Negative: blob with `"streamtyped"` at offset 25 returns `unrecoverable` (marker outside the scan window).
+- Negative: random 200-byte buffer with no `streamtyped` substring returns `unrecoverable`.
+- Defense: nil and empty blobs still return `unrecoverable` (pre-existing behavior preserved).
+
+**Verification**: `go test ./internal/cli/ -run TestDecodeAttributedBody -v` shows the new canonical-format tests passing alongside the existing ones; old tests continue to pass.
+
+---
+
+### U2. Fix control-byte ratio denominator (Greptile G4)
+
+**Goal**: Replace `len(s)` with `utf8.RuneCountInString(s)` in the control-character rejection threshold so the 25% gate compares like units.
+
+**Requirements**: Greptile G4; correctness on emoji and CJK message bodies.
+
+**Dependencies**: U1 (same file) — sequence after to keep diff hunks separated cleanly.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages_decode.go`
+
+**Approach**:
+- At line 202-204, replace `control*4 > len(s)` with `runeCount := utf8.RuneCountInString(s); runeCount > 0 && control*4 > runeCount`.
+- `utf8` is already imported; no new imports.
+- Keep the early-return for `s == ""` at line 167 (covers the zero-rune case redundantly but harmlessly).
+
+**Patterns to follow**: Single-statement guard mirrors the existing structure.
+
+**Test scenarios**:
+- Emoji-heavy text (≤25% control runes) passes `looksLikeMessageText` after the fix.
+- CJK-heavy text passes after the fix (regression target — previous byte-denominator was slacker, so this is a parity case, not a behavior shift; document in test name).
+- Synthetic high-control string (`"\x01\x02\x03hello"`) is rejected before and after the fix.
+- Boundary: exactly 25% control runes is rejected (strict `>` retained).
+
+**Verification**: `TestDecodeAttributedBody_LooksLikeMessageText` cases for "with emoji" and a new CJK case pass.
+
+---
+
+### U3. Add canonical-format synthetic blob test coverage
+
+**Goal**: Add a `buildCanonicalBlob` helper to `messages_decode_test.go` that writes the canonical `\x04\x0Bstreamtyped` header + intervening NSArchiver class-table bytes + string tag + UTF-8 text, then exercise U1's permissive scan against it. Ensures the test suite catches a regression of the prefix bug.
+
+**Requirements**: Prevents recurrence of the false-green decoder test problem.
+
+**Dependencies**: U1 (the production fix the new tests validate).
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages_decode_test.go`
+
+**Approach**:
+- Keep existing `buildSimpleBlob` for the legacy bare-`"streamtyped"` cases (those exercise the permissive-scan backward-compat case).
+- Add `buildCanonicalBlob(text string, prefixVariant byte) []byte` that prepends `\x04\x0B` before `"streamtyped"` and emits a representative NSArchiver class-table pattern observed in published typedstream documentation (e.g., `NSAttributedString` → `NSObject` → `NSString` class chain). All synthetic, derived from the format spec — not lifted from any real chat.db.
+- Add `TestDecodeAttributedBody_CanonicalFormat` exercising the four length-prefix variants (direct, 1-byte, 2-byte, 4-byte) against `buildCanonicalBlob`.
+- Add `TestDecodeAttributedBody_NonCanonicalRejected` exercising a blob whose `"streamtyped"` literal sits at offset 30 — should return unrecoverable.
+
+**Patterns to follow**: Existing `TestDecodeAttributedBody_Length{1,2,4}Byte` shape; reuse the prefix-variant switch from `buildSimpleBlob`.
+
+**Test scenarios**: enumerated by U3 itself — this unit is the test-scenario unit.
+
+**Verification**: New tests pass alongside U1's behavior change; remove or update any `buildSimpleBlob`-based test if it now becomes redundant.
+
+---
+
+### U4. Fix `--since` epoch unit mismatch on `list-chats` (Greptile G1)
+
+**Goal**: Make `--since` actually filter results on modern macOS by converting `MAX(m.date)` from nanoseconds-since-Cocoa-epoch to seconds before comparing against the user-supplied threshold.
+
+**Requirements**: Greptile G1; user-visible correctness — `messages list-chats --since 2026-01-01` currently returns every chat regardless.
+
+**Dependencies**: None.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages_db.go`
+
+**Approach**:
+- At lines 299-302, mirror the `searchMessages` pattern (line 462) and the `statsByYear` CASE-based conversion. Either:
+  - Multiply the user's threshold by 1_000_000_000 in Go before binding (matches `searchMessages` style), OR
+  - Use the SQL-side `CASE WHEN last_msg.last_date >= <nanosecond magnitude> THEN last_msg.last_date / 1000000000 ELSE last_msg.last_date END + <cocoa epoch>` form per Greptile's suggestion.
+- Prefer the Go-side multiplication for symmetry with `searchMessages` — reviewer can compare two adjacent functions for the same pattern.
+- Extract the nanosecond multiplier and Cocoa-epoch constant to package-level named constants if not already present.
+
+**Patterns to follow**: `searchMessages` at `messages_db.go:462` is the working sibling.
+
+**Test scenarios**:
+- Integration-style: against an in-memory SQLite db seeded with three messages at nanosecond timestamps spanning two years, `list-chats --since <year boundary>` returns only chats with a recent-enough `last_msg.last_date`. Pre-fix this returns all three; post-fix returns one.
+- Edge: `--since` of "now" returns zero chats.
+- Edge: `--since` of "1970-01-01" (well before any plausible iMessage timestamp) returns all chats.
+
+**Verification**: New integration test against a temp SQLite DB; existing search/stats tests unaffected.
+
+---
+
+### U5. Add `ESCAPE '\'` clause to LIKE patterns (Greptile G2)
+
+**Goal**: Make `escapeLike`-escaped `%` and `_` characters in search queries actually behave as literals at the SQL layer.
+
+**Requirements**: Greptile G2; user-visible correctness — searches containing literal `%` or `_` silently miss matching messages.
+
+**Dependencies**: None.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages_db.go`
+
+**Approach**:
+- At line 473-474, append `ESCAPE '\\'` (Go-source double-backslash → single backslash in the SQL string) to the LIKE expression.
+- Audit every other LIKE expression in `messages_db.go` for the same omission. If any other LIKE uses `escapeLike`, add the same `ESCAPE` clause.
+- Keep the Go-level re-filter in `searchMessages` unchanged — it operates on decoded `attributedBody` text and the escape change doesn't affect that pass.
+
+**Patterns to follow**: SQLite docs `https://www.sqlite.org/lang_expr.html#like` — the `ESCAPE` clause is part of the LIKE expression itself, applies per-expression.
+
+**Test scenarios**:
+- Search for `"50%"` against a corpus containing `"got 50% off"` and `"another row"` returns the first row only. Pre-fix the SQL layer returns nothing for the literal-percent case.
+- Search for `"foo_bar"` against a corpus containing `"foo_bar"` and `"fooXbar"` returns only the first row.
+- Search for a plain word like `"hello"` against `"hello world"` continues to work (regression check).
+
+**Verification**: New `TestSearchMessages_LiteralPercent` and `TestSearchMessages_LiteralUnderscore` cases pass.
+
+---
+
+### U6. Move `--messages-db` to root persistent flags (Greptile G3)
+
+**Goal**: Make `--messages-db /path/to/chat.db` work from both `doctor` and `messages` subcommands.
+
+**Requirements**: Greptile G3; `AGENTS.md`-documented behavior.
+
+**Dependencies**: None.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/messages.go`
+- `library/media-and-entertainment/icloud/internal/cli/root.go`
+
+**Approach**:
+- Remove the `--messages-db` registration from the `messages` command's persistent-flag set in `messages.go:17-18`.
+- Add it to `root.go`'s persistent flags alongside `--library`, with the same field on `rootFlags`.
+- Confirm `doctor.go` already reads from the rootFlags-resident path field. If it currently reads from a messages-local field, plumb through the rootFlags-resident field.
+
+**Patterns to follow**: The existing `--library` flag at root scope.
+
+**Test scenarios**:
+- `icloud-pp-cli doctor --messages-db /tmp/foo.db` no longer errors with `unknown flag`. Use `cobra`'s command execution helper or shell out to the built binary in an integration test.
+- `icloud-pp-cli messages list-chats --messages-db /tmp/foo.db` continues to work.
+- `icloud-pp-cli --messages-db /tmp/foo.db doctor` (flag before subcommand) works — confirms persistent-at-root behavior.
+
+**Verification**: Manual CLI invocations + a unit test that constructs the root command and inspects its persistent flag set.
+
+---
+
+### U7. Probe junction tables in `checkMessagesSchema` (Greptile G5)
+
+**Goal**: Surface `chat_message_join` or `message_attachment_join` absence at `doctor` preflight time rather than at first-query failure.
+
+**Requirements**: Greptile G5.
+
+**Dependencies**: None.
+
+**Files**:
+- `library/media-and-entertainment/icloud/internal/cli/doctor.go`
+
+**Approach**:
+- At `doctor.go:194-205`, extend the table loop from `{"message", "chat", "handle"}` to `{"message", "chat", "handle", "chat_message_join", "message_attachment_join"}`.
+- Keep the existing per-table failure-message format. Doctor's Messages section already uses yellow ⚠ rather than red ✗, so additional schema-missing reports don't escalate severity.
+
+**Patterns to follow**: Existing table loop structure.
+
+**Test scenarios**:
+- Against a synthetic SQLite db with only `message`, `chat`, `handle` (missing junction tables), doctor reports the schema-incomplete state.
+- Against a complete db, doctor reports schema valid.
+
+**Verification**: `doctor` integration test against two seeded temp databases.
+
+---
+
+## Verification Strategy
+
+- `go test ./...` from `library/media-and-entertainment/icloud/` is green post-changes.
+- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/icloud/` continues to pass — no SKILL.md flags reference changed; `--messages-db` was already documented at root scope per `AGENTS.md`.
+- `go vet ./...` and `govulncheck ./...` from the icloud directory: clean.
+- Manual smoke against a real `~/Library/Messages/chat.db` after fixes: `icloud-pp-cli messages stats --agent` and `icloud-pp-cli messages search "test" --limit 5 --agent` show non-zero `text_source: decoded` counts where previously all results were `text_column` or `unrecoverable`. Smoke is local-only — no captured output enters the PR.
+- Greptile re-review on the next push: confirm G1–G5 are resolved (👍 status); no new findings introduced.
+
+## System-Wide Impact
+
+- **Decoder behavior change is observable.** Callers reading the `text_source` field will see `decoded` rows appear in counts where they previously saw `unrecoverable`. This is the intended behavior — callers were already designed to surface the field. SKILL.md already documents the three values.
+- **`--since` semantics change on `list-chats`.** Previously a no-op; now filters. Any caller (human or agent) that was depending on the no-op behavior (e.g., passing `--since` "defensively" but expecting all chats back) will see fewer results. The fix matches documented intent.
+- **Search results may expand on patterns containing `%` or `_`.** Previously missed; now returned. Strictly additive — no previously-returned row is dropped.
+- **`--messages-db` flag scope is wider.** Now accepted by `doctor` and at root level. No removal; flag still works on `messages` subcommands.
+- **Doctor preflight may now report previously-silent junction-table absence.** Strictly informational — yellow ⚠, not blocking.
+
+## Risk Analysis
+
+- **R1. Permissive scan over-decodes random binary.** Risk: the substring scan finds `"streamtyped"` inside a non-typedstream blob (e.g., binary payload that happens to contain the byte sequence). Mitigation: the downstream string-tag scan still has to find a `0x2B` tag with a valid length prefix and a UTF-8 candidate passing `looksLikeMessageText`. False positives at all three gates are extremely unlikely. Severity: low.
+- **R2. Backward-compat with old test fixtures.** Risk: U1 changes the entry condition from prefix to substring; some tests relying on the old prefix-required behavior may now decode where they previously returned unrecoverable. Mitigation: audit existing tests in U3 and explicitly cover the bare-`"streamtyped"` case (which still passes — the marker is at offset 0). Severity: low.
+- **R3. `--since` epoch fix mis-converts on edge cases.** Risk: if any chats genuinely have second-domain timestamps (pre-iCloud-sync messages, imported data), the conditional conversion logic must handle both. Mitigation: mirror `searchMessages` exactly — it has been in production through the photos-side feature set without issue. Severity: low.
+- **R4. SQLite `ESCAPE` clause semantics on `COLLATE NOCASE`.** Risk: `ESCAPE` and `COLLATE` interact in subtle ways across SQLite versions. Mitigation: SQLite's documented behavior is that `ESCAPE` is per-expression and orthogonal to `COLLATE`. Add explicit test cases for case-insensitive search with literal `%`. Severity: low.
+- **R5. Privacy in test fixtures.** Risk: a future contributor "improves coverage" by pasting hex from their own chat.db. Mitigation: U3's helper docstring states explicitly that fixtures are synthesized from the format spec and not captured. Severity: low if documented; medium if the comment is lost.
+
+## Sequencing
+
+- U1 first (the catastrophic bug; everything else can land regardless of order).
+- U3 immediately after U1 to lock the test fixture against regression.
+- U2 next (same file as U1; co-resident commits keep file-level diff coherent).
+- U4, U5, U6, U7 in any order — independent surfaces.
+- Final pass: update `.printing-press-patches.json`'s `messages-attributedbody-heuristic` entry to reference this plan and the corrected behavior summary.
+
+## Privacy Constraint (load-bearing)
+
+**No real message content, phone numbers, contact identifiers, captured `attributedBody` hex, or other PII enters this plan, commits, PR body, or test fixtures.** All test fixtures are synthesized from the published canonical typedstream format (Sardegna's blog, `dgelessus/python-typedstream` documentation, the upstream `teslashibe/imessage-go` MIT reference). Smoke verification against real chat.db data is local-only; any output shared with reviewers is summary-level (counts, ratios) with no decoded text.
+
+This is a public repository. Treat any temptation to "just paste a hex dump for clarity" as a hard stop.

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-17",
+  "applied_at": "2026-05-23",
   "base_run_id": "hand-written",
   "base_printing_press_version": "0.1.3",
   "patches": [
@@ -39,6 +39,43 @@
       "summary": "messages_db.go classifies EPERM and modernc.org/sqlite's SQLITE_CANTOPEN surrogate as a Full Disk Access denial; doctor.go's Messages section surfaces it with copy-paste remediation.",
       "reason": "macOS TCC has no public Go API and modernc.org/sqlite does not always surface the underlying EPERM (it reports TCC denials as SQLITE_CANTOPEN with surrogate text 'out of memory (14)'). Detecting the broader error shape gives users a clear, actionable error instead of a confusing 'database is corrupt' message. The doctor section warns rather than fails so Photos-only users are not blocked.",
       "files": ["internal/cli/messages_db.go", "internal/cli/doctor.go"]
+    },
+    {
+      "id": "messages-attributedbody-prefix-scan",
+      "summary": "messages_decode.go scans the first 20 bytes for the 'streamtyped' marker instead of requiring HasPrefix.",
+      "reason": "Real Apple NSArchiver typedstream blobs begin with a 2-byte version+length header (\\x04\\x0B) before the 'streamtyped' literal, so the marker sits at offset 2, not 0. The earlier HasPrefix check rejected every real chat.db row and the `decoded` text-source path was dead in production. Synthetic-only canonical test fixtures (buildCanonicalBlob) lock the new shape.",
+      "files": ["internal/cli/messages_decode.go", "internal/cli/messages_decode_test.go"],
+      "validated_outcome": "Real chat.db sample that previously returned 0 decoded / 9030 unrecoverable now returns 8998 decoded / 39 unrecoverable (the residual rows are legitimately tapback/effect rows without typedstream content)."
+    },
+    {
+      "id": "messages-control-byte-rune-denominator",
+      "summary": "looksLikeMessageText compares rune-counted control characters against utf8.RuneCountInString, not against byte length.",
+      "reason": "Emoji and CJK characters are multi-byte; using len(s) as the denominator inflated against a rune-counted numerator and slackened the 25%% rejection threshold below intent. Greptile G4 on PR #766.",
+      "files": ["internal/cli/messages_decode.go"]
+    },
+    {
+      "id": "messages-list-chats-since-nanosecond-conversion",
+      "summary": "listChats multiplies the seconds-domain --since threshold by 1_000_000_000 before comparing against MAX(m.date), matching searchMessages.",
+      "reason": "On modern macOS m.date is nanoseconds since the Cocoa epoch (~7e14 for current rows). Comparing it against a seconds-domain threshold (~7e8) made the predicate always true, so --since was a silent no-op on list-chats. Greptile G1 on PR #766.",
+      "files": ["internal/cli/messages_db.go"]
+    },
+    {
+      "id": "messages-like-escape-clause",
+      "summary": "searchMessages adds an explicit ESCAPE '\\' clause to the LIKE expression so escapeLike's backslash sequences are honored.",
+      "reason": "escapeLike writes \\%% and \\_ into the pattern but SQLite ignores the backslash without an explicit ESCAPE clause, treating it as a literal. Queries containing %% or _ silently missed matching rows from the SQL phase. Greptile G2 on PR #766.",
+      "files": ["internal/cli/messages_db.go"]
+    },
+    {
+      "id": "messages-db-flag-root-scope",
+      "summary": "--messages-db is registered on the root command's persistent flag set so doctor and other siblings can read the override.",
+      "reason": "Previously registered on the messages persistent flag set, which made `doctor --messages-db ...` exit with `unknown flag` even though doctor's body reads f.messagesDBPath and AGENTS.md documents the override at the root level. Greptile G3 on PR #766.",
+      "files": ["internal/cli/root.go", "internal/cli/messages.go"]
+    },
+    {
+      "id": "messages-doctor-junction-tables",
+      "summary": "checkMessagesSchema additionally probes chat_message_join and message_attachment_join.",
+      "reason": "Every messages query joins chat_message_join, and `messages export` additionally touches message_attachment_join. A stripped or very old chat.db can be missing either without missing the primary tables, which made doctor report 'schema valid' but the first real query fail. Greptile G5 on PR #766.",
+      "files": ["internal/cli/doctor.go"]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -18,9 +18,27 @@
     },
     {
       "id": "doctor-sectioned-output",
-      "summary": "doctor.go emits System / Library / Assets sections with colored pass/fail checks.",
-      "reason": "Agents need to verify macOS, Photos.app, library path, schema, and asset count before running any query. A structured pre-flight keeps error surfaces small.",
+      "summary": "doctor.go emits System / Library / Assets / Messages sections with colored pass/fail checks.",
+      "reason": "Agents need to verify macOS, Photos.app, library path, schema, asset count, and chat.db access before running any query. A structured pre-flight keeps error surfaces small.",
       "files": ["internal/cli/doctor.go"]
+    },
+    {
+      "id": "messages-readonly-chatdb",
+      "summary": "messages_db.go opens ~/Library/Messages/chat.db read-only via the file: URI prefix with mode=ro and _query_only=1 PRAGMA.",
+      "reason": "chat.db is a system-owned SQLite database read by imagent in WAL mode. The file: URI prefix is load-bearing on modernc.org/sqlite; bare ?mode=ro is silently dropped and the driver returns a read-write handle. _query_only=1 is a second belt at the connection level.",
+      "files": ["internal/cli/messages_db.go"]
+    },
+    {
+      "id": "messages-attributedbody-heuristic",
+      "summary": "messages_decode.go vendors a ~150-line MIT-licensed heuristic typedstream parser for the attributedBody column.",
+      "reason": "Since macOS 11+, message.text is often NULL and the actual content lives in attributedBody (an NSArchiver typedstream blob, not a binary plist). The Go ecosystem's full typedstream parsers are GPL/AGPL-licensed; a small MIT-licensed heuristic ported from teslashibe/imessage-go covers the dominant message shape without license contamination or new go.mod entries.",
+      "files": ["internal/cli/messages_decode.go", "internal/cli/messages_decode_test.go"]
+    },
+    {
+      "id": "messages-fda-doctor-check",
+      "summary": "messages_db.go classifies EPERM and modernc.org/sqlite's SQLITE_CANTOPEN surrogate as a Full Disk Access denial; doctor.go's Messages section surfaces it with copy-paste remediation.",
+      "reason": "macOS TCC has no public Go API and modernc.org/sqlite does not always surface the underlying EPERM (it reports TCC denials as SQLITE_CANTOPEN with surrogate text 'out of memory (14)'). Detecting the broader error shape gives users a clear, actionable error instead of a confusing 'database is corrupt' message. The doctor section warns rather than fails so Photos-only users are not blocked.",
+      "files": ["internal/cli/messages_db.go", "internal/cli/doctor.go"]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -76,6 +76,12 @@
       "summary": "checkMessagesSchema additionally probes chat_message_join and message_attachment_join.",
       "reason": "Every messages query joins chat_message_join, and `messages export` additionally touches message_attachment_join. A stripped or very old chat.db can be missing either without missing the primary tables, which made doctor report 'schema valid' but the first real query fail. Greptile G5 on PR #766.",
       "files": ["internal/cli/doctor.go"]
+    },
+    {
+      "id": "messages-preview-rune-aware-truncate",
+      "summary": "fillLastPreviews and printSearchTable slice text via []rune so previews don't split multi-byte UTF-8 runes at the truncation boundary.",
+      "reason": "Byte-index truncation (text[:maxLen]) on emoji or CJK previews left a half rune at the end, which both JSON encoders and terminals render as U+FFFD mojibake. Rune-aware slicing keeps the cut at a glyph boundary. Greptile P1 on PR #766.",
+      "files": ["internal/cli/messages_db.go", "internal/cli/messages_search.go"]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/AGENTS.md
+++ b/library/media-and-entertainment/icloud/AGENTS.md
@@ -40,12 +40,29 @@ The `photos` subcommands fall into two categories:
 - `photos delete` requires `--confirm` to move items to Recently Deleted. Items are NOT permanently deleted — they stay in Recently Deleted for 30 days.
 - `photos download` exports originals to a local folder. When `--sensitive` is used (targets Apple's on-device nudity-flagged assets), `--confirm` is also required to prevent accidental bulk export of private content.
 
+The `messages` subcommands (`list-chats`, `search`, `stats`, `export`) are read-only against `~/Library/Messages/chat.db`. The database is opened via the `file:` URI prefix with `mode=ro&_query_only=1`. macOS Full Disk Access is required for the terminal app invoking the binary; `doctor` reports FDA state automatically.
+
 ## Local Customizations
 
-This CLI is hand-written (not generated), so all code is intentional. The `.printing-press-patches.json` at this directory's root documents the three design decisions that differ from a typical generated CLI:
+This CLI is hand-written (not generated), so all code is intentional. The `.printing-press-patches.json` at this directory's root documents the design decisions that differ from a typical generated CLI:
 
 1. `macos-only-guard` — structured error on non-Darwin
 2. `applescript-delete` — Photos.app scripting for deletion
-3. `doctor-sectioned-output` — System / Library / Assets pre-flight sections
+3. `doctor-sectioned-output` — System / Library / Assets / Messages pre-flight sections
+4. `messages-readonly-chatdb` — `file:` URI prefix on `modernc.org/sqlite` to avoid silent read-write fallback
+5. `messages-attributedbody-heuristic` — vendored MIT heuristic typedstream parser for the `attributedBody` column
+6. `messages-fda-doctor-check` — EPERM / SQLITE_CANTOPEN classification as Full Disk Access denial
 
 `grep -rn 'PATCH' .` surfaces any additional inline customization comments added after initial authoring.
+
+## Source Files
+
+Per-resource organization under `internal/cli/`:
+
+- `root.go` — Cobra root + `rootFlags` (shared by photos and messages subtrees).
+- `helpers.go` — color, JSON, tabwriter, size formatting helpers; `cliError` + `usageErr`/`configErr`.
+- `doctor.go` — sectioned pre-flight.
+
+Photos: `photos.go`, `photos_db.go`, `photos_top.go`, `photos_videos.go`, `photos_storage.go`, `photos_stats.go`, `photos_delete.go`, `photos_download.go`.
+
+Messages: `messages.go` (parent), `messages_db.go` (chat.db reader + types + queries), `messages_decode.go` (vendored MIT typedstream heuristic) + `messages_decode_test.go`, `messages_list_chats.go`, `messages_search.go`, `messages_stats.go`, `messages_export.go`.

--- a/library/media-and-entertainment/icloud/README.md
+++ b/library/media-and-entertainment/icloud/README.md
@@ -74,16 +74,17 @@ Install the pp-icloud skill from https://github.com/mvanhorn/printing-press-libr
 ## Quick start
 
 ```bash
-icloud-pp-cli doctor              # verify library is readable
-icloud-pp-cli photos top          # top 25 heaviest files
-icloud-pp-cli photos storage      # breakdown by type and year
-icloud-pp-cli photos stats        # total size + item count
+icloud-pp-cli doctor                            # verify Photos + Messages access
+icloud-pp-cli photos top                        # top 25 heaviest files
+icloud-pp-cli messages list-chats --limit 10    # 10 most-recently-active chats
+icloud-pp-cli messages search "lunch"           # search your message history
 ```
 
 Pipe any command for automatic JSON:
 
 ```bash
 icloud-pp-cli photos top | jq '.[0:5]'
+icloud-pp-cli messages list-chats --agent | jq '[.[] | select(.is_group)]'
 ```
 
 ---
@@ -93,16 +94,34 @@ icloud-pp-cli photos top | jq '.[0:5]'
 ```
 icloud-pp-cli
   photos
-    top        Top N heaviest files (--limit, --type all|photo|video)
-    videos     Largest videos (--limit, --year, --month)
-    storage    Breakdown by media type and year
-    stats      Total items and library size
-  doctor       Verify Photos library is readable
+    top         Top N heaviest files (--limit, --type all|photo|video)
+    videos      Largest videos (--limit, --year, --month)
+    storage     Breakdown by media type and year
+    stats       Total items and library size
+    delete      Move items to Recently Deleted (requires --confirm)
+    download    Export originals to a local folder
+  messages
+    list-chats  Chats ordered by most-recent activity (--limit, --since, --include-empty)
+    search      Full-text search of message bodies (--chat, --handle, --from-me, --since, --until, --limit)
+    stats       Total messages / chats / handles + by-year + top handles
+    export      Export a chat or all chats to JSON (--chat, --out, --since, --until)
+  doctor        Pre-flight: System / Library / Assets / Messages
 ```
 
-All commands accept: `--json` `--compact` `--no-color` `--agent` `--library PATH`
+All commands accept: `--json` `--compact` `--no-color` `--agent`.
+`photos` commands also accept `--library PATH`; `messages` commands accept `--messages-db PATH`.
 
 `--agent` sets `--json --compact --no-color` in one flag — use it in AI workflows.
+
+## Messages: Full Disk Access required
+
+Reading `~/Library/Messages/chat.db` requires macOS Full Disk Access for the
+terminal app invoking the binary. If a messages command fails with
+"Full Disk Access not granted," open System Settings > Privacy & Security >
+Full Disk Access, add your terminal, quit and reopen the terminal, and rerun.
+
+`doctor` reports this automatically — the Messages section shows green when
+FDA is granted and a yellow warning (with remediation) when it is not.
 
 ---
 

--- a/library/media-and-entertainment/icloud/SKILL.md
+++ b/library/media-and-entertainment/icloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icloud-pp-cli
-description: "Query your iCloud data from the command line — Photos library storage analysis, largest-file finder, and delete via AppleScript. macOS only. No network calls or iCloud API token required."
+description: "Query your iCloud data from the command line — Photos library storage analysis, iMessage history search and export, largest-file finder, and delete via AppleScript. macOS only. No network calls or iCloud API token required."
 author: "Matias Sanchez Moises"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install"
@@ -45,13 +45,21 @@ Always run `doctor` first to confirm your setup:
 icloud-pp-cli doctor
 ```
 
-Verifies: macOS, Photos.app installed, library path found, database schema valid, asset count queryable.
+Verifies: macOS, Photos.app installed, library path found, database schema valid, asset count queryable, chat.db readable (Full Disk Access).
 
 If your Photos library is in a non-default location:
 
 ```bash
 icloud-pp-cli doctor --library "/Volumes/External/Photos Library.photoslibrary/database/Photos.sqlite"
 ```
+
+## Messages: Full Disk Access required
+
+`messages` subcommands read `~/Library/Messages/chat.db` directly, which on
+macOS requires Full Disk Access (FDA) for the terminal app invoking the binary.
+If a messages command fails with "Full Disk Access not granted", open System
+Settings > Privacy & Security > Full Disk Access, add your terminal, quit and
+reopen the terminal, and rerun. `doctor` reports FDA state automatically.
 
 ## Command Reference
 
@@ -65,6 +73,13 @@ icloud-pp-cli doctor --library "/Volumes/External/Photos Library.photoslibrary/d
 - `icloud-pp-cli photos download [uuid...] --output <dir>` — Export originals from iCloud to a local folder. Photos.app downloads from iCloud automatically if Optimize Mac Storage is enabled.
 - `icloud-pp-cli photos download --sensitive --confirm --output <dir>` — Export items Apple's on-device ML has flagged as containing nudity (`--confirm` required).
 
+**messages** — Read your iMessage history from `~/Library/Messages/chat.db`. Requires Full Disk Access.
+
+- `icloud-pp-cli messages list-chats` — Chats ordered by most-recent activity. Flags: `--limit`, `--since`, `--include-empty`.
+- `icloud-pp-cli messages search <query>` — Full-text search across message bodies (decoded from `attributedBody` when `text` is NULL). Flags: `--chat`, `--handle`, `--from-me`, `--from-others`, `--since`, `--until`, `--limit`.
+- `icloud-pp-cli messages stats` — Total messages / chats / handles, by-year breakdown, top N handles. Flags: `--top-handles`, `--include-tapbacks`.
+- `icloud-pp-cli messages export --chat <guid|all>` — Export a chat (or every chat) to JSON with attachment paths. Flags: `--out`, `--since`, `--until`, `--include-tapbacks`.
+
 **doctor** — Run pre-flight checks before using any other command.
 
 ## Agent Mode
@@ -75,9 +90,14 @@ Add `--agent` to any command. Expands to `--json --compact --no-color`.
 icloud-pp-cli photos top --agent
 icloud-pp-cli photos storage --agent | jq '.by_year'
 icloud-pp-cli photos stats --agent
+
+icloud-pp-cli messages list-chats --limit 10 --agent | jq '[.[] | {chat: .display_name // .chat_identifier, last: .last_message_date}]'
+icloud-pp-cli messages search "lunch" --limit 5 --agent
+icloud-pp-cli messages stats --agent
+icloud-pp-cli messages export --chat <guid> --out /tmp/chat.json
 ```
 
-Output is always JSON on stdout with no color. Pipe-friendly — commands also auto-detect pipes and switch to JSON without `--agent`.
+Output is always JSON on stdout with no color. Pipe-friendly — commands also auto-detect pipes and switch to JSON without `--agent`. Messages JSON includes a `text_source` field on every row (`decoded`, `text_column`, or `unrecoverable`) so agents can detect coverage gaps from the typedstream decoder.
 
 ## Common Workflows
 
@@ -123,6 +143,32 @@ icloud-pp-cli photos videos --year 2022 --json
 
 # Videos from January 2022
 icloud-pp-cli photos videos --year 2022 --month 1 --json
+```
+
+### Search a chat history for a phrase
+
+```bash
+# Recent messages mentioning "lunch"
+icloud-pp-cli messages search "lunch" --since 2026-01-01
+
+# Only messages I sent, last 6 months
+icloud-pp-cli messages search "thanks" --from-me --since 2025-11-22
+
+# Find a message in a specific chat
+icloud-pp-cli messages search "happy birthday" --chat +15551234567
+```
+
+### Export a chat for downstream analysis
+
+```bash
+# One chat to stdout
+icloud-pp-cli messages export --chat +15551234567
+
+# One chat to a file
+icloud-pp-cli messages export --chat +15551234567 --out /tmp/family.json
+
+# Every chat in one document (large)
+icloud-pp-cli messages export --chat all --out /tmp/all-messages.json
 ```
 
 ## Exit Codes

--- a/library/media-and-entertainment/icloud/internal/cli/doctor.go
+++ b/library/media-and-entertainment/icloud/internal/cli/doctor.go
@@ -191,9 +191,22 @@ database schema, and asset count.`,
 	return cmd
 }
 
-// checkMessagesSchema verifies the three tables an iMessage query touches.
+// checkMessagesSchema verifies the tables an iMessage query touches.
+//
+// PATCH(messages-doctor-junction-tables): every messages query joins
+// chat_message_join, and `messages export` additionally touches
+// message_attachment_join. A stripped or very old chat.db can be missing
+// these without missing the primary tables, which used to make doctor
+// report "schema valid" but the first real query fail.
 func checkMessagesSchema(db *sql.DB) bool {
-	for _, table := range []string{"message", "chat", "handle"} {
+	tables := []string{
+		"message",
+		"chat",
+		"handle",
+		"chat_message_join",
+		"message_attachment_join",
+	}
+	for _, table := range tables {
 		var name string
 		if err := db.QueryRow(
 			"SELECT name FROM sqlite_master WHERE type='table' AND name=?", table,

--- a/library/media-and-entertainment/icloud/internal/cli/doctor.go
+++ b/library/media-and-entertainment/icloud/internal/cli/doctor.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,7 +14,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// PATCH(doctor-sectioned-output): emits System/Library/Assets sections for structured pre-flight.
+// PATCH(doctor-sectioned-output): emits System/Library/Assets/Messages sections for structured pre-flight.
+// PATCH(messages-fda-doctor-check): the Messages section classifies EPERM (and modernc.org/sqlite's
+// SQLITE_CANTOPEN surrogate) on chat.db open as a Full Disk Access denial with copy-paste remediation.
 func newDoctorCmd(f *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
@@ -131,6 +134,48 @@ database schema, and asset count.`,
 				}
 			}
 
+			// ── Messages ──────────────────────────────────────────────
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, bold(f, out, "Messages"))
+
+			msgPath := f.messagesDBPath
+			if msgPath == "" {
+				msgPath = defaultMessagesDBPath()
+			}
+
+			_, msgStatErr := os.Stat(msgPath)
+			if msgStatErr != nil {
+				warn("chat.db not present — messages commands unavailable",
+					fmt.Sprintf("Open Messages.app once to initialize the database, or use --messages-db.\n      Expected at: %s", msgPath))
+			} else {
+				fmt.Fprintf(out, "      %s\n", msgPath)
+				msgDB, msgOpenErr := openMessagesDB(msgPath)
+				switch {
+				case msgOpenErr == nil:
+					fmt.Fprintf(out, "  %s %s\n", green(f, out, "✓"), "chat.db readable (Full Disk Access granted)")
+					msgSchemaOK := checkMessagesSchema(msgDB)
+					if msgSchemaOK {
+						fmt.Fprintf(out, "  %s %s\n", green(f, out, "✓"), "Messages schema valid (message + chat + handle)")
+						msgTotals, totalsErr := statsTotals(msgDB, false)
+						if totalsErr == nil {
+							fmt.Fprintf(out, "      %s messages · %s chats · %s handles\n",
+								formatInt(msgTotals.TotalMessages),
+								formatInt(msgTotals.TotalChats),
+								formatInt(msgTotals.TotalHandles))
+						}
+					} else {
+						warn("Messages schema unexpected", "")
+					}
+					msgDB.Close()
+				case errors.Is(msgOpenErr, errFDADenied):
+					warn("Full Disk Access not granted — messages commands unavailable",
+						"Open System Settings > Privacy & Security > Full Disk Access,\n      add your terminal app, quit and reopen the terminal, then rerun doctor.")
+				default:
+					warn("chat.db cannot be opened",
+						msgOpenErr.Error())
+				}
+			}
+
 			// ── Result ────────────────────────────────────────────────
 			fmt.Fprintln(out)
 			if allOK {
@@ -144,6 +189,19 @@ database schema, and asset count.`,
 	}
 
 	return cmd
+}
+
+// checkMessagesSchema verifies the three tables an iMessage query touches.
+func checkMessagesSchema(db *sql.DB) bool {
+	for _, table := range []string{"message", "chat", "handle"} {
+		var name string
+		if err := db.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name=?", table,
+		).Scan(&name); err != nil || name != table {
+			return false
+		}
+	}
+	return true
 }
 
 func photosAppPath() string {

--- a/library/media-and-entertainment/icloud/internal/cli/messages.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages.go
@@ -1,0 +1,23 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import "github.com/spf13/cobra"
+
+func newMessagesCmd(f *rootFlags) *cobra.Command {
+	messages := &cobra.Command{
+		Use:   "messages",
+		Short: "Query your iMessage history",
+		Long: `Read your macOS Messages database (~/Library/Messages/chat.db) directly.
+
+All commands open chat.db in read-only mode. Full Disk Access is required —
+run "icloud-pp-cli doctor" if any command fails with a permission error.`,
+	}
+
+	messages.PersistentFlags().StringVar(&f.messagesDBPath, "messages-db", "",
+		"Path to chat.db (default: ~/Library/Messages/chat.db)")
+
+	messages.AddCommand(newMessagesListChatsCmd(f))
+
+	return messages
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages.go
@@ -14,8 +14,8 @@ All commands open chat.db in read-only mode. Full Disk Access is required —
 run "icloud-pp-cli doctor" if any command fails with a permission error.`,
 	}
 
-	messages.PersistentFlags().StringVar(&f.messagesDBPath, "messages-db", "",
-		"Path to chat.db (default: ~/Library/Messages/chat.db)")
+	// --messages-db is registered at the root level (see root.go) so that
+	// `doctor` and any future sibling command can read the same override.
 
 	messages.AddCommand(newMessagesListChatsCmd(f))
 	messages.AddCommand(newMessagesSearchCmd(f))

--- a/library/media-and-entertainment/icloud/internal/cli/messages.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages.go
@@ -19,6 +19,7 @@ run "icloud-pp-cli doctor" if any command fails with a permission error.`,
 
 	messages.AddCommand(newMessagesListChatsCmd(f))
 	messages.AddCommand(newMessagesSearchCmd(f))
+	messages.AddCommand(newMessagesStatsCmd(f))
 
 	return messages
 }

--- a/library/media-and-entertainment/icloud/internal/cli/messages.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages.go
@@ -18,6 +18,7 @@ run "icloud-pp-cli doctor" if any command fails with a permission error.`,
 		"Path to chat.db (default: ~/Library/Messages/chat.db)")
 
 	messages.AddCommand(newMessagesListChatsCmd(f))
+	messages.AddCommand(newMessagesSearchCmd(f))
 
 	return messages
 }

--- a/library/media-and-entertainment/icloud/internal/cli/messages.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages.go
@@ -20,6 +20,7 @@ run "icloud-pp-cli doctor" if any command fails with a permission error.`,
 	messages.AddCommand(newMessagesListChatsCmd(f))
 	messages.AddCommand(newMessagesSearchCmd(f))
 	messages.AddCommand(newMessagesStatsCmd(f))
+	messages.AddCommand(newMessagesExportCmd(f))
 
 	return messages
 }

--- a/library/media-and-entertainment/icloud/internal/cli/messages_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_db.go
@@ -177,7 +177,7 @@ func openMessagesDB(dbPath string) (*sql.DB, error) {
 			)
 		}
 		if isPermissionError(err) {
-			return nil, fmt.Errorf("%w: %s", errFDADenied, dbPath)
+			return nil, configErr(fmt.Errorf("%w: %s", errFDADenied, dbPath))
 		}
 		return nil, err
 	}
@@ -193,15 +193,19 @@ func openMessagesDB(dbPath string) (*sql.DB, error) {
 	if err := db.Ping(); err != nil {
 		db.Close()
 		if isPermissionError(err) {
-			return nil, fmt.Errorf("%w: %s", errFDADenied, dbPath)
+			return nil, configErr(fmt.Errorf("%w: %s", errFDADenied, dbPath))
 		}
 		return nil, fmt.Errorf("cannot read chat.db: %w", err)
 	}
 	return db, nil
 }
 
-// isPermissionError detects EPERM regardless of whether the driver surfaces it
-// as syscall.EPERM, os.PathError wrapping it, or a string-only error message.
+// isPermissionError detects access denials surfaced by the OS or the SQLite
+// driver. macOS TCC denials don't always reach Go as EPERM — modernc.org/sqlite
+// often reports them as SQLITE_CANTOPEN ("unable to open database file") or a
+// surrogate code like "out of memory" because the OS withholds enough state
+// from the driver to distinguish the cause. Treat any open-side failure as a
+// likely permission issue when chat.db itself exists.
 func isPermissionError(err error) bool {
 	if err == nil {
 		return false
@@ -210,8 +214,17 @@ func isPermissionError(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "operation not permitted") ||
-		strings.Contains(msg, "permission denied")
+	for _, marker := range []string{
+		"operation not permitted",
+		"permission denied",
+		"unable to open database file",
+		"out of memory (14)", // SQLITE_CANTOPEN surrogate
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // cocoaToUnix converts a chat.db timestamp to time.Time. The encoding is

--- a/library/media-and-entertainment/icloud/internal/cli/messages_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_db.go
@@ -297,8 +297,12 @@ func listChats(db *sql.DB, opts ChatListOpts) ([]ChatRow, error) {
 	var whereLastDate string
 	args := []any{}
 	if opts.Since != nil {
+		// PATCH(messages-list-chats-since-nanosecond-conversion): last_msg.last_date
+		// is MAX(m.date) which is nanoseconds-since-Cocoa-epoch on modern macOS.
+		// Convert the user-supplied seconds-domain threshold to nanoseconds so
+		// the comparison meets in the same unit. Matches searchMessages's pattern.
 		whereLastDate = " AND last_msg.last_date >= ?"
-		args = append(args, opts.Since.Unix()-cocoaEpoch)
+		args = append(args, (opts.Since.Unix()-cocoaEpoch)*1_000_000_000)
 	}
 	if !opts.IncludeEmpty {
 		whereLastDate += " AND last_msg.last_date IS NOT NULL"
@@ -468,9 +472,14 @@ func searchMessages(db *sql.DB, opts SearchOpts) ([]MessageRow, error) {
 
 	// SQL LIKE phase. Match against text column only; attributedBody hits
 	// are caught in the post-scan filter below.
+	//
+	// PATCH(messages-like-escape-clause): escapeLike writes \% and \_ into the
+	// pattern but the LIKE expression must carry an explicit ESCAPE clause for
+	// SQLite to honor the backslash as an escape character. Without it, queries
+	// containing literal % or _ silently miss rows from the SQL phase.
 	textCond := ""
 	if opts.Query != "" {
-		textCond = " AND (m.text LIKE ? COLLATE NOCASE OR m.text IS NULL)"
+		textCond = ` AND (m.text LIKE ? COLLATE NOCASE ESCAPE '\' OR m.text IS NULL)`
 		args = append(args, "%"+escapeLike(opts.Query)+"%")
 	}
 
@@ -517,10 +526,11 @@ func searchMessages(db *sql.DB, opts SearchOpts) ([]MessageRow, error) {
 	return out, rows.Err()
 }
 
-// escapeLike escapes the SQL LIKE metacharacters in a user query. Returned
-// string is safe to embed in a `%query%` LIKE pattern without an ESCAPE clause
-// for the common case; callers wanting strict escaping should use a parameter
-// binding and explicit ESCAPE clause.
+// escapeLike escapes the SQL LIKE metacharacters in a user query. The returned
+// string contains backslash-prefixed `\%`, `\_`, and `\\` sequences and MUST
+// be paired with an explicit `ESCAPE '\'` clause in the LIKE expression for
+// SQLite to honor the escapes. Without the ESCAPE clause SQLite treats the
+// backslash as a literal character and the intended escaping does not fire.
 func escapeLike(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, "%", `\%`)

--- a/library/media-and-entertainment/icloud/internal/cli/messages_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_db.go
@@ -1,0 +1,780 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+//
+// PATCH(messages-readonly-chatdb): opens ~/Library/Messages/chat.db read-only
+// via the file: URI prefix on modernc.org/sqlite. Without that prefix the
+// driver silently drops mode=ro and returns a writable handle.
+
+package cli
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// cocoaEpoch is the Cocoa reference date (2001-01-01 00:00:00 UTC) offset from
+// Unix epoch in seconds.
+const cocoaEpoch int64 = 978307200
+
+// nanosecondMagnitude is the boundary above which a chat.db timestamp is
+// nanoseconds (since macOS 10.13 / iOS 11) rather than plain seconds. The
+// magnitude check is per-row, not per-database — chat_message_join.message_date
+// is not uniformly backfilled to nanoseconds on every row even on modern DBs.
+const nanosecondMagnitude int64 = 1_000_000_000_000
+
+// errFDADenied is the sentinel returned when chat.db access fails with EPERM,
+// which on macOS indicates Full Disk Access has not been granted to the
+// running process. The doctor command checks for this with errors.Is.
+var errFDADenied = errors.New("chat.db cannot be read: Full Disk Access not granted")
+
+// Tapback associated_message_type values. Rows whose associated_message_guid
+// is non-null and type falls in this range are reactions, not real messages,
+// and are filtered from list/search output by default. The "removed" variants
+// live at the upper end of the range.
+const (
+	tapbackTypeMin = 2000
+	tapbackTypeMax = 3005
+)
+
+// ── types ─────────────────────────────────────────────────────────────────────
+
+// ChatRow is one row from the chat table augmented with participant + message
+// statistics that the subcommands surface together.
+type ChatRow struct {
+	ROWID            int64      `json:"rowid"`
+	GUID             string     `json:"guid"`
+	ChatIdentifier   string     `json:"chat_identifier"`
+	DisplayName      string     `json:"display_name,omitempty"`
+	Style            int        `json:"style"`
+	ParticipantCount int        `json:"participants"`
+	MessageCount     int64      `json:"message_count"`
+	LastMessageDate  *time.Time `json:"last_message_date,omitempty"`
+	LastPreview      string     `json:"last_preview,omitempty"`
+	IsGroup          bool       `json:"is_group"`
+}
+
+// MessageRow is one row from the message table with text decoded from
+// attributedBody when message.text is NULL.
+type MessageRow struct {
+	ROWID            int64      `json:"rowid"`
+	GUID             string     `json:"guid"`
+	ChatGUID         string     `json:"chat_guid,omitempty"`
+	ChatDisplayName  string     `json:"chat_display_name,omitempty"`
+	HandleID         *int64     `json:"handle_id,omitempty"`
+	HandleAddress    string     `json:"handle,omitempty"`
+	IsFromMe         bool       `json:"is_from_me"`
+	Date             time.Time  `json:"date"`
+	DateEdited       *time.Time `json:"date_edited,omitempty"`
+	Text             string     `json:"text"`
+	TextSource       string     `json:"text_source"`
+	HasAttachments   bool       `json:"has_attachments"`
+	AssociatedType   *int       `json:"associated_type,omitempty"`
+}
+
+// HandleRow is one row from the handle table.
+type HandleRow struct {
+	ROWID   int64  `json:"rowid"`
+	Address string `json:"address"`
+	Service string `json:"service"`
+}
+
+// AttachmentRow is one row from the attachment table joined with the message.
+type AttachmentRow struct {
+	ROWID         int64  `json:"rowid"`
+	Filename      string `json:"filename,omitempty"`
+	ResolvedPath  string `json:"resolved_path,omitempty"`
+	MIMEType      string `json:"mime_type,omitempty"`
+	TransferState int    `json:"transfer_state"`
+	Missing       bool   `json:"missing,omitempty"`
+}
+
+// YearStats is one row of the by-year stats breakdown.
+type YearStats struct {
+	Year         string `json:"year"`
+	MessageCount int64  `json:"message_count"`
+}
+
+// HandleStats is one row of the top-handles stats breakdown.
+type HandleStats struct {
+	Handle       string `json:"handle"`
+	MessageCount int64  `json:"message_count"`
+}
+
+// MessagesTotals summarises the corpus.
+type MessagesTotals struct {
+	TotalMessages int64 `json:"total_messages"`
+	TotalChats    int64 `json:"total_chats"`
+	TotalHandles  int64 `json:"total_handles"`
+}
+
+// ── options ───────────────────────────────────────────────────────────────────
+
+// ChatListOpts controls listChats query behavior.
+type ChatListOpts struct {
+	Limit        int
+	Since        *time.Time
+	IncludeEmpty bool
+}
+
+// SearchOpts controls searchMessages query behavior.
+type SearchOpts struct {
+	Query           string
+	ChatFilter      string // GUID or chat_identifier
+	HandleFilter    string // address (phone/email)
+	FromMe          *bool
+	Since           *time.Time
+	Until           *time.Time
+	Limit           int
+	IncludeTapbacks bool
+}
+
+// MessageWindowOpts controls messagesForChat query behavior.
+type MessageWindowOpts struct {
+	Since           *time.Time
+	Until           *time.Time
+	Limit           int
+	IncludeTapbacks bool
+}
+
+// ── open + helpers ────────────────────────────────────────────────────────────
+
+func defaultMessagesDBPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Messages", "chat.db")
+}
+
+func defaultAttachmentsRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Messages", "Attachments")
+}
+
+// openMessagesDB opens chat.db read-only. Returns errFDADenied (wrapped) when
+// the OS reports EPERM, which on macOS indicates Full Disk Access has not been
+// granted to the running process.
+func openMessagesDB(dbPath string) (*sql.DB, error) {
+	if runtime.GOOS != "darwin" {
+		return nil, configErr(fmt.Errorf(
+			"icloud-pp-cli messages requires macOS — this is %s", runtime.GOOS,
+		))
+	}
+	if dbPath == "" {
+		dbPath = defaultMessagesDBPath()
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf(
+				"chat.db not found at %s\n\nOpen Messages.app once to initialize the database, or use --messages-db to specify a path.",
+				dbPath,
+			)
+		}
+		if isPermissionError(err) {
+			return nil, fmt.Errorf("%w: %s", errFDADenied, dbPath)
+		}
+		return nil, err
+	}
+	u := &url.URL{
+		Scheme:   "file",
+		Path:     dbPath,
+		RawQuery: "mode=ro&_busy_timeout=5000&_query_only=1",
+	}
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return nil, fmt.Errorf("cannot open chat.db: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		if isPermissionError(err) {
+			return nil, fmt.Errorf("%w: %s", errFDADenied, dbPath)
+		}
+		return nil, fmt.Errorf("cannot read chat.db: %w", err)
+	}
+	return db, nil
+}
+
+// isPermissionError detects EPERM regardless of whether the driver surfaces it
+// as syscall.EPERM, os.PathError wrapping it, or a string-only error message.
+func isPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPERM) || errors.Is(err, os.ErrPermission) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "operation not permitted") ||
+		strings.Contains(msg, "permission denied")
+}
+
+// cocoaToUnix converts a chat.db timestamp to time.Time. The encoding is
+// either plain seconds or nanoseconds since the Cocoa epoch (2001-01-01 UTC),
+// determined per-row by magnitude — chat_message_join.message_date is not
+// uniformly backfilled to nanoseconds even on modern databases (bagoup #40).
+func cocoaToUnix(raw int64) time.Time {
+	if raw == 0 {
+		return time.Time{}
+	}
+	seconds := raw
+	if raw >= nanosecondMagnitude {
+		seconds = raw / 1_000_000_000
+	}
+	return time.Unix(seconds+cocoaEpoch, 0).UTC()
+}
+
+// nullStringToValue returns the dereferenced string or empty.
+func nullStringToValue(ns sql.NullString) string {
+	if ns.Valid {
+		return ns.String
+	}
+	return ""
+}
+
+// nullInt64ToPtr returns a pointer to the int64 value or nil.
+func nullInt64ToPtr(ni sql.NullInt64) *int64 {
+	if ni.Valid {
+		v := ni.Int64
+		return &v
+	}
+	return nil
+}
+
+// nullIntToPtr returns a pointer to int or nil.
+func nullIntToPtr(ni sql.NullInt64) *int {
+	if ni.Valid {
+		v := int(ni.Int64)
+		return &v
+	}
+	return nil
+}
+
+// extractMessageText returns the message body from the text column when
+// non-null, falling back to the attributedBody decoder, with the source
+// classification surfaced to callers.
+func extractMessageText(text sql.NullString, attributedBody []byte) (string, string) {
+	if text.Valid && text.String != "" {
+		return text.String, textSourceTextColumn
+	}
+	if len(attributedBody) > 0 {
+		decoded, source := decodeAttributedBody(attributedBody)
+		if source == textSourceDecoded {
+			return decoded, textSourceDecoded
+		}
+	}
+	if text.Valid {
+		// text column existed but was empty string
+		return text.String, textSourceTextColumn
+	}
+	return "", textSourceUnrecoverable
+}
+
+// ── queries ───────────────────────────────────────────────────────────────────
+
+// listChats returns chats ordered by most-recent activity. Group vs DM is
+// determined by participant count (chat_handle_join), not chat.style, because
+// chat.style has been observed to drift across schema generations.
+func listChats(db *sql.DB, opts ChatListOpts) ([]ChatRow, error) {
+	var whereLastDate string
+	args := []any{}
+	if opts.Since != nil {
+		whereLastDate = " AND last_msg.last_date >= ?"
+		args = append(args, opts.Since.Unix()-cocoaEpoch)
+	}
+	if !opts.IncludeEmpty {
+		whereLastDate += " AND last_msg.last_date IS NOT NULL"
+	}
+
+	q := fmt.Sprintf(`
+		SELECT
+			c.ROWID,
+			COALESCE(c.guid, ''),
+			COALESCE(c.chat_identifier, ''),
+			c.display_name,
+			COALESCE(c.style, 0),
+			COALESCE(participants.cnt, 0),
+			COALESCE(last_msg.msg_count, 0),
+			last_msg.last_date
+		FROM chat c
+		LEFT JOIN (
+			SELECT chat_id, COUNT(handle_id) AS cnt
+			FROM chat_handle_join
+			GROUP BY chat_id
+		) participants ON participants.chat_id = c.ROWID
+		LEFT JOIN (
+			SELECT cmj.chat_id,
+				COUNT(*) AS msg_count,
+				MAX(m.date) AS last_date
+			FROM chat_message_join cmj
+			JOIN message m ON m.ROWID = cmj.message_id
+			WHERE m.associated_message_guid IS NULL
+			GROUP BY cmj.chat_id
+		) last_msg ON last_msg.chat_id = c.ROWID
+		WHERE 1 = 1%s
+		ORDER BY last_msg.last_date DESC NULLS LAST
+	`, whereLastDate)
+
+	if opts.Limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list chats: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ChatRow
+	for rows.Next() {
+		var c ChatRow
+		var displayName sql.NullString
+		var lastDate sql.NullInt64
+		if err := rows.Scan(
+			&c.ROWID,
+			&c.GUID,
+			&c.ChatIdentifier,
+			&displayName,
+			&c.Style,
+			&c.ParticipantCount,
+			&c.MessageCount,
+			&lastDate,
+		); err != nil {
+			return nil, fmt.Errorf("scan chat row: %w", err)
+		}
+		c.DisplayName = nullStringToValue(displayName)
+		if lastDate.Valid {
+			t := cocoaToUnix(lastDate.Int64)
+			c.LastMessageDate = &t
+		}
+		c.IsGroup = c.ParticipantCount > 1
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// fillLastPreviews populates the LastPreview field on each chat by fetching
+// the most recent non-tapback message and decoding its body. Done in a
+// follow-up pass so listChats stays a single aggregate query rather than a
+// correlated subquery per row.
+func fillLastPreviews(db *sql.DB, chats []ChatRow, maxLen int) error {
+	for i := range chats {
+		if chats[i].MessageCount == 0 {
+			continue
+		}
+		text, source, err := fetchLastMessageText(db, chats[i].ROWID)
+		if err != nil {
+			return err
+		}
+		_ = source
+		if text == "" {
+			continue
+		}
+		if maxLen > 0 && len(text) > maxLen {
+			text = text[:maxLen] + "..."
+		}
+		chats[i].LastPreview = text
+	}
+	return nil
+}
+
+func fetchLastMessageText(db *sql.DB, chatROWID int64) (string, string, error) {
+	q := `
+		SELECT m.text, m.attributedBody
+		FROM chat_message_join cmj
+		JOIN message m ON m.ROWID = cmj.message_id
+		WHERE cmj.chat_id = ?
+		  AND m.associated_message_guid IS NULL
+		ORDER BY m.date DESC
+		LIMIT 1
+	`
+	row := db.QueryRow(q, chatROWID)
+	var text sql.NullString
+	var attrBody []byte
+	if err := row.Scan(&text, &attrBody); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", textSourceUnrecoverable, nil
+		}
+		return "", textSourceUnrecoverable, err
+	}
+	body, source := extractMessageText(text, attrBody)
+	return body, source, nil
+}
+
+// searchMessages performs a text-content search with optional filters. Returns
+// at most opts.Limit rows. Two-phase: SQL LIKE matches text-column hits
+// efficiently, then a second pass scans attributedBody-only rows when
+// opts.Query is set so post-Big-Sur messages aren't silently missed.
+func searchMessages(db *sql.DB, opts SearchOpts) ([]MessageRow, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 1000 {
+		opts.Limit = 1000
+	}
+
+	conds := []string{"1 = 1"}
+	args := []any{}
+
+	if !opts.IncludeTapbacks {
+		conds = append(conds, "m.associated_message_guid IS NULL")
+	}
+
+	if opts.ChatFilter != "" {
+		conds = append(conds, "(c.guid = ? OR c.chat_identifier = ?)")
+		args = append(args, opts.ChatFilter, opts.ChatFilter)
+	}
+	if opts.HandleFilter != "" {
+		conds = append(conds, "h.id = ?")
+		args = append(args, opts.HandleFilter)
+	}
+	if opts.FromMe != nil {
+		v := 0
+		if *opts.FromMe {
+			v = 1
+		}
+		conds = append(conds, "m.is_from_me = ?")
+		args = append(args, v)
+	}
+	if opts.Since != nil {
+		conds = append(conds, "m.date >= ?")
+		args = append(args, (opts.Since.Unix()-cocoaEpoch)*1_000_000_000)
+	}
+	if opts.Until != nil {
+		conds = append(conds, "m.date <= ?")
+		args = append(args, (opts.Until.Unix()-cocoaEpoch)*1_000_000_000)
+	}
+
+	// SQL LIKE phase. Match against text column only; attributedBody hits
+	// are caught in the post-scan filter below.
+	textCond := ""
+	if opts.Query != "" {
+		textCond = " AND (m.text LIKE ? COLLATE NOCASE OR m.text IS NULL)"
+		args = append(args, "%"+escapeLike(opts.Query)+"%")
+	}
+
+	q := fmt.Sprintf(`
+		SELECT
+			m.ROWID, COALESCE(m.guid, ''),
+			COALESCE(c.guid, ''), c.display_name,
+			m.handle_id, h.id,
+			COALESCE(m.is_from_me, 0),
+			COALESCE(m.date, 0),
+			m.date_edited,
+			m.text, m.attributedBody,
+			COALESCE(m.cache_has_attachments, 0),
+			m.associated_message_type
+		FROM message m
+		LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+		LEFT JOIN chat c ON c.ROWID = cmj.chat_id
+		LEFT JOIN handle h ON h.ROWID = m.handle_id
+		WHERE %s%s
+		ORDER BY m.date DESC
+		LIMIT %d
+	`, strings.Join(conds, " AND "), textCond, opts.Limit*4) // overscan to allow filtering
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search messages: %w", err)
+	}
+	defer rows.Close()
+
+	var out []MessageRow
+	for rows.Next() {
+		m, err := scanMessageRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		if opts.Query != "" && !strings.Contains(strings.ToLower(m.Text), strings.ToLower(opts.Query)) {
+			continue
+		}
+		out = append(out, m)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, rows.Err()
+}
+
+// escapeLike escapes the SQL LIKE metacharacters in a user query. Returned
+// string is safe to embed in a `%query%` LIKE pattern without an ESCAPE clause
+// for the common case; callers wanting strict escaping should use a parameter
+// binding and explicit ESCAPE clause.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
+}
+
+// scanMessageRow scans a single row from the search/window query into a
+// MessageRow with text decoded.
+func scanMessageRow(rows *sql.Rows) (MessageRow, error) {
+	var m MessageRow
+	var chatDisplay sql.NullString
+	var handleID sql.NullInt64
+	var handleAddr sql.NullString
+	var isFromMe int
+	var dateRaw int64
+	var dateEdited sql.NullInt64
+	var text sql.NullString
+	var attrBody []byte
+	var hasAttach int
+	var assocType sql.NullInt64
+
+	if err := rows.Scan(
+		&m.ROWID, &m.GUID,
+		&m.ChatGUID, &chatDisplay,
+		&handleID, &handleAddr,
+		&isFromMe,
+		&dateRaw,
+		&dateEdited,
+		&text, &attrBody,
+		&hasAttach,
+		&assocType,
+	); err != nil {
+		return m, fmt.Errorf("scan message row: %w", err)
+	}
+	m.ChatDisplayName = nullStringToValue(chatDisplay)
+	m.HandleID = nullInt64ToPtr(handleID)
+	m.HandleAddress = nullStringToValue(handleAddr)
+	m.IsFromMe = isFromMe != 0
+	m.Date = cocoaToUnix(dateRaw)
+	if dateEdited.Valid && dateEdited.Int64 != 0 {
+		t := cocoaToUnix(dateEdited.Int64)
+		m.DateEdited = &t
+	}
+	m.HasAttachments = hasAttach != 0
+	m.AssociatedType = nullIntToPtr(assocType)
+	m.Text, m.TextSource = extractMessageText(text, attrBody)
+	return m, nil
+}
+
+// messagesForChat returns the message history for a chat in chronological order.
+func messagesForChat(db *sql.DB, chatROWID int64, opts MessageWindowOpts) ([]MessageRow, error) {
+	conds := []string{"cmj.chat_id = ?"}
+	args := []any{chatROWID}
+	if !opts.IncludeTapbacks {
+		conds = append(conds, "m.associated_message_guid IS NULL")
+	}
+	if opts.Since != nil {
+		conds = append(conds, "m.date >= ?")
+		args = append(args, (opts.Since.Unix()-cocoaEpoch)*1_000_000_000)
+	}
+	if opts.Until != nil {
+		conds = append(conds, "m.date <= ?")
+		args = append(args, (opts.Until.Unix()-cocoaEpoch)*1_000_000_000)
+	}
+
+	limit := ""
+	if opts.Limit > 0 {
+		limit = fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	q := fmt.Sprintf(`
+		SELECT
+			m.ROWID, COALESCE(m.guid, ''),
+			COALESCE(c.guid, ''), c.display_name,
+			m.handle_id, h.id,
+			COALESCE(m.is_from_me, 0),
+			COALESCE(m.date, 0),
+			m.date_edited,
+			m.text, m.attributedBody,
+			COALESCE(m.cache_has_attachments, 0),
+			m.associated_message_type
+		FROM message m
+		JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+		LEFT JOIN chat c ON c.ROWID = cmj.chat_id
+		LEFT JOIN handle h ON h.ROWID = m.handle_id
+		WHERE %s
+		ORDER BY m.date ASC%s
+	`, strings.Join(conds, " AND "), limit)
+
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("messages for chat: %w", err)
+	}
+	defer rows.Close()
+
+	var out []MessageRow
+	for rows.Next() {
+		m, err := scanMessageRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// chatByIdentifier resolves a chat by GUID or chat_identifier (which is the
+// underlying phone/email for DMs or "chat<n>" for groups).
+func chatByIdentifier(db *sql.DB, ident string) (ChatRow, error) {
+	q := `
+		SELECT c.ROWID, COALESCE(c.guid, ''), COALESCE(c.chat_identifier, ''),
+		       c.display_name, COALESCE(c.style, 0),
+		       COALESCE((SELECT COUNT(*) FROM chat_handle_join chj WHERE chj.chat_id = c.ROWID), 0)
+		FROM chat c
+		WHERE c.guid = ? OR c.chat_identifier = ?
+		LIMIT 1
+	`
+	row := db.QueryRow(q, ident, ident)
+	var c ChatRow
+	var displayName sql.NullString
+	if err := row.Scan(&c.ROWID, &c.GUID, &c.ChatIdentifier, &displayName, &c.Style, &c.ParticipantCount); err != nil {
+		return c, err
+	}
+	c.DisplayName = nullStringToValue(displayName)
+	c.IsGroup = c.ParticipantCount > 1
+	return c, nil
+}
+
+// attachmentsForMessage returns attachment rows for a message with resolved
+// filesystem paths and a missing flag.
+func attachmentsForMessage(db *sql.DB, messageROWID int64) ([]AttachmentRow, error) {
+	q := `
+		SELECT a.ROWID, a.filename, a.mime_type, COALESCE(a.transfer_state, 0)
+		FROM attachment a
+		JOIN message_attachment_join maj ON maj.attachment_id = a.ROWID
+		WHERE maj.message_id = ?
+	`
+	rows, err := db.Query(q, messageROWID)
+	if err != nil {
+		return nil, fmt.Errorf("attachments for message: %w", err)
+	}
+	defer rows.Close()
+
+	home, _ := os.UserHomeDir()
+	var out []AttachmentRow
+	for rows.Next() {
+		var a AttachmentRow
+		var filename, mime sql.NullString
+		if err := rows.Scan(&a.ROWID, &filename, &mime, &a.TransferState); err != nil {
+			return nil, fmt.Errorf("scan attachment row: %w", err)
+		}
+		a.Filename = nullStringToValue(filename)
+		a.MIMEType = nullStringToValue(mime)
+		if a.Filename != "" {
+			path := a.Filename
+			if strings.HasPrefix(path, "~/") && home != "" {
+				path = filepath.Join(home, path[2:])
+			}
+			a.ResolvedPath = path
+			if _, err := os.Stat(path); err != nil {
+				a.Missing = true
+			}
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// statsTotals returns the top-level row counts for the corpus.
+func statsTotals(db *sql.DB, includeTapbacks bool) (MessagesTotals, error) {
+	var t MessagesTotals
+	cond := ""
+	if !includeTapbacks {
+		cond = " WHERE associated_message_guid IS NULL"
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM message" + cond).Scan(&t.TotalMessages); err != nil {
+		return t, fmt.Errorf("stats totals (messages): %w", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM chat").Scan(&t.TotalChats); err != nil {
+		return t, fmt.Errorf("stats totals (chats): %w", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM handle").Scan(&t.TotalHandles); err != nil {
+		return t, fmt.Errorf("stats totals (handles): %w", err)
+	}
+	return t, nil
+}
+
+// statsByYear groups message counts by year. Cocoa-epoch dates are converted
+// to Unix seconds in SQL via the magnitude check (nanoseconds vs seconds).
+func statsByYear(db *sql.DB, includeTapbacks bool) ([]YearStats, error) {
+	cond := ""
+	if !includeTapbacks {
+		cond = " AND associated_message_guid IS NULL"
+	}
+	q := fmt.Sprintf(`
+		SELECT
+			strftime('%%Y', datetime(
+				CASE WHEN date >= %d
+					 THEN date / 1000000000 + %d
+					 ELSE date + %d
+				END,
+				'unixepoch'
+			)) AS yr,
+			COUNT(*)
+		FROM message
+		WHERE date > 0%s
+		GROUP BY yr
+		ORDER BY yr DESC
+	`, nanosecondMagnitude, cocoaEpoch, cocoaEpoch, cond)
+
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("stats by year: %w", err)
+	}
+	defer rows.Close()
+
+	var out []YearStats
+	for rows.Next() {
+		var y YearStats
+		if err := rows.Scan(&y.Year, &y.MessageCount); err != nil {
+			return nil, fmt.Errorf("scan year row: %w", err)
+		}
+		out = append(out, y)
+	}
+	return out, rows.Err()
+}
+
+// statsByHandle returns the top N handles by message count.
+func statsByHandle(db *sql.DB, top int, includeTapbacks bool) ([]HandleStats, error) {
+	if top <= 0 {
+		top = 10
+	}
+	cond := ""
+	if !includeTapbacks {
+		cond = " AND m.associated_message_guid IS NULL"
+	}
+	q := fmt.Sprintf(`
+		SELECT COALESCE(h.id, '(me)'), COUNT(*) AS cnt
+		FROM message m
+		LEFT JOIN handle h ON h.ROWID = m.handle_id
+		WHERE 1 = 1%s
+		GROUP BY h.id
+		ORDER BY cnt DESC
+		LIMIT %d
+	`, cond, top)
+
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("stats by handle: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HandleStats
+	for rows.Next() {
+		var h HandleStats
+		if err := rows.Scan(&h.Handle, &h.MessageCount); err != nil {
+			return nil, fmt.Errorf("scan handle row: %w", err)
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+// tapbackTypeRange returns the documented inclusive range for tapback rows.
+// v1 queries filter tapbacks via `associated_message_guid IS NULL`, which is
+// the cheaper shortcut; this helper exists so future surfaces that want to
+// distinguish tapbacks from regular associated messages have a single source
+// of truth for the range.
+func tapbackTypeRange() (int, int) { return tapbackTypeMin, tapbackTypeMax }

--- a/library/media-and-entertainment/icloud/internal/cli/messages_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_db.go
@@ -395,8 +395,12 @@ func fillLastPreviews(db *sql.DB, chats []ChatRow, maxLen int) error {
 		if text == "" {
 			continue
 		}
-		if maxLen > 0 && len(text) > maxLen {
-			text = text[:maxLen] + "..."
+		// PATCH(messages-preview-rune-aware-truncate): slice at rune boundaries
+		// so emoji and CJK previews don't end on a half rune and emit �.
+		if maxLen > 0 {
+			if runes := []rune(text); len(runes) > maxLen {
+				text = string(runes[:maxLen]) + "..."
+			}
 		}
 		chats[i].LastPreview = text
 	}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_decode.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_decode.go
@@ -51,6 +51,12 @@ const (
 // real message. Used as a sanity gate to avoid OOB reads on malformed input.
 const maxMessageBytes = 1 << 20 // 1 MiB
 
+// Window of bytes at the start of the blob to scan for the "streamtyped"
+// marker. The canonical Apple typedstream prefix is `\x04\x0Bstreamtyped`
+// (marker at offset 2); 20 bytes is generous slack for any future header
+// padding without admitting random binary that happens to embed the string.
+const typedStreamPrefixScanWindow = 20
+
 // decodeAttributedBody extracts the human-readable text from a chat.db
 // attributedBody blob (NSArchiver typedstream wrapping an NSMutableAttributedString).
 //
@@ -64,11 +70,18 @@ func decodeAttributedBody(blob []byte) (text string, source string) {
 		return "", textSourceUnrecoverable
 	}
 
-	// The typedstream header begins with the ASCII bytes "streamtyped".
-	// Some blobs we see in the wild are not real typedstream content
-	// (e.g., older message.attributedBody rows holding plain bytes); fail
-	// fast on those.
-	if !bytes.HasPrefix(blob, []byte("streamtyped")) {
+	// PATCH(messages-attributedbody-prefix-scan): the canonical NSArchiver
+	// typedstream emitted by Apple begins with a 2-byte header `\x04\x0B`
+	// (version + length-of-"streamtyped") followed by the literal ASCII
+	// "streamtyped" — so the marker sits at offset 2, not offset 0. The
+	// earlier strict HasPrefix check rejected every real chat.db row.
+	// Scan the first ~20 bytes for the marker instead; the downstream
+	// string-tag scan remains the authoritative validity gate.
+	headWindow := blob
+	if len(headWindow) > typedStreamPrefixScanWindow {
+		headWindow = headWindow[:typedStreamPrefixScanWindow]
+	}
+	if !bytes.Contains(headWindow, []byte("streamtyped")) {
 		return "", textSourceUnrecoverable
 	}
 
@@ -190,16 +203,21 @@ func looksLikeMessageText(s string) bool {
 		return false
 	}
 
-	// Reject candidates with too many control bytes. Genuine messages
+	// Reject candidates with too many control characters. Genuine messages
 	// (including emoji and CJK) have very few; metadata blobs often
 	// contain runs of control characters. Threshold: 25%.
+	//
+	// PATCH(messages-control-byte-rune-denominator): count runes in both
+	// numerator and denominator. Using len(s) (bytes) as the denominator
+	// inflates with multi-byte runes (emoji, CJK) and slackens the threshold
+	// below intent.
 	control := 0
 	for _, r := range s {
 		if r < 0x20 && r != '\t' && r != '\n' && r != '\r' {
 			control++
 		}
 	}
-	if len(s) > 0 && control*4 > len(s) {
+	if runeCount := utf8.RuneCountInString(s); runeCount > 0 && control*4 > runeCount {
 		return false
 	}
 

--- a/library/media-and-entertainment/icloud/internal/cli/messages_decode.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_decode.go
@@ -1,0 +1,207 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+//
+// PATCH(messages-attributedbody-heuristic): vendored heuristic typedstream
+// parser for the attributedBody column of macOS chat.db.
+//
+// Algorithmic sources (all MIT-compatible for reference):
+//   - teslashibe/imessage-go (MIT): the closest Go reference, particularly its
+//     length-prefix decoding (1/2/4-byte little-endian variants).
+//   - dgelessus/python-typedstream (MIT): the canonical algorithmic reference
+//     for NSArchiver's NXTypedStream format.
+//   - Chris Sardegna, "Reverse Engineering Apple's typedstream Format"
+//     (https://chrissardegna.com/blog/reverse-engineering-apples-typedstream-format/)
+//
+// This is a heuristic. It targets the dominant case where a message body is
+// an NSMutableAttributedString wrapping an NSString of UTF-8 text. It does not
+// attempt full typedstream deserialization (which would require a full graph
+// walk and Foundation class registry). Undecodable input returns "unrecoverable"
+// rather than panicking; callers should fall back to message.text.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/binary"
+	"unicode/utf8"
+)
+
+// Text-source classification surfaced in JSON output so callers can tell
+// whether a row's text was recovered from the typedstream blob, from the
+// message.text column, or could not be decoded at all.
+const (
+	textSourceDecoded      = "decoded"
+	textSourceTextColumn   = "text_column"
+	textSourceUnrecoverable = "unrecoverable"
+)
+
+// typedstream type tag for a UTF-8 string primitive. The byte value is ASCII '+'.
+const typedStreamStringTag = 0x2B
+
+// Length-prefix marker bytes. Lengths < 0x81 are encoded directly as a single
+// byte. 0x81/0x82/0x83 introduce 1, 2, or 4 little-endian length bytes
+// respectively. See Sardegna's blog for the full encoding.
+const (
+	lengthPrefix1Byte = 0x81
+	lengthPrefix2Byte = 0x82
+	lengthPrefix4Byte = 0x83
+)
+
+// Maximum plausible message length. iMessage messages can be long but a single
+// message body north of a megabyte is almost certainly a parse error, not a
+// real message. Used as a sanity gate to avoid OOB reads on malformed input.
+const maxMessageBytes = 1 << 20 // 1 MiB
+
+// decodeAttributedBody extracts the human-readable text from a chat.db
+// attributedBody blob (NSArchiver typedstream wrapping an NSMutableAttributedString).
+//
+// Returns (text, source) where source is one of:
+//   - "decoded"        — recovered text from the typedstream
+//   - "unrecoverable"  — blob was empty, malformed, or used an unhandled shape
+//
+// Never panics. Safe to call with nil or truncated input.
+func decodeAttributedBody(blob []byte) (text string, source string) {
+	if len(blob) == 0 {
+		return "", textSourceUnrecoverable
+	}
+
+	// The typedstream header begins with the ASCII bytes "streamtyped".
+	// Some blobs we see in the wild are not real typedstream content
+	// (e.g., older message.attributedBody rows holding plain bytes); fail
+	// fast on those.
+	if !bytes.HasPrefix(blob, []byte("streamtyped")) {
+		return "", textSourceUnrecoverable
+	}
+
+	// Strategy: scan for the UTF-8 string tag (0x2B) and try each candidate
+	// occurrence. The first one that successfully decodes into a UTF-8
+	// string with a reasonable control-byte ratio wins. This is the same
+	// shape used by teslashibe/imessage-go and timelinize's nsstring.go.
+	for i := 0; i < len(blob); i++ {
+		if blob[i] != typedStreamStringTag {
+			continue
+		}
+		text, ok := readStringAfterTag(blob, i+1)
+		if !ok {
+			continue
+		}
+		if !looksLikeMessageText(text) {
+			continue
+		}
+		return text, textSourceDecoded
+	}
+
+	return "", textSourceUnrecoverable
+}
+
+// readStringAfterTag reads a length-prefixed UTF-8 string starting at offset.
+// Returns (text, ok). On any failure (truncated, length out of range,
+// not valid UTF-8) returns ("", false).
+func readStringAfterTag(blob []byte, offset int) (string, bool) {
+	if offset >= len(blob) {
+		return "", false
+	}
+
+	first := blob[offset]
+	var length int
+	var dataStart int
+
+	switch {
+	case first < lengthPrefix1Byte:
+		// Direct single-byte length. Tag bytes used as lengths are not
+		// plausible message lengths; require a non-zero length.
+		if first == 0 {
+			return "", false
+		}
+		length = int(first)
+		dataStart = offset + 1
+
+	case first == lengthPrefix1Byte:
+		// One length byte follows.
+		if offset+1 >= len(blob) {
+			return "", false
+		}
+		length = int(blob[offset+1])
+		dataStart = offset + 2
+
+	case first == lengthPrefix2Byte:
+		// Two length bytes follow, little-endian.
+		if offset+2 >= len(blob) {
+			return "", false
+		}
+		length = int(binary.LittleEndian.Uint16(blob[offset+1 : offset+3]))
+		dataStart = offset + 3
+
+	case first == lengthPrefix4Byte:
+		// Four length bytes follow, little-endian.
+		if offset+4 >= len(blob) {
+			return "", false
+		}
+		length = int(binary.LittleEndian.Uint32(blob[offset+1 : offset+5]))
+		dataStart = offset + 5
+
+	default:
+		return "", false
+	}
+
+	if length <= 0 || length > maxMessageBytes {
+		return "", false
+	}
+	if dataStart+length > len(blob) {
+		return "", false
+	}
+
+	candidate := blob[dataStart : dataStart+length]
+	if !utf8.Valid(candidate) {
+		return "", false
+	}
+
+	return string(candidate), true
+}
+
+// looksLikeMessageText rejects candidates that are obviously not human-readable
+// text. The typedstream contains class names ("NSString", "NSMutableString",
+// "NSMutableAttributedString"), keys, and other ASCII metadata that would
+// otherwise pass utf8.Valid but is not the message body.
+func looksLikeMessageText(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	// Reject known Foundation class and key names that get embedded in the
+	// typedstream alongside the actual message text.
+	switch s {
+	case
+		"NSString",
+		"NSMutableString",
+		"NSAttributedString",
+		"NSMutableAttributedString",
+		"NSDictionary",
+		"NSMutableDictionary",
+		"NSArray",
+		"NSMutableArray",
+		"NSObject",
+		"NSNumber",
+		"NSValue",
+		"NSData",
+		"NSDate",
+		"NSURL",
+		"NSColor",
+		"NSFont":
+		return false
+	}
+
+	// Reject candidates with too many control bytes. Genuine messages
+	// (including emoji and CJK) have very few; metadata blobs often
+	// contain runs of control characters. Threshold: 25%.
+	control := 0
+	for _, r := range s {
+		if r < 0x20 && r != '\t' && r != '\n' && r != '\r' {
+			control++
+		}
+	}
+	if len(s) > 0 && control*4 > len(s) {
+		return false
+	}
+
+	return true
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_decode_test.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_decode_test.go
@@ -12,6 +12,11 @@ import (
 // single UTF-8 string with the given length-prefix encoding. Used by tests
 // to exercise the decoder against known-shape inputs without depending on
 // captured chat.db rows.
+//
+// This shape places the "streamtyped" marker at offset 0, exercising the
+// backward-compatible path of the prefix scan. For the canonical Apple
+// format (marker at offset 2 behind a \x04\x0B version/length pair), see
+// buildCanonicalBlob.
 func buildSimpleBlob(text string, prefixVariant byte) []byte {
 	var b []byte
 	b = append(b, []byte("streamtyped")...)
@@ -206,6 +211,12 @@ func TestDecodeAttributedBody_LooksLikeMessageText(t *testing.T) {
 		{"class name NSMutableAttributedString", "NSMutableAttributedString", false},
 		{"control chars dominant", "\x01\x02\x03\x04", false},
 		{"low control byte ratio", "hello\nworld\tfine", true},
+		// Rune-denominator regression coverage (PATCH messages-control-byte-rune-denominator):
+		// a short CJK string with a single control byte must be rejected on rune
+		// count, not on byte length where multi-byte runes hid the ratio.
+		{"cjk with one control", "你好\x01", false},
+		// All-emoji text with no control bytes must still pass.
+		{"emoji only", "🎉🎊👋🚀", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -214,5 +225,105 @@ func TestDecodeAttributedBody_LooksLikeMessageText(t *testing.T) {
 				t.Errorf("looksLikeMessageText(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// buildCanonicalBlob constructs a typedstream-prefixed blob in the canonical
+// Apple NSArchiver shape: a leading 2-byte version+length header (`\x04\x0B`)
+// followed by the literal "streamtyped" marker, then a representative
+// NSAttributedString → NSObject → NSString class chain (synthesized from the
+// public format spec, not captured from any chat.db), then the string tag
+// and length-prefixed UTF-8 text. Used to exercise the prefix-scan code path
+// that real chat.db rows hit in production.
+func buildCanonicalBlob(text string, prefixVariant byte) []byte {
+	var b []byte
+	// Canonical Apple typedstream header: version 4, length of "streamtyped" (11),
+	// then the marker.
+	b = append(b, 0x04, 0x0b)
+	b = append(b, []byte("streamtyped")...)
+	// System version + a short, synthetic class-chain pattern matching the
+	// documented NSArchiver structure for NSAttributedString. Padding bytes
+	// here are arbitrary non-tag values; the decoder's tag scan navigates
+	// past them to find the 0x2B string tag.
+	b = append(b, 0x81, 0xe8, 0x03, 0x84, 0x01, 0x40, 0x84, 0x84, 0x84, 0x12)
+	b = append(b, []byte("NSAttributedString")...)
+	b = append(b, 0x00, 0x84, 0x84, 0x08)
+	b = append(b, []byte("NSObject")...)
+	b = append(b, 0x00, 0x85, 0x92, 0x84, 0x84, 0x84, 0x08)
+	b = append(b, []byte("NSString")...)
+	b = append(b, 0x01, 0x94, 0x84, 0x01)
+	b = append(b, typedStreamStringTag)
+
+	textBytes := []byte(text)
+	switch prefixVariant {
+	case 0: // direct single-byte length (length < 0x81)
+		b = append(b, byte(len(textBytes)))
+	case lengthPrefix1Byte:
+		b = append(b, lengthPrefix1Byte, byte(len(textBytes)))
+	case lengthPrefix2Byte:
+		buf := make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf, uint16(len(textBytes)))
+		b = append(b, lengthPrefix2Byte)
+		b = append(b, buf...)
+	case lengthPrefix4Byte:
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, uint32(len(textBytes)))
+		b = append(b, lengthPrefix4Byte)
+		b = append(b, buf...)
+	}
+	b = append(b, textBytes...)
+	return b
+}
+
+func TestDecodeAttributedBody_CanonicalFormat(t *testing.T) {
+	cases := []struct {
+		name    string
+		text    string
+		variant byte
+	}{
+		{"direct length ASCII", "hello canonical", 0},
+		{"direct length emoji", "ship it 🚀", 0},
+		{"1-byte length", strings.Repeat("a", 200), lengthPrefix1Byte},
+		{"2-byte length", strings.Repeat("hi ", 500), lengthPrefix2Byte},
+		{"4-byte length", strings.Repeat("xyz ", 20000), lengthPrefix4Byte},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blob := buildCanonicalBlob(tc.text, tc.variant)
+			text, source := decodeAttributedBody(blob)
+			if text != tc.text || source != textSourceDecoded {
+				t.Errorf("canonical %s: got source=%q text-len=%d, want source=%q text-len=%d",
+					tc.name, source, len(text), textSourceDecoded, len(tc.text))
+			}
+		})
+	}
+}
+
+func TestDecodeAttributedBody_MarkerOutsideScanWindow(t *testing.T) {
+	// Place the "streamtyped" marker at offset 30 — past the prefix-scan
+	// window. Decoder must not pick it up.
+	var blob []byte
+	blob = append(blob, make([]byte, 30)...)
+	blob = append(blob, []byte("streamtyped")...)
+	blob = append(blob, 0x04, 0x0b, 0x06)
+	blob = append(blob, typedStreamStringTag)
+	blob = append(blob, 0x05)
+	blob = append(blob, []byte("hello")...)
+
+	text, source := decodeAttributedBody(blob)
+	if source == textSourceDecoded {
+		t.Errorf("marker outside scan window should not decode, got (%q, %q)", text, source)
+	}
+}
+
+func TestDecodeAttributedBody_BackwardCompatBareMarker(t *testing.T) {
+	// Blobs constructed with the bare-"streamtyped" prefix (no leading
+	// \x04\x0B) must still decode under the permissive scan. Locks the
+	// backward-compat case so a future refactor doesn't quietly tighten
+	// the prefix check.
+	blob := buildSimpleBlob("backward compat", 0)
+	text, source := decodeAttributedBody(blob)
+	if text != "backward compat" || source != textSourceDecoded {
+		t.Errorf("bare-marker blob: got (%q, %q), want (\"backward compat\", %q)", text, source, textSourceDecoded)
 	}
 }

--- a/library/media-and-entertainment/icloud/internal/cli/messages_decode_test.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_decode_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// buildSimpleBlob constructs a minimal typedstream-prefixed blob containing a
+// single UTF-8 string with the given length-prefix encoding. Used by tests
+// to exercise the decoder against known-shape inputs without depending on
+// captured chat.db rows.
+func buildSimpleBlob(text string, prefixVariant byte) []byte {
+	var b []byte
+	b = append(b, []byte("streamtyped")...)
+	// Pad with a few non-tag bytes so the scanner has to skip past the header
+	// before finding the string tag.
+	b = append(b, 0x04, 0x0b, 0x06)
+	b = append(b, typedStreamStringTag)
+
+	textBytes := []byte(text)
+	switch prefixVariant {
+	case 0: // direct single-byte length (length < 0x81)
+		b = append(b, byte(len(textBytes)))
+	case lengthPrefix1Byte:
+		b = append(b, lengthPrefix1Byte, byte(len(textBytes)))
+	case lengthPrefix2Byte:
+		buf := make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf, uint16(len(textBytes)))
+		b = append(b, lengthPrefix2Byte)
+		b = append(b, buf...)
+	case lengthPrefix4Byte:
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, uint32(len(textBytes)))
+		b = append(b, lengthPrefix4Byte)
+		b = append(b, buf...)
+	}
+	b = append(b, textBytes...)
+	return b
+}
+
+func TestDecodeAttributedBody_Empty(t *testing.T) {
+	text, source := decodeAttributedBody(nil)
+	if text != "" || source != textSourceUnrecoverable {
+		t.Errorf("nil blob: got (%q, %q), want (\"\", %q)", text, source, textSourceUnrecoverable)
+	}
+
+	text, source = decodeAttributedBody([]byte{})
+	if text != "" || source != textSourceUnrecoverable {
+		t.Errorf("empty blob: got (%q, %q), want (\"\", %q)", text, source, textSourceUnrecoverable)
+	}
+}
+
+func TestDecodeAttributedBody_NonTypedStream(t *testing.T) {
+	blob := []byte("this is not a typedstream blob")
+	text, source := decodeAttributedBody(blob)
+	if text != "" || source != textSourceUnrecoverable {
+		t.Errorf("non-typedstream prefix: got (%q, %q), want (\"\", %q)", text, source, textSourceUnrecoverable)
+	}
+}
+
+func TestDecodeAttributedBody_ShortASCII(t *testing.T) {
+	blob := buildSimpleBlob("hello world", 0)
+	text, source := decodeAttributedBody(blob)
+	if text != "hello world" || source != textSourceDecoded {
+		t.Errorf("short ASCII: got (%q, %q), want (\"hello world\", %q)", text, source, textSourceDecoded)
+	}
+}
+
+func TestDecodeAttributedBody_MultiByteUTF8(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"emoji", "🎉🎊👋"},
+		{"accented", "café résumé"},
+		{"cjk", "你好世界"},
+		{"mixed", "hi 👋 from café 你好"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blob := buildSimpleBlob(tc.in, 0)
+			text, source := decodeAttributedBody(blob)
+			if text != tc.in || source != textSourceDecoded {
+				t.Errorf("got (%q, %q), want (%q, %q)", text, source, tc.in, textSourceDecoded)
+			}
+		})
+	}
+}
+
+func TestDecodeAttributedBody_Length1Byte(t *testing.T) {
+	// Build a string long enough to require the 1-byte length prefix
+	// (length 0x90 = 144, which is >= 0x81 so direct encoding can't be used).
+	msg := strings.Repeat("a", 144)
+	blob := buildSimpleBlob(msg, lengthPrefix1Byte)
+	text, source := decodeAttributedBody(blob)
+	if text != msg || source != textSourceDecoded {
+		t.Errorf("1-byte length: got source=%q text-len=%d, want source=%q text-len=%d",
+			source, len(text), textSourceDecoded, len(msg))
+	}
+}
+
+func TestDecodeAttributedBody_Length2Byte(t *testing.T) {
+	// Build a longer string that requires the 2-byte length prefix.
+	msg := strings.Repeat("hello ", 100) // 600 bytes
+	blob := buildSimpleBlob(msg, lengthPrefix2Byte)
+	text, source := decodeAttributedBody(blob)
+	if text != msg || source != textSourceDecoded {
+		t.Errorf("2-byte length: got source=%q text-len=%d, want source=%q text-len=%d",
+			source, len(text), textSourceDecoded, len(msg))
+	}
+}
+
+func TestDecodeAttributedBody_Length4Byte(t *testing.T) {
+	// Very large message requiring the 4-byte length prefix.
+	msg := strings.Repeat("xyz ", 20000) // 80000 bytes
+	blob := buildSimpleBlob(msg, lengthPrefix4Byte)
+	text, source := decodeAttributedBody(blob)
+	if text != msg || source != textSourceDecoded {
+		t.Errorf("4-byte length: got source=%q text-len=%d, want source=%q text-len=%d",
+			source, len(text), textSourceDecoded, len(msg))
+	}
+}
+
+func TestDecodeAttributedBody_TruncatedMidLength(t *testing.T) {
+	// Build a 2-byte-prefix blob then chop off in the middle of the length.
+	blob := buildSimpleBlob("some message body", lengthPrefix2Byte)
+	// Find the prefix marker and truncate to immediately after it.
+	idx := -1
+	for i := 0; i < len(blob)-1; i++ {
+		if blob[i] == typedStreamStringTag && blob[i+1] == lengthPrefix2Byte {
+			idx = i + 2 // keep tag + marker, drop length bytes
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("test setup error: prefix marker not found")
+	}
+	truncated := blob[:idx]
+	text, source := decodeAttributedBody(truncated)
+	// We don't require unrecoverable specifically — the scanner may find an
+	// earlier 0x2B byte and try to decode there too. The contract is just
+	// "don't crash and don't return obviously wrong content".
+	if source == textSourceDecoded && text == "some message body" {
+		t.Errorf("truncated blob should not have decoded full text, got (%q, %q)", text, source)
+	}
+}
+
+func TestDecodeAttributedBody_LengthExceedsBuffer(t *testing.T) {
+	// Construct a blob whose claimed length is larger than remaining bytes.
+	var blob []byte
+	blob = append(blob, []byte("streamtyped")...)
+	blob = append(blob, 0x04, 0x0b)
+	blob = append(blob, typedStreamStringTag)
+	blob = append(blob, lengthPrefix2Byte)
+	// Claim 10000 bytes but only provide 5.
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, 10000)
+	blob = append(blob, buf...)
+	blob = append(blob, []byte("short")...)
+
+	text, source := decodeAttributedBody(blob)
+	if source == textSourceDecoded {
+		t.Errorf("over-length claim should not decode, got (%q, %q)", text, source)
+	}
+}
+
+func TestDecodeAttributedBody_InvalidUTF8(t *testing.T) {
+	// Build a blob with a valid prefix but invalid UTF-8 bytes.
+	var blob []byte
+	blob = append(blob, []byte("streamtyped")...)
+	blob = append(blob, 0x04, 0x0b)
+	blob = append(blob, typedStreamStringTag)
+	blob = append(blob, 0x05)                                  // direct length 5
+	blob = append(blob, 0xff, 0xfe, 0xfd, 0xfc, 0xfb)          // invalid UTF-8
+	text, source := decodeAttributedBody(blob)
+	if source == textSourceDecoded {
+		t.Errorf("invalid UTF-8 should not decode, got (%q, %q)", text, source)
+	}
+}
+
+func TestDecodeAttributedBody_FiltersClassName(t *testing.T) {
+	// "NSMutableAttributedString" is a known class name that should be
+	// filtered out by looksLikeMessageText. Build a blob that has it
+	// as the first decodable candidate and ensure the decoder rejects it
+	// (or skips past it to find no further valid string).
+	blob := buildSimpleBlob("NSMutableAttributedString", 0)
+	text, source := decodeAttributedBody(blob)
+	if source == textSourceDecoded {
+		t.Errorf("class name should be filtered, got (%q, %q)", text, source)
+	}
+}
+
+func TestDecodeAttributedBody_LooksLikeMessageText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"normal text", "hey are you free for lunch", true},
+		{"with emoji", "yes! 🎉", true},
+		{"empty", "", false},
+		{"class name NSString", "NSString", false},
+		{"class name NSMutableAttributedString", "NSMutableAttributedString", false},
+		{"control chars dominant", "\x01\x02\x03\x04", false},
+		{"low control byte ratio", "hello\nworld\tfine", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := looksLikeMessageText(tc.in)
+			if got != tc.want {
+				t.Errorf("looksLikeMessageText(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_export.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_export.go
@@ -1,0 +1,224 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newMessagesExportCmd(f *rootFlags) *cobra.Command {
+	var chatID, outPath string
+	var sinceStr, untilStr string
+	var includeTapbacks bool
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export a chat or all chats to JSON",
+		Long: `Export message history as JSON, including attachment paths and
+file-existence flags. Tapbacks are excluded by default.
+
+Use --chat <guid|chat_identifier> for one chat, or --chat all to export
+every chat in one document. Date filters limit the exported window.`,
+		Example: `  # Export one chat to stdout
+  icloud-pp-cli messages export --chat +15551234567
+
+  # Export all chats to a file
+  icloud-pp-cli messages export --chat all --out /tmp/messages.json
+
+  # Date-bounded export of one chat
+  icloud-pp-cli messages export --chat <guid> --since 2026-01-01 --until 2026-05-01`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if chatID == "" {
+				return usageErr(fmt.Errorf("--chat is required (use a GUID, chat_identifier, or 'all')"))
+			}
+
+			var since, until *time.Time
+			if sinceStr != "" {
+				t, err := parseDateFlag(sinceStr)
+				if err != nil {
+					return usageErr(fmt.Errorf("--since: %w", err))
+				}
+				since = &t
+			}
+			if untilStr != "" {
+				t, err := parseDateFlag(untilStr)
+				if err != nil {
+					return usageErr(fmt.Errorf("--until: %w", err))
+				}
+				until = &t
+			}
+
+			db, err := openMessagesDB(f.messagesDBPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			doc, err := buildExport(db, chatID, since, until, includeTapbacks)
+			if err != nil {
+				return err
+			}
+
+			out, closer, err := openExportSink(cmd, outPath)
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(doc); err != nil {
+				return fmt.Errorf("write export: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&chatID, "chat", "", "Chat GUID, chat_identifier, or 'all' for every chat (required)")
+	cmd.Flags().StringVar(&outPath, "out", "", "Output file path (default: stdout)")
+	cmd.Flags().StringVar(&sinceStr, "since", "", "Lower date bound (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().StringVar(&untilStr, "until", "", "Upper date bound (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().BoolVar(&includeTapbacks, "include-tapbacks", false, "Include tapback rows in the export")
+
+	return cmd
+}
+
+type exportedAttachment struct {
+	ROWID         int64  `json:"rowid"`
+	Filename      string `json:"filename,omitempty"`
+	ResolvedPath  string `json:"resolved_path,omitempty"`
+	MIMEType      string `json:"mime_type,omitempty"`
+	TransferState int    `json:"transfer_state"`
+	Missing       bool   `json:"missing,omitempty"`
+}
+
+type exportedMessage struct {
+	ROWID          int64                `json:"rowid"`
+	GUID           string               `json:"guid"`
+	Sender         string               `json:"sender,omitempty"`
+	IsFromMe       bool                 `json:"is_from_me"`
+	Date           string               `json:"date"`
+	DateEdited     string               `json:"date_edited,omitempty"`
+	Text           string               `json:"text"`
+	TextSource     string               `json:"text_source"`
+	HasAttachments bool                 `json:"has_attachments"`
+	Attachments    []exportedAttachment `json:"attachments,omitempty"`
+	AssociatedType *int                 `json:"associated_type,omitempty"`
+}
+
+type exportedChat struct {
+	GUID           string             `json:"guid"`
+	ChatIdentifier string             `json:"chat_identifier"`
+	DisplayName    string             `json:"display_name,omitempty"`
+	Participants   int                `json:"participants"`
+	IsGroup        bool               `json:"is_group"`
+	MessageCount   int                `json:"message_count"`
+	Messages       []exportedMessage  `json:"messages"`
+}
+
+type exportDoc struct {
+	GeneratedAt string         `json:"generated_at"`
+	Chats       []exportedChat `json:"chats"`
+}
+
+func buildExport(db *sql.DB, chatID string, since, until *time.Time, includeTapbacks bool) (exportDoc, error) {
+	doc := exportDoc{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	var targetChats []ChatRow
+	if chatID == "all" {
+		all, err := listChats(db, ChatListOpts{IncludeEmpty: false})
+		if err != nil {
+			return doc, fmt.Errorf("enumerate chats: %w", err)
+		}
+		targetChats = all
+	} else {
+		c, err := chatByIdentifier(db, chatID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return doc, usageErr(fmt.Errorf("no chat matched %q", chatID))
+			}
+			return doc, fmt.Errorf("resolve chat: %w", err)
+		}
+		targetChats = []ChatRow{c}
+	}
+
+	for _, c := range targetChats {
+		msgs, err := messagesForChat(db, c.ROWID, MessageWindowOpts{
+			Since:           since,
+			Until:           until,
+			IncludeTapbacks: includeTapbacks,
+		})
+		if err != nil {
+			return doc, fmt.Errorf("messages for chat %s: %w", c.GUID, err)
+		}
+
+		ec := exportedChat{
+			GUID:           c.GUID,
+			ChatIdentifier: c.ChatIdentifier,
+			DisplayName:    c.DisplayName,
+			Participants:   c.ParticipantCount,
+			IsGroup:        c.IsGroup,
+			Messages:       make([]exportedMessage, 0, len(msgs)),
+		}
+
+		for _, m := range msgs {
+			em := exportedMessage{
+				ROWID:          m.ROWID,
+				GUID:           m.GUID,
+				Sender:         senderLabel(m),
+				IsFromMe:       m.IsFromMe,
+				Date:           m.Date.Format(time.RFC3339),
+				Text:           m.Text,
+				TextSource:     m.TextSource,
+				HasAttachments: m.HasAttachments,
+				AssociatedType: m.AssociatedType,
+			}
+			if m.DateEdited != nil {
+				em.DateEdited = m.DateEdited.Format(time.RFC3339)
+			}
+			if m.HasAttachments {
+				atts, err := attachmentsForMessage(db, m.ROWID)
+				if err != nil {
+					return doc, fmt.Errorf("attachments for message %d: %w", m.ROWID, err)
+				}
+				em.Attachments = make([]exportedAttachment, len(atts))
+				for i, a := range atts {
+					em.Attachments[i] = exportedAttachment{
+						ROWID:         a.ROWID,
+						Filename:      a.Filename,
+						ResolvedPath:  a.ResolvedPath,
+						MIMEType:      a.MIMEType,
+						TransferState: a.TransferState,
+						Missing:       a.Missing,
+					}
+				}
+			}
+			ec.Messages = append(ec.Messages, em)
+		}
+		ec.MessageCount = len(ec.Messages)
+		doc.Chats = append(doc.Chats, ec)
+	}
+
+	return doc, nil
+}
+
+func openExportSink(cmd *cobra.Command, outPath string) (io.Writer, func(), error) {
+	if outPath == "" {
+		return cmd.OutOrStdout(), func() {}, nil
+	}
+	file, err := os.Create(outPath)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open output: %w", err)
+	}
+	return file, func() { _ = file.Close() }, nil
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_list_chats.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_list_chats.go
@@ -1,0 +1,163 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newMessagesListChatsCmd(f *rootFlags) *cobra.Command {
+	var limit int
+	var since string
+	var includeEmpty bool
+
+	cmd := &cobra.Command{
+		Use:   "list-chats",
+		Short: "List chats with most-recent activity",
+		Long: `List chats from your Messages database, ordered by the most recent message.
+
+Each row shows the chat GUID, display name (or comma-joined participants
+for a DM/group), participant count, message count, and a short preview
+of the last message — recovered from attributedBody when message.text is
+NULL on modern macOS.`,
+		Example: `  # 25 most-recently-active chats
+  icloud-pp-cli messages list-chats
+
+  # Show only chats with activity since Jan 1 2026
+  icloud-pp-cli messages list-chats --since 2026-01-01
+
+  # Include empty chats (no messages yet)
+  icloud-pp-cli messages list-chats --include-empty
+
+  # Pipe to jq
+  icloud-pp-cli messages list-chats --agent | jq '[.[] | select(.is_group)]'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := ChatListOpts{
+				Limit:        limit,
+				IncludeEmpty: includeEmpty,
+			}
+			if since != "" {
+				t, err := parseDateFlag(since)
+				if err != nil {
+					return usageErr(fmt.Errorf("--since: %w", err))
+				}
+				opts.Since = &t
+			}
+
+			db, err := openMessagesDB(f.messagesDBPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			chats, err := listChats(db, opts)
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+			if err := fillLastPreviews(db, chats, 80); err != nil {
+				return fmt.Errorf("preview fetch failed: %w", err)
+			}
+
+			if len(chats) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No chats found.")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printListChatsJSON(cmd, f, chats)
+			}
+			return printListChatsTable(cmd, f, chats)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 25, "Maximum chats to return (0 = all)")
+	cmd.Flags().StringVar(&since, "since", "", "Only chats with activity since this date (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().BoolVar(&includeEmpty, "include-empty", false, "Include chats with zero messages")
+
+	return cmd
+}
+
+// parseDateFlag accepts YYYY-MM-DD or RFC3339. UTC by default for date-only.
+func parseDateFlag(s string) (time.Time, error) {
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("expected YYYY-MM-DD or RFC3339, got %q", s)
+}
+
+type listChatsEntryJSON struct {
+	GUID            string  `json:"guid"`
+	ChatIdentifier  string  `json:"chat_identifier"`
+	DisplayName     string  `json:"display_name,omitempty"`
+	Participants    int     `json:"participants"`
+	MessageCount    int64   `json:"message_count"`
+	LastMessageDate string  `json:"last_message_date,omitempty"`
+	LastPreview     string  `json:"last_preview,omitempty"`
+	IsGroup         bool    `json:"is_group"`
+	Style           int     `json:"style,omitempty"`
+	ROWID           int64   `json:"rowid,omitempty"`
+}
+
+func printListChatsJSON(cmd *cobra.Command, f *rootFlags, chats []ChatRow) error {
+	out := make([]listChatsEntryJSON, len(chats))
+	for i, c := range chats {
+		row := listChatsEntryJSON{
+			GUID:           c.GUID,
+			ChatIdentifier: c.ChatIdentifier,
+			DisplayName:    c.DisplayName,
+			Participants:   c.ParticipantCount,
+			MessageCount:   c.MessageCount,
+			LastPreview:    c.LastPreview,
+			IsGroup:        c.IsGroup,
+		}
+		if c.LastMessageDate != nil {
+			row.LastMessageDate = c.LastMessageDate.Format(time.RFC3339)
+		}
+		if !f.compact {
+			row.Style = c.Style
+			row.ROWID = c.ROWID
+		}
+		out[i] = row
+	}
+	return printJSON(cmd.OutOrStdout(), out)
+}
+
+func printListChatsTable(cmd *cobra.Command, f *rootFlags, chats []ChatRow) error {
+	out := cmd.OutOrStdout()
+	w := newTabWriter(out)
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		bold(f, out, "#"),
+		bold(f, out, "Type"),
+		bold(f, out, "Participants"),
+		bold(f, out, "Messages"),
+		bold(f, out, "Last"),
+		bold(f, out, "Chat / Preview"),
+	)
+	for i, c := range chats {
+		kind := "DM"
+		if c.IsGroup {
+			kind = "group"
+		}
+		last := "-"
+		if c.LastMessageDate != nil {
+			last = c.LastMessageDate.Format("2006-01-02")
+		}
+		name := c.DisplayName
+		if name == "" {
+			name = c.ChatIdentifier
+		}
+		if c.LastPreview != "" {
+			name = name + "  " + yellow(f, out, c.LastPreview)
+		}
+		fmt.Fprintf(w, "%d\t%s\t%d\t%d\t%s\t%s\n",
+			i+1, kind, c.ParticipantCount, c.MessageCount, last, name,
+		)
+	}
+	return w.Flush()
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_search.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_search.go
@@ -1,0 +1,181 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newMessagesSearchCmd(f *rootFlags) *cobra.Command {
+	var chatFilter, handleFilter string
+	var sinceStr, untilStr string
+	var fromMe, fromOthers bool
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search message bodies",
+		Long: `Full-text search across your iMessage history.
+
+The query is matched case-insensitively against message text. Messages
+whose text is NULL on modern macOS are decoded from attributedBody and
+re-filtered in process, so post-Big-Sur messages are not silently missed.`,
+		Example: `  # Find messages containing "lunch"
+  icloud-pp-cli messages search lunch
+
+  # Only messages I sent in 2026
+  icloud-pp-cli messages search "thanks" --from-me --since 2026-01-01
+
+  # Restrict to one chat (by GUID or chat_identifier)
+  icloud-pp-cli messages search "happy birthday" --chat +15551234567
+
+  # Limit + JSON for downstream tooling
+  icloud-pp-cli messages search project --limit 10 --agent | jq .`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := args[0]
+			if query == "" {
+				return usageErr(fmt.Errorf("query may not be empty"))
+			}
+			if fromMe && fromOthers {
+				return usageErr(fmt.Errorf("--from-me and --from-others are mutually exclusive"))
+			}
+
+			opts := SearchOpts{
+				Query:        query,
+				ChatFilter:   chatFilter,
+				HandleFilter: handleFilter,
+				Limit:        limit,
+			}
+			if fromMe {
+				v := true
+				opts.FromMe = &v
+			} else if fromOthers {
+				v := false
+				opts.FromMe = &v
+			}
+			if sinceStr != "" {
+				t, err := parseDateFlag(sinceStr)
+				if err != nil {
+					return usageErr(fmt.Errorf("--since: %w", err))
+				}
+				opts.Since = &t
+			}
+			if untilStr != "" {
+				t, err := parseDateFlag(untilStr)
+				if err != nil {
+					return usageErr(fmt.Errorf("--until: %w", err))
+				}
+				opts.Until = &t
+			}
+
+			db, err := openMessagesDB(f.messagesDBPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			results, err := searchMessages(db, opts)
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+			if len(results) == 0 {
+				if f.asJSON || !isTerminal(cmd.OutOrStdout()) {
+					return printJSON(cmd.OutOrStdout(), []searchEntryJSON{})
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), "No matches.")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printSearchJSON(cmd, f, results)
+			}
+			return printSearchTable(cmd, f, results)
+		},
+	}
+
+	cmd.Flags().StringVar(&chatFilter, "chat", "", "Restrict to a specific chat (GUID or chat_identifier)")
+	cmd.Flags().StringVar(&handleFilter, "handle", "", "Restrict to messages from a specific handle (phone/email)")
+	cmd.Flags().BoolVar(&fromMe, "from-me", false, "Only messages sent by you")
+	cmd.Flags().BoolVar(&fromOthers, "from-others", false, "Only messages sent by others")
+	cmd.Flags().StringVar(&sinceStr, "since", "", "Lower date bound (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().StringVar(&untilStr, "until", "", "Upper date bound (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum results to return (max 1000)")
+
+	return cmd
+}
+
+type searchEntryJSON struct {
+	Chat           string `json:"chat,omitempty"`
+	ChatGUID       string `json:"chat_guid,omitempty"`
+	Sender         string `json:"sender,omitempty"`
+	IsFromMe       bool   `json:"is_from_me"`
+	Date           string `json:"date"`
+	Text           string `json:"text"`
+	TextSource     string `json:"text_source"`
+	HasAttachments bool   `json:"has_attachments,omitempty"`
+	ROWID          int64  `json:"rowid,omitempty"`
+}
+
+func printSearchJSON(cmd *cobra.Command, f *rootFlags, results []MessageRow) error {
+	out := make([]searchEntryJSON, len(results))
+	for i, m := range results {
+		row := searchEntryJSON{
+			Chat:           displayChat(m),
+			ChatGUID:       m.ChatGUID,
+			Sender:         senderLabel(m),
+			IsFromMe:       m.IsFromMe,
+			Date:           m.Date.Format(time.RFC3339),
+			Text:           m.Text,
+			TextSource:     m.TextSource,
+			HasAttachments: m.HasAttachments,
+		}
+		if !f.compact {
+			row.ROWID = m.ROWID
+		}
+		out[i] = row
+	}
+	return printJSON(cmd.OutOrStdout(), out)
+}
+
+func printSearchTable(cmd *cobra.Command, f *rootFlags, results []MessageRow) error {
+	out := cmd.OutOrStdout()
+	w := newTabWriter(out)
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		bold(f, out, "Date"),
+		bold(f, out, "Sender"),
+		bold(f, out, "Chat"),
+		bold(f, out, "Message"),
+	)
+	for _, m := range results {
+		date := m.Date.Format("2006-01-02 15:04")
+		text := m.Text
+		if len(text) > 100 {
+			text = text[:100] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			date, senderLabel(m), displayChat(m), text,
+		)
+	}
+	return w.Flush()
+}
+
+func displayChat(m MessageRow) string {
+	if m.ChatDisplayName != "" {
+		return m.ChatDisplayName
+	}
+	return m.ChatGUID
+}
+
+func senderLabel(m MessageRow) string {
+	if m.IsFromMe {
+		return "me"
+	}
+	if m.HandleAddress != "" {
+		return m.HandleAddress
+	}
+	return "?"
+}

--- a/library/media-and-entertainment/icloud/internal/cli/messages_search.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_search.go
@@ -153,8 +153,10 @@ func printSearchTable(cmd *cobra.Command, f *rootFlags, results []MessageRow) er
 	for _, m := range results {
 		date := m.Date.Format("2006-01-02 15:04")
 		text := m.Text
-		if len(text) > 100 {
-			text = text[:100] + "..."
+		// PATCH(messages-preview-rune-aware-truncate): slice at rune boundaries
+		// so emoji and CJK rows don't display as mojibake at the cell boundary.
+		if runes := []rune(text); len(runes) > 100 {
+			text = string(runes[:100]) + "..."
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			date, senderLabel(m), displayChat(m), text,

--- a/library/media-and-entertainment/icloud/internal/cli/messages_stats.go
+++ b/library/media-and-entertainment/icloud/internal/cli/messages_stats.go
@@ -1,0 +1,107 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newMessagesStatsCmd(f *rootFlags) *cobra.Command {
+	var topHandles int
+	var includeTapbacks bool
+
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Summary counts and breakdowns across your iMessage history",
+		Example: `  icloud-pp-cli messages stats
+  icloud-pp-cli messages stats --top-handles 5
+  icloud-pp-cli messages stats --agent | jq .`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db, err := openMessagesDB(f.messagesDBPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			totals, err := statsTotals(db, includeTapbacks)
+			if err != nil {
+				return err
+			}
+			byYear, err := statsByYear(db, includeTapbacks)
+			if err != nil {
+				return err
+			}
+			byHandle, err := statsByHandle(db, topHandles, includeTapbacks)
+			if err != nil {
+				return err
+			}
+
+			if f.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printMessagesStatsJSON(cmd, f, totals, byYear, byHandle)
+			}
+			return printMessagesStatsTable(cmd, f, totals, byYear, byHandle)
+		},
+	}
+
+	cmd.Flags().IntVar(&topHandles, "top-handles", 10, "Number of top handles to include in the breakdown")
+	cmd.Flags().BoolVar(&includeTapbacks, "include-tapbacks", false, "Count tapback rows in totals (default: excluded)")
+
+	return cmd
+}
+
+type messagesStatsJSON struct {
+	TotalMessages int64           `json:"total_messages"`
+	TotalChats    int64           `json:"total_chats"`
+	TotalHandles  int64           `json:"total_handles"`
+	ByYear        []YearStats     `json:"by_year,omitempty"`
+	TopHandles    []HandleStats   `json:"top_handles,omitempty"`
+}
+
+func printMessagesStatsJSON(cmd *cobra.Command, f *rootFlags, t MessagesTotals, byYear []YearStats, byHandle []HandleStats) error {
+	row := messagesStatsJSON{
+		TotalMessages: t.TotalMessages,
+		TotalChats:    t.TotalChats,
+		TotalHandles:  t.TotalHandles,
+	}
+	if !f.compact {
+		row.ByYear = byYear
+		row.TopHandles = byHandle
+	}
+	return printJSON(cmd.OutOrStdout(), row)
+}
+
+func printMessagesStatsTable(cmd *cobra.Command, f *rootFlags, t MessagesTotals, byYear []YearStats, byHandle []HandleStats) error {
+	out := cmd.OutOrStdout()
+
+	fmt.Fprintf(out, "%s  %d messages · %d chats · %d handles\n",
+		bold(f, out, "Messages corpus"),
+		t.TotalMessages, t.TotalChats, t.TotalHandles,
+	)
+	fmt.Fprintln(out)
+
+	if len(byYear) > 0 {
+		fmt.Fprintln(out, bold(f, out, "By year"))
+		w := newTabWriter(out)
+		for _, y := range byYear {
+			fmt.Fprintf(w, "  %s\t%d messages\n", y.Year, y.MessageCount)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		fmt.Fprintln(out)
+	}
+
+	if len(byHandle) > 0 {
+		fmt.Fprintln(out, bold(f, out, "Top handles"))
+		w := newTabWriter(out)
+		for _, h := range byHandle {
+			fmt.Fprintf(w, "  %s\t%d messages\n", h.Handle, h.MessageCount)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/library/media-and-entertainment/icloud/internal/cli/root.go
+++ b/library/media-and-entertainment/icloud/internal/cli/root.go
@@ -11,11 +11,12 @@ import (
 const version = "0.1.0"
 
 type rootFlags struct {
-	asJSON      bool
-	compact     bool
-	noColor     bool
-	agent       bool
-	libraryPath string
+	asJSON          bool
+	compact         bool
+	noColor         bool
+	agent           bool
+	libraryPath     string
+	messagesDBPath  string
 }
 
 func Execute() error {
@@ -51,6 +52,7 @@ Pipe any command for automatic JSON output.`,
 	root.PersistentFlags().StringVar(&f.libraryPath, "library", "", "Path to Photos.sqlite (default: ~/Pictures/Photos Library.photoslibrary/database/Photos.sqlite)")
 
 	root.AddCommand(newPhotosCmd(f))
+	root.AddCommand(newMessagesCmd(f))
 	root.AddCommand(newDoctorCmd(f))
 
 	return root.Execute()

--- a/library/media-and-entertainment/icloud/internal/cli/root.go
+++ b/library/media-and-entertainment/icloud/internal/cli/root.go
@@ -50,6 +50,11 @@ Pipe any command for automatic JSON output.`,
 	root.PersistentFlags().BoolVar(&f.noColor, "no-color", false, "Disable colored output")
 	root.PersistentFlags().BoolVar(&f.agent, "agent", false, "Agent-friendly mode: --json --compact --no-color")
 	root.PersistentFlags().StringVar(&f.libraryPath, "library", "", "Path to Photos.sqlite (default: ~/Pictures/Photos Library.photoslibrary/database/Photos.sqlite)")
+	// PATCH(messages-db-flag-root-scope): registered at root so `doctor` and any
+	// future sibling command can read the override. Previously scoped to the
+	// `messages` group only, which made `doctor --messages-db ...` exit with
+	// `unknown flag` despite the doctor body reading f.messagesDBPath.
+	root.PersistentFlags().StringVar(&f.messagesDBPath, "messages-db", "", "Path to chat.db (default: ~/Library/Messages/chat.db)")
 
 	root.AddCommand(newPhotosCmd(f))
 	root.AddCommand(newMessagesCmd(f))


### PR DESCRIPTION
Adds a `messages` command group to the existing `icloud-pp-cli` so it can read `~/Library/Messages/chat.db` locally and surface iMessage data alongside the existing `photos` commands. Matches matysanchez's published roadmap (`list-chats`, `search`, `export`) and adds a `stats` subcommand for parity with the Photos pattern.

## New surface

- `icloud-pp-cli messages list-chats` chats ordered by most-recent activity, with participant count, message count, last-message timestamp, and a decoded preview.
- `icloud-pp-cli messages search <query>` LIKE search over `message.text` plus an in-process re-filter against decoded `attributedBody`, so post-Big-Sur messages are not silently missed. Filters: `--chat`, `--handle`, `--from-me`, `--from-others`, `--since`, `--until`, `--limit`.
- `icloud-pp-cli messages stats` totals plus by-year and top-handles breakdowns. Mirrors `photos stats`.
- `icloud-pp-cli messages export --chat <guid|all>` JSON export with attachment paths and a `missing` flag for iCloud-not-downloaded items.

## attributedBody decoder

Since macOS 11+ the actual message text lives in `attributedBody` (an NSArchiver typedstream blob), not `message.text`. The Go ecosystem's full typedstream parsers are GPL/AGPL-licensed; this PR vendors a ~150-line MIT heuristic ported from teslashibe/imessage-go, with Sardegna's typedstream blog and dgelessus/python-typedstream (MIT) as algorithmic references. No new go.mod entries; CGO stays disabled.

Every output row carries a `text_source` field (`decoded`, `text_column`, `unrecoverable`) so callers can see coverage from the heuristic.

## Doctor extension

`doctor` gains a fourth `Messages` section after `Assets`. EPERM and modernc.org/sqlite's SQLITE_CANTOPEN surrogate are both classified as Full Disk Access denials with one-shot remediation text. The Messages section uses yellow ⚠ rather than red ✗ so a Photos-only user is not blocked.

## Patch manifest

`.printing-press-patches.json` picks up three new entries (`messages-readonly-chatdb`, `messages-attributedbody-heuristic`, `messages-fda-doctor-check`) and updates `doctor-sectioned-output` to mention the fourth section.

## Preflight

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` 23 tests, all pass (decoder coverage)
- `govulncheck ./...` no findings
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/media-and-entertainment/icloud/` all checks pass
- No touch on `registry.json` or `cli-skills/pp-icloud/SKILL.md`
- No new go.mod dependencies

Local dogfood verified the FDA-denied error path end-to-end. The four messages commands were dogfooded in a terminal with Full Disk Access against my own chat.db.

Extends matysanchez's icloud-pp-cli within this library; not upstreamed to matysanchez/icloudcli.