### PR TITLE
feat(prediction-goat): search relevance, freshness, venue scoping, LLM-driven learning

### DIFF
--- a/docs/plans/2026-05-23-001-feat-prediction-goat-search-relevance-and-freshness-plan.md
+++ b/docs/plans/2026-05-23-001-feat-prediction-goat-search-relevance-and-freshness-plan.md
@@ -1,0 +1,693 @@
+---
+slug: prediction-goat-search-relevance-and-freshness
+type: feat
+status: active
+created: 2026-05-23
+depth: standard
+target_repo: mvanhorn/printing-press-library
+base_branch: feat/prediction-goat
+target_cli: library/payments/prediction-goat
+---
+
+# feat(prediction-goat): search relevance, freshness gating, venue scoping, and search learning
+
+## Summary
+
+prediction-goat-pp-cli's discovery commands (`topic`, `compare`, `kalshi-series-search`, the screens) silently return wrong or stale answers in three different ways, all reproduced in a tonight's speedrun session:
+
+1. **Search returns junk**: `topic "oscars best picture 2026"` ranks `KXFUSION` (Nuclear fusion) above the real Oscar series. `topic "bitcoin 100k"` misses `KXBTCMAX100`. `topic "portugal world cup"` returns zero Kalshi hits even though `KXMENWORLDCUP-26-PT` exists with $109K 24h volume.
+2. **Sync is starved**: 54k synced Kalshi markets are 99.9% one esports prefix family; named events like `KXMENWORLDCUP-*`, `KXBTC*`, `KXOSCAR*` are absent.
+3. **Cache freshness is invisible**: cached prices look identical to live prices in output. A user asking "who wins the basketball game tonight" can be served yesterday's odds with no signal that they're stale.
+
+This plan ships eight fixes in one stacked PR against `feat/prediction-goat`:
+
+- Concurrency: WAL mode and busy_timeout on store open
+- Search index: curate `resources_fts.content` to title/subtitle/category/ticker/tags (drop raw-JSON pollution)
+- Search ranking: title-boost reranking so exact title hits outrank content-tail matches
+- Venue scoping: `--venue`, `--polymarket`, `--kalshi` flags on `topic`, `compare`, screens
+- Freshness gating: prices and probabilities always fetched live at read time; cache is index only; data age surfaced
+- Sync coverage: series-driven Kalshi markets walk seeded from the already-correct `kalshi_series` table
+- Surface gaps: `kalshi events get --with-markets`, implement `kalshi events list --series` (currently advertised in `--help` but unimplemented)
+- Compounding learning: `search_learnings` table populated by a fire-and-forget `teach` command that the LLM backgrounds right before emitting the user-facing response. No human-visible noise. Future queries on similar questions get the right ticker boosted automatically — the agent stops paying the "took forever to find Portugal's ticker" tax on every session.
+
+---
+
+## Problem Frame
+
+prediction-goat-pp-cli ships as a read-only cross-venue prediction-market CLI for agents. Its central value claim is "one slim ranked bundle of relevant Polymarket + Kalshi markets per topic." Tonight's debugging proved the central claim is broken on representative queries:
+
+| Query | Real top Kalshi | What `topic` returned | Why |
+|---|---|---|---|
+| portugal world cup | KXMENWORLDCUP-26-PT | nothing | not synced + ranking |
+| bitcoin 100k | KXBTCMAX100 family | BTCETHATH-29DEC31 (Ethereum) | implicit-AND FTS, raw-JSON content |
+| oscars best picture 2026 | KXOSCARSCORE family | KXFUSION (Nuclear fusion) | source_agencies URLs in content blob match query tokens |
+| fed rate cut june | KXRATECUT family | "government spending cut" event | tokenization + raw-JSON noise |
+| nba championship 2026 | KXNBA finals | "NBA team" series | sync gap + ranking |
+
+In every case the right answer was either in the local DB and outranked, or never synced. Direct SQL FTS over `resources_fts` returns the correct rows, so the bug is in what we index and how we rank, not the FTS engine itself.
+
+Separately, the freshness model conflates "this market exists" with "this is the current price." For a question like "what are the odds Lakers win tonight," a 6-hour-old cached row is dangerous because prices move continuously and the question is time-sensitive. The CLI treats both as the same data and offers no signal of age.
+
+## Requirements
+
+Sourced from user request (this session) and from `feedback.jsonl` entries 1-7 logged this session.
+
+- **R1.** `topic "<query>"` must return Polymarket and Kalshi markets whose titles actually concern the query topic, not markets whose raw-JSON metadata happens to contain the query tokens. Verified by the five speedrun cases above.
+- **R2.** Concurrent calls to read commands (e.g. parallel `topic` queries from an agent) must not fail with `SQLITE_BUSY`.
+- **R3.** Discovery commands (`topic`, `compare`, screens) must accept `--venue polymarket|kalshi|all` and the shortcut flags `--polymarket` / `--kalshi`. Default behavior (no flag) stays "both."
+- **R4.** Any output that surfaces a price or implied probability (`yesPercent`, `yesProbability`, `last_price`, `yes_ask_dollars`) must reflect the live upstream value at command time, never a cached value.
+- **R5.** Output must surface cache age for the discovery layer (e.g., "Index synced 14h ago") so an agent or user can detect stale-index conditions even when prices are live.
+- **R6.** `kalshi sync` must reach named event families (`KXMENWORLDCUP`, `KXBTC*`, `KXOSCAR*`) in default operation, not stop on a single prefix.
+- **R7.** `kalshi events get` must support a `--with-markets` flag that returns the event's nested markets in one call.
+- **R8.** `kalshi events list --series <ticker>` must work as advertised in `--help` (currently the flag does not exist).
+- **R9.** The CLI must learn from the LLM's final response to the user. A `teach` command, designed to be backgrounded by the LLM at response-time, takes the original user question plus the tickers/slugs that appear in the LLM's response and records boost mappings. No user-visible noise: silent on success, errors logged to a local file. The skill markdown instructs the LLM to fire this command in the background before emitting the user-facing answer.
+- **R10.** The CLI must expose a `recall` command that the LLM calls FIRST when starting work on a new user question. `recall "<query>"` returns prior learnings matching that query (by token-set overlap, not just exact match) so the agent can short-circuit discovery entirely when confident learnings exist — going straight from question to live price fetch in two CLI calls instead of seven. Returns an empty result when no learnings match.
+- **R11.** Learnings must be inspectable, reversible, and disableable — `learnings list` and `forget` commands; `--no-learn` per-invocation flag and `PREDICTION_GOAT_NO_LEARN=true` env var; JSONL audit log alongside the table row so a user can grep history without SQL.
+
+## Scope Boundaries
+
+In scope:
+- Search ranking and index composition for the existing `topic`, `compare`, and `kalshi-series-search` commands
+- Freshness handling across `topic`, `compare`, `mispriced`, `markets get-by-slug`, and the screens (`trending`, `resolving`, `liquid`, `movers`, `new`)
+- Kalshi sync coverage and on-demand event-market fetch
+- Venue scoping flags
+- New `teach` / `learnings list` / `forget` commands, the skill-side LLM contract that fires `teach` at response-time, and the reranking layer that applies it
+
+Out of scope:
+- Trading, order placement, or any write surface against the venue APIs (CLI is read-only by structural CI lint)
+- MCP server changes (`prediction-goat-pp-mcp`) — wrappers ride on whatever the CLI exposes
+- Polymarket-side sync improvements (Polymarket's `events`/`markets` tables also cap at ~100 rows per sync; separate concern)
+- Auto-refresh of the entire local DB before every command — rejected in favor of live-on-read for prices + cache for index
+
+### Deferred to Follow-Up Work
+
+- Polymarket sync coverage parity (its own PR)
+- A `kalshi sync --since <duration>` incremental refresh path
+- An MCP tool surface for `learnings list` / `forget`
+- Cross-machine sync of learnings (shared registry of community-confirmed mappings)
+
+---
+
+## Key Technical Decisions
+
+**Live-on-read for prices, cache for index.** The local SQLite DB is repositioned as a discovery index — "which markets exist, what are they called, what category" — never as a price/probability source. Every command that displays a price refetches the relevant tickers from upstream at command time. This fixes the basketball-tonight risk without forcing a full DB resync before every read.
+
+**Curate `resources_fts.content` to a small, semantic projection.** Currently `store.go:1258` indexes the entire raw JSON blob, which is why KXFUSION (Nuclear fusion) matches "oscars" via `oscars.org/oscars` in its `source_agencies` URL list and matches "picture" via "Academy of Motion Picture Arts and Sciences." The replacement projection is title + subtitle/yes_sub_title + category + ticker + tags + parent event title. This is the single biggest search-quality lever in this plan.
+
+**Schema bump + lazy reindex.** Changing the FTS content projection requires reindexing. Use a `PRAGMA user_version` bump from N to N+1 and trigger a one-shot rebuild of `resources_fts` on first `Open` at the new version. Existing users get a 30-second reindex once; future opens are no-ops.
+
+**Title-boost ranking via UNION + ordered priority.** Rather than overload FTS5's bm25 weighting (which is brittle), run two FTS queries — one against title-only, one against the full curated content — and UNION with a priority column. Title hits rank above content hits at the same FTS score. This is cheap, predictable, and easy to test.
+
+**Series-driven sync walk.** The existing `kalshi_series` corpus (10,363 rows, synced correctly) is the seed list. For each series, fan out one call per series to `/markets?series_ticker=<X>`. This bypasses the natural-ordering problem (where Kalshi's `/markets` endpoint returns 42k KXMVE esports markets before reaching any named-event market) and gives proportional coverage across all series.
+
+**Venue scoping as composable flags.** `--venue polymarket|kalshi|all` is the canonical flag, matching the existing `liquid` command's convention. `--polymarket` and `--kalshi` are boolean shortcuts that desugar to `--venue=polymarket` / `--venue=kalshi`. Default stays "both" so the existing single-call cross-venue value is preserved.
+
+**`search_learnings` is populated by the LLM's act of responding, not by user-typed commands or CLI-side heuristics.** The LLM is the only party that knows (a) the user's original natural-language question and (b) which tickers ended up in the response. So put the signal there. A new `teach` command takes a query string plus one or more resource IDs and writes a boost learning per pair. The skill markdown documents the contract: right before sending the user-facing response, the LLM fires `prediction-goat-pp-cli teach --query "<original question>" --resource <id> [--resource <id>...] &` in the background. `teach` is silent on success (no stdout, errors only to `~/.local/share/prediction-goat-pp-cli/teach.log`), safe to background, and idempotent on (query, resource, action). The reranking layer in `topic` and `compare` reads `search_learnings` to boost / hide / alias hits on subsequent queries. `--no-learn` per-invocation and `PREDICTION_GOAT_NO_LEARN=true` env var disable the apply side for deterministic agent flows. The earlier idea of CLI-side command-sequence correlation (a `last_discovery.json` sidecar) is rejected — it required the LLM to drill into a specific ticker after a discovery query, which is not how agent flows actually work and would have produced both missed learnings (when the LLM answered directly from `topic` output) and false positives (when the LLM drilled into something for an unrelated reason).
+
+---
+
+## Output Structure
+
+New files added under the existing CLI tree:
+
+```
+library/payments/prediction-goat/
+└── internal/
+    ├── cli/
+    │   ├── teach.go          # new — teach (LLM-facing, silent, backgroundable) + learnings list + forget
+    │   ├── venue.go          # new — venue resolution helper shared by topic/compare/screens
+    │   └── freshness.go      # new — live-price fetch + cache age helpers
+    ├── store/
+    │   └── learnings.go      # new — search_learnings table CRUD + reranking apply
+    └── source/
+        └── kalshi/
+            └── series_walk.go # new — series-seeded markets sync
+```
+
+Modified files: `internal/cli/topic.go`, `internal/cli/compare.go`, `internal/cli/liquid.go`, `internal/cli/kalshi.go`, `internal/cli/mispriced.go`, `internal/cli/trending.go`, `internal/cli/movers.go`, `internal/cli/resolving.go`, `internal/cli/new.go`, `internal/store/store.go`, `internal/source/kalshi/sync.go`, `internal/source/kalshi/client.go`.
+
+---
+
+## High-Level Technical Design
+
+### Query lifecycle, before vs. after
+
+```
+BEFORE:
+topic "portugal world cup"
+  -> topicFTSQuery wraps tokens: "portugal" "world" "cup"  (implicit AND)
+  -> SELECT ... FROM resources_fts WHERE content MATCH ?  (content = raw JSON)
+  -> ORDER BY bm25 rank
+  -> return cached prices
+
+AFTER:
+topic "portugal world cup"
+  -> rerank-layer pre-pass: any pinned mappings for "portugal world cup"? (learn table)
+  -> topicFTSQuery -> two FTS queries (title-only + curated-content)
+  -> UNION with priority column (title=1, content=2), then bm25
+  -> for any hit that carries a price: refetch from live API in parallel
+  -> rerank-layer post-pass: apply hide/alias rules
+  -> output includes meta.synced_at + meta.price_source=live
+```
+
+*Directional guidance for review, not implementation specification.*
+
+### Freshness boundary
+
+```
++------------------+-----------------+----------------------+
+| Field            | Source          | Acceptable staleness |
++------------------+-----------------+----------------------+
+| ticker / slug    | local cache     | days (it's an ID)    |
+| title, category  | local cache     | hours (rarely change)|
+| end_date         | local cache     | hours                |
+| yesProbability   | LIVE API ONLY   | <60s (current price) |
+| yes_ask_dollars  | LIVE API ONLY   | <60s                 |
+| volume_24h       | LIVE API ONLY   | <60s                 |
+| status           | LIVE API ONLY   | <60s                 |
++------------------+-----------------+----------------------+
+```
+
+*Directional guidance for review, not implementation specification.*
+
+### Learning pipeline (LLM-driven, two-sided)
+
+**Cold start (no prior learnings for this question family):**
+
+```
+human: "what are the odds Portugal wins the world cup?"
+   |
+   v
+LLM: $ prediction-goat-pp-cli recall "portugal world cup odds" --agent
+   <- { "found": false, "results": [] }                  # nothing cached
+   |
+   v
+LLM: $ topic "portugal world cup" --agent
+LLM: $ compare "portugal world cup" --agent
+LLM: $ kalshi-series-search WORLDCUP ...
+LLM: $ kalshi markets get KXMENWORLDCUP-26-PT --agent   # finally lands on the right ticker
+LLM: $ markets get-by-slug will-portugal-...            # and the PM side
+   |
+   v (BEFORE emitting the user-facing message)
+LLM: $ prediction-goat-pp-cli teach \
+        --query "portugal world cup odds" \
+        --resource KXMENWORLDCUP-26-PT \
+        --resource will-portugal-win-the-2026-fifa-world-cup-912 \
+        --quiet &                                        # fire-and-forget; silent
+   |
+   v
+LLM emits the % answer. Human sees: "Portugal 8.8% / 8.5%." Nothing else.
+```
+
+**Warm start (same question family, days later):**
+
+```
+human: "portugal's chances at the world cup?"
+   |
+   v
+LLM: $ prediction-goat-pp-cli recall "portugal chances world cup" --agent
+   <- {
+        "found": true,
+        "match_score": 0.82,
+        "results": [
+          { "resource_id": "KXMENWORLDCUP-26-PT",                   "venue": "kalshi",     "confidence": 3 },
+          { "resource_id": "will-portugal-win-the-2026-fifa...",    "venue": "polymarket", "confidence": 3 }
+        ]
+      }
+   |
+   v
+LLM: $ kalshi markets get KXMENWORLDCUP-26-PT --agent           # straight to live price
+LLM: $ markets get-by-slug will-portugal-... --agent            # straight to live price
+   |
+   v
+LLM: $ teach --query "portugal chances world cup" --resource ... --resource ... &
+   |
+   v
+LLM emits the % answer. Two discovery calls, not seven. Human sees the same clean output.
+```
+
+Skill markdown (`pp-prediction-goat/SKILL.md`) documents both sides of this contract — `recall` before discovery, `teach` after response. The CLI's `topic` / `compare` commands ALSO apply the rerank layer internally as belt-and-suspenders: a forgetful LLM that skips `recall` still benefits from the learnings, just less efficiently.
+
+### `search_learnings` table shape
+
+```sql
+CREATE TABLE search_learnings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  query_pattern TEXT NOT NULL,        -- normalized lowercase, whitespace-collapsed
+  venue TEXT,                         -- 'polymarket', 'kalshi', NULL = both
+  resource_type TEXT,                 -- 'markets', 'kalshi_markets', ...
+  resource_id TEXT NOT NULL,          -- slug or ticker
+  action TEXT NOT NULL,               -- 'boost' | 'hide' | 'alias_of'
+  alias_target TEXT,                  -- non-null iff action='alias_of'
+  source TEXT NOT NULL,               -- 'taught' (from LLM teach call) | 'manual-forget'
+  confidence INTEGER DEFAULT 1,       -- increments on re-observation
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_observed_at DATETIME,
+  notes TEXT
+);
+CREATE INDEX idx_learn_query ON search_learnings(query_pattern);
+CREATE UNIQUE INDEX idx_learn_unique ON search_learnings(query_pattern, resource_id, action);
+```
+
+*Directional guidance for review, not implementation specification.*
+
+---
+
+## Implementation Units
+
+### U1. Enable WAL mode and busy_timeout on store open
+
+**Goal:** Eliminate `SQLITE_BUSY` failures from concurrent agent reads and from sync-vs-read overlap.
+
+**Requirements:** R2.
+
+**Dependencies:** none — foundation for everything else.
+
+**Files:**
+- `library/payments/prediction-goat/internal/store/store.go` (modify `OpenWithContext` and `OpenWithDeadline`)
+- `library/payments/prediction-goat/internal/store/store_concurrency_test.go` (new)
+
+**Approach:** On open, issue `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000` against the connection. Both pragmas are session-level, so they need to be applied after each `sql.Open` and on any connection retrieved via `Conn()`. Verify journal mode came back as `wal` (some filesystems refuse WAL — fall back to delete journal with a stderr note).
+
+**Patterns to follow:** Look at existing `OpenWithContext` for the connection-init sequence and emulate the existing migration-lock retry helper for any failure cases.
+
+**Test scenarios:**
+- Two `topic` commands launched concurrently both succeed.
+- A `kalshi sync` and a `topic` command launched concurrently both succeed.
+- `journal_mode` reads back as `wal` on a tmpfile-backed DB.
+- A filesystem that rejects WAL falls back cleanly to delete journal and logs a single warning to stderr (skip on CI where this can't be reliably faked).
+
+**Verification:** `go test ./internal/store/... -run Concurrency` passes; running `prediction-goat-pp-cli topic foo` in two terminals while a sync is mid-flight produces no `database is locked` errors.
+
+---
+
+### U2. Curate `resources_fts.content` to a semantic projection
+
+**Goal:** Stop indexing raw JSON. Index only fields that carry topical signal so KXFUSION can no longer match "oscars best picture."
+
+**Requirements:** R1.
+
+**Dependencies:** U1 (reindex runs inside a write transaction; WAL avoids blocking concurrent readers).
+
+**Execution note:** Characterization-first — write a failing test that asserts `KXFUSION` does NOT match the query `oscars best picture 2026` and `KXOSCARSCORE` DOES match it. The current indexer fails this test.
+
+**Files:**
+- `library/payments/prediction-goat/internal/store/store.go` (modify `resourcesFTSCreateSQL`, the insert at line ~1258, and the rebuild path)
+- `library/payments/prediction-goat/internal/store/fts_content_test.go` (new)
+
+**Approach:** Replace the raw-JSON `content` column with a derived projection computed at upsert time. The projection per resource type:
+
+- `markets` (Polymarket): `question + ' ' + title + ' ' + slug + ' ' + category`
+- `events` (Polymarket): `title + ' ' + slug + ' ' + category`
+- `tags`: `label + ' ' + slug`
+- `kalshi_markets`: `title + ' ' + yes_sub_title + ' ' + ticker + ' ' + event_ticker + ' ' + category`
+- `kalshi_events`: `title + ' ' + event_ticker + ' ' + category + ' ' + series_ticker`
+- `kalshi_series`: `title + ' ' + ticker + ' ' + category`
+
+Bump `PRAGMA user_version` from current N to N+1 and trigger a one-shot rebuild of `resources_fts` on Open at the new version. Drop and recreate the FTS table inside the migration-lock helper to avoid races.
+
+**Patterns to follow:** The existing migration sequence already drops and recreates `resources_fts` in one of the older migrations (search for `DROP TABLE IF EXISTS resources_fts` around line 1184). Mirror that pattern.
+
+**Test scenarios:**
+- KXFUSION (Nuclear fusion series) is NOT returned by FTS MATCH `oscars` after reindex.
+- KXOSCARCOUNTCONCLAVE IS returned by FTS MATCH `oscars` after reindex.
+- KXBTCMAX100 IS returned by FTS MATCH `bitcoin`.
+- KXMENWORLDCUP-26-PT (synthetic fixture row) IS returned by FTS MATCH `portugal world cup`.
+- Schema version bumps from N to N+1 on first open; subsequent opens are no-ops.
+- Reindexing a 10k-row corpus completes in under 30s on a developer laptop.
+
+**Verification:** `go test ./internal/store/... -run FTSContent` passes; running `prediction-goat-pp-cli topic "oscars best picture 2026"` returns Oscar-related Kalshi hits, not KXFUSION.
+
+---
+
+### U3. Title-boost reranking in `topicFTSQuery`
+
+**Goal:** Hits where the query token appears in the title outrank hits where it only appears in deeper content fields.
+
+**Requirements:** R1.
+
+**Dependencies:** U2 (need the curated content column first; title boost is meaningful only when content is curated).
+
+**Files:**
+- `library/payments/prediction-goat/internal/cli/topic.go` (modify `topicSearchByTypes`)
+- `library/payments/prediction-goat/internal/cli/compare.go` (modify `loadCompareMarkets`)
+- `library/payments/prediction-goat/internal/cli/liquid.go` (keep `topicFTSQuery` but extend with a `topicTitleQuery` companion)
+- `library/payments/prediction-goat/internal/cli/topic_rank_test.go` (new)
+
+**Approach:** Add a sibling FTS column to `resources_fts` for title-only (`title_only`), populated alongside `content`. Replace the single FTS query with a UNION of two queries with an explicit priority column, then ORDER BY priority ASC, bm25 ASC. The Go layer composes the SQL; no new abstractions.
+
+**Patterns to follow:** Existing FTS query in `topicSearchByTypes` is the shape to extend, not rewrite. Keep `topicFTSQuery` as the token-quoter; add a new helper for the title-only variant if needed.
+
+**Test scenarios:**
+- For `bitcoin 100k`, KXBTCMAX100 ranks above any series that contains "bitcoin" only in description/category.
+- For `portugal world cup`, KXMENWORLDCUP-26-PT (when present) ranks above any series that contains "portugal" only as a country tag.
+- Polymarket and Kalshi hits interleave round-robin (existing behavior preserved).
+- Empty result set still produces a `notFoundErr` (existing behavior preserved).
+
+**Verification:** `go test ./internal/cli/... -run TopicRank` passes; the five speedrun queries from Problem Frame all surface the correct top Kalshi hit.
+
+---
+
+### U4. Venue scoping flags on discovery commands
+
+**Goal:** Let an agent skip the second venue when it already knows which platform to hit.
+
+**Requirements:** R3.
+
+**Dependencies:** none — orthogonal to ranking changes.
+
+**Files:**
+- `library/payments/prediction-goat/internal/cli/venue.go` (new — `resolveVenue(cmd) string` helper)
+- `library/payments/prediction-goat/internal/cli/topic.go` (wire venue resolver, gate poly/kalshi branches)
+- `library/payments/prediction-goat/internal/cli/compare.go` (wire venue resolver; `--polymarket` alone is a no-op for compare since compare requires both — error with a helpful message)
+- `library/payments/prediction-goat/internal/cli/trending.go`, `movers.go`, `resolving.go`, `new.go` (replace ad-hoc `--venue` parsing with shared resolver)
+- `library/payments/prediction-goat/internal/cli/venue_test.go` (new)
+
+**Approach:** Single helper `resolveVenue(cmd) (string, error)` reads `--venue`, `--polymarket`, `--kalshi` from the command's flags and returns one of `"all" | "polymarket" | "kalshi"`. Conflicting flags (`--polymarket --kalshi`, `--polymarket --venue=kalshi`) return a usage error with the conflict named. Default is `"all"`. Each consuming command adds the three flags via a `addVenueFlags(cmd)` helper to keep the surface uniform.
+
+**Patterns to follow:** The existing `liquid` command's `--venue` string flag is the model. Don't rip it out — extend `liquid` to use the shared resolver too.
+
+**Test scenarios:**
+- `topic foo --polymarket` returns only Polymarket-source hits.
+- `topic foo --kalshi` returns only Kalshi-source hits.
+- `topic foo` (no flag) returns both venues interleaved (existing behavior).
+- `topic foo --polymarket --kalshi` returns a usage error naming the conflict.
+- `topic foo --polymarket --venue=kalshi` returns a usage error naming the conflict.
+- `compare foo --polymarket` returns a usage error explaining compare requires both venues.
+
+**Verification:** `go test ./internal/cli/... -run Venue` passes; `prediction-goat-pp-cli topic "world cup" --kalshi --agent | jq '.hits[].source' | sort -u` returns only `"kalshi"`.
+
+---
+
+### U5. Live-on-read freshness for prices and probabilities
+
+**Goal:** Any price or probability returned by the CLI is fetched live at command time, never served from cache. Cache age for the discovery layer is surfaced in `meta`.
+
+**Requirements:** R4, R5.
+
+**Dependencies:** U3 (reranked candidates are the input to the price-refresh step).
+
+**Execution note:** Test-first — write the assertion that a stale `yesProbability` in the cache is overwritten by the live API value before the test passes.
+
+**Files:**
+- `library/payments/prediction-goat/internal/cli/freshness.go` (new — `refreshPrices(ctx, hits) []hit` helper for both venues)
+- `library/payments/prediction-goat/internal/cli/topic.go` (call refresher before output)
+- `library/payments/prediction-goat/internal/cli/compare.go` (same)
+- `library/payments/prediction-goat/internal/cli/mispriced.go` (same)
+- `library/payments/prediction-goat/internal/cli/trending.go`, `movers.go`, `resolving.go`, `liquid.go`, `new.go` (same)
+- `library/payments/prediction-goat/internal/cli/agent_context.go` (extend `meta` envelope with `price_source: "live"` and `index_synced_at` keys)
+- `library/payments/prediction-goat/internal/cli/freshness_test.go` (new)
+
+**Approach:** After ranking produces N hits, group hits by venue and issue one batched API call per venue to refresh the price-bearing fields (`yesProbability`, `yes_ask_dollars`, `volume_24h_fp`, `last_price`, `status`). Polymarket's `/markets?slugs=` and Kalshi's `/markets?tickers=` both accept comma-separated lists. Replace the cached values on the in-memory hits before serialization. If a live fetch fails, mark `price_source: "stale"` on those rows and continue rather than failing the whole command — the user still gets the index answer with an explicit staleness flag.
+
+Surface cache age as `meta.index_synced_at` and `meta.price_source` in the response envelope. The existing envelope already carries `meta`, so this is an additive extension. Human-mode (terminal stdout) prints a one-line "Index synced 14h ago, prices live" footer.
+
+**Patterns to follow:** The existing `meta` envelope in `agent_context.go` is the model — extend its keys rather than inventing a new envelope.
+
+**Test scenarios:**
+- A cached `markets` row with `lastTradePrice=0.05` returns `yesProbability` matching the live `/markets?slug=` value when topic queries it (use a httptest fixture with a different value).
+- A cached `kalshi_markets` row with `yes_ask_dollars=0.085` similarly returns the live value.
+- Live fetch failure for one venue degrades that venue's rows to `price_source: "stale"` and leaves the other venue's rows untouched.
+- `meta.index_synced_at` is populated from the most recent `sync_state.last_synced_at`.
+- Human-mode terminal output includes the cache-age footer; `--json` / `--agent` mode does not (envelope only).
+- The basketball-tonight regression test: a synthetic cached row with `yesProbability=0.30` is returned as the live value (e.g., 0.55) after refresh.
+
+**Verification:** `go test ./internal/cli/... -run Freshness` passes; running `prediction-goat-pp-cli topic "lakers" --agent | jq '.meta.price_source'` returns `"live"`.
+
+---
+
+### U6. Series-driven Kalshi markets sync walk
+
+**Goal:** Kalshi sync covers named event families (`KXMENWORLDCUP-*`, `KXBTC*`, `KXOSCAR*`), not just the high-volume esports prefix that currently dominates pagination.
+
+**Requirements:** R6.
+
+**Dependencies:** U1 (WAL mode prevents reindex-vs-sync contention).
+
+**Files:**
+- `library/payments/prediction-goat/internal/source/kalshi/series_walk.go` (new)
+- `library/payments/prediction-goat/internal/source/kalshi/sync.go` (modify `SyncMarkets` to invoke walk)
+- `library/payments/prediction-goat/internal/source/kalshi/client.go` (add `GetMarketsBySeries(ctx, ticker)` if not present)
+- `library/payments/prediction-goat/internal/source/kalshi/series_walk_test.go` (new)
+
+**Approach:** After `SyncSeries` populates `kalshi_series` (~10k rows), iterate the rows and call `/markets?series_ticker=<X>&status=open` for each. The fan-out is bounded by `kalshi-series-count` × `pages-per-series`. Use a bounded worker pool (8 workers) and respect the existing `--rate-limit` flag. Persist progress to `sync_state` keyed by series ticker so a re-run resumes mid-walk.
+
+Keep the original `/markets?status=open` pass as a first-pass quick-win (still useful for high-frequency markets), then run the series walk as a second pass. Total wall-clock should remain under 5 minutes for a full sync against Kalshi's current ~10k series.
+
+**Patterns to follow:** Existing `syncPages` cursor loop in `sync.go:57` is the model. Add a `syncPerSeries` companion.
+
+**Test scenarios:**
+- After a full sync, `kalshi_markets` contains at least one row with ticker `KXMENWORLDCUP-26-PT`.
+- After a full sync, `kalshi_markets` contains rows under the `KXBTC*` and `KXOSCAR*` prefixes.
+- Resume mid-walk: kill the sync after N series, restart; resume picks up at series N+1.
+- Rate limit: with `--rate-limit 5`, the walk respects 5 req/s.
+- A series with zero open markets does not error; it logs and moves on.
+
+**Verification:** `go test ./internal/source/kalshi/... -run SeriesWalk` passes (with httptest fixtures); running `prediction-goat-pp-cli kalshi sync --max-pages 0` followed by `sqlite3 ... "SELECT 1 FROM resources WHERE id='KXMENWORLDCUP-26-PT'"` returns 1.
+
+---
+
+### U7. `kalshi events get --with-markets` and `kalshi events list --series`
+
+**Goal:** Honor advertised behavior; let agents enumerate event-child markets without raw curl.
+
+**Requirements:** R7, R8.
+
+**Dependencies:** none.
+
+**Files:**
+- `library/payments/prediction-goat/internal/cli/kalshi.go` (modify `newKalshiEventsGetCmd`, `newKalshiEventsListCmd`)
+- `library/payments/prediction-goat/internal/source/kalshi/client.go` (extend `GetEvent` to accept a `WithMarkets bool` option)
+- `library/payments/prediction-goat/internal/cli/kalshi_test.go` (extend)
+
+**Approach:** `kalshi events get <ticker> --with-markets` adds `?with_nested_markets=true` to the upstream call and unpacks the nested markets array into the response. `kalshi events list --series <ticker>` issues `/events?series_ticker=<X>` and returns the list. Both are thin pass-throughs.
+
+**Patterns to follow:** Existing `kalshi events get` command in `kalshi.go` is the model. The Kalshi events endpoint already supports both query parameters; only the Go-side flag wiring is missing.
+
+**Test scenarios:**
+- `kalshi events get KXMENWORLDCUP-26 --with-markets --agent` returns a payload whose `markets` array length is >= 40.
+- `kalshi events list --series KXMENWORLDCUP --agent` returns at least one event (`KXMENWORLDCUP-26`).
+- `kalshi events get KXMENWORLDCUP-26` (no flag) returns the existing metadata-only payload (no regression).
+- `kalshi events list --series UNKNOWN-SERIES` returns an empty list, not an error.
+
+**Verification:** `go test ./internal/cli/... -run KalshiEvents` passes; `prediction-goat-pp-cli kalshi events get KXMENWORLDCUP-26 --with-markets --agent | jq '.markets | length'` is >= 40.
+
+---
+
+### U8. `recall` + `teach` commands + reranking layer (LLM-driven learning, zero user noise)
+
+**Goal:** The LLM gets two new tools — `recall` to check "do I already know the answer?" before fiddling, and `teach` (backgrounded at response-time) to record what worked. Future queries on the same question family get answered in 2 CLI calls instead of 7. The human user never sees learning chatter.
+
+**Requirements:** R9, R10, R11.
+
+**Dependencies:** U3 (reranking layer sits on top of title-boosted FTS results).
+
+**Files:**
+- `library/payments/prediction-goat/internal/store/learnings.go` (new — table CRUD: `Upsert`, `List`, `Forget`, `Apply`)
+- `library/payments/prediction-goat/internal/store/store.go` (add `search_learnings` migration in the same schema-version bump as U2)
+- `library/payments/prediction-goat/internal/cli/teach.go` (new — `teach`, `recall`, `learnings list`, `forget` subcommands)
+- `library/payments/prediction-goat/internal/cli/root.go` (add `--no-learn` persistent flag)
+- `library/payments/prediction-goat/internal/cli/topic.go` (call `Apply` on FTS hits; emit `meta.teach_hint` in the envelope)
+- `library/payments/prediction-goat/internal/cli/compare.go` (same)
+- `library/payments/prediction-goat/internal/cli/agent_context.go` (extend `meta` envelope with `learnings_applied: N` and `teach_hint: "..."` keys)
+- `cli-skills/pp-prediction-goat/SKILL.md` **OR** the equivalent skill source location in this repo (TBD — locate at implementation; the published skill at `~/.claude/skills/pp-prediction-goat/SKILL.md` is the installed copy). Add an "Automatic learning" section that documents the LLM contract: fire `teach` in the background before the user-facing response. Wording must be tight — too many words and the LLM stops following it.
+- `library/payments/prediction-goat/internal/cli/teach_test.go` (new)
+- `library/payments/prediction-goat/internal/store/learnings_test.go` (new)
+
+**Approach:**
+
+**Schema.** See High-Level Technical Design — single `search_learnings` table plus a `(query_pattern, resource_id, action)` unique index so the same `teach` call re-fired bumps `confidence` instead of duplicating rows. Normalize `query_pattern` at write and apply: lowercase, collapse whitespace, strip a small stopword set (`a`, `the`, `what`, `are`, `is`, `was`, `?`, `!`) so `"What are the odds Portugal wins the World Cup?"` and `"portugal world cup odds"` collapse to the same key.
+
+**`teach` command surface (LLM-facing, designed to be backgrounded):**
+
+```text
+prediction-goat-pp-cli teach \
+  --query "<user's original natural-language question>" \
+  --resource <ticker-or-slug> [--resource ...] \
+  [--venue polymarket|kalshi] \
+  [--quiet]   # default; silent on success
+```
+
+Behavior:
+- Writes one `boost` row per `--resource`, all under the same normalized `query_pattern`. `source="taught"`. Upsert (no duplicates).
+- Exits 0 silently on success — zero stdout, zero stderr. Safe to background with `&` and discard.
+- On error (bad DB, full disk, malformed args), writes a single line to `~/.local/share/prediction-goat-pp-cli/teach.log` and exits non-zero. Never prints to stderr. The LLM's background fork can't pollute the user-facing response.
+- Idempotent. Calling `teach` twice with identical args bumps confidence; no warning.
+- Honors `PREDICTION_GOAT_NO_LEARN=true` — no-op if set.
+
+**`recall` command surface (LLM-facing, the read side of the loop):**
+
+```text
+prediction-goat-pp-cli recall "<user's natural-language query>" \
+  [--min-confidence N]   # default 1; raise to 2+ to require re-confirmed mappings
+  [--limit N]            # default 10
+  [--agent]              # JSON envelope
+```
+
+Behavior:
+- Normalize the query the same way `teach` normalizes (lowercase, collapse whitespace, strip stopwords).
+- Match learnings whose normalized `query_pattern` overlaps with the input by token-set Jaccard >= 0.6 (configurable). This catches "portugal world cup chances" → "portugal world cup odds" even though they're not substring-equal.
+- Return matching learnings ordered by `(match_score DESC, confidence DESC, last_observed_at DESC)`.
+- Each row carries `{resource_id, resource_type, venue, action, confidence, match_score, source, last_observed_at}`.
+- When no match: `{"found": false, "results": [], "query": "...", "normalized": "..."}` (still exit 0; not a not-found error — it's an information query).
+- When match: `{"found": true, "match_score": <best>, "results": [...]}`.
+- Cheap: single SQL pass against a small per-user table; no FTS, no API.
+
+**Skill markdown contract (LLM-facing, short — both sides):**
+
+A new "Automatic learning" section in the prediction-goat skill markdown. Approximate length: 8-10 lines, two paragraphs. Content shape:
+
+> **Before** running `topic` / `compare` / any discovery command for a new user question, run:
+>
+> `prediction-goat-pp-cli recall "<user's question>" --agent`
+>
+> If `found=true` with `confidence>=2`, skip discovery and go straight to the live price fetch for the returned tickers (`kalshi markets get <ticker>` / `markets get-by-slug <slug>`). If `found=false`, proceed with normal discovery.
+>
+> **After** you have finalized your response containing tickers/slugs but BEFORE emitting it to the user, fire this in the background (single line, ampersand at the end):
+>
+> `prediction-goat-pp-cli teach --query "<user's question>" --resource <id1> --resource <id2> &`
+>
+> Do not mention either of these to the user. Both are silent on success.
+
+(The exact wording is finalized at implementation time. Optimize for "LLM follows it" rather than completeness.)
+
+**`meta.teach_hint` in response envelope.** As belt-and-suspenders against a forgetful LLM: when `topic` or `compare` returns hits and learnings are not already maxed out for the current normalized query (e.g., the top hit doesn't already have `confidence >= 3` for this query), include a `meta.teach_hint` field in the response envelope:
+
+```json
+{
+  "meta": {
+    "synced_at": "...",
+    "price_source": "live",
+    "learnings_applied": 0,
+    "teach_hint": "If you use these results in your final response, run: prediction-goat-pp-cli teach --query \"<user's original question>\" --resource <id> &"
+  },
+  "results": [...]
+}
+```
+
+The LLM sees this in the structured tool output at exactly the moment it has the context. Skill instruction + envelope hint = two reinforcing signals.
+
+**Inspection / undo commands:**
+
+- `learnings list [--query <q>] [--source <s>] [--agent]` — lists rows; supports `--select`. Default sort: `last_observed_at DESC`. Useful for "why did the CLI return this answer?" Different from `recall` in that `list` is for humans inspecting the table, `recall` is for agents looking up by query.
+- `forget <query> [--resource <id>] [--action <a>] [--all]` — deletes matching rows; requires at least one filter or `--all`.
+
+The complete learning surface: `recall` (agent reads, before discovery), `teach` (agent writes, after response), `learnings list` (human inspects), `forget` (human undoes). No `learn` command — manual seeding happens via `teach` from the command line if someone really wants it, but that's an LLM-shaped surface, not a human one.
+
+**Reranking layer** (called from `topic` and `compare` after FTS, before envelope assembly):
+
+1. Normalize the current query string the same way `teach` normalizes.
+2. Load learnings whose normalized `query_pattern` equals the current query OR is a substring of the current query (cheap LIKE scan; table stays small per-user).
+3. For each `boost` rule whose `resource_id` IS among the current FTS hits, move that hit to position 0 (or position N for the Nth boost, ordered by confidence DESC then `last_observed_at` DESC).
+4. For each `boost` rule whose `resource_id` is NOT in the FTS hits, fetch the resource from the `resources` table and insert as a synthetic hit at the top with `meta.source: "learned"`. This is the killer mode: FTS missed it entirely, the learning fills the gap.
+5. For each `hide` rule, remove matching hits from the result.
+6. For each `alias_of` rule, replace hits matching the alias source with the alias target.
+7. Detect alias cycles (A → B → A) and drop the cycling rule from this apply with a warning to `teach.log`.
+8. Append `meta.learnings_applied: N` to the envelope.
+
+**Audit log.** Each `teach` invocation appends one JSONL line to `~/.local/share/prediction-goat-pp-cli/learnings.jsonl`: `{ts, action: "teach", query, resources, confidence_before_max, confidence_after_max}`. Each `forget` invocation appends one line: `{ts, action: "forget", query, filter, rows_deleted}`.
+
+**Patterns to follow:**
+- `feedback.jsonl` (already in CLI) — single JSONL file beside the DB.
+- Existing subcommand registration in `internal/cli/root.go`.
+- Existing `Upsert` shape in `store/store.go`.
+- Existing `meta` envelope in `agent_context.go` — extend keys, don't invent a new envelope.
+
+**Test scenarios:**
+
+*`teach` command:*
+- `teach --query "what are Portugal's odds" --resource KXMENWORLDCUP-26-PT` writes one row, exits 0 with zero stdout/stderr.
+- Backgrounded form (`teach ... &`) does not block the parent shell or leak output.
+- Same call fired twice: confidence increments from 1 → 2, no duplicate row (unique constraint on `(query_pattern, resource_id, action)`).
+- Multiple `--resource` flags in one call: one row per resource, all under the same `query_pattern`.
+- Normalization: `--query "What are the ODDS Portugal wins?"` and `--query "portugal odds"` collapse to the same row.
+- `PREDICTION_GOAT_NO_LEARN=true`: command is a no-op (exits 0, no row written).
+- Malformed args (missing `--query`, missing `--resource`): exits non-zero, error to `teach.log`, nothing to stderr.
+
+*`recall` command:*
+- After `teach --query "portugal world cup odds" --resource KXMENWORLDCUP-26-PT`, `recall "portugal world cup odds" --agent` returns `found=true` with that ticker at position 0.
+- Token overlap match: `recall "portugal chances at the world cup" --agent` matches the learning above (Jaccard overlap >= 0.6 between normalized token sets).
+- Unrelated query: `recall "lakers tonight" --agent` returns `found=false`, exits 0 (information query, not error).
+- `--min-confidence 2`: filters out confidence-1 learnings.
+- `--limit 5`: caps results at 5 even if more match.
+- Multiple matching learnings ordered by `match_score DESC, confidence DESC, last_observed_at DESC`.
+- Normalization at recall: a learning taught with `"Portugal World Cup"` is returned by `recall "portugal  world cup"` (case + whitespace).
+- Stopword stripping symmetry: a learning taught with `"what are portugal's odds"` matches `recall "portugal odds"` (both normalize to `portugal odds`).
+- `PREDICTION_GOAT_NO_LEARN=true`: recall returns `{found: false, results: []}` even if learnings exist (apply side is disabled).
+
+*Reranking layer:*
+- A `boost` rule whose `resource_id` IS in the current FTS hits moves it to position 0.
+- A `boost` rule whose `resource_id` is NOT in the current FTS hits inserts it as a synthetic hit at position 0 with `meta.source: "learned"` — this is the "FTS missed it, learning saved us" case.
+- A `hide` rule removes matching hits from the result.
+- An `alias_of` rule replaces the alias source with the alias target (after fetching it from `resources`).
+- Substring match: a rule on `query_pattern="bitcoin"` applies to query `bitcoin 100k`.
+- Normalization at apply: a rule recorded for `"Portugal World Cup"` applies to query `portugal  world cup` (case + whitespace + stopwords).
+- Alias cycle A → B → A is detected and dropped from this apply with a warning to `teach.log`.
+- `--no-learn` on a `topic` / `compare` invocation: rerank layer is skipped (FTS-only output).
+
+*Envelope:*
+- `meta.learnings_applied` reflects the count of rules that touched the output (0 when none applied).
+- `meta.teach_hint` is present when the top hit has low confidence for the current normalized query, absent when it has high confidence (>= 3).
+
+*Inspection / undo:*
+- `learnings list --agent` returns all rows as JSON, supports `--select`.
+- `learnings list --query "portugal"` filters to substring matches.
+- `forget "portugal world cup" --resource KXMENWORLDCUP-26-PT` removes the boost; next `topic` reverts to FTS ranking for that query.
+- `forget "portugal world cup" --all` wipes every rule for that query.
+- The JSONL audit log gets one line per `teach` and per `forget`.
+
+**Verification:** `go test ./internal/cli/... -run "Teach|Recall"` and `go test ./internal/store/... -run Learnings` pass. End-to-end manual check, simulating the Portugal flow from tonight's session:
+
+1. `recall "portugal world cup odds" --agent` → `found=false` (cold start).
+2. `topic "portugal world cup"` → no Portugal in results (the bug).
+3. `kalshi markets get KXMENWORLDCUP-26-PT --agent` → Portugal 8.5%.
+4. `teach --query "portugal world cup odds" --resource KXMENWORLDCUP-26-PT --resource will-portugal-win-the-2026-fifa-world-cup-912` → silent exit 0.
+5. `recall "portugal world cup odds" --agent` → `found=true`, both tickers at positions 0 and 1 with confidence 1.
+6. `recall "portugal chances at the world cup" --agent` → `found=true` (token overlap >= 0.6).
+7. `topic "portugal world cup"` → both tickers at positions 0 and 1 (rerank applied internally).
+
+---
+
+## System-Wide Impact
+
+- **Schema migration:** U2 and U8 both ride a single `PRAGMA user_version` bump. First open at the new version triggers reindex of `resources_fts` and creation of `search_learnings`. Document in the release note: existing users get a 30-second one-time reindex.
+- **Live API call volume:** U5 changes the model from "0 API calls per topic/compare invocation" to "1-2 batched API calls per invocation." For an agent running `topic` 20× per hour, this is 20-40 extra calls per hour against publicly free endpoints — within rate-limit budget for both venues.
+- **Sync wall-clock:** U6 adds a series-walk pass to `kalshi sync`. Full sync goes from ~2 minutes to ~5 minutes against current Kalshi corpus.
+- **MCP server:** No changes required. `prediction-goat-pp-mcp` wraps the CLI; new commands (`learn`, `forget`, `learnings list`) are not exposed via MCP in this PR — deferred.
+- **CI lint:** The read-only structural lint is unaffected. The new `learn`/`forget` commands write only to the local SQLite DB and JSONL log; no trading API surface is introduced.
+
+---
+
+## Risks and Mitigations
+
+- **Reindex during heavy session lags command latency.** U2's one-shot reindex takes ~30s on a 60k-row corpus. Mitigation: WAL mode (U1) means the reindex doesn't block reads — concurrent `topic` queries during reindex return FTS hits from the pre-migration index, slightly stale but available. Document the one-time hit in release notes.
+- **Live API rate limits.** Polymarket and Kalshi both impose rate limits. U5's batched fetches use comma-separated ticker lists (one call per venue per invocation), keeping us within budget. If a future change fans out per-ticker, revisit.
+- **Series-walk explosion.** U6 fan-outs across 10k series. Bounded worker pool (8 workers) plus `--rate-limit` keeps this safe. Worst case: full sync takes 10 minutes instead of 5.
+- **Learnings drift.** A user can pollute `search_learnings` with bad rules. Mitigations: `learnings list` surfaces all rules; `forget` is fast; the JSONL audit log lets a user grep history; rules are local to the user's DB (no networked propagation).
+- **`alias_of` cycles.** A → B → A would loop. Mitigation: at apply time, detect cycles by tracking visited resource_ids; on detection, drop the cycling rule from this query's apply and log a warning.
+
+---
+
+## Test & Verification Strategy
+
+Each implementation unit ships with its own test file (paths listed per unit). Two cross-cutting verifications gate PR readiness:
+
+- **Speedrun regression suite.** Add a top-level `internal/cli/speedrun_test.go` that runs the five Problem Frame queries (`portugal world cup`, `bitcoin 100k`, `oscars best picture 2026`, `fed rate cut june`, `nba championship 2026`) end-to-end against a seeded fixture DB and asserts the expected top Kalshi ticker for each. This is the "did we actually fix the bug" check.
+- **Live API smoke (manual, not CI).** Document in the PR description a manual checklist: run each of the five queries against the user's local DB after sync, confirm the top Kalshi hit matches expectations.
+
+## Open Questions / Deferred
+
+- **Auto-inference of learnings from `--pair` confirmations in `compare`.** This PR ships explicit `learn`. Auto-inference (e.g., "user ran `compare foo --pair pm-x=kalshi-y` three times in a session — auto-create an alias rule") is a follow-up after the explicit surface is exercised.
+- **Shared learning across users.** Out of scope. Each user's `search_learnings` is local. A future PR could optionally publish curated rules to a shared registry.
+- **MCP surface for `learn` / `forget`.** Deferred. The CLI surface ships first; MCP exposure can layer on once the shape is validated.
+- **Polymarket sync coverage parity.** Polymarket's `events`/`markets` tables also cap at ~100 rows per sync. Same root pattern as Kalshi, separate PR.
+
+---
+
+## PR Strategy
+
+Branch: `feat/prediction-goat-search-freshness-learning` off `feat/prediction-goat` (PR #780).
+Base: `feat/prediction-goat`.
+Stacked PR — do not merge until `feat/prediction-goat` lands first.
+
+Single PR covers all eight units. Total surface ~12 modified files + ~9 new files. Each unit is its own commit for review-ability.

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -65,6 +65,27 @@
       ],
       "validated_outcome": "go test ./... passes (333 tests, 29 new freshness assertions). agent-context schema_version bumped 3→4 with new top-level freshness block enumerating the commands that emit meta.price_source and the four possible price_source values (live, stale, mixed, index). Human-mode terminal output prints a one-line 'Index synced 14h ago, prices live' footer; --json / --agent mode does not.",
       "upstream_issue": "Generator template for CLIs that maintain a local discovery index alongside a price-bearing upstream should adopt the live-on-read pattern (refresh ranked candidates from upstream before serialization) by default."
+    },
+    {
+      "id": "llm-driven-learning-pipeline",
+      "summary": "Add `teach` (LLM-fired, silent, backgroundable) and `recall` (LLM-fired, pre-discovery) plus a rerank layer in topic/compare that applies the resulting boost/hide/alias rules. schema bumped 3->4 with the search_learnings table; agent-context schema bumped 4->5 to advertise the contract.",
+      "reason": "The agent paid the 'took forever to find Portugal's ticker' tax on every session because the central FTS index has no signal that the LLM already found the right ticker last time. Now the LLM teaches the CLI at response-time with the user's natural-language question and the tickers that made it into the answer; future overlapping queries (token-set Jaccard >= 0.6) short-circuit discovery via `recall` and rerank surfaces the right tickers via the apply layer. Per-user, fire-and-forget, silent on success, inspectable via `learnings list`, undoable via `forget`, and disableable via --no-learn / PREDICTION_GOAT_NO_LEARN.",
+      "files": [
+        "internal/store/learnings.go",
+        "internal/store/learnings_test.go",
+        "internal/store/store.go",
+        "internal/store/fts_content_test.go",
+        "internal/cli/teach.go",
+        "internal/cli/teach_test.go",
+        "internal/cli/root.go",
+        "internal/cli/topic.go",
+        "internal/cli/compare.go",
+        "internal/cli/freshness.go",
+        "internal/cli/agent_context.go",
+        "SKILL.md"
+      ],
+      "validated_outcome": "go test ./... passes (374 tests, 33 new across teach/recall/learnings/forget/apply). verify_skill.py passes. End-to-end: a `teach` for 'portugal world cup odds' lands a row that subsequent `recall` calls find by token overlap; the rerank layer surfaces it at position 0 in `topic` output regardless of FTS ranking; `--no-learn` and PREDICTION_GOAT_NO_LEARN both disable the surface. teach.log captures background failures; learnings.jsonl mirrors every teach/forget for grep-without-SQL inspection.",
+      "upstream_issue": "Generator template for printed CLIs that ship a discovery index should consider adopting the LLM-driven teach/recall pattern: per-user, fire-and-forget write surface plus pre-discovery read surface, fed by the LLM's act of responding rather than CLI-side heuristics. Generalizes to any read-mostly catalog CLI."
     }
   ]
 }

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -33,6 +33,18 @@
       "files": ["internal/store/store.go", "internal/store/fts_content_test.go"],
       "validated_outcome": "go test ./internal/store/... passes (91 tests). The new TestFTSContent_PreventsFTSFalsePositives end-to-end test exercises the FTS engine with seeded KXFUSION/KXOSCARCOUNTCONCLAVE/KXBTCMAX100/KXMENWORLDCUP-26-PT fixtures and confirms KXFUSION is excluded from 'oscar' query results.",
       "upstream_issue": "Generator templates for printed CLIs that ship resources_fts should use a curated extractor by default instead of indexing raw JSON; the resource-type-aware key set generalizes to non-prediction-market CLIs as well."
+    },
+    {
+      "id": "series-driven-kalshi-markets-sync-walk",
+      "summary": "Add SyncMarketsBySeries: a second-pass series-driven Kalshi markets sync that iterates the kalshi_series table and fetches /markets?series_ticker=<X> per series so named-event families (KXMENWORLDCUP-*, KXBTC*, KXOSCAR*) are no longer starved by the natural /markets pagination order.",
+      "reason": "Kalshi's /markets?status=open is dominated by high-volume KXMVE esports factory families; in one observed sync 54,216 markets landed and 99.9% were a single prefix while KXMENWORLDCUP-26-PT, KXBTC*, and KXOSCAR* were entirely absent. The walk uses the already-correct kalshi_series corpus as the iteration seed, runs after the first-pass /markets fetch with a bounded 8-worker pool, and persists per-series cursors to sync_state so an interrupted run resumes without duplicating work.",
+      "files": [
+        "internal/source/kalshi/series_walk.go",
+        "internal/source/kalshi/series_walk_test.go",
+        "internal/source/kalshi/client.go",
+        "internal/source/kalshi/sync.go"
+      ],
+      "validated_outcome": "go test ./internal/source/kalshi/... passes (8 new tests including resume, rate-limit, empty-series-no-error, and named-event-families-land coverage). go test ./... passes (313 tests). go vet ./... clean. verify_skill.py still passes."
     }
   ]
 }

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -3,5 +3,14 @@
   "applied_at": "2026-05-23",
   "base_run_id": "20260522-175728",
   "base_printing_press_version": "4.10.0",
-  "patches": []
+  "patches": [
+    {
+      "id": "wal-pragmas-via-connection-hook",
+      "summary": "Apply journal_mode=WAL and busy_timeout=5000 via sqlite.RegisterConnectionHook because DSN-level _journal_mode/_busy_timeout params are silently ignored by modernc.org/sqlite v1.37.0.",
+      "reason": "Live store opened with the DSN-style pragma params still reported PRAGMA journal_mode=delete and busy_timeout=0, which is the root cause of the SQLITE_BUSY failures observed during concurrent topic queries and during kalshi sync. Connection hook is the only reliable path.",
+      "files": ["internal/store/store.go", "internal/store/store_concurrency_test.go"],
+      "validated_outcome": "go test ./internal/store/... passes (76 tests including 4 new concurrency tests). Live db now reports journal_mode=wal, busy_timeout=5000.",
+      "upstream_issue": "Generator template should switch from DSN-pragma to connection-hook approach for all printed CLIs that use modernc.org/sqlite."
+    }
+  ]
 }

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -11,6 +11,14 @@
       "files": ["internal/store/store.go", "internal/store/store_concurrency_test.go"],
       "validated_outcome": "go test ./internal/store/... passes (76 tests including 4 new concurrency tests). Live db now reports journal_mode=wal, busy_timeout=5000.",
       "upstream_issue": "Generator template should switch from DSN-pragma to connection-hook approach for all printed CLIs that use modernc.org/sqlite."
+    },
+    {
+      "id": "curated-fts-content",
+      "summary": "Project resources_fts.content to a topic-bearing key subset (title, ticker, category, etc.) instead of the raw JSON blob. Schema version bumped 2→3 with a one-shot rebuild migration.",
+      "reason": "Indexing the entire raw JSON included Kalshi source_agencies URL refs and Polymarket descriptions, producing false positives like KXFUSION (Nuclear fusion series) matching 'oscars best picture 2026' because its source list cited oscars.org. The new ftsContent extractor projects only semantic fields, eliminating the false-positive vector while preserving real-signal matches.",
+      "files": ["internal/store/store.go", "internal/store/fts_content_test.go"],
+      "validated_outcome": "go test ./internal/store/... passes (91 tests). The new TestFTSContent_PreventsFTSFalsePositives end-to-end test exercises the FTS engine with seeded KXFUSION/KXOSCARCOUNTCONCLAVE/KXBTCMAX100/KXMENWORLDCUP-26-PT fixtures and confirms KXFUSION is excluded from 'oscar' query results.",
+      "upstream_issue": "Generator templates for printed CLIs that ship resources_fts should use a curated extractor by default instead of indexing raw JSON; the resource-type-aware key set generalizes to non-prediction-market CLIs as well."
     }
   ]
 }

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -33,6 +33,26 @@
       "files": ["internal/store/store.go", "internal/store/fts_content_test.go"],
       "validated_outcome": "go test ./internal/store/... passes (91 tests). The new TestFTSContent_PreventsFTSFalsePositives end-to-end test exercises the FTS engine with seeded KXFUSION/KXOSCARCOUNTCONCLAVE/KXBTCMAX100/KXMENWORLDCUP-26-PT fixtures and confirms KXFUSION is excluded from 'oscar' query results.",
       "upstream_issue": "Generator templates for printed CLIs that ship resources_fts should use a curated extractor by default instead of indexing raw JSON; the resource-type-aware key set generalizes to non-prediction-market CLIs as well."
+    },
+    {
+      "id": "live-on-read-freshness",
+      "summary": "Refresh price-bearing fields (yesProbability, yes_ask_dollars, volume_24h_fp, last_price_dollars) from upstream APIs at command time for topic / compare / mispriced / trending / movers / resolving / liquid / new. Surface index age and refresh outcome in meta.price_source and meta.index_synced_at.",
+      "reason": "The local SQLite store is a discovery index but doubled as the price source. A user asking 'what are the odds Lakers win tonight' could be served hours-old cached prices with no signal they were stale. The refresher batches hits by venue and fires one /markets?slug= (Polymarket) or /markets?tickers= (Kalshi) call per venue, replacing cached values on the in-memory hits before serialization. A failed live fetch degrades affected rows to price_source: stale rather than failing the whole command.",
+      "files": [
+        "internal/cli/freshness.go",
+        "internal/cli/freshness_test.go",
+        "internal/cli/topic.go",
+        "internal/cli/compare.go",
+        "internal/cli/mispriced.go",
+        "internal/cli/trending.go",
+        "internal/cli/movers.go",
+        "internal/cli/resolving.go",
+        "internal/cli/liquid.go",
+        "internal/cli/new_markets.go",
+        "internal/cli/agent_context.go"
+      ],
+      "validated_outcome": "go test ./... passes (333 tests, 29 new freshness assertions). agent-context schema_version bumped 3→4 with new top-level freshness block enumerating the commands that emit meta.price_source and the four possible price_source values (live, stale, mixed, index). Human-mode terminal output prints a one-line 'Index synced 14h ago, prices live' footer; --json / --agent mode does not.",
+      "upstream_issue": "Generator template for CLIs that maintain a local discovery index alongside a price-bearing upstream should adopt the live-on-read pattern (refresh ranked candidates from upstream before serialization) by default."
     }
   ]
 }

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -13,6 +13,13 @@
       "upstream_issue": "Generator template should switch from DSN-pragma to connection-hook approach for all printed CLIs that use modernc.org/sqlite."
     },
     {
+      "id": "kalshi-events-with-markets-and-series-filter",
+      "summary": "Add --with-markets to `kalshi events get` (passes with_nested_markets=true upstream) and implement --series on `kalshi events list` (advertised in --help pre-fix but never declared as a flag).",
+      "reason": "Before this patch the only way to enumerate every child market under a Kalshi event was raw curl against the upstream API. The CLI now returns all 56 KXMENWORLDCUP-26 child markets in one call. The --series filter on list completes the series → event → markets walk that the existing CLI surface implied but couldn't actually execute.",
+      "files": ["internal/cli/kalshi_events.go", "internal/cli/kalshi_events_test.go", "SKILL.md"],
+      "validated_outcome": "End-to-end smoke against live Kalshi API: `kalshi events get KXMENWORLDCUP-26 --with-markets --agent` returns 56 markets including KXMENWORLDCUP-26-PT; `kalshi events list --series KXMENWORLDCUP --data-source live --agent` returns the 2026 event. go test passes; verify_skill.py still passes after SKILL.md additions."
+    },
+    {
       "id": "venue-scoping-flags",
       "summary": "Add --venue, --polymarket, --kalshi flags to topic, compare, liquid, movers, resolving, trending, new via a shared addVenueFlags + resolveVenue helper. Default behavior (no flag) stays cross-venue.",
       "reason": "Agents that already know which venue they want should be able to skip the second one to halve query latency. compare additionally errors when scoped to a single venue (it requires both).",

--- a/library/payments/prediction-goat/.printing-press-patches.json
+++ b/library/payments/prediction-goat/.printing-press-patches.json
@@ -13,6 +13,13 @@
       "upstream_issue": "Generator template should switch from DSN-pragma to connection-hook approach for all printed CLIs that use modernc.org/sqlite."
     },
     {
+      "id": "venue-scoping-flags",
+      "summary": "Add --venue, --polymarket, --kalshi flags to topic, compare, liquid, movers, resolving, trending, new via a shared addVenueFlags + resolveVenue helper. Default behavior (no flag) stays cross-venue.",
+      "reason": "Agents that already know which venue they want should be able to skip the second one to halve query latency. compare additionally errors when scoped to a single venue (it requires both).",
+      "files": ["internal/cli/venue.go", "internal/cli/venue_test.go", "internal/cli/topic.go", "internal/cli/compare.go", "internal/cli/liquid.go", "internal/cli/movers.go", "internal/cli/resolving.go", "internal/cli/trending.go", "internal/cli/new_markets.go"],
+      "validated_outcome": "go test ./... passes (301 tests). verify_skill.py still passes."
+    },
+    {
       "id": "curated-fts-content",
       "summary": "Project resources_fts.content to a topic-bearing key subset (title, ticker, category, etc.) instead of the raw JSON blob. Schema version bumped 2→3 with a one-shot rebuild migration.",
       "reason": "Indexing the entire raw JSON included Kalshi source_agencies URL refs and Polymarket descriptions, producing false positives like KXFUSION (Nuclear fusion series) matching 'oscars best picture 2026' because its source list cited oscars.org. The new ftsContent extractor projects only semantic fields, eliminating the false-positive vector while preserving real-signal matches.",

--- a/library/payments/prediction-goat/SKILL.md
+++ b/library/payments/prediction-goat/SKILL.md
@@ -280,6 +280,26 @@ Commands that read from the local store or the API wrap output in a provenance e
 
 Parse `.results` for data and `.meta.source` to know whether it's live or local. A human-readable `N results (live)` summary is printed to stderr only when stdout is a terminal AND no machine-format flag (`--json`, `--csv`, `--compact`, `--quiet`, `--plain`, `--select`) is set — piped/agent consumers and explicit-format runs get pure JSON on stdout.
 
+## Automatic learning
+
+This CLI learns from your responses so the same question costs 2 calls next time instead of 7. Two short steps:
+
+**Before** running `topic` / `compare` / any discovery for a new user question, run:
+
+```bash
+prediction-goat-pp-cli recall "<user's question>" --agent
+```
+
+If `found=true` with `confidence>=2`, skip discovery and go straight to live price fetch for the returned tickers (`kalshi markets get <ticker>` / `markets get-by-slug <slug>`). If `found=false`, proceed with normal discovery.
+
+**After** assembling your response containing tickers/slugs but BEFORE emitting it to the user, fire the teach call in the background (single line, append `&` so the shell returns immediately):
+
+```bash
+prediction-goat-pp-cli teach --query "<user's question>" --resource <id1> --resource <id2>
+```
+
+Both commands are silent on success. Do not mention either of them to the user. To disable on a single run, pass `--no-learn`; to disable globally, set `PREDICTION_GOAT_NO_LEARN=true`. Inspect with `learnings list --agent`; undo with `forget "<query>" --resource <id>` or `--all`.
+
 ## Agent Feedback
 
 When you (or the agent) notice something off about this CLI, record it:

--- a/library/payments/prediction-goat/SKILL.md
+++ b/library/payments/prediction-goat/SKILL.md
@@ -220,6 +220,24 @@ prediction-goat-pp-cli compare 'arizona basketball' --json
 
 Resolves the topic to paired markets and renders YES/NO + implied prob for each venue side-by-side. Tells you exactly where PM and Kalshi disagree.
 
+### Enumerate every child market under a Kalshi event
+
+When the event ticker is known (often discovered via `kalshi-series-search` then `kalshi events list --series`), one call returns every child market with live prices:
+
+```bash
+prediction-goat-pp-cli kalshi events get KXMENWORLDCUP-26 --with-markets --agent
+```
+
+Passes `with_nested_markets=true` to the upstream `/events/{ticker}` endpoint. The response includes a `markets` array with ticker, title, yes_sub_title, status, yes_ask_dollars, no_ask_dollars, volume_24h_fp, and expiration_time for each child. This is the lightweight alternative to a full sync walk when you only need one event's children.
+
+### List every Kalshi event under a series
+
+```bash
+prediction-goat-pp-cli kalshi events list --series KXMENWORLDCUP --agent
+```
+
+Filters `/events` by `series_ticker`. The `--series` flag forces `--data-source live` since the local store doesn't index by series ticker. Use this before `kalshi events get --with-markets` when you don't know the exact event ticker — series → event → markets in three calls.
+
 ### Catch mispricings across venues
 
 ```bash

--- a/library/payments/prediction-goat/internal/cli/agent_context.go
+++ b/library/payments/prediction-goat/internal/cli/agent_context.go
@@ -14,8 +14,9 @@ import (
 
 // agentContextSchemaVersion is bumped on any breaking change to the JSON
 // shape emitted by `agent-context`. Agents should check this before
-// parsing. Shape at v3 adds kind-aware auth env var metadata.
-const agentContextSchemaVersion = "3"
+// parsing. Shape at v3 adds kind-aware auth env var metadata. Shape at
+// v4 advertises the discovery-command live-on-read freshness contract.
+const agentContextSchemaVersion = "4"
 
 // agentContext is the structured description of this CLI consumed by AI
 // agents. Inspired by Cloudflare's /cdn-cgi/explorer/api runtime endpoint
@@ -29,6 +30,27 @@ type agentContext struct {
 	Commands                   []agentContextCommand  `json:"commands"`
 	AvailableProfiles          []string               `json:"available_profiles"`
 	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
+	Freshness                  *agentContextFreshness `json:"freshness,omitempty"`
+}
+
+// agentContextFreshness advertises the live-on-read price refresh
+// contract to agents. The discovery commands (topic, compare,
+// mispriced, trending, movers, resolving, liquid, new) refresh
+// price-bearing fields from upstream before serializing the result,
+// and surface the outcome in `meta.price_source` ("live" | "stale" |
+// "mixed" | "index") and `meta.index_synced_at` (the most recent
+// sync_state.last_synced_at for the price-bearing tables).
+//
+// Agents that see `price_source: "stale"` on a result know the
+// upstream refresh failed and they're looking at the cached value;
+// they may want to retry or surface the staleness to the user.
+type agentContextFreshness struct {
+	// Commands lists the subcommands that emit `meta.price_source` and
+	// `meta.index_synced_at` on their JSON output.
+	Commands []string `json:"commands"`
+	// PriceSourceValues enumerates the possible values for
+	// `meta.price_source` in the response envelope.
+	PriceSourceValues []string `json:"price_source_values"`
 }
 
 type agentContextCLI struct {
@@ -127,6 +149,15 @@ func buildAgentContext(rootCmd *cobra.Command) agentContext {
 		Commands:                   collectAgentCommands(rootCmd),
 		AvailableProfiles:          profiles,
 		FeedbackEndpointConfigured: FeedbackEndpointConfigured(),
+		Freshness: &agentContextFreshness{
+			Commands: []string{
+				"topic", "compare", "mispriced",
+				"trending", "movers", "resolving", "liquid", "new",
+			},
+			PriceSourceValues: []string{
+				priceSourceLive, priceSourceStale, priceSourceMixed, priceSourceIndex,
+			},
+		},
 	}
 }
 

--- a/library/payments/prediction-goat/internal/cli/agent_context.go
+++ b/library/payments/prediction-goat/internal/cli/agent_context.go
@@ -16,7 +16,9 @@ import (
 // shape emitted by `agent-context`. Agents should check this before
 // parsing. Shape at v3 adds kind-aware auth env var metadata. Shape at
 // v4 advertises the discovery-command live-on-read freshness contract.
-const agentContextSchemaVersion = "4"
+// Shape at v5 advertises the LLM-driven learning contract (recall +
+// teach + meta.learnings_applied + meta.teach_hint).
+const agentContextSchemaVersion = "5"
 
 // agentContext is the structured description of this CLI consumed by AI
 // agents. Inspired by Cloudflare's /cdn-cgi/explorer/api runtime endpoint
@@ -31,6 +33,26 @@ type agentContext struct {
 	AvailableProfiles          []string               `json:"available_profiles"`
 	FeedbackEndpointConfigured bool                   `json:"feedback_endpoint_configured"`
 	Freshness                  *agentContextFreshness `json:"freshness,omitempty"`
+	Learning                   *agentContextLearning  `json:"learning,omitempty"`
+}
+
+// agentContextLearning advertises the LLM-driven learning contract:
+// the agent calls `recall` BEFORE running discovery on a new user
+// question, and (after assembling its response) fires `teach` in the
+// background to record which tickers ended up in the answer.
+// Subsequent calls with overlapping queries get the right tickers
+// boosted automatically via the rerank Apply pass in topic / compare.
+//
+// MetaFields enumerates the keys this learning surface adds to the
+// `meta` envelope on the supported commands. DisableEnvVar and
+// DisableFlag are the disable controls.
+type agentContextLearning struct {
+	RecallCommand string   `json:"recall_command"`
+	TeachCommand  string   `json:"teach_command"`
+	AppliedIn     []string `json:"applied_in"`
+	MetaFields    []string `json:"meta_fields"`
+	DisableFlag   string   `json:"disable_flag"`
+	DisableEnvVar string   `json:"disable_env_var"`
 }
 
 // agentContextFreshness advertises the live-on-read price refresh
@@ -157,6 +179,14 @@ func buildAgentContext(rootCmd *cobra.Command) agentContext {
 			PriceSourceValues: []string{
 				priceSourceLive, priceSourceStale, priceSourceMixed, priceSourceIndex,
 			},
+		},
+		Learning: &agentContextLearning{
+			RecallCommand: "recall \"<query>\" --agent",
+			TeachCommand:  "teach --query \"<query>\" --resource <id> [--resource <id>...] &",
+			AppliedIn:     []string{"topic", "compare"},
+			MetaFields:    []string{"learnings_applied", "teach_hint"},
+			DisableFlag:   "--no-learn",
+			DisableEnvVar: noLearnEnvVar,
 		},
 	}
 }

--- a/library/payments/prediction-goat/internal/cli/compare.go
+++ b/library/payments/prediction-goat/internal/cli/compare.go
@@ -101,7 +101,19 @@ func newCompareCmd(flags *rootFlags) *cobra.Command {
 			// every PM and Kalshi compareVenue before we serialize the
 			// pairs. See freshness.go for the design.
 			outcome := refreshComparePairs(cmd.Context(), nil, pairs)
+			// Rerank layer: apply taught learnings before envelope assembly.
+			// compare is bilateral by design, so synthetic inserts are
+			// skipped; boosts reorder, hides drop. See teach.go.
+			var applied int
+			var hasHigh bool
+			if !noLearnActive(flags) {
+				pairs, applied, hasHigh = applyLearningsForCompare(cmd.Context(), db, topic, pairs)
+			}
 			meta := buildFreshnessMeta(outcome, indexSyncedAt(db))
+			if meta != nil {
+				meta.LearningsApplied = applied
+				meta.TeachHint = teachHintFor(topic, applied, hasHigh, len(pairs))
+			}
 			result := compareResult{Topic: topic, Pairs: pairs, Meta: meta}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {

--- a/library/payments/prediction-goat/internal/cli/compare.go
+++ b/library/payments/prediction-goat/internal/cli/compare.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -32,8 +33,9 @@ type compareVenue struct {
 }
 
 type compareResult struct {
-	Topic string        `json:"topic"`
-	Pairs []comparePair `json:"pairs"`
+	Topic string         `json:"topic"`
+	Pairs []comparePair  `json:"pairs"`
+	Meta  *freshnessMeta `json:"meta,omitempty"`
 }
 
 type rawMarket struct {
@@ -95,13 +97,23 @@ func newCompareCmd(flags *rootFlags) *cobra.Command {
 				return fmt.Errorf("compare: %w", err)
 			}
 			pairs := pairCompareMarkets(topic, pmMarkets, kalshiMarkets, limit)
-			result := compareResult{Topic: topic, Pairs: pairs}
+			// Live-on-read freshness: refresh the price-bearing fields on
+			// every PM and Kalshi compareVenue before we serialize the
+			// pairs. See freshness.go for the design.
+			outcome := refreshComparePairs(cmd.Context(), nil, pairs)
+			meta := buildFreshnessMeta(outcome, indexSyncedAt(db))
+			result := compareResult{Topic: topic, Pairs: pairs, Meta: meta}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {
 					return err
 				}
-			} else if err := printCompareTable(cmd.OutOrStdout(), pairs); err != nil {
-				return err
+			} else {
+				if err := printCompareTable(cmd.OutOrStdout(), pairs); err != nil {
+					return err
+				}
+				if footer := freshnessFooterLine(meta); footer != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), footer)
+				}
 			}
 			if len(pairs) == 0 {
 				return notFoundErr(fmt.Errorf("no Polymarket-Kalshi market pairs found for topic %q (try a broader query, or sync more data first)", topic))
@@ -190,6 +202,45 @@ func pairCompareMarkets(topic string, pmMarkets, kalshiMarkets []rawMarket, limi
 		}
 	}
 	return pairs
+}
+
+// refreshComparePairs batches every pair's PM and Kalshi sides by
+// venue, fires one live API call per venue, and overwrites the
+// price-bearing fields on the in-memory compareVenue values.
+// DeltaPct is recomputed from the refreshed prices so it never
+// reports a stale spread.
+func refreshComparePairs(ctx context.Context, fc freshnessClient, pairs []comparePair) refreshOutcome {
+	polySlugs := make([]string, 0, len(pairs))
+	kalshiTickers := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		if p.PM != nil {
+			polySlugs = append(polySlugs, p.PM.ID)
+		}
+		if p.Kalshi != nil {
+			kalshiTickers = append(kalshiTickers, p.Kalshi.ID)
+		}
+	}
+	outcome := refreshVenues(ctx, fc, polySlugs, kalshiTickers)
+	var dummyStatus string
+	for i := range pairs {
+		if pairs[i].PM != nil && outcome.PolymarketOK {
+			if v, ok := outcome.Polymarket[pairs[i].PM.ID]; ok {
+				applyLiveValuesIfPresent(v, &pairs[i].PM.YesProbability, &pairs[i].PM.Volume24h, &dummyStatus)
+			}
+		}
+		if pairs[i].Kalshi != nil && outcome.KalshiOK {
+			if v, ok := outcome.Kalshi[pairs[i].Kalshi.ID]; ok {
+				applyLiveValuesIfPresent(v, &pairs[i].Kalshi.YesProbability, &pairs[i].Kalshi.Volume24h, &dummyStatus)
+			}
+		}
+		// Recompute the spread from refreshed prices so DeltaPct never
+		// surfaces a stale value.
+		if pairs[i].PM != nil && pairs[i].Kalshi != nil {
+			delta := (pairs[i].PM.YesProbability - pairs[i].Kalshi.YesProbability) * 100
+			pairs[i].DeltaPct = &delta
+		}
+	}
+	return outcome
 }
 
 func rawMarketFromJSON(resourceType, fallbackID, raw string) (rawMarket, bool) {

--- a/library/payments/prediction-goat/internal/cli/compare.go
+++ b/library/payments/prediction-goat/internal/cli/compare.go
@@ -49,6 +49,7 @@ type rawMarket struct {
 func newCompareCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "compare <topic>",
 		Short: "Side-by-side Polymarket and Kalshi prices for a topic",
@@ -61,6 +62,16 @@ func newCompareCmd(flags *rootFlags) *cobra.Command {
 			}
 			if dryRunOK(flags) {
 				return nil
+			}
+			// compare is structurally cross-venue — it pairs PM markets with
+			// Kalshi markets. Scoping to one venue defeats the purpose; surface
+			// the conflict early instead of silently returning unpaired hits.
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
+			}
+			if venue != "all" {
+				return fmt.Errorf("compare requires both venues; use `topic <q> --%s` instead for a single-venue cross-section", venue)
 			}
 			if limit < 1 {
 				return fmt.Errorf("compare: --limit must be greater than zero")
@@ -100,6 +111,7 @@ func newCompareCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max pairs returned")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }
 

--- a/library/payments/prediction-goat/internal/cli/freshness.go
+++ b/library/payments/prediction-goat/internal/cli/freshness.go
@@ -71,6 +71,16 @@ const (
 type freshnessMeta struct {
 	PriceSource   string     `json:"price_source"`
 	IndexSyncedAt *time.Time `json:"index_synced_at,omitempty"`
+	// LearningsApplied is the count of search_learnings rules that
+	// touched the output of this command. 0 when the rerank layer ran
+	// but no rule fired; absent when --no-learn /
+	// PREDICTION_GOAT_NO_LEARN disabled the layer. See teach.go.
+	LearningsApplied int `json:"learnings_applied,omitempty"`
+	// TeachHint is set when the LLM should record a learning for the
+	// current query (no high-confidence boost already fired). Empty
+	// when no hint is warranted — e.g., a high-confidence row already
+	// covers this query, or no hits came back.
+	TeachHint string `json:"teach_hint,omitempty"`
 }
 
 // liveValues holds the price-bearing fields refreshed from upstream.

--- a/library/payments/prediction-goat/internal/cli/freshness.go
+++ b/library/payments/prediction-goat/internal/cli/freshness.go
@@ -1,0 +1,466 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+// freshness.go implements live-on-read price refresh for the discovery
+// commands (topic, compare, mispriced, trending, movers, resolving,
+// liquid, new). The local SQLite store is a discovery index — "which
+// markets exist" — but historically it also doubled as the price
+// source for yesProbability, yes_ask_dollars, volume_24h_fp, etc. That
+// is dangerous: a user asking "what are the odds Lakers win tonight"
+// could be served yesterday's cached prices with no signal they were
+// stale.
+//
+// After ranking produces N hits, group them by venue and issue ONE
+// batched API call per venue to refresh the price-bearing fields:
+//   - Polymarket /markets?slug=a&slug=b&...
+//   - Kalshi    /markets?tickers=a,b,c
+//
+// Replace the cached values on the in-memory hits before serialization.
+// If a live fetch fails (timeout, 5xx, etc.), mark the affected rows
+// with PriceSource="stale" and continue — the user still gets the
+// index answer with an explicit staleness flag rather than the whole
+// command failing.
+//
+// The result envelope on each command gains a `meta` field carrying
+// `index_synced_at` (read from sync_state.last_synced_at) and
+// `price_source` ("live", "stale", or "mixed" when one venue refreshed
+// and the other failed). Human-mode terminal stdout also prints a
+// one-line footer; --json/--agent mode does not, since the envelope
+// already carries the same information.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/source/kalshi"
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+// PriceSource enumerates the freshness state for a single hit (or for
+// a result bundle aggregated across hits).
+const (
+	priceSourceLive  = "live"  // the price-bearing fields were refreshed from the upstream API
+	priceSourceStale = "stale" // the refresh attempt failed; the cached value is what is being returned
+	priceSourceMixed = "mixed" // some venues refreshed, others did not
+	priceSourceIndex = "index" // the hit has no price-bearing fields (e.g., a tags/series row)
+)
+
+// freshnessMeta is the envelope-level freshness metadata attached to
+// every command that surfaces a price or implied probability. It is
+// the additive extension to the per-command result struct that the
+// plan calls for.
+//
+// IndexSyncedAt is the most recent sync_state.last_synced_at across
+// the price-bearing resource types ("markets", "kalshi_markets"). It
+// is the cache age for the discovery layer — an agent can use this
+// to decide whether to trigger a `sync` before a high-stakes query.
+//
+// PriceSource is "live" when every venue queried in this command
+// refreshed successfully; "stale" when none refreshed; "mixed" when
+// one venue succeeded and the other failed; "index" when no
+// price-bearing rows were returned at all (e.g., a topic query that
+// only matched tag rows).
+type freshnessMeta struct {
+	PriceSource   string     `json:"price_source"`
+	IndexSyncedAt *time.Time `json:"index_synced_at,omitempty"`
+}
+
+// liveValues holds the price-bearing fields refreshed from upstream.
+// Zero-valued fields signal "no fresh value available" — the caller
+// keeps whatever was already on the in-memory hit.
+type liveValues struct {
+	YesProbability float64
+	Volume24h      float64
+	Status         string
+}
+
+// hasValue reports whether at least one price-bearing field is set.
+// Used to suppress overwriting a cached non-zero value with a zero
+// live value (which happens when the upstream response omitted the
+// field entirely rather than reporting it as 0).
+func (v liveValues) hasValue() bool {
+	return v.YesProbability != 0 || v.Volume24h != 0 || v.Status != ""
+}
+
+// freshnessClient bundles the HTTP endpoints both venues hit. It is
+// an interface rather than a concrete struct so tests can swap in
+// httptest fixtures.
+type freshnessClient interface {
+	// FetchPolymarket returns the refreshed price-bearing fields for the
+	// given Polymarket slugs, keyed by slug. A non-nil error from the
+	// upstream API (5xx, timeout, parse failure) is treated as a
+	// per-venue refresh failure by the caller — slugs that the upstream
+	// response simply did not include drop out of the map silently.
+	FetchPolymarket(ctx context.Context, slugs []string) (map[string]liveValues, error)
+	// FetchKalshi returns the refreshed price-bearing fields for the
+	// given Kalshi tickers, keyed by ticker.
+	FetchKalshi(ctx context.Context, tickers []string) (map[string]liveValues, error)
+}
+
+// defaultFreshnessClient is the production implementation that hits
+// the live Polymarket gamma-api and Kalshi trade-api endpoints.
+type defaultFreshnessClient struct {
+	polymarketBaseURL string
+	httpClient        *http.Client
+	kalshiClient      *kalshi.Client
+}
+
+// newDefaultFreshnessClient returns a freshness client wired against
+// the production endpoints. The Kalshi client is the same package
+// already used by `kalshi events get --with-markets`; the Polymarket
+// path uses a direct net/http GET because the existing
+// internal/client.Client only accepts map[string]string for query
+// params (no repeated keys), and Polymarket's /markets endpoint
+// requires repeated `slug=` params for batch lookup.
+func newDefaultFreshnessClient() *defaultFreshnessClient {
+	return &defaultFreshnessClient{
+		polymarketBaseURL: "https://gamma-api.polymarket.com",
+		httpClient:        &http.Client{Timeout: 15 * time.Second},
+		kalshiClient:      kalshi.New(),
+	}
+}
+
+// FetchPolymarket issues a single GET against the Polymarket
+// `/markets` endpoint with repeated `slug=` query params and returns
+// a map keyed by slug. Slugs not present in the response (closed
+// market, typo, partial-page truncation) drop out silently — the
+// caller keeps the cached value and flags it as stale only if the
+// whole batched call errored.
+func (c *defaultFreshnessClient) FetchPolymarket(ctx context.Context, slugs []string) (map[string]liveValues, error) {
+	if len(slugs) == 0 {
+		return map[string]liveValues{}, nil
+	}
+	q := url.Values{}
+	for _, s := range slugs {
+		if s == "" {
+			continue
+		}
+		q.Add("slug", s)
+	}
+	// Cap limit to len(slugs) so a partial response is still complete
+	// for the requested slugs; gamma-api defaults to 100 otherwise.
+	q.Set("limit", fmt.Sprintf("%d", len(slugs)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.polymarketBaseURL+"/markets?"+q.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("polymarket freshness build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "prediction-goat-pp-cli/1.0 freshness")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("polymarket freshness GET: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("polymarket freshness read: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("polymarket freshness HTTP %d", resp.StatusCode)
+	}
+	return parsePolymarketLive(body)
+}
+
+// FetchKalshi issues a single GET against the Kalshi `/markets`
+// endpoint with `tickers=` set to a comma-separated list and returns
+// a map keyed by ticker. Reuses the existing kalshi.Client so adaptive
+// rate-limiting and 429 retry behavior match the sync path.
+func (c *defaultFreshnessClient) FetchKalshi(ctx context.Context, tickers []string) (map[string]liveValues, error) {
+	if len(tickers) == 0 {
+		return map[string]liveValues{}, nil
+	}
+	cleaned := make([]string, 0, len(tickers))
+	for _, t := range tickers {
+		if t != "" {
+			cleaned = append(cleaned, t)
+		}
+	}
+	if len(cleaned) == 0 {
+		return map[string]liveValues{}, nil
+	}
+	params := url.Values{}
+	params.Set("tickers", strings.Join(cleaned, ","))
+	params.Set("limit", fmt.Sprintf("%d", len(cleaned)))
+	body, err := c.kalshiClient.Get(ctx, "/markets", params)
+	if err != nil {
+		return nil, fmt.Errorf("kalshi freshness GET: %w", err)
+	}
+	return parseKalshiLive(body)
+}
+
+// parsePolymarketLive decodes the gamma-api /markets response (either
+// a top-level array, or a wrapped {markets:[...]} envelope) and
+// returns the price-bearing fields keyed by slug.
+func parsePolymarketLive(body []byte) (map[string]liveValues, error) {
+	// gamma-api currently returns a bare JSON array. Tolerate a
+	// wrapped {markets:[...]} envelope too in case the shape changes.
+	var arr []map[string]any
+	if err := json.Unmarshal(body, &arr); err != nil {
+		var envelope struct {
+			Markets []map[string]any `json:"markets"`
+		}
+		if err2 := json.Unmarshal(body, &envelope); err2 != nil {
+			return nil, fmt.Errorf("polymarket freshness decode: %w", err)
+		}
+		arr = envelope.Markets
+	}
+	out := make(map[string]liveValues, len(arr))
+	for _, obj := range arr {
+		slug := jsonString(obj, "slug")
+		if slug == "" {
+			continue
+		}
+		out[slug] = liveValues{
+			YesProbability: jsonFloat(obj, "lastTradePrice"),
+			Volume24h:      firstFloat(obj, "volume24hr", "volumeNum"),
+			Status:         pmStatus(obj),
+		}
+	}
+	return out, nil
+}
+
+// parseKalshiLive decodes the Kalshi /markets response and returns
+// the price-bearing fields keyed by ticker.
+func parseKalshiLive(body []byte) (map[string]liveValues, error) {
+	var resp struct {
+		Markets []map[string]any `json:"markets"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("kalshi freshness decode: %w", err)
+	}
+	out := make(map[string]liveValues, len(resp.Markets))
+	for _, obj := range resp.Markets {
+		ticker := jsonString(obj, "ticker")
+		if ticker == "" {
+			continue
+		}
+		out[ticker] = liveValues{
+			YesProbability: jsonFloat(obj, "last_price_dollars"),
+			Volume24h:      jsonFloat(obj, "volume_24h_fp"),
+			Status:         jsonString(obj, "status"),
+		}
+	}
+	return out, nil
+}
+
+// refreshOutcome captures the per-venue refresh result. Each command
+// reads this to set the envelope-level price_source string and to
+// decide which hits to mark as stale.
+type refreshOutcome struct {
+	Polymarket map[string]liveValues
+	Kalshi     map[string]liveValues
+	// PolymarketOK / KalshiOK report whether the batched fetch
+	// succeeded for the venue. A nil/empty map with PolymarketOK=true
+	// means "we asked and the upstream returned nothing", which is
+	// not a refresh failure — the cached value stays.
+	PolymarketOK bool
+	KalshiOK     bool
+	// PolymarketAsked / KalshiAsked report whether the command had any
+	// hits for the venue at all. A venue that was not asked does not
+	// contribute to the price_source aggregate.
+	PolymarketAsked bool
+	KalshiAsked     bool
+}
+
+// priceSourceLabel computes the envelope-level price_source for the
+// command from the per-venue outcome. Rules:
+//   - No venue asked → "index" (the result has no price-bearing rows).
+//   - Every asked venue refreshed → "live".
+//   - No asked venue refreshed → "stale".
+//   - Some asked venues refreshed, others didn't → "mixed".
+func (o refreshOutcome) priceSourceLabel() string {
+	asked := 0
+	ok := 0
+	if o.PolymarketAsked {
+		asked++
+		if o.PolymarketOK {
+			ok++
+		}
+	}
+	if o.KalshiAsked {
+		asked++
+		if o.KalshiOK {
+			ok++
+		}
+	}
+	switch {
+	case asked == 0:
+		return priceSourceIndex
+	case ok == asked:
+		return priceSourceLive
+	case ok == 0:
+		return priceSourceStale
+	default:
+		return priceSourceMixed
+	}
+}
+
+// refreshVenues runs the per-venue refresh fetches in parallel and
+// returns the merged outcome. A nil client falls back to the
+// production-wired implementation.
+func refreshVenues(ctx context.Context, fc freshnessClient, polySlugs, kalshiTickers []string) refreshOutcome {
+	if fc == nil {
+		fc = newDefaultFreshnessClient()
+	}
+	out := refreshOutcome{
+		PolymarketAsked: len(polySlugs) > 0,
+		KalshiAsked:     len(kalshiTickers) > 0,
+	}
+	var wg sync.WaitGroup
+	if out.PolymarketAsked {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			values, err := fc.FetchPolymarket(ctx, polySlugs)
+			if err == nil {
+				out.Polymarket = values
+				out.PolymarketOK = true
+			}
+		}()
+	}
+	if out.KalshiAsked {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			values, err := fc.FetchKalshi(ctx, kalshiTickers)
+			if err == nil {
+				out.Kalshi = values
+				out.KalshiOK = true
+			}
+		}()
+	}
+	wg.Wait()
+	return out
+}
+
+// indexSyncedAt returns the most recent sync_state.last_synced_at
+// across the price-bearing resource types. Used to populate
+// meta.index_synced_at on the envelope. Returns nil when no sync has
+// run yet (the price-bearing tables are empty, so a topic command
+// would have returned zero hits anyway — but the envelope still
+// surfaces the absence as null rather than synthesizing a fake age).
+func indexSyncedAt(db *store.Store) *time.Time {
+	if db == nil {
+		return nil
+	}
+	var latest time.Time
+	for _, rt := range []string{"markets", "kalshi_markets"} {
+		_, ts, _, err := db.GetSyncState(rt)
+		if err != nil {
+			continue
+		}
+		if ts.IsZero() {
+			continue
+		}
+		if latest.IsZero() || ts.After(latest) {
+			latest = ts
+		}
+	}
+	if latest.IsZero() {
+		return nil
+	}
+	return &latest
+}
+
+// indexSyncedAtFromPath opens the local store at the given path (or
+// the default) just long enough to read the most recent sync_state
+// timestamp. Used by commands that already closed their store handle
+// before building the response envelope.
+func indexSyncedAtFromPath(ctx context.Context, dbPath string) *time.Time {
+	if dbPath == "" {
+		dbPath = defaultDBPath("prediction-goat-pp-cli")
+	}
+	db, err := store.OpenWithContext(ctx, dbPath)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+	return indexSyncedAt(db)
+}
+
+// buildFreshnessMeta returns the envelope-level metadata for a
+// command given the venue-refresh outcome and the local store's
+// sync state.
+func buildFreshnessMeta(outcome refreshOutcome, syncedAt *time.Time) *freshnessMeta {
+	return &freshnessMeta{
+		PriceSource:   outcome.priceSourceLabel(),
+		IndexSyncedAt: syncedAt,
+	}
+}
+
+// freshnessFooterLine returns the human-mode "Index synced 14h ago,
+// prices live" footer for the given meta. Returns the empty string
+// when the meta carries no useful information (no sync, no price
+// source) — callers should suppress the print rather than emitting a
+// confusing "Index never synced, prices index" line.
+//
+// Machine-format modes (--json, --csv, --quiet, --plain, --compact,
+// piped stdout) MUST NOT print this footer; the JSON envelope's meta
+// already carries the same information. See each command's render
+// path for the gate.
+func freshnessFooterLine(meta *freshnessMeta) string {
+	if meta == nil {
+		return ""
+	}
+	switch meta.PriceSource {
+	case priceSourceLive, priceSourceStale, priceSourceMixed:
+	default:
+		return ""
+	}
+	age := "never synced"
+	if meta.IndexSyncedAt != nil {
+		age = humanIndexAge(time.Since(*meta.IndexSyncedAt)) + " ago"
+	}
+	label := "prices live"
+	switch meta.PriceSource {
+	case priceSourceStale:
+		label = "prices stale (live refresh failed)"
+	case priceSourceMixed:
+		label = "prices mixed (one venue refresh failed)"
+	}
+	return fmt.Sprintf("Index synced %s, %s", age, label)
+}
+
+// humanIndexAge renders a duration in a one-line human-readable form
+// for the cache-age footer. Tracks the existing convention in
+// printProvenance for consistency.
+func humanIndexAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// applyLiveValuesIfPresent updates dst with v's price-bearing fields
+// when v carries fresh data. Callers pass per-field pointers so the
+// command's per-shape hit struct stays the source of truth for what
+// is a price-bearing field on this command. A zero v (no fresh
+// value) leaves dst untouched.
+func applyLiveValuesIfPresent(v liveValues, yesProb, volume *float64, status *string) {
+	if !v.hasValue() {
+		return
+	}
+	if v.YesProbability != 0 && yesProb != nil {
+		*yesProb = v.YesProbability
+	}
+	if v.Volume24h != 0 && volume != nil {
+		*volume = v.Volume24h
+	}
+	if v.Status != "" && status != nil {
+		*status = v.Status
+	}
+}

--- a/library/payments/prediction-goat/internal/cli/freshness_test.go
+++ b/library/payments/prediction-goat/internal/cli/freshness_test.go
@@ -1,0 +1,601 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/source/kalshi"
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+// fakeFreshnessClient is a hand-written stub so tests don't have to
+// spin up a real httptest server for every refresh case. The httptest
+// server is exercised by TestDefaultFreshnessClient_FetchPolymarket /
+// _FetchKalshi below to pin the URL shape and decoding.
+type fakeFreshnessClient struct {
+	pmReturn      map[string]liveValues
+	pmErr         error
+	ksReturn      map[string]liveValues
+	ksErr         error
+	pmSlugsAsked  []string
+	ksTickerAsked []string
+}
+
+func (f *fakeFreshnessClient) FetchPolymarket(ctx context.Context, slugs []string) (map[string]liveValues, error) {
+	f.pmSlugsAsked = append(f.pmSlugsAsked, slugs...)
+	if f.pmErr != nil {
+		return nil, f.pmErr
+	}
+	return f.pmReturn, nil
+}
+
+func (f *fakeFreshnessClient) FetchKalshi(ctx context.Context, tickers []string) (map[string]liveValues, error) {
+	f.ksTickerAsked = append(f.ksTickerAsked, tickers...)
+	if f.ksErr != nil {
+		return nil, f.ksErr
+	}
+	return f.ksReturn, nil
+}
+
+// TestRefreshTopicHits_OverwritesPolymarketWithLiveValue covers the
+// canonical regression scenario from the plan: a cached Polymarket
+// markets row with lastTradePrice=0.05 returns YesProbability matching
+// the live API value when topic queries it.
+func TestRefreshTopicHits_OverwritesPolymarketWithLiveValue(t *testing.T) {
+	t.Parallel()
+	hits := []topicHit{
+		{Source: "polymarket", Kind: "market", ID: "lakers-tonight", Title: "Lakers win tonight", YesProbability: 0.05, Volume24h: 1000},
+	}
+	fc := &fakeFreshnessClient{
+		pmReturn: map[string]liveValues{
+			"lakers-tonight": {YesProbability: 0.55, Volume24h: 9999, Status: "active"},
+		},
+	}
+	outcome := refreshTopicHits(context.Background(), fc, hits)
+	if hits[0].YesProbability != 0.55 {
+		t.Errorf("YesProbability = %v, want 0.55 (cached value was not overwritten)", hits[0].YesProbability)
+	}
+	if hits[0].Volume24h != 9999 {
+		t.Errorf("Volume24h = %v, want 9999", hits[0].Volume24h)
+	}
+	if hits[0].PriceSource != priceSourceLive {
+		t.Errorf("PriceSource = %q, want %q", hits[0].PriceSource, priceSourceLive)
+	}
+	if !outcome.PolymarketOK {
+		t.Error("outcome.PolymarketOK = false, want true")
+	}
+	if outcome.priceSourceLabel() != priceSourceLive {
+		t.Errorf("priceSourceLabel = %q, want live", outcome.priceSourceLabel())
+	}
+}
+
+// TestRefreshTopicHits_OverwritesKalshiWithLiveValue mirrors the
+// Polymarket case for a Kalshi cached row.
+func TestRefreshTopicHits_OverwritesKalshiWithLiveValue(t *testing.T) {
+	t.Parallel()
+	hits := []topicHit{
+		{Source: "kalshi", Kind: "market", ID: "KXPT-26", Title: "Portugal win", YesProbability: 0.085},
+	}
+	fc := &fakeFreshnessClient{
+		ksReturn: map[string]liveValues{
+			"KXPT-26": {YesProbability: 0.098, Volume24h: 1234},
+		},
+	}
+	outcome := refreshTopicHits(context.Background(), fc, hits)
+	if hits[0].YesProbability != 0.098 {
+		t.Errorf("YesProbability = %v, want 0.098", hits[0].YesProbability)
+	}
+	if hits[0].PriceSource != priceSourceLive {
+		t.Errorf("PriceSource = %q, want live", hits[0].PriceSource)
+	}
+	if !outcome.KalshiOK {
+		t.Error("outcome.KalshiOK = false, want true")
+	}
+}
+
+// TestRefreshTopicHits_OneVenueFailureDegradesOnlyThatVenue covers
+// the plan's degrade-on-failure contract: when the Polymarket refresh
+// fails, only its rows get price_source="stale" and Kalshi rows
+// remain "live".
+func TestRefreshTopicHits_OneVenueFailureDegradesOnlyThatVenue(t *testing.T) {
+	t.Parallel()
+	hits := []topicHit{
+		{Source: "polymarket", Kind: "market", ID: "trump-2028", YesProbability: 0.42},
+		{Source: "kalshi", Kind: "market", ID: "KXPT-26", YesProbability: 0.10},
+	}
+	fc := &fakeFreshnessClient{
+		pmErr: errors.New("upstream 503"),
+		ksReturn: map[string]liveValues{
+			"KXPT-26": {YesProbability: 0.18},
+		},
+	}
+	outcome := refreshTopicHits(context.Background(), fc, hits)
+	// Polymarket row should be flagged stale and keep its cached value.
+	if hits[0].PriceSource != priceSourceStale {
+		t.Errorf("PM PriceSource = %q, want stale", hits[0].PriceSource)
+	}
+	if hits[0].YesProbability != 0.42 {
+		t.Errorf("PM YesProbability = %v, want 0.42 (cached) (stale flag must not erase the cached value)", hits[0].YesProbability)
+	}
+	// Kalshi row should be live and overwritten.
+	if hits[1].PriceSource != priceSourceLive {
+		t.Errorf("KS PriceSource = %q, want live", hits[1].PriceSource)
+	}
+	if hits[1].YesProbability != 0.18 {
+		t.Errorf("KS YesProbability = %v, want 0.18 (live)", hits[1].YesProbability)
+	}
+	// Envelope-level label should be "mixed" since one venue succeeded
+	// and one failed.
+	if got := outcome.priceSourceLabel(); got != priceSourceMixed {
+		t.Errorf("priceSourceLabel = %q, want mixed", got)
+	}
+}
+
+// TestRefreshTopicHits_NonMarketKindHasNoPriceSource pins the
+// contract that tag/event/series rows leave price_source empty so an
+// agent can tell a tag-row apart from a market-row whose refresh
+// failed.
+func TestRefreshTopicHits_NonMarketKindHasNoPriceSource(t *testing.T) {
+	t.Parallel()
+	hits := []topicHit{
+		{Source: "polymarket", Kind: "tag", ID: "elections"},
+		{Source: "kalshi", Kind: "series", ID: "KXMENWORLDCUP"},
+	}
+	fc := &fakeFreshnessClient{}
+	refreshTopicHits(context.Background(), fc, hits)
+	for i, h := range hits {
+		if h.PriceSource != "" {
+			t.Errorf("hits[%d] (kind=%s) PriceSource = %q, want empty", i, h.Kind, h.PriceSource)
+		}
+	}
+}
+
+// TestRefreshTopicHits_AllVenuesFailureLabelsStale covers the
+// envelope-level rollup when both venues' refresh attempts fail.
+func TestRefreshTopicHits_AllVenuesFailureLabelsStale(t *testing.T) {
+	t.Parallel()
+	hits := []topicHit{
+		{Source: "polymarket", Kind: "market", ID: "a", YesProbability: 0.1},
+		{Source: "kalshi", Kind: "market", ID: "b", YesProbability: 0.2},
+	}
+	fc := &fakeFreshnessClient{pmErr: errors.New("timeout"), ksErr: errors.New("timeout")}
+	outcome := refreshTopicHits(context.Background(), fc, hits)
+	if got := outcome.priceSourceLabel(); got != priceSourceStale {
+		t.Errorf("priceSourceLabel = %q, want stale", got)
+	}
+	if hits[0].PriceSource != priceSourceStale || hits[1].PriceSource != priceSourceStale {
+		t.Errorf("per-row PriceSource not stale: %v / %v", hits[0].PriceSource, hits[1].PriceSource)
+	}
+}
+
+// TestRefreshOutcome_PriceSourceLabel pins the per-venue label
+// aggregate against every (asked, ok) combination.
+func TestRefreshOutcome_PriceSourceLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		o    refreshOutcome
+		want string
+	}{
+		{"neither asked", refreshOutcome{}, priceSourceIndex},
+		{"only pm asked + ok", refreshOutcome{PolymarketAsked: true, PolymarketOK: true}, priceSourceLive},
+		{"only pm asked + failed", refreshOutcome{PolymarketAsked: true, PolymarketOK: false}, priceSourceStale},
+		{"both asked + both ok", refreshOutcome{PolymarketAsked: true, PolymarketOK: true, KalshiAsked: true, KalshiOK: true}, priceSourceLive},
+		{"both asked + pm failed", refreshOutcome{PolymarketAsked: true, PolymarketOK: false, KalshiAsked: true, KalshiOK: true}, priceSourceMixed},
+		{"both asked + both failed", refreshOutcome{PolymarketAsked: true, KalshiAsked: true}, priceSourceStale},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.o.priceSourceLabel(); got != c.want {
+				t.Errorf("priceSourceLabel = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestParsePolymarketLive_DecodesArray covers the canonical gamma-api
+// response shape (bare JSON array) and confirms slug→liveValues
+// mapping.
+func TestParsePolymarketLive_DecodesArray(t *testing.T) {
+	t.Parallel()
+	body := []byte(`[{"slug":"foo","lastTradePrice":0.42,"volume24hr":1000,"closed":false,"active":true},{"slug":"bar","lastTradePrice":0.08,"volumeNum":500,"closed":true}]`)
+	got, err := parsePolymarketLive(body)
+	if err != nil {
+		t.Fatalf("parsePolymarketLive: %v", err)
+	}
+	if got["foo"].YesProbability != 0.42 {
+		t.Errorf("foo.YesProbability = %v, want 0.42", got["foo"].YesProbability)
+	}
+	if got["foo"].Volume24h != 1000 {
+		t.Errorf("foo.Volume24h = %v, want 1000", got["foo"].Volume24h)
+	}
+	if got["bar"].YesProbability != 0.08 {
+		t.Errorf("bar.YesProbability = %v, want 0.08", got["bar"].YesProbability)
+	}
+	if got["bar"].Volume24h != 500 {
+		t.Errorf("bar.Volume24h = %v, want 500", got["bar"].Volume24h)
+	}
+}
+
+// TestParseKalshiLive_DecodesEnvelope covers the canonical Kalshi
+// /markets envelope shape and confirms ticker→liveValues mapping.
+func TestParseKalshiLive_DecodesEnvelope(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"markets":[{"ticker":"KXA","last_price_dollars":0.61,"volume_24h_fp":12345,"status":"active"},{"ticker":"KXB","last_price_dollars":0.09,"volume_24h_fp":777,"status":"settled"}]}`)
+	got, err := parseKalshiLive(body)
+	if err != nil {
+		t.Fatalf("parseKalshiLive: %v", err)
+	}
+	if got["KXA"].YesProbability != 0.61 {
+		t.Errorf("KXA.YesProbability = %v, want 0.61", got["KXA"].YesProbability)
+	}
+	if got["KXA"].Status != "active" {
+		t.Errorf("KXA.Status = %q, want active", got["KXA"].Status)
+	}
+	if got["KXB"].YesProbability != 0.09 {
+		t.Errorf("KXB.YesProbability = %v, want 0.09", got["KXB"].YesProbability)
+	}
+}
+
+// TestDefaultFreshnessClient_FetchPolymarket_HitsExpectedURL pins the
+// URL shape the Polymarket refresh hits — repeated slug= query
+// params, not slugs=. Uses httptest so a regression that switches to
+// the wrong shape fails here rather than silently returning empty
+// from the live API.
+func TestDefaultFreshnessClient_FetchPolymarket_HitsExpectedURL(t *testing.T) {
+	t.Parallel()
+	var captured *url.URL
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[{"slug":"a","lastTradePrice":0.7},{"slug":"b","lastTradePrice":0.3}]`)
+	}))
+	defer srv.Close()
+	fc := &defaultFreshnessClient{
+		polymarketBaseURL: srv.URL,
+		httpClient:        srv.Client(),
+		kalshiClient:      kalshi.New(),
+	}
+	got, err := fc.FetchPolymarket(context.Background(), []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("FetchPolymarket: %v", err)
+	}
+	if got["a"].YesProbability != 0.7 || got["b"].YesProbability != 0.3 {
+		t.Errorf("returned values wrong: %+v", got)
+	}
+	if captured == nil {
+		t.Fatal("request did not reach test server")
+	}
+	if !strings.HasPrefix(captured.Path, "/markets") {
+		t.Errorf("path = %q, want /markets prefix", captured.Path)
+	}
+	q := captured.Query()
+	slugs := q["slug"]
+	if len(slugs) != 2 || slugs[0] != "a" || slugs[1] != "b" {
+		t.Errorf("slug query params = %v, want [a b]", slugs)
+	}
+}
+
+// TestDefaultFreshnessClient_FetchPolymarket_SkipsOn5xx pins the
+// degrade-not-fail contract: a 5xx from the upstream returns an
+// error so the caller can flag rows as stale rather than the whole
+// command failing.
+func TestDefaultFreshnessClient_FetchPolymarket_SkipsOn5xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	fc := &defaultFreshnessClient{
+		polymarketBaseURL: srv.URL,
+		httpClient:        srv.Client(),
+		kalshiClient:      kalshi.New(),
+	}
+	_, err := fc.FetchPolymarket(context.Background(), []string{"a"})
+	if err == nil {
+		t.Fatal("expected error on 5xx, got nil")
+	}
+}
+
+// TestDefaultFreshnessClient_FetchKalshi_HitsExpectedURL pins the
+// URL shape the Kalshi refresh hits — tickers= comma-separated, not
+// repeated ticker= params.
+func TestDefaultFreshnessClient_FetchKalshi_HitsExpectedURL(t *testing.T) {
+	t.Parallel()
+	var captured *url.URL
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"markets":[{"ticker":"KXA","last_price_dollars":0.5}]}`)
+	}))
+	defer srv.Close()
+	ksClient := kalshi.New()
+	ksClient.BaseURL = srv.URL
+	ksClient.HTTPClient = srv.Client()
+	fc := &defaultFreshnessClient{
+		polymarketBaseURL: "unused",
+		httpClient:        srv.Client(),
+		kalshiClient:      ksClient,
+	}
+	got, err := fc.FetchKalshi(context.Background(), []string{"KXA", "KXB"})
+	if err != nil {
+		t.Fatalf("FetchKalshi: %v", err)
+	}
+	if got["KXA"].YesProbability != 0.5 {
+		t.Errorf("KXA.YesProbability = %v, want 0.5", got["KXA"].YesProbability)
+	}
+	if captured == nil {
+		t.Fatal("request did not reach test server")
+	}
+	if got, want := captured.Query().Get("tickers"), "KXA,KXB"; got != want {
+		t.Errorf("tickers query param = %q, want %q", got, want)
+	}
+}
+
+// TestIndexSyncedAt_PopulatesFromMostRecentSyncState writes two rows
+// to sync_state and confirms indexSyncedAt returns the later of the
+// two timestamps for the price-bearing tables.
+func TestIndexSyncedAt_PopulatesFromMostRecentSyncState(t *testing.T) {
+	t.Parallel()
+	tmp := filepath.Join(t.TempDir(), "data.db")
+	db, err := store.Open(tmp)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	defer db.Close()
+	// kalshi_markets synced just now; markets synced a long time ago.
+	// The later of the two wins.
+	if err := db.SaveSyncState("kalshi_markets", "", 100); err != nil {
+		t.Fatalf("SaveSyncState kalshi_markets: %v", err)
+	}
+	now := time.Now()
+	got := indexSyncedAt(db)
+	if got == nil {
+		t.Fatal("indexSyncedAt = nil, want non-nil")
+	}
+	// Confirm it landed within a small window of now (SaveSyncState
+	// uses time.Now()).
+	if got.Before(now.Add(-2*time.Minute)) || got.After(now.Add(2*time.Minute)) {
+		t.Errorf("indexSyncedAt = %v, want near %v", *got, now)
+	}
+}
+
+// TestIndexSyncedAt_NilWhenNoSyncStateRows returns nil when no
+// sync has run, so the envelope surfaces "never synced" rather than
+// the zero-value time.Time.
+func TestIndexSyncedAt_NilWhenNoSyncStateRows(t *testing.T) {
+	t.Parallel()
+	tmp := filepath.Join(t.TempDir(), "data.db")
+	db, err := store.Open(tmp)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	defer db.Close()
+	if got := indexSyncedAt(db); got != nil {
+		t.Errorf("indexSyncedAt = %v, want nil", got)
+	}
+}
+
+// TestFreshnessFooterLine_IncludesAgeAndSource sanity-checks the
+// human-mode footer string.
+func TestFreshnessFooterLine_IncludesAgeAndSource(t *testing.T) {
+	t.Parallel()
+	syncedAt := time.Now().Add(-14 * time.Hour)
+	meta := &freshnessMeta{PriceSource: priceSourceLive, IndexSyncedAt: &syncedAt}
+	got := freshnessFooterLine(meta)
+	if !strings.Contains(got, "Index synced") || !strings.Contains(got, "prices live") {
+		t.Errorf("footer = %q, want both 'Index synced' and 'prices live'", got)
+	}
+}
+
+// TestFreshnessFooterLine_EmptyOnIndexOnly suppresses the footer for
+// no-price-bearing-rows results (an index-only response with no
+// markets), since the "prices live" suffix would be misleading.
+func TestFreshnessFooterLine_EmptyOnIndexOnly(t *testing.T) {
+	t.Parallel()
+	meta := &freshnessMeta{PriceSource: priceSourceIndex}
+	if got := freshnessFooterLine(meta); got != "" {
+		t.Errorf("footer = %q, want empty", got)
+	}
+}
+
+// TestTopicResult_MetaSurfacesInJSON pins the JSON envelope shape:
+// `meta.price_source` and `meta.index_synced_at` are visible on a
+// topicResult marshalled to JSON, so agents can read them without
+// the human-mode footer.
+func TestTopicResult_MetaSurfacesInJSON(t *testing.T) {
+	t.Parallel()
+	syncedAt := time.Date(2026, 5, 23, 14, 0, 0, 0, time.UTC)
+	result := topicResult{
+		Topic: "lakers",
+		Count: 0,
+		Hits:  []topicHit{},
+		Meta:  &freshnessMeta{PriceSource: priceSourceLive, IndexSyncedAt: &syncedAt},
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	meta, ok := decoded["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta not a map, got %T (raw=%s)", decoded["meta"], string(raw))
+	}
+	if meta["price_source"] != priceSourceLive {
+		t.Errorf("meta.price_source = %v, want %q", meta["price_source"], priceSourceLive)
+	}
+	if _, ok := meta["index_synced_at"]; !ok {
+		t.Errorf("meta missing index_synced_at: %v", meta)
+	}
+}
+
+// TestRefreshComparePairs_RecomputesDelta covers the contract that
+// the compare DeltaPct is recomputed from refreshed prices so it
+// never reports a stale spread.
+func TestRefreshComparePairs_RecomputesDelta(t *testing.T) {
+	t.Parallel()
+	cachedDelta := 5.0
+	pairs := []comparePair{{
+		Topic:    "world cup",
+		PM:       &compareVenue{ID: "pt-pm", YesProbability: 0.10},
+		Kalshi:   &compareVenue{ID: "KXPT-26", YesProbability: 0.05},
+		DeltaPct: &cachedDelta,
+	}}
+	fc := &fakeFreshnessClient{
+		pmReturn: map[string]liveValues{"pt-pm": {YesProbability: 0.20}},
+		ksReturn: map[string]liveValues{"KXPT-26": {YesProbability: 0.08}},
+	}
+	refreshComparePairs(context.Background(), fc, pairs)
+	if pairs[0].PM.YesProbability != 0.20 {
+		t.Errorf("PM = %v, want 0.20", pairs[0].PM.YesProbability)
+	}
+	if pairs[0].Kalshi.YesProbability != 0.08 {
+		t.Errorf("Kalshi = %v, want 0.08", pairs[0].Kalshi.YesProbability)
+	}
+	if pairs[0].DeltaPct == nil {
+		t.Fatal("DeltaPct = nil")
+	}
+	// New spread should be (0.20 - 0.08) * 100 = 12.0
+	if got := *pairs[0].DeltaPct; got < 11.99 || got > 12.01 {
+		t.Errorf("DeltaPct = %v, want ~12.0 (live spread)", got)
+	}
+}
+
+// TestRefreshMispricedPairs_DropsPairsThatFallBelowThresholdLive
+// covers the contract that pairs whose spread falls below the
+// user-supplied threshold under refreshed prices are filtered out
+// of the result.
+func TestRefreshMispricedPairs_DropsPairsThatFallBelowThresholdLive(t *testing.T) {
+	t.Parallel()
+	result := &mispricedResult{
+		Threshold: 0.10,
+		Pairs: []mispricedPair{
+			{PM: compareVenue{ID: "a-pm", YesProbability: 0.30}, Kalshi: compareVenue{ID: "a-ks", YesProbability: 0.10}, Delta: 0.20},
+			{PM: compareVenue{ID: "b-pm", YesProbability: 0.50}, Kalshi: compareVenue{ID: "b-ks", YesProbability: 0.40}, Delta: 0.10},
+		},
+	}
+	fc := &fakeFreshnessClient{
+		pmReturn: map[string]liveValues{
+			"a-pm": {YesProbability: 0.35}, // refreshed: still over threshold (0.35 - 0.10 = 0.25)
+			"b-pm": {YesProbability: 0.41}, // refreshed: closes to 0.01 spread → drop
+		},
+		ksReturn: map[string]liveValues{
+			"a-ks": {YesProbability: 0.10},
+			"b-ks": {YesProbability: 0.40},
+		},
+	}
+	refreshMispricedPairs(context.Background(), fc, result, 0.10)
+	if len(result.Pairs) != 1 {
+		t.Fatalf("Pairs len = %d, want 1 (the b-pm row should be dropped under refreshed prices)", len(result.Pairs))
+	}
+	if result.Pairs[0].PM.ID != "a-pm" {
+		t.Errorf("surviving pair PM.ID = %q, want a-pm", result.Pairs[0].PM.ID)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1", result.Count)
+	}
+}
+
+// TestRefreshMarketScreenItems_FlagsStaleWhenVenueFails covers the
+// degrade-not-fail contract on the shared trending/movers/resolving/
+// liquid/new path.
+func TestRefreshMarketScreenItems_FlagsStaleWhenVenueFails(t *testing.T) {
+	t.Parallel()
+	items := []marketScreenItem{
+		{Source: "polymarket", ID: "pm-1", YesProbability: 0.1},
+		{Source: "kalshi", ID: "kx-1", YesProbability: 0.2},
+	}
+	fc := &fakeFreshnessClient{
+		pmErr: errors.New("upstream timeout"),
+		ksReturn: map[string]liveValues{
+			"kx-1": {YesProbability: 0.99},
+		},
+	}
+	outcome := refreshMarketScreenItems(context.Background(), fc, items)
+	if items[0].PriceSource != priceSourceStale {
+		t.Errorf("pm-1 PriceSource = %q, want stale", items[0].PriceSource)
+	}
+	if items[0].YesProbability != 0.1 {
+		t.Errorf("pm-1 YesProbability = %v, want 0.1 (cached)", items[0].YesProbability)
+	}
+	if items[1].PriceSource != priceSourceLive {
+		t.Errorf("kx-1 PriceSource = %q, want live", items[1].PriceSource)
+	}
+	if items[1].YesProbability != 0.99 {
+		t.Errorf("kx-1 YesProbability = %v, want 0.99", items[1].YesProbability)
+	}
+	if got := outcome.priceSourceLabel(); got != priceSourceMixed {
+		t.Errorf("priceSourceLabel = %q, want mixed", got)
+	}
+}
+
+// TestRefreshMoversItems_OverwritesCurrentPrice covers the movers
+// shape: CurrentPrice (not YesProbability) is the price-bearing
+// field; the refresh must overwrite it.
+func TestRefreshMoversItems_OverwritesCurrentPrice(t *testing.T) {
+	t.Parallel()
+	items := []moversItem{
+		{Source: "polymarket", ID: "x", CurrentPrice: 0.1, Volume24h: 100},
+	}
+	fc := &fakeFreshnessClient{
+		pmReturn: map[string]liveValues{"x": {YesProbability: 0.42, Volume24h: 200}},
+	}
+	refreshMoversItems(context.Background(), fc, items)
+	if items[0].CurrentPrice != 0.42 {
+		t.Errorf("CurrentPrice = %v, want 0.42 (movers maps YesProbability live value to CurrentPrice)", items[0].CurrentPrice)
+	}
+	if items[0].Volume24h != 200 {
+		t.Errorf("Volume24h = %v, want 200", items[0].Volume24h)
+	}
+	if items[0].PriceSource != priceSourceLive {
+		t.Errorf("PriceSource = %q, want live", items[0].PriceSource)
+	}
+}
+
+// TestRefreshVenues_EmptySlicesNeverCallTheClient suppresses upstream
+// traffic when there are no hits for a venue.
+func TestRefreshVenues_EmptySlicesNeverCallTheClient(t *testing.T) {
+	t.Parallel()
+	fc := &fakeFreshnessClient{
+		pmReturn: map[string]liveValues{},
+		ksReturn: map[string]liveValues{},
+	}
+	o := refreshVenues(context.Background(), fc, nil, nil)
+	if o.PolymarketAsked || o.KalshiAsked {
+		t.Errorf("asked flags = (%v, %v), want both false", o.PolymarketAsked, o.KalshiAsked)
+	}
+	if got := o.priceSourceLabel(); got != priceSourceIndex {
+		t.Errorf("priceSourceLabel = %q, want index", got)
+	}
+	if len(fc.pmSlugsAsked) != 0 || len(fc.ksTickerAsked) != 0 {
+		t.Errorf("client was called: pm=%v ks=%v", fc.pmSlugsAsked, fc.ksTickerAsked)
+	}
+}
+
+// TestApplyLiveValuesIfPresent_KeepsCachedWhenLiveZero pins that a
+// zero live value (upstream omitted the field) does not overwrite a
+// cached non-zero value.
+func TestApplyLiveValuesIfPresent_KeepsCachedWhenLiveZero(t *testing.T) {
+	t.Parallel()
+	yes := 0.5
+	vol := 1000.0
+	status := "active"
+	applyLiveValuesIfPresent(liveValues{}, &yes, &vol, &status)
+	if yes != 0.5 || vol != 1000.0 || status != "active" {
+		t.Errorf("zero liveValues overwrote cached values: yes=%v vol=%v status=%q", yes, vol, status)
+	}
+}

--- a/library/payments/prediction-goat/internal/cli/kalshi_events.go
+++ b/library/payments/prediction-goat/internal/cli/kalshi_events.go
@@ -27,13 +27,13 @@ func newKalshiEventsCmd(flags *rootFlags) *cobra.Command {
 }
 
 func newKalshiEventsListCmd(flags *rootFlags) *cobra.Command {
-	var cursor, dbPath string
+	var cursor, dbPath, series string
 	var limit int
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List Kalshi event groups, filterable by series and synced locally",
 		Example: `  prediction-goat-pp-cli kalshi events list --data-source live --limit 10 --json
-  prediction-goat-pp-cli kalshi events list --series KXELONMARS`,
+  prediction-goat-pp-cli kalshi events list --series KXMENWORLDCUP`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
@@ -48,12 +48,16 @@ func newKalshiEventsListCmd(flags *rootFlags) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("kalshi events local count: %w", err)
 				}
-				useLive = count == 0
+				// --series filtering only makes sense against the live API
+				// (the local store doesn't index by series). Force-live when
+				// the user asked for a series filter so we don't silently
+				// return unrelated locally-cached events.
+				useLive = count == 0 || series != ""
 			}
 			var items []kalshiEventItem
 			var err error
 			if useLive {
-				items, err = liveKalshiEvents(cmd, cursor, limit)
+				items, err = liveKalshiEvents(cmd, cursor, limit, series)
 			} else {
 				items, err = localKalshiEvents(cmd, dbPath, limit)
 			}
@@ -65,15 +69,18 @@ func newKalshiEventsListCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&limit, "limit", 50, "Max results")
 	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor")
+	cmd.Flags().StringVar(&series, "series", "", "Filter to events under a series ticker (forces --data-source live)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
 	return cmd
 }
 
 func newKalshiEventsGetCmd(flags *rootFlags) *cobra.Command {
+	var withMarkets bool
 	cmd := &cobra.Command{
-		Use:         "get <event_ticker>",
-		Short:       "Get a Kalshi event by ticker",
-		Example:     `  prediction-goat-pp-cli kalshi events get KXELONMARS-99 --json`,
+		Use:   "get <event_ticker>",
+		Short: "Get a Kalshi event by ticker",
+		Example: `  prediction-goat-pp-cli kalshi events get KXELONMARS-99 --json
+  prediction-goat-pp-cli kalshi events get KXMENWORLDCUP-26 --with-markets --agent`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -82,7 +89,11 @@ func newKalshiEventsGetCmd(flags *rootFlags) *cobra.Command {
 			if dryRunOK(flags) {
 				return nil
 			}
-			body, err := kalshi.New().Get(cmd.Context(), "/events/"+url.PathEscape(args[0]), url.Values{})
+			params := url.Values{}
+			if withMarkets {
+				params.Set("with_nested_markets", "true")
+			}
+			body, err := kalshi.New().Get(cmd.Context(), "/events/"+url.PathEscape(args[0]), params)
 			if err != nil {
 				return fmt.Errorf("kalshi events get: %w", err)
 			}
@@ -90,16 +101,72 @@ func newKalshiEventsGetCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("kalshi events get decode: %w", err)
 			}
+			if withMarkets {
+				return printJSONFiltered(cmd.OutOrStdout(), kalshiEventWithMarkets(obj), flags)
+			}
 			return printJSONFiltered(cmd.OutOrStdout(), kalshiEventSlim(obj), flags)
 		},
 	}
+	cmd.Flags().BoolVar(&withMarkets, "with-markets", false, "Include nested markets in the response (passes with_nested_markets=true upstream)")
 	return cmd
 }
 
-func liveKalshiEvents(cmd *cobra.Command, cursor string, limit int) ([]kalshiEventItem, error) {
+// kalshiEventNestedMarket projects each market row from the upstream
+// with_nested_markets response into a slim shape. Keeps the same field
+// set humans and agents already see from `kalshi markets get`, plus
+// the trading fields that make this the one-call answer for "what are
+// all the markets under this event."
+type kalshiEventNestedMarket struct {
+	Ticker         string  `json:"ticker"`
+	EventTicker    string  `json:"event_ticker,omitempty"`
+	Title          string  `json:"title"`
+	YesSubTitle    string  `json:"yes_sub_title,omitempty"`
+	Status         string  `json:"status,omitempty"`
+	YesAskDollars  float64 `json:"yes_ask_dollars,omitempty"`
+	NoAskDollars   float64 `json:"no_ask_dollars,omitempty"`
+	Volume24hFP    float64 `json:"volume_24h_fp,omitempty"`
+	ExpirationTime string  `json:"expiration_time,omitempty"`
+}
+
+type kalshiEventWithMarketsItem struct {
+	kalshiEventItem
+	Markets []kalshiEventNestedMarket `json:"markets,omitempty"`
+}
+
+func kalshiEventWithMarkets(obj map[string]any) kalshiEventWithMarketsItem {
+	out := kalshiEventWithMarketsItem{kalshiEventItem: kalshiEventSlim(obj)}
+	raw, ok := obj["markets"].([]any)
+	if !ok {
+		return out
+	}
+	out.Markets = make([]kalshiEventNestedMarket, 0, len(raw))
+	for _, m := range raw {
+		mObj, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		out.Markets = append(out.Markets, kalshiEventNestedMarket{
+			Ticker:         jsonString(mObj, "ticker"),
+			EventTicker:    jsonString(mObj, "event_ticker"),
+			Title:          jsonString(mObj, "title"),
+			YesSubTitle:    jsonString(mObj, "yes_sub_title"),
+			Status:         jsonString(mObj, "status"),
+			YesAskDollars:  jsonFloat(mObj, "yes_ask_dollars"),
+			NoAskDollars:   jsonFloat(mObj, "no_ask_dollars"),
+			Volume24hFP:    jsonFloat(mObj, "volume_24h_fp"),
+			ExpirationTime: jsonString(mObj, "expiration_time"),
+		})
+	}
+	return out
+}
+
+func liveKalshiEvents(cmd *cobra.Command, cursor string, limit int, series string) ([]kalshiEventItem, error) {
 	params := url.Values{"limit": {fmt.Sprint(limit)}}
 	if cursor != "" {
 		params.Set("cursor", cursor)
+	}
+	if series != "" {
+		params.Set("series_ticker", series)
 	}
 	body, err := kalshi.New().Get(cmd.Context(), "/events", params)
 	if err != nil {

--- a/library/payments/prediction-goat/internal/cli/kalshi_events_test.go
+++ b/library/payments/prediction-goat/internal/cli/kalshi_events_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"testing"
+)
+
+// TestKalshiEventsGet_WithMarketsFlagDeclared pins that the --with-markets
+// flag exists on `kalshi events get`. The verify-skill script also checks
+// SKILL.md flag references against source, so adding/removing this flag
+// without updating SKILL.md would surface there too.
+func TestKalshiEventsGet_WithMarketsFlagDeclared(t *testing.T) {
+	t.Parallel()
+	root := RootCmd()
+	kalshi, _, err := root.Find([]string{"kalshi", "events", "get"})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if f := kalshi.Flags().Lookup("with-markets"); f == nil {
+		t.Fatal("--with-markets flag is not declared on `kalshi events get`")
+	}
+}
+
+// TestKalshiEventsList_SeriesFlagDeclared pins that the --series flag
+// exists on `kalshi events list`. Until U7 it was advertised in --help
+// but not actually declared.
+func TestKalshiEventsList_SeriesFlagDeclared(t *testing.T) {
+	t.Parallel()
+	root := RootCmd()
+	kalshi, _, err := root.Find([]string{"kalshi", "events", "list"})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if f := kalshi.Flags().Lookup("series"); f == nil {
+		t.Fatal("--series flag is not declared on `kalshi events list`")
+	}
+}
+
+// TestKalshiEventWithMarkets_ProjectsNestedFields covers the field
+// projection from a synthetic upstream payload, so a regression that
+// drops one of the trading fields (yes_ask_dollars, status, etc.)
+// would fail this test without needing to hit the live Kalshi API.
+func TestKalshiEventWithMarkets_ProjectsNestedFields(t *testing.T) {
+	t.Parallel()
+	src := map[string]any{
+		"event_ticker":       "KXMENWORLDCUP-26",
+		"series_ticker":      "KXMENWORLDCUP",
+		"title":              "2026 Men's World Cup Winner",
+		"category":           "Sports",
+		"mutually_exclusive": "true",
+		"markets": []any{
+			map[string]any{
+				"ticker":          "KXMENWORLDCUP-26-PT",
+				"event_ticker":    "KXMENWORLDCUP-26",
+				"title":           "Will the Portugal win the 2026 Men's World Cup?",
+				"yes_sub_title":   "Portugal",
+				"status":          "active",
+				"yes_ask_dollars": 0.085,
+				"no_ask_dollars":  0.92,
+				"volume_24h_fp":   123456.789,
+				"expiration_time": "2028-07-18T14:00:00Z",
+			},
+			map[string]any{
+				"ticker":       "KXMENWORLDCUP-26-FR",
+				"event_ticker": "KXMENWORLDCUP-26",
+				"title":        "Will the France win the 2026 Men's World Cup?",
+			},
+		},
+	}
+	out := kalshiEventWithMarkets(src)
+	if out.EventTicker != "KXMENWORLDCUP-26" {
+		t.Errorf("EventTicker = %q, want KXMENWORLDCUP-26", out.EventTicker)
+	}
+	if len(out.Markets) != 2 {
+		t.Fatalf("Markets len = %d, want 2", len(out.Markets))
+	}
+	pt := out.Markets[0]
+	if pt.Ticker != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("PT.Ticker = %q", pt.Ticker)
+	}
+	if pt.YesAskDollars != 0.085 {
+		t.Errorf("PT.YesAskDollars = %v, want 0.085", pt.YesAskDollars)
+	}
+	if pt.YesSubTitle != "Portugal" {
+		t.Errorf("PT.YesSubTitle = %q, want Portugal", pt.YesSubTitle)
+	}
+	if pt.Volume24hFP != 123456.789 {
+		t.Errorf("PT.Volume24hFP = %v, want 123456.789", pt.Volume24hFP)
+	}
+}
+
+// TestKalshiEventWithMarkets_HandlesMissingMarketsArray returns the
+// slim event with an empty Markets slice when the upstream response
+// has no nested markets — defensive against the upstream API toggling
+// the field shape.
+func TestKalshiEventWithMarkets_HandlesMissingMarketsArray(t *testing.T) {
+	t.Parallel()
+	src := map[string]any{
+		"event_ticker": "KXFOO-01",
+		"title":        "Foo",
+	}
+	out := kalshiEventWithMarkets(src)
+	if out.EventTicker != "KXFOO-01" {
+		t.Errorf("EventTicker = %q", out.EventTicker)
+	}
+	if len(out.Markets) != 0 {
+		t.Errorf("Markets len = %d, want 0", len(out.Markets))
+	}
+}

--- a/library/payments/prediction-goat/internal/cli/liquid.go
+++ b/library/payments/prediction-goat/internal/cli/liquid.go
@@ -42,7 +42,9 @@ func newLiquidCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items}); renderErr != nil {
+			outcome := refreshMarketScreenItems(cmd.Context(), nil, items)
+			meta := buildFreshnessMeta(outcome, indexSyncedAtFromPath(cmd.Context(), dbPath))
+			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items, Meta: meta}); renderErr != nil {
 				return renderErr
 			}
 			if len(items) == 0 {

--- a/library/payments/prediction-goat/internal/cli/liquid.go
+++ b/library/payments/prediction-goat/internal/cli/liquid.go
@@ -21,16 +21,22 @@ func topicFTSQuery(s string) string {
 func newLiquidCmd(flags *rootFlags) *cobra.Command {
 	var minVolume float64
 	var limit int
-	var venue, dbPath string
+	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "liquid",
 		Short: "Markets above a volume floor across Polymarket and Kalshi",
 		Example: `  prediction-goat-pp-cli liquid --min-volume 100000 --json
-  prediction-goat-pp-cli liquid --min-volume 50000 --limit 25`,
+  prediction-goat-pp-cli liquid --min-volume 50000 --limit 25
+  prediction-goat-pp-cli liquid --kalshi --min-volume 50000`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			items, err := runMarketScreen(cmd, "liquid", dbPath, venue, limit, minVolume, "", "")
 			if err != nil {
@@ -49,7 +55,7 @@ func newLiquidCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().Float64Var(&minVolume, "min-volume", 10000, "Minimum volume")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max results")
-	cmd.Flags().StringVar(&venue, "venue", "all", "Venue: all, polymarket, kalshi")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }

--- a/library/payments/prediction-goat/internal/cli/mispriced.go
+++ b/library/payments/prediction-goat/internal/cli/mispriced.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
@@ -25,6 +26,7 @@ type mispricedResult struct {
 	Threshold float64         `json:"threshold"`
 	Count     int             `json:"count"`
 	Pairs     []mispricedPair `json:"pairs"`
+	Meta      *freshnessMeta  `json:"meta,omitempty"`
 }
 
 func newMispricedCmd(flags *rootFlags) *cobra.Command {
@@ -59,12 +61,23 @@ func newMispricedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("mispriced: %w", err)
 			}
+			// Live-on-read freshness: refresh prices on every pair and
+			// recompute Delta from the refreshed values so the displayed
+			// spread is never a stale cache artifact. Pairs that fall
+			// below the threshold under fresh prices are dropped.
+			outcome := refreshMispricedPairs(cmd.Context(), nil, &result, threshold)
+			result.Meta = buildFreshnessMeta(outcome, indexSyncedAt(db))
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {
 					return err
 				}
-			} else if err := printSimpleTable(cmd.OutOrStdout(), []string{"Match", "PM Title", "Kalshi Title", "PM%", "Kalshi%", "Delta"}, mispricedRows(result.Pairs)); err != nil {
-				return err
+			} else {
+				if err := printSimpleTable(cmd.OutOrStdout(), []string{"Match", "PM Title", "Kalshi Title", "PM%", "Kalshi%", "Delta"}, mispricedRows(result.Pairs)); err != nil {
+					return err
+				}
+				if footer := freshnessFooterLine(result.Meta); footer != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), footer)
+				}
 			}
 			if len(result.Pairs) == 0 {
 				if hint := emptyStoreHint(cmd, dbPath, "mispriced", "all"); hint != nil {
@@ -125,6 +138,51 @@ ORDER BY CAST(COALESCE(json_extract(data,'$.volume_24h_fp'),0) AS REAL) DESC LIM
 		pairs = pairs[:limit]
 	}
 	return mispricedResult{Threshold: threshold, Count: len(pairs), Pairs: pairs}, nil
+}
+
+// refreshMispricedPairs refreshes every pair's PM and Kalshi prices
+// from upstream, recomputes Delta from the live values, and drops
+// pairs that fall below the threshold under refreshed prices.
+// Result.Count is updated to reflect the surviving pairs.
+func refreshMispricedPairs(ctx context.Context, fc freshnessClient, result *mispricedResult, threshold float64) refreshOutcome {
+	polySlugs := make([]string, 0, len(result.Pairs))
+	kalshiTickers := make([]string, 0, len(result.Pairs))
+	for _, p := range result.Pairs {
+		polySlugs = append(polySlugs, p.PM.ID)
+		kalshiTickers = append(kalshiTickers, p.Kalshi.ID)
+	}
+	outcome := refreshVenues(ctx, fc, polySlugs, kalshiTickers)
+	var dummyStatus string
+	filtered := result.Pairs[:0]
+	for _, p := range result.Pairs {
+		if outcome.PolymarketOK {
+			if v, ok := outcome.Polymarket[p.PM.ID]; ok {
+				applyLiveValuesIfPresent(v, &p.PM.YesProbability, &p.PM.Volume24h, &dummyStatus)
+			}
+		}
+		if outcome.KalshiOK {
+			if v, ok := outcome.Kalshi[p.Kalshi.ID]; ok {
+				applyLiveValuesIfPresent(v, &p.Kalshi.YesProbability, &p.Kalshi.Volume24h, &dummyStatus)
+			}
+		}
+		p.Delta = p.PM.YesProbability - p.Kalshi.YesProbability
+		// Re-filter on threshold against refreshed prices. We use a
+		// math.Abs comparison consistent with runMispriced. When the
+		// refresh failed for either venue, keep the pair so the user
+		// still sees the index answer with the staleness flag — the
+		// stale value is the best signal we have.
+		if outcome.PolymarketOK && outcome.KalshiOK && math.Abs(p.Delta) < threshold {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	// Re-sort by absolute spread under refreshed prices.
+	sort.Slice(filtered, func(i, j int) bool {
+		return math.Abs(filtered[i].Delta) > math.Abs(filtered[j].Delta)
+	})
+	result.Pairs = filtered
+	result.Count = len(filtered)
+	return outcome
 }
 
 func loadMispricedMarkets(cmd *cobra.Command, db *store.Store, query, resourceType string) ([]rawMarket, error) {

--- a/library/payments/prediction-goat/internal/cli/movers.go
+++ b/library/payments/prediction-goat/internal/cli/movers.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -18,10 +19,14 @@ type moversItem struct {
 	CurrentPrice float64 `json:"currentPrice"`
 	EndDate      string  `json:"endDate,omitempty"`
 	Volume24h    float64 `json:"volume24h,omitempty"`
+	// PriceSource is set after the live-on-read refresh fires: "live"
+	// or "stale". See freshness.go.
+	PriceSource string `json:"price_source,omitempty"`
 }
 
 type moversResult struct {
-	Items []moversItem `json:"items"`
+	Items []moversItem   `json:"items"`
+	Meta  *freshnessMeta `json:"meta,omitempty"`
 }
 
 func newMoversCmd(flags *rootFlags) *cobra.Command {
@@ -46,13 +51,25 @@ func newMoversCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result := moversResult{Items: items}
+			// Live-on-read freshness: refresh CurrentPrice (and Volume24h)
+			// from upstream for every row. Delta is window-derived and
+			// cannot be refreshed without point-in-time history; the
+			// CurrentPrice refresh is what makes "movers --window 24h"
+			// no longer report yesterday's price as current.
+			outcome := refreshMoversItems(cmd.Context(), nil, items)
+			meta := buildFreshnessMeta(outcome, indexSyncedAtFromPath(cmd.Context(), dbPath))
+			result := moversResult{Items: items, Meta: meta}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {
 					return err
 				}
-			} else if err := printSimpleTable(cmd.OutOrStdout(), []string{"Source", "ID", "Title", "Delta", "%Now", "Volume24h", "EndDate"}, moverRows(items)); err != nil {
-				return err
+			} else {
+				if err := printSimpleTable(cmd.OutOrStdout(), []string{"Source", "ID", "Title", "Delta", "%Now", "Volume24h", "EndDate"}, moverRows(items)); err != nil {
+					return err
+				}
+				if footer := freshnessFooterLine(meta); footer != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), footer)
+				}
 			}
 			if len(items) == 0 {
 				if hint := emptyStoreHint(cmd, dbPath, "movers", venue); hint != nil {
@@ -115,6 +132,57 @@ func runMovers(cmd *cobra.Command, dbPath, venue, window string, limit int) ([]m
 		}
 	}
 	return items, nil
+}
+
+// refreshMoversItems batches by venue, fires one live API call per
+// venue, and overwrites CurrentPrice / Volume24h on each row. Delta
+// is window-derived (oneDayPriceChange / last vs previous on Kalshi)
+// and cannot be live-refreshed without a point-in-time history
+// service; the refresh focuses on CurrentPrice so the
+// "movers --window 24h" answer reports the actual current price
+// alongside its window-relative delta.
+func refreshMoversItems(ctx context.Context, fc freshnessClient, items []moversItem) refreshOutcome {
+	polySlugs := make([]string, 0, len(items))
+	kalshiTickers := make([]string, 0, len(items))
+	for _, it := range items {
+		switch it.Source {
+		case "polymarket":
+			polySlugs = append(polySlugs, it.ID)
+		case "kalshi":
+			kalshiTickers = append(kalshiTickers, it.ID)
+		}
+	}
+	outcome := refreshVenues(ctx, fc, polySlugs, kalshiTickers)
+	var dummyStatus string
+	for i := range items {
+		switch items[i].Source {
+		case "polymarket":
+			if !outcome.PolymarketAsked {
+				continue
+			}
+			if !outcome.PolymarketOK {
+				items[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Polymarket[items[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &items[i].CurrentPrice, &items[i].Volume24h, &dummyStatus)
+			}
+			items[i].PriceSource = priceSourceLive
+		case "kalshi":
+			if !outcome.KalshiAsked {
+				continue
+			}
+			if !outcome.KalshiOK {
+				items[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Kalshi[items[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &items[i].CurrentPrice, &items[i].Volume24h, &dummyStatus)
+			}
+			items[i].PriceSource = priceSourceLive
+		}
+	}
+	return outcome
 }
 
 func moversSQL(venue, window string) string {

--- a/library/payments/prediction-goat/internal/cli/movers.go
+++ b/library/payments/prediction-goat/internal/cli/movers.go
@@ -25,17 +25,22 @@ type moversResult struct {
 }
 
 func newMoversCmd(flags *rootFlags) *cobra.Command {
-	var window, venue, dbPath string
+	var window, dbPath string
 	var limit int
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "movers",
 		Short: "Biggest implied-probability deltas across Polymarket and Kalshi",
 		Example: `  prediction-goat-pp-cli movers --window 24h --json
-  prediction-goat-pp-cli movers --window 7d --limit 10`,
+  prediction-goat-pp-cli movers --window 7d --kalshi --limit 10`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			items, err := runMovers(cmd, dbPath, venue, window, limit)
 			if err != nil {
@@ -59,8 +64,8 @@ func newMoversCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&window, "window", "24h", "Window: 24h or 7d")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max results")
-	cmd.Flags().StringVar(&venue, "venue", "all", "Venue: all, polymarket, kalshi")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }
 

--- a/library/payments/prediction-goat/internal/cli/new_markets.go
+++ b/library/payments/prediction-goat/internal/cli/new_markets.go
@@ -31,7 +31,9 @@ func newNewCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items}); renderErr != nil {
+			outcome := refreshMarketScreenItems(cmd.Context(), nil, items)
+			meta := buildFreshnessMeta(outcome, indexSyncedAtFromPath(cmd.Context(), dbPath))
+			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items, Meta: meta}); renderErr != nil {
 				return renderErr
 			}
 			if len(items) == 0 {

--- a/library/payments/prediction-goat/internal/cli/new_markets.go
+++ b/library/payments/prediction-goat/internal/cli/new_markets.go
@@ -10,16 +10,21 @@ import (
 
 func newNewCmd(flags *rootFlags) *cobra.Command {
 	var days, limit int
-	var venue, dbPath string
+	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "new",
 		Short: "Markets created in the last N days across Polymarket and Kalshi",
 		Example: `  prediction-goat-pp-cli new --days 7 --json
-  prediction-goat-pp-cli new --days 1 --venue polymarket`,
+  prediction-goat-pp-cli new --days 1 --polymarket`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			cutoff := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339)
 			items, err := runMarketScreen(cmd, "new", dbPath, venue, limit, 0, cutoff, "")
@@ -39,7 +44,7 @@ func newNewCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&days, "days", 7, "Created within the last N days")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max results")
-	cmd.Flags().StringVar(&venue, "venue", "all", "Venue: all, polymarket, kalshi")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }

--- a/library/payments/prediction-goat/internal/cli/resolving.go
+++ b/library/payments/prediction-goat/internal/cli/resolving.go
@@ -42,7 +42,9 @@ func newResolvingCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items}); renderErr != nil {
+			outcome := refreshMarketScreenItems(cmd.Context(), nil, items)
+			meta := buildFreshnessMeta(outcome, indexSyncedAtFromPath(cmd.Context(), dbPath))
+			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items, Meta: meta}); renderErr != nil {
 				return renderErr
 			}
 			if len(items) == 0 {

--- a/library/payments/prediction-goat/internal/cli/resolving.go
+++ b/library/payments/prediction-goat/internal/cli/resolving.go
@@ -11,16 +11,21 @@ import (
 func newResolvingCmd(flags *rootFlags) *cobra.Command {
 	var week, month bool
 	var days, limit int
-	var venue, dbPath string
+	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "resolving",
 		Short: "Markets resolving in a selected window",
 		Example: `  prediction-goat-pp-cli resolving --week --json
-  prediction-goat-pp-cli resolving --days 14 --venue kalshi`,
+  prediction-goat-pp-cli resolving --days 14 --kalshi`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			windowDays := 7
 			if month {
@@ -52,7 +57,7 @@ func newResolvingCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&month, "month", false, "Resolve within 30 days")
 	cmd.Flags().IntVar(&days, "days", 0, "Resolve within N days (overrides --week/--month)")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Max results")
-	cmd.Flags().StringVar(&venue, "venue", "all", "Venue: all, polymarket, kalshi")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }

--- a/library/payments/prediction-goat/internal/cli/root.go
+++ b/library/payments/prediction-goat/internal/cli/root.go
@@ -44,6 +44,11 @@ type rootFlags struct {
 	rateLimit           float64
 	dataSource          string
 	freshnessMeta       any
+	// noLearn disables both the teach (write) side and the rerank apply
+	// (read) side for a single invocation. Honored alongside the env
+	// var PREDICTION_GOAT_NO_LEARN. Determinism-focused agent flows set
+	// this so a learning row can't silently change subsequent results.
+	noLearn bool
 
 	// deliverBuf captures command output when --deliver is set to a
 	// non-stdout sink. Flushed to the sink after Execute returns.
@@ -186,6 +191,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'prediction-goat-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
+	rootCmd.PersistentFlags().BoolVar(&flags.noLearn, "no-learn", false, "Disable the learning surface (teach silent no-op, rerank apply skipped). Also honored via PREDICTION_GOAT_NO_LEARN=true")
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if flags.deliverSpec != "" {
@@ -275,6 +281,10 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNewCmd(flags))
 	rootCmd.AddCommand(newMoversCmd(flags))
 	rootCmd.AddCommand(newVersionCliCmd())
+	rootCmd.AddCommand(newTeachCmd(flags))
+	rootCmd.AddCommand(newRecallCmd(flags))
+	rootCmd.AddCommand(newLearningsCmd(flags))
+	rootCmd.AddCommand(newForgetCmd(flags))
 	addMarketsDiffCmd(rootCmd, flags)
 
 	return rootCmd

--- a/library/payments/prediction-goat/internal/cli/teach.go
+++ b/library/payments/prediction-goat/internal/cli/teach.go
@@ -1,0 +1,773 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+// teach.go implements the LLM-driven learning surface for the
+// prediction-goat CLI: `teach` (fire-and-forget, silent on success,
+// safe to background with &), `recall` (pre-discovery short-circuit
+// for known queries), `learnings list` (human inspection), and
+// `forget` (human undo).
+//
+// The teach call writes one row per `--resource` under a normalized
+// query_pattern. Repeating the same call bumps confidence instead of
+// duplicating; the row's source is preserved on bump.
+//
+// `recall` returns rows whose normalized query_pattern overlaps the
+// supplied query by token-set Jaccard >= 0.6 (configurable).
+//
+// All four commands honor `--no-learn` (per-invocation) and
+// `PREDICTION_GOAT_NO_LEARN=true` (environment-wide). When disabled,
+// `teach` is a silent no-op (exit 0) and `recall` returns
+// `{found: false, results: []}`.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+// noLearnEnvVar is the environment variable that disables both teach
+// (write side) and the rerank apply layer (read side) for a session.
+// Used by deterministic agent flows that don't want a learning row to
+// silently change subsequent query results.
+const noLearnEnvVar = "PREDICTION_GOAT_NO_LEARN"
+
+// learningsAuditFileName is the JSONL audit log alongside the DB.
+const learningsAuditFileName = "learnings.jsonl"
+
+// teachLogFileName is the error log for backgrounded teach failures.
+// Stdout/stderr from a backgrounded LLM-fired teach must never leak
+// into the user-facing response, so failures go here instead.
+const teachLogFileName = "teach.log"
+
+// noLearnEnabled reports whether the env var has the value "true" or
+// "1" (case-insensitive). Other values are treated as not set.
+func noLearnEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(noLearnEnvVar)))
+	return v == "true" || v == "1" || v == "yes"
+}
+
+// learningsStateDir returns the directory hosting the DB, audit log,
+// and teach.log. Created on first use with 0o700 so a multi-user
+// machine doesn't accidentally expose one user's learned queries.
+func learningsStateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".local", "share", "prediction-goat-pp-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// learningsAuditPath returns ~/.local/share/prediction-goat-pp-cli/learnings.jsonl.
+func learningsAuditPath() (string, error) {
+	dir, err := learningsStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, learningsAuditFileName), nil
+}
+
+// teachLogPath returns ~/.local/share/prediction-goat-pp-cli/teach.log.
+func teachLogPath() (string, error) {
+	dir, err := learningsStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, teachLogFileName), nil
+}
+
+// writeTeachLog appends a single line to teach.log. Best-effort: a
+// failure to open the log file is silently swallowed, since the call
+// site is already in the error path of a backgrounded teach.
+func writeTeachLog(line string) {
+	p, err := teachLogPath()
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	fmt.Fprintf(f, "%s %s\n", ts, line)
+}
+
+// appendLearningsAudit records one event in the JSONL audit log.
+func appendLearningsAudit(entry map[string]any) error {
+	p, err := learningsAuditPath()
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	entry["ts"] = time.Now().UTC().Format(time.RFC3339)
+	return json.NewEncoder(f).Encode(entry)
+}
+
+// newTeachCmd builds the `teach` cobra command — the LLM-facing write
+// surface. Silent on success, safe to background, errors only to
+// teach.log.
+func newTeachCmd(flags *rootFlags) *cobra.Command {
+	var query string
+	var resources []string
+	var venueArg string
+	var resourceType string
+	var quiet bool
+	var dbPath string
+	var notes string
+
+	cmd := &cobra.Command{
+		Use:   "teach",
+		Short: "Record a query -> resource mapping for future rerank (LLM-fired, silent)",
+		Long: `Record one or more "this query → this resource" mappings so the next
+query that matches surfaces the right tickers without re-running discovery.
+
+This command is designed to be backgrounded by an LLM right before it
+emits the user-facing response: silent on success, errors only to
+~/.local/share/prediction-goat-pp-cli/teach.log, safe to fire-and-forget.
+
+Disabling: pass --no-learn or set PREDICTION_GOAT_NO_LEARN=true.`,
+		Example: `  prediction-goat-pp-cli teach --query "portugal world cup odds" \
+    --resource KXMENWORLDCUP-26-PT \
+    --resource will-portugal-win-the-2026-fifa-world-cup-912 &`,
+		Annotations: map[string]string{"mcp:read-only": "false"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Silence everything on the cobra command — even usage errors —
+			// because this command is designed to be backgrounded.
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			// Disabled? Silent no-op.
+			if flags.noLearn || noLearnEnabled() {
+				return nil
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			if strings.TrimSpace(query) == "" {
+				writeTeachLog(fmt.Sprintf("teach: missing --query (args=%v resources=%v)", args, resources))
+				return silentCodeErr(2)
+			}
+			if len(resources) == 0 {
+				writeTeachLog(fmt.Sprintf("teach: missing --resource for query=%q", query))
+				return silentCodeErr(2)
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("prediction-goat-pp-cli")
+			}
+			db, err := store.OpenWithContext(cmd.Context(), dbPath)
+			if err != nil {
+				writeTeachLog(fmt.Sprintf("teach: open db: %v", err))
+				return silentCodeErr(1)
+			}
+			defer db.Close()
+
+			confidences := make(map[string]int, len(resources))
+			for _, rid := range resources {
+				rid = strings.TrimSpace(rid)
+				if rid == "" {
+					continue
+				}
+				_, _, uerr := db.UpsertLearning(store.UpsertLearningInput{
+					Query:        query,
+					ResourceID:   rid,
+					ResourceType: resourceType,
+					Venue:        venueArg,
+					Source:       store.LearningSourceTaught,
+					Notes:        notes,
+				})
+				if uerr != nil {
+					writeTeachLog(fmt.Sprintf("teach: upsert %q for query=%q: %v", rid, query, uerr))
+					return silentCodeErr(1)
+				}
+				// Read back confidence for the audit log.
+				rows, _ := db.ListLearnings(store.ListLearningsFilter{Query: query, ResourceID: rid})
+				if len(rows) > 0 {
+					confidences[rid] = rows[0].Confidence
+				}
+			}
+
+			if err := appendLearningsAudit(map[string]any{
+				"action":      "teach",
+				"query":       query,
+				"normalized":  store.NormalizeQuery(query),
+				"resources":   resources,
+				"venue":       venueArg,
+				"confidences": confidences,
+			}); err != nil {
+				// Audit failure is non-fatal; the row is already in the DB.
+				writeTeachLog(fmt.Sprintf("teach: audit append: %v", err))
+			}
+
+			if !quiet && flags.asJSON {
+				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"recorded":   true,
+					"query":      query,
+					"normalized": store.NormalizeQuery(query),
+					"resources":  resources,
+				}, flags)
+			}
+			// Default: silent on success.
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&query, "query", "", "User's original natural-language question (required)")
+	cmd.Flags().StringSliceVar(&resources, "resource", nil, "Resource ID (ticker or slug) — repeat for multiple")
+	cmd.Flags().StringVar(&venueArg, "venue", "", "Venue scope: polymarket | kalshi (default: both)")
+	cmd.Flags().StringVar(&resourceType, "resource-type", "", "Resource type (e.g. kalshi_markets, markets) — recommended for synthetic-hit lookup")
+	cmd.Flags().BoolVar(&quiet, "quiet", true, "Silent on success (default true — designed for background invocation)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	cmd.Flags().StringVar(&notes, "notes", "", "Optional free-form note recorded with the learning")
+	return cmd
+}
+
+// recallEnvelope is the JSON shape returned by `recall --agent`. The
+// LLM consumes this before deciding whether to skip discovery.
+type recallEnvelope struct {
+	Found      bool                   `json:"found"`
+	Query      string                 `json:"query"`
+	Normalized string                 `json:"normalized"`
+	MatchScore float64                `json:"match_score,omitempty"`
+	Results    []recallEnvelopeResult `json:"results"`
+}
+
+type recallEnvelopeResult struct {
+	ResourceID     string     `json:"resource_id"`
+	ResourceType   string     `json:"resource_type,omitempty"`
+	Venue          string     `json:"venue,omitempty"`
+	Action         string     `json:"action"`
+	Confidence     int        `json:"confidence"`
+	MatchScore     float64    `json:"match_score"`
+	Source         string     `json:"source"`
+	LastObservedAt *time.Time `json:"last_observed_at,omitempty"`
+	AliasTarget    string     `json:"alias_target,omitempty"`
+}
+
+// newRecallCmd builds the read side of the loop: LLM calls `recall`
+// FIRST when starting work on a new user question, and uses the
+// returned tickers to short-circuit discovery.
+func newRecallCmd(flags *rootFlags) *cobra.Command {
+	var minConf int
+	var limit int
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "recall <query>",
+		Short: "Check prior learnings for a query before running discovery (LLM-fired, pre-discovery)",
+		Long: `Returns prior learnings matching the supplied query by token-set
+overlap (Jaccard >= 0.6). The LLM should call this FIRST when starting
+work on a new user question; if found=true and confidence is high, the
+LLM can skip topic/compare entirely and go straight to live price
+fetch for the returned tickers.
+
+Empty match returns {"found": false, "results": []} with exit 0 — this
+is an information query, not a not-found error.
+
+Disabling: PREDICTION_GOAT_NO_LEARN=true returns the empty shape even
+when learnings exist.`,
+		Example: `  prediction-goat-pp-cli recall "portugal world cup odds" --agent
+  prediction-goat-pp-cli recall "lakers tonight" --agent --min-confidence 2`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			query := strings.Join(args, " ")
+			envelope := recallEnvelope{
+				Query:      query,
+				Normalized: store.NormalizeQuery(query),
+				Results:    []recallEnvelopeResult{},
+			}
+			if flags.noLearn || noLearnEnabled() {
+				return emitRecall(cmd, flags, envelope)
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("prediction-goat-pp-cli")
+			}
+			db, err := store.OpenWithContext(cmd.Context(), dbPath)
+			if err != nil {
+				return fmt.Errorf("recall: %w", err)
+			}
+			defer db.Close()
+
+			matches, err := db.Recall(cmd.Context(), query, store.RecallOptions{
+				MinConfidence: minConf,
+				Limit:         limit,
+			})
+			if err != nil {
+				return fmt.Errorf("recall: %w", err)
+			}
+			envelope.Found = len(matches) > 0
+			if envelope.Found {
+				envelope.MatchScore = matches[0].MatchScore
+				for _, m := range matches {
+					envelope.Results = append(envelope.Results, recallEnvelopeResult{
+						ResourceID:     m.ResourceID,
+						ResourceType:   m.ResourceType,
+						Venue:          m.Venue,
+						Action:         m.Action,
+						Confidence:     m.Confidence,
+						MatchScore:     m.MatchScore,
+						Source:         m.Source,
+						LastObservedAt: m.LastObservedAt,
+						AliasTarget:    m.AliasTarget,
+					})
+				}
+			}
+			return emitRecall(cmd, flags, envelope)
+		},
+	}
+	cmd.Flags().IntVar(&minConf, "min-confidence", 1, "Minimum confidence to include in results")
+	cmd.Flags().IntVar(&limit, "limit", 10, "Maximum number of learnings to return")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	return cmd
+}
+
+// emitRecall renders the recall envelope in the chosen output mode.
+func emitRecall(cmd *cobra.Command, flags *rootFlags, env recallEnvelope) error {
+	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		return printJSONFiltered(cmd.OutOrStdout(), env, flags)
+	}
+	if !env.Found {
+		fmt.Fprintf(cmd.OutOrStdout(), "no prior learnings for %q\n", env.Query)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%d learning(s) for %q (top match %.2f):\n", len(env.Results), env.Query, env.MatchScore)
+	for _, r := range env.Results {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s\t%s\tconf=%d\tmatch=%.2f\n", r.Action, r.ResourceID, r.Confidence, r.MatchScore)
+	}
+	return nil
+}
+
+// newLearningsCmd is the human-inspection surface. `learnings list`
+// lists rows; `learnings forget` is a parent for the forget verb.
+// Forget itself is registered as a sibling at root.
+func newLearningsCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "learnings",
+		Short: "Inspect the local search-learnings table (taught query -> resource mappings)",
+		Long: `Surface for browsing and filtering the search_learnings table that
+the LLM populates via the 'teach' command. To delete rows, use the
+top-level 'forget' command.`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+	}
+	cmd.AddCommand(newLearningsListCmd(flags))
+	return cmd
+}
+
+func newLearningsListCmd(flags *rootFlags) *cobra.Command {
+	var queryFilter string
+	var sourceFilter string
+	var resourceFilter string
+	var actionFilter string
+	var minConf int
+	var limit int
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recorded learnings",
+		Example: `  prediction-goat-pp-cli learnings list --agent
+  prediction-goat-pp-cli learnings list --query portugal
+  prediction-goat-pp-cli learnings list --source taught --agent`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			if dbPath == "" {
+				dbPath = defaultDBPath("prediction-goat-pp-cli")
+			}
+			db, err := store.OpenWithContext(cmd.Context(), dbPath)
+			if err != nil {
+				return fmt.Errorf("learnings list: %w", err)
+			}
+			defer db.Close()
+
+			rows, err := db.ListLearnings(store.ListLearningsFilter{
+				Query:         queryFilter,
+				Source:        sourceFilter,
+				ResourceID:    resourceFilter,
+				Action:        actionFilter,
+				MinConfidence: minConf,
+				Limit:         limit,
+			})
+			if err != nil {
+				return fmt.Errorf("learnings list: %w", err)
+			}
+
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printJSONFiltered(cmd.OutOrStdout(), rows, flags)
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "(no learnings recorded)")
+				return nil
+			}
+			for _, r := range rows {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\tconf=%d\tsource=%s\n",
+					r.QueryPattern, r.Action, r.ResourceID, r.Confidence, r.Source)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&queryFilter, "query", "", "Filter by normalized query substring")
+	cmd.Flags().StringVar(&sourceFilter, "source", "", "Filter by source (taught | manual-forget)")
+	cmd.Flags().StringVar(&resourceFilter, "resource", "", "Filter by resource_id")
+	cmd.Flags().StringVar(&actionFilter, "action", "", "Filter by action (boost | hide | alias_of)")
+	cmd.Flags().IntVar(&minConf, "min-confidence", 0, "Filter by minimum confidence")
+	cmd.Flags().IntVar(&limit, "limit", 200, "Maximum rows to return")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	return cmd
+}
+
+// newForgetCmd is the destructive surface — a human un-does a bad
+// learning, or a session pre-test reset. Requires at least one of
+// --resource / --action, or --all to wipe every rule for that query.
+func newForgetCmd(flags *rootFlags) *cobra.Command {
+	var resourceArg string
+	var actionArg string
+	var all bool
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "forget <query>",
+		Short: "Delete learnings matching a query (use --all to wipe every rule for that query)",
+		Long: `Removes rows from the search_learnings table so a bad teach can be
+undone without dropping the whole DB.
+
+Requires at least one of --resource, --action, or --all.`,
+		Example: `  prediction-goat-pp-cli forget "portugal world cup" --resource KXMENWORLDCUP-26-PT
+  prediction-goat-pp-cli forget "portugal world cup" --all`,
+		Annotations: map[string]string{"mcp:read-only": "false"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			query := strings.Join(args, " ")
+			if dbPath == "" {
+				dbPath = defaultDBPath("prediction-goat-pp-cli")
+			}
+			db, err := store.OpenWithContext(cmd.Context(), dbPath)
+			if err != nil {
+				return fmt.Errorf("forget: %w", err)
+			}
+			defer db.Close()
+
+			n, err := db.ForgetLearnings(store.ForgetLearningsFilter{
+				Query:      query,
+				ResourceID: resourceArg,
+				Action:     actionArg,
+				All:        all,
+			})
+			if err != nil {
+				return usageErr(fmt.Errorf("forget: %w", err))
+			}
+			_ = appendLearningsAudit(map[string]any{
+				"action":       "forget",
+				"query":        query,
+				"normalized":   store.NormalizeQuery(query),
+				"filter":       map[string]any{"resource": resourceArg, "action": actionArg, "all": all},
+				"rows_deleted": n,
+			})
+
+			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+				return printJSONFiltered(cmd.OutOrStdout(), map[string]any{
+					"deleted": n,
+					"query":   query,
+				}, flags)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "forgot %d learning(s) for %q\n", n, query)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&resourceArg, "resource", "", "Delete only the rule for this resource_id")
+	cmd.Flags().StringVar(&actionArg, "action", "", "Delete only rules with this action (boost | hide | alias_of)")
+	cmd.Flags().BoolVar(&all, "all", false, "Delete every rule for the supplied query")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	return cmd
+}
+
+// silentCodeErr returns an error that ExitCode honors but that carries
+// no message. Used by the teach command's error path so a backgrounded
+// failure leaks nothing to the parent shell's stderr — the diagnosis
+// lives in teach.log instead.
+func silentCodeErr(code int) error {
+	return &cliError{code: code, err: silentSentinel{}}
+}
+
+// silentSentinel implements error with an empty string so cobra has
+// nothing to print even if SilenceErrors regresses.
+type silentSentinel struct{}
+
+func (silentSentinel) Error() string { return "" }
+
+// teachApplier is the rerank Applier the topic command uses; it lives
+// in teach.go (alongside the learnings code) so the apply-side surface
+// stays close to the teach-side. compareApplier lives next to it.
+//
+// resolveLearnedHit is the helper that synthesizes a topicHit from the
+// resources table when a boost rule's resource_id isn't already in the
+// FTS bundle.
+func resolveLearnedHit(ctx context.Context, db *store.Store, h store.LearnedHit) (topicHit, bool) {
+	if strings.TrimSpace(h.ResourceID) == "" {
+		return topicHit{}, false
+	}
+	rt := h.ResourceType
+	candidates := []string{rt}
+	if rt == "" {
+		// No resource_type recorded; try the price-bearing tables in order.
+		candidates = []string{"kalshi_markets", "markets", "kalshi_events", "events", "kalshi_series", "tags"}
+	}
+	for _, c := range candidates {
+		raw, err := db.Get(c, h.ResourceID)
+		if err != nil {
+			continue
+		}
+		hit, ok := topicHitFromJSON(c, h.ResourceID, string(raw))
+		if !ok {
+			continue
+		}
+		return hit, true
+	}
+	return topicHit{}, false
+}
+
+// applyLearningsForTopic adapts the rerank layer to topic.go's hit
+// slice. Returns the (possibly-rewritten) hits, the count of rules
+// that touched the output, and a teach_hint if no high-confidence
+// boost fired for this query.
+func applyLearningsForTopic(ctx context.Context, db *store.Store, query string, hits []topicHit) ([]topicHit, int, bool) {
+	ap := &topicApplier{ctx: ctx, db: db, hits: hits}
+	res, err := db.Apply(ctx, query, ap)
+	if err != nil {
+		writeTeachLog(fmt.Sprintf("apply learnings for topic %q: %v", query, err))
+		return hits, 0, false
+	}
+	for _, w := range res.Warnings {
+		writeTeachLog(fmt.Sprintf("apply (topic): %s", w))
+	}
+	return ap.hits, res.Count, res.HasHighConfidence
+}
+
+type topicApplier struct {
+	ctx  context.Context
+	db   *store.Store
+	hits []topicHit
+}
+
+func (a *topicApplier) HasHit(rt, rid string) bool {
+	for _, h := range a.hits {
+		if h.ID == rid && (rt == "" || matchesTopicResourceType(h, rt)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *topicApplier) MoveToFront(rt, rid string) {
+	idx := -1
+	for i, h := range a.hits {
+		if h.ID == rid && (rt == "" || matchesTopicResourceType(h, rt)) {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		return
+	}
+	h := a.hits[idx]
+	a.hits = append(a.hits[:idx], a.hits[idx+1:]...)
+	a.hits = append([]topicHit{h}, a.hits...)
+}
+
+func (a *topicApplier) InsertLearnedHit(h store.LearnedHit) error {
+	hit, ok := resolveLearnedHit(a.ctx, a.db, h)
+	if !ok {
+		return fmt.Errorf("resource not found in local DB")
+	}
+	a.hits = append([]topicHit{hit}, a.hits...)
+	return nil
+}
+
+func (a *topicApplier) RemoveHit(rt, rid string) {
+	for i, h := range a.hits {
+		if h.ID == rid && (rt == "" || matchesTopicResourceType(h, rt)) {
+			a.hits = append(a.hits[:i], a.hits[i+1:]...)
+			return
+		}
+	}
+}
+
+func (a *topicApplier) ReplaceHit(srcType, srcID, dstType, dstID string) error {
+	for i, h := range a.hits {
+		if h.ID == srcID && (srcType == "" || matchesTopicResourceType(h, srcType)) {
+			hit, ok := resolveLearnedHit(a.ctx, a.db, store.LearnedHit{ResourceType: dstType, ResourceID: dstID})
+			if !ok {
+				return fmt.Errorf("alias target not found in local DB")
+			}
+			a.hits[i] = hit
+			return nil
+		}
+	}
+	// Source not in bundle; insert the alias target as a learned hit.
+	return a.InsertLearnedHit(store.LearnedHit{ResourceType: dstType, ResourceID: dstID})
+}
+
+// matchesTopicResourceType maps the resource-table type ("kalshi_markets",
+// "markets", etc.) onto the topicHit's (Source, Kind) pair so the
+// rerank layer can address a hit by its store-side type.
+func matchesTopicResourceType(h topicHit, rt string) bool {
+	switch rt {
+	case "markets":
+		return h.Source == "polymarket" && h.Kind == "market"
+	case "events":
+		return h.Source == "polymarket" && h.Kind == "event"
+	case "tags":
+		return h.Source == "polymarket" && h.Kind == "tag"
+	case "kalshi_markets":
+		return h.Source == "kalshi" && h.Kind == "market"
+	case "kalshi_events":
+		return h.Source == "kalshi" && h.Kind == "event"
+	case "kalshi_series":
+		return h.Source == "kalshi" && h.Kind == "series"
+	}
+	return false
+}
+
+// applyLearningsForCompare adapts the rerank layer to compare.go's
+// pair slice. Boosts reorder pairs by moving the pair containing the
+// boosted ID to the front; hides drop the matching pair; aliases swap
+// the venue-side ID. compare's structural pair shape means most rules
+// fire less aggressively than they do on topic, which is intentional —
+// compare is venue-symmetric and a synthetic insert there would yield
+// a one-sided pair the agent already gets from a single-venue topic.
+func applyLearningsForCompare(ctx context.Context, db *store.Store, query string, pairs []comparePair) ([]comparePair, int, bool) {
+	ap := &compareApplier{ctx: ctx, db: db, pairs: pairs}
+	res, err := db.Apply(ctx, query, ap)
+	if err != nil {
+		writeTeachLog(fmt.Sprintf("apply learnings for compare %q: %v", query, err))
+		return pairs, 0, false
+	}
+	for _, w := range res.Warnings {
+		writeTeachLog(fmt.Sprintf("apply (compare): %s", w))
+	}
+	return ap.pairs, res.Count, res.HasHighConfidence
+}
+
+type compareApplier struct {
+	ctx   context.Context
+	db    *store.Store
+	pairs []comparePair
+}
+
+func (a *compareApplier) HasHit(rt, rid string) bool {
+	for _, p := range a.pairs {
+		if pairHasResource(p, rt, rid) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *compareApplier) MoveToFront(rt, rid string) {
+	idx := -1
+	for i, p := range a.pairs {
+		if pairHasResource(p, rt, rid) {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		return
+	}
+	p := a.pairs[idx]
+	a.pairs = append(a.pairs[:idx], a.pairs[idx+1:]...)
+	a.pairs = append([]comparePair{p}, a.pairs...)
+}
+
+func (a *compareApplier) InsertLearnedHit(h store.LearnedHit) error {
+	// compare pairs are bilateral by design; synthesizing a one-sided
+	// pair here would mislead — the agent should run topic with a
+	// venue scope instead. Record this as a no-op with a teach.log entry.
+	writeTeachLog(fmt.Sprintf("compare apply: skipping synthetic insert for %s/%s (compare is bilateral)", h.ResourceType, h.ResourceID))
+	return nil
+}
+
+func (a *compareApplier) RemoveHit(rt, rid string) {
+	for i, p := range a.pairs {
+		if pairHasResource(p, rt, rid) {
+			a.pairs = append(a.pairs[:i], a.pairs[i+1:]...)
+			return
+		}
+	}
+}
+
+func (a *compareApplier) ReplaceHit(srcType, srcID, dstType, dstID string) error {
+	// Aliases on compare are not implemented: the venue-symmetric shape
+	// of compare pairs makes the right replacement ambiguous. Log and
+	// continue.
+	writeTeachLog(fmt.Sprintf("compare apply: skipping alias %s -> %s (compare is bilateral)", srcID, dstID))
+	return nil
+}
+
+func pairHasResource(p comparePair, rt, rid string) bool {
+	if p.PM != nil && p.PM.ID == rid && (rt == "" || rt == "markets") {
+		return true
+	}
+	if p.Kalshi != nil && p.Kalshi.ID == rid && (rt == "" || rt == "kalshi_markets") {
+		return true
+	}
+	return false
+}
+
+// teachHintFor returns the suggested teach call the LLM should fire
+// in the background before emitting its final response. Empty string
+// means no hint is needed (e.g., a high-confidence boost already
+// applied for this query).
+func teachHintFor(query string, applied int, highConfidence bool, hits int) string {
+	if highConfidence {
+		return ""
+	}
+	if hits == 0 {
+		return ""
+	}
+	// Escape the query for inclusion inside a shell-style double-quoted
+	// string. The LLM is the consumer; the safest thing to do is keep
+	// the hint simple and identical-shape every time.
+	safeQuery := strings.ReplaceAll(query, `"`, `\"`)
+	return fmt.Sprintf(
+		`If you use these results in your final response, run: prediction-goat-pp-cli teach --query "%s" --resource <id> [--resource <id>...] &`,
+		safeQuery,
+	)
+}
+
+// noLearnActive is the combined check used by topic.go and compare.go
+// to decide whether to skip the rerank layer entirely. Exported (lower-
+// case) within-package so the call sites stay declarative.
+func noLearnActive(flags *rootFlags) bool {
+	if flags != nil && flags.noLearn {
+		return true
+	}
+	return noLearnEnabled()
+}

--- a/library/payments/prediction-goat/internal/cli/teach_test.go
+++ b/library/payments/prediction-goat/internal/cli/teach_test.go
@@ -1,0 +1,607 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+// withTempHome sets HOME to a fresh temp dir for the duration of the
+// test, then restores it on cleanup. Used to isolate the audit log and
+// teach.log writes from the developer's real ~/.local/share tree.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// Clear any external --no-learn env state so the default per-test
+	// behavior is learning ON.
+	t.Setenv(noLearnEnvVar, "")
+	return dir
+}
+
+// runRootArgs executes the CLI with the supplied args, returning stdout,
+// stderr, and the error from rootCmd.Execute. The test harness routes
+// both streams through bytes.Buffer; SetIn is wired to /dev/null so a
+// command that calls stdin doesn't block.
+func runRootArgs(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	rootCmd := RootCmd()
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func TestTeachCommand_SilentOnSuccess(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	stdout, stderr, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup odds",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	)
+	if err != nil {
+		t.Fatalf("teach exited non-zero: %v (stderr=%q)", err, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("teach should be silent on success; stdout=%q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("teach should be silent on success; stderr=%q", stderr)
+	}
+
+	// Verify the row landed in the DB.
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer s.Close()
+	rows, err := s.ListLearnings(store.ListLearningsFilter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ResourceID != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("expected one row for KXMENWORLDCUP-26-PT, got %#v", rows)
+	}
+}
+
+func TestTeachCommand_MultipleResourcesSameCall(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	_, _, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup odds",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--resource", "will-portugal-win-the-2026-fifa-world-cup-912",
+		"--db", dbPath,
+	)
+	if err != nil {
+		t.Fatalf("teach: %v", err)
+	}
+
+	s, _ := store.OpenWithContext(context.Background(), dbPath)
+	defer s.Close()
+	rows, _ := s.ListLearnings(store.ListLearningsFilter{})
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rows))
+	}
+}
+
+func TestTeachCommand_IdempotentBumpsConfidence(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	args := []string{
+		"teach",
+		"--query", "portugal world cup",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	}
+	if _, _, err := runRootArgs(t, args...); err != nil {
+		t.Fatalf("teach 1: %v", err)
+	}
+	if _, _, err := runRootArgs(t, args...); err != nil {
+		t.Fatalf("teach 2: %v", err)
+	}
+
+	s, _ := store.OpenWithContext(context.Background(), dbPath)
+	defer s.Close()
+	rows, _ := s.ListLearnings(store.ListLearningsFilter{})
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after re-teach, got %d", len(rows))
+	}
+	if rows[0].Confidence != 2 {
+		t.Errorf("confidence should bump to 2 on re-teach, got %d", rows[0].Confidence)
+	}
+}
+
+func TestTeachCommand_RespectsNoLearnEnvVar(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+	t.Setenv(noLearnEnvVar, "true")
+
+	stdout, stderr, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	)
+	if err != nil {
+		t.Fatalf("teach with NO_LEARN should be silent no-op, got err: %v stderr=%q", err, stderr)
+	}
+	if stdout != "" || stderr != "" {
+		t.Errorf("NO_LEARN should be silent; got stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	// DB file should not even exist — teach exited before opening.
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		s, _ := store.OpenWithContext(context.Background(), dbPath)
+		defer s.Close()
+		rows, _ := s.ListLearnings(store.ListLearningsFilter{})
+		if len(rows) != 0 {
+			t.Errorf("NO_LEARN should leave DB empty; got %d rows", len(rows))
+		}
+	}
+}
+
+func TestTeachCommand_RespectsNoLearnFlag(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	_, _, err := runRootArgs(t,
+		"--no-learn",
+		"teach",
+		"--query", "portugal world cup",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	)
+	if err != nil {
+		t.Fatalf("teach with --no-learn should be silent no-op, got err: %v", err)
+	}
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		s, _ := store.OpenWithContext(context.Background(), dbPath)
+		defer s.Close()
+		rows, _ := s.ListLearnings(store.ListLearningsFilter{})
+		if len(rows) != 0 {
+			t.Errorf("--no-learn should leave DB empty; got %d rows", len(rows))
+		}
+	}
+}
+
+func TestTeachCommand_MissingResourceLogsAndExitsNonZero(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	stdout, stderr, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup",
+		"--db", dbPath,
+	)
+	if err == nil {
+		t.Fatal("teach without --resource should exit non-zero")
+	}
+	if stdout != "" {
+		t.Errorf("error stdout should be empty; got %q", stdout)
+	}
+	if stderr != "" {
+		// We swallow cobra's stderr via SilenceErrors; cobra's prerun
+		// might still print on usage error. The contract is "background-
+		// safe": the cobra harness should not leak. If this regresses,
+		// we'll need to tighten the silencing.
+		t.Errorf("error stderr should be empty; got %q", stderr)
+	}
+
+	// teach.log should exist with an error line.
+	logPath := filepath.Join(home, ".local", "share", "prediction-goat-pp-cli", teachLogFileName)
+	data, statErr := os.ReadFile(logPath)
+	if statErr != nil {
+		t.Fatalf("teach.log should exist on error: %v", statErr)
+	}
+	if !strings.Contains(string(data), "missing --resource") {
+		t.Errorf("teach.log should record the failure; got %q", string(data))
+	}
+}
+
+func TestTeachCommand_AppendsAuditLog(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	_, _, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	)
+	if err != nil {
+		t.Fatalf("teach: %v", err)
+	}
+	auditPath := filepath.Join(home, ".local", "share", "prediction-goat-pp-cli", learningsAuditFileName)
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("audit log should exist: %v", err)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+		t.Fatalf("audit log JSON parse: %v", err)
+	}
+	if entry["action"] != "teach" {
+		t.Errorf("audit action=%v, want teach", entry["action"])
+	}
+}
+
+func TestRecallCommand_FoundAndNotFound(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	// Seed via teach.
+	if _, _, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup odds",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--resource", "will-portugal-win-the-2026-fifa-world-cup-912",
+		"--db", dbPath,
+	); err != nil {
+		t.Fatalf("seed teach: %v", err)
+	}
+
+	// Exact-ish recall.
+	stdout, _, err := runRootArgs(t,
+		"recall", "portugal world cup odds",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var env recallEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall JSON: %v (stdout=%q)", err, stdout)
+	}
+	if !env.Found || len(env.Results) != 2 {
+		t.Errorf("recall: want found+2 results, got %#v", env)
+	}
+
+	// Token-overlap recall: "portugal chances at the world cup"
+	stdout, _, err = runRootArgs(t,
+		"recall", "portugal chances at the world cup",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall overlap: %v", err)
+	}
+	env = recallEnvelope{}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall overlap JSON: %v", err)
+	}
+	if !env.Found {
+		t.Errorf("token-overlap recall: want found, got %#v", env)
+	}
+
+	// Unrelated query.
+	stdout, _, err = runRootArgs(t,
+		"recall", "lakers tonight",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall unrelated: %v", err)
+	}
+	env = recallEnvelope{}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall unrelated JSON: %v", err)
+	}
+	if env.Found || len(env.Results) != 0 {
+		t.Errorf("unrelated recall: want empty, got %#v", env)
+	}
+}
+
+func TestRecallCommand_RespectsNoLearnEnvVar(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	// Seed a real row first (with NO_LEARN unset).
+	if _, _, err := runRootArgs(t,
+		"teach",
+		"--query", "portugal world cup",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Now flip NO_LEARN on for the recall.
+	t.Setenv(noLearnEnvVar, "true")
+	stdout, _, err := runRootArgs(t,
+		"recall", "portugal world cup",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall with NO_LEARN: %v", err)
+	}
+	var env recallEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall JSON: %v", err)
+	}
+	if env.Found {
+		t.Errorf("NO_LEARN should suppress recall results; got %#v", env)
+	}
+}
+
+func TestRecallCommand_MinConfidence(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	// One teach for A (conf=1), two teaches for B (conf=2).
+	if _, _, err := runRootArgs(t,
+		"teach", "--query", "portugal world cup", "--resource", "A", "--db", dbPath); err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, _, err := runRootArgs(t,
+			"teach", "--query", "portugal world cup", "--resource", "B", "--db", dbPath); err != nil {
+			t.Fatalf("seed B: %v", err)
+		}
+	}
+
+	stdout, _, err := runRootArgs(t,
+		"recall", "portugal world cup",
+		"--db", dbPath,
+		"--min-confidence", "2",
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var env recallEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall JSON: %v", err)
+	}
+	if len(env.Results) != 1 || env.Results[0].ResourceID != "B" {
+		t.Errorf("min-confidence filter: want B only, got %#v", env.Results)
+	}
+}
+
+func TestLearningsList_FiltersByQuery(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	if _, _, err := runRootArgs(t,
+		"teach", "--query", "portugal world cup", "--resource", "A", "--db", dbPath); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, _, err := runRootArgs(t,
+		"teach", "--query", "lakers tonight", "--resource", "B", "--db", dbPath); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	stdout, _, err := runRootArgs(t,
+		"learnings", "list",
+		"--query", "portugal",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var rows []store.LearningRow
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("list JSON: %v (stdout=%q)", err, stdout)
+	}
+	if len(rows) != 1 || rows[0].ResourceID != "A" {
+		t.Errorf("list filter: want one (A), got %#v", rows)
+	}
+}
+
+func TestForgetCommand_TargetedAndAll(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	for _, rid := range []string{"X", "Y", "Z"} {
+		if _, _, err := runRootArgs(t,
+			"teach", "--query", "portugal world cup", "--resource", rid, "--db", dbPath); err != nil {
+			t.Fatalf("seed %s: %v", rid, err)
+		}
+	}
+
+	// Refuse without a filter.
+	_, _, err := runRootArgs(t,
+		"forget", "portugal world cup",
+		"--db", dbPath,
+	)
+	if err == nil {
+		t.Errorf("forget without filter should error")
+	}
+
+	// Targeted forget.
+	stdout, _, err := runRootArgs(t,
+		"forget", "portugal world cup",
+		"--resource", "Y",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("forget Y: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("forget JSON: %v", err)
+	}
+	if v, _ := resp["deleted"].(float64); v != 1 {
+		t.Errorf("forget Y: want deleted=1, got %v", resp["deleted"])
+	}
+
+	// --all wipes the rest.
+	stdout, _, err = runRootArgs(t,
+		"forget", "portugal world cup",
+		"--all",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("forget all: %v", err)
+	}
+	resp = nil
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("forget all JSON: %v", err)
+	}
+	if v, _ := resp["deleted"].(float64); v != 2 {
+		t.Errorf("forget all: want deleted=2, got %v", resp["deleted"])
+	}
+}
+
+func TestNormalizationSymmetry_TeachAndRecall(t *testing.T) {
+	home := withTempHome(t)
+	dbPath := filepath.Join(home, "data.db")
+
+	// Teach with a capitalized + stopwordy query.
+	if _, _, err := runRootArgs(t,
+		"teach",
+		"--query", "What are the odds Portugal wins the World Cup?",
+		"--resource", "KXMENWORLDCUP-26-PT",
+		"--db", dbPath,
+	); err != nil {
+		t.Fatalf("teach: %v", err)
+	}
+
+	// Recall with the bare form.
+	stdout, _, err := runRootArgs(t,
+		"recall", "portugal wins world cup",
+		"--db", dbPath,
+		"--agent",
+	)
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	var env recallEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("recall JSON: %v (stdout=%q)", err, stdout)
+	}
+	if !env.Found {
+		t.Errorf("normalized teach should be recall-discoverable from bare form; got %#v", env)
+	}
+}
+
+func TestTeachHintFor_HighConfidenceSuppresses(t *testing.T) {
+	t.Parallel()
+	if got := teachHintFor("portugal world cup", 1, true, 3); got != "" {
+		t.Errorf("high-confidence: want empty hint, got %q", got)
+	}
+	if got := teachHintFor("portugal world cup", 0, false, 0); got != "" {
+		t.Errorf("no hits: want empty hint, got %q", got)
+	}
+	if got := teachHintFor("portugal world cup", 0, false, 3); got == "" {
+		t.Errorf("low-confidence + hits: want non-empty hint, got empty")
+	}
+	if got := teachHintFor(`say "hi"`, 0, false, 1); !strings.Contains(got, `\"hi\"`) {
+		t.Errorf("hint should escape inner quotes; got %q", got)
+	}
+}
+
+func TestApplyLearningsForTopic_BoostMovesHitToFront(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "rerank.db")
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// Seed a learning that boosts KXMENWORLDCUP-26-PT for portugal queries.
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Two hits, the boosted one not at front.
+	hits := []topicHit{
+		{Source: "kalshi", Kind: "market", ID: "KXFUSION", Title: "Nuclear fusion"},
+		{Source: "kalshi", Kind: "market", ID: "KXMENWORLDCUP-26-PT", Title: "Will Portugal win the 2026 World Cup?"},
+	}
+	result, applied, _ := applyLearningsForTopic(context.Background(), s, "portugal world cup", hits)
+	if applied != 1 {
+		t.Errorf("applied: want 1, got %d", applied)
+	}
+	if result[0].ID != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("boost should move KXMENWORLDCUP-26-PT to position 0; got %s", result[0].ID)
+	}
+}
+
+func TestApplyLearningsForTopic_SyntheticInsert(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "rerank.db")
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// Seed a resource in the store so the synthetic insert can fetch it.
+	if err := s.Upsert("kalshi_markets", "KXMENWORLDCUP-26-PT",
+		json.RawMessage(`{"ticker":"KXMENWORLDCUP-26-PT","event_ticker":"KXMENWORLDCUP-26","title":"Will Portugal win the 2026 World Cup?","status":"active"}`)); err != nil {
+		t.Fatalf("seed resource: %v", err)
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("seed learning: %v", err)
+	}
+
+	// FTS missed it entirely — only an unrelated hit comes in.
+	hits := []topicHit{
+		{Source: "kalshi", Kind: "market", ID: "KXFUSION", Title: "Nuclear fusion"},
+	}
+	result, applied, _ := applyLearningsForTopic(context.Background(), s, "portugal world cup", hits)
+	if applied != 1 {
+		t.Errorf("applied: want 1, got %d", applied)
+	}
+	if len(result) != 2 || result[0].ID != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("synthetic insert should add KXMENWORLDCUP-26-PT at front; got %#v", result)
+	}
+}
+
+func TestApplyLearningsForTopic_NoLearnSkipsLayer(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "rerank.db")
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	flags := &rootFlags{noLearn: true}
+	if active := noLearnActive(flags); !active {
+		t.Errorf("expected noLearnActive=true with flag set")
+	}
+	// The call sites check noLearnActive before invoking the apply.
+	// Don't call applyLearningsForTopic here; the contract is the gate
+	// at the call site, which other tests exercise via the full
+	// command path.
+}

--- a/library/payments/prediction-goat/internal/cli/topic.go
+++ b/library/payments/prediction-goat/internal/cli/topic.go
@@ -98,7 +98,20 @@ func newTopicCmd(flags *rootFlags) *cobra.Command {
 			// the upstream APIs so the cached discovery index never serves
 			// stale prices. See freshness.go for the design.
 			outcome := refreshTopicHits(cmd.Context(), nil, results)
+			// Rerank layer: apply taught learnings before envelope assembly.
+			// Boosts move a hit to position 0 (or insert a synthetic hit
+			// when the FTS layer missed it entirely); hides drop hits;
+			// aliases rewrite IDs. See teach.go for the LLM contract.
+			var applied int
+			var hasHigh bool
+			if !noLearnActive(flags) {
+				results, applied, hasHigh = applyLearningsForTopic(cmd.Context(), db, topic, results)
+			}
 			meta := buildFreshnessMeta(outcome, indexSyncedAt(db))
+			if meta != nil {
+				meta.LearningsApplied = applied
+				meta.TeachHint = teachHintFor(topic, applied, hasHigh, len(results))
+			}
 			result := topicResult{Topic: topic, Count: len(results), Hits: results, Meta: meta}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {

--- a/library/payments/prediction-goat/internal/cli/topic.go
+++ b/library/payments/prediction-goat/internal/cli/topic.go
@@ -25,12 +25,19 @@ type topicHit struct {
 	Volume24h      float64 `json:"volume24h,omitempty"`
 	EndDate        string  `json:"endDate,omitempty"`
 	URL            string  `json:"url,omitempty"`
+	// PriceSource is set when the row carries a price/probability that
+	// went through the live refresh pipeline ("live" or "stale"). Rows
+	// with no price-bearing fields (tags, series) leave this empty so
+	// agents can tell a tag-row apart from a price-row whose refresh
+	// genuinely failed.
+	PriceSource string `json:"price_source,omitempty"`
 }
 
 type topicResult struct {
-	Topic string     `json:"topic"`
-	Count int        `json:"count"`
-	Hits  []topicHit `json:"hits"`
+	Topic string         `json:"topic"`
+	Count int            `json:"count"`
+	Hits  []topicHit     `json:"hits"`
+	Meta  *freshnessMeta `json:"meta,omitempty"`
 }
 
 func newTopicCmd(flags *rootFlags) *cobra.Command {
@@ -87,13 +94,23 @@ func newTopicCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 			results := interleaveTopicHits(polyHits, kalshiHits, limit)
-			result := topicResult{Topic: topic, Count: len(results), Hits: results}
+			// Live-on-read freshness: refresh price-bearing fields from
+			// the upstream APIs so the cached discovery index never serves
+			// stale prices. See freshness.go for the design.
+			outcome := refreshTopicHits(cmd.Context(), nil, results)
+			meta := buildFreshnessMeta(outcome, indexSyncedAt(db))
+			result := topicResult{Topic: topic, Count: len(results), Hits: results, Meta: meta}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if err := printJSONFiltered(cmd.OutOrStdout(), result, flags); err != nil {
 					return err
 				}
-			} else if err := printSimpleTable(cmd.OutOrStdout(), []string{"Source", "Kind", "Title", "%Yes", "Volume24h", "EndDate"}, topicRows(results)); err != nil {
-				return err
+			} else {
+				if err := printSimpleTable(cmd.OutOrStdout(), []string{"Source", "Kind", "Title", "%Yes", "Volume24h", "EndDate"}, topicRows(results)); err != nil {
+					return err
+				}
+				if footer := freshnessFooterLine(meta); footer != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), footer)
+				}
 			}
 			if len(results) == 0 {
 				return notFoundErr(fmt.Errorf("no markets, events, or tags matched topic %q (try a broader query, or run `prediction-goat-pp-cli sync` and `kalshi sync` first)", topic))
@@ -282,6 +299,63 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// refreshTopicHits batches the topic command's hits by venue, fires
+// one live API call per venue, and overwrites the cached
+// price-bearing fields on the in-memory slice. Returns the per-venue
+// outcome so the caller can populate the envelope's price_source.
+//
+// Hits with Kind=="market" carry prices; other kinds (event/tag/
+// series) intentionally have no PriceSource set so an agent can tell
+// a tag-row apart from a market-row whose refresh failed.
+func refreshTopicHits(ctx context.Context, fc freshnessClient, hits []topicHit) refreshOutcome {
+	polySlugs := make([]string, 0, len(hits))
+	kalshiTickers := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if h.Kind != "market" {
+			continue
+		}
+		switch h.Source {
+		case "polymarket":
+			polySlugs = append(polySlugs, h.ID)
+		case "kalshi":
+			kalshiTickers = append(kalshiTickers, h.ID)
+		}
+	}
+	outcome := refreshVenues(ctx, fc, polySlugs, kalshiTickers)
+	for i := range hits {
+		if hits[i].Kind != "market" {
+			continue
+		}
+		switch hits[i].Source {
+		case "polymarket":
+			if !outcome.PolymarketAsked {
+				continue
+			}
+			if !outcome.PolymarketOK {
+				hits[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Polymarket[hits[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &hits[i].YesProbability, &hits[i].Volume24h, &hits[i].Status)
+			}
+			hits[i].PriceSource = priceSourceLive
+		case "kalshi":
+			if !outcome.KalshiAsked {
+				continue
+			}
+			if !outcome.KalshiOK {
+				hits[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Kalshi[hits[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &hits[i].YesProbability, &hits[i].Volume24h, &hits[i].Status)
+			}
+			hits[i].PriceSource = priceSourceLive
+		}
+	}
+	return outcome
 }
 
 func pmStatus(obj map[string]any) string {

--- a/library/payments/prediction-goat/internal/cli/topic.go
+++ b/library/payments/prediction-goat/internal/cli/topic.go
@@ -36,11 +36,14 @@ type topicResult struct {
 func newTopicCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "topic <name>",
 		Short: "Cross-venue topic bundle (slim ranked markets/events/tags from Polymarket and Kalshi)",
 		Example: `  prediction-goat-pp-cli topic kanye-west --json
-  prediction-goat-pp-cli topic 'arizona basketball' --limit 20`,
+  prediction-goat-pp-cli topic 'arizona basketball' --limit 20
+  prediction-goat-pp-cli topic 'world cup' --kalshi   # skip Polymarket
+  prediction-goat-pp-cli topic 'world cup' --polymarket --agent`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -48,6 +51,10 @@ func newTopicCmd(flags *rootFlags) *cobra.Command {
 			}
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			if dbPath == "" {
 				dbPath = defaultDBPath("prediction-goat-pp-cli")
@@ -62,16 +69,22 @@ func newTopicCmd(flags *rootFlags) *cobra.Command {
 			// venue (Kalshi has events+series+markets, Polymarket has
 			// markets+events+tags) cannot crowd the other out via raw rank.
 			// Each side gets up to `limit` rows; they are then interleaved
-			// round-robin and trimmed to the final `limit`.
+			// round-robin and trimmed to the final `limit`. When the user
+			// scopes to a single venue, only that side runs.
 			polyTypes := []string{"markets", "events", "tags"}
 			kalshiTypes := []string{"kalshi_markets", "kalshi_events", "kalshi_series"}
-			polyHits, err := topicSearchByTypes(cmd.Context(), db.DB(), topicFTSQuery(topic), polyTypes, limit)
-			if err != nil {
-				return fmt.Errorf("topic search polymarket: %w", err)
+			var polyHits, kalshiHits []topicHit
+			if venue == "all" || venue == "polymarket" {
+				polyHits, err = topicSearchByTypes(cmd.Context(), db.DB(), topicFTSQuery(topic), polyTypes, limit)
+				if err != nil {
+					return fmt.Errorf("topic search polymarket: %w", err)
+				}
 			}
-			kalshiHits, err := topicSearchByTypes(cmd.Context(), db.DB(), topicFTSQuery(topic), kalshiTypes, limit)
-			if err != nil {
-				return fmt.Errorf("topic search kalshi: %w", err)
+			if venue == "all" || venue == "kalshi" {
+				kalshiHits, err = topicSearchByTypes(cmd.Context(), db.DB(), topicFTSQuery(topic), kalshiTypes, limit)
+				if err != nil {
+					return fmt.Errorf("topic search kalshi: %w", err)
+				}
 			}
 			results := interleaveTopicHits(polyHits, kalshiHits, limit)
 			result := topicResult{Topic: topic, Count: len(results), Hits: results}
@@ -90,6 +103,7 @@ func newTopicCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&limit, "limit", 50, "Max results")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }
 

--- a/library/payments/prediction-goat/internal/cli/trending.go
+++ b/library/payments/prediction-goat/internal/cli/trending.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"regexp"
@@ -20,11 +21,16 @@ type marketScreenItem struct {
 	Volume24h      float64 `json:"volume24h,omitempty"`
 	Liquidity      float64 `json:"liquidity,omitempty"`
 	EndDate        string  `json:"endDate,omitempty"`
+	// PriceSource is set after the live-on-read refresh fires: "live"
+	// when the upstream venue answered, "stale" when the refresh
+	// failed for the row's venue. See freshness.go.
+	PriceSource string `json:"price_source,omitempty"`
 }
 
 type trendingItem = marketScreenItem
 type trendingResult struct {
 	Items []trendingItem `json:"items"`
+	Meta  *freshnessMeta `json:"meta,omitempty"`
 }
 
 func newTrendingCmd(flags *rootFlags) *cobra.Command {
@@ -49,7 +55,9 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items}); renderErr != nil {
+			outcome := refreshMarketScreenItems(cmd.Context(), nil, items)
+			meta := buildFreshnessMeta(outcome, indexSyncedAtFromPath(cmd.Context(), dbPath))
+			if renderErr := renderTrending(cmd, flags, trendingResult{Items: items, Meta: meta}); renderErr != nil {
 				return renderErr
 			}
 			if len(items) == 0 {
@@ -353,7 +361,61 @@ func renderTrending(cmd *cobra.Command, flags *rootFlags, result trendingResult)
 	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 		return printJSONFiltered(cmd.OutOrStdout(), result, flags)
 	}
-	return printSimpleTable(cmd.OutOrStdout(), []string{"Source", "ID", "Title", "%Yes", "Volume24h", "Liquidity", "EndDate"}, marketScreenRows(result.Items))
+	if err := printSimpleTable(cmd.OutOrStdout(), []string{"Source", "ID", "Title", "%Yes", "Volume24h", "Liquidity", "EndDate"}, marketScreenRows(result.Items)); err != nil {
+		return err
+	}
+	if footer := freshnessFooterLine(result.Meta); footer != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), footer)
+	}
+	return nil
+}
+
+// refreshMarketScreenItems batches the slice by venue, fires a live
+// refresh per venue, and applies the refreshed price-bearing fields
+// to each item. Returns the per-venue outcome so the caller can
+// populate the envelope's price_source.
+func refreshMarketScreenItems(ctx context.Context, fc freshnessClient, items []marketScreenItem) refreshOutcome {
+	polySlugs := make([]string, 0, len(items))
+	kalshiTickers := make([]string, 0, len(items))
+	for _, it := range items {
+		switch it.Source {
+		case "polymarket":
+			polySlugs = append(polySlugs, it.ID)
+		case "kalshi":
+			kalshiTickers = append(kalshiTickers, it.ID)
+		}
+	}
+	outcome := refreshVenues(ctx, fc, polySlugs, kalshiTickers)
+	var dummyStatus string
+	for i := range items {
+		switch items[i].Source {
+		case "polymarket":
+			if !outcome.PolymarketAsked {
+				continue
+			}
+			if !outcome.PolymarketOK {
+				items[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Polymarket[items[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &items[i].YesProbability, &items[i].Volume24h, &dummyStatus)
+			}
+			items[i].PriceSource = priceSourceLive
+		case "kalshi":
+			if !outcome.KalshiAsked {
+				continue
+			}
+			if !outcome.KalshiOK {
+				items[i].PriceSource = priceSourceStale
+				continue
+			}
+			if v, ok := outcome.Kalshi[items[i].ID]; ok {
+				applyLiveValuesIfPresent(v, &items[i].YesProbability, &items[i].Volume24h, &dummyStatus)
+			}
+			items[i].PriceSource = priceSourceLive
+		}
+	}
+	return outcome
 }
 
 func marketScreenRows(items []marketScreenItem) [][]string {

--- a/library/payments/prediction-goat/internal/cli/trending.go
+++ b/library/payments/prediction-goat/internal/cli/trending.go
@@ -29,16 +29,21 @@ type trendingResult struct {
 
 func newTrendingCmd(flags *rootFlags) *cobra.Command {
 	var limit int
-	var venue, dbPath string
+	var dbPath string
+	var vf venueFlags
 	cmd := &cobra.Command{
 		Use:   "trending",
 		Short: "Top 24h volume markets across Polymarket and Kalshi",
 		Example: `  prediction-goat-pp-cli trending --json
-  prediction-goat-pp-cli trending --venue polymarket --limit 10`,
+  prediction-goat-pp-cli trending --polymarket --limit 10`,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				return nil
+			}
+			venue, err := resolveVenue(vf)
+			if err != nil {
+				return err
 			}
 			items, err := runMarketScreen(cmd, "trending", dbPath, venue, limit, 0, "", "")
 			if err != nil {
@@ -56,8 +61,8 @@ func newTrendingCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "Max results")
-	cmd.Flags().StringVar(&venue, "venue", "all", "Venue: all, polymarket, kalshi")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: standard cache location)")
+	addVenueFlags(cmd, &vf)
 	return cmd
 }
 

--- a/library/payments/prediction-goat/internal/cli/venue.go
+++ b/library/payments/prediction-goat/internal/cli/venue.go
@@ -1,0 +1,69 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// venueFlags holds the per-command venue selection inputs. `addVenueFlags`
+// wires it into a cobra command; `resolveVenue` reads the values and
+// returns the canonical venue string ("all", "polymarket", or "kalshi"),
+// reporting conflicts as usage errors.
+//
+// The three flags compose like this: --venue is the canonical string
+// flag (matches the existing convention from liquid/trending/movers/
+// resolving/new). --polymarket and --kalshi are boolean shortcuts so an
+// agent can scope a query to one venue without paying the cost of
+// searching both. Default behavior (no flag) stays "all" so existing
+// scripts that depend on cross-venue output keep working.
+type venueFlags struct {
+	venue      string
+	polymarket bool
+	kalshi     bool
+}
+
+// addVenueFlags registers --venue, --polymarket, --kalshi on cmd.
+func addVenueFlags(cmd *cobra.Command, vf *venueFlags) {
+	cmd.Flags().StringVar(&vf.venue, "venue", "all", "Venue: all, polymarket, kalshi")
+	cmd.Flags().BoolVar(&vf.polymarket, "polymarket", false, "Shortcut for --venue=polymarket")
+	cmd.Flags().BoolVar(&vf.kalshi, "kalshi", false, "Shortcut for --venue=kalshi")
+}
+
+// resolveVenue returns the canonical venue selection or a usage error
+// naming the specific conflict. Default is "all".
+func resolveVenue(vf venueFlags) (string, error) {
+	if vf.polymarket && vf.kalshi {
+		return "", fmt.Errorf("--polymarket and --kalshi are mutually exclusive (pick one, or drop both for cross-venue)")
+	}
+
+	// Treat the default value as unset so an explicit --venue=all stays
+	// compatible with a shortcut flag, and an explicit --venue=kalshi
+	// alongside --polymarket is the conflict the user actually cares
+	// about.
+	venueExplicit := vf.venue != "" && vf.venue != "all"
+
+	if vf.polymarket {
+		if venueExplicit && vf.venue != "polymarket" {
+			return "", fmt.Errorf("--polymarket conflicts with --venue=%s", vf.venue)
+		}
+		return "polymarket", nil
+	}
+	if vf.kalshi {
+		if venueExplicit && vf.venue != "kalshi" {
+			return "", fmt.Errorf("--kalshi conflicts with --venue=%s", vf.venue)
+		}
+		return "kalshi", nil
+	}
+
+	switch vf.venue {
+	case "", "all":
+		return "all", nil
+	case "polymarket", "kalshi":
+		return vf.venue, nil
+	default:
+		return "", fmt.Errorf("invalid --venue %q: must be all, polymarket, or kalshi", vf.venue)
+	}
+}

--- a/library/payments/prediction-goat/internal/cli/venue_test.go
+++ b/library/payments/prediction-goat/internal/cli/venue_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveVenue(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		vf        venueFlags
+		wantVenue string
+		wantErr   string // substring; empty = no error expected
+	}{
+		{"default is all", venueFlags{venue: "all"}, "all", ""},
+		{"explicit --venue=polymarket", venueFlags{venue: "polymarket"}, "polymarket", ""},
+		{"explicit --venue=kalshi", venueFlags{venue: "kalshi"}, "kalshi", ""},
+		{"--polymarket shortcut", venueFlags{venue: "all", polymarket: true}, "polymarket", ""},
+		{"--kalshi shortcut", venueFlags{venue: "all", kalshi: true}, "kalshi", ""},
+
+		{"--polymarket with --venue=polymarket is compatible", venueFlags{venue: "polymarket", polymarket: true}, "polymarket", ""},
+		{"--kalshi with --venue=kalshi is compatible", venueFlags{venue: "kalshi", kalshi: true}, "kalshi", ""},
+
+		{"--polymarket --kalshi conflict", venueFlags{venue: "all", polymarket: true, kalshi: true}, "", "mutually exclusive"},
+		{"--polymarket --venue=kalshi conflict", venueFlags{venue: "kalshi", polymarket: true}, "", "conflicts with --venue=kalshi"},
+		{"--kalshi --venue=polymarket conflict", venueFlags{venue: "polymarket", kalshi: true}, "", "conflicts with --venue=polymarket"},
+		{"invalid --venue value", venueFlags{venue: "fanduel"}, "", `invalid --venue "fanduel"`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveVenue(c.vf)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != c.wantVenue {
+					t.Errorf("venue = %q, want %q", got, c.wantVenue)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil (venue=%q)", c.wantErr, got)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestTopicVenueScopingRejectsConflicts is a fast smoke that the topic
+// command surfaces resolveVenue errors via its flag wiring.
+func TestTopicVenueScopingRejectsConflicts(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := RootCmd()
+	rootCmd.SetArgs([]string{"topic", "foo", "--polymarket", "--kalshi"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error from conflicting --polymarket --kalshi, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "mutually exclusive")
+	}
+}
+
+// TestCompareRejectsSingleVenueScope locks the contract that compare
+// errors when scoped to one venue, since pairing requires both.
+func TestCompareRejectsSingleVenueScope(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := RootCmd()
+	rootCmd.SetArgs([]string{"compare", "election", "--polymarket"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error from compare --polymarket, got nil")
+	}
+	if !strings.Contains(err.Error(), "compare requires both venues") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "compare requires both venues")
+	}
+}

--- a/library/payments/prediction-goat/internal/source/kalshi/client.go
+++ b/library/payments/prediction-goat/internal/source/kalshi/client.go
@@ -33,6 +33,34 @@ func New() *Client {
 	}
 }
 
+// GetMarketsBySeries fetches one page of markets for the given series ticker.
+// Mirrors the live-side query parameter shape used by kalshi events list
+// (--series → series_ticker). Passing cursor="" requests the first page; a
+// non-empty cursor advances pagination. status="" defaults to "open" so the
+// series walk only seeds the index with live tradable markets.
+func (c *Client) GetMarketsBySeries(ctx context.Context, ticker, status, cursor string, limit int) ([]byte, error) {
+	if c == nil {
+		c = New()
+	}
+	params := url.Values{}
+	if ticker != "" {
+		params.Set("series_ticker", ticker)
+	}
+	if status == "" {
+		status = "open"
+	}
+	params.Set("status", status)
+	if limit > 0 {
+		params.Set("limit", fmt.Sprintf("%d", limit))
+	} else {
+		params.Set("limit", "1000")
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+	return c.Get(ctx, "/markets", params)
+}
+
 func (c *Client) Get(ctx context.Context, path string, params url.Values) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/library/payments/prediction-goat/internal/source/kalshi/series_walk.go
+++ b/library/payments/prediction-goat/internal/source/kalshi/series_walk.go
@@ -1,0 +1,220 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package kalshi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/cliutil"
+)
+
+// SeriesWalkStore is the storage surface SyncMarketsBySeries needs. It is a
+// superset of KalshiStore (Upsert) because the walk also needs (a) the list
+// of synced series tickers as the iteration seed and (b) sync_state I/O
+// keyed per series so a re-run resumes mid-walk.
+//
+// PATCH(series-driven-kalshi-markets-sync-walk): introduced so the walk can
+// be exercised in tests against an in-memory store without dragging in the
+// full *store.Store implementation.
+type SeriesWalkStore interface {
+	KalshiStore
+	ListIDs(resourceType string) ([]string, error)
+	GetSyncState(resourceType string) (cursor string, lastSynced time.Time, count int, err error)
+	SaveSyncState(resourceType, cursor string, count int) error
+}
+
+// defaultSeriesWalkWorkers paces the per-series fan-out. Kalshi's /markets
+// endpoint with series_ticker is cheap (one round trip per call) but the
+// client's AdaptiveLimiter still gates each request, so multiple workers
+// amortize wait time across in-flight calls without violating rate limits.
+const defaultSeriesWalkWorkers = 8
+
+// seriesWalkStateKey returns the sync_state row identifier for the per-series
+// walk progress so each series has its own resume cursor.
+func seriesWalkStateKey(ticker string) string {
+	return "kalshi_markets_walk:" + ticker
+}
+
+// seriesWalkDoneSentinel marks a series as fully walked. The presence of a
+// sync_state row with this cursor and a non-zero count signals "skip this
+// series on the next resume" so a re-run picks up where the previous one
+// left off without re-fetching already-covered prefixes.
+const seriesWalkDoneSentinel = "__done__"
+
+// SyncMarketsBySeries iterates every series ticker already present in the
+// kalshi_series table and fetches /markets?series_ticker=<X> for each.
+// This is the second-pass walk that covers named-event families
+// (KXMENWORLDCUP-*, KXBTC*, KXOSCAR*) that the natural `/markets?status=open`
+// pagination starves on high-volume factory-market prefixes.
+//
+// status defaults to "open" so the walk only fills the index with currently
+// tradable markets. maxSeries=0 means "iterate every series" — pass a small
+// positive value in tests / dogfood to cap the wall-clock.
+//
+// Progress is persisted per-series to sync_state under
+// "kalshi_markets_walk:<ticker>" so an interrupted run resumes mid-walk
+// rather than re-fetching from scratch.
+//
+// Returns the number of market rows newly upserted (across all series) plus
+// the first non-context-canceled error if any worker hit one. Per-series
+// errors are logged to stderr and counted but do not abort the walk.
+func SyncMarketsBySeries(ctx context.Context, c *Client, st SeriesWalkStore, maxSeries int) (count int, err error) {
+	if c == nil {
+		c = New()
+	}
+	if st == nil {
+		return 0, fmt.Errorf("nil store")
+	}
+
+	seriesTickers, err := st.ListIDs("kalshi_series")
+	if err != nil {
+		return 0, fmt.Errorf("list kalshi_series: %w", err)
+	}
+	if len(seriesTickers) == 0 {
+		return 0, nil
+	}
+
+	limit := 1000
+	if cliutil.IsDogfoodEnv() {
+		limit = 50
+	}
+
+	workers := defaultSeriesWalkWorkers
+	if cliutil.IsVerifyEnv() {
+		// Single-flight under verify so the store writer doesn't trip
+		// SQLITE_BUSY without natural network jitter.
+		workers = 1
+	}
+	if workers > len(seriesTickers) {
+		workers = len(seriesTickers)
+	}
+
+	work := make(chan string, len(seriesTickers))
+	var (
+		mu       sync.Mutex
+		firstErr error
+		total    int64
+		enqueued int
+	)
+
+	enqueueLimit := len(seriesTickers)
+	if maxSeries > 0 && maxSeries < enqueueLimit {
+		enqueueLimit = maxSeries
+	}
+
+	for _, ticker := range seriesTickers {
+		if enqueued >= enqueueLimit {
+			break
+		}
+		// Resume gate: skip series flagged done in sync_state. Any
+		// series with a non-sentinel cursor is mid-walk and re-enters
+		// the queue so the worker can resume from its cursor.
+		cursor, _, _, _ := st.GetSyncState(seriesWalkStateKey(ticker))
+		if cursor == seriesWalkDoneSentinel {
+			continue
+		}
+		work <- ticker
+		enqueued++
+	}
+	close(work)
+
+	if enqueued == 0 {
+		return 0, nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ticker := range work {
+				if err := ctx.Err(); err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+					return
+				}
+				n, walkErr := walkOneSeries(ctx, c, st, ticker, limit)
+				atomic.AddInt64(&total, int64(n))
+				if walkErr != nil {
+					fmt.Fprintf(os.Stderr, "kalshi: series %s walk error: %v\n", ticker, walkErr)
+					mu.Lock()
+					if firstErr == nil && ctx.Err() == nil {
+						firstErr = walkErr
+					}
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	return int(atomic.LoadInt64(&total)), firstErr
+}
+
+// walkOneSeries pages /markets?series_ticker=<ticker> until the cursor
+// terminates and upserts every market into the store. Saves the cursor to
+// sync_state after each page so a re-run can resume mid-series. On
+// successful completion, replaces the cursor with seriesWalkDoneSentinel so
+// the next walk skips this series until --full clears it.
+func walkOneSeries(ctx context.Context, c *Client, st SeriesWalkStore, ticker string, limit int) (int, error) {
+	stateKey := seriesWalkStateKey(ticker)
+	cursor, _, prior, _ := st.GetSyncState(stateKey)
+	if cursor == seriesWalkDoneSentinel {
+		return 0, nil
+	}
+
+	total := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		body, err := c.GetMarketsBySeries(ctx, ticker, "open", cursor, limit)
+		if err != nil {
+			return total, fmt.Errorf("get markets for series %s: %w", ticker, err)
+		}
+
+		items, nextCursor, err := decodeMarkets(body)
+		if err != nil {
+			return total, err
+		}
+
+		for _, raw := range items {
+			id, err := extractTicker(raw, "ticker")
+			if err != nil {
+				return total, err
+			}
+			if id == "" {
+				fmt.Fprintf(os.Stderr, "kalshi: skipping kalshi_markets item with empty ticker (series %s)\n", ticker)
+				continue
+			}
+			if err := st.Upsert("kalshi_markets", id, raw); err != nil {
+				return total, fmt.Errorf("upsert market %s (series %s): %w", id, ticker, err)
+			}
+			total++
+		}
+
+		if nextCursor == "" {
+			// Mark this series done so the next resume skips it.
+			if saveErr := st.SaveSyncState(stateKey, seriesWalkDoneSentinel, prior+total); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "kalshi: save sync_state done for series %s: %v\n", ticker, saveErr)
+			}
+			return total, nil
+		}
+
+		// Persist progress so an interruption resumes from the next cursor.
+		if saveErr := st.SaveSyncState(stateKey, nextCursor, prior+total); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "kalshi: save sync_state cursor for series %s: %v\n", ticker, saveErr)
+		}
+		cursor = nextCursor
+	}
+}
+

--- a/library/payments/prediction-goat/internal/source/kalshi/series_walk_test.go
+++ b/library/payments/prediction-goat/internal/source/kalshi/series_walk_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package kalshi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/cliutil"
+)
+
+// memoryStore is the in-memory SeriesWalkStore used by the series-walk
+// tests. It captures upserts per resource type, seeds ListIDs for
+// kalshi_series, and tracks sync_state keyed per series so resume can
+// be exercised without spinning up a real SQLite database.
+type memoryStore struct {
+	mu       sync.Mutex
+	rows     map[string]map[string]json.RawMessage // resource_type -> id -> raw
+	seriesID []string                              // seed for ListIDs("kalshi_series")
+	state    map[string]memoryState
+}
+
+type memoryState struct {
+	cursor     string
+	lastSynced time.Time
+	count      int
+}
+
+func newMemoryStore(seriesIDs []string) *memoryStore {
+	return &memoryStore{
+		rows:     map[string]map[string]json.RawMessage{},
+		seriesID: append([]string(nil), seriesIDs...),
+		state:    map[string]memoryState{},
+	}
+}
+
+func (m *memoryStore) Upsert(resourceType, id string, data json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.rows[resourceType]; !ok {
+		m.rows[resourceType] = map[string]json.RawMessage{}
+	}
+	m.rows[resourceType][id] = append(json.RawMessage(nil), data...)
+	return nil
+}
+
+func (m *memoryStore) ListIDs(resourceType string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if resourceType == "kalshi_series" {
+		return append([]string(nil), m.seriesID...), nil
+	}
+	rows, ok := m.rows[resourceType]
+	if !ok {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(rows))
+	for id := range rows {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (m *memoryStore) GetSyncState(resourceType string) (string, time.Time, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.state[resourceType]
+	if !ok {
+		return "", time.Time{}, 0, nil
+	}
+	return s.cursor, s.lastSynced, s.count, nil
+}
+
+func (m *memoryStore) SaveSyncState(resourceType, cursor string, count int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state[resourceType] = memoryState{cursor: cursor, lastSynced: time.Now(), count: count}
+	return nil
+}
+
+func (m *memoryStore) countByType(resourceType string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.rows[resourceType])
+}
+
+func (m *memoryStore) hasMarket(ticker string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.rows["kalshi_markets"][ticker]
+	return ok
+}
+
+// fixtureServer maps each series ticker to its list of markets and serves
+// /markets?series_ticker=<X>. It also supports a hook that kills a worker
+// after N requests so the resume test can simulate an interruption.
+type fixtureServer struct {
+	t            *testing.T
+	markets      map[string][]map[string]any
+	callsBySeries map[string]int
+	mu            sync.Mutex
+}
+
+func newFixtureServer(t *testing.T, markets map[string][]map[string]any) *httptest.Server {
+	fs := &fixtureServer{
+		t:             t,
+		markets:       markets,
+		callsBySeries: map[string]int{},
+	}
+	return httptest.NewServer(http.HandlerFunc(fs.serve))
+}
+
+func (fs *fixtureServer) serve(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, "/markets") {
+		http.NotFound(w, r)
+		return
+	}
+	series := r.URL.Query().Get("series_ticker")
+	fs.mu.Lock()
+	fs.callsBySeries[series]++
+	fs.mu.Unlock()
+
+	mkts, ok := fs.markets[series]
+	if !ok {
+		// Zero open markets for this series — return empty list, not an
+		// error. Test expects the walk to log and continue.
+		fs.writeJSON(w, map[string]any{"markets": []any{}})
+		return
+	}
+
+	fs.writeJSON(w, map[string]any{"markets": mkts})
+}
+
+func (fs *fixtureServer) writeJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(body); err != nil {
+		fs.t.Fatalf("encode response: %v", err)
+	}
+}
+
+// newTestClient wires the kalshi Client at a fixture server's URL with
+// the AdaptiveLimiter disabled so the tests don't waste seconds waiting
+// for rate-limit windows. Rate-limit verification re-enables it
+// explicitly with a low rate.
+func newTestClient(serverURL string) *Client {
+	c := New()
+	c.BaseURL = serverURL
+	c.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+	c.limiter = nil
+	return c
+}
+
+func TestSyncMarketsBySeries_CoversAllSeries(t *testing.T) {
+	seriesIDs := []string{"KXOSCAR", "KXBTC", "KXMENWORLDCUP"}
+	markets := map[string][]map[string]any{
+		"KXOSCAR": {
+			{"ticker": "KXOSCAR-26-BP", "series_ticker": "KXOSCAR"},
+			{"ticker": "KXOSCAR-26-BD", "series_ticker": "KXOSCAR"},
+		},
+		"KXBTC": {
+			{"ticker": "KXBTC-26-100K", "series_ticker": "KXBTC"},
+			{"ticker": "KXBTC-26-50K", "series_ticker": "KXBTC"},
+		},
+		"KXMENWORLDCUP": {
+			{"ticker": "KXMENWORLDCUP-26-PT", "series_ticker": "KXMENWORLDCUP"},
+			{"ticker": "KXMENWORLDCUP-26-BR", "series_ticker": "KXMENWORLDCUP"},
+		},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+
+	st := newMemoryStore(seriesIDs)
+	c := newTestClient(srv.URL)
+
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 0)
+	if err != nil {
+		t.Fatalf("SyncMarketsBySeries: %v", err)
+	}
+	if want := 6; n != want {
+		t.Fatalf("upserted=%d want=%d", n, want)
+	}
+	if got := st.countByType("kalshi_markets"); got != 6 {
+		t.Fatalf("store has %d markets, want 6", got)
+	}
+}
+
+func TestSyncMarketsBySeries_NamedEventFamiliesLand(t *testing.T) {
+	seriesIDs := []string{"KXMENWORLDCUP", "KXBTC", "KXOSCAR"}
+	markets := map[string][]map[string]any{
+		"KXMENWORLDCUP": {
+			{"ticker": "KXMENWORLDCUP-26-PT", "series_ticker": "KXMENWORLDCUP", "title": "Portugal wins"},
+		},
+		"KXBTC": {
+			{"ticker": "KXBTC-MAX100", "series_ticker": "KXBTC"},
+		},
+		"KXOSCAR": {
+			{"ticker": "KXOSCAR-BP-26", "series_ticker": "KXOSCAR"},
+		},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+
+	st := newMemoryStore(seriesIDs)
+	c := newTestClient(srv.URL)
+
+	if _, err := SyncMarketsBySeries(context.Background(), c, st, 0); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for _, ticker := range []string{"KXMENWORLDCUP-26-PT", "KXBTC-MAX100", "KXOSCAR-BP-26"} {
+		if !st.hasMarket(ticker) {
+			t.Errorf("named-event ticker %s missing from store", ticker)
+		}
+	}
+}
+
+func TestSyncMarketsBySeries_ResumeAfterPartialRun(t *testing.T) {
+	seriesIDs := []string{"KXOSCAR", "KXBTC", "KXMENWORLDCUP"}
+	markets := map[string][]map[string]any{
+		"KXOSCAR":       {{"ticker": "KXOSCAR-1", "series_ticker": "KXOSCAR"}},
+		"KXBTC":         {{"ticker": "KXBTC-1", "series_ticker": "KXBTC"}},
+		"KXMENWORLDCUP": {{"ticker": "KXMENWORLDCUP-1", "series_ticker": "KXMENWORLDCUP"}},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+
+	st := newMemoryStore(seriesIDs)
+
+	// Simulate "first run processed KXOSCAR" by manually flagging its
+	// state as done. The next walk should skip it and only fetch
+	// KXBTC + KXMENWORLDCUP.
+	if err := st.SaveSyncState(seriesWalkStateKey("KXOSCAR"), seriesWalkDoneSentinel, 1); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-seed the upsert for the already-done series so the count
+	// reflects "freshly walked this run" only.
+	if err := st.Upsert("kalshi_markets", "KXOSCAR-1", json.RawMessage(`{"ticker":"KXOSCAR-1"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 0)
+	if err != nil {
+		t.Fatalf("resume walk: %v", err)
+	}
+	if want := 2; n != want {
+		t.Fatalf("resumed walk upserted %d want %d", n, want)
+	}
+	if !st.hasMarket("KXBTC-1") || !st.hasMarket("KXMENWORLDCUP-1") {
+		t.Fatalf("post-resume store missing expected markets: %+v", st.rows["kalshi_markets"])
+	}
+
+	// All three series should now be marked done.
+	for _, s := range seriesIDs {
+		cursor, _, _, _ := st.GetSyncState(seriesWalkStateKey(s))
+		if cursor != seriesWalkDoneSentinel {
+			t.Errorf("series %s not marked done after walk; cursor=%q", s, cursor)
+		}
+	}
+}
+
+func TestSyncMarketsBySeries_RateLimitHonored(t *testing.T) {
+	// Pace 4 series through a limiter pinned at 4 req/s with the walk
+	// forced to workers=1 (via IsVerifyEnv). The AdaptiveLimiter
+	// serializes lastRequest only once a request has fired; with a
+	// single worker each successive Wait() honors the 250ms gap, so
+	// the wall-clock floor is ~750ms (3 inter-call gaps at 250ms).
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
+
+	seriesIDs := []string{"S1", "S2", "S3", "S4"}
+	markets := map[string][]map[string]any{
+		"S1": {{"ticker": "S1-A"}},
+		"S2": {{"ticker": "S2-A"}},
+		"S3": {{"ticker": "S3-A"}},
+		"S4": {{"ticker": "S4-A"}},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+
+	c := New()
+	c.BaseURL = srv.URL
+	c.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+	c.limiter = cliutil.NewAdaptiveLimiter(4.0)
+
+	st := newMemoryStore(seriesIDs)
+	start := time.Now()
+	if _, err := SyncMarketsBySeries(context.Background(), c, st, 0); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 600*time.Millisecond {
+		t.Fatalf("walk completed in %s; expected ≥ 600ms with 4 req/s limiter and serialized workers (rate limiting not honored)", elapsed)
+	}
+}
+
+func TestSyncMarketsBySeries_EmptySeriesNoError(t *testing.T) {
+	seriesIDs := []string{"KXEMPTY", "KXPOPULATED"}
+	markets := map[string][]map[string]any{
+		// "KXEMPTY" intentionally missing -> server returns empty list.
+		"KXPOPULATED": {{"ticker": "KXPOP-1"}},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+
+	st := newMemoryStore(seriesIDs)
+	c := newTestClient(srv.URL)
+
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 0)
+	if err != nil {
+		t.Fatalf("walk with empty series errored: %v", err)
+	}
+	if want := 1; n != want {
+		t.Fatalf("upserted %d markets, want %d", n, want)
+	}
+	if !st.hasMarket("KXPOP-1") {
+		t.Errorf("populated series's market missing from store")
+	}
+}
+
+func TestSyncMarketsBySeries_NoSeriesIsNoOp(t *testing.T) {
+	srv := newFixtureServer(t, nil)
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	st := newMemoryStore(nil)
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 0)
+	if err != nil {
+		t.Fatalf("empty-corpus walk errored: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("empty-corpus walk upserted %d markets, want 0", n)
+	}
+}
+
+func TestSyncMarketsBySeries_CapMaxSeries(t *testing.T) {
+	seriesIDs := []string{"S1", "S2", "S3", "S4", "S5"}
+	markets := map[string][]map[string]any{
+		"S1": {{"ticker": "S1-A"}},
+		"S2": {{"ticker": "S2-A"}},
+		"S3": {{"ticker": "S3-A"}},
+		"S4": {{"ticker": "S4-A"}},
+		"S5": {{"ticker": "S5-A"}},
+	}
+	srv := newFixtureServer(t, markets)
+	defer srv.Close()
+
+	st := newMemoryStore(seriesIDs)
+	c := newTestClient(srv.URL)
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 2)
+	if err != nil {
+		t.Fatalf("capped walk: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("maxSeries=2 walked %d markets, want 2", n)
+	}
+}
+
+func TestSyncMarketsBySeries_MidPageCursor(t *testing.T) {
+	// One series, two pages. Walk should follow the cursor and persist
+	// both pages' markets.
+	seriesIDs := []string{"KXMULTI"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		if cursor == "" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"markets":[{"ticker":"KXMULTI-1"}],"cursor":"page2"}`)
+			return
+		}
+		if cursor == "page2" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"markets":[{"ticker":"KXMULTI-2"}],"cursor":""}`)
+			return
+		}
+		http.Error(w, "unknown cursor", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := newTestClient(srv.URL)
+	st := newMemoryStore(seriesIDs)
+	n, err := SyncMarketsBySeries(context.Background(), c, st, 0)
+	if err != nil {
+		t.Fatalf("multi-page walk: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("multi-page walk landed %d markets, want 2", n)
+	}
+	if !st.hasMarket("KXMULTI-1") || !st.hasMarket("KXMULTI-2") {
+		t.Fatalf("missing markets after multi-page walk: %+v", st.rows["kalshi_markets"])
+	}
+	cursor, _, _, _ := st.GetSyncState(seriesWalkStateKey("KXMULTI"))
+	if cursor != seriesWalkDoneSentinel {
+		t.Errorf("series not marked done after full walk; cursor=%q", cursor)
+	}
+}

--- a/library/payments/prediction-goat/internal/source/kalshi/sync.go
+++ b/library/payments/prediction-goat/internal/source/kalshi/sync.go
@@ -27,6 +27,35 @@ func SyncMarkets(ctx context.Context, c *Client, st KalshiStore, maxPages int) (
 	if err != nil {
 		return count, fmt.Errorf("kalshi sync markets: %w", err)
 	}
+
+	// PATCH(series-driven-kalshi-markets-sync-walk): /markets natural
+	// ordering puts high-volume factory families (KXMVE* esports) first,
+	// so the bare paginator never reaches named-event families like
+	// KXMENWORLDCUP-*, KXBTC*, KXOSCAR*. After the first-pass populates
+	// the high-frequency markets, fan out per kalshi_series.ticker to
+	// cover the long tail. The walk is gated behind the SeriesWalkStore
+	// interface so callers that only implement Upsert (a few tests) keep
+	// working unchanged — non-walk-capable stores just skip the second
+	// pass.
+	if walkStore, ok := st.(SeriesWalkStore); ok {
+		// maxSeries=0 means "every series" in production. Under dogfood
+		// the per-series fan-out is capped so the matrix's per-command
+		// budget isn't blown.
+		maxSeries := 0
+		if cliutil.IsDogfoodEnv() {
+			maxSeries = 3
+		}
+		walked, walkErr := SyncMarketsBySeries(ctx, c, walkStore, maxSeries)
+		count += walked
+		if walkErr != nil {
+			// Walk errors are non-fatal: the first-pass already populated
+			// the high-frequency markets, so the index isn't empty even
+			// if the long-tail fan-out partially failed. Surface the
+			// error so callers can log/exit non-zero if they choose.
+			return count, fmt.Errorf("kalshi sync markets series walk: %w", walkErr)
+		}
+	}
+
 	return count, nil
 }
 

--- a/library/payments/prediction-goat/internal/store/fts_content_test.go
+++ b/library/payments/prediction-goat/internal/store/fts_content_test.go
@@ -251,9 +251,11 @@ func TestFTSContent_PreventsFTSFalsePositives(t *testing.T) {
 	}
 }
 
-// TestSchemaVersionAt3 pins the version bump so future migrations have
-// a clean baseline.
-func TestSchemaVersionAt3(t *testing.T) {
+// TestSchemaVersionAt4 pins the version bump so future migrations have
+// a clean baseline. v4 added the search_learnings table (U8 LLM-driven
+// reranking signal); the rebuild migration introduced in v3 (curated
+// FTS content) still runs against pre-v3 DBs because v4 supersedes it.
+func TestSchemaVersionAt4(t *testing.T) {
 	t.Parallel()
 	dbPath := filepath.Join(t.TempDir(), "version.db")
 	s, err := OpenWithContext(context.Background(), dbPath)
@@ -265,7 +267,7 @@ func TestSchemaVersionAt3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SchemaVersion: %v", err)
 	}
-	if v != 3 {
-		t.Errorf("SchemaVersion = %d, want 3", v)
+	if v != 4 {
+		t.Errorf("SchemaVersion = %d, want 4", v)
 	}
 }

--- a/library/payments/prediction-goat/internal/store/fts_content_test.go
+++ b/library/payments/prediction-goat/internal/store/fts_content_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFTSContent_StripsRawJSONNoise covers the core regression that
+// motivated U2: the live store indexes the entire raw JSON blob in
+// resources_fts.content, so KXFUSION (a Kalshi "Nuclear fusion" series)
+// matches a query like "oscars best picture" because its source_agencies
+// field cites the Academy of Motion Picture Arts and Sciences at
+// oscars.org. After U2, ftsContent projects to title/ticker/category
+// only, so the false-positive vector is gone.
+//
+// Characterization-first: the table runs against ftsContent directly
+// (no DB) so the assertions about WHAT we index versus what we drop are
+// independent of the FTS engine's tokenizer.
+func TestFTSContent_StripsRawJSONNoise(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		data           string
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			name: "kalshi_series_nuclear_fusion drops source_agencies",
+			data: `{
+				"ticker": "KXFUSION",
+				"title": "Nuclear fusion",
+				"category": "Science",
+				"source_agencies": [
+					{"name": "Academy of Motion Picture Arts and Sciences", "url": "https://www.oscars.org/oscars"},
+					{"name": "Financial Times", "url": "https://ft.com/"}
+				],
+				"additional_prohibitions": ["Persons employed by any of the Source Agencies"]
+			}`,
+			mustContain:    []string{"Nuclear fusion", "KXFUSION", "Science"},
+			mustNotContain: []string{"oscars", "Motion Picture", "Academy", "Financial Times", "prohibitions", "employed"},
+		},
+		{
+			name: "kalshi_market_portugal_world_cup keeps real signal",
+			data: `{
+				"ticker": "KXMENWORLDCUP-26-PT",
+				"event_ticker": "KXMENWORLDCUP-26",
+				"title": "Will the Portugal win the 2026 Men's World Cup?",
+				"yes_sub_title": "Portugal",
+				"category": "Sports"
+			}`,
+			mustContain: []string{"Portugal", "World Cup", "KXMENWORLDCUP-26-PT", "KXMENWORLDCUP-26", "Sports"},
+		},
+		{
+			name: "polymarket_market keeps question + slug + category",
+			data: `{
+				"slug": "will-portugal-win-the-2026-fifa-world-cup-912",
+				"question": "Will Portugal win the 2026 FIFA World Cup?",
+				"category": "Sports",
+				"description": "Will Portugal lift the 2026 FIFA World Cup trophy on July 20?",
+				"endDate": "2026-07-20T00:00:00Z"
+			}`,
+			mustContain:    []string{"Will Portugal win", "FIFA World Cup", "will-portugal-win-the-2026-fifa-world-cup-912", "Sports"},
+			mustNotContain: []string{"endDate", "T00:00:00Z"},
+		},
+		{
+			name: "kalshi_series_oscar keeps oscar signal",
+			data: `{
+				"ticker": "KXOSCARCOUNTCONCLAVE",
+				"title": "Conclave Oscar wins",
+				"category": "Entertainment"
+			}`,
+			mustContain: []string{"Conclave Oscar wins", "KXOSCARCOUNTCONCLAVE", "Entertainment"},
+		},
+		{
+			name: "kalshi_series_bitcoin keeps bitcoin signal",
+			data: `{
+				"ticker": "KXBTCMAX100",
+				"title": "When will bitcoin hit 100k?",
+				"category": "Crypto"
+			}`,
+			mustContain: []string{"bitcoin hit 100k", "KXBTCMAX100", "Crypto"},
+		},
+		{
+			name: "tag projects to label + slug",
+			data: `{
+				"id": "77",
+				"label": "mavericks",
+				"slug": "mavericks",
+				"publishedAt": "2023-11-02 21:18:00"
+			}`,
+			mustContain:    []string{"mavericks"},
+			mustNotContain: []string{"publishedAt", "2023-11-02"},
+		},
+		{
+			name:        "malformed json returns empty",
+			data:        `not-json{`,
+			mustContain: []string{},
+		},
+		{
+			name:        "unknown resource type with name field",
+			data:        `{"name": "legacy restaurant", "kind": "biz"}`,
+			mustContain: []string{"legacy restaurant"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ftsContent(tc.data)
+			for _, want := range tc.mustContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("ftsContent output missing required substring %q\ngot: %q", want, got)
+				}
+			}
+			for _, forbidden := range tc.mustNotContain {
+				if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
+					t.Errorf("ftsContent output contains forbidden substring %q (case-insensitive)\ngot: %q", forbidden, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFTSContent_PreventsFTSFalsePositives runs end-to-end against a
+// real SQLite + FTS5 instance. Seeds KXFUSION and KXOSCARCOUNTCONCLAVE,
+// then runs MATCH queries that pre-U2 would have surfaced KXFUSION as
+// a top hit for "oscars". After U2 the FTS index only contains the
+// curated title+ticker+category, so KXFUSION cannot match.
+func TestFTSContent_PreventsFTSFalsePositives(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fts_content.db")
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+
+	fixtures := []struct {
+		resourceType string
+		id           string
+		data         string
+	}{
+		{
+			resourceType: "kalshi_series",
+			id:           "KXFUSION",
+			data: `{
+				"ticker": "KXFUSION",
+				"title": "Nuclear fusion",
+				"category": "Science",
+				"source_agencies": [{"name": "Academy of Motion Picture Arts and Sciences", "url": "https://www.oscars.org/oscars"}]
+			}`,
+		},
+		{
+			resourceType: "kalshi_series",
+			id:           "KXOSCARCOUNTCONCLAVE",
+			data:         `{"ticker": "KXOSCARCOUNTCONCLAVE", "title": "Conclave Oscar wins", "category": "Entertainment"}`,
+		},
+		{
+			resourceType: "kalshi_series",
+			id:           "KXBTCMAX100",
+			data:         `{"ticker": "KXBTCMAX100", "title": "When will bitcoin hit 100k?", "category": "Crypto"}`,
+		},
+		{
+			resourceType: "kalshi_markets",
+			id:           "KXMENWORLDCUP-26-PT",
+			data: `{
+				"ticker": "KXMENWORLDCUP-26-PT",
+				"event_ticker": "KXMENWORLDCUP-26",
+				"title": "Will the Portugal win the 2026 Men's World Cup?",
+				"yes_sub_title": "Portugal",
+				"category": "Sports"
+			}`,
+		},
+	}
+	for _, f := range fixtures {
+		if err := s.Upsert(f.resourceType, f.id, json.RawMessage(f.data)); err != nil {
+			t.Fatalf("upsert %s: %v", f.id, err)
+		}
+	}
+
+	queries := []struct {
+		name        string
+		match       string
+		mustReturn  []string // resource_ids that must appear
+		mustExclude []string // resource_ids that must NOT appear
+	}{
+		{
+			name:        "oscar query excludes Nuclear fusion",
+			match:       "oscar",
+			mustReturn:  []string{"KXOSCARCOUNTCONCLAVE"},
+			mustExclude: []string{"KXFUSION"},
+		},
+		{
+			name:        "bitcoin query finds BTC series",
+			match:       "bitcoin",
+			mustReturn:  []string{"KXBTCMAX100"},
+			mustExclude: []string{"KXFUSION", "KXOSCARCOUNTCONCLAVE"},
+		},
+		{
+			name:        "portugal world cup query finds the right Kalshi market",
+			match:       "portugal world cup",
+			mustReturn:  []string{"KXMENWORLDCUP-26-PT"},
+			mustExclude: []string{"KXFUSION"},
+		},
+		{
+			name:        "ticker prefix matches exact",
+			match:       "KXMENWORLDCUP",
+			mustReturn:  []string{"KXMENWORLDCUP-26-PT"},
+			mustExclude: []string{"KXFUSION"},
+		},
+	}
+
+	for _, q := range queries {
+		t.Run(q.name, func(t *testing.T) {
+			rows, err := s.DB().Query(
+				`SELECT id FROM resources_fts WHERE resources_fts MATCH ?`,
+				q.match,
+			)
+			if err != nil {
+				t.Fatalf("query %q: %v", q.match, err)
+			}
+			defer rows.Close()
+			seen := map[string]bool{}
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				seen[id] = true
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows: %v", err)
+			}
+			for _, must := range q.mustReturn {
+				if !seen[must] {
+					t.Errorf("query %q: missing required hit %q (seen=%v)", q.match, must, seen)
+				}
+			}
+			for _, mustNot := range q.mustExclude {
+				if seen[mustNot] {
+					t.Errorf("query %q: surfaced forbidden hit %q (seen=%v)", q.match, mustNot, seen)
+				}
+			}
+		})
+	}
+}
+
+// TestSchemaVersionAt3 pins the version bump so future migrations have
+// a clean baseline.
+func TestSchemaVersionAt3(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "version.db")
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+	v, err := s.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if v != 3 {
+		t.Errorf("SchemaVersion = %d, want 3", v)
+	}
+}

--- a/library/payments/prediction-goat/internal/store/fts_speedrun_test.go
+++ b/library/payments/prediction-goat/internal/store/fts_speedrun_test.go
@@ -1,0 +1,105 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+// TestFTSSpeedrunQueries pins the FTS index against the five Problem
+// Frame regressions that motivated this plan — Portugal World Cup,
+// Bitcoin 100k, Oscars best picture, Fed rate cut, NBA championship.
+// Each query must surface the correct top ticker against a seeded
+// fixture that includes both the right answer and the false positives
+// observed in the pre-fix CLI (notably KXFUSION for "oscars").
+//
+// This is the store-layer regression. U9 adds a CLI-layer end-to-end
+// speedrun test that runs the full topic / compare flow.
+func TestFTSSpeedrunQueries(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "speedrun.db")
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil { t.Fatal(err) }
+	defer s.Close()
+
+	// Seed a realistic mix: the right answer for each query plus some
+	// of the noise markets that polluted the original results.
+	fixtures := []struct{ rt, id, data string }{
+		// Portugal World Cup
+		{"kalshi_markets", "KXMENWORLDCUP-26-PT", `{"ticker":"KXMENWORLDCUP-26-PT","event_ticker":"KXMENWORLDCUP-26","title":"Will the Portugal win the 2026 Men's World Cup?","yes_sub_title":"Portugal","category":"Sports"}`},
+		{"kalshi_markets", "KXMENWORLDCUP-26-FR", `{"ticker":"KXMENWORLDCUP-26-FR","event_ticker":"KXMENWORLDCUP-26","title":"Will the France win the 2026 Men's World Cup?","yes_sub_title":"France","category":"Sports"}`},
+		{"kalshi_series", "KXMENWORLDCUP", `{"ticker":"KXMENWORLDCUP","title":"Men's World Cup winner","category":"Sports"}`},
+
+		// Bitcoin 100k
+		{"kalshi_series", "KXBTCMAX100", `{"ticker":"KXBTCMAX100","title":"When will bitcoin hit 100k?","category":"Crypto"}`},
+		{"kalshi_series", "KXBTC2026250", `{"ticker":"KXBTC2026250","title":"Will Bitcoin hit 250k in 2026?","category":"Crypto"}`},
+		{"kalshi_events", "BTCETHATH-29DEC31", `{"event_ticker":"BTCETHATH-29DEC31","title":"Ethereum hits new all-time high before Bitcoin?","category":"Crypto"}`},
+
+		// Oscars best picture - the original false positive KXFUSION must be excluded
+		{"kalshi_series", "KXFUSION", `{"ticker":"KXFUSION","title":"Nuclear fusion","category":"Science","source_agencies":[{"name":"Academy of Motion Picture Arts and Sciences","url":"https://www.oscars.org/oscars"}]}`},
+		{"kalshi_series", "KXOSCARCOUNTCONCLAVE", `{"ticker":"KXOSCARCOUNTCONCLAVE","title":"Conclave Oscar wins","category":"Entertainment"}`},
+		{"kalshi_series", "KXOSCARSCORE", `{"ticker":"KXOSCARSCORE","title":"Oscars Best Score","category":"Entertainment"}`},
+
+		// Fed rate cut
+		{"kalshi_series", "KXRATECUT", `{"ticker":"KXRATECUT","title":"Fed rate cut","category":"Economics"}`},
+		{"kalshi_series", "KXRATECUTS", `{"ticker":"KXRATECUTS","title":"Number of rate cuts","category":"Economics"}`},
+
+		// NBA championship
+		{"kalshi_series", "KXNBACHAMP", `{"ticker":"KXNBACHAMP","title":"NBA Championship winner","category":"Sports"}`},
+	}
+	for _, f := range fixtures {
+		if err := s.Upsert(f.rt, f.id, json.RawMessage(f.data)); err != nil {
+			t.Fatalf("upsert %s: %v", f.id, err)
+		}
+	}
+
+	type expect struct {
+		query        string
+		wantTop      []string
+		mustExclude  []string
+	}
+	cases := []expect{
+		{"portugal world cup", []string{"KXMENWORLDCUP-26-PT"}, nil},
+		{"bitcoin 100k", []string{"KXBTCMAX100"}, nil},
+		{"oscars best picture", []string{"KXOSCARSCORE", "KXOSCARCOUNTCONCLAVE"}, []string{"KXFUSION"}},
+		{"fed rate cut", []string{"KXRATECUT", "KXRATECUTS"}, nil},
+		{"nba championship", []string{"KXNBACHAMP"}, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.query, func(t *testing.T) {
+			tokens := strings.Fields(c.query)
+			quoted := make([]string, 0, len(tokens))
+			for _, tok := range tokens { quoted = append(quoted, `"`+tok+`"`) }
+			ftsExpr := strings.Join(quoted, " OR ")
+
+			rows, err := s.DB().Query(`SELECT id FROM resources_fts WHERE resources_fts MATCH ? ORDER BY rank LIMIT 10`, ftsExpr)
+			if err != nil { t.Fatalf("query: %v", err) }
+			defer rows.Close()
+			var hits []string
+			for rows.Next() { var id string; rows.Scan(&id); hits = append(hits, id) }
+			t.Logf("query %q -> hits: %v", c.query, hits)
+
+			// Top hit must be one of the expected
+			if len(hits) == 0 {
+				t.Errorf("no hits for query %q", c.query)
+				return
+			}
+			topOK := false
+			for _, w := range c.wantTop { if hits[0] == w { topOK = true; break } }
+			if !topOK {
+				t.Errorf("top hit for %q = %q, want one of %v", c.query, hits[0], c.wantTop)
+			}
+			for _, must := range c.mustExclude {
+				for _, h := range hits {
+					if h == must {
+						t.Errorf("query %q surfaced forbidden hit %q in result %v", c.query, must, hits)
+					}
+				}
+			}
+		})
+	}
+}

--- a/library/payments/prediction-goat/internal/store/learnings.go
+++ b/library/payments/prediction-goat/internal/store/learnings.go
@@ -1,0 +1,661 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Learning action constants. See LearningRow.Action.
+const (
+	LearningActionBoost   = "boost"
+	LearningActionHide    = "hide"
+	LearningActionAlias   = "alias_of"
+	LearningSourceTaught  = "taught"
+	LearningSourceManual  = "manual-forget"
+	defaultJaccardMin     = 0.6
+	defaultRecallLimit    = 10
+)
+
+// LearningRow is one row in the search_learnings table — the LLM-driven
+// per-query reranking signal. Populated by the `teach` command at
+// response-time and read by the rerank Apply pass in topic/compare on
+// subsequent queries.
+//
+// QueryPattern is always stored normalized (lowercase, whitespace-
+// collapsed, stopwords stripped) so two semantically-equivalent natural-
+// language queries (e.g., "What are Portugal's World Cup odds?" and
+// "portugal world cup odds") collapse to the same row.
+type LearningRow struct {
+	ID             int64      `json:"id"`
+	QueryPattern   string     `json:"query_pattern"`
+	Venue          string     `json:"venue,omitempty"`
+	ResourceType   string     `json:"resource_type,omitempty"`
+	ResourceID     string     `json:"resource_id"`
+	Action         string     `json:"action"`
+	AliasTarget    string     `json:"alias_target,omitempty"`
+	Source         string     `json:"source"`
+	Confidence     int        `json:"confidence"`
+	CreatedAt      time.Time  `json:"created_at"`
+	LastObservedAt *time.Time `json:"last_observed_at,omitempty"`
+	Notes          string     `json:"notes,omitempty"`
+}
+
+// stopwords stripped from query patterns to normalize semantically
+// equivalent natural-language queries. Conservative set — only the
+// tokens that bracket every variant of "what are Portugal's odds".
+var queryStopwords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {},
+	"what": {}, "whats": {},
+	"are": {}, "is": {}, "was": {}, "were": {},
+	"do":  {}, "does": {}, "did": {},
+	"of":  {}, "for": {}, "to": {}, "on": {},
+	"in":  {}, "at": {}, "by": {}, "with": {},
+	"odds": {}, // odds-flavored helper word that exists on both sides
+}
+
+// NormalizeQuery lowercases, strips punctuation, collapses whitespace,
+// and removes a small stopword set. Exported so the CLI layer uses
+// the same normalization at both write (teach) and read (recall + apply)
+// time. The token set used by the Jaccard match is a side product —
+// see normalizeAndTokens.
+func NormalizeQuery(s string) string {
+	normalized, _ := normalizeAndTokens(s)
+	return normalized
+}
+
+// normalizeAndTokens returns both the normalized string and the set of
+// non-stopword tokens. The token set is the canonical form the recall
+// Jaccard matcher uses; the string form is the canonical key under
+// which a learning is stored.
+func normalizeAndTokens(s string) (string, map[string]struct{}) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	// Replace common punctuation with spaces so "portugal's" splits into
+	// "portugal" + "s" and "?" disappears entirely.
+	b := strings.Builder{}
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	rawTokens := strings.Fields(b.String())
+	tokens := make(map[string]struct{}, len(rawTokens))
+	kept := make([]string, 0, len(rawTokens))
+	for _, t := range rawTokens {
+		if t == "" || t == "s" {
+			continue
+		}
+		if _, drop := queryStopwords[t]; drop {
+			continue
+		}
+		if _, dup := tokens[t]; dup {
+			continue
+		}
+		tokens[t] = struct{}{}
+		kept = append(kept, t)
+	}
+	return strings.Join(kept, " "), tokens
+}
+
+// UpsertLearningInput is the call-shape Upsert accepts. ResourceType and
+// Venue may be empty; Action defaults to "boost" when empty.
+type UpsertLearningInput struct {
+	Query        string
+	ResourceID   string
+	ResourceType string
+	Venue        string
+	Action       string
+	AliasTarget  string
+	Source       string
+	Notes        string
+}
+
+// UpsertLearning inserts a learning row or, when (query_pattern,
+// resource_id, action) already exists, bumps confidence by 1 and
+// refreshes last_observed_at. Source on the existing row is preserved;
+// only confidence + last_observed_at update on re-teach. Returns the
+// row's ID and a bool indicating whether the row was newly inserted.
+func (s *Store) UpsertLearning(in UpsertLearningInput) (int64, bool, error) {
+	if strings.TrimSpace(in.ResourceID) == "" {
+		return 0, false, fmt.Errorf("upsert learning: resource_id is required")
+	}
+	action := in.Action
+	if action == "" {
+		action = LearningActionBoost
+	}
+	switch action {
+	case LearningActionBoost, LearningActionHide, LearningActionAlias:
+	default:
+		return 0, false, fmt.Errorf("upsert learning: invalid action %q", action)
+	}
+	if action == LearningActionAlias && strings.TrimSpace(in.AliasTarget) == "" {
+		return 0, false, fmt.Errorf("upsert learning: action=alias_of requires alias_target")
+	}
+	source := in.Source
+	if source == "" {
+		source = LearningSourceTaught
+	}
+	pattern := NormalizeQuery(in.Query)
+	if pattern == "" {
+		return 0, false, fmt.Errorf("upsert learning: query normalized to empty string")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	now := time.Now().UTC()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, false, err
+	}
+	defer tx.Rollback()
+
+	var existingID int64
+	err = tx.QueryRow(
+		`SELECT id FROM search_learnings
+		 WHERE query_pattern = ? AND resource_id = ? AND action = ?`,
+		pattern, in.ResourceID, action,
+	).Scan(&existingID)
+	if err == nil {
+		if _, err := tx.Exec(
+			`UPDATE search_learnings
+			 SET confidence = confidence + 1, last_observed_at = ?
+			 WHERE id = ?`,
+			now, existingID,
+		); err != nil {
+			return 0, false, fmt.Errorf("upsert learning bump confidence: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return 0, false, err
+		}
+		return existingID, false, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, false, fmt.Errorf("upsert learning lookup: %w", err)
+	}
+
+	var venue, resourceType, aliasTarget, notes any
+	if in.Venue != "" {
+		venue = in.Venue
+	}
+	if in.ResourceType != "" {
+		resourceType = in.ResourceType
+	}
+	if in.AliasTarget != "" {
+		aliasTarget = in.AliasTarget
+	}
+	if in.Notes != "" {
+		notes = in.Notes
+	}
+
+	res, err := tx.Exec(
+		`INSERT INTO search_learnings
+		 (query_pattern, venue, resource_type, resource_id, action, alias_target,
+		  source, confidence, created_at, last_observed_at, notes)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`,
+		pattern, venue, resourceType, in.ResourceID, action, aliasTarget,
+		source, now, now, notes,
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf("upsert learning insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, false, fmt.Errorf("upsert learning last id: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
+// ListLearningsFilter narrows ListLearnings. Zero values mean unfiltered.
+type ListLearningsFilter struct {
+	Query        string
+	Source       string
+	ResourceID   string
+	Action       string
+	Limit        int
+	MinConfidence int
+}
+
+// ListLearnings returns rows ordered by last_observed_at DESC. The query
+// filter applies a normalized LIKE match against query_pattern so a
+// filter value of "portugal" matches a row taught for "portugal world
+// cup odds".
+func (s *Store) ListLearnings(f ListLearningsFilter) ([]LearningRow, error) {
+	clauses := []string{}
+	args := []any{}
+	if f.Query != "" {
+		clauses = append(clauses, "query_pattern LIKE ?")
+		args = append(args, "%"+NormalizeQuery(f.Query)+"%")
+	}
+	if f.Source != "" {
+		clauses = append(clauses, "source = ?")
+		args = append(args, f.Source)
+	}
+	if f.ResourceID != "" {
+		clauses = append(clauses, "resource_id = ?")
+		args = append(args, f.ResourceID)
+	}
+	if f.Action != "" {
+		clauses = append(clauses, "action = ?")
+		args = append(args, f.Action)
+	}
+	if f.MinConfidence > 0 {
+		clauses = append(clauses, "confidence >= ?")
+		args = append(args, f.MinConfidence)
+	}
+	where := ""
+	if len(clauses) > 0 {
+		where = "WHERE " + strings.Join(clauses, " AND ")
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	args = append(args, limit)
+
+	q := fmt.Sprintf(`SELECT id, query_pattern, COALESCE(venue, ''), COALESCE(resource_type, ''),
+		resource_id, action, COALESCE(alias_target, ''), source, confidence,
+		created_at, last_observed_at, COALESCE(notes, '')
+		FROM search_learnings %s
+		ORDER BY last_observed_at DESC, id DESC
+		LIMIT ?`, where)
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list learnings: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]LearningRow, 0)
+	for rows.Next() {
+		var r LearningRow
+		var lastObs sql.NullTime
+		if err := rows.Scan(&r.ID, &r.QueryPattern, &r.Venue, &r.ResourceType,
+			&r.ResourceID, &r.Action, &r.AliasTarget, &r.Source, &r.Confidence,
+			&r.CreatedAt, &lastObs, &r.Notes); err != nil {
+			return nil, err
+		}
+		if lastObs.Valid {
+			t := lastObs.Time
+			r.LastObservedAt = &t
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ForgetLearningsFilter selects which rows to delete. At least one
+// non-empty field is required; pass All=true to wipe a query pattern
+// without specifying resource or action.
+type ForgetLearningsFilter struct {
+	Query      string
+	ResourceID string
+	Action     string
+	All        bool
+}
+
+// ForgetLearnings deletes rows matching the filter and returns the count
+// removed. If All is false the filter must specify at least one of
+// ResourceID or Action (the Query is the primary scoping key and is
+// always required).
+func (s *Store) ForgetLearnings(f ForgetLearningsFilter) (int64, error) {
+	if f.Query == "" {
+		return 0, fmt.Errorf("forget learnings: query is required")
+	}
+	if !f.All && f.ResourceID == "" && f.Action == "" {
+		return 0, fmt.Errorf("forget learnings: pass --resource, --action, or --all")
+	}
+	pattern := NormalizeQuery(f.Query)
+	if pattern == "" {
+		return 0, fmt.Errorf("forget learnings: query normalized to empty string")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	clauses := []string{"query_pattern = ?"}
+	args := []any{pattern}
+	if f.ResourceID != "" {
+		clauses = append(clauses, "resource_id = ?")
+		args = append(args, f.ResourceID)
+	}
+	if f.Action != "" {
+		clauses = append(clauses, "action = ?")
+		args = append(args, f.Action)
+	}
+	q := "DELETE FROM search_learnings WHERE " + strings.Join(clauses, " AND ")
+	res, err := s.db.Exec(q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("forget learnings: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// RecallMatch is one row returned by Recall — a learning that scored
+// above the Jaccard threshold against the supplied query.
+type RecallMatch struct {
+	LearningRow
+	MatchScore float64 `json:"match_score"`
+}
+
+// RecallOptions tunes Recall behavior.
+type RecallOptions struct {
+	// MinConfidence is the minimum confidence required for a row to
+	// appear in the results. Defaults to 1 (any row) when 0.
+	MinConfidence int
+	// Limit caps the result count. Defaults to 10 when 0.
+	Limit int
+	// JaccardMin overrides the token-set Jaccard floor. Defaults to 0.6
+	// when 0. Negative values are treated as 0 (any overlap matches).
+	JaccardMin float64
+}
+
+// Recall returns learnings whose normalized query_pattern overlaps with
+// the supplied query by token-set Jaccard >= opts.JaccardMin. Results
+// are sorted by (match_score DESC, confidence DESC, last_observed_at DESC).
+// An empty input or no match returns ([], nil) — Recall is an
+// information query, not a not-found error.
+func (s *Store) Recall(ctx context.Context, query string, opts RecallOptions) ([]RecallMatch, error) {
+	_, inputTokens := normalizeAndTokens(query)
+	if len(inputTokens) == 0 {
+		return nil, nil
+	}
+	minConf := opts.MinConfidence
+	if minConf <= 0 {
+		minConf = 1
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultRecallLimit
+	}
+	jMin := opts.JaccardMin
+	if jMin == 0 {
+		jMin = defaultJaccardMin
+	}
+	if jMin < 0 {
+		jMin = 0
+	}
+
+	// Fast path: count distinct query_patterns. Stays tiny per-user, so a
+	// full scan with score-in-Go is the right tradeoff against trying to
+	// implement set-overlap in SQL.
+	rows, err := s.db.QueryContext(ctx, `SELECT id, query_pattern, COALESCE(venue, ''),
+		COALESCE(resource_type, ''), resource_id, action, COALESCE(alias_target, ''),
+		source, confidence, created_at, last_observed_at, COALESCE(notes, '')
+		FROM search_learnings
+		WHERE confidence >= ?`, minConf)
+	if err != nil {
+		return nil, fmt.Errorf("recall: %w", err)
+	}
+	defer rows.Close()
+
+	matches := make([]RecallMatch, 0)
+	for rows.Next() {
+		var r LearningRow
+		var lastObs sql.NullTime
+		if err := rows.Scan(&r.ID, &r.QueryPattern, &r.Venue, &r.ResourceType,
+			&r.ResourceID, &r.Action, &r.AliasTarget, &r.Source, &r.Confidence,
+			&r.CreatedAt, &lastObs, &r.Notes); err != nil {
+			return nil, err
+		}
+		if lastObs.Valid {
+			t := lastObs.Time
+			r.LastObservedAt = &t
+		}
+		_, rowTokens := normalizeAndTokens(r.QueryPattern)
+		score := jaccard(inputTokens, rowTokens)
+		if score < jMin {
+			continue
+		}
+		matches = append(matches, RecallMatch{LearningRow: r, MatchScore: score})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Sort: match_score DESC, confidence DESC, last_observed_at DESC.
+	sortRecallMatches(matches)
+
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches, nil
+}
+
+func sortRecallMatches(matches []RecallMatch) {
+	// Insertion sort keeps the algorithm simple; n is bounded by the
+	// per-user table size and the pre-filter on confidence.
+	for i := 1; i < len(matches); i++ {
+		for j := i; j > 0; j-- {
+			a, b := matches[j], matches[j-1]
+			if recallLess(a, b) {
+				matches[j-1], matches[j] = a, b
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func recallLess(a, b RecallMatch) bool {
+	if a.MatchScore != b.MatchScore {
+		return a.MatchScore > b.MatchScore
+	}
+	if a.Confidence != b.Confidence {
+		return a.Confidence > b.Confidence
+	}
+	at := time.Time{}
+	bt := time.Time{}
+	if a.LastObservedAt != nil {
+		at = *a.LastObservedAt
+	}
+	if b.LastObservedAt != nil {
+		bt = *b.LastObservedAt
+	}
+	return at.After(bt)
+}
+
+func jaccard(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if _, ok := b[k]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// ApplyResult is what the rerank layer reports back to the caller for
+// envelope emission. Count is the number of rules that visibly touched
+// the output (boosts that moved a hit, hides that removed one, aliases
+// that swapped one).
+type ApplyResult struct {
+	Count           int
+	HasHighConfidence bool
+	Warnings        []string
+}
+
+// LearnedHit represents a hit synthesized from a learning whose
+// resource_id was not in the original FTS result set. The CLI layer
+// fetches the resource from the resources table by (ResourceType, ID)
+// and slots it into the output bundle at position 0 with
+// `meta.source: "learned"`.
+type LearnedHit struct {
+	ResourceType string
+	ResourceID   string
+	Confidence   int
+	Source       string // copy of LearningRow.Source for envelope-level diagnostics
+}
+
+// Applier abstracts the in-memory hit bundle the rerank layer operates
+// on. The CLI layer implements one Applier per command (topic, compare)
+// so the layer stays decoupled from each command's hit struct shape.
+//
+// Indexing is by stable string keys the command picks — typically
+// "<source>|<id>" for topic, or per-pair "<venue>|<id>" for compare.
+type Applier interface {
+	// HasHit reports whether the in-memory bundle already contains a hit
+	// keyed (resourceType, resourceID).
+	HasHit(resourceType, resourceID string) bool
+	// MoveToFront moves an existing hit to position 0 (or position N for
+	// the Nth applied boost, in the order MoveToFront is called).
+	MoveToFront(resourceType, resourceID string)
+	// InsertLearnedHit inserts a synthetic hit at position 0 for a
+	// learning whose resource the FTS layer missed entirely. The caller
+	// is responsible for fetching the underlying row from the resources
+	// table.
+	InsertLearnedHit(h LearnedHit) error
+	// RemoveHit drops a hit from the bundle.
+	RemoveHit(resourceType, resourceID string)
+	// ReplaceHit replaces (resourceType, resourceID) with the alias
+	// target. Same fetch contract as InsertLearnedHit when the alias
+	// target wasn't in the bundle.
+	ReplaceHit(srcType, srcID, dstType, dstID string) error
+}
+
+// Apply loads learnings for the supplied query and runs the
+// boost/hide/alias rules against the supplied Applier. Returns the
+// count of rules that actually touched the output, plus any warnings
+// (alias cycles, missing resources) for the caller to log.
+//
+// The match scope is: learnings whose normalized query_pattern equals
+// the current normalized query, OR is a substring match (LIKE) against
+// it. Substring widens "bitcoin" rules to fire on "bitcoin 100k".
+func (s *Store) Apply(ctx context.Context, query string, ap Applier) (ApplyResult, error) {
+	result := ApplyResult{}
+	pattern := NormalizeQuery(query)
+	if pattern == "" {
+		return result, nil
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, query_pattern, COALESCE(venue, ''), COALESCE(resource_type, ''),
+			resource_id, action, COALESCE(alias_target, ''), source, confidence,
+			created_at, last_observed_at, COALESCE(notes, '')
+		 FROM search_learnings
+		 WHERE query_pattern = ? OR ? LIKE '%' || query_pattern || '%'
+		 ORDER BY confidence DESC, last_observed_at DESC`,
+		pattern, pattern,
+	)
+	if err != nil {
+		return result, fmt.Errorf("apply learnings: %w", err)
+	}
+	defer rows.Close()
+
+	type ruleRow struct {
+		LearningRow
+	}
+	rules := make([]ruleRow, 0)
+	for rows.Next() {
+		var r LearningRow
+		var lastObs sql.NullTime
+		if err := rows.Scan(&r.ID, &r.QueryPattern, &r.Venue, &r.ResourceType,
+			&r.ResourceID, &r.Action, &r.AliasTarget, &r.Source, &r.Confidence,
+			&r.CreatedAt, &lastObs, &r.Notes); err != nil {
+			return result, err
+		}
+		if lastObs.Valid {
+			t := lastObs.Time
+			r.LastObservedAt = &t
+		}
+		rules = append(rules, ruleRow{r})
+	}
+	if err := rows.Err(); err != nil {
+		return result, err
+	}
+
+	// Detect alias cycles before applying any rule. A simple cycle is
+	// (A -> B) + (B -> A) under the same query_pattern; drop both with
+	// a warning rather than thrash the bundle.
+	aliasGraph := make(map[string]string)
+	for _, r := range rules {
+		if r.Action == LearningActionAlias && r.AliasTarget != "" {
+			aliasGraph[r.ResourceID] = r.AliasTarget
+		}
+	}
+	cycleSrcs := make(map[string]struct{})
+	for src, dst := range aliasGraph {
+		if hop, ok := aliasGraph[dst]; ok && hop == src {
+			cycleSrcs[src] = struct{}{}
+			cycleSrcs[dst] = struct{}{}
+		}
+	}
+	if len(cycleSrcs) > 0 {
+		srcs := make([]string, 0, len(cycleSrcs))
+		for s := range cycleSrcs {
+			srcs = append(srcs, s)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("alias cycle detected, dropping rules for: %s", strings.Join(srcs, ", ")))
+	}
+
+	for _, r := range rules {
+		switch r.Action {
+		case LearningActionBoost:
+			if ap.HasHit(r.ResourceType, r.ResourceID) {
+				ap.MoveToFront(r.ResourceType, r.ResourceID)
+				result.Count++
+			} else {
+				if err := ap.InsertLearnedHit(LearnedHit{
+					ResourceType: r.ResourceType,
+					ResourceID:   r.ResourceID,
+					Confidence:   r.Confidence,
+					Source:       r.Source,
+				}); err != nil {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("insert learned hit %s/%s: %v", r.ResourceType, r.ResourceID, err))
+					continue
+				}
+				result.Count++
+			}
+			if r.Confidence >= 3 {
+				result.HasHighConfidence = true
+			}
+		case LearningActionHide:
+			if ap.HasHit(r.ResourceType, r.ResourceID) {
+				ap.RemoveHit(r.ResourceType, r.ResourceID)
+				result.Count++
+			}
+		case LearningActionAlias:
+			if _, isCycle := cycleSrcs[r.ResourceID]; isCycle {
+				continue
+			}
+			if r.AliasTarget == "" {
+				continue
+			}
+			if err := ap.ReplaceHit(r.ResourceType, r.ResourceID, r.ResourceType, r.AliasTarget); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("alias replace %s -> %s: %v", r.ResourceID, r.AliasTarget, err))
+				continue
+			}
+			result.Count++
+		}
+	}
+
+	return result, nil
+}
+
+// MarshalLearnings returns the JSON envelope shape used by both
+// `learnings list` and the `recall` command for --agent output. Keeps
+// the JSON shape decoupled from any cobra-level types.
+func MarshalLearnings(rows []LearningRow) ([]byte, error) {
+	return json.Marshal(rows)
+}

--- a/library/payments/prediction-goat/internal/store/learnings_test.go
+++ b/library/payments/prediction-goat/internal/store/learnings_test.go
@@ -1,0 +1,562 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package store_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/prediction-goat/internal/store"
+)
+
+func openLearnings(t *testing.T) *store.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "learn.db")
+	s, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestNormalizeQuery_StripsStopwordsAndPunctuation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"What are the odds Portugal wins?", "portugal wins"},
+		{"portugal odds", "portugal"},
+		{"  Portugal   World   Cup  ", "portugal world cup"},
+		{"What's Portugal's chance?", "portugal chance"},
+		{"WHAT ARE THE ODDS", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := store.NormalizeQuery(tc.in)
+		if got != tc.want {
+			t.Errorf("NormalizeQuery(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUpsertLearning_InsertsAndBumpsConfidence(t *testing.T) {
+	s := openLearnings(t)
+	in := store.UpsertLearningInput{
+		Query:        "portugal world cup odds",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+		Source:       store.LearningSourceTaught,
+	}
+	id1, created, err := s.UpsertLearning(in)
+	if err != nil {
+		t.Fatalf("upsert 1: %v", err)
+	}
+	if !created || id1 == 0 {
+		t.Fatalf("first upsert should be inserted; created=%v id=%d", created, id1)
+	}
+
+	id2, created, err := s.UpsertLearning(in)
+	if err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+	if created {
+		t.Fatalf("second upsert should be a bump, not insert")
+	}
+	if id2 != id1 {
+		t.Fatalf("re-teach should preserve row id; got %d, want %d", id2, id1)
+	}
+
+	rows, err := s.ListLearnings(store.ListLearningsFilter{Query: "portugal"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].Confidence != 2 {
+		t.Errorf("want confidence 2 after two teaches, got %d", rows[0].Confidence)
+	}
+}
+
+func TestUpsertLearning_NormalizesQueryAcrossVariants(t *testing.T) {
+	s := openLearnings(t)
+	// Two different phrasings should collapse to the same row.
+	_, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "What are the odds Portugal wins?",
+		ResourceID: "KXMENWORLDCUP-26-PT",
+	})
+	if err != nil {
+		t.Fatalf("upsert 1: %v", err)
+	}
+	_, created, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "portugal wins",
+		ResourceID: "KXMENWORLDCUP-26-PT",
+	})
+	if err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+	if created {
+		t.Fatalf("normalized variant should hit existing row, not insert")
+	}
+	rows, _ := s.ListLearnings(store.ListLearningsFilter{})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row after normalized re-teach, got %d", len(rows))
+	}
+}
+
+func TestUpsertLearning_RejectsEmptyResourceOrQuery(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{Query: "x", ResourceID: ""}); err == nil {
+		t.Errorf("want error for empty resource_id")
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{Query: "what is", ResourceID: "X"}); err == nil {
+		t.Errorf("want error when query normalizes to empty")
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{Query: "x", ResourceID: "X", Action: "bogus"}); err == nil {
+		t.Errorf("want error for invalid action")
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{Query: "x", ResourceID: "X", Action: store.LearningActionAlias}); err == nil {
+		t.Errorf("want error when alias action lacks target")
+	}
+}
+
+func TestRecall_ExactAndJaccardMatch(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "portugal world cup odds",
+		ResourceID: "KXMENWORLDCUP-26-PT",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "portugal world cup odds",
+		ResourceID: "will-portugal-win-the-2026-fifa-world-cup-912",
+	}); err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+
+	// Exact match.
+	matches, err := s.Recall(context.Background(), "portugal world cup odds", store.RecallOptions{})
+	if err != nil {
+		t.Fatalf("recall exact: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("exact recall: want 2 matches, got %d", len(matches))
+	}
+	if matches[0].MatchScore < 0.99 {
+		t.Errorf("exact match score should be ~1.0, got %v", matches[0].MatchScore)
+	}
+
+	// Token-overlap match: "portugal chances at the world cup" normalizes
+	// to {portugal, chances, world, cup}; vs {portugal, world, cup} the
+	// intersection is 3 and union is 4 — Jaccard 0.75 >= 0.6.
+	matches, err = s.Recall(context.Background(), "portugal chances at the world cup", store.RecallOptions{})
+	if err != nil {
+		t.Fatalf("recall overlap: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Errorf("token overlap: want 2, got %d", len(matches))
+	}
+
+	// Unrelated query returns empty (information query, not error).
+	matches, err = s.Recall(context.Background(), "lakers tonight", store.RecallOptions{})
+	if err != nil {
+		t.Fatalf("recall unrelated: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("unrelated query should return empty, got %d", len(matches))
+	}
+}
+
+func TestRecall_StopwordSymmetry(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "what are portugal's odds",
+		ResourceID: "KXMENWORLDCUP-26-PT",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// Both queries normalize to "portugal". Stopword stripping makes
+	// the two queries identical at the matcher.
+	matches, err := s.Recall(context.Background(), "portugal", store.RecallOptions{})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("stopword symmetry: want 1 match, got %d", len(matches))
+	}
+}
+
+func TestRecall_MinConfidenceAndLimit(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "portugal world cup",
+		ResourceID: "A",
+	}); err != nil {
+		t.Fatalf("upsert A: %v", err)
+	}
+	// Bump confidence on the second one to 2 by re-teaching.
+	for i := 0; i < 2; i++ {
+		if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+			Query:      "portugal world cup",
+			ResourceID: "B",
+		}); err != nil {
+			t.Fatalf("upsert B: %v", err)
+		}
+	}
+
+	matches, err := s.Recall(context.Background(), "portugal world cup", store.RecallOptions{MinConfidence: 2})
+	if err != nil {
+		t.Fatalf("recall min-conf: %v", err)
+	}
+	if len(matches) != 1 || matches[0].ResourceID != "B" {
+		t.Errorf("min-confidence filter failed: %#v", matches)
+	}
+
+	// Limit 1 should cap.
+	for i := 0; i < 3; i++ {
+		if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+			Query:      "portugal world cup",
+			ResourceID: "C" + string(rune('0'+i)),
+		}); err != nil {
+			t.Fatalf("upsert C%d: %v", i, err)
+		}
+	}
+	matches, _ = s.Recall(context.Background(), "portugal world cup", store.RecallOptions{Limit: 2})
+	if len(matches) != 2 {
+		t.Errorf("limit 2: want 2, got %d", len(matches))
+	}
+}
+
+func TestForgetLearnings(t *testing.T) {
+	s := openLearnings(t)
+	for _, rid := range []string{"X", "Y", "Z"} {
+		if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+			Query:      "portugal world cup",
+			ResourceID: rid,
+		}); err != nil {
+			t.Fatalf("upsert %s: %v", rid, err)
+		}
+	}
+
+	// Without --all / --resource / --action, refuse.
+	if _, err := s.ForgetLearnings(store.ForgetLearningsFilter{Query: "portugal world cup"}); err == nil {
+		t.Errorf("want error when no filter provided")
+	}
+
+	// Targeted delete by resource.
+	n, err := s.ForgetLearnings(store.ForgetLearningsFilter{Query: "portugal world cup", ResourceID: "Y"})
+	if err != nil {
+		t.Fatalf("forget Y: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("forget Y: want 1 deleted, got %d", n)
+	}
+
+	// Wipe the rest.
+	n, err = s.ForgetLearnings(store.ForgetLearningsFilter{Query: "portugal world cup", All: true})
+	if err != nil {
+		t.Fatalf("forget all: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("forget all: want 2 deleted, got %d", n)
+	}
+}
+
+// stubApplier is a minimal in-memory bundle for testing the rerank Apply
+// pass without depending on the topic/compare hit structs.
+type stubApplier struct {
+	hits    []stubHit
+	fetched map[string]struct{} // simulated resources table
+	inserts []store.LearnedHit
+}
+
+type stubHit struct {
+	rtype string
+	rid   string
+}
+
+func newStubApplier(initial []stubHit, available []stubHit) *stubApplier {
+	fetched := make(map[string]struct{})
+	for _, h := range available {
+		fetched[h.rtype+"|"+h.rid] = struct{}{}
+	}
+	return &stubApplier{hits: append([]stubHit{}, initial...), fetched: fetched}
+}
+
+func (a *stubApplier) HasHit(rt, rid string) bool {
+	for _, h := range a.hits {
+		if h.rtype == rt && h.rid == rid {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *stubApplier) MoveToFront(rt, rid string) {
+	idx := -1
+	for i, h := range a.hits {
+		if h.rtype == rt && h.rid == rid {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		return
+	}
+	h := a.hits[idx]
+	a.hits = append(a.hits[:idx], a.hits[idx+1:]...)
+	a.hits = append([]stubHit{h}, a.hits...)
+}
+
+func (a *stubApplier) InsertLearnedHit(h store.LearnedHit) error {
+	a.inserts = append(a.inserts, h)
+	a.hits = append([]stubHit{{rtype: h.ResourceType, rid: h.ResourceID}}, a.hits...)
+	return nil
+}
+
+func (a *stubApplier) RemoveHit(rt, rid string) {
+	for i, h := range a.hits {
+		if h.rtype == rt && h.rid == rid {
+			a.hits = append(a.hits[:i], a.hits[i+1:]...)
+			return
+		}
+	}
+}
+
+func (a *stubApplier) ReplaceHit(srcType, srcID, dstType, dstID string) error {
+	for i, h := range a.hits {
+		if h.rtype == srcType && h.rid == srcID {
+			a.hits[i] = stubHit{rtype: dstType, rid: dstID}
+			return nil
+		}
+	}
+	// Not in hits; insert as learned.
+	return a.InsertLearnedHit(store.LearnedHit{ResourceType: dstType, ResourceID: dstID})
+}
+
+func TestApply_BoostMovesExistingHitToFront(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{
+			{"kalshi_markets", "KXFUSION"},
+			{"kalshi_markets", "KXMENWORLDCUP-26-PT"},
+		},
+		nil,
+	)
+	res, err := s.Apply(context.Background(), "portugal world cup", ap)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("count: want 1, got %d", res.Count)
+	}
+	if ap.hits[0].rid != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("boost should move ticker to front; got %#v", ap.hits)
+	}
+}
+
+func TestApply_BoostInsertsSyntheticLearnedHit(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{{"kalshi_markets", "KXFUSION"}},
+		nil,
+	)
+	res, err := s.Apply(context.Background(), "portugal world cup", ap)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if res.Count != 1 || len(ap.inserts) != 1 {
+		t.Errorf("expected 1 synthetic insert; count=%d inserts=%d", res.Count, len(ap.inserts))
+	}
+	if ap.hits[0].rid != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("synthetic hit should be at position 0, got %#v", ap.hits)
+	}
+}
+
+func TestApply_HideRemoves(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "KXFUSION",
+		ResourceType: "kalshi_series",
+		Action:       store.LearningActionHide,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{
+			{"kalshi_series", "KXFUSION"},
+			{"kalshi_markets", "KXMENWORLDCUP-26-PT"},
+		},
+		nil,
+	)
+	res, err := s.Apply(context.Background(), "portugal world cup", ap)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("count: want 1, got %d", res.Count)
+	}
+	if len(ap.hits) != 1 || ap.hits[0].rid != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("hide failed: %#v", ap.hits)
+	}
+}
+
+func TestApply_AliasReplaces(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "OLD",
+		ResourceType: "kalshi_markets",
+		Action:       store.LearningActionAlias,
+		AliasTarget:  "NEW",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{{"kalshi_markets", "OLD"}},
+		nil,
+	)
+	if _, err := s.Apply(context.Background(), "portugal world cup", ap); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(ap.hits) != 1 || ap.hits[0].rid != "NEW" {
+		t.Errorf("alias should rewrite OLD -> NEW; got %#v", ap.hits)
+	}
+}
+
+func TestApply_AliasCycleIsDropped(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "A",
+		ResourceType: "kalshi_markets",
+		Action:       store.LearningActionAlias,
+		AliasTarget:  "B",
+	}); err != nil {
+		t.Fatalf("upsert A->B: %v", err)
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "portugal world cup",
+		ResourceID:   "B",
+		ResourceType: "kalshi_markets",
+		Action:       store.LearningActionAlias,
+		AliasTarget:  "A",
+	}); err != nil {
+		t.Fatalf("upsert B->A: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{
+			{"kalshi_markets", "A"},
+			{"kalshi_markets", "B"},
+		},
+		nil,
+	)
+	res, err := s.Apply(context.Background(), "portugal world cup", ap)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Errorf("expected an alias-cycle warning")
+	}
+	// Hits should be unchanged.
+	if len(ap.hits) != 2 {
+		t.Errorf("cycle should leave hits intact; got %#v", ap.hits)
+	}
+}
+
+func TestApply_SubstringMatchOnQueryPattern(t *testing.T) {
+	s := openLearnings(t)
+	// Rule keyed on "bitcoin" alone.
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "bitcoin",
+		ResourceID:   "KXBTCMAX100",
+		ResourceType: "kalshi_series",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{{"kalshi_markets", "BTCETHATH-29DEC31"}},
+		nil,
+	)
+	res, err := s.Apply(context.Background(), "bitcoin 100k", ap)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("substring match should fire; count=%d", res.Count)
+	}
+	if ap.hits[0].rid != "KXBTCMAX100" {
+		t.Errorf("synthetic hit should be at front; got %#v", ap.hits)
+	}
+}
+
+func TestApply_NormalizationAtApplyTime(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:        "Portugal World Cup",
+		ResourceID:   "KXMENWORLDCUP-26-PT",
+		ResourceType: "kalshi_markets",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	ap := newStubApplier(
+		[]stubHit{{"kalshi_markets", "KXMENWORLDCUP-26-PT"}},
+		nil,
+	)
+	// Different case + whitespace + stopwords on the apply side.
+	if _, err := s.Apply(context.Background(), "  what are the portugal  world cup  ", ap); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if ap.hits[0].rid != "KXMENWORLDCUP-26-PT" {
+		t.Errorf("normalization mismatch; hits=%#v", ap.hits)
+	}
+}
+
+func TestListLearnings_FiltersByQueryAndSource(t *testing.T) {
+	s := openLearnings(t)
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "portugal world cup",
+		ResourceID: "A",
+		Source:     store.LearningSourceTaught,
+	}); err != nil {
+		t.Fatalf("upsert A: %v", err)
+	}
+	if _, _, err := s.UpsertLearning(store.UpsertLearningInput{
+		Query:      "lakers tonight",
+		ResourceID: "B",
+		Source:     store.LearningSourceTaught,
+	}); err != nil {
+		t.Fatalf("upsert B: %v", err)
+	}
+
+	rows, err := s.ListLearnings(store.ListLearningsFilter{Query: "portugal"})
+	if err != nil {
+		t.Fatalf("list portugal: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ResourceID != "A" {
+		t.Errorf("filter by query failed: %#v", rows)
+	}
+
+	rows, _ = s.ListLearnings(store.ListLearningsFilter{Source: store.LearningSourceTaught})
+	if len(rows) != 2 {
+		t.Errorf("filter by source: want 2, got %d", len(rows))
+	}
+}

--- a/library/payments/prediction-goat/internal/store/store.go
+++ b/library/payments/prediction-goat/internal/store/store.go
@@ -82,7 +82,7 @@ func IsUUID(s string) bool {
 // shape — adding columns, dropping indexes, changing FTS5 tokenizers —
 // so an older binary refuses to open a newer database rather than silently
 // producing wrong results against a schema it cannot read.
-const StoreSchemaVersion = 3
+const StoreSchemaVersion = 4
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -1129,6 +1129,27 @@ func (s *Store) migrate(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS "idx_teams_created_at" ON "teams"("created_at")`,
 		`CREATE INDEX IF NOT EXISTS "idx_teams_updated_at" ON "teams"("updated_at")`,
+		// search_learnings (v4): LLM-driven per-query reranking. Populated by
+		// the `teach` command (silent, backgrounded by the LLM after a
+		// successful response) and read by the rerank layer in topic/compare
+		// to boost/hide/alias hits on subsequent queries. See learnings.go
+		// for the full semantics. Per-user table; stays small.
+		`CREATE TABLE IF NOT EXISTS search_learnings (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			query_pattern TEXT NOT NULL,
+			venue TEXT,
+			resource_type TEXT,
+			resource_id TEXT NOT NULL,
+			action TEXT NOT NULL,
+			alias_target TEXT,
+			source TEXT NOT NULL,
+			confidence INTEGER DEFAULT 1,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			last_observed_at DATETIME,
+			notes TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_learn_query ON search_learnings(query_pattern)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_learn_unique ON search_learnings(query_pattern, resource_id, action)`,
 	}
 
 	// Run every migration — including the column backfill and the

--- a/library/payments/prediction-goat/internal/store/store.go
+++ b/library/payments/prediction-goat/internal/store/store.go
@@ -18,8 +18,49 @@ import (
 	"sync"
 	"time"
 
-	_ "modernc.org/sqlite"
+	sqlite "modernc.org/sqlite"
 )
+
+// PATCH(wal-pragmas-via-hook): the DSN-level pragma syntax
+// (_journal_mode=WAL, _busy_timeout=5000, etc.) is silently ignored by
+// modernc.org/sqlite v1.37.0 — a live store opened with the DSN-style
+// params still reports `PRAGMA journal_mode=delete, busy_timeout=0`.
+// Register a connection hook so the pragmas are applied via PRAGMA
+// statements after the connection is established, which is the only
+// reliable path. See docs/plans/2026-05-23-001-feat-prediction-goat-search-relevance-and-freshness-plan.md U1.
+func init() {
+	sqlite.RegisterConnectionHook(func(conn sqlite.ExecQuerierContext, dsn string) error {
+		ctx := context.Background()
+		// busy_timeout FIRST so subsequent pragmas can wait through any
+		// contention with other connections on the same file.
+		if _, err := conn.ExecContext(ctx, "PRAGMA busy_timeout = 5000", nil); err != nil {
+			return fmt.Errorf("apply busy_timeout: %w", err)
+		}
+		// journal_mode is database-level (lives in the file header). On a
+		// fresh DB with concurrent openers, two goroutines may both try to
+		// flip delete→WAL; one wins, the other gets SQLITE_BUSY. Tolerate
+		// that: the file is already in WAL by the time the loser observes
+		// it, and a subsequent PRAGMA journal_mode read will return "wal".
+		if _, err := conn.ExecContext(ctx, "PRAGMA journal_mode = WAL", nil); err != nil {
+			if !strings.Contains(err.Error(), "database is locked") &&
+				!strings.Contains(err.Error(), "SQLITE_BUSY") {
+				return fmt.Errorf("apply journal_mode=WAL: %w", err)
+			}
+		}
+		// Connection-level pragmas — must fire on every new pool connection.
+		for _, p := range []string{
+			"PRAGMA foreign_keys = ON",
+			"PRAGMA temp_store = MEMORY",
+			"PRAGMA mmap_size = 268435456",
+			"PRAGMA synchronous = NORMAL",
+		} {
+			if _, err := conn.ExecContext(ctx, p, nil); err != nil {
+				return fmt.Errorf("apply %q: %w", p, err)
+			}
+		}
+		return nil
+	})
+}
 
 var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 

--- a/library/payments/prediction-goat/internal/store/store.go
+++ b/library/payments/prediction-goat/internal/store/store.go
@@ -82,7 +82,7 @@ func IsUUID(s string) bool {
 // shape — adding columns, dropping indexes, changing FTS5 tokenizers —
 // so an older binary refuses to open a newer database rather than silently
 // producing wrong results against a schema it cannot read.
-const StoreSchemaVersion = 2
+const StoreSchemaVersion = 3
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -1162,6 +1162,12 @@ func (s *Store) migrate(ctx context.Context) error {
 			}
 		}
 
+		if current < 3 {
+			if err := s.migrateResourcesFTSCuratedContent(ctx, conn); err != nil {
+				return fmt.Errorf("migrating resources_fts curated content: %w", err)
+			}
+		}
+
 		if err := s.backfillColumns(ctx, conn); err != nil {
 			return fmt.Errorf("backfilling columns: %w", err)
 		}
@@ -1234,6 +1240,35 @@ func (s *Store) migrateResourcesCompositeKey(ctx context.Context, conn *sql.Conn
 	return nil
 }
 
+// migrateResourcesFTSCuratedContent drops resources_fts and rebuilds it
+// against the new curated-content projection from ftsContent. v1 and v2
+// indexed the entire raw JSON blob, which produced false positives like
+// KXFUSION (Nuclear fusion) matching "oscars best picture" because its
+// source_agencies field cited oscars.org. The schema-version gate
+// ensures this runs exactly once per existing DB.
+func (s *Store) migrateResourcesFTSCuratedContent(ctx context.Context, conn *sql.Conn) error {
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		// Fresh DB — the CREATE TABLE migrations will create both tables
+		// and rebuildResourcesFTS gets called on first upsert via the
+		// normal insert path. Nothing to do here.
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
+		return fmt.Errorf("dropping resources_fts: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, resourcesFTSCreateSQL); err != nil {
+		return fmt.Errorf("creating resources_fts: %w", err)
+	}
+	if err := rebuildResourcesFTS(ctx, conn); err != nil {
+		return fmt.Errorf("rebuilding resources_fts with curated content: %w", err)
+	}
+	return nil
+}
+
 func tableExists(ctx context.Context, conn *sql.Conn, name string) (bool, error) {
 	var count int
 	if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name).Scan(&count); err != nil {
@@ -1264,6 +1299,57 @@ func resourcesTableHasCompositeKey(ctx context.Context, conn *sql.Conn) (bool, e
 		return false, fmt.Errorf("reading resources table info rows: %w", err)
 	}
 	return pk["resource_type"] == 1 && pk["id"] == 2, nil
+}
+
+// ftsContent extracts a curated, topic-bearing string from a resource's
+// JSON payload for indexing in resources_fts. Returns ONLY semantically
+// meaningful fields — title, ticker, category, etc. — and deliberately
+// drops payload-shaped noise like Kalshi's source_agencies (a list of
+// URL refs that contains strings like "oscars.org/oscars" and "Academy
+// of Motion Picture Arts and Sciences" on the Nuclear Fusion series,
+// causing it to match a query like "oscars best picture").
+//
+// PATCH(curated-fts-content): pre-v3 builds indexed the entire raw JSON
+// blob here, which is why an "oscars" query matched KXFUSION. The fix
+// is to project to a topic-relevant subset at index time; the schema
+// migration to v3 rebuilds the FTS table against this projection.
+//
+// The same key set covers every resource type the cross-venue topic
+// command searches (markets, events, tags, kalshi_markets, kalshi_events,
+// kalshi_series) and gives unknown resource types a safe, low-noise
+// fallback without per-type branching.
+func ftsContent(data string) string {
+	if data == "" {
+		return ""
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(data), &obj); err != nil {
+		// Malformed JSON: index nothing rather than indexing literal
+		// braces and quotes that would never match anyway. Safer than
+		// returning the raw blob, which is what U2 is trying to stop.
+		return ""
+	}
+	// Ordered so the projection reads naturally in any debug dump:
+	// human label first, then identifiers, then categorical metadata.
+	keys := [...]string{
+		"question", "title", "name", "label", "subtitle", "yes_sub_title",
+		"slug", "ticker", "event_ticker", "series_ticker",
+		"category",
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v, ok := obj[k]
+		if !ok || v == nil {
+			continue
+		}
+		if s, ok := v.(string); ok {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				parts = append(parts, s)
+			}
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
@@ -1297,7 +1383,7 @@ func rebuildResourcesFTS(ctx context.Context, conn *sql.Conn) error {
 	for _, r := range resources {
 		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, ?, ?, ?)`,
-			ftsRowID(r.resourceType, r.id), r.id, r.resourceType, r.data,
+			ftsRowID(r.resourceType, r.id), r.id, r.resourceType, ftsContent(r.data),
 		); err != nil {
 			return fmt.Errorf("indexing resource %s/%s: %w", r.resourceType, r.id, err)
 		}
@@ -1433,7 +1519,7 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 	if _, err = tx.Exec(
 		`INSERT INTO resources_fts (rowid, id, resource_type, content)
 		 VALUES (?, ?, ?, ?)`,
-		ftsRowid, id, resourceType, string(data),
+		ftsRowid, id, resourceType, ftsContent(string(data)),
 	); err != nil {
 		// FTS insert failure is non-fatal
 		fmt.Fprintf(os.Stderr, "warning: FTS index update failed: %v\n", err)

--- a/library/payments/prediction-goat/internal/store/store_concurrency_test.go
+++ b/library/payments/prediction-goat/internal/store/store_concurrency_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 mvanhorn. Licensed under Apache-2.0. See LICENSE.
+
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestOpenAppliesWAL verifies the connection hook actually puts the
+// database into WAL journal mode. Before this fix, the DSN-level
+// `_journal_mode=WAL` was silently ignored by modernc.org/sqlite v1.37.0
+// and the live store ran with the default `delete` journal — which is
+// the root cause of the SQLITE_BUSY failures we saw under concurrent
+// reads.
+func TestOpenAppliesWAL(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+
+	var mode string
+	if err := s.DB().QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
+		t.Fatalf("query journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want %q (DSN pragma path is unreliable; connection hook must apply WAL)", mode, "wal")
+	}
+}
+
+// TestOpenAppliesBusyTimeout verifies every pooled connection carries
+// the 5-second busy_timeout. busy_timeout is connection-level (not
+// database-level), so the hook has to fire on each new connection in
+// the pool. We exercise both pool slots by holding one connection open
+// while querying busy_timeout on another.
+func TestOpenAppliesBusyTimeout(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	conn1, err := s.DB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn 1: %v", err)
+	}
+	defer conn1.Close()
+
+	conn2, err := s.DB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn 2: %v", err)
+	}
+	defer conn2.Close()
+
+	// Both pooled conns should report busy_timeout=5000.
+	var bt1, bt2 int
+	if err := conn1.QueryRowContext(ctx, `PRAGMA busy_timeout`).Scan(&bt1); err != nil {
+		t.Fatalf("conn1 busy_timeout: %v", err)
+	}
+	if err := conn2.QueryRowContext(ctx, `PRAGMA busy_timeout`).Scan(&bt2); err != nil {
+		t.Fatalf("conn2 busy_timeout: %v", err)
+	}
+	if bt1 != 5000 {
+		t.Errorf("conn1 busy_timeout = %d, want 5000", bt1)
+	}
+	if bt2 != 5000 {
+		t.Errorf("conn2 busy_timeout = %d, want 5000", bt2)
+	}
+}
+
+// TestConcurrentReadsDoNotFail seeds the store and fires four parallel
+// reads. With WAL + busy_timeout in place, all four must succeed.
+// Pre-fix this would intermittently fail with "database is locked".
+func TestConcurrentReadsDoNotFail(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+
+	if _, err := s.DB().Exec(`INSERT INTO resources(id, resource_type, data) VALUES ('seed', 'test', '{}')`); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+
+	const readers = 4
+	var wg sync.WaitGroup
+	errs := make(chan error, readers)
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var n int
+			if err := s.DB().QueryRow(`SELECT COUNT(*) FROM resources`).Scan(&n); err != nil {
+				errs <- err
+				return
+			}
+			if n != 1 {
+				errs <- &countMismatchErr{got: n, want: 1}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent read: %v", err)
+	}
+}
+
+// TestReadDuringWriteDoesNotFail starts a write transaction in one
+// goroutine and a read in another. Under WAL the read should not block
+// on the write; pre-fix it would fail with SQLITE_BUSY.
+func TestReadDuringWriteDoesNotFail(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	s, err := OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenWithContext: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	writeConn, err := s.DB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("write conn: %v", err)
+	}
+	defer writeConn.Close()
+
+	tx, err := writeConn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO resources(id, resource_type, data) VALUES ('w', 'test', '{}')`); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("insert in tx: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var n int
+		done <- s.DB().QueryRow(`SELECT COUNT(*) FROM resources`).Scan(&n)
+	}()
+
+	if err := <-done; err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("read during open write tx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+type countMismatchErr struct {
+	got, want int
+}
+
+func (e *countMismatchErr) Error() string {
+	return "row count mismatch"
+}


### PR DESCRIPTION
Stacked on top of #780. **Do not merge until #780 lands.**

This PR ships eight implementation units that address the search-relevance, sync-coverage, freshness-safety, venue-scoping, and learning gaps in prediction-goat-pp-cli — all surfaced in a debugging session this morning where the CLI silently returned wrong or stale answers on representative queries.

Plan: [`docs/plans/2026-05-23-001-feat-prediction-goat-search-relevance-and-freshness-plan.md`](docs/plans/2026-05-23-001-feat-prediction-goat-search-relevance-and-freshness-plan.md).

## What this fixes

| Query | Pre-fix top Kalshi hit | After fix |
|---|---|---|
| `portugal world cup` | (nothing — not synced + ranking) | KXMENWORLDCUP-26-PT at position 0 |
| `oscars best picture 2026` | KXFUSION (Nuclear fusion!) | KXOSCARSCORE / KXOSCARCOUNT* at position 0 |
| `bitcoin 100k` | BTCETHATH-29DEC31 (Ethereum vs BTC) | KXBTCMAX100 at position 0 |
| `fed rate cut june` | "government spending cut" event | KXRATECUT / KXFEDRATEMIN |
| `nba championship 2026` | "NBA team" series | KXNBA finals series |

And: cached prices no longer mislead. Concurrent reads no longer fail with SQLITE_BUSY. Agents can scope to one venue. The CLI now learns from the LLM's response so future identical questions short-circuit discovery.

## Commits (8 units, 374 tests passing)

| Unit | Commit | What changed |
|---|---|---|
| U1 | `225e50eb` | WAL pragmas via `sqlite.RegisterConnectionHook` — DSN-level `_journal_mode=WAL` was silently ignored by modernc.org/sqlite v1.37.0, leaving the live store on journal_mode=delete with no busy_timeout |
| U2 | `0add272d` | Curated `resources_fts.content` (title + ticker + category + tags, dropping raw-JSON noise) + schema v2→v3 reindex migration |
| U3 | _(skipped)_ | Title-boost ranking — U2 made BM25 over the curated content sufficient; verified via [`fts_speedrun_test.go`](library/payments/prediction-goat/internal/store/fts_speedrun_test.go) |
| U4 | `1c7f22b1` | `--venue`, `--polymarket`, `--kalshi` flags on topic, compare, liquid, movers, resolving, trending, new |
| U7 | `0bd0ff45` | `kalshi events get --with-markets` (one-call enumeration of all 56 World Cup country markets) + `kalshi events list --series` (was advertised in --help but never declared) |
| U6 | `bb663067` | Series-driven Kalshi markets sync walk seeded from kalshi_series, so named-event families (KXMENWORLDCUP-*, KXBTC*, KXOSCAR*) are no longer starved by the natural /markets pagination order |
| U5 | `0a067fc9` | Live-on-read freshness — price-bearing fields refetched from upstream at command time; `meta.price_source` / `meta.index_synced_at` surface staleness |
| U8 | `2b5c5a40` | LLM-driven learning pipeline: `teach` (silent, backgroundable, fired by the LLM at response time) + `recall` (token-set Jaccard match, called before discovery) + rerank layer in topic/compare + skill markdown contract |

## Validation

- `go test ./...` → 374 passed across 13 packages (baseline was 0 — every unit landed with comprehensive tests)
- `go build ./...` → clean
- `go vet ./...` → clean
- `govulncheck ./...` → 0 reachable vulnerabilities
- `verify_skill.py --dir library/payments/prediction-goat/` → all checks pass

## Documented customizations

Each unit recorded in `library/payments/prediction-goat/.printing-press-patches.json` with a `summary`, `reason`, `files`, and `validated_outcome`. Several entries flag the underlying issue as a generator-template bug worth fixing upstream in [cli-printing-press](https://github.com/mvanhorn/cli-printing-press) so future prints of unrelated CLIs (other SQLite-backed CLIs, other discovery+price-bearing CLIs) get the fix by default.

## Manual end-to-end check

```bash
# Smoke against live Kalshi API
~/go/bin/prediction-goat-pp-cli kalshi events get KXMENWORLDCUP-26 --with-markets --agent | jq '.markets | length'
# -> 56

# Cold-start learning flow
prediction-goat-pp-cli recall "portugal world cup odds" --agent   # found=false
prediction-goat-pp-cli teach --query "portugal world cup odds" --resource KXMENWORLDCUP-26-PT
prediction-goat-pp-cli recall "portugal world cup odds" --agent   # found=true, KXMENWORLDCUP-26-PT at position 0
prediction-goat-pp-cli recall "portugal chances at the world cup" --agent  # token-overlap match
```