### PR TITLE
feat(library): adopt agentcookie v0.14 secrets-bus across the catalog

### DIFF
--- a/library/ai/elevenlabs/agentcookie.toml
+++ b/library/ai/elevenlabs/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/elevenlabs-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ELEVENLABS_API_KEY = true
+"ELEVENLABS_API_KEY" = true

--- a/library/ai/elevenlabs/agentcookie.toml
+++ b/library/ai/elevenlabs/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "elevenlabs-pp-cli"
+display_name = "ElevenLabs"
+description = "Generate, transform, transcribe, dub, and manage AI audio, voices, music, and conversational agents with ElevenLabs."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/elevenlabs-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ELEVENLABS_API_KEY = true

--- a/library/ai/midjourney/agentcookie.toml
+++ b/library/ai/midjourney/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "midjourney-pp-cli"
+display_name = "Midjourney"
+description = "Inspect Midjourney jobs, queue, folders, and discovery feeds from the terminal"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/midjourney-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"MIDJOURNEY_COOKIE_HEADER" = true

--- a/library/ai/ollama-cloud/agentcookie.toml
+++ b/library/ai/ollama-cloud/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "ollama-cloud-pp-cli"
+display_name = "Ollama Cloud"
+description = "Ollama Cloud is Ollama's hosted inference API."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/ollama-cloud-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"OLLAMA_CLOUD_API_KEY" = true

--- a/library/ai/surgegraph/agentcookie.toml
+++ b/library/ai/surgegraph/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/surgegraph-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SURGEGRAPH_TOKEN = true
+"SURGEGRAPH_TOKEN" = true

--- a/library/ai/surgegraph/agentcookie.toml
+++ b/library/ai/surgegraph/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "surgegraph-pp-cli"
+display_name = "Surgegraph Facade"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/surgegraph-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SURGEGRAPH_TOKEN = true

--- a/library/ai/twelvelabs/agentcookie.toml
+++ b/library/ai/twelvelabs/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/twelvelabs-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TWELVELABS_X_API_KEY = true
+"TWELVELABS_X_API_KEY" = true

--- a/library/cloud/azure-functions-admin/agentcookie.toml
+++ b/library/cloud/azure-functions-admin/agentcookie.toml
@@ -13,7 +13,7 @@ path = "~/.config/azure-functions-admin-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-AZURE_CLIENT_ID = true
-AZURE_CLIENT_SECRET = true
-AZURE_SUBSCRIPTION_ID = true
-AZURE_TENANT_ID = true
+"AZURE_CLIENT_ID" = true
+"AZURE_CLIENT_SECRET" = true
+"AZURE_SUBSCRIPTION_ID" = true
+"AZURE_TENANT_ID" = true

--- a/library/cloud/cf-domain/agentcookie.toml
+++ b/library/cloud/cf-domain/agentcookie.toml
@@ -13,7 +13,7 @@ path = "~/.config/cf-domain-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ACCOUNT_ID = true
-CLOUDFLARE_ACCOUNT_ID = true
-CLOUDFLARE_API_TOKEN = true
-CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH = true
+"ACCOUNT_ID" = true
+"CLOUDFLARE_ACCOUNT_ID" = true
+"CLOUDFLARE_API_TOKEN" = true
+"CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH" = true

--- a/library/cloud/cf-domain/agentcookie.toml
+++ b/library/cloud/cf-domain/agentcookie.toml
@@ -1,0 +1,19 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "cf-domain-pp-cli"
+display_name = "Cloudflare Registrar Domains"
+description = "Agent-native Cloudflare Registrar CLI for domain search, live pricing checks, and gated registration."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/cf-domain-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ACCOUNT_ID = true
+CLOUDFLARE_ACCOUNT_ID = true
+CLOUDFLARE_API_TOKEN = true
+CLOUDFLARE_REGISTRAR_DOMAINS_BEARER_AUTH = true

--- a/library/cloud/cloud-run-admin/agentcookie.toml
+++ b/library/cloud/cloud-run-admin/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/cloud-run-admin-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-CLOUD_RUN_ADMIN_OAUTH2C = true
+"CLOUD_RUN_ADMIN_OAUTH2C" = true

--- a/library/cloud/cloud-run-admin/agentcookie.toml
+++ b/library/cloud/cloud-run-admin/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "cloud-run-admin-pp-cli"
+display_name = "Google Cloud Run"
+description = "Cloud Run Admin API for deploying and managing serverless container services, revisions, jobs, and executions"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/cloud-run-admin-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+CLOUD_RUN_ADMIN_OAUTH2C = true

--- a/library/cloud/digitalocean/agentcookie.toml
+++ b/library/cloud/digitalocean/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/digitalocean-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DIGITALOCEAN_BEARER_AUTH = true
+"DIGITALOCEAN_BEARER_AUTH" = true

--- a/library/cloud/digitalocean/agentcookie.toml
+++ b/library/cloud/digitalocean/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "digitalocean-pp-cli"
+display_name = "DigitalOcean"
+description = "Manage DigitalOcean Droplets, Kubernetes, databases, firewalls, networking, billing, and other cloud resources from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/digitalocean-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DIGITALOCEAN_BEARER_AUTH = true

--- a/library/cloud/here-now/agentcookie.toml
+++ b/library/cloud/here-now/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/here-now-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-HERENOW_API_KEY = true
+"HERENOW_API_KEY" = true

--- a/library/cloud/render/agentcookie.toml
+++ b/library/cloud/render/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/render-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-RENDER_API_KEY = true
+"RENDER_API_KEY" = true

--- a/library/cloud/render/agentcookie.toml
+++ b/library/cloud/render/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "render-pp-cli"
+display_name = "Render"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/render-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+RENDER_API_KEY = true

--- a/library/commerce/amazon-ads/agentcookie.toml
+++ b/library/commerce/amazon-ads/agentcookie.toml
@@ -3,7 +3,7 @@
 schema_version = 2
 name = "amazon-ads-pp-cli"
 display_name = "Amazon Ads"
-description = "Combined CLI for multiple API services"
+description = "Amazon Ads CLI for OAuth profile setup, reports, profitability analytics, keyword optimization, and guarded campaign automation."
 project_kind = "cli"
 
 [secrets.file]
@@ -13,6 +13,6 @@ path = "~/.config/amazon-ads-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-AMAZON_ADS_CLIENT_ID = true
-AMAZON_ADS_CLIENT_SECRET = true
-AMAZON_ADS_REFRESH_TOKEN = true
+"AMAZON_ADS_CLIENT_ID" = true
+"AMAZON_ADS_CLIENT_SECRET" = true
+"AMAZON_ADS_REFRESH_TOKEN" = true

--- a/library/commerce/amazon-orders/agentcookie.toml
+++ b/library/commerce/amazon-orders/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/amazon-orders-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-AMAZON_COOKIES = true
+"AMAZON_COOKIES" = true

--- a/library/commerce/amazon-orders/agentcookie.toml
+++ b/library/commerce/amazon-orders/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "amazon-orders-pp-cli"
+display_name = "Amazon Orders"
+description = "Sync your Amazon order history into a local SQLite store, then ask cross-cutting questions offline: which deliveries are slipping, what did I spend last quarter, when did I order that thing, where is my stuff right now."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/amazon-orders-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+AMAZON_COOKIES = true

--- a/library/commerce/amazon-seller/agentcookie.toml
+++ b/library/commerce/amazon-seller/agentcookie.toml
@@ -13,6 +13,6 @@ path = "~/.config/amazon-seller-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SP_API_LWA_CLIENT_ID = true
-SP_API_LWA_CLIENT_SECRET = true
-SP_API_REFRESH_TOKEN = true
+"SP_API_LWA_CLIENT_ID" = true
+"SP_API_LWA_CLIENT_SECRET" = true
+"SP_API_REFRESH_TOKEN" = true

--- a/library/commerce/amazon-seller/agentcookie.toml
+++ b/library/commerce/amazon-seller/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "amazon-seller-pp-cli"
+display_name = "Amazon Seller"
+description = "Operate an Amazon seller account from the terminal: inventory, orders, reports, listings, and catalog."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/amazon-seller-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SP_API_LWA_CLIENT_ID = true
+SP_API_LWA_CLIENT_SECRET = true
+SP_API_REFRESH_TOKEN = true

--- a/library/commerce/facebook-marketplace/agentcookie.toml
+++ b/library/commerce/facebook-marketplace/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/facebook-marketplace-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FACEBOOK_MARKET_COOKIES = true
+"FACEBOOK_MARKET_COOKIES" = true

--- a/library/commerce/facebook-marketplace/agentcookie.toml
+++ b/library/commerce/facebook-marketplace/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "facebook-marketplace-pp-cli"
+display_name = "Facebook Marketplace"
+description = "Search, publish, mirror, and manage Facebook Marketplace seller workflows with explicit write checkpoints."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/facebook-marketplace-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FACEBOOK_MARKET_COOKIES = true

--- a/library/commerce/fedex/agentcookie.toml
+++ b/library/commerce/fedex/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/fedex-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FEDEX_API_KEY = true
-FEDEX_SECRET_KEY = true
+"FEDEX_API_KEY" = true
+"FEDEX_SECRET_KEY" = true

--- a/library/commerce/fedex/agentcookie.toml
+++ b/library/commerce/fedex/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "fedex-pp-cli"
+display_name = "FedEx"
+description = "Ship, rate, and track FedEx packages from the terminal — built for small business shippers."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/fedex-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FEDEX_API_KEY = true
+FEDEX_SECRET_KEY = true

--- a/library/commerce/gumroad/agentcookie.toml
+++ b/library/commerce/gumroad/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/gumroad-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GUMROAD_ACCESS_TOKEN = true
+"GUMROAD_ACCESS_TOKEN" = true

--- a/library/commerce/gumroad/agentcookie.toml
+++ b/library/commerce/gumroad/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "gumroad-pp-cli"
+display_name = "Gumroad"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/gumroad-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GUMROAD_ACCESS_TOKEN = true

--- a/library/commerce/offerup/agentcookie.toml
+++ b/library/commerce/offerup/agentcookie.toml
@@ -2,8 +2,8 @@
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
 name = "offerup-pp-cli"
-display_name = "Offerup"
-description = "Search local OfferUp listings, track prices, and surface deals from your terminal"
+display_name = "OfferUp"
+description = "Search local OfferUp listings from your terminal, keep them in a local database, and spot underpriced deals before anyone else — no login and no paid key for the things that matter most."
 project_kind = "cli"
 
 [secrets.file]
@@ -13,4 +13,4 @@ path = "~/.config/offerup-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OFFERUP_COOKIE = true
+"OFFERUP_COOKIE" = true

--- a/library/commerce/printify/agentcookie.toml
+++ b/library/commerce/printify/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "printify-pp-cli"
+display_name = "Printify"
+description = "Create and audit Printify products with manifest-driven image uploads, personalization checks, and local proofing."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/printify-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"PRINTIFY_BEARER_AUTH" = true

--- a/library/commerce/restaurant365-odata/agentcookie.toml
+++ b/library/commerce/restaurant365-odata/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/restaurant365-odata-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-RESTAURANT365_ODATA_PASSWORD = true
-RESTAURANT365_ODATA_USERNAME = false
+"RESTAURANT365_ODATA_PASSWORD" = true
+"RESTAURANT365_ODATA_USERNAME" = true

--- a/library/commerce/shopify/agentcookie.toml
+++ b/library/commerce/shopify/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/shopify-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SHOPIFY_ACCESS_TOKEN = true
+"SHOPIFY_ACCESS_TOKEN" = true

--- a/library/commerce/shopify/agentcookie.toml
+++ b/library/commerce/shopify/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "shopify-pp-cli"
+display_name = "Shopify"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/shopify-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SHOPIFY_ACCESS_TOKEN = true

--- a/library/commerce/shopify/agentcookie.toml
+++ b/library/commerce/shopify/agentcookie.toml
@@ -3,6 +3,7 @@
 schema_version = 2
 name = "shopify-pp-cli"
 display_name = "Shopify"
+description = "Operate a Shopify store from the terminal with local sync, analytics, and bulk exports."
 project_kind = "cli"
 
 [secrets.file]

--- a/library/commerce/squarespace/agentcookie.toml
+++ b/library/commerce/squarespace/agentcookie.toml
@@ -12,6 +12,6 @@ path = "~/.config/squarespace-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-COMMERCE_AUTHORIZATION = true
-SQUARESPACE_ACCOUNT_COOKIE = true
-SQUARESPACE_ACCOUNT_COOKIE_FILE = true
+"COMMERCE_AUTHORIZATION" = true
+"SQUARESPACE_ACCOUNT_COOKIE" = true
+"SQUARESPACE_ACCOUNT_COOKIE_FILE" = true

--- a/library/commerce/squarespace/agentcookie.toml
+++ b/library/commerce/squarespace/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "squarespace-pp-cli"
+display_name = "Squarespace"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/squarespace-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+COMMERCE_AUTHORIZATION = true
+SQUARESPACE_ACCOUNT_COOKIE = true
+SQUARESPACE_ACCOUNT_COOKIE_FILE = true

--- a/library/commerce/tiktok-shop/agentcookie.toml
+++ b/library/commerce/tiktok-shop/agentcookie.toml
@@ -13,8 +13,8 @@ path = "~/.config/tiktok-shop-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TIKTOK_SHOP_ACCESS_TOKEN = true
-TIKTOK_SHOP_APP_KEY = true
-TIKTOK_SHOP_APP_SECRET = true
-TIKTOK_SHOP_REFRESH_TOKEN = true
-TIKTOK_SHOP_SHOP_CIPHER = true
+"TIKTOK_SHOP_ACCESS_TOKEN" = true
+"TIKTOK_SHOP_APP_KEY" = true
+"TIKTOK_SHOP_APP_SECRET" = true
+"TIKTOK_SHOP_REFRESH_TOKEN" = true
+"TIKTOK_SHOP_SHOP_CIPHER" = true

--- a/library/commerce/tiktok-shop/agentcookie.toml
+++ b/library/commerce/tiktok-shop/agentcookie.toml
@@ -1,0 +1,20 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "tiktok-shop-pp-cli"
+display_name = "TikTok Shop"
+description = "Safe v1 TikTok Shop Seller API CLI/MCP for auth readiness, token exchange and read endpoints; pre-flight checks gate live writes by default."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/tiktok-shop-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TIKTOK_SHOP_ACCESS_TOKEN = true
+TIKTOK_SHOP_APP_KEY = true
+TIKTOK_SHOP_APP_SECRET = true
+TIKTOK_SHOP_REFRESH_TOKEN = true
+TIKTOK_SHOP_SHOP_CIPHER = true

--- a/library/commerce/ucp/agentcookie.toml
+++ b/library/commerce/ucp/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "ucp-pp-cli"
+display_name = "UCP"
+description = "A Go CLI for Google's Universal Commerce Protocol — talk to UCP merchants over REST or MCP, search across them in parallel, build carts, and prep checkout drafts that an AP2 CLI can authorize."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/ucp-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"API_TOKEN" = true

--- a/library/developer-tools/apify/agentcookie.toml
+++ b/library/developer-tools/apify/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/apify-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-APIFY_TOKEN = true
+"APIFY_TOKEN" = true

--- a/library/developer-tools/apify/agentcookie.toml
+++ b/library/developer-tools/apify/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "apify-pp-cli"
+display_name = "Apify"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/apify-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+APIFY_TOKEN = true

--- a/library/developer-tools/firecrawl/agentcookie.toml
+++ b/library/developer-tools/firecrawl/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/firecrawl-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FIRECRAWL_BEARER_AUTH = true
+"FIRECRAWL_BEARER_AUTH" = true

--- a/library/developer-tools/firecrawl/agentcookie.toml
+++ b/library/developer-tools/firecrawl/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "firecrawl-pp-cli"
+display_name = "Firecrawl"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/firecrawl-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FIRECRAWL_BEARER_AUTH = true

--- a/library/developer-tools/namecheap/agentcookie.toml
+++ b/library/developer-tools/namecheap/agentcookie.toml
@@ -13,7 +13,7 @@ path = "~/.config/namecheap-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-NAMECHEAP_API_KEY = true
-NAMECHEAP_CLIENT_IP = true
-NAMECHEAP_SANDBOX = true
-NAMECHEAP_USERNAME = true
+"NAMECHEAP_API_KEY" = true
+"NAMECHEAP_CLIENT_IP" = true
+"NAMECHEAP_SANDBOX" = true
+"NAMECHEAP_USERNAME" = true

--- a/library/developer-tools/namecheap/agentcookie.toml
+++ b/library/developer-tools/namecheap/agentcookie.toml
@@ -1,0 +1,19 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "namecheap-pp-cli"
+display_name = "Namecheap"
+description = "Manage Namecheap domains, DNS, account balances, pricing, contacts, TLDs, and SSL metadata from the terminal using Namecheap’s XML API."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/namecheap-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+NAMECHEAP_API_KEY = true
+NAMECHEAP_CLIENT_IP = true
+NAMECHEAP_SANDBOX = true
+NAMECHEAP_USERNAME = true

--- a/library/developer-tools/openfda/agentcookie.toml
+++ b/library/developer-tools/openfda/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/openfda-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FDA_API_KEY = true
+"FDA_API_KEY" = true

--- a/library/developer-tools/openfda/agentcookie.toml
+++ b/library/developer-tools/openfda/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "openfda-pp-cli"
+display_name = "OpenFDA"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/openfda-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FDA_API_KEY = true

--- a/library/developer-tools/posthog/agentcookie.toml
+++ b/library/developer-tools/posthog/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/posthog-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-POSTHOG_PERSONAL_APIKEY_AUTH = true
+"POSTHOG_PERSONAL_APIKEY_AUTH" = true

--- a/library/developer-tools/posthog/agentcookie.toml
+++ b/library/developer-tools/posthog/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "posthog-pp-cli"
+display_name = "PostHog"
+description = "Every PostHog resource in one CLI — with offline search, agent-native output, and cross-resource analytics no dashboard exposes."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/posthog-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+POSTHOG_PERSONAL_APIKEY_AUTH = true

--- a/library/developer-tools/scrape-creators/agentcookie.toml
+++ b/library/developer-tools/scrape-creators/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/scrape-creators-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SCRAPECREATORS_API_KEY = true
+"SCRAPECREATORS_API_KEY" = true

--- a/library/developer-tools/sec-edgar/agentcookie.toml
+++ b/library/developer-tools/sec-edgar/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/sec-edgar-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SEC_EDGAR_USER_AGENT = true
+"SEC_EDGAR_USER_AGENT" = true

--- a/library/developer-tools/sec-edgar/agentcookie.toml
+++ b/library/developer-tools/sec-edgar/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "sec-edgar-pp-cli"
+display_name = "SEC EDGAR"
+description = "Every SEC filing, every XBRL fact, every insider trade — synced into a local SQLite store you can pivot, search, and watch offline."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/sec-edgar-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SEC_EDGAR_USER_AGENT = true

--- a/library/developer-tools/supabase/agentcookie.toml
+++ b/library/developer-tools/supabase/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/supabase-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SUPABASE_ACCESS_TOKEN = true
+"SUPABASE_ACCESS_TOKEN" = true

--- a/library/developer-tools/supabase/agentcookie.toml
+++ b/library/developer-tools/supabase/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "supabase-pp-cli"
+display_name = "Supabase"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/supabase-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SUPABASE_ACCESS_TOKEN = true

--- a/library/developer-tools/trigger-dev/agentcookie.toml
+++ b/library/developer-tools/trigger-dev/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/trigger-dev-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TRIGGER_SECRET_KEY = true
+"TRIGGER_SECRET_KEY" = true

--- a/library/developer-tools/trigger-dev/agentcookie.toml
+++ b/library/developer-tools/trigger-dev/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "trigger-dev-pp-cli"
+display_name = "Trigger.dev"
+description = "Durable background jobs and AI agent orchestration — runs, schedules, deployments, batches, queues, waitpoints, env vars, and TRQL analytics"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/trigger-dev-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TRIGGER_SECRET_KEY = true

--- a/library/developer-tools/uspto-tsdr/agentcookie.toml
+++ b/library/developer-tools/uspto-tsdr/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/uspto-tsdr-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TSDR_APIKEY_HEADER = true
+"TSDR_APIKEY_HEADER" = true

--- a/library/developer-tools/uspto-tsdr/agentcookie.toml
+++ b/library/developer-tools/uspto-tsdr/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "uspto-tsdr-pp-cli"
+display_name = "Tsdr"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/uspto-tsdr-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TSDR_APIKEY_HEADER = true

--- a/library/devices/adminbyrequest/agentcookie.toml
+++ b/library/devices/adminbyrequest/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/adminbyrequest-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ADMINBYREQUEST_API_KEY = true
+"ADMINBYREQUEST_API_KEY" = true

--- a/library/devices/adminbyrequest/agentcookie.toml
+++ b/library/devices/adminbyrequest/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "adminbyrequest-pp-cli"
+display_name = "Admin By Request"
+description = "Sync Admin By Request audit, event, inventory, and elevation-request data for approvals, quota checks, and admin-risk reports."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/adminbyrequest-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ADMINBYREQUEST_API_KEY = true

--- a/library/devices/dreo/agentcookie.toml
+++ b/library/devices/dreo/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/dreo-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DREO_PASSWORD = true
-DREO_USERNAME = true
+"DREO_PASSWORD" = true
+"DREO_USERNAME" = true

--- a/library/devices/dreo/agentcookie.toml
+++ b/library/devices/dreo/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "dreo-pp-cli"
+display_name = "Dreo"
+description = "Control Dreo smart fans, heaters, air purifiers, humidifiers, and ACs from the command line."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/dreo-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DREO_PASSWORD = true
+DREO_USERNAME = true

--- a/library/devices/tesla/agentcookie.toml
+++ b/library/devices/tesla/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/tesla-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TESLA_AUTH_TOKEN = true
+"TESLA_AUTH_TOKEN" = true

--- a/library/devices/tesla/agentcookie.toml
+++ b/library/devices/tesla/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "tesla-pp-cli"
+display_name = "Tesla"
+description = "Every Tesla mobile-API feature, plus offline charging history and a SQLite-backed vehicle log no other Tesla CLI has"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/tesla-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TESLA_AUTH_TOKEN = true

--- a/library/devices/vestaboard/agentcookie.toml
+++ b/library/devices/vestaboard/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/vestaboard-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-VESTABOARD_API_KEY = true
+"VESTABOARD_API_KEY" = true

--- a/library/devices/whoop/agentcookie.toml
+++ b/library/devices/whoop/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/whoop-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-WHOOP_OAUTH = true
+"WHOOP_OAUTH" = true

--- a/library/devices/whoop/agentcookie.toml
+++ b/library/devices/whoop/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "whoop-pp-cli"
+display_name = "WHOOP"
+description = "Fetch WHOOP recovery, strain, sleep, workout, cycle, profile, and body-measurement data with OAuth-backed API access."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/whoop-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+WHOOP_OAUTH = true

--- a/library/education/ankiweb/agentcookie.toml
+++ b/library/education/ankiweb/agentcookie.toml
@@ -1,16 +1,15 @@
 # agentcookie.toml: secrets-bus adoption manifest v2
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
-name = "wavespeed-pp-cli"
-display_name = "WaveSpeed"
-description = "Docs-derived OpenAPI spec for WaveSpeed AI's REST API."
+name = "ankiweb-pp-cli"
+display_name = "Ankiweb"
 project_kind = "cli"
 
 [secrets.file]
-path = "~/.config/wavespeed-pp-cli/config.toml"
+path = "~/.config/ankiweb-pp-cli/config.toml"
 
 [sync]
 default = false
 
 [sync.keys]
-"WAVESPEED_API_KEY" = true
+"ANKIWEB_COOKIES" = true

--- a/library/education/lawhub/agentcookie.toml
+++ b/library/education/lawhub/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/lawhub-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-LAWHUB_USER_ID = true
+"LAWHUB_USER_ID" = true

--- a/library/education/lawhub/agentcookie.toml
+++ b/library/education/lawhub/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "lawhub-pp-cli"
+display_name = "LawHub"
+description = "Local-first LSAT practice analytics from authenticated LawHub score metadata, with SQLite, weakness reports, question notes, and safe review links back to LawHub."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/lawhub-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+LAWHUB_USER_ID = true

--- a/library/food-and-dining/allrecipes/agentcookie.toml
+++ b/library/food-and-dining/allrecipes/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/allrecipes-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ALLRECIPES_COOKIES = true
+"ALLRECIPES_COOKIES" = true

--- a/library/food-and-dining/allrecipes/agentcookie.toml
+++ b/library/food-and-dining/allrecipes/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "allrecipes-pp-cli"
+display_name = "Allrecipes"
+description = "Search Allrecipes, fetch structured recipe data, scale servings, build grocery lists, and rank cached recipes by popularity."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/allrecipes-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ALLRECIPES_COOKIES = true

--- a/library/food-and-dining/anylist/agentcookie.toml
+++ b/library/food-and-dining/anylist/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/anylist-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ANYLIST_ACCESS_TOKEN = true
+"ANYLIST_ACCESS_TOKEN" = true

--- a/library/food-and-dining/anylist/agentcookie.toml
+++ b/library/food-and-dining/anylist/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "anylist-pp-cli"
+display_name = "AnyList"
+description = "AnyList shopping, recipes, meal planning, and local grocery automation CLI."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/anylist-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ANYLIST_ACCESS_TOKEN = true

--- a/library/food-and-dining/dominos/agentcookie.toml
+++ b/library/food-and-dining/dominos/agentcookie.toml
@@ -13,6 +13,6 @@ path = "~/.config/dominos-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DOMINOS_PASSWORD = true
-DOMINOS_TOKEN = true
-DOMINOS_USERNAME = true
+"DOMINOS_PASSWORD" = true
+"DOMINOS_TOKEN" = true
+"DOMINOS_USERNAME" = true

--- a/library/food-and-dining/dominos/agentcookie.toml
+++ b/library/food-and-dining/dominos/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "dominos-pp-cli"
+display_name = "Domino's"
+description = "Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool offers."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/dominos-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DOMINOS_PASSWORD = true
+DOMINOS_TOKEN = true
+DOMINOS_USERNAME = true

--- a/library/food-and-dining/recipe-goat/agentcookie.toml
+++ b/library/food-and-dining/recipe-goat/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/recipe-goat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-USDA_FDC_API_KEY = true
+"USDA_FDC_API_KEY" = true

--- a/library/food-and-dining/recipe-goat/agentcookie.toml
+++ b/library/food-and-dining/recipe-goat/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "recipe-goat-pp-cli"
+display_name = "Recipe GOAT"
+description = "Search trusted recipe sites, rank results, save a local cookbook, and enrich nutrition data with USDA FoodData Central."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/recipe-goat-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+USDA_FDC_API_KEY = true

--- a/library/marketing/ahrefs/agentcookie.toml
+++ b/library/marketing/ahrefs/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/ahrefs-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-AHREFS_API_KEY = true
+"AHREFS_API_KEY" = true

--- a/library/marketing/ahrefs/agentcookie.toml
+++ b/library/marketing/ahrefs/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "ahrefs-pp-cli"
+display_name = "Ahrefs"
+description = "Query Ahrefs backlinks, keyword, rank tracking, site audit, and SERP data from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/ahrefs-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+AHREFS_API_KEY = true

--- a/library/marketing/beehiiv/agentcookie.toml
+++ b/library/marketing/beehiiv/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/beehiiv-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-BEEHIIV_BEARER_AUTH = true
+"BEEHIIV_BEARER_AUTH" = true

--- a/library/marketing/beehiiv/agentcookie.toml
+++ b/library/marketing/beehiiv/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "beehiiv-pp-cli"
+display_name = "beehiiv"
+description = "Manage beehiiv publications, subscribers, segments, posts, automations, and newsletter analytics from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/beehiiv-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+BEEHIIV_BEARER_AUTH = true

--- a/library/marketing/bento/agentcookie.toml
+++ b/library/marketing/bento/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "bento-pp-cli"
+display_name = "Bento"
+description = "Every Bento feature, plus the ones their own CLI does not have, plus a local SQLite store that turns 'who are my top spenders by tag' into a one-liner."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/bento-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"BENTO_PUBLISHABLE_KEY" = true
+"BENTO_SECRET_KEY" = true
+"BENTO_SITE_UUID" = true

--- a/library/marketing/botsee/agentcookie.toml
+++ b/library/marketing/botsee/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/botsee-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-BOTSEE_API_KEY = true
+"BOTSEE_API_KEY" = true

--- a/library/marketing/botsee/agentcookie.toml
+++ b/library/marketing/botsee/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "botsee-pp-cli"
+display_name = "Botsee"
+description = "Have your agents measure and improve your brand's AI Visibility with botsee.io. Run audits across every major LLM, see what's missing, then get specific recommendations and ready-to-publish content to close the gap. API-first, agent-native"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/botsee-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+BOTSEE_API_KEY = true

--- a/library/marketing/customer-io/agentcookie.toml
+++ b/library/marketing/customer-io/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/customer-io-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-CUSTOMERIO_TOKEN = true
+"CUSTOMERIO_TOKEN" = true

--- a/library/marketing/customer-io/agentcookie.toml
+++ b/library/marketing/customer-io/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "customer-io-pp-cli"
+display_name = "Customer.io"
+description = "Manage Customer.io campaigns, broadcasts, segments, deliveries, exports, and Reverse-ETL via the Service Account token."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/customer-io-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+CUSTOMERIO_TOKEN = true

--- a/library/marketing/dub/agentcookie.toml
+++ b/library/marketing/dub/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/dub-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DUB_TOKEN = true
+"DUB_TOKEN" = true

--- a/library/marketing/dub/agentcookie.toml
+++ b/library/marketing/dub/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "dub-pp-cli"
+display_name = "Dub"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/dub-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DUB_TOKEN = true

--- a/library/marketing/emailoctopus/agentcookie.toml
+++ b/library/marketing/emailoctopus/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/emailoctopus-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-EMAILOCTOPUS_API_KEY = true
+"EMAILOCTOPUS_API_KEY" = true

--- a/library/marketing/emailoctopus/agentcookie.toml
+++ b/library/marketing/emailoctopus/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "emailoctopus-pp-cli"
+display_name = "EmailOctopus"
+description = "Manage EmailOctopus lists, contacts, campaigns, automations, reports, and cross-list cleanup workflows from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/emailoctopus-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+EMAILOCTOPUS_API_KEY = true

--- a/library/marketing/erank/agentcookie.toml
+++ b/library/marketing/erank/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "erank-pp-cli"
+display_name = "eRank"
+description = "Keyword Tool data from eRank, plus local scoring, drift, and listing-gap analysis for Etsy sellers."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/erank-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"ERANK_XSRF_TOKEN" = true

--- a/library/marketing/everbee/agentcookie.toml
+++ b/library/marketing/everbee/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/everbee-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-EVERBEE_ACCESS_TOKEN = true
+"EVERBEE_ACCESS_TOKEN" = true

--- a/library/marketing/google-ads/agentcookie.toml
+++ b/library/marketing/google-ads/agentcookie.toml
@@ -13,6 +13,6 @@ path = "~/.config/google-ads-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GOOGLE_ADS_ACCESS_TOKEN = true
-GOOGLE_ADS_DEVELOPER_TOKEN = true
-GOOGLE_ADS_LOGIN_CUSTOMER_ID = true
+"GOOGLE_ADS_ACCESS_TOKEN" = true
+"GOOGLE_ADS_DEVELOPER_TOKEN" = true
+"GOOGLE_ADS_LOGIN_CUSTOMER_ID" = true

--- a/library/marketing/google-ads/agentcookie.toml
+++ b/library/marketing/google-ads/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "google-ads-pp-cli"
+display_name = "Google Ads"
+description = "Query and manage Google Ads accounts from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/google-ads-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GOOGLE_ADS_ACCESS_TOKEN = true
+GOOGLE_ADS_DEVELOPER_TOKEN = true
+GOOGLE_ADS_LOGIN_CUSTOMER_ID = true

--- a/library/marketing/google-search-console/agentcookie.toml
+++ b/library/marketing/google-search-console/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/google-search-console-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GSC_ACCESS_TOKEN = true
+"GSC_ACCESS_TOKEN" = true

--- a/library/marketing/google-search-console/agentcookie.toml
+++ b/library/marketing/google-search-console/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "google-search-console-pp-cli"
+display_name = "Google Search Console"
+description = "Every Google Search Console feature you'd reach for, plus an offline SQLite cache that powers quick-wins, cannibalization, period compare, and historical queries beyond the 16-month API window."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/google-search-console-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GSC_ACCESS_TOKEN = true

--- a/library/marketing/kit/agentcookie.toml
+++ b/library/marketing/kit/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/kit-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-KIT_API_KEY = true
+"KIT_API_KEY" = true

--- a/library/marketing/kit/agentcookie.toml
+++ b/library/marketing/kit/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "kit-pp-cli"
+display_name = "Kit"
+description = "Manage Kit subscribers, tags, forms, sequences, broadcasts, purchases, and email marketing automation data from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/kit-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+KIT_API_KEY = true

--- a/library/marketing/klaviyo/agentcookie.toml
+++ b/library/marketing/klaviyo/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/klaviyo-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-KLAVIYO_API_KEY = true
+"KLAVIYO_API_KEY" = true

--- a/library/marketing/klaviyo/agentcookie.toml
+++ b/library/marketing/klaviyo/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "klaviyo-pp-cli"
+display_name = "Klaviyo"
+description = "Marketing automation, profiles, events, campaigns, flows, segments, and templates."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/klaviyo-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+KLAVIYO_API_KEY = true

--- a/library/marketing/mailchimp/agentcookie.toml
+++ b/library/marketing/mailchimp/agentcookie.toml
@@ -12,5 +12,5 @@ path = "~/.config/mailchimp-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-MAILCHIMP_PASSWORD = true
-MAILCHIMP_USERNAME = true
+"MAILCHIMP_PASSWORD" = true
+"MAILCHIMP_USERNAME" = true

--- a/library/marketing/mailchimp/agentcookie.toml
+++ b/library/marketing/mailchimp/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "mailchimp-pp-cli"
+display_name = "Mailchimp Marketing"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/mailchimp-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+MAILCHIMP_PASSWORD = true
+MAILCHIMP_USERNAME = true

--- a/library/marketing/meta-ads/agentcookie.toml
+++ b/library/marketing/meta-ads/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/meta-ads-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-META_ACCESS_TOKEN = true
+"META_ACCESS_TOKEN" = true

--- a/library/marketing/producthunt/agentcookie.toml
+++ b/library/marketing/producthunt/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/producthunt-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-PRODUCT_HUNT_TOKEN = true
+"PRODUCT_HUNT_TOKEN" = true

--- a/library/marketing/producthunt/agentcookie.toml
+++ b/library/marketing/producthunt/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "producthunt-pp-cli"
+display_name = "Producthunt"
+description = "Find, monitor, and export Product Hunt launches for launch research, scouting, and competitive tracking without requiring a Product Hunt API application."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/producthunt-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+PRODUCT_HUNT_TOKEN = true

--- a/library/marketing/semrush/agentcookie.toml
+++ b/library/marketing/semrush/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "semrush-pp-cli"
+display_name = "Semrush"
+description = "Every Semrush Analytics + Projects feature, plus a local SQLite store and cross-domain joins no other Semrush tool has."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/semrush-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"SEMRUSH_API_KEY" = true

--- a/library/marketing/stackadapt/agentcookie.toml
+++ b/library/marketing/stackadapt/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/stackadapt-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-STACKADAPT_API_TOKEN = true
+"STACKADAPT_API_TOKEN" = true

--- a/library/media-and-entertainment/art-goat/agentcookie.toml
+++ b/library/media-and-entertainment/art-goat/agentcookie.toml
@@ -1,16 +1,16 @@
 # agentcookie.toml: secrets-bus adoption manifest v2
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
-name = "wavespeed-pp-cli"
-display_name = "WaveSpeed"
-description = "Docs-derived OpenAPI spec for WaveSpeed AI's REST API."
+name = "art-goat-pp-cli"
+display_name = "Art Goat"
 project_kind = "cli"
 
 [secrets.file]
-path = "~/.config/wavespeed-pp-cli/config.toml"
+path = "~/.config/art-goat-pp-cli/config.toml"
 
 [sync]
 default = false
 
 [sync.keys]
-"WAVESPEED_API_KEY" = true
+"ART_GOAT_API_KEY" = true
+"NASA_API_KEY" = true

--- a/library/media-and-entertainment/dice-fm/agentcookie.toml
+++ b/library/media-and-entertainment/dice-fm/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "dice-fm-pp-cli"
+display_name = "DICE"
+description = "Every ticket, fan, and pound of revenue from your DICE events — queryable, exportable, and joinable across shows."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/dice-fm-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"DICE_FM_TOKEN" = true

--- a/library/media-and-entertainment/eventbrite/agentcookie.toml
+++ b/library/media-and-entertainment/eventbrite/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "eventbrite-pp-cli"
+display_name = "Eventbrite"
+description = "Every Eventbrite organizer endpoint, plus a local SQLite mirror of your events, orders, and attendees you can search offline — the cross-event search Eventbrite removed, restored over your own data."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/eventbrite-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"EVENTBRITE_API_KEY" = true

--- a/library/media-and-entertainment/goodreads/agentcookie.toml
+++ b/library/media-and-entertainment/goodreads/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "goodreads-pp-cli"
+display_name = "Goodreads"
+description = "Agent-native CLI + MCP for Goodreads, read and write. Rate books via the modern AppSync GraphQL API (RateBook/UnrateBook), write reviews with spoiler + feed-publicize via the legacy form, add to and create shelves, browse the home updates feed, friends, recommendations, genre/topic search, book pages, and Goodreads Giveaways. Goodreads has no public developer API; routes are reverse-engineered from the logged-in web app and live-verified."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/goodreads-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"GOODREADS_GOODREADS_COOKIE_SESSION" = true

--- a/library/media-and-entertainment/google-photos/agentcookie.toml
+++ b/library/media-and-entertainment/google-photos/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/google-photos-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GOOGLE_PHOTOS_TOKEN = true
+"GOOGLE_PHOTOS_TOKEN" = true

--- a/library/media-and-entertainment/google-photos/agentcookie.toml
+++ b/library/media-and-entertainment/google-photos/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "google-photos-pp-cli"
+display_name = "Google Photos"
+description = "Manage Google Photos app-created albums and media, upload files, and work with Picker sessions from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/google-photos-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GOOGLE_PHOTOS_TOKEN = true

--- a/library/media-and-entertainment/movie-goat/agentcookie.toml
+++ b/library/media-and-entertainment/movie-goat/agentcookie.toml
@@ -12,5 +12,5 @@ path = "~/.config/movie-goat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OMDB_API_KEY = true
-TMDB_API_KEY = true
+"OMDB_API_KEY" = true
+"TMDB_API_KEY" = true

--- a/library/media-and-entertainment/movie-goat/agentcookie.toml
+++ b/library/media-and-entertainment/movie-goat/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "movie-goat-pp-cli"
+display_name = "Movie Goat"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/movie-goat-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+OMDB_API_KEY = true
+TMDB_API_KEY = true

--- a/library/media-and-entertainment/podcast-goat/agentcookie.toml
+++ b/library/media-and-entertainment/podcast-goat/agentcookie.toml
@@ -12,9 +12,9 @@ path = "~/.config/podcast-goat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DEEPGRAM_API_KEY = true
-ELEVENLABS_API_KEY = true
-OPENAI_API_KEY = true
-SPOKEN_API_KEY = true
-TADDY_API_KEY = true
-TADDY_USER_ID = true
+"DEEPGRAM_API_KEY" = true
+"ELEVENLABS_API_KEY" = true
+"OPENAI_API_KEY" = true
+"SPOKEN_API_KEY" = true
+"TADDY_API_KEY" = true
+"TADDY_USER_ID" = true

--- a/library/media-and-entertainment/podcast-goat/agentcookie.toml
+++ b/library/media-and-entertainment/podcast-goat/agentcookie.toml
@@ -1,0 +1,20 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "podcast-goat-pp-cli"
+display_name = "Podcast GOAT"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/podcast-goat-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DEEPGRAM_API_KEY = true
+ELEVENLABS_API_KEY = true
+OPENAI_API_KEY = true
+SPOKEN_API_KEY = true
+TADDY_API_KEY = true
+TADDY_USER_ID = true

--- a/library/media-and-entertainment/podscan/agentcookie.toml
+++ b/library/media-and-entertainment/podscan/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/podscan-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-PODSCAN_BEARER_AUTH = true
+"PODSCAN_BEARER_AUTH" = true

--- a/library/media-and-entertainment/podscan/agentcookie.toml
+++ b/library/media-and-entertainment/podscan/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "podscan-pp-cli"
+display_name = "Podscan"
+description = "Search every public podcast conversation. Wraps the Podscan REST/Firehose/Exports APIs with mention monitoring, guest history, topic trend charts, idea sourcing, and sponsor intel — across 51M+ episodes, 4.4M+ podcasts."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/podscan-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+PODSCAN_BEARER_AUTH = true

--- a/library/media-and-entertainment/setlist-fm/agentcookie.toml
+++ b/library/media-and-entertainment/setlist-fm/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/setlist-fm-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SETLIST_FM_API_KEY = true
+"SETLIST_FM_API_KEY" = true

--- a/library/media-and-entertainment/setlist-fm/agentcookie.toml
+++ b/library/media-and-entertainment/setlist-fm/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "setlist-fm-pp-cli"
+display_name = "setlist.fm"
+description = "Search setlist.fm artists, setlists, venues, cities, and concert histories through the setlist.fm API."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/setlist-fm-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SETLIST_FM_API_KEY = true

--- a/library/media-and-entertainment/spotify/agentcookie.toml
+++ b/library/media-and-entertainment/spotify/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/spotify-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SPOTIFY_OAUTH_2_0 = true
+"SPOTIFY_OAUTH_2_0" = true

--- a/library/media-and-entertainment/steam-web/agentcookie.toml
+++ b/library/media-and-entertainment/steam-web/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/steam-web-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-STEAM_WEB_API_KEY = true
+"STEAM_WEB_API_KEY" = true

--- a/library/media-and-entertainment/steam-web/agentcookie.toml
+++ b/library/media-and-entertainment/steam-web/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "steam-web-pp-cli"
+display_name = "Steam Web"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/steam-web-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+STEAM_WEB_API_KEY = true

--- a/library/media-and-entertainment/suno/agentcookie.toml
+++ b/library/media-and-entertainment/suno/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/suno-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SUNO_TOKEN = true
+"SUNO_TOKEN" = true

--- a/library/media-and-entertainment/suno/agentcookie.toml
+++ b/library/media-and-entertainment/suno/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "suno-pp-cli"
+display_name = "Suno"
+description = "Every Suno feature, plus a local SQLite library, offline FTS5 search, MCP-native agent surface, and a single-binary Go install."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/suno-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SUNO_TOKEN = true

--- a/library/media-and-entertainment/suno/agentcookie.toml
+++ b/library/media-and-entertainment/suno/agentcookie.toml
@@ -3,7 +3,7 @@
 schema_version = 2
 name = "suno-pp-cli"
 display_name = "Suno"
-description = "Every Suno feature, plus a local SQLite library, offline FTS5 search, MCP-native agent surface, and a single-binary Go install."
+description = "The correct, offline-first Suno CLI — every feature the abandoned clients have, plus a local SQLite library, full-text search, and agent-native output none of them ship."
 project_kind = "cli"
 
 [secrets.file]
@@ -13,4 +13,5 @@ path = "~/.config/suno-pp-cli/config.toml"
 default = false
 
 [sync.keys]
+"SUNO_JWT" = true
 "SUNO_TOKEN" = true

--- a/library/media-and-entertainment/tella/agentcookie.toml
+++ b/library/media-and-entertainment/tella/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/tella-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TELLA_API_KEY = true
+"TELLA_API_KEY" = true

--- a/library/media-and-entertainment/tella/agentcookie.toml
+++ b/library/media-and-entertainment/tella/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "tella-pp-cli"
+display_name = "Tella Public"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/tella-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TELLA_API_KEY = true

--- a/library/media-and-entertainment/ticketmaster/agentcookie.toml
+++ b/library/media-and-entertainment/ticketmaster/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/ticketmaster-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TICKETMASTER_API_KEY = true
+"TICKETMASTER_API_KEY" = true

--- a/library/media-and-entertainment/youtube/agentcookie.toml
+++ b/library/media-and-entertainment/youtube/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/youtube-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-YOUTUBE_API_KEY = true
+"YOUTUBE_API_KEY" = true

--- a/library/media-and-entertainment/youtube/agentcookie.toml
+++ b/library/media-and-entertainment/youtube/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "youtube-pp-cli"
+display_name = "Youtube Data"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/youtube-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+YOUTUBE_API_KEY = true

--- a/library/monitoring/adguard-home/agentcookie.toml
+++ b/library/monitoring/adguard-home/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "adguard-home-pp-cli"
+display_name = "AdGuard Home"
+description = "DNS-level ad/tracker/malware blocking via AdGuard Home REST API for self-hosted network DNS management"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/adguard-home-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"ADGUARD_HOME_PASSWORD" = true
+"ADGUARD_HOME_USERNAME" = true

--- a/library/monitoring/sentry/agentcookie.toml
+++ b/library/monitoring/sentry/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/sentry-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SENTRY_AUTH_TOKEN = true
+"SENTRY_AUTH_TOKEN" = true

--- a/library/monitoring/sentry/agentcookie.toml
+++ b/library/monitoring/sentry/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "sentry-pp-cli"
+display_name = "Sentry"
+description = "Error tracking and performance monitoring - projects, issues, events, releases"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/sentry-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SENTRY_AUTH_TOKEN = true

--- a/library/other/gravitus/agentcookie.toml
+++ b/library/other/gravitus/agentcookie.toml
@@ -1,16 +1,15 @@
 # agentcookie.toml: secrets-bus adoption manifest v2
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
-name = "wavespeed-pp-cli"
-display_name = "WaveSpeed"
-description = "Docs-derived OpenAPI spec for WaveSpeed AI's REST API."
+name = "gravitus-pp-cli"
+display_name = "Gravitus"
 project_kind = "cli"
 
 [secrets.file]
-path = "~/.config/wavespeed-pp-cli/config.toml"
+path = "~/.config/gravitus-pp-cli/config.toml"
 
 [sync]
 default = false
 
 [sync.keys]
-"WAVESPEED_API_KEY" = true
+"GRAVITUS_SESSION_ID" = true

--- a/library/other/greatclips/agentcookie.toml
+++ b/library/other/greatclips/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/greatclips-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GREATCLIPS_TOKEN = true
+"GREATCLIPS_TOKEN" = true

--- a/library/other/greatclips/agentcookie.toml
+++ b/library/other/greatclips/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "greatclips-pp-cli"
+display_name = "Great Clips"
+description = "Check Great Clips salon wait times, prepare Online Check-In requests, inspect route shapes, and track local wait history."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/greatclips-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GREATCLIPS_TOKEN = true

--- a/library/other/numista/agentcookie.toml
+++ b/library/other/numista/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/numista-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-NUMISTA_API_KEY = true
+"NUMISTA_API_KEY" = true

--- a/library/other/numista/agentcookie.toml
+++ b/library/other/numista/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "numista-pp-cli"
+display_name = "Numista Documentation"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/numista-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+NUMISTA_API_KEY = true

--- a/library/other/openalex/agentcookie.toml
+++ b/library/other/openalex/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/openalex-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OPENALEX_API_KEY = true
+"OPENALEX_API_KEY" = true

--- a/library/other/openalex/agentcookie.toml
+++ b/library/other/openalex/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "openalex-pp-cli"
+display_name = "OpenAlex"
+description = "Free scholarly graph API for works, authors, sources, institutions, topics, funders, and citation-aware research intelligence."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/openalex-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+OPENALEX_API_KEY = true

--- a/library/other/pcgs/agentcookie.toml
+++ b/library/other/pcgs/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/pcgs-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-PCGS_AUTH_TOKEN = true
+"PCGS_AUTH_TOKEN" = true

--- a/library/other/pcgs/agentcookie.toml
+++ b/library/other/pcgs/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "pcgs-pp-cli"
+display_name = "Pcgs"
+description = "PCGS Public API CLI — verify PCGS-graded coin certs, extract full CoinFacts metadata, and stay under the 1,000-call-per-day budget."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/pcgs-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+PCGS_AUTH_TOKEN = true

--- a/library/payments/exchangerate-api/agentcookie.toml
+++ b/library/payments/exchangerate-api/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/exchangerate-api-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-EXCHANGERATE_API_KEY = true
+"EXCHANGERATE_API_KEY" = true

--- a/library/payments/exchangerate-api/agentcookie.toml
+++ b/library/payments/exchangerate-api/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "exchangerate-api-pp-cli"
+display_name = "Exchangerate Api"
+description = "Every ExchangeRate-API endpoint, plus a local rate history, watchlists, drift alerts, and an MCP server."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/exchangerate-api-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+EXCHANGERATE_API_KEY = true

--- a/library/payments/kalshi/agentcookie.toml
+++ b/library/payments/kalshi/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/kalshi-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY = true
+"KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY" = true

--- a/library/payments/kalshi/agentcookie.toml
+++ b/library/payments/kalshi/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "kalshi-pp-cli"
+display_name = "Kalshi Trade Manual"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/kalshi-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+KALSHI_TRADE_MANUAL_KALSHI_ACCESS_KEY = true

--- a/library/payments/lemonsqueezy/agentcookie.toml
+++ b/library/payments/lemonsqueezy/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/lemonsqueezy-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-LEMONSQUEEZY_API_KEY = true
+"LEMONSQUEEZY_API_KEY" = true

--- a/library/payments/lunch-money/agentcookie.toml
+++ b/library/payments/lunch-money/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/lunch-money-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-LUNCHMONEY_API_KEY = true
+"LUNCHMONEY_API_KEY" = true

--- a/library/payments/lunch-money/agentcookie.toml
+++ b/library/payments/lunch-money/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "lunch-money-pp-cli"
+display_name = "Lunch Money"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/lunch-money-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+LUNCHMONEY_API_KEY = true

--- a/library/payments/mercury/agentcookie.toml
+++ b/library/payments/mercury/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/mercury-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-MERCURY_BEARER_AUTH = true
+"MERCURY_BEARER_AUTH" = true

--- a/library/payments/mercury/agentcookie.toml
+++ b/library/payments/mercury/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "mercury-pp-cli"
+display_name = "Mercury"
+description = "Business banking API for accounts, transactions, payments, recipients, cards, invoices, treasury, and webhooks"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/mercury-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+MERCURY_BEARER_AUTH = true

--- a/library/payments/monarch-money/agentcookie.toml
+++ b/library/payments/monarch-money/agentcookie.toml
@@ -13,6 +13,6 @@ path = "~/.config/monarch-money-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-MONARCH_EMAIL = true
-MONARCH_PASSWORD = true
-MONARCH_TOKEN = true
+"MONARCH_EMAIL" = true
+"MONARCH_PASSWORD" = true
+"MONARCH_TOKEN" = true

--- a/library/payments/monarch-money/agentcookie.toml
+++ b/library/payments/monarch-money/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "monarch-money-pp-cli"
+display_name = "Monarch Money"
+description = "Use Monarch Money account balances, tags, transactions, cashflow summaries, and explicit transaction CRUD workflows from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/monarch-money-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+MONARCH_EMAIL = true
+MONARCH_PASSWORD = true
+MONARCH_TOKEN = true

--- a/library/payments/pop/agentcookie.toml
+++ b/library/payments/pop/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/pop-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-POP_API_KEY = true
+"POP_API_KEY" = true

--- a/library/payments/pop/agentcookie.toml
+++ b/library/payments/pop/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "pop-pp-cli"
+display_name = "POP"
+description = "European electronic invoicing API for compliant XML, PEPPOL, PDF, validation, status tracking, and archival workflows."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/pop-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+POP_API_KEY = true

--- a/library/payments/revenuecat/agentcookie.toml
+++ b/library/payments/revenuecat/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/revenuecat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DEVELOPER_BEARER_AUTH = true
-REVENUECAT_API_KEY = true
+"DEVELOPER_BEARER_AUTH" = true
+"REVENUECAT_API_KEY" = true

--- a/library/payments/robinhood/agentcookie.toml
+++ b/library/payments/robinhood/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "robinhood-pp-cli"
+display_name = "Robinhood"
+description = "Agent-native CLI + MCP for the whole of Robinhood: brokerage accounts (individual + retirement), positions, options and option chains, portfolio performance (YTD/1w/1m/1y/5y/all), transfers, dividends, orders, and watchlists across api.robinhood.com and the bonfire gateway — plus the official Robinhood Crypto Trading API as the documented subset. Reads are live; writes default to dry-run behind a ROBINHOOD_PP_ALLOW_WRITES gate."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/robinhood-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"ROBINHOOD_API_KEY" = true
+"ROBINHOOD_PRIVATE_KEY_B64" = true

--- a/library/payments/splitwise/agentcookie.toml
+++ b/library/payments/splitwise/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/splitwise-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SPLITWISE_API_KEY = true
+"SPLITWISE_API_KEY" = true

--- a/library/payments/stripe/agentcookie.toml
+++ b/library/payments/stripe/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/stripe-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-STRIPE_SECRET_KEY = true
+"STRIPE_SECRET_KEY" = true

--- a/library/payments/stripe/agentcookie.toml
+++ b/library/payments/stripe/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "stripe-pp-cli"
+display_name = "Stripe"
+description = "Payment processing and financial infrastructure API"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/stripe-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+STRIPE_SECRET_KEY = true

--- a/library/productivity/breezedoc/agentcookie.toml
+++ b/library/productivity/breezedoc/agentcookie.toml
@@ -13,6 +13,6 @@ path = "~/.config/breezedoc-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-BREEZEDOC_API_TOKEN = true
-BREEZEDOC_BEARER_AUTH = true
-BREEZEDOC_BEARER_TOKEN = true
+"BREEZEDOC_API_TOKEN" = true
+"BREEZEDOC_BEARER_AUTH" = true
+"BREEZEDOC_BEARER_TOKEN" = true

--- a/library/productivity/cal-com/agentcookie.toml
+++ b/library/productivity/cal-com/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/cal-com-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-CAL_COM_TOKEN = true
+"CAL_COM_TOKEN" = true

--- a/library/productivity/cal-com/agentcookie.toml
+++ b/library/productivity/cal-com/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "cal-com-pp-cli"
+display_name = "Cal.com"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/cal-com-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+CAL_COM_TOKEN = true

--- a/library/productivity/clockify/agentcookie.toml
+++ b/library/productivity/clockify/agentcookie.toml
@@ -1,16 +1,15 @@
 # agentcookie.toml: secrets-bus adoption manifest v2
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
-name = "wavespeed-pp-cli"
-display_name = "WaveSpeed"
-description = "Docs-derived OpenAPI spec for WaveSpeed AI's REST API."
+name = "clockify-pp-cli"
+display_name = "Clockify"
 project_kind = "cli"
 
 [secrets.file]
-path = "~/.config/wavespeed-pp-cli/config.toml"
+path = "~/.config/clockify-pp-cli/config.toml"
 
 [sync]
 default = false
 
 [sync.keys]
-"WAVESPEED_API_KEY" = true
+"CLOCKIFY_API_KEY" = true

--- a/library/productivity/etherpad/agentcookie.toml
+++ b/library/productivity/etherpad/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/etherpad-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ETHERPAD_OPENID = true
+"ETHERPAD_OPENID" = true

--- a/library/productivity/etherpad/agentcookie.toml
+++ b/library/productivity/etherpad/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "etherpad-pp-cli"
+display_name = "Etherpad"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/etherpad-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ETHERPAD_OPENID = true

--- a/library/productivity/fathom/agentcookie.toml
+++ b/library/productivity/fathom/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/fathom-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FATHOM_PP_CLI_API_KEY = true
+"FATHOM_PP_CLI_API_KEY" = true

--- a/library/productivity/fathom/agentcookie.toml
+++ b/library/productivity/fathom/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "fathom-pp-cli"
+display_name = "Fathom"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/fathom-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FATHOM_PP_CLI_API_KEY = true

--- a/library/productivity/figma/agentcookie.toml
+++ b/library/productivity/figma/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/figma-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FIGMA_OAUTH2 = true
+"FIGMA_OAUTH2" = true

--- a/library/productivity/figma/agentcookie.toml
+++ b/library/productivity/figma/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "figma-pp-cli"
+display_name = "Figma"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/figma-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FIGMA_OAUTH2 = true

--- a/library/productivity/fireflies/agentcookie.toml
+++ b/library/productivity/fireflies/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/fireflies-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FIREFLIES_PP_CLI_API_KEY = true
+"FIREFLIES_PP_CLI_API_KEY" = true

--- a/library/productivity/fireflies/agentcookie.toml
+++ b/library/productivity/fireflies/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "fireflies-pp-cli"
+display_name = "Fireflies Pp Cli"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/fireflies-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FIREFLIES_PP_CLI_API_KEY = true

--- a/library/productivity/freshservice/agentcookie.toml
+++ b/library/productivity/freshservice/agentcookie.toml
@@ -12,5 +12,5 @@ path = "~/.config/freshservice-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FRESHSERVICE_APIKEY = true
-FRESHSERVICE_DOMAIN = true
+"FRESHSERVICE_APIKEY" = true
+"FRESHSERVICE_DOMAIN" = true

--- a/library/productivity/freshservice/agentcookie.toml
+++ b/library/productivity/freshservice/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "freshservice-pp-cli"
+display_name = "Freshservice"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/freshservice-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+FRESHSERVICE_APIKEY = true
+FRESHSERVICE_DOMAIN = true

--- a/library/productivity/granola/agentcookie.toml
+++ b/library/productivity/granola/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/granola-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GRANOLA_API_KEY = true
+"GRANOLA_API_KEY" = true

--- a/library/productivity/granola/agentcookie.toml
+++ b/library/productivity/granola/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "granola-pp-cli"
+display_name = "Granola"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/granola-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GRANOLA_API_KEY = true

--- a/library/productivity/notion/agentcookie.toml
+++ b/library/productivity/notion/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/notion-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-NOTION_BEARER_AUTH = true
+"NOTION_BEARER_AUTH" = true

--- a/library/productivity/notion/agentcookie.toml
+++ b/library/productivity/notion/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "notion-pp-cli"
+display_name = "Notion"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/notion-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+NOTION_BEARER_AUTH = true

--- a/library/productivity/nylas/agentcookie.toml
+++ b/library/productivity/nylas/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/nylas-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-NYLAS_API_KEY = true
+"NYLAS_API_KEY" = true

--- a/library/productivity/nylas/agentcookie.toml
+++ b/library/productivity/nylas/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "nylas-pp-cli"
+display_name = "Nylas"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/nylas-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+NYLAS_API_KEY = true

--- a/library/productivity/opensnow/agentcookie.toml
+++ b/library/productivity/opensnow/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/opensnow-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OPENSNOW_API_KEY = true
+"OPENSNOW_API_KEY" = true

--- a/library/productivity/opensnow/agentcookie.toml
+++ b/library/productivity/opensnow/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "opensnow-pp-cli"
+display_name = "OpenSnow"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/opensnow-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+OPENSNOW_API_KEY = true

--- a/library/productivity/outlook-calendar/agentcookie.toml
+++ b/library/productivity/outlook-calendar/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/outlook-calendar-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OUTLOOK_CALENDAR_TOKEN = true
+"OUTLOOK_CALENDAR_TOKEN" = true

--- a/library/productivity/outlook-calendar/agentcookie.toml
+++ b/library/productivity/outlook-calendar/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "outlook-calendar-pp-cli"
+display_name = "Outlook Calendar"
+description = "Drive your personal Microsoft 365 calendar from agentic workflows: read, write, sync, and run offline analytics like conflicts, freetime, and recurring-drift that no Graph endpoint exposes."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/outlook-calendar-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+OUTLOOK_CALENDAR_TOKEN = true

--- a/library/productivity/outlook-email/agentcookie.toml
+++ b/library/productivity/outlook-email/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/outlook-email-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-OUTLOOK_EMAIL_TOKEN = true
+"OUTLOOK_EMAIL_TOKEN" = true

--- a/library/productivity/outlook-email/agentcookie.toml
+++ b/library/productivity/outlook-email/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "outlook-email-pp-cli"
+display_name = "Outlook Email"
+description = "Drive your personal Microsoft 365 inbox from agentic workflows: read, send, sync, and run offline triage analytics like followup, senders, waiting, and digest that no Graph endpoint exposes."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/outlook-email-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+OUTLOOK_EMAIL_TOKEN = true

--- a/library/productivity/resend/agentcookie.toml
+++ b/library/productivity/resend/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/resend-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-RESEND_API_KEY = true
+"RESEND_API_KEY" = true

--- a/library/productivity/resend/agentcookie.toml
+++ b/library/productivity/resend/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "resend-pp-cli"
+display_name = "Resend"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/resend-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+RESEND_API_KEY = true

--- a/library/productivity/roam/agentcookie.toml
+++ b/library/productivity/roam/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/roam-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ROAM_API_KEY = true
+"ROAM_API_KEY" = true

--- a/library/productivity/roam/agentcookie.toml
+++ b/library/productivity/roam/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "roam-pp-cli"
+display_name = "Roam HQ"
+description = "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/roam-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ROAM_API_KEY = true

--- a/library/productivity/sendgrid/agentcookie.toml
+++ b/library/productivity/sendgrid/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/sendgrid-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SENDGRID_API_KEY = true
+"SENDGRID_API_KEY" = true

--- a/library/productivity/sendgrid/agentcookie.toml
+++ b/library/productivity/sendgrid/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "sendgrid-pp-cli"
+display_name = "Twilio Sendgrid"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/sendgrid-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SENDGRID_API_KEY = true

--- a/library/productivity/strava/agentcookie.toml
+++ b/library/productivity/strava/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/strava-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-STRAVA_STRAVA_OAUTH = true
+"STRAVA_STRAVA_OAUTH" = true

--- a/library/productivity/strava/agentcookie.toml
+++ b/library/productivity/strava/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "strava-pp-cli"
+display_name = "Strava"
+description = "Every Strava feature, plus offline analytics — training load, power curves, zone time, and segment progression — that the website can't show you."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/strava-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+STRAVA_STRAVA_OAUTH = true

--- a/library/productivity/superhuman/agentcookie.toml
+++ b/library/productivity/superhuman/agentcookie.toml
@@ -1,16 +1,15 @@
 # agentcookie.toml: secrets-bus adoption manifest v2
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
-name = "wavespeed-pp-cli"
-display_name = "WaveSpeed"
-description = "Docs-derived OpenAPI spec for WaveSpeed AI's REST API."
+name = "superhuman-pp-cli"
+display_name = "Superhuman"
 project_kind = "cli"
 
 [secrets.file]
-path = "~/.config/wavespeed-pp-cli/config.toml"
+path = "~/.config/superhuman-pp-cli/config.toml"
 
 [sync]
 default = false
 
 [sync.keys]
-"WAVESPEED_API_KEY" = true
+"SUPERHUMAN_JWT" = true

--- a/library/productivity/tidycal/agentcookie.toml
+++ b/library/productivity/tidycal/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/tidycal-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TIDYCAL_API_TOKEN = true
-TIDYCAL_BEARER_AUTH = true
+"TIDYCAL_API_TOKEN" = true
+"TIDYCAL_BEARER_AUTH" = true

--- a/library/productivity/zoho-expense/agentcookie.toml
+++ b/library/productivity/zoho-expense/agentcookie.toml
@@ -1,0 +1,19 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "zoho-expense-pp-cli"
+display_name = "Zoho Expense"
+description = "Upload receipts, tag expenses, and bundle monthly reports on Zoho Expense from the terminal"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/zoho-expense-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"ZOHO_EXPENSE_CLIENT_ID" = true
+"ZOHO_EXPENSE_CLIENT_SECRET" = true
+"ZOHO_EXPENSE_ORGANIZATION_ID" = true
+"ZOHO_EXPENSE_REFRESH_TOKEN" = true

--- a/library/project-management/clickup/agentcookie.toml
+++ b/library/project-management/clickup/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/clickup-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-CLICKUP_AUTHORIZATION_TOKEN = true
+"CLICKUP_AUTHORIZATION_TOKEN" = true

--- a/library/project-management/clickup/agentcookie.toml
+++ b/library/project-management/clickup/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "clickup-pp-cli"
+display_name = "Clickup"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/clickup-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+CLICKUP_AUTHORIZATION_TOKEN = true

--- a/library/project-management/linear/agentcookie.toml
+++ b/library/project-management/linear/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/linear-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-LINEAR_API_KEY = true
+"LINEAR_API_KEY" = true

--- a/library/project-management/linear/agentcookie.toml
+++ b/library/project-management/linear/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "linear-pp-cli"
+display_name = "Linear"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/linear-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+LINEAR_API_KEY = true

--- a/library/project-management/plane/agentcookie.toml
+++ b/library/project-management/plane/agentcookie.toml
@@ -3,7 +3,7 @@
 schema_version = 2
 name = "plane-pp-cli"
 display_name = "Plane"
-description = "Open-source project management — issues, cycles, modules, sub-issues, and workspaces. A self-hostable Jira/Linear/ClickUp alternative."
+description = "Open-source project management вЂ” issues, cycles, modules, sub-issues, and workspaces. A self-hostable Jira/Linear/ClickUp alternative."
 project_kind = "cli"
 
 [secrets.file]
@@ -13,4 +13,4 @@ path = "~/.config/plane-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-PLANE_API_KEY_AUTHENTICATION = true
+"PLANE_API_KEY_AUTHENTICATION" = true

--- a/library/sales-and-crm/conduyt-crm/agentcookie.toml
+++ b/library/sales-and-crm/conduyt-crm/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/conduyt-crm-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-CONDUYT_CRM_TOKEN = true
+"CONDUYT_CRM_TOKEN" = true

--- a/library/sales-and-crm/conduyt-crm/agentcookie.toml
+++ b/library/sales-and-crm/conduyt-crm/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "conduyt-crm-pp-cli"
+display_name = "Conduyt CRM"
+description = "Manage Conduyt CRM contacts, deals, pipelines, automations, campaigns, invoices, and local insight reports from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/conduyt-crm-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+CONDUYT_CRM_TOKEN = true

--- a/library/sales-and-crm/contact-goat/agentcookie.toml
+++ b/library/sales-and-crm/contact-goat/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/contact-goat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-DEEPLINE_API_KEY = true
-HAPPENSTANCE_API_KEY = true
+"DEEPLINE_API_KEY" = true
+"HAPPENSTANCE_API_KEY" = true

--- a/library/sales-and-crm/contact-goat/agentcookie.toml
+++ b/library/sales-and-crm/contact-goat/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "contact-goat-pp-cli"
+display_name = "Contact GOAT"
+description = "Search, enrich, and map warm-introduction paths across LinkedIn, Happenstance, Deepline, and a unified local contacts store."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/contact-goat-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+DEEPLINE_API_KEY = true
+HAPPENSTANCE_API_KEY = true

--- a/library/sales-and-crm/gohighlevel/agentcookie.toml
+++ b/library/sales-and-crm/gohighlevel/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/gohighlevel-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-GHL_PIT_TOKEN = true
+"GHL_PIT_TOKEN" = true

--- a/library/sales-and-crm/gohighlevel/agentcookie.toml
+++ b/library/sales-and-crm/gohighlevel/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "gohighlevel-pp-cli"
+display_name = "GoHighLevel"
+description = "Sync GoHighLevel CRM data for contacts, opportunities, pipelines, custom fields, tags, bulk operations, and funnel reports."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/gohighlevel-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+GHL_PIT_TOKEN = true

--- a/library/sales-and-crm/gorgias/agentcookie.toml
+++ b/library/sales-and-crm/gorgias/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "gorgias-pp-cli"
+display_name = "Gorgias"
+description = "Gorgias support CLI with offline sync, local search, read-only SQL, and MCP tools for agent-native support workflows."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/gorgias-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"GORGIAS_API_KEY" = true
+"GORGIAS_BASE_URL" = true
+"GORGIAS_USERNAME" = true

--- a/library/sales-and-crm/intercom/agentcookie.toml
+++ b/library/sales-and-crm/intercom/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/intercom-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-INTERCOM_ACCESS_TOKEN = true
+"INTERCOM_ACCESS_TOKEN" = true

--- a/library/sales-and-crm/jobber/agentcookie.toml
+++ b/library/sales-and-crm/jobber/agentcookie.toml
@@ -1,0 +1,20 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "jobber-pp-cli"
+display_name = "Jobber"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/jobber-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"JOBBER_ACCESS_TOKEN" = true
+"JOBBER_CALLBACK_URL" = true
+"JOBBER_CLIENT_ID" = true
+"JOBBER_CLIENT_SECRET" = true
+"JOBBER_GRAPHQL_VERSION" = true
+"JOBBER_REFRESH_TOKEN" = true

--- a/library/sales-and-crm/servicetitan-pricebook/agentcookie.toml
+++ b/library/sales-and-crm/servicetitan-pricebook/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/servicetitan-pricebook-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-ST_CLIENT_ID = true
-ST_CLIENT_SECRET = true
+"ST_CLIENT_ID" = true
+"ST_CLIENT_SECRET" = true

--- a/library/sales-and-crm/servicetitan-pricebook/agentcookie.toml
+++ b/library/sales-and-crm/servicetitan-pricebook/agentcookie.toml
@@ -1,0 +1,17 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "servicetitan-pricebook-pp-cli"
+display_name = "ServiceTitan Pricebook"
+description = "Sync ServiceTitan Pricebook services, materials, equipment, vendors, markups, warranties, and cost-drift audits."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/servicetitan-pricebook-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+ST_CLIENT_ID = true
+ST_CLIENT_SECRET = true

--- a/library/sales-and-crm/smartlead/agentcookie.toml
+++ b/library/sales-and-crm/smartlead/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/smartlead-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SMARTLEAD_API_KEY = true
+"SMARTLEAD_API_KEY" = true

--- a/library/sales-and-crm/smartlead/agentcookie.toml
+++ b/library/sales-and-crm/smartlead/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "smartlead-pp-cli"
+display_name = "Smartlead"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/smartlead-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SMARTLEAD_API_KEY = true

--- a/library/sales-and-crm/sumble/agentcookie.toml
+++ b/library/sales-and-crm/sumble/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "sumble-pp-cli"
+display_name = "Sumble"
+description = "Every Sumble v6 feature, plus the credit-awareness the API itself won't give you: cost estimates before every billed call, a running balance, a budget guard, and a local SQLite cache so you never pay twice."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/sumble-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"SUMBLE_API_KEY" = true

--- a/library/social-and-messaging/bird/agentcookie.toml
+++ b/library/social-and-messaging/bird/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/bird-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-BIRD_API_KEY = true
+"BIRD_API_KEY" = true

--- a/library/social-and-messaging/bird/agentcookie.toml
+++ b/library/social-and-messaging/bird/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "bird-pp-cli"
+display_name = "Bird"
+description = "A terminal-native CLI for Bird's Conversations and SMS APIs, with offline search, batch reconcile, and a local SQLite mirror nobody else ships."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/bird-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+BIRD_API_KEY = true

--- a/library/social-and-messaging/multimail/agentcookie.toml
+++ b/library/social-and-messaging/multimail/agentcookie.toml
@@ -12,4 +12,4 @@ path = "~/.config/multimail-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-MULTIMAIL_BEARER_AUTH = true
+"MULTIMAIL_BEARER_AUTH" = true

--- a/library/social-and-messaging/multimail/agentcookie.toml
+++ b/library/social-and-messaging/multimail/agentcookie.toml
@@ -1,0 +1,15 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "multimail-pp-cli"
+display_name = "Multimail"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/multimail-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+MULTIMAIL_BEARER_AUTH = true

--- a/library/social-and-messaging/multimail/agentcookie.toml
+++ b/library/social-and-messaging/multimail/agentcookie.toml
@@ -2,7 +2,7 @@
 # See docs/spec-agentcookie-secrets-bus-v2-adoption.md
 schema_version = 2
 name = "multimail-pp-cli"
-display_name = "Multimail"
+display_name = "MultiMail"
 project_kind = "cli"
 
 [secrets.file]

--- a/library/social-and-messaging/twilio/agentcookie.toml
+++ b/library/social-and-messaging/twilio/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/twilio-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-TWILIO_ACCOUNT_SID_AUTH_TOKEN = true
+"TWILIO_ACCOUNT_SID_AUTH_TOKEN" = true

--- a/library/social-and-messaging/twilio/agentcookie.toml
+++ b/library/social-and-messaging/twilio/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "twilio-pp-cli"
+display_name = "Twilio"
+description = "Communication APIs for SMS, voice, and messaging"
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/twilio-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+TWILIO_ACCOUNT_SID_AUTH_TOKEN = true

--- a/library/social-and-messaging/x-twitter/agentcookie.toml
+++ b/library/social-and-messaging/x-twitter/agentcookie.toml
@@ -13,5 +13,5 @@ path = "~/.config/x-twitter-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-X_BEARER_TOKEN = true
-X_OAUTH2_USER_TOKEN = true
+"X_BEARER_TOKEN" = true
+"X_OAUTH2_USER_TOKEN" = true

--- a/library/social-and-messaging/x-twitter/agentcookie.toml
+++ b/library/social-and-messaging/x-twitter/agentcookie.toml
@@ -3,7 +3,7 @@
 schema_version = 2
 name = "x-twitter-pp-cli"
 display_name = "X (Twitter)"
-description = "The only X CLI with an offline, searchable local mirror — full-text search and SQL over your archived posts without re-spending per-read API credits — plus a full-surface MCP server and honest tier/reachability diagnostics."
+description = "The only X CLI with an offline, searchable local mirror — full-text search and analytics over your archived posts without re-spending per-read API credits — plus a full-surface MCP server and honest tier/reachability diagnostics."
 project_kind = "cli"
 
 [secrets.file]

--- a/library/travel/alltrails/agentcookie.toml
+++ b/library/travel/alltrails/agentcookie.toml
@@ -1,0 +1,18 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "alltrails-pp-cli"
+display_name = "Alltrails Unofficial Seed"
+description = "Evidence-labeled, live-capable route map for AllTrails browser/mobile surfaces. Not an official API contract."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/alltrails-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"ALLTRAILS_ACCESS_TOKEN" = true
+"ALLTRAILS_COOKIE" = true
+"ALLTRAILS_CSRF_TOKEN" = true

--- a/library/travel/flight-goat/agentcookie.toml
+++ b/library/travel/flight-goat/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/flight-goat-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-FLIGHT_GOAT_API_KEY = true
+"FLIGHT_GOAT_API_KEY" = true

--- a/library/travel/infotbm/agentcookie.toml
+++ b/library/travel/infotbm/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/infotbm-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-INFOTBM_API_KEY = true
+"INFOTBM_API_KEY" = true

--- a/library/travel/seats-aero/agentcookie.toml
+++ b/library/travel/seats-aero/agentcookie.toml
@@ -13,4 +13,4 @@ path = "~/.config/seats-aero-pp-cli/config.toml"
 default = false
 
 [sync.keys]
-SEATS_AERO_API_KEY = true
+"SEATS_AERO_API_KEY" = true

--- a/library/travel/seats-aero/agentcookie.toml
+++ b/library/travel/seats-aero/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "seats-aero-pp-cli"
+display_name = "Seats Aero Partner"
+description = "Search Seats.aero award-flight availability, route coverage, and trip details from the terminal."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/seats-aero-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+SEATS_AERO_API_KEY = true

--- a/library/travel/sncf-connect/agentcookie.toml
+++ b/library/travel/sncf-connect/agentcookie.toml
@@ -1,0 +1,16 @@
+# agentcookie.toml: secrets-bus adoption manifest v2
+# See docs/spec-agentcookie-secrets-bus-v2-adoption.md
+schema_version = 2
+name = "sncf-connect-pp-cli"
+display_name = "Navitia"
+description = "navitia.io is the open API for building cool stuff with mobility data."
+project_kind = "cli"
+
+[secrets.file]
+path = "~/.config/sncf-connect-pp-cli/config.toml"
+
+[sync]
+default = false
+
+[sync.keys]
+"SNCF_API_KEY" = true

--- a/tools/sweep-canonical/.gitignore
+++ b/tools/sweep-canonical/.gitignore
@@ -1,0 +1,1 @@
+/sweep-canonical

--- a/tools/sweep-canonical/agentcookie.go
+++ b/tools/sweep-canonical/agentcookie.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// agentcookieToml is the per-CLI adoption manifest emitted alongside
+// .printing-press.json. Mirror of agentcookie v2 adoption-standard
+// schema. The sweep tool inlines the TOML render rather than importing
+// pkg/agentcookieadoption because the sweep-canonical tool runs in
+// GOPATH mode (no go.mod) — see AGENTS.md "Bulk SKILL.md/README.md
+// retrofits" for the why.
+const agentcookieTomlFilename = "agentcookie.toml"
+
+// agentcookieOverrideMarker, when present in the first kilobyte of an
+// existing agentcookie.toml, signals that an author hand-edited the
+// file and the sweep tool must not overwrite it.
+const agentcookieOverrideMarker = "# agentcookie-manual-override"
+
+// extendedManifest carries the subset of .printing-press.json that the
+// agentcookie sweep step needs. The narrower top-level manifest struct
+// continues to live in main.go; this is an additive read so existing
+// sweep paths are unaffected.
+type extendedManifest struct {
+	APIName     string   `json:"api_name"`
+	CLIName     string   `json:"cli_name"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description"`
+	AuthType    string   `json:"auth_type"`
+	AuthEnvVars []string `json:"auth_env_vars"`
+}
+
+// sweepAgentcookieManifest emits agentcookie.toml into cliDir when the
+// CLI has env-var-based auth. Returns (changed, err). Idempotent: a
+// second call against the same inputs produces zero textual diff.
+//
+// Skip semantics:
+//   - CLIs with no auth_env_vars (cookie-only or no auth): skip, no
+//     error, returns (false, nil). Logged to stderr for visibility.
+//   - Existing agentcookie.toml carrying the override marker: skip
+//     with stderr note. Returns (false, nil).
+func sweepAgentcookieManifest(cliDir string) (bool, error) {
+	mfPath := filepath.Join(cliDir, ".printing-press.json")
+	raw, err := os.ReadFile(mfPath)
+	if err != nil {
+		return false, fmt.Errorf("read manifest: %w", err)
+	}
+	var mf extendedManifest
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		return false, fmt.Errorf("parse manifest: %w", err)
+	}
+	if !hasNonCookieAuth(mf) {
+		fmt.Fprintf(os.Stderr, "  agentcookie: skipping %s (cookie-only or no env-var auth)\n", mf.CLIName)
+		return false, nil
+	}
+	outPath := filepath.Join(cliDir, agentcookieTomlFilename)
+	if hasAgentcookieOverrideMarker(outPath) {
+		fmt.Fprintf(os.Stderr, "  agentcookie: skipping %s (manual override marker)\n", mf.CLIName)
+		return false, nil
+	}
+	body := renderAgentcookieToml(mf)
+	before, _ := os.ReadFile(outPath)
+	if string(before) == body {
+		return false, nil
+	}
+	if err := os.WriteFile(outPath, []byte(body), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", outPath, err)
+	}
+	return true, nil
+}
+
+// agentcookieManifestWouldChange returns true when sweepAgentcookieManifest
+// would write a new or modified file for cliDir, without performing the
+// write. Used by sweepCLI's early-return path so a CLI whose only
+// pending change is the agentcookie manifest still gets swept.
+func agentcookieManifestWouldChange(cliDir string) (bool, error) {
+	mfPath := filepath.Join(cliDir, ".printing-press.json")
+	raw, err := os.ReadFile(mfPath)
+	if err != nil {
+		return false, fmt.Errorf("read manifest: %w", err)
+	}
+	var mf extendedManifest
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		return false, fmt.Errorf("parse manifest: %w", err)
+	}
+	if !hasNonCookieAuth(mf) {
+		return false, nil
+	}
+	outPath := filepath.Join(cliDir, agentcookieTomlFilename)
+	if hasAgentcookieOverrideMarker(outPath) {
+		return false, nil
+	}
+	body := renderAgentcookieToml(mf)
+	before, _ := os.ReadFile(outPath)
+	return string(before) != body, nil
+}
+
+// hasNonCookieAuth returns true when the CLI has at least one env-var
+// based credential. Mirrors the cli-printing-press helper of the same
+// name so sweep and generator agree on which CLIs are eligible.
+func hasNonCookieAuth(mf extendedManifest) bool {
+	for _, v := range mf.AuthEnvVars {
+		if strings.TrimSpace(v) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAgentcookieOverrideMarker returns true when an existing file at
+// path begins with the manual-override marker. Missing files and read
+// errors return false.
+func hasAgentcookieOverrideMarker(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	head := data
+	if len(head) > 1024 {
+		head = head[:1024]
+	}
+	return strings.Contains(string(head), agentcookieOverrideMarker)
+}
+
+// renderAgentcookieToml produces the canonical TOML body for the given
+// manifest. Byte-for-byte deterministic. Mirrors the output of
+// agentcookie/pkg/agentcookieadoption.Render so the sweep-side emit
+// matches generator-side fresh prints exactly.
+func renderAgentcookieToml(mf extendedManifest) string {
+	cliName := strings.TrimSpace(mf.CLIName)
+	if cliName == "" {
+		cliName = mf.APIName + "-pp-cli"
+	}
+	displayName := strings.TrimSpace(mf.DisplayName)
+	if displayName == "" {
+		displayName = cliName
+	}
+	description := strings.TrimSpace(mf.Description)
+
+	var b strings.Builder
+	b.WriteString("# agentcookie.toml: secrets-bus adoption manifest v2\n")
+	b.WriteString("# See docs/spec-agentcookie-secrets-bus-v2-adoption.md\n")
+	b.WriteString("schema_version = 2\n")
+	fmt.Fprintf(&b, "name = %q\n", cliName)
+	fmt.Fprintf(&b, "display_name = %q\n", displayName)
+	if description != "" {
+		fmt.Fprintf(&b, "description = %q\n", description)
+	}
+	b.WriteString("project_kind = \"cli\"\n")
+	b.WriteString("\n")
+	b.WriteString("[secrets.file]\n")
+	fmt.Fprintf(&b, "path = %q\n", fmt.Sprintf("~/.config/%s/config.toml", cliName))
+	b.WriteString("\n")
+	b.WriteString("[sync]\n")
+	b.WriteString("default = false\n")
+	b.WriteString("\n")
+	// Only emit [sync.keys] when there's at least one key. The
+	// hasNonCookieAuth guard above ensures we don't reach here with an
+	// empty list, but defend in depth so renderAgentcookieToml is safe
+	// to call independently from tests.
+	keys := make([]string, 0, len(mf.AuthEnvVars))
+	for _, k := range mf.AuthEnvVars {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		b.WriteString("[sync.keys]\n")
+		for _, k := range keys {
+			// Auth env vars are credentials by definition; flag every
+			// one sensitive=true. Per-key sensitivity refinement (e.g.
+			// client_id paired with a sensitive client_secret) lands
+			// when the generator's EnvVarSpecs path emits the manifest
+			// directly, not via this retrofit sweep.
+			fmt.Fprintf(&b, "%s = true\n", k)
+		}
+	}
+	return b.String()
+}

--- a/tools/sweep-canonical/agentcookie.go
+++ b/tools/sweep-canonical/agentcookie.go
@@ -35,69 +35,52 @@ type extendedManifest struct {
 	AuthEnvVars []string `json:"auth_env_vars"`
 }
 
-// sweepAgentcookieManifest emits agentcookie.toml into cliDir when the
-// CLI has env-var-based auth. Returns (changed, err). Idempotent: a
-// second call against the same inputs produces zero textual diff.
+// agentcookieManifestForSweep computes the next-state body for
+// agentcookie.toml at cliDir, returning (body, changed, err).
+// Idempotent: a second call against the same inputs returns changed=false.
 //
-// Skip semantics:
-//   - CLIs with no auth_env_vars (cookie-only or no auth): skip, no
-//     error, returns (false, nil). Logged to stderr for visibility.
-//   - Existing agentcookie.toml carrying the override marker: skip
-//     with stderr note. Returns (false, nil).
-func sweepAgentcookieManifest(cliDir string) (bool, error) {
+// Skip semantics — all return ("", false, nil):
+//   - CLIs with no auth_env_vars (cookie-only or no auth). Logged to stderr.
+//   - Existing agentcookie.toml carrying the override marker. Logged to stderr.
+//
+// The caller owns the os.WriteFile (mirroring the skill/readme pattern in
+// sweepCLI) so a partial write failure can't leave a malformed file
+// alongside correctly rolled-back peer artifacts.
+func agentcookieManifestForSweep(cliDir string) (string, bool, error) {
 	mfPath := filepath.Join(cliDir, ".printing-press.json")
 	raw, err := os.ReadFile(mfPath)
 	if err != nil {
-		return false, fmt.Errorf("read manifest: %w", err)
+		return "", false, fmt.Errorf("read manifest: %w", err)
 	}
 	var mf extendedManifest
 	if err := json.Unmarshal(raw, &mf); err != nil {
-		return false, fmt.Errorf("parse manifest: %w", err)
+		return "", false, fmt.Errorf("parse manifest: %w", err)
 	}
 	if !hasNonCookieAuth(mf) {
 		fmt.Fprintf(os.Stderr, "  agentcookie: skipping %s (cookie-only or no env-var auth)\n", mf.CLIName)
-		return false, nil
+		return "", false, nil
 	}
 	outPath := filepath.Join(cliDir, agentcookieTomlFilename)
 	if hasAgentcookieOverrideMarker(outPath) {
 		fmt.Fprintf(os.Stderr, "  agentcookie: skipping %s (manual override marker)\n", mf.CLIName)
-		return false, nil
+		return "", false, nil
 	}
 	body := renderAgentcookieToml(mf)
 	before, _ := os.ReadFile(outPath)
 	if string(before) == body {
-		return false, nil
+		return body, false, nil
 	}
-	if err := os.WriteFile(outPath, []byte(body), 0o644); err != nil {
-		return false, fmt.Errorf("write %s: %w", outPath, err)
-	}
-	return true, nil
+	return body, true, nil
 }
 
-// agentcookieManifestWouldChange returns true when sweepAgentcookieManifest
-// would write a new or modified file for cliDir, without performing the
-// write. Used by sweepCLI's early-return path so a CLI whose only
-// pending change is the agentcookie manifest still gets swept.
+// agentcookieManifestWouldChange returns true when the sweep would
+// produce a new or modified file for cliDir. Used by sweepCLI's
+// early-return path so a CLI whose only pending change is the
+// agentcookie manifest still gets swept. Thin wrapper around
+// agentcookieManifestForSweep.
 func agentcookieManifestWouldChange(cliDir string) (bool, error) {
-	mfPath := filepath.Join(cliDir, ".printing-press.json")
-	raw, err := os.ReadFile(mfPath)
-	if err != nil {
-		return false, fmt.Errorf("read manifest: %w", err)
-	}
-	var mf extendedManifest
-	if err := json.Unmarshal(raw, &mf); err != nil {
-		return false, fmt.Errorf("parse manifest: %w", err)
-	}
-	if !hasNonCookieAuth(mf) {
-		return false, nil
-	}
-	outPath := filepath.Join(cliDir, agentcookieTomlFilename)
-	if hasAgentcookieOverrideMarker(outPath) {
-		return false, nil
-	}
-	body := renderAgentcookieToml(mf)
-	before, _ := os.ReadFile(outPath)
-	return string(before) != body, nil
+	_, changed, err := agentcookieManifestForSweep(cliDir)
+	return changed, err
 }
 
 // hasNonCookieAuth returns true when the CLI has at least one env-var
@@ -178,7 +161,12 @@ func renderAgentcookieToml(mf extendedManifest) string {
 			// client_id paired with a sensitive client_secret) lands
 			// when the generator's EnvVarSpecs path emits the manifest
 			// directly, not via this retrofit sweep.
-			fmt.Fprintf(&b, "%s = true\n", k)
+			//
+			// %q quotes the key so a future env var containing a dot
+			// or other non-bare-key character can't accidentally land
+			// as TOML dotted-table notation (nested sub-table under
+			// [sync.keys] instead of the intended flat key).
+			fmt.Fprintf(&b, "%q = true\n", k)
 		}
 	}
 	return b.String()

--- a/tools/sweep-canonical/agentcookie_test.go
+++ b/tools/sweep-canonical/agentcookie_test.go
@@ -14,6 +14,24 @@ func writeManifestFile(t *testing.T, dir, body string) {
 	}
 }
 
+// emitAgentcookieToml is a test helper that renders + writes in one step,
+// mirroring what sweepCLI does in production. Tests can use this to
+// verify end-to-end behavior without each test repeating the write boilerplate.
+func emitAgentcookieToml(t *testing.T, dir string) (bool, error) {
+	t.Helper()
+	body, changed, err := agentcookieManifestForSweep(dir)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	if err := os.WriteFile(filepath.Join(dir, agentcookieTomlFilename), []byte(body), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func TestSweepAgentcookieManifest_BearerToken(t *testing.T) {
 	dir := t.TempDir()
 	writeManifestFile(t, dir, `{
@@ -24,9 +42,9 @@ func TestSweepAgentcookieManifest_BearerToken(t *testing.T) {
   "auth_type": "bearer_token",
   "auth_env_vars": ["STRIPE_SECRET_KEY"]
 }`)
-	changed, err := sweepAgentcookieManifest(dir)
+	changed, err := emitAgentcookieToml(t, dir)
 	if err != nil {
-		t.Fatalf("sweepAgentcookieManifest: %v", err)
+		t.Fatalf("emitAgentcookieToml: %v", err)
 	}
 	if !changed {
 		t.Fatal("expected changed=true on first emit")
@@ -43,7 +61,7 @@ func TestSweepAgentcookieManifest_BearerToken(t *testing.T) {
 		"[sync]",
 		"default = false",
 		"[sync.keys]",
-		"STRIPE_SECRET_KEY = true",
+		`"STRIPE_SECRET_KEY" = true`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected emit to contain %q; got:\n%s", want, got)
@@ -58,9 +76,9 @@ func TestSweepAgentcookieManifest_SkipsCookieOnly(t *testing.T) {
   "cli_name": "instacart-pp-cli",
   "auth_type": "cookie"
 }`)
-	changed, err := sweepAgentcookieManifest(dir)
+	changed, err := emitAgentcookieToml(t, dir)
 	if err != nil {
-		t.Fatalf("sweepAgentcookieManifest: %v", err)
+		t.Fatalf("emitAgentcookieToml: %v", err)
 	}
 	if changed {
 		t.Error("expected changed=false for cookie-only CLI")
@@ -79,11 +97,11 @@ func TestSweepAgentcookieManifest_Idempotent(t *testing.T) {
   "auth_type": "bearer_token",
   "auth_env_vars": ["STRIPE_SECRET_KEY"]
 }`)
-	changed1, err := sweepAgentcookieManifest(dir)
+	changed1, err := emitAgentcookieToml(t, dir)
 	if err != nil || !changed1 {
 		t.Fatalf("first emit: changed=%v err=%v", changed1, err)
 	}
-	changed2, err := sweepAgentcookieManifest(dir)
+	changed2, err := emitAgentcookieToml(t, dir)
 	if err != nil {
 		t.Fatalf("second emit: %v", err)
 	}
@@ -104,9 +122,9 @@ func TestSweepAgentcookieManifest_OverrideMarkerRespected(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, agentcookieTomlFilename), []byte(override), 0o644); err != nil {
 		t.Fatalf("seed override: %v", err)
 	}
-	changed, err := sweepAgentcookieManifest(dir)
+	changed, err := emitAgentcookieToml(t, dir)
 	if err != nil {
-		t.Fatalf("sweepAgentcookieManifest: %v", err)
+		t.Fatalf("emitAgentcookieToml: %v", err)
 	}
 	if changed {
 		t.Error("expected changed=false when override marker present")
@@ -128,9 +146,9 @@ func TestSweepAgentcookieManifest_MultipleEnvVarsSorted(t *testing.T) {
   "auth_type": "oauth2",
   "auth_env_vars": ["EXAMPLE_CLIENT_SECRET", "EXAMPLE_CLIENT_ID"]
 }`)
-	_, err := sweepAgentcookieManifest(dir)
+	_, err := emitAgentcookieToml(t, dir)
 	if err != nil {
-		t.Fatalf("sweepAgentcookieManifest: %v", err)
+		t.Fatalf("emitAgentcookieToml: %v", err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, agentcookieTomlFilename))
 	got := string(body)
@@ -151,9 +169,9 @@ func TestSweepAgentcookieManifest_NoEnvVarsSkipped(t *testing.T) {
   "cli_name": "noauth-public-api-pp-cli",
   "auth_type": "none"
 }`)
-	changed, err := sweepAgentcookieManifest(dir)
+	changed, err := emitAgentcookieToml(t, dir)
 	if err != nil {
-		t.Fatalf("sweepAgentcookieManifest: %v", err)
+		t.Fatalf("emitAgentcookieToml: %v", err)
 	}
 	if changed {
 		t.Error("expected changed=false for no-auth CLI")
@@ -172,7 +190,7 @@ func TestAgentcookieManifestWouldChange(t *testing.T) {
 	if err != nil || !would {
 		t.Fatalf("expected would-change=true on first probe; got would=%v err=%v", would, err)
 	}
-	if _, err := sweepAgentcookieManifest(dir); err != nil {
+	if _, err := emitAgentcookieToml(t, dir); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
 	would, err = agentcookieManifestWouldChange(dir)

--- a/tools/sweep-canonical/agentcookie_test.go
+++ b/tools/sweep-canonical/agentcookie_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifestFile(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestSweepAgentcookieManifest_BearerToken(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "stripe",
+  "cli_name": "stripe-pp-cli",
+  "display_name": "Stripe",
+  "description": "Payment processing and financial infrastructure API",
+  "auth_type": "bearer_token",
+  "auth_env_vars": ["STRIPE_SECRET_KEY"]
+}`)
+	changed, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("sweepAgentcookieManifest: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on first emit")
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, agentcookieTomlFilename))
+	got := string(body)
+	for _, want := range []string{
+		"schema_version = 2",
+		`name = "stripe-pp-cli"`,
+		`display_name = "Stripe"`,
+		`project_kind = "cli"`,
+		"[secrets.file]",
+		`path = "~/.config/stripe-pp-cli/config.toml"`,
+		"[sync]",
+		"default = false",
+		"[sync.keys]",
+		"STRIPE_SECRET_KEY = true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected emit to contain %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestSweepAgentcookieManifest_SkipsCookieOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "instacart",
+  "cli_name": "instacart-pp-cli",
+  "auth_type": "cookie"
+}`)
+	changed, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("sweepAgentcookieManifest: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for cookie-only CLI")
+	}
+	if _, err := os.Stat(filepath.Join(dir, agentcookieTomlFilename)); err == nil {
+		t.Error("agentcookie.toml created for cookie-only CLI")
+	}
+}
+
+func TestSweepAgentcookieManifest_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "stripe",
+  "cli_name": "stripe-pp-cli",
+  "display_name": "Stripe",
+  "auth_type": "bearer_token",
+  "auth_env_vars": ["STRIPE_SECRET_KEY"]
+}`)
+	changed1, err := sweepAgentcookieManifest(dir)
+	if err != nil || !changed1 {
+		t.Fatalf("first emit: changed=%v err=%v", changed1, err)
+	}
+	changed2, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("second emit: %v", err)
+	}
+	if changed2 {
+		t.Error("expected idempotent second run (changed=false)")
+	}
+}
+
+func TestSweepAgentcookieManifest_OverrideMarkerRespected(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "stripe",
+  "cli_name": "stripe-pp-cli",
+  "auth_type": "bearer_token",
+  "auth_env_vars": ["STRIPE_SECRET_KEY"]
+}`)
+	override := "# agentcookie-manual-override\nname = \"hand-edited\"\n"
+	if err := os.WriteFile(filepath.Join(dir, agentcookieTomlFilename), []byte(override), 0o644); err != nil {
+		t.Fatalf("seed override: %v", err)
+	}
+	changed, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("sweepAgentcookieManifest: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false when override marker present")
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, agentcookieTomlFilename))
+	if !strings.HasPrefix(string(body), agentcookieOverrideMarker) {
+		t.Error("override file was overwritten")
+	}
+	if strings.Contains(string(body), "STRIPE_SECRET_KEY") {
+		t.Error("override file gained generated content")
+	}
+}
+
+func TestSweepAgentcookieManifest_MultipleEnvVarsSorted(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "example",
+  "cli_name": "example-pp-cli",
+  "auth_type": "oauth2",
+  "auth_env_vars": ["EXAMPLE_CLIENT_SECRET", "EXAMPLE_CLIENT_ID"]
+}`)
+	_, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("sweepAgentcookieManifest: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, agentcookieTomlFilename))
+	got := string(body)
+	idIdx := strings.Index(got, "EXAMPLE_CLIENT_ID")
+	secretIdx := strings.Index(got, "EXAMPLE_CLIENT_SECRET")
+	if idIdx < 0 || secretIdx < 0 {
+		t.Fatalf("expected both keys present; got:\n%s", got)
+	}
+	if idIdx > secretIdx {
+		t.Errorf("expected EXAMPLE_CLIENT_ID before EXAMPLE_CLIENT_SECRET (alphabetical sort); got:\n%s", got)
+	}
+}
+
+func TestSweepAgentcookieManifest_NoEnvVarsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "noauth-public-api",
+  "cli_name": "noauth-public-api-pp-cli",
+  "auth_type": "none"
+}`)
+	changed, err := sweepAgentcookieManifest(dir)
+	if err != nil {
+		t.Fatalf("sweepAgentcookieManifest: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for no-auth CLI")
+	}
+}
+
+func TestAgentcookieManifestWouldChange(t *testing.T) {
+	dir := t.TempDir()
+	writeManifestFile(t, dir, `{
+  "api_name": "stripe",
+  "cli_name": "stripe-pp-cli",
+  "auth_type": "bearer_token",
+  "auth_env_vars": ["STRIPE_SECRET_KEY"]
+}`)
+	would, err := agentcookieManifestWouldChange(dir)
+	if err != nil || !would {
+		t.Fatalf("expected would-change=true on first probe; got would=%v err=%v", would, err)
+	}
+	if _, err := sweepAgentcookieManifest(dir); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	would, err = agentcookieManifestWouldChange(dir)
+	if err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+	if would {
+		t.Error("expected would-change=false after emit (idempotent)")
+	}
+}

--- a/tools/sweep-canonical/main.go
+++ b/tools/sweep-canonical/main.go
@@ -329,7 +329,16 @@ func findCLIDirs(libraryRoot string) ([]string, error) {
 // summary of what changed (e.g. "42 files").
 type sweepStatus string
 
-const statusUnchanged sweepStatus = "unchanged"
+const (
+	statusUnchanged       sweepStatus = "unchanged"
+	statusSkillOnly       sweepStatus = "skill-only"
+	statusReadmeOnly      sweepStatus = "readme-only"
+	statusBoth            sweepStatus = "both"
+	statusAgentcookieOnly sweepStatus = "agentcookie-only"
+	statusBothPlusAC      sweepStatus = "skill+readme+agentcookie"
+	statusReadmePlusAC    sweepStatus = "readme+agentcookie"
+	statusSkillPlusAC     sweepStatus = "skill+agentcookie"
+)
 
 const minimumGoVersion = "Go 1.26.5 or newer"
 
@@ -403,6 +412,7 @@ func sweepCLI(cliDir, ownerName string, readmeOnly, attributionOnly bool, contri
 	creator := resolveCreator(mf)
 
 	var edits []fileEdit
+	skillChanged := false
 
 	// SKILL.md (canonical docs shape) — skipped in readme-only and
 	// attribution-only modes.
@@ -421,6 +431,7 @@ func sweepCLI(cliDir, ownerName string, readmeOnly, attributionOnly bool, contri
 			return statusUnchanged, fmt.Errorf("patch SKILL.md: %w", err)
 		}
 		if skillAfter != string(skillBefore) {
+			skillChanged = true
 			edits = append(edits, fileEdit{skillPath, skillBefore, []byte(skillAfter)})
 		}
 	}
@@ -441,7 +452,8 @@ func sweepCLI(cliDir, ownerName string, readmeOnly, attributionOnly bool, contri
 	if err != nil {
 		return statusUnchanged, fmt.Errorf("patch README.md: %w", err)
 	}
-	if readmeAfter != string(readmeBefore) {
+	readmeChanged := readmeAfter != string(readmeBefore)
+	if readmeChanged {
 		edits = append(edits, fileEdit{readmePath, readmeBefore, []byte(readmeAfter)})
 	}
 
@@ -471,25 +483,60 @@ func sweepCLI(cliDir, ownerName string, readmeOnly, attributionOnly bool, contri
 	}
 	edits = append(edits, headerEdits...)
 
-	if len(edits) == 0 {
+	// Probe whether agentcookie.toml would change so we can fast-return
+	// statusUnchanged when nothing at all is dirty. The probe re-renders
+	// against current inputs; the real write happens below inside the
+	// snapshot-tracked block.
+	agentcookieWouldChange, agentcookieProbeErr := agentcookieManifestWouldChange(cliDir)
+	if agentcookieProbeErr != nil {
+		return statusUnchanged, fmt.Errorf("probe agentcookie.toml: %w", agentcookieProbeErr)
+	}
+	if !skillChanged && !readmeChanged && !agentcookieWouldChange {
 		return statusUnchanged, nil
 	}
 
 	// Write all edits, rolling back already-written files on any failure.
 	var written []fileEdit
+	rollback := func() {
+		for _, w := range written {
+			if rerr := os.WriteFile(w.path, w.before, 0o644); rerr != nil {
+				fmt.Printf("    WARN restore %s failed: %v\n", w.path, rerr)
+			}
+		}
+	}
 	for _, e := range edits {
 		if err := os.WriteFile(e.path, e.after, 0o644); err != nil {
-			for _, w := range written {
-				if rerr := os.WriteFile(w.path, w.before, 0o644); rerr != nil {
-					fmt.Printf("    WARN restore %s failed: %v\n", w.path, rerr)
-				}
-			}
+			rollback()
 			return statusUnchanged, fmt.Errorf("write %s: %w", e.path, err)
 		}
 		written = append(written, e)
 	}
 
-	return sweepStatus(fmt.Sprintf("%d files", len(edits))), nil
+	// agentcookie.toml emit. Skipped CLIs (cookie-only, override marker)
+	// silently return changed=false; readability of the per-CLI sweep
+	// line takes priority over surfacing every skip in the status field.
+	agentcookieChanged, agentcookieErr := sweepAgentcookieManifest(cliDir)
+	if agentcookieErr != nil {
+		rollback()
+		return statusUnchanged, fmt.Errorf("emit agentcookie.toml: %w", agentcookieErr)
+	}
+
+	switch {
+	case skillChanged && readmeChanged && agentcookieChanged:
+		return statusBothPlusAC, nil
+	case skillChanged && readmeChanged:
+		return statusBoth, nil
+	case readmeChanged && agentcookieChanged:
+		return statusReadmePlusAC, nil
+	case skillChanged && agentcookieChanged:
+		return statusSkillPlusAC, nil
+	case agentcookieChanged:
+		return statusAgentcookieOnly, nil
+	case skillChanged:
+		return statusSkillOnly, nil
+	default:
+		return statusReadmeOnly, nil
+	}
 }
 
 type patchSkillCtx struct {

--- a/tools/sweep-canonical/main.go
+++ b/tools/sweep-canonical/main.go
@@ -515,10 +515,23 @@ func sweepCLI(cliDir, ownerName string, readmeOnly, attributionOnly bool, contri
 	// agentcookie.toml emit. Skipped CLIs (cookie-only, override marker)
 	// silently return changed=false; readability of the per-CLI sweep
 	// line takes priority over surfacing every skip in the status field.
-	agentcookieChanged, agentcookieErr := sweepAgentcookieManifest(cliDir)
+	// Render here, then write inside the snapshot block, so a partial
+	// write failure (e.g. ENOSPC mid-write) lands the snapshot in
+	// `written` and rollback() can restore the prior contents — matching
+	// the skill/readme pattern above.
+	agentcookieBody, agentcookieChanged, agentcookieErr := agentcookieManifestForSweep(cliDir)
 	if agentcookieErr != nil {
 		rollback()
-		return statusUnchanged, fmt.Errorf("emit agentcookie.toml: %w", agentcookieErr)
+		return statusUnchanged, fmt.Errorf("render agentcookie.toml: %w", agentcookieErr)
+	}
+	if agentcookieChanged {
+		agentcookiePath := filepath.Join(cliDir, agentcookieTomlFilename)
+		agentcookieBefore, _ := os.ReadFile(agentcookiePath)
+		written = append(written, fileEdit{path: agentcookiePath, before: agentcookieBefore, after: []byte(agentcookieBody)})
+		if err := os.WriteFile(agentcookiePath, []byte(agentcookieBody), 0o644); err != nil {
+			rollback()
+			return statusUnchanged, fmt.Errorf("write agentcookie.toml: %w", err)
+		}
 	}
 
 	switch {


### PR DESCRIPTION
## Summary

Companion to [cli-printing-press#1972](https://github.com/mvanhorn/cli-printing-press/pull/1972). Retrofits every eligible already-published CLI in this catalog with an `agentcookie.toml` adoption manifest, plus extends `tools/sweep-canonical/` to keep the dimension idempotent on future runs.

After this lands, an agentcookie user installing any non-cookie-auth CLI from this library gets explicit-manifest secrets-bus integration automatically. Tier transitions from `pp-cli-derived` (best-effort auto-detect via `~/printing-press/library/*/.printing-press.json`) to `explicit-manifest` (deterministic, machine-independent). Both tiers continue to work; explicit is faster and cleaner.

Plan: `cli-printing-press/docs/plans/2026-05-23-001-feat-agentcookie-secrets-bus-hookup-plan.md`.

## Commits

1. **`feat(cli): extend sweep-canonical to emit agentcookie.toml per CLI`** — Adds a new sweep dimension. Inline TOML render (sweep tool runs in GOPATH mode, can't import the agentcookie helper). 7 new tests cover idempotency, cookie-only skip, override marker, multi-env-var sorting, and the would-change probe.
2. **`feat(trigger-dev): adopt agentcookie v2 explicit-manifest tier (canary)`** — First per-CLI rollout. trigger-dev-pp-cli has Matt's `TRIGGER_SECRET_KEY` on the source side; this is the validation anchor.
3. **`feat(library): bulk sweep adopts agentcookie v2 across 96 CLIs`** — Bulk emit. Total 97 agentcookie.toml files across the library. 72 CLIs (cookie-only or no-auth) are intentionally skipped.
4. **`docs(cli): document agentcookie.toml dimension in sweep-canonical AGENTS`** — Documents the new sweep dimension and the upstream pointer-rot rule.

## Scope discipline

- **No code changes** to any generated CLI source. Only `agentcookie.toml` files added at the CLI directory root. Each retrofitted CLI's `internal/config/config.go` keeps its existing `os.Getenv` auth handling; the bus-aware `Load()` lands via fresh regens once cli-printing-press#1972 merges.
- **No `.printing-press-patches.json` updates.** Per `AGENTS.md`, sweep-canonical changes are owned by the sweep tool and don't need patches-manifest entries — the patches index is for code-level customizations.
- **No README/SKILL.md drift fixes** included. The sweep run detected drift in three unrelated CLIs (tesla/botsee/strava); those updates are restored to leave a separate sweep PR.

## Test plan

- [x] `cd tools/sweep-canonical && GO111MODULE=off go test .` — 34 cases pass (27 existing + 7 new).
- [x] `go build ./...` from `library/developer-tools/trigger-dev/` — passes.
- [x] `go vet ./...` from `library/developer-tools/trigger-dev/` — clean.
- [x] Idempotency: a second sweep run produces zero diff for the agentcookie dimension (verified locally).
- [ ] Spot-check 5 random `agentcookie.toml` outputs after CI runs.
- [ ] Matt's end-to-end verification on source+sink (drop `TRIGGER_SECRET_KEY` in the bus, observe arrival on sink, confirm trigger-dev-pp-cli picks it up after cli-printing-press#1972 ships and trigger-dev gets a fresh print).

🤖 Generated with [Claude Code](https://claude.com/claude-code)