### PR TITLE
feat(youtube): add playlist-enrich, videos-enrich, and videos-links commands

### DIFF
--- a/library/media-and-entertainment/youtube/.printing-press-patches.json
+++ b/library/media-and-entertainment/youtube/.printing-press-patches.json
@@ -47,6 +47,24 @@
         "F2"
       ],
       "patch_count": 2
+    },
+    {
+      "id": "feat-videos-enrich-and-greptile-fixes",
+      "summary": "Add a third novel read-only command, videos-enrich (single-video analog of playlist-enrich: one call -> one video's metadata + transcript + description in the same enrichedVideo shape, --lang/--no-transcript), and resolve the three Greptile P2 findings on the playlist-enrich/videos-links commits.",
+      "reason": "playlist-enrich only handled whole playlists; the single-video path still required chaining videos-list + videos-transcript, so videos-enrich collapses that into one call by reusing fetchVideoMetadata and fetchTranscriptForVideo (no new payloads). Greptile P2 (PR #803): (1) resolveRedirect set http.Client.Timeout equal to the rctx context deadline, which was dead/misleading since both requests run under rctx via NewRequestWithContext; removed it. (2) parseVideoID accepted any final path segment, so /c/Name, /channel/UC..., /user/Name, @handle, and /playlist returned a bogus ID that reached videos.list and produced a confusing 'video X not found'; tightened to require an 11-char video-ID shape and to read a path segment only for known video URLs (youtu.be/, /embed/, /shorts/, /live/), returning '' otherwise so the caller emits a clear 'could not extract a video ID' error. (3) playlist-enrich reported totalItems as the scanned count, capping at the page window; now reads the true playlist length from playlistItems.list pageInfo.totalResults so startIndex+returned < totalItems is a valid has-more test.",
+      "files": [
+        "internal/cli/videos_enrich.go",
+        "internal/cli/videos_enrich_test.go",
+        "internal/cli/videos_links.go",
+        "internal/cli/playlist_enrich.go",
+        "internal/cli/playlist_enrich_test.go",
+        "internal/cli/youtube.go"
+      ],
+      "validated_outcome": "go build ./..., go vet ./..., go test ./..., and gofmt clean on the youtube module. Added 7 parseVideoID regression cases (channel/playlist/user/@handle URLs and bad-length bare tokens all -> '') and a new videos_enrich_test.go fakeAPIGetter suite covering fetchVideoMetadata field mapping, HTML-entity unescaping, thumbnail priority (high>medium>default), and the missing-video case. videos-enrich live-verified against dQw4w9WgXcQ (metadata + 458-word transcript + 332-word description in one call; --no-transcript drops the transcript). All 5 PR CI checks green (Verify, Validate SKILL.md, Govulncheck, Greptile Review, Greptile policy gate).",
+      "findings_addressed": [
+        "F3"
+      ],
+      "patch_count": 1
     }
   ],
   "machine_followups": [

--- a/library/media-and-entertainment/youtube/.printing-press-patches.json
+++ b/library/media-and-entertainment/youtube/.printing-press-patches.json
@@ -29,6 +29,24 @@
         "internal/cli/videos_related.go"
       ],
       "validated_outcome": "Output-review WARN count went from 2 to 0 (entities decoded; cross-channel diversity improved). videos-related dQw4w9WgXcQ --limit 10 returns mixed-channel results dominated by topic/tag matches, with apostrophes rendered correctly."
+    },
+    {
+      "id": "feat-playlist-enrich-and-description-links",
+      "summary": "Add two novel read-only commands for yt-video-mcp parity: playlist-enrich (resolves a playlist URL/ID -> per-video metadata + transcript + description in one concurrent, start-index/limit-paged call with per-row error isolation) and videos-links (extracts HTTP(S) links from a video description, expands known short-link redirects, and skips social/storefront noise).",
+      "reason": "The published CLI had per-video transcript (videos-transcript) and uploads-playlist walking (channel-uploads) but no command that resolves an arbitrary playlist to enriched per-video rows in one call, and no command that surfaces the resource links creators put in descriptions. playlist-enrich collapses the playlistItems.list -> videos.list -> per-video InnerTube transcript workflow with cliutil.FanoutRun-bounded concurrency, --start-index/--limit paging over the resolved ID list, and per-row transcriptError/metadataError fields so one captionless video never aborts the run. videos-links calls videos.list for the description, regex-extracts URLs, and (under --resolve, default on) follows redirects for known shorteners (amzn.to, bit.ly, goo.gl, ow.ly, t.co, tinyurl.com, buff.ly) to their final URL; --include-social (default off) controls the social/storefront skip filter. Both reuse the existing transcript helpers and HTML-unescape titles/descriptions to match the existing novel commands.",
+      "files": [
+        "internal/cli/playlist_enrich.go",
+        "internal/cli/playlist_enrich_test.go",
+        "internal/cli/videos_links.go",
+        "internal/cli/videos_links_test.go",
+        "internal/cli/youtube.go"
+      ],
+      "validated_outcome": "publish validate: 11/12 checks pass (manifest, transcendence, phase5, go mod tidy, govulncheck, go vet, go build, --help, --version, manuscripts). The one failure (verify-skill: SKILL.md install-section drift) is pre-existing on upstream/main and unrelated to this amend — SKILL.md is untouched; the public library refreshes generator-owned skill sections post-merge. go test ./... clean; new table-driven tests cover parsePlaylistID, parseVideoID, hostOf, isNoisyHost, and extractDescriptionLinks (dedupe, trailing-punct trim, shortener flagging, social skip). Dry-run verified for both commands against the test playlist PLkdrbggVaVRDNyR3b5SlqcI9Z0xJjShTh and watch/bare-ID inputs; bad-input usage errors exit 2.",
+      "findings_addressed": [
+        "F1",
+        "F2"
+      ],
+      "patch_count": 2
     }
   ],
   "machine_followups": [

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich.go
@@ -1,0 +1,456 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-20260523: novel command) — collapses the playlistItems.list ->
+// videos.list -> per-video transcript workflow into one call with bounded
+// concurrency, start-index/limit paging, and per-row error isolation. Brings
+// the CLI to parity with the yt-video-mcp fetch_playlist_full tool. Calls the
+// real Data API (playlistItems.list, videos.list) and the real InnerTube
+// transcript path; no hand-rolled payloads.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/youtube/internal/cliutil"
+
+	"github.com/spf13/cobra"
+)
+
+type enrichedVideo struct {
+	VideoID         string            `json:"videoId"`
+	Position        int               `json:"position"`
+	Title           string            `json:"title"`
+	Description     string            `json:"description,omitempty"`
+	ChannelTitle    string            `json:"channelTitle,omitempty"`
+	PublishedAt     string            `json:"publishedAt,omitempty"`
+	Duration        string            `json:"duration,omitempty"`
+	ViewCount       string            `json:"viewCount,omitempty"`
+	LikeCount       string            `json:"likeCount,omitempty"`
+	WatchURL        string            `json:"watchUrl"`
+	EmbedURL        string            `json:"embedUrl"`
+	ThumbnailURL    string            `json:"thumbnailUrl,omitempty"`
+	Transcript      *transcriptResult `json:"transcript,omitempty"`
+	TranscriptError string            `json:"transcriptError,omitempty"`
+	MetadataError   string            `json:"metadataError,omitempty"`
+}
+
+type playlistEnrichResponse struct {
+	PlaylistID    string          `json:"playlistId"`
+	PlaylistTitle string          `json:"playlistTitle,omitempty"`
+	TotalItems    int             `json:"totalItems"`
+	StartIndex    int             `json:"startIndex"`
+	Limit         int             `json:"limit"`
+	Returned      int             `json:"returned"`
+	Videos        []enrichedVideo `json:"videos"`
+	Warnings      []string        `json:"warnings,omitempty"`
+}
+
+func newYoutubePlaylistEnrichCmd(flags *rootFlags) *cobra.Command {
+	var startIndex int
+	var limit int
+	var lang string
+	var noTranscript bool
+	var concurrency int
+
+	cmd := &cobra.Command{
+		Use:         "playlist-enrich <playlistUrlOrId>",
+		Short:       "Resolve a playlist to per-video metadata + transcript + description in one concurrent call",
+		Example:     "  youtube-pp-cli youtube playlist-enrich https://www.youtube.com/playlist?list=PLxxxx --limit 25",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			playlistID := parsePlaylistID(strings.TrimSpace(args[0]))
+			if playlistID == "" {
+				return usageErr(fmt.Errorf("could not extract a playlist ID from %q (expected a playlist URL or a PL.../UU.../LL... ID)", args[0]))
+			}
+			if limit <= 0 {
+				return usageErr(fmt.Errorf("--limit must be > 0"))
+			}
+			if startIndex < 0 {
+				return usageErr(fmt.Errorf("--start-index must be >= 0"))
+			}
+			if concurrency < 1 {
+				concurrency = 1
+			}
+
+			if dryRunOK(flags) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "GET /youtube/v3/playlistItems (playlistId=%s)\n", playlistID)
+				fmt.Fprintln(cmd.ErrOrStderr(), "GET /youtube/v3/videos (batched metadata for the paged window)")
+				if !noTranscript {
+					fmt.Fprintln(cmd.ErrOrStderr(), "POST https://www.youtube.com/youtubei/v1/player (transcript per video, concurrent)")
+				}
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			c = c.WithContext(cmd.Context())
+
+			out := playlistEnrichResponse{
+				PlaylistID: playlistID,
+				StartIndex: startIndex,
+				Limit:      limit,
+			}
+
+			// 1. Resolve the playlist title (best-effort; playlistItems.list
+			// does not carry it). A failure here is non-fatal — enrichment
+			// proceeds without the title.
+			out.PlaylistTitle = fetchPlaylistTitle(c, playlistID)
+
+			// 2. Walk the playlist to collect ordered video IDs. Cap the page
+			// walk so a giant playlist doesn't burn quota; we only need enough
+			// items to cover startIndex+limit.
+			needed := startIndex + limit
+			ordered, walkWarns, err := walkPlaylistItems(c, playlistID, needed, flags)
+			if err != nil {
+				return err
+			}
+			out.TotalItems = len(ordered)
+			out.Warnings = append(out.Warnings, walkWarns...)
+
+			// 3. Apply start-index / limit window over the resolved IDs.
+			if startIndex >= len(ordered) {
+				out.Returned = 0
+				out.Videos = []enrichedVideo{}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+			end := startIndex + limit
+			if end > len(ordered) {
+				end = len(ordered)
+			}
+			window := ordered[startIndex:end]
+
+			// 4. Batch-fetch metadata via videos.list (50 IDs per call).
+			meta, metaWarns := fetchVideoMetadata(c, window)
+			out.Warnings = append(out.Warnings, metaWarns...)
+
+			// 5. Assemble rows, fanning out transcript fetches concurrently.
+			rows := make([]enrichedVideo, len(window))
+			for i, pe := range window {
+				row := enrichedVideo{
+					VideoID:  pe.videoID,
+					Position: pe.position,
+					Title:    pe.title,
+					WatchURL: fmt.Sprintf("https://www.youtube.com/watch?v=%s", pe.videoID),
+					EmbedURL: fmt.Sprintf("https://www.youtube.com/embed/%s", pe.videoID),
+				}
+				if m, ok := meta[pe.videoID]; ok {
+					row.Title = m.title
+					row.Description = m.description
+					row.ChannelTitle = m.channelTitle
+					row.PublishedAt = m.publishedAt
+					row.Duration = m.duration
+					row.ViewCount = m.viewCount
+					row.LikeCount = m.likeCount
+					row.ThumbnailURL = m.thumbnailURL
+				} else {
+					row.MetadataError = "metadata not returned by videos.list (video may be private or deleted)"
+				}
+				rows[i] = row
+			}
+
+			if !noTranscript {
+				// Per-video transcript fetch, bounded concurrency. Each fetch
+				// gets its own timeout so one slow video can't stall the pool.
+				type tResult struct {
+					idx        int
+					transcript *transcriptResult
+					err        error
+				}
+				idxs := make([]int, len(rows))
+				for i := range rows {
+					idxs[i] = i
+				}
+				results, ferrs := cliutil.FanoutRun(
+					cmd.Context(),
+					idxs,
+					func(i int) string { return rows[i].VideoID },
+					func(ctx context.Context, i int) (tResult, error) {
+						tctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+						defer cancel()
+						tr, terr := fetchTranscriptForVideo(tctx, rows[i].VideoID, lang)
+						return tResult{idx: i, transcript: tr, err: terr}, nil
+					},
+					cliutil.WithConcurrency(concurrency),
+				)
+				for _, r := range results {
+					if r.Value.err != nil {
+						rows[r.Value.idx].TranscriptError = r.Value.err.Error()
+					} else {
+						rows[r.Value.idx].Transcript = r.Value.transcript
+					}
+				}
+				// Fanout-level errors (cancellation, panic) surface to stderr;
+				// they're rare but must not be silently dropped.
+				cliutil.FanoutReportErrors(cmd.ErrOrStderr(), ferrs)
+			}
+
+			out.Videos = rows
+			out.Returned = len(rows)
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
+		},
+	}
+
+	cmd.Flags().IntVar(&startIndex, "start-index", 0, "0-based index into the playlist to start enrichment from")
+	cmd.Flags().IntVar(&limit, "limit", 25, "Number of videos to enrich starting at --start-index")
+	cmd.Flags().StringVar(&lang, "lang", "en", "Caption language code for transcripts")
+	cmd.Flags().BoolVar(&noTranscript, "no-transcript", false, "Skip transcript fetch (metadata + description only)")
+	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Max concurrent transcript fetches")
+
+	return cmd
+}
+
+// apiGetter is the slice of *client.Client the enrichment helpers depend on.
+// Narrowing to this interface keeps the helpers testable without constructing
+// a full client and avoids importing the client package in helper signatures.
+type apiGetter interface {
+	GetWithHeaders(path string, params, headers map[string]string) (json.RawMessage, error)
+}
+
+// playlistEntry is one resolved playlist item before metadata enrichment.
+type playlistEntry struct {
+	videoID  string
+	title    string
+	position int
+}
+
+// videoMeta is the subset of videos.list fields we surface per row.
+type videoMeta struct {
+	title        string
+	description  string
+	channelTitle string
+	publishedAt  string
+	duration     string
+	viewCount    string
+	likeCount    string
+	thumbnailURL string
+}
+
+// parsePlaylistID extracts a playlist ID from a URL or returns the input if it
+// already looks like a bare playlist ID. Recognizes the `list=` query param on
+// playlist and watch URLs, and bare IDs with the known playlist prefixes.
+func parsePlaylistID(in string) string {
+	if in == "" {
+		return ""
+	}
+	if strings.Contains(in, "://") {
+		if u, err := url.Parse(in); err == nil {
+			if id := u.Query().Get("list"); id != "" {
+				return id
+			}
+		}
+	}
+	// Bare ID? YouTube playlist IDs start with PL, UU, LL, FL, RD, OL, etc.
+	// Accept any token that has no spaces and no scheme — videos.list will
+	// reject a genuinely bad ID with a clean API error.
+	if !strings.ContainsAny(in, " \t/?&") {
+		return in
+	}
+	return ""
+}
+
+// walkPlaylistItems pages playlistItems.list until it has at least `needed`
+// video IDs or the playlist ends. maxPages caps quota use; under verify env we
+// cap hard so the verifier's per-command timeout isn't tripped.
+func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFlags) ([]playlistEntry, []string, error) {
+	var warnings []string
+	maxPages := (needed + 49) / 50
+	if maxPages < 1 {
+		maxPages = 1
+	}
+	if maxPages > 10 {
+		maxPages = 10
+		warnings = append(warnings, "playlist walk capped at 500 items (10 pages of 50)")
+	}
+	if cliutil.IsVerifyEnv() && maxPages > 1 {
+		maxPages = 1
+	}
+
+	ordered := []playlistEntry{}
+	pageToken := ""
+	for page := 0; page < maxPages; page++ {
+		params := map[string]string{
+			"playlistId": playlistID,
+			"part":       "snippet,contentDetails",
+			"maxResults": "50",
+		}
+		if pageToken != "" {
+			params["pageToken"] = pageToken
+		}
+		data, err := c.GetWithHeaders("/youtube/v3/playlistItems", params, nil)
+		if err != nil {
+			if page == 0 {
+				return nil, warnings, classifyAPIError(err, flags)
+			}
+			warnings = append(warnings, fmt.Sprintf("playlist page %d fetch failed: %v", page+1, err))
+			break
+		}
+		var resp struct {
+			NextPageToken string `json:"nextPageToken"`
+			Items         []struct {
+				Snippet struct {
+					Title      string `json:"title"`
+					Position   int    `json:"position"`
+					ResourceID struct {
+						VideoID string `json:"videoId"`
+					} `json:"resourceId"`
+				} `json:"snippet"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, warnings, apiErr(fmt.Errorf("parse playlistItems page %d: %w", page+1, err))
+		}
+		for _, it := range resp.Items {
+			vid := it.Snippet.ResourceID.VideoID
+			if vid == "" {
+				continue
+			}
+			ordered = append(ordered, playlistEntry{
+				videoID:  vid,
+				title:    html.UnescapeString(it.Snippet.Title),
+				position: it.Snippet.Position,
+			})
+		}
+		if len(ordered) >= needed || resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	if len(ordered) == 0 {
+		return nil, warnings, notFoundErr(fmt.Errorf("playlist %q returned no items (private, empty, or invalid ID)", playlistID))
+	}
+	return ordered, warnings, nil
+}
+
+// fetchPlaylistTitle resolves the playlist's display title via playlists.list.
+// Best-effort: returns "" on any error so enrichment is never blocked.
+func fetchPlaylistTitle(c apiGetter, playlistID string) string {
+	data, err := c.GetWithHeaders("/youtube/v3/playlists", map[string]string{
+		"id":   playlistID,
+		"part": "snippet",
+	}, nil)
+	if err != nil {
+		return ""
+	}
+	var resp struct {
+		Items []struct {
+			Snippet struct {
+				Title string `json:"title"`
+			} `json:"snippet"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil || len(resp.Items) == 0 {
+		return ""
+	}
+	return html.UnescapeString(resp.Items[0].Snippet.Title)
+}
+
+// fetchVideoMetadata batch-fetches videos.list (50 IDs per call) and returns a
+// map keyed by video ID. Per-batch errors become warnings, never abort.
+func fetchVideoMetadata(c apiGetter, entries []playlistEntry) (map[string]videoMeta, []string) {
+	meta := make(map[string]videoMeta, len(entries))
+	var warnings []string
+	const batchSize = 50
+	for start := 0; start < len(entries); start += batchSize {
+		end := start + batchSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		ids := make([]string, 0, end-start)
+		for _, e := range entries[start:end] {
+			ids = append(ids, e.videoID)
+		}
+		params := map[string]string{
+			"id":   strings.Join(ids, ","),
+			"part": "snippet,contentDetails,statistics",
+		}
+		data, err := c.GetWithHeaders("/youtube/v3/videos", params, nil)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("videos.list batch %d-%d failed: %v", start, end, err))
+			continue
+		}
+		var resp struct {
+			Items []struct {
+				ID      string `json:"id"`
+				Snippet struct {
+					Title        string `json:"title"`
+					Description  string `json:"description"`
+					ChannelTitle string `json:"channelTitle"`
+					PublishedAt  string `json:"publishedAt"`
+					Thumbnails   map[string]struct {
+						URL string `json:"url"`
+					} `json:"thumbnails"`
+				} `json:"snippet"`
+				ContentDetails struct {
+					Duration string `json:"duration"`
+				} `json:"contentDetails"`
+				Statistics struct {
+					ViewCount string `json:"viewCount"`
+					LikeCount string `json:"likeCount"`
+				} `json:"statistics"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			warnings = append(warnings, fmt.Sprintf("parse videos.list batch %d-%d: %v", start, end, err))
+			continue
+		}
+		for _, it := range resp.Items {
+			thumb := ""
+			for _, key := range []string{"high", "medium", "default"} {
+				if t, ok := it.Snippet.Thumbnails[key]; ok {
+					thumb = t.URL
+					break
+				}
+			}
+			meta[it.ID] = videoMeta{
+				title:        html.UnescapeString(it.Snippet.Title),
+				description:  html.UnescapeString(it.Snippet.Description),
+				channelTitle: html.UnescapeString(it.Snippet.ChannelTitle),
+				publishedAt:  it.Snippet.PublishedAt,
+				duration:     it.ContentDetails.Duration,
+				viewCount:    it.Statistics.ViewCount,
+				likeCount:    it.Statistics.LikeCount,
+				thumbnailURL: thumb,
+			}
+		}
+	}
+	return meta, warnings
+}
+
+// fetchTranscriptForVideo resolves and fetches a single video's transcript
+// using the existing InnerTube path. Returns a clean error for the per-row
+// transcriptError field on any failure.
+func fetchTranscriptForVideo(ctx context.Context, videoID, lang string) (*transcriptResult, error) {
+	tracks, err := fetchCaptionTracks(ctx, videoID)
+	if err != nil {
+		return nil, err
+	}
+	if len(tracks) == 0 {
+		return nil, fmt.Errorf("video has no captions")
+	}
+	picked, err := pickCaptionTrack(tracks, lang)
+	if err != nil {
+		return nil, err
+	}
+	kind := "manual"
+	if picked.Kind == "asr" {
+		kind = "asr"
+	}
+	return fetchJSON3Transcript(ctx, picked, videoID, lang, kind)
+}

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich.go
@@ -42,14 +42,17 @@ type enrichedVideo struct {
 }
 
 type playlistEnrichResponse struct {
-	PlaylistID    string          `json:"playlistId"`
-	PlaylistTitle string          `json:"playlistTitle,omitempty"`
-	TotalItems    int             `json:"totalItems"`
-	StartIndex    int             `json:"startIndex"`
-	Limit         int             `json:"limit"`
-	Returned      int             `json:"returned"`
-	Videos        []enrichedVideo `json:"videos"`
-	Warnings      []string        `json:"warnings,omitempty"`
+	PlaylistID    string `json:"playlistId"`
+	PlaylistTitle string `json:"playlistTitle,omitempty"`
+	// TotalItems is the playlist's full length (playlistItems.list
+	// pageInfo.totalResults), so startIndex+returned < totalItems is a valid
+	// "more pages exist" test even though only the scan window is enriched.
+	TotalItems int             `json:"totalItems"`
+	StartIndex int             `json:"startIndex"`
+	Limit      int             `json:"limit"`
+	Returned   int             `json:"returned"`
+	Videos     []enrichedVideo `json:"videos"`
+	Warnings   []string        `json:"warnings,omitempty"`
 }
 
 func newYoutubePlaylistEnrichCmd(flags *rootFlags) *cobra.Command {
@@ -112,11 +115,17 @@ func newYoutubePlaylistEnrichCmd(flags *rootFlags) *cobra.Command {
 			// walk so a giant playlist doesn't burn quota; we only need enough
 			// items to cover startIndex+limit.
 			needed := startIndex + limit
-			ordered, walkWarns, err := walkPlaylistItems(c, playlistID, needed, flags)
+			ordered, totalItems, walkWarns, err := walkPlaylistItems(c, playlistID, needed, flags)
 			if err != nil {
 				return err
 			}
-			out.TotalItems = len(ordered)
+			// totalItems is the playlist's true length (playlistItems.list
+			// pageInfo.totalResults), not the count we scanned. Fall back to
+			// the scanned count if the API omitted/under-reported it.
+			if totalItems < len(ordered) {
+				totalItems = len(ordered)
+			}
+			out.TotalItems = totalItems
 			out.Warnings = append(out.Warnings, walkWarns...)
 
 			// 3. Apply start-index / limit window over the resolved IDs.
@@ -268,8 +277,12 @@ func parsePlaylistID(in string) string {
 // walkPlaylistItems pages playlistItems.list until it has at least `needed`
 // video IDs or the playlist ends. maxPages caps quota use; under verify env we
 // cap hard so the verifier's per-command timeout isn't tripped.
-func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFlags) ([]playlistEntry, []string, error) {
+// walkPlaylistItems returns the ordered entries scanned (capped at needed/500),
+// the playlist's true total length (from pageInfo.totalResults on the first
+// page), and any warnings.
+func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFlags) ([]playlistEntry, int, []string, error) {
 	var warnings []string
+	var total int
 	maxPages := (needed + 49) / 50
 	if maxPages < 1 {
 		maxPages = 1
@@ -296,14 +309,17 @@ func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFl
 		data, err := c.GetWithHeaders("/youtube/v3/playlistItems", params, nil)
 		if err != nil {
 			if page == 0 {
-				return nil, warnings, classifyAPIError(err, flags)
+				return nil, 0, warnings, classifyAPIError(err, flags)
 			}
 			warnings = append(warnings, fmt.Sprintf("playlist page %d fetch failed: %v", page+1, err))
 			break
 		}
 		var resp struct {
 			NextPageToken string `json:"nextPageToken"`
-			Items         []struct {
+			PageInfo      struct {
+				TotalResults int `json:"totalResults"`
+			} `json:"pageInfo"`
+			Items []struct {
 				Snippet struct {
 					Title      string `json:"title"`
 					Position   int    `json:"position"`
@@ -314,7 +330,10 @@ func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFl
 			} `json:"items"`
 		}
 		if err := json.Unmarshal(data, &resp); err != nil {
-			return nil, warnings, apiErr(fmt.Errorf("parse playlistItems page %d: %w", page+1, err))
+			return nil, 0, warnings, apiErr(fmt.Errorf("parse playlistItems page %d: %w", page+1, err))
+		}
+		if page == 0 {
+			total = resp.PageInfo.TotalResults
 		}
 		for _, it := range resp.Items {
 			vid := it.Snippet.ResourceID.VideoID
@@ -333,9 +352,9 @@ func walkPlaylistItems(c apiGetter, playlistID string, needed int, flags *rootFl
 		pageToken = resp.NextPageToken
 	}
 	if len(ordered) == 0 {
-		return nil, warnings, notFoundErr(fmt.Errorf("playlist %q returned no items (private, empty, or invalid ID)", playlistID))
+		return nil, 0, warnings, notFoundErr(fmt.Errorf("playlist %q returned no items (private, empty, or invalid ID)", playlistID))
 	}
-	return ordered, warnings, nil
+	return ordered, total, warnings, nil
 }
 
 // fetchPlaylistTitle resolves the playlist's display title via playlists.list.

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import "testing"
+
+func TestParsePlaylistID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"playlist url", "https://www.youtube.com/playlist?list=PLkdrbggVaVRDNyR3b5SlqcI9Z0xJjShTh", "PLkdrbggVaVRDNyR3b5SlqcI9Z0xJjShTh"},
+		{"watch url with list", "https://www.youtube.com/watch?v=abc123&list=PLfoo", "PLfoo"},
+		{"bare PL id", "PLkdrbggVaVRDNyR3b5SlqcI9Z0xJjShTh", "PLkdrbggVaVRDNyR3b5SlqcI9Z0xJjShTh"},
+		{"bare UU id", "UUabcdefghijklmnopqrstuv", "UUabcdefghijklmnopqrstuv"},
+		{"url without list param", "https://www.youtube.com/watch?v=abc123", ""},
+		{"junk with spaces", "not a playlist", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parsePlaylistID(tc.in); got != tc.want {
+				t.Errorf("parsePlaylistID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseVideoID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"watch url", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"watch url with extra params", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLfoo&t=10s", "dQw4w9WgXcQ"},
+		{"youtu.be short", "https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"embed url", "https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"shorts url", "https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"bare id", "dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"junk with spaces", "not a video", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseVideoID(tc.in); got != tc.want {
+				t.Errorf("parseVideoID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
@@ -38,9 +38,19 @@ func TestParseVideoID(t *testing.T) {
 		{"youtu.be short", "https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"embed url", "https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"shorts url", "https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"live url", "https://www.youtube.com/live/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"bare id", "dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"junk with spaces", "not a video", ""},
 		{"empty", "", ""},
+		// Non-video URLs must return "" so the caller errors clearly rather
+		// than passing a bogus ID to videos.list (Greptile #803).
+		{"channel /c/ url", "https://www.youtube.com/c/SomeChannel", ""},
+		{"channel /channel/ url", "https://www.youtube.com/channel/UCabcdefghijklmnopqrstuv", ""},
+		{"user url", "https://www.youtube.com/user/SomeUser", ""},
+		{"playlist url", "https://www.youtube.com/playlist?list=PLfoo", ""},
+		{"handle url", "https://www.youtube.com/@SomeHandle", ""},
+		{"too-short bare token", "abc", ""},
+		{"too-long bare token", "dQw4w9WgXcQ123", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_enrich.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_enrich.go
@@ -1,0 +1,99 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-20260523: novel command) — single-video analog of
+// playlist-enrich: one call returns a video's metadata + transcript +
+// description in the same enrichedVideo shape. Reuses fetchVideoMetadata
+// (videos.list) and fetchTranscriptForVideo (InnerTube); no hand-rolled
+// payloads. For the per-playlist version use playlist-enrich.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newYoutubeVideosEnrichCmd(flags *rootFlags) *cobra.Command {
+	var lang string
+	var noTranscript bool
+
+	cmd := &cobra.Command{
+		Use:         "videos-enrich <videoId|url>",
+		Short:       "Resolve a single video to metadata + transcript + description in one call",
+		Example:     "  youtube-pp-cli youtube videos-enrich dQw4w9WgXcQ",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
+
+			if dryRunOK(flags) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "GET /youtube/v3/videos (id=%s, part=snippet,contentDetails,statistics)\n", videoID)
+				if !noTranscript {
+					fmt.Fprintf(cmd.ErrOrStderr(), "POST https://www.youtube.com/youtubei/v1/player (videoId=%s)\n", videoID)
+				}
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			c = c.WithContext(cmd.Context())
+
+			// Position is playlist-only; it stays 0 for a standalone video.
+			row := enrichedVideo{
+				VideoID:  videoID,
+				Title:    videoID,
+				WatchURL: fmt.Sprintf("https://www.youtube.com/watch?v=%s", videoID),
+				EmbedURL: fmt.Sprintf("https://www.youtube.com/embed/%s", videoID),
+			}
+
+			// Metadata + description via videos.list (single-element batch).
+			meta, metaWarns := fetchVideoMetadata(c, []playlistEntry{{videoID: videoID}})
+			for _, w := range metaWarns {
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning:", w)
+			}
+			if m, ok := meta[videoID]; ok {
+				row.Title = m.title
+				row.Description = m.description
+				row.ChannelTitle = m.channelTitle
+				row.PublishedAt = m.publishedAt
+				row.Duration = m.duration
+				row.ViewCount = m.viewCount
+				row.LikeCount = m.likeCount
+				row.ThumbnailURL = m.thumbnailURL
+			} else {
+				row.MetadataError = "metadata not returned by videos.list (video may be private, deleted, or the ID is wrong)"
+			}
+
+			if !noTranscript {
+				tctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+				defer cancel()
+				tr, terr := fetchTranscriptForVideo(tctx, videoID, lang)
+				if terr != nil {
+					row.TranscriptError = terr.Error()
+				} else {
+					row.Transcript = tr
+				}
+			}
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(row)
+		},
+	}
+
+	cmd.Flags().StringVar(&lang, "lang", "en", "Caption language code for the transcript")
+	cmd.Flags().BoolVar(&noTranscript, "no-transcript", false, "Skip transcript fetch (metadata + description only)")
+	return cmd
+}

--- a/library/media-and-entertainment/youtube/internal/cli/videos_enrich_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_enrich_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// fakeAPIGetter satisfies apiGetter with a canned response, so the metadata
+// path that videos-enrich and playlist-enrich share can be tested without a
+// real client or network.
+type fakeAPIGetter struct {
+	data json.RawMessage
+	err  error
+}
+
+func (f fakeAPIGetter) GetWithHeaders(string, map[string]string, map[string]string) (json.RawMessage, error) {
+	return f.data, f.err
+}
+
+func TestFetchVideoMetadata(t *testing.T) {
+	resp := `{"items":[{
+		"id":"vid12345678",
+		"snippet":{
+			"title":"Bread &amp; Butter",
+			"description":"see &lt;link&gt; below",
+			"channelTitle":"Baker &amp; Co",
+			"publishedAt":"2020-01-02T03:04:05Z",
+			"thumbnails":{"default":{"url":"https://i/d.jpg"},"high":{"url":"https://i/h.jpg"}}
+		},
+		"contentDetails":{"duration":"PT3M34S"},
+		"statistics":{"viewCount":"1775537066","likeCount":"42"}
+	}]}`
+
+	meta, warns := fetchVideoMetadata(fakeAPIGetter{data: json.RawMessage(resp)},
+		[]playlistEntry{{videoID: "vid12345678"}})
+	if len(warns) != 0 {
+		t.Fatalf("unexpected warnings: %v", warns)
+	}
+	m, ok := meta["vid12345678"]
+	if !ok {
+		t.Fatal("expected vid12345678 in metadata map")
+	}
+	// HTML entities must be decoded (matches the existing novel commands).
+	if m.title != "Bread & Butter" {
+		t.Errorf("title = %q, want %q", m.title, "Bread & Butter")
+	}
+	if m.description != "see <link> below" {
+		t.Errorf("description = %q, want %q", m.description, "see <link> below")
+	}
+	if m.channelTitle != "Baker & Co" {
+		t.Errorf("channelTitle = %q, want %q", m.channelTitle, "Baker & Co")
+	}
+	// Thumbnail priority is high > medium > default.
+	if m.thumbnailURL != "https://i/h.jpg" {
+		t.Errorf("thumbnailURL = %q, want the high thumbnail", m.thumbnailURL)
+	}
+	if m.duration != "PT3M34S" || m.viewCount != "1775537066" || m.likeCount != "42" {
+		t.Errorf("scalar fields wrong: dur=%q views=%q likes=%q", m.duration, m.viewCount, m.likeCount)
+	}
+}
+
+func TestFetchVideoMetadataThumbnailFallback(t *testing.T) {
+	// Only a default thumbnail present — must fall back to it.
+	resp := `{"items":[{"id":"vidABCDEFGH","snippet":{"title":"x","thumbnails":{"default":{"url":"https://i/d.jpg"}}}}]}`
+	meta, _ := fetchVideoMetadata(fakeAPIGetter{data: json.RawMessage(resp)},
+		[]playlistEntry{{videoID: "vidABCDEFGH"}})
+	if got := meta["vidABCDEFGH"].thumbnailURL; got != "https://i/d.jpg" {
+		t.Errorf("thumbnailURL = %q, want default fallback", got)
+	}
+}
+
+func TestFetchVideoMetadataMissingVideo(t *testing.T) {
+	// videos.list returns no items (private/deleted/bad ID): the video must be
+	// absent from the map so the caller can set metadataError.
+	meta, warns := fetchVideoMetadata(fakeAPIGetter{data: json.RawMessage(`{"items":[]}`)},
+		[]playlistEntry{{videoID: "missing1234"}})
+	if _, ok := meta["missing1234"]; ok {
+		t.Error("expected missing video to be absent from metadata map")
+	}
+	if len(warns) != 0 {
+		t.Errorf("empty items is not a warning condition, got: %v", warns)
+	}
+}

--- a/library/media-and-entertainment/youtube/internal/cli/videos_links.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_links.go
@@ -47,6 +47,11 @@ type videoLinksResponse struct {
 // trimmed after the match so a URL ending a sentence doesn't keep its period.
 var urlRegex = regexp.MustCompile(`https?://[^\s<>"')\]]+`)
 
+// videoIDRe matches a bare YouTube video ID: exactly 11 chars from the
+// URL-safe base64 alphabet. Used to reject channel/playlist/user URLs whose
+// final path segment is not a video ID.
+var videoIDRe = regexp.MustCompile(`^[A-Za-z0-9_-]{11}$`)
+
 // knownShorteners are hosts whose links we expand to a final URL when
 // --resolve is on. Match is on exact host (case-insensitive, www-stripped).
 var knownShorteners = map[string]bool{
@@ -196,11 +201,14 @@ func isNoisyHost(host string) bool {
 }
 
 // resolveRedirect follows redirects for a short link and returns the final
-// URL. Uses a bounded timeout so a dead shortener can't hang the command.
+// URL. The 8s context (shared across the HEAD+GET fallback) is the sole bound,
+// so a dead shortener can't hang the command.
 func resolveRedirect(ctx context.Context, rawURL string) (string, error) {
 	rctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
-	client := &http.Client{Timeout: 8 * time.Second}
+	// No http.Client.Timeout: both requests run under rctx via
+	// NewRequestWithContext, so a per-client timeout would be dead code.
+	client := &http.Client{}
 	// HEAD first (cheap); some shorteners only redirect on GET, so fall back.
 	for _, method := range []string{http.MethodHead, http.MethodGet} {
 		req, err := http.NewRequestWithContext(rctx, method, rawURL, nil)
@@ -254,30 +262,42 @@ func fetchVideoSnippet(ctx context.Context, flags *rootFlags, videoID string) (t
 		html.UnescapeString(resp.Items[0].Snippet.Description), nil
 }
 
-// parseVideoID extracts a video ID from a watch/short/embed URL, or returns the
-// input when it already looks like a bare 11-char video ID.
+// parseVideoID extracts an 11-char video ID from a watch/shorts/embed/live URL
+// or a bare ID. It deliberately returns "" for channel, playlist, and user URLs
+// (e.g. /c/Name, /channel/UC…, /user/Name, /playlist?list=…) rather than
+// guessing a non-video path segment, so the caller can report a clear
+// "could not extract a video ID" error instead of a confusing "video X not
+// found" after a wasted videos.list call.
 func parseVideoID(in string) string {
 	if in == "" {
 		return ""
 	}
 	if strings.Contains(in, "://") {
-		if u, err := url.Parse(in); err == nil {
-			if v := u.Query().Get("v"); v != "" {
-				return v
-			}
-			// youtu.be/<id> or /embed/<id> or /shorts/<id>
-			parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-			if len(parts) > 0 {
-				last := parts[len(parts)-1]
-				if last != "" {
-					return last
-				}
+		u, err := url.Parse(in)
+		if err != nil {
+			return ""
+		}
+		if v := u.Query().Get("v"); videoIDRe.MatchString(v) {
+			return v
+		}
+		// Only known video-bearing shapes carry an ID in the path:
+		// youtu.be/<id>, /embed/<id>, /shorts/<id>, /live/<id>.
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) > 0 {
+			last := parts[len(parts)-1]
+			fromShortHost := strings.EqualFold(u.Hostname(), "youtu.be")
+			fromVideoPath := len(parts) >= 2 &&
+				(parts[len(parts)-2] == "embed" ||
+					parts[len(parts)-2] == "shorts" ||
+					parts[len(parts)-2] == "live")
+			if (fromShortHost || fromVideoPath) && videoIDRe.MatchString(last) {
+				return last
 			}
 		}
 		return ""
 	}
-	// Bare ID: no scheme, no spaces.
-	if !strings.ContainsAny(in, " \t/?&") {
+	// Bare ID.
+	if videoIDRe.MatchString(in) {
 		return in
 	}
 	return ""

--- a/library/media-and-entertainment/youtube/internal/cli/videos_links.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_links.go
@@ -1,0 +1,284 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH(amend-20260523: novel command) — extracts HTTP(S) links from a video
+// description (real videos.list call), expands known short-link redirects, and
+// filters social/storefront noise. Brings the CLI to parity with the
+// yt-video-mcp fetch_description tool. Calls the real Data API; redirect
+// resolution follows public redirects only and is short-circuited under verify
+// env so the verifier never dials out.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/youtube/internal/cliutil"
+
+	"github.com/spf13/cobra"
+)
+
+type descriptionLink struct {
+	URL          string `json:"url"`
+	Host         string `json:"host"`
+	Shortener    bool   `json:"shortener"`
+	FinalURL     string `json:"finalUrl,omitempty"`
+	FinalHost    string `json:"finalHost,omitempty"`
+	Skipped      bool   `json:"skipped,omitempty"`
+	SkipReason   string `json:"skipReason,omitempty"`
+	ResolveError string `json:"resolveError,omitempty"`
+}
+
+type videoLinksResponse struct {
+	VideoID  string            `json:"videoId"`
+	Title    string            `json:"title,omitempty"`
+	Returned int               `json:"returned"`
+	Links    []descriptionLink `json:"links"`
+}
+
+// urlRegex matches bare HTTP(S) URLs in free text. Trailing punctuation is
+// trimmed after the match so a URL ending a sentence doesn't keep its period.
+var urlRegex = regexp.MustCompile(`https?://[^\s<>"')\]]+`)
+
+// knownShorteners are hosts whose links we expand to a final URL when
+// --resolve is on. Match is on exact host (case-insensitive, www-stripped).
+var knownShorteners = map[string]bool{
+	"amzn.to":     true,
+	"bit.ly":      true,
+	"goo.gl":      true,
+	"ow.ly":       true,
+	"t.co":        true,
+	"tinyurl.com": true,
+	"buff.ly":     true,
+}
+
+// noisyHostSuffixes are storefront/social hosts skipped unless --include-social.
+// Matched as a suffix so subdomains (e.g. m.facebook.com) are covered.
+var noisyHostSuffixes = []string{
+	"instagram.com",
+	"twitter.com",
+	"x.com",
+	"tiktok.com",
+	"facebook.com",
+	"fb.com",
+	"patreon.com",
+	"threads.net",
+	"snapchat.com",
+	"discord.gg",
+	"discord.com",
+	"youtube.com",
+	"youtu.be",
+}
+
+func newYoutubeVideosLinksCmd(flags *rootFlags) *cobra.Command {
+	var resolve bool
+	var includeSocial bool
+
+	cmd := &cobra.Command{
+		Use:         "videos-links <videoId>",
+		Short:       "Extract resource links from a video's description (expands short links, skips social/storefront noise)",
+		Example:     "  youtube-pp-cli youtube videos-links dQw4w9WgXcQ",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
+
+			if dryRunOK(flags) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "GET /youtube/v3/videos (id=%s, part=snippet)\n", videoID)
+				if resolve {
+					fmt.Fprintln(cmd.ErrOrStderr(), "HEAD <shortener URLs> (redirect resolution)")
+				}
+				return nil
+			}
+
+			title, description, err := fetchVideoSnippet(cmd.Context(), flags, videoID)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			out := videoLinksResponse{VideoID: videoID, Title: title}
+			out.Links = extractDescriptionLinks(cmd.Context(), description, resolve, includeSocial)
+			// Returned counts non-skipped links so consumers see the
+			// resource-shaped total, not the raw match count.
+			for _, l := range out.Links {
+				if !l.Skipped {
+					out.Returned++
+				}
+			}
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
+		},
+	}
+
+	cmd.Flags().BoolVar(&resolve, "resolve", true, "Follow redirects for known short links to their final URL")
+	cmd.Flags().BoolVar(&includeSocial, "include-social", false, "Include social/storefront links instead of skipping them")
+
+	return cmd
+}
+
+// extractDescriptionLinks pulls URLs from the description, normalizes hosts,
+// flags shorteners and noisy hosts, and optionally resolves shorteners. It
+// dedupes by raw URL so a link repeated in the description appears once.
+func extractDescriptionLinks(ctx context.Context, description string, resolve, includeSocial bool) []descriptionLink {
+	matches := urlRegex.FindAllString(description, -1)
+	links := make([]descriptionLink, 0, len(matches))
+	seen := map[string]bool{}
+	for _, raw := range matches {
+		clean := strings.TrimRight(raw, ".,;:!?)\"'")
+		if clean == "" || seen[clean] {
+			continue
+		}
+		seen[clean] = true
+
+		host := hostOf(clean)
+		link := descriptionLink{
+			URL:       clean,
+			Host:      host,
+			Shortener: knownShorteners[host],
+		}
+
+		if !includeSocial && isNoisyHost(host) {
+			link.Skipped = true
+			link.SkipReason = "social/storefront host (use --include-social to keep)"
+			links = append(links, link)
+			continue
+		}
+
+		// Resolve known shorteners to their final URL. Skip outbound dials
+		// under verify env so the verifier never reaches the network.
+		if resolve && link.Shortener && !cliutil.IsVerifyEnv() {
+			final, ferr := resolveRedirect(ctx, clean)
+			if ferr != nil {
+				link.ResolveError = ferr.Error()
+			} else if final != "" && final != clean {
+				link.FinalURL = final
+				link.FinalHost = hostOf(final)
+			}
+		}
+		links = append(links, link)
+	}
+	return links
+}
+
+// hostOf returns the lowercased, www-stripped host of a URL, or "" on parse
+// failure.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(strings.ToLower(u.Hostname()), "www.")
+}
+
+// isNoisyHost reports whether host is (or is a subdomain of) a known
+// social/storefront host.
+func isNoisyHost(host string) bool {
+	for _, suffix := range noisyHostSuffixes {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveRedirect follows redirects for a short link and returns the final
+// URL. Uses a bounded timeout so a dead shortener can't hang the command.
+func resolveRedirect(ctx context.Context, rawURL string) (string, error) {
+	rctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	client := &http.Client{Timeout: 8 * time.Second}
+	// HEAD first (cheap); some shorteners only redirect on GET, so fall back.
+	for _, method := range []string{http.MethodHead, http.MethodGet} {
+		req, err := http.NewRequestWithContext(rctx, method, rawURL, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("User-Agent", watchPageUserAgent)
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		final := resp.Request.URL.String()
+		resp.Body.Close()
+		if final != "" && final != rawURL {
+			return final, nil
+		}
+	}
+	return "", nil
+}
+
+// fetchVideoSnippet pulls the title and description for a video in one
+// videos.list call.
+func fetchVideoSnippet(ctx context.Context, flags *rootFlags, videoID string) (title, description string, err error) {
+	c, err := flags.newClient()
+	if err != nil {
+		return "", "", err
+	}
+	c = c.WithContext(ctx)
+	data, err := c.GetWithHeaders("/youtube/v3/videos", map[string]string{
+		"id":   videoID,
+		"part": "snippet",
+	}, nil)
+	if err != nil {
+		return "", "", err
+	}
+	var resp struct {
+		Items []struct {
+			Snippet struct {
+				Title       string `json:"title"`
+				Description string `json:"description"`
+			} `json:"snippet"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", "", err
+	}
+	if len(resp.Items) == 0 {
+		return "", "", fmt.Errorf("video %s not found", videoID)
+	}
+	return html.UnescapeString(resp.Items[0].Snippet.Title),
+		html.UnescapeString(resp.Items[0].Snippet.Description), nil
+}
+
+// parseVideoID extracts a video ID from a watch/short/embed URL, or returns the
+// input when it already looks like a bare 11-char video ID.
+func parseVideoID(in string) string {
+	if in == "" {
+		return ""
+	}
+	if strings.Contains(in, "://") {
+		if u, err := url.Parse(in); err == nil {
+			if v := u.Query().Get("v"); v != "" {
+				return v
+			}
+			// youtu.be/<id> or /embed/<id> or /shorts/<id>
+			parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+			if len(parts) > 0 {
+				last := parts[len(parts)-1]
+				if last != "" {
+					return last
+				}
+			}
+		}
+		return ""
+	}
+	// Bare ID: no scheme, no spaces.
+	if !strings.ContainsAny(in, " \t/?&") {
+		return in
+	}
+	return ""
+}

--- a/library/media-and-entertainment/youtube/internal/cli/videos_links_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_links_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 justinwfu. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHostOf(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://www.example.com/path", "example.com"},
+		{"https://EXAMPLE.com", "example.com"},
+		{"https://sub.example.com/x", "sub.example.com"},
+		{"https://amzn.to/abc", "amzn.to"},
+		{"not a url", ""},
+	}
+	for _, tc := range cases {
+		if got := hostOf(tc.in); got != tc.want {
+			t.Errorf("hostOf(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsNoisyHost(t *testing.T) {
+	noisy := []string{"instagram.com", "m.facebook.com", "twitter.com", "x.com", "youtube.com", "youtu.be"}
+	for _, h := range noisy {
+		if !isNoisyHost(h) {
+			t.Errorf("isNoisyHost(%q) = false, want true", h)
+		}
+	}
+	clean := []string{"example.com", "github.com", "amzn.to", "nottwitter.com.evil.example"}
+	for _, h := range clean {
+		if isNoisyHost(h) {
+			t.Errorf("isNoisyHost(%q) = true, want false", h)
+		}
+	}
+}
+
+// extractDescriptionLinks with resolve=false performs no network I/O, so it is
+// safe to test directly. Covers dedupe, trailing-punctuation trim, shortener
+// flagging, and the social-skip filter.
+func TestExtractDescriptionLinks(t *testing.T) {
+	desc := `Check out my gear: https://amzn.to/3abc.
+Repo: https://github.com/foo/bar
+Follow me: https://instagram.com/me
+Dup: https://github.com/foo/bar
+Sentence end (https://example.com/page).`
+
+	t.Run("skips social by default", func(t *testing.T) {
+		links := extractDescriptionLinks(context.Background(), desc, false, false)
+		var resolved, skipped int
+		var sawShortener, sawTrimmed bool
+		for _, l := range links {
+			if l.Skipped {
+				skipped++
+				continue
+			}
+			resolved++
+			if l.Host == "amzn.to" && l.Shortener {
+				sawShortener = true
+			}
+			if l.URL == "https://example.com/page" {
+				sawTrimmed = true // trailing ). was trimmed
+			}
+		}
+		if !sawShortener {
+			t.Error("expected amzn.to flagged as shortener")
+		}
+		if !sawTrimmed {
+			t.Error("expected trailing punctuation trimmed from example.com link")
+		}
+		if skipped == 0 {
+			t.Error("expected instagram.com link to be skipped")
+		}
+		// github appears twice but must dedupe to one non-skipped link.
+		var githubCount int
+		for _, l := range links {
+			if l.Host == "github.com" {
+				githubCount++
+			}
+		}
+		if githubCount != 1 {
+			t.Errorf("expected github.com deduped to 1, got %d", githubCount)
+		}
+	})
+
+	t.Run("include-social keeps social", func(t *testing.T) {
+		links := extractDescriptionLinks(context.Background(), desc, false, true)
+		var sawInstagram bool
+		for _, l := range links {
+			if l.Host == "instagram.com" && !l.Skipped {
+				sawInstagram = true
+			}
+		}
+		if !sawInstagram {
+			t.Error("expected instagram.com kept with include-social")
+		}
+	})
+}

--- a/library/media-and-entertainment/youtube/internal/cli/youtube.go
+++ b/library/media-and-entertainment/youtube/internal/cli/youtube.go
@@ -28,5 +28,7 @@ func newYoutubeCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newYoutubeVideosRelatedCmd(flags))
 	cmd.AddCommand(newYoutubeVideosCommentsCmd(flags))
 	cmd.AddCommand(newYoutubeChannelUploadsCmd(flags))
+	cmd.AddCommand(newYoutubePlaylistEnrichCmd(flags))
+	cmd.AddCommand(newYoutubeVideosLinksCmd(flags))
 	return cmd
 }

--- a/library/media-and-entertainment/youtube/internal/cli/youtube.go
+++ b/library/media-and-entertainment/youtube/internal/cli/youtube.go
@@ -29,6 +29,7 @@ func newYoutubeCmd(flags *rootFlags) *cobra.Command {
 	cmd.AddCommand(newYoutubeVideosCommentsCmd(flags))
 	cmd.AddCommand(newYoutubeChannelUploadsCmd(flags))
 	cmd.AddCommand(newYoutubePlaylistEnrichCmd(flags))
+	cmd.AddCommand(newYoutubeVideosEnrichCmd(flags))
 	cmd.AddCommand(newYoutubeVideosLinksCmd(flags))
 	return cmd
 }


### PR DESCRIPTION
## Summary

Adds **three** read-only novel commands to `youtube-pp-cli`, bringing it to parity with (and past) the prior `yt-video-mcp` tools: `playlist-enrich` (a `fetch_playlist_full` equivalent), `videos-enrich` (the single-video analog of `playlist-enrich`), and `videos-links` (a `fetch_description` equivalent). All reuse the CLI's existing InnerTube transcript path and Data API client; no hand-rolled payloads.

_Review:_ the three Greptile P2 findings on the initial commits are resolved — see **Review Fixes** below.

## Published CLI Metadata

This PR modifies `library/media-and-entertainment/youtube/`.

**API:** `youtube` | **Category:** `media-and-entertainment` | **Press version:** `4.2.2`
**Spec:** `spec.yaml`
**Required env:** `YOUTUBE_API_KEY`

## What Changed

- **`youtube playlist-enrich <playlistUrlOrId>`** — resolves a playlist URL or ID to per-video metadata + transcript + description in one concurrent call. Pages `playlistItems.list` for video IDs, applies `--start-index`/`--limit` over the resolved list, batch-fetches `videos.list` metadata (50 IDs/call), and fans out per-video transcript fetches via `cliutil.FanoutRun` (`--concurrency`, default 4). Per-row failures become `transcriptError`/`metadataError` fields and never abort the run. `--no-transcript` skips transcripts; `--lang` picks caption language.
- **`youtube videos-links <videoId>`** — extracts HTTP(S) links from a video description (`videos.list` call), expands known short-link redirects (amzn.to, bit.ly, goo.gl, ow.ly, t.co, tinyurl.com, buff.ly) to their final URL under `--resolve` (default on), and skips social/storefront hosts unless `--include-social` is set.
- **`youtube videos-enrich <videoId|url>`** — the single-video analog of `playlist-enrich`: one call returns a video's metadata + transcript + description in the same `enrichedVideo` JSON shape (a single object, not an envelope). Reuses `fetchVideoMetadata` (`videos.list`) and `fetchTranscriptForVideo` (InnerTube). Same `--lang` / `--no-transcript` flags; parses watch/shorts/embed/`youtu.be`/bare-ID inputs and rejects channel/playlist URLs with a clear error. Collapses the previous `videos-list` + `videos-transcript` single-video chain into one call.
- Registered all three in `internal/cli/youtube.go`; appended patch entries to `.printing-press-patches.json`.

Both commands are `mcp:read-only`, honor `--dry-run`, and short-circuit outbound dials under the verify env (`cliutil.IsVerifyEnv()`). Redirect resolution is bounded by an 8s timeout so a dead shortener can't hang the command.

## Findings

| ID | Category | Type | Rationale |
|---|---|---|---|
| F1 | command-add | feature | Combined playlist enrichment — collapse playlistItems.list -> videos.list -> per-video transcript into one concurrent, paged call (fetch_playlist_full parity). |
| F2 | command-add | feature | Description resource-link extraction — pull links, expand shorteners, filter social/storefront noise (fetch_description parity). |
| F3 | command-add | feature | Single-video enrichment — `videos-enrich` returns one video's metadata + transcript + description in one call (single-video analog of `playlist-enrich`). |

## Review Fixes

Three Greptile P2 findings on the initial commits, all resolved (commit `5ecce8d3`):

1. **`videos-links` — dead `http.Client.Timeout`** in `resolveRedirect`: removed; the 8s `rctx` context already bounds both the HEAD and GET requests via `NewRequestWithContext`, so the per-client timeout was unreachable and misleading.
2. **`videos-links` — `parseVideoID` accepted any path segment**: tightened to require an 11-char video-ID shape and to read a path segment only for known video URLs (`youtu.be/`, `/embed/`, `/shorts/`, `/live/`). Channel/playlist/user URLs (`/c/`, `/channel/`, `/user/`, `@handle`, `/playlist`) now return `""` so the caller emits a clear `could not extract a video ID` error instead of a confusing `video X not found`. +7 regression tests.
3. **`playlist-enrich` — `totalItems` was the scanned count**: now reports the playlist's true length from `playlistItems.list` `pageInfo.totalResults`, so `startIndex + returned < totalItems` is a valid has-more test on large playlists.

## CLI Shape

```bash
$ youtube-pp-cli youtube playlist-enrich --help
Resolve a playlist to per-video metadata + transcript + description in one concurrent call

Usage:
  youtube-pp-cli youtube playlist-enrich <playlistUrlOrId> [flags]

Flags:
      --concurrency int   Max concurrent transcript fetches (default 4)
      --lang string       Caption language code for transcripts (default "en")
      --limit int         Number of videos to enrich starting at --start-index (default 25)
      --no-transcript     Skip transcript fetch (metadata + description only)
      --start-index int   0-based index into the playlist to start enrichment from

$ youtube-pp-cli youtube videos-enrich --help
Resolve a single video to metadata + transcript + description in one call

Usage:
  youtube-pp-cli youtube videos-enrich <videoId|url> [flags]

Flags:
      --lang string     Caption language code for the transcript (default "en")
      --no-transcript   Skip transcript fetch (metadata + description only)

$ youtube-pp-cli youtube videos-links --help
Extract resource links from a video's description (expands short links, skips social/storefront noise)

Usage:
  youtube-pp-cli youtube videos-links <videoId> [flags]

Flags:
      --include-social   Include social/storefront links instead of skipping them
      --resolve          Follow redirects for known short links to their final URL (default true)
```

## What This CLI Does

`youtube-pp-cli` wraps the YouTube Data API v3 for the search-to-content workflow: bulk search, transcripts, embed snippets, related videos, top comments, and channel uploads. These two additions extend it to whole-playlist enrichment and description-link harvesting.

## Manuscripts

Local amend-run artifacts (plan doc, scrub report) stay local by design and are not included in this PR.

## Validation

- [x] `go build ./...` from the touched CLI root — clean
- [x] `go vet ./...` from the touched CLI root — clean
- [x] `go test ./...` from the touched CLI root — pass (table-driven tests for parsePlaylistID, parseVideoID incl. 7 channel/playlist/user regression cases, hostOf, isNoisyHost, extractDescriptionLinks, and fetchVideoMetadata field-mapping / HTML-unescape / thumbnail-priority / missing-video)
- [x] `govulncheck ./...` from the touched CLI root — pass (via `cli-printing-press publish validate`)
- [x] `git diff --check` — clean
- [ ] `verify-skill` reports a **pre-existing** SKILL.md install-section drift on `upstream/main` (SKILL.md is untouched by this PR; the library refreshes generator-owned skill sections post-merge). All other 11 `publish validate` checks pass.

## Changes

```
 .../youtube/.printing-press-patches.json           |  36 ++
 .../youtube/internal/cli/playlist_enrich.go        | 475 +++++++++++++++++++
 .../youtube/internal/cli/playlist_enrich_test.go   |  62 +++
 .../youtube/internal/cli/videos_enrich.go          |  99 +++++
 .../youtube/internal/cli/videos_enrich_test.go     |  85 ++++
 .../youtube/internal/cli/videos_links.go           | 304 +++++++++++++
 .../youtube/internal/cli/videos_links_test.go      | 103 +++++
 .../youtube/internal/cli/youtube.go                |   3 +
 8 files changed, 1167 insertions(+)
```

## Gaps / Follow-Up

- Playlist title is resolved best-effort via `playlists.list`; a failure there is non-fatal and enrichment proceeds without the title.
- Transcript availability is per-video; captionless videos yield a `transcriptError` row, which is expected, not a failure.

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

