### PR TITLE
fix(fireflies): tolerate paid_required GraphQL errors

### DIFF
--- a/library/productivity/fireflies/internal/cli/transcripts_ff.go
+++ b/library/productivity/fireflies/internal/cli/transcripts_ff.go
@@ -32,7 +32,6 @@ query Transcript($id: String!) {
     privacy
     transcript_url
     audio_url
-    video_url
     is_live
     meeting_link
     calendar_type

--- a/library/productivity/fireflies/internal/gql/client.go
+++ b/library/productivity/fireflies/internal/gql/client.go
@@ -54,7 +54,22 @@ type response struct {
 }
 
 type gqlError struct {
-	Message string `json:"message"`
+	Message    string         `json:"message"`
+	Path       []any          `json:"path,omitempty"`
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
+// isPlanGated returns true if the error is a per-field plan restriction
+// (paid_required) rather than a request-wide failure. The Fireflies API
+// returns partial data alongside these so the caller can continue.
+func (e gqlError) isPlanGated() bool {
+	if e.Extensions == nil {
+		return false
+	}
+	if code, ok := e.Extensions["code"].(string); ok && code == "paid_required" {
+		return true
+	}
+	return false
 }
 
 // Do executes a GraphQL query and returns the raw data field.
@@ -104,6 +119,20 @@ func (c *Client) Do(ctx context.Context, query string, variables map[string]any)
 		return nil, fmt.Errorf("parsing response: %w", err)
 	}
 	if len(gqlResp.Errors) > 0 {
+		allPlanGated := true
+		var nonGated []string
+		for _, e := range gqlResp.Errors {
+			if !e.isPlanGated() {
+				allPlanGated = false
+				nonGated = append(nonGated, e.Message)
+			}
+		}
+		if !allPlanGated {
+			return nil, fmt.Errorf("GraphQL error: %s", nonGated[0])
+		}
+		if len(gqlResp.Data) > 0 {
+			return gqlResp.Data, nil
+		}
 		return nil, fmt.Errorf("GraphQL error: %s", gqlResp.Errors[0].Message)
 	}
 	return gqlResp.Data, nil


### PR DESCRIPTION
## Summary

The Fireflies GraphQL API returns per-field `paid_required` errors (in `extensions.code`) alongside partial data for fields like `video_url` that are gated behind paid plans. The previous client treated any non-empty `errors` array as a hard failure, dropping otherwise-valid transcript data on the floor for non-business-tier accounts.

This PR makes the GraphQL client tolerant of plan-gated errors and drops `video_url` from the transcript query so the round-trip isn't wasted on a guaranteed plan-gated field.

## Changes

- `internal/gql/client.go` — parse `extensions.code`, classify each error as plan-gated vs. genuine, return partial `data` when every error is plan-gated. Non-plan-gated errors still fail the request.
- `internal/cli/transcripts_ff.go` — remove `video_url` from the Transcript query (paid-tier field).

## Verification

- ` + "`go build ./...`" + ` clean
- ` + "`go vet ./...`" + ` clean
- Dogfooded against Shane's Fireflies account (non-business tier): ` + "`fireflies transcripts get <id>`" + ` now returns transcript data instead of failing with ` + "`GraphQL error: paid_required`" + `.

## Commits

1. ` + "`fix(fireflies): tolerate paid_required GraphQL errors`" + ` — client.go tolerance logic
2. ` + "`fix(fireflies): drop video_url from transcript query`" + ` — remove the field that triggers the gate