### PR TITLE
feat(agent-registry): add agent-facing catalog + install_module field

### DIFF
--- a/.github/workflows/generate-agent-registry.yml
+++ b/.github/workflows/generate-agent-registry.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Commit if changed
         run: |
           set -euo pipefail
-          if git diff --quiet -- agent-registry.json; then
+          # git status --porcelain (not git diff) so the brand-new,
+          # still-untracked agent-registry.json is detected on the first
+          # run — git diff only compares tracked files and would exit 0,
+          # silently skipping the initial commit.
+          if [ -z "$(git status --porcelain -- agent-registry.json)" ]; then
             echo "No agent-registry.json changes; nothing to commit."
             exit 0
           fi

--- a/.github/workflows/generate-agent-registry.yml
+++ b/.github/workflows/generate-agent-registry.yml
@@ -1,0 +1,59 @@
+name: Regenerate agent-registry.json
+
+# Regenerates agent-registry.json from each CLI's .printing-press.json
+# + tools-manifest.json after library/** changes land on main. Commits
+# with [skip ci] so the regen doesn't chain workflows. Source of truth
+# for the field shape: tools/generate-agent-registry/main.go.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'library/**/.printing-press.json'
+      - 'library/**/tools-manifest.json'
+      # Only MCP server main.go affects transport detection; the
+      # ~130 cmd/*-pp-cli/main.go files don't change output.
+      - 'library/**/cmd/*-pp-mcp/main.go'
+      - 'tools/generate-agent-registry/**'
+      - '.github/workflows/generate-agent-registry.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    name: Regenerate and commit
+    runs-on: ubuntu-latest
+    # Same single-lane concurrency the sibling regen workflows use:
+    # all three commit generated artifacts back to main and would
+    # otherwise race on non-fast-forward push.
+    concurrency:
+      group: generated-artifact-push-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.ADMIN_PUSH_PAT }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.3'
+      - name: Run generator
+        run: go run ./tools/generate-agent-registry/main.go
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- agent-registry.json; then
+            echo "No agent-registry.json changes; nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add agent-registry.json
+          git commit -m "chore(agent-registry): regenerate from library/ [skip ci]"
+          # Same rebase-before-push pattern the sibling regen workflows
+          # use to handle the concurrency-window race when a sibling
+          # workflow lands between our checkout and our push.
+          git pull --rebase origin main
+          git push

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -158,10 +158,10 @@ jobs:
           # making the whole step exit 1 with no stdout. awk's exit code
           # reflects script errors only, not match counts.
           touched=$(git log "${BASE_REMOTE_REF}..HEAD" --name-only --format= \
-            -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
+            -- 'registry.json' 'agent-registry.json' 'cli-skills/pp-*/SKILL.md' \
             | awk 'NF' | sort -u)
           differs=$(git diff --name-only "${BASE_REMOTE_REF}" HEAD \
-            -- 'registry.json' 'cli-skills/pp-*/SKILL.md' \
+            -- 'registry.json' 'agent-registry.json' 'cli-skills/pp-*/SKILL.md' \
             | sort -u)
 
           if [ -z "$touched" ] || [ -z "$differs" ]; then
@@ -179,11 +179,12 @@ jobs:
           echo "::error::This PR modifies generated artifacts that are regenerated post-merge:"
           while IFS= read -r file; do
             [ -z "$file" ] && continue
-            echo "::error file=${file}::Remove this file from the PR. It is regenerated post-merge by generate-registry.yml or generate-skills.yml."
+            echo "::error file=${file}::Remove this file from the PR. It is regenerated post-merge by generate-registry.yml, generate-agent-registry.yml, or generate-skills.yml."
           done <<< "$violations"
           echo
           echo "::error::Edit the source instead:"
-          echo "::error::  - registry.json source: library/<cat>/<slug>/.printing-press.json + manifest.json"
+          echo "::error::  - registry.json source:        library/<cat>/<slug>/.printing-press.json + manifest.json"
+          echo "::error::  - agent-registry.json source:  library/<cat>/<slug>/.printing-press.json + tools-manifest.json"
           echo "::error::  - cli-skills/pp-<slug>/SKILL.md source: library/<cat>/<slug>/SKILL.md"
           exit 1
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,72 @@ claude mcp add espn-pp-mcp -- espn-pp-mcp
 
 If a CLI needs credentials, the focused skill and the per-CLI README document the required environment variables.
 
+## Programmatic consumers
+
+Two machine-readable catalogs live at the repo root, generated post-merge from `library/`. Both are public surfaces — fetch them directly rather than parsing the README or walking `library/`.
+
+### `registry.json` — lean catalog for installers and humans
+
+Pulled by the npm installer in this repo and by any tool that needs the per-CLI identity, path, and MCP shape without the full per-endpoint tool list.
+
+```
+https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/registry.json
+```
+
+```json
+{
+  "schema_version": 2,
+  "entries": [
+    {
+      "name": "hackernews",
+      "category": "media-and-entertainment",
+      "api": "Hacker News",
+      "description": "...",
+      "search_terms": ["hackernews", "Hacker News", "..."],
+      "path": "library/media-and-entertainment/hackernews",
+      "install_module": "github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli",
+      "printer": "mvanhorn",
+      "printer_name": "Matt Van Horn",
+      "mcp": { "binary": "hackernews-pp-mcp", "transports": ["stdio"], "tool_count": 8, "public_tool_count": 6, "auth_type": "none", "env_vars": [], "mcp_ready": "full" }
+    }
+  ]
+}
+```
+
+`install_module` is the Go module path that `go install <install_module>@latest` resolves to. `search_terms` is a deduped keyword corpus (API/CLI name, description, novel-feature metadata) for consumers that rank CLIs by relevance. The `mcp` block is present only on CLIs that ship an MCP server companion. Generator: [`tools/generate-registry/main.go`](tools/generate-registry/main.go).
+
+### `agent-registry.json` — agent-facing catalog with per-CLI tool tree
+
+Built for agent runners that need the full tool list per CLI without making a fan-out of N+1 HTTP requests to fetch each CLI's `tools-manifest.json` separately. External consumers like [cocoon](https://github.com/vu1n/cocoon) (lazy CLI/MCP runner over the printing-press corpus) are the design target.
+
+```
+https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/agent-registry.json
+```
+
+```json
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "name": "hackernews",
+      "api": "Hacker News",
+      "category": "media-and-entertainment",
+      "description": "...",
+      "install_module": "github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli",
+      "skill": "pp-hackernews",
+      "auth": { "type": "none", "env_vars": [] },
+      "mcp": { "binary": "hackernews-pp-mcp", "transports": ["stdio", "http"], "tool_count": 10, "public_tool_count": 10, "env_vars": [], "mcp_ready": "full" },
+      "tools_source": "tools-manifest",
+      "tools": [ { "name": "items_get", "description": "...", "params": [ ... ] } ]
+    }
+  ]
+}
+```
+
+`tools` is the verbatim contents of each CLI's `tools-manifest.json` `tools[]` array. Docs-driven and sniff-driven CLIs ship no static manifest; those emit `tools: null` with `tools_source: "agent-context"`, signaling that the consumer should call `<binary> agent-context` after install to capture the live command tree. Generator: [`tools/generate-agent-registry/main.go`](tools/generate-agent-registry/main.go).
+
+Schema bumps for either file land via their top-level `schema_version`. Regen runs post-merge on `library/**` changes, so a freshly-merged CLI is in both catalogs within minutes.
+
 ## Repo structure
 
 ```text

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -18,8 +18,6 @@ export interface RegistryEntry {
   description: string;
   search_terms?: string[];
   path: string;
-  // Optional so cached older payloads without the field don't fail parsing.
-  install_module?: string;
   mcp?: MCPBlock;
 }
 

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -18,6 +18,8 @@ export interface RegistryEntry {
   description: string;
   search_terms?: string[];
   path: string;
+  // Optional so cached older payloads without the field don't fail parsing.
+  install_module?: string;
   mcp?: MCPBlock;
 }
 

--- a/tools/generate-agent-registry/go.mod
+++ b/tools/generate-agent-registry/go.mod
@@ -1,0 +1,3 @@
+module generate-agent-registry
+
+go 1.23

--- a/tools/generate-agent-registry/main.go
+++ b/tools/generate-agent-registry/main.go
@@ -1,0 +1,349 @@
+// generate-agent-registry emits agent-registry.json — the agent-facing
+// counterpart to registry.json that inlines each CLI's tools-manifest
+// so consumers don't fan out N+1 HTTP requests to assemble the catalog.
+//
+// Per-entry sources: library/<cat>/<slug>/.printing-press.json (identity,
+// install, auth, MCP) and library/<cat>/<slug>/tools-manifest.json (the
+// tool list, passed through verbatim). CLIs without a tools-manifest
+// emit tools=null with tools_source="agent-context"; consumers capture
+// the live tree via `<binary> agent-context` after install.
+//
+// Usage:
+//
+//	go run ./tools/generate-agent-registry             # write agent-registry.json
+//	go run ./tools/generate-agent-registry --check     # exit non-zero if drift detected
+//	go run ./tools/generate-agent-registry --print     # print to stdout, do not write
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	libraryDir          = "library"
+	outputPath          = "agent-registry.json"
+	schemaVersion       = 1
+	toolsSourceManifest = "tools-manifest"
+	toolsSourceAgentCtx = "agent-context"
+)
+
+type AgentRegistry struct {
+	SchemaVersion int          `json:"schema_version"`
+	Entries       []AgentEntry `json:"entries"`
+}
+
+type AgentEntry struct {
+	Name          string    `json:"name"`
+	API           string    `json:"api"`
+	Category      string    `json:"category"`
+	Description   string    `json:"description"`
+	InstallModule string    `json:"install_module"`
+	Skill         string    `json:"skill"`
+	Auth          AuthBlock `json:"auth"`
+	MCP           *MCPBlock `json:"mcp,omitempty"`
+	// ToolsSource is "tools-manifest" when Tools is the verbatim
+	// upstream array, "agent-context" when Tools is null and consumers
+	// must capture the live tree via `<binary> agent-context`.
+	ToolsSource string            `json:"tools_source"`
+	Tools       []json.RawMessage `json:"tools"`
+}
+
+type AuthBlock struct {
+	// Consumers should treat unknown Type values as "credentials
+	// required" rather than hard-failing — new auth types may land
+	// before consumer updates.
+	Type    string   `json:"type"`
+	EnvVars []string `json:"env_vars"`
+}
+
+type MCPBlock struct {
+	Binary          string   `json:"binary"`
+	Transports      []string `json:"transports"`
+	ToolCount       int      `json:"tool_count"`
+	PublicToolCount int      `json:"public_tool_count"`
+	EnvVars         []string `json:"env_vars"`
+	MCPReady        string   `json:"mcp_ready,omitempty"`
+}
+
+type printingPressManifest struct {
+	APIName            string   `json:"api_name"`
+	DisplayName        string   `json:"display_name"`
+	Description        string   `json:"description"`
+	AuthType           string   `json:"auth_type"`
+	AuthEnvVars        []string `json:"auth_env_vars"`
+	MCPBinary          string   `json:"mcp_binary"`
+	MCPToolCount       int      `json:"mcp_tool_count"`
+	MCPPublicToolCount *int     `json:"mcp_public_tool_count"`
+	MCPReady           string   `json:"mcp_ready"`
+}
+
+// toolsManifest is the read-subset of tools-manifest.json: the auth
+// block (runtime-authoritative when .printing-press.json's auth_type
+// is empty) and the tools array (passed through as json.RawMessage
+// so we don't strip fields the manifest carries that we don't model).
+type toolsManifest struct {
+	Auth  *toolsManifestAuth `json:"auth"`
+	Tools []json.RawMessage  `json:"tools"`
+}
+
+type toolsManifestAuth struct {
+	Type string `json:"type"`
+}
+
+func main() {
+	check := flag.Bool("check", false, "exit non-zero if generated output differs from on-disk agent-registry.json")
+	printOnly := flag.Bool("print", false, "print generated registry to stdout instead of writing")
+	flag.Parse()
+
+	entries, err := buildEntries(libraryDir)
+	if err != nil {
+		log.Fatalf("building entries: %v", err)
+	}
+
+	registry := AgentRegistry{
+		SchemaVersion: schemaVersion,
+		Entries:       entries,
+	}
+
+	out, err := marshalRegistry(registry)
+	if err != nil {
+		log.Fatalf("marshaling: %v", err)
+	}
+
+	if *printOnly {
+		if _, err := os.Stdout.Write(out); err != nil {
+			log.Fatalf("writing to stdout: %v", err)
+		}
+		return
+	}
+
+	if *check {
+		current, err := os.ReadFile(outputPath)
+		if err != nil {
+			log.Fatalf("reading %s for check: %v", outputPath, err)
+		}
+		if !bytes.Equal(current, out) {
+			fmt.Fprintf(os.Stderr, "drift detected in %s\nRun `go run ./tools/generate-agent-registry` and commit the result.\n", outputPath)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "%s is in sync with library/\n", outputPath)
+		return
+	}
+
+	if err := os.WriteFile(outputPath, out, 0o644); err != nil {
+		log.Fatalf("writing %s: %v", outputPath, err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote %s (%d entries)\n", outputPath, len(entries))
+}
+
+func buildEntries(root string) ([]AgentEntry, error) {
+	categories, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("reading library dir: %w", err)
+	}
+	var entries []AgentEntry
+	for _, cat := range categories {
+		if !cat.IsDir() {
+			continue
+		}
+		catPath := filepath.Join(root, cat.Name())
+		slugs, err := os.ReadDir(catPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", catPath, err)
+		}
+		for _, slug := range slugs {
+			if !slug.IsDir() {
+				continue
+			}
+			cliDir := filepath.Join(catPath, slug.Name())
+			entry, err := buildEntry(cliDir, cat.Name(), slug.Name())
+			if err != nil {
+				return nil, fmt.Errorf("building entry for %s: %w", cliDir, err)
+			}
+			if entry == nil {
+				continue
+			}
+			entries = append(entries, *entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+	return entries, nil
+}
+
+// buildEntry returns (nil, nil) when the directory carries no
+// .printing-press.json — the gate for "is this an actual CLI directory?"
+// that lets unrelated scratch dirs coexist under library/.
+func buildEntry(dir, category, slug string) (*AgentEntry, error) {
+	pp, err := readPrintingPressManifest(filepath.Join(dir, ".printing-press.json"))
+	if err != nil {
+		return nil, err
+	}
+	if pp == nil {
+		return nil, nil
+	}
+	tm, err := readToolsManifest(filepath.Join(dir, "tools-manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	pathSlash := filepath.ToSlash(dir)
+	entry := AgentEntry{
+		Name:          slug,
+		API:           pickAPIName(pp, slug),
+		Category:      category,
+		Description:   pp.Description,
+		InstallModule: installModulePath(pathSlash, slug),
+		Skill:         "pp-" + slug,
+		Auth: AuthBlock{
+			Type:    pickAuthType(pp, tm),
+			EnvVars: nonNilStrings(pp.AuthEnvVars),
+		},
+	}
+
+	if pp.MCPBinary != "" {
+		// EnvVars sources from pp.AuthEnvVars: by convention the MCP
+		// server and the CLI share credentials, matching the source
+		// generate-registry uses for registry.json's mcp.env_vars.
+		mcp := &MCPBlock{
+			Binary:     pp.MCPBinary,
+			Transports: detectMCPTransports(dir, pp.MCPBinary),
+			ToolCount:  pp.MCPToolCount,
+			EnvVars:    nonNilStrings(pp.AuthEnvVars),
+			MCPReady:   pp.MCPReady,
+		}
+		if pp.MCPPublicToolCount != nil {
+			mcp.PublicToolCount = *pp.MCPPublicToolCount
+		}
+		entry.MCP = mcp
+	}
+
+	if tm != nil {
+		entry.ToolsSource = toolsSourceManifest
+		entry.Tools = tm.Tools
+	} else {
+		entry.ToolsSource = toolsSourceAgentCtx
+	}
+
+	return &entry, nil
+}
+
+// pickAuthType resolves the auth.type field through three tiers:
+// the press manifest (authoritative when populated), the tools-manifest
+// (runtime-authoritative — what the binary actually consumes), and
+// finally "none" so consumers see a stable non-empty string.
+func pickAuthType(pp *printingPressManifest, tm *toolsManifest) string {
+	if pp.AuthType != "" {
+		return pp.AuthType
+	}
+	if tm != nil && tm.Auth != nil && tm.Auth.Type != "" {
+		return tm.Auth.Type
+	}
+	return "none"
+}
+
+// readPrintingPressManifest returns (nil, nil) when the file is absent;
+// any other read or parse error is fatal.
+func readPrintingPressManifest(path string) (*printingPressManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var pp printingPressManifest
+	if err := json.Unmarshal(data, &pp); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &pp, nil
+}
+
+// readToolsManifest returns (nil, nil) when tools-manifest.json is
+// absent (docs-driven / sniff-driven CLIs ship none).
+func readToolsManifest(path string) (*toolsManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var tm toolsManifest
+	if err := json.Unmarshal(data, &tm); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &tm, nil
+}
+
+// pickAPIName resolves the api display name: display_name > api_name > slug.
+// Reproducible from sources only — unlike generate-registry's equivalent,
+// we don't curate from a prior agent-registry.json.
+func pickAPIName(pp *printingPressManifest, slug string) string {
+	if pp.DisplayName != "" {
+		return pp.DisplayName
+	}
+	if pp.APIName != "" {
+		return pp.APIName
+	}
+	return slug
+}
+
+// detectMCPTransports source-greps the MCP binary's main.go: stdio is
+// always linked; streamable-HTTP is reported only when
+// NewStreamableHTTPServer is referenced. Kept in lockstep with
+// generate-registry's identical helper — the two tools live in
+// separate modules and don't share code yet.
+func detectMCPTransports(cliDir, binary string) []string {
+	transports := []string{"stdio"}
+	if binary == "" {
+		return transports
+	}
+	mainPath := filepath.Join(cliDir, "cmd", binary, "main.go")
+	data, err := os.ReadFile(mainPath)
+	if err != nil {
+		return transports
+	}
+	if bytes.Contains(data, []byte("NewStreamableHTTPServer")) {
+		transports = append(transports, "http")
+	}
+	return transports
+}
+
+// installModulePath duplicates generate-registry's helper; see the note
+// on detectMCPTransports above.
+func installModulePath(path, slug string) string {
+	if path == "" || slug == "" {
+		return ""
+	}
+	return fmt.Sprintf("github.com/mvanhorn/printing-press-library/%s/cmd/%s-pp-cli", path, slug)
+}
+
+// nonNilStrings ensures JSON encodes empty arrays as [] not null.
+func nonNilStrings(src []string) []string {
+	if src == nil {
+		return []string{}
+	}
+	return src
+}
+
+// marshalRegistry produces the canonical encoding: 2-space indent, no
+// HTML escaping, trailing newline.
+func marshalRegistry(r AgentRegistry) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(r); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/tools/generate-agent-registry/main.go
+++ b/tools/generate-agent-registry/main.go
@@ -228,7 +228,10 @@ func buildEntry(dir, category, slug string) (*AgentEntry, error) {
 
 	if tm != nil {
 		entry.ToolsSource = toolsSourceManifest
-		entry.Tools = tm.Tools
+		// A manifest with a null/absent tools field still means
+		// "manifest-sourced": emit [] not null, so tools:null stays
+		// reserved for the agent-context case (the README invariant).
+		entry.Tools = nonNilRawMessages(tm.Tools)
 	} else {
 		entry.ToolsSource = toolsSourceAgentCtx
 	}
@@ -331,6 +334,15 @@ func installModulePath(path, slug string) string {
 func nonNilStrings(src []string) []string {
 	if src == nil {
 		return []string{}
+	}
+	return src
+}
+
+// nonNilRawMessages is nonNilStrings for the tools array — keeps
+// manifest-sourced entries emitting [] rather than null.
+func nonNilRawMessages(src []json.RawMessage) []json.RawMessage {
+	if src == nil {
+		return []json.RawMessage{}
 	}
 	return src
 }

--- a/tools/generate-agent-registry/main_test.go
+++ b/tools/generate-agent-registry/main_test.go
@@ -117,6 +117,35 @@ func TestBuildEntry_NoToolsManifest(t *testing.T) {
 	}
 }
 
+// A tools-manifest.json with a null/absent tools field is still
+// manifest-sourced: tools must serialize as [] (not null) so tools:null
+// stays reserved for the agent-context case.
+func TestBuildEntry_ManifestWithNullTools(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".printing-press.json"), map[string]any{
+		"api_name":    "nulltools",
+		"description": "Manifest present, tools null.",
+	})
+	writeJSON(t, filepath.Join(dir, "tools-manifest.json"), map[string]any{
+		"auth":  map[string]any{"type": "none"},
+		"tools": nil,
+	})
+
+	entry, err := buildEntry(dir, "tools", "nulltools")
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry.ToolsSource != toolsSourceManifest {
+		t.Errorf("tools_source = %q, want %q", entry.ToolsSource, toolsSourceManifest)
+	}
+	if entry.Tools == nil {
+		t.Error("tools is nil; want non-nil empty slice so it serializes as [] not null")
+	}
+	if len(entry.Tools) != 0 {
+		t.Errorf("tools len = %d, want 0", len(entry.Tools))
+	}
+}
+
 // Directories without .printing-press.json should skip cleanly so
 // scratch dirs under library/ don't break the walk.
 func TestBuildEntry_MissingManifestSkipped(t *testing.T) {

--- a/tools/generate-agent-registry/main_test.go
+++ b/tools/generate-agent-registry/main_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildEntry_WithToolsManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".printing-press.json"), map[string]any{
+		"api_name":              "hackernews",
+		"display_name":          "Hacker News",
+		"description":           "HN from the terminal.",
+		"auth_type":             "none",
+		"auth_env_vars":         []string{},
+		"mcp_binary":            "hackernews-pp-mcp",
+		"mcp_tool_count":        8,
+		"mcp_public_tool_count": 6,
+		"mcp_ready":             "full",
+	})
+	writeJSON(t, filepath.Join(dir, "tools-manifest.json"), map[string]any{
+		"auth": map[string]any{"type": "none"},
+		"tools": []map[string]any{
+			{
+				"name":        "items_get",
+				"description": "Get an item.",
+				"params": []map[string]any{
+					{"name": "itemId", "type": "string", "location": "path", "required": true},
+				},
+			},
+		},
+	})
+
+	entry, err := buildEntry(dir, "media", "hackernews")
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("buildEntry returned nil entry; expected populated entry")
+	}
+
+	if entry.Name != "hackernews" || entry.API != "Hacker News" || entry.Category != "media" {
+		t.Errorf("identity mismatch: got name=%q api=%q category=%q", entry.Name, entry.API, entry.Category)
+	}
+	if entry.Skill != "pp-hackernews" {
+		t.Errorf("skill = %q, want pp-hackernews", entry.Skill)
+	}
+	wantInstall := "github.com/mvanhorn/printing-press-library/" + filepath.ToSlash(dir) + "/cmd/hackernews-pp-cli"
+	if entry.InstallModule != wantInstall {
+		t.Errorf("install_module = %q, want %q", entry.InstallModule, wantInstall)
+	}
+	if entry.Auth.Type != "none" {
+		t.Errorf("auth.type = %q, want none", entry.Auth.Type)
+	}
+	if entry.MCP == nil {
+		t.Fatal("mcp block missing for entry with mcp_binary")
+	}
+	if entry.MCP.Binary != "hackernews-pp-mcp" {
+		t.Errorf("mcp.binary = %q, want hackernews-pp-mcp", entry.MCP.Binary)
+	}
+	if entry.MCP.ToolCount != 8 || entry.MCP.PublicToolCount != 6 {
+		t.Errorf("mcp tool counts wrong: tool=%d public=%d", entry.MCP.ToolCount, entry.MCP.PublicToolCount)
+	}
+	if entry.MCP.MCPReady != "full" {
+		t.Errorf("mcp.mcp_ready = %q, want full", entry.MCP.MCPReady)
+	}
+	// No cmd/<binary>/main.go in the fixture → transports falls back to ["stdio"].
+	if len(entry.MCP.Transports) != 1 || entry.MCP.Transports[0] != "stdio" {
+		t.Errorf("mcp.transports = %v, want [stdio] when main.go is absent", entry.MCP.Transports)
+	}
+	if entry.ToolsSource != toolsSourceManifest {
+		t.Errorf("tools_source = %q, want %q", entry.ToolsSource, toolsSourceManifest)
+	}
+	if len(entry.Tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(entry.Tools))
+	}
+	var tool map[string]any
+	if err := json.Unmarshal(entry.Tools[0], &tool); err != nil {
+		t.Fatalf("unmarshal tool: %v", err)
+	}
+	if tool["name"] != "items_get" {
+		t.Errorf("tool.name = %v, want items_get", tool["name"])
+	}
+}
+
+// CLIs without tools-manifest.json should still produce an entry —
+// identity + auth + install path are usable; tools=null signals the
+// consumer to call agent-context after install.
+func TestBuildEntry_NoToolsManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".printing-press.json"), map[string]any{
+		"api_name":      "airframe",
+		"display_name":  "airframe",
+		"description":   "Aircraft forensics.",
+		"auth_type":     "none",
+		"auth_env_vars": []string{},
+	})
+
+	entry, err := buildEntry(dir, "developer-tools", "airframe")
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("buildEntry returned nil; expected entry even without manifest")
+	}
+	if entry.ToolsSource != toolsSourceAgentCtx {
+		t.Errorf("tools_source = %q, want %q", entry.ToolsSource, toolsSourceAgentCtx)
+	}
+	if entry.Tools != nil {
+		t.Errorf("tools = %v, want nil", entry.Tools)
+	}
+	if entry.MCP != nil {
+		t.Errorf("mcp = %+v, want nil for CLI without mcp_binary", entry.MCP)
+	}
+}
+
+// Directories without .printing-press.json should skip cleanly so
+// scratch dirs under library/ don't break the walk.
+func TestBuildEntry_MissingManifestSkipped(t *testing.T) {
+	dir := t.TempDir()
+	entry, err := buildEntry(dir, "tools", "scratch")
+	if err != nil {
+		t.Fatalf("buildEntry on dir without .printing-press.json should not error: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("buildEntry returned %+v, want nil for non-CLI directory", entry)
+	}
+}
+
+// When .printing-press.json omits auth_type, the tools-manifest.json
+// auth.type (runtime-authoritative) should fill in.
+func TestBuildEntry_AuthFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".printing-press.json"), map[string]any{
+		"api_name":    "legacy",
+		"description": "Pre-auth_type CLI.",
+	})
+	writeJSON(t, filepath.Join(dir, "tools-manifest.json"), map[string]any{
+		"auth":  map[string]any{"type": "api_key"},
+		"tools": []map[string]any{},
+	})
+
+	entry, err := buildEntry(dir, "tools", "legacy")
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry.Auth.Type != "api_key" {
+		t.Errorf("auth.type = %q, want api_key (from tools-manifest fallback)", entry.Auth.Type)
+	}
+}
+
+// When no source declares an auth.type, the entry should default to
+// "none" rather than an empty string (consumer contract: always non-empty).
+func TestBuildEntry_DefaultsAuthToNone(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, ".printing-press.json"), map[string]any{
+		"api_name":    "unknown-auth",
+		"description": "CLI with no declared auth.",
+	})
+
+	entry, err := buildEntry(dir, "tools", "unknown-auth")
+	if err != nil {
+		t.Fatalf("buildEntry: %v", err)
+	}
+	if entry.Auth.Type != "none" {
+		t.Errorf("auth.type = %q, want none (default)", entry.Auth.Type)
+	}
+}
+
+func TestDetectMCPTransports(t *testing.T) {
+	dir := t.TempDir()
+	cmdDir := filepath.Join(dir, "cmd", "x-pp-mcp")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatalf("mkdir cmd dir: %v", err)
+	}
+
+	// stdio-only main.go (no streamable-HTTP reference).
+	stdioOnly := []byte("package main\nfunc main() { ServeStdio() }\n")
+	if err := os.WriteFile(filepath.Join(cmdDir, "main.go"), stdioOnly, 0o644); err != nil {
+		t.Fatalf("write stdio-only main.go: %v", err)
+	}
+	if got := detectMCPTransports(dir, "x-pp-mcp"); !equalSlices(got, []string{"stdio"}) {
+		t.Errorf("stdio-only: detectMCPTransports = %v, want [stdio]", got)
+	}
+
+	// Same dir, swap in a main.go that references streamable-HTTP.
+	stdioPlusHTTP := []byte("package main\nfunc main() { server.NewStreamableHTTPServer(...) }\n")
+	if err := os.WriteFile(filepath.Join(cmdDir, "main.go"), stdioPlusHTTP, 0o644); err != nil {
+		t.Fatalf("write dual-transport main.go: %v", err)
+	}
+	if got := detectMCPTransports(dir, "x-pp-mcp"); !equalSlices(got, []string{"stdio", "http"}) {
+		t.Errorf("stdio+http: detectMCPTransports = %v, want [stdio http]", got)
+	}
+
+	// Missing binary name short-circuits to the stdio default — guards
+	// the CLI-only path (no MCP) without erroring.
+	if got := detectMCPTransports(dir, ""); !equalSlices(got, []string{"stdio"}) {
+		t.Errorf("empty binary: detectMCPTransports = %v, want [stdio]", got)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Cross-check against generate-registry's helper: both must produce
+// the same module path for the same inputs.
+func TestInstallModulePath(t *testing.T) {
+	got := installModulePath("library/dev/github", "github")
+	want := "github.com/mvanhorn/printing-press-library/library/dev/github/cmd/github-pp-cli"
+	if got != want {
+		t.Errorf("installModulePath = %q, want %q", got, want)
+	}
+}
+
+func TestMarshalRegistry_StableShape(t *testing.T) {
+	reg := AgentRegistry{
+		SchemaVersion: 1,
+		Entries: []AgentEntry{
+			{
+				Name:          "x",
+				API:           "X",
+				Category:      "tools",
+				Description:   "Test.",
+				InstallModule: "github.com/example/x/cmd/x-pp-cli",
+				Skill:         "pp-x",
+				Auth:          AuthBlock{Type: "none", EnvVars: []string{}},
+				ToolsSource:   toolsSourceAgentCtx,
+				Tools:         nil,
+			},
+		},
+	}
+	out, err := marshalRegistry(reg)
+	if err != nil {
+		t.Fatalf("marshalRegistry: %v", err)
+	}
+	if !strings.HasSuffix(string(out), "\n") {
+		t.Error("output must end with a newline")
+	}
+	if !strings.Contains(string(out), "  \"schema_version\": 1") {
+		t.Errorf("expected 2-space indent for schema_version; got:\n%s", out)
+	}
+	if strings.Contains(string(out), `&gt;`) {
+		t.Errorf("HTML escaping leaked into output:\n%s", out)
+	}
+}
+
+func writeJSON(t *testing.T, path string, body any) {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -531,8 +531,9 @@ func dedupeStrings(values []string) []string {
 }
 
 // installModulePath returns the canonical Go install path for a CLI.
-// Returns "" when either input is empty so partial entries surface in
-// --validate rather than emitting a bogus path.
+// Returns "" when either input is empty — purely defensive, since path
+// and slug are both required fields validateEntries already enforces,
+// so a populated entry never carries an empty install_module.
 func installModulePath(path, slug string) string {
 	if path == "" || slug == "" {
 		return ""

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -72,7 +72,10 @@ type RegistryEntry struct {
 	Description string   `json:"description"`
 	SearchTerms []string `json:"search_terms,omitempty"`
 	Path        string   `json:"path"`
-	sourceAPI   string
+	// InstallModule is the Go module path for `go install`. Inlined so
+	// programmatic consumers don't have to reconstruct the path convention.
+	InstallModule string `json:"install_module"`
+	sourceAPI     string
 	// Printer is the GitHub @handle of the human who originally ran the
 	// press for this CLI. Sourced verbatim from .printing-press.json's
 	// `printer` field; never derived from operator git config or curated
@@ -352,11 +355,13 @@ func buildEntry(dir, category, slug string, existing map[string]RegistryEntry) (
 
 	prior := existing[slug]
 
+	pathSlash := filepath.ToSlash(dir)
 	entry := RegistryEntry{
-		Name:     slug,
-		Category: category,
-		API:      apiDisplayName(pp, prior, slug),
-		Path:     filepath.ToSlash(dir),
+		Name:          slug,
+		Category:      category,
+		API:           apiDisplayName(pp, prior, slug),
+		Path:          pathSlash,
+		InstallModule: installModulePath(pathSlash, slug),
 		sourceAPI: strings.TrimSpace(firstNonEmpty(
 			pp.DisplayName,
 			pp.APIName,
@@ -523,6 +528,16 @@ func dedupeStrings(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+// installModulePath returns the canonical Go install path for a CLI.
+// Returns "" when either input is empty so partial entries surface in
+// --validate rather than emitting a bogus path.
+func installModulePath(path, slug string) string {
+	if path == "" || slug == "" {
+		return ""
+	}
+	return fmt.Sprintf("github.com/mvanhorn/printing-press-library/%s/cmd/%s-pp-cli", path, slug)
 }
 
 // validateEntries returns one human-readable error per missing required

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -575,6 +575,48 @@ func TestFilterEntriesBySlug(t *testing.T) {
 	})
 }
 
+// Locks the install-path format. Schema_version bump if this changes.
+func TestInstallModulePath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		slug string
+		want string
+	}{
+		{
+			name: "canonical layout",
+			path: "library/dev/github",
+			slug: "github",
+			want: "github.com/mvanhorn/printing-press-library/library/dev/github/cmd/github-pp-cli",
+		},
+		{
+			name: "hyphenated slug",
+			path: "library/travel/alaska-airlines",
+			slug: "alaska-airlines",
+			want: "github.com/mvanhorn/printing-press-library/library/travel/alaska-airlines/cmd/alaska-airlines-pp-cli",
+		},
+		{
+			name: "empty path returns empty string",
+			path: "",
+			slug: "x",
+			want: "",
+		},
+		{
+			name: "empty slug returns empty string",
+			path: "library/tools/x",
+			slug: "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := installModulePath(tc.path, tc.slug); got != tc.want {
+				t.Errorf("installModulePath(%q, %q) = %q, want %q", tc.path, tc.slug, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestRenderCatalogCounts checks both pluralization branches and the
 // happy multi-entry / multi-category path. The pluralization matters
 // because the rendered string lands in human-readable prose; "1 CLIs


### PR DESCRIPTION
## What

Adds **`agent-registry.json`** — a generated catalog shaped for agent runners that need each CLI's full tool tree without a fan-out of N+1 HTTP requests to fetch every `tools-manifest.json` separately. Also inlines **`install_module`** into `registry.json` entries so consumers stop reconstructing the `cmd/<name>-pp-cli` path convention.

[cocoon](https://github.com/vu1n/cocoon) (a lazy CLI/MCP runner over this corpus) is the design target: today it harvests `registry.json` nightly and then fetches each CLI's `tools-manifest.json` individually. `agent-registry.json` collapses that into one fetch.

## The two catalogs

| File | Audience | Shape |
|------|----------|-------|
| `registry.json` (existing) | npm installer, humans | lean per-CLI identity + path + MCP block; now also `install_module` |
| `agent-registry.json` (new) | agent runners | identity + `install_module` + `skill` + `auth` + MCP block + verbatim `tools[]` from each `tools-manifest.json` |

CLIs without a static manifest (docs-/sniff-driven) emit `tools: null` with `tools_source: "agent-context"`, signaling the consumer to call `<binary> agent-context` after install.

Local generation against the current library: 135 entries, 96 with inlined `tools-manifest`, 39 with the `agent-context` fallback.

## How it's wired

- `tools/generate-agent-registry/` — new stdlib-only Go module mirroring `generate-registry`'s conventions.
- `generate-agent-registry.yml` — post-merge regen, commits with `[skip ci]`. Trigger paths scoped to `.printing-press.json`, `tools-manifest.json`, and `cmd/*-pp-mcp/main.go` (transport detection) only.
- `verify-library-conventions.yml` — the generated-artifact gate now also blocks PR-time hand-edits of `agent-registry.json`.

## Not in this diff (by design)

`agent-registry.json` and `registry.json` themselves are **not** committed — both are regenerated post-merge by their workflows, exactly as the repo already handles `registry.json`. The artifact gate hard-fails PRs that commit them directly.

## Notes

- Rebased onto current `main`; reconciled with the new `search_terms` field (kept both `search_terms` and `install_module` on `RegistryEntry`). `search_terms` is now documented alongside `install_module` in the README's new "Programmatic consumers" section.
- The `install_module`, `detectMCPTransports`, and `marshalRegistry` helpers are duplicated from `generate-registry` rather than shared — the two tools live in separate Go modules and there's no shared-package pattern in `tools/` yet. Flagged in-code as a future consolidation, not blocking.

## Testing

- `go vet` + `go test ./...` pass in both `tools/generate-registry` and `tools/generate-agent-registry`.
- `--print` output verified against the live library (counts above).