### PR TITLE
feat(openipa): add servizi command group + sede_aoo normalizeNome

### DIFF
--- a/library/developer-tools/openipa/.printing-press-patches.json
+++ b/library/developer-tools/openipa/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-18",
+  "applied_at": "2026-05-20",
   "base_run_id": "20260514-212234",
   "base_printing_press_version": "4.6.1",
   "patches": [
@@ -50,6 +50,18 @@
         "internal/cli/root.go"
       ],
       "validated_outcome": "go build ./... passes. Live test against IPA pending (requires AUTH_ID)."
+    },
+    {
+      "id": "servizi-help-docs",
+      "summary": "Expand servizi command help for IPA digital services discovery.",
+      "reason": "The servizi command exposed portal-only digital service data, but its help did not explain practical workflows such as finding an Albo Pretorio URL via tipologia 1 or filtering broad text matches.",
+      "files": [
+        "internal/cli/servizi.go",
+        "internal/cli/servizi_ente.go",
+        "internal/cli/servizi_tipi.go",
+        "internal/cli/servizi_uo.go"
+      ],
+      "validated_outcome": "go run ./cmd/openipa-pp-cli servizi --help and subcommand help render expanded guidance."
     }
   ]
 }

--- a/library/developer-tools/openipa/SKILL.md
+++ b/library/developer-tools/openipa/SKILL.md
@@ -161,6 +161,28 @@ These capabilities aren't available in any other tool for this API.
 - `openipa-pp-cli uo get` — Dettagli di una singola UO per codice univoco
 - `openipa-pp-cli uo list` — Lista delle UO di un ente
 
+**servizi** — Servizi digitali pubblicati sul portale IPA (non API pubblica, nessun AUTH_ID richiesto)
+
+- `openipa-pp-cli servizi tipi` — Lista le tipologie di servizi digitali degli enti. Usa questi ID con `servizi ente --tipologia`.
+- `openipa-pp-cli servizi tipi --uo` — Lista le categorie dei servizi erogati dalle UO. Usa questi ID con `servizi uo --categoria`.
+- `openipa-pp-cli servizi ente` — Cerca servizi online erogati da enti, con URL quando presente: albo pretorio, pagoPA, SUAP, tributi, pratiche edilizie, concorsi, contravvenzioni, appalti.
+- `openipa-pp-cli servizi uo` — Cerca UO per categoria o descrizione del servizio erogato, spesso con email e codice UO.
+
+Esempi:
+
+```bash
+# Albo pretorio / accesso agli atti del Comune di Bari
+openipa-pp-cli servizi ente --nome-ente "Comune di Bari" --nome-servizio "albo" --json
+
+# Scoprire l'ID tipologia: Accesso agli atti = 1, include Albo Pretorio
+openipa-pp-cli servizi tipi --json | jq '.data[] | select(.tipo == "Accesso agli atti")'
+
+# Tutti i servizi di una tipologia in un'area
+openipa-pp-cli servizi ente --area "Bari" --tipologia 1 --json
+```
+
+> `--nome-ente` è una ricerca testuale ampia: `"Comune di Bari"` può restituire anche Bariano, Baricella, Barisardo, ecc. Filtra per `.denominazioneEnte == "Comune di Bari"` quando serve una corrispondenza esatta.
+
 **sede** — Ricerca per nome/area (portale IPA — non API pubblica, nessun AUTH_ID richiesto)
 
 - `openipa-pp-cli sede enti` — Cerca enti per nome, CF, area geografica, categoria
@@ -169,13 +191,25 @@ These capabilities aren't available in any other tool for this API.
 
 Restituisce 30 risultati per pagina; aggiungere `--tutti` per scaricare tutto.
 
+**Ricerca per nome senza conoscere il tipo di entità:**
+
+IPA distingue tre tipi: enti autonomi, AOO, UO. Se non sai di che tipo è la struttura che cerchi, prova in cascata:
+
+| Passo | Comando | Trova |
+|-------|---------|-------|
+| 1 | `enti cerca --nome <nome>` | ente con codice IPA proprio (comuni, ministeri, università…) |
+| 2 | `sede aoo --nome <keyword>` | AOO di un ente padre (prefetture, questure, provveditorati…) |
+| 3 | `sede uo --nome <keyword>` | UO interna a un ente |
+
+> **Limite `--nome` su `sede`**: accetta una singola parola chiave; con più parole il risultato è spesso vuoto. Usa la keyword più distintiva e filtra via jq.
+
 **Riepilogo modalità di ricerca AOO:**
 
 | Comando | Input | Quando usarlo |
 |---------|-------|---------------|
 | `aoo list --codice <cod_amm>` | codice ente padre | vuoi tutte le AOO di un ente noto |
-| `aoo cerca <cod_uni_aoo>` | codice univoco IPA a 7 car. | hai già il cod_uni_aoo (es. `A463BFE`) — recuperalo con `aoo storico` |
-| `sede aoo --nome <nome>` | testo libero | cerchi per denominazione senza codice — **usa questo come fallback** |
+| `aoo cerca <cod_uni_aoo>` | codice univoco IPA a 7 car. | hai già il cod_uni_aoo — recuperalo con `sede aoo` o `aoo storico` |
+| `sede aoo --nome <keyword>` | singola parola chiave | cerchi per denominazione senza codice — poi `aoo cerca <cod_uni_aoo>` per i contatti |
 
 **rtd** — Responsabile Transizione Digitale (portale IPA — non API pubblica)
 
@@ -225,6 +259,15 @@ openipa-pp-cli sede enti --area "Sicilia" --tutti --json | jq '.meta.total'
 
 Conta gli enti siciliani — usa il portale IPA con auto-paginazione
 
+### Trovare l'Albo Pretorio online di un ente
+
+```bash
+openipa-pp-cli servizi ente --nome-ente "Comune di Bari" --nome-servizio "albo" --json \
+  | jq -r '.data[] | select(.denominazioneEnte == "Comune di Bari") | .uri'
+```
+
+Cerca nei servizi digitali IPA: l'Albo Pretorio è tipicamente nella tipologia `Accesso agli atti` (`--tipologia 1`).
+
 ### Verifica PEC valida
 
 ```bash
@@ -269,25 +312,53 @@ Con `--tutti` vengono scaricate automaticamente tutte le pagine (default: 30 ris
 openipa-pp-cli sede enti --nome "ospedale" --tutti --json | jq '[.data[] | .denominazioneEnte]'
 ```
 
-### Enti che sono AOO, non enti autonomi
+### Cercare per nome senza sapere il tipo di entità
 
-**Regola generale:** se `enti cerca --nome "<nome>"` restituisce 0 risultati, la struttura cercata potrebbe essere una **AOO di un ente padre** (ministero, agenzia, etc.) anziché un ente IPA autonomo. In questo caso usare `sede aoo --nome "<nome>"` per la ricerca per testo libero.
+Quando non sai se la struttura è un ente autonomo, una AOO o una UO, prova in cascata — la maggior parte dei casi si risolve al passo 1 o 2.
 
 ```bash
-# fallback generico quando enti cerca non trova nulla
-openipa-pp-cli sede aoo --nome "<nome struttura>" --json | jq '.data[0] | {nome: .denominazioneAoo, ente: .denominazioneEnte, pec: .domicili[0].domicilioDigitale}'
+# Passo 1 — enti autonomi (comuni, ministeri, università…)
+openipa-pp-cli enti cerca --nome "<nome>" --agent
+
+# Passo 2 — AOO (usa una sola parola chiave, non frasi composte)
+openipa-pp-cli sede aoo --nome "<keyword>" --tutti --agent | \
+  jq '.data[] | select(.denominazioneAoo | test("<filtro>"; "i")) | {nome: .denominazioneAoo, ente: .denominazioneEnte, cod_uni_aoo: .codUniAoo}'
+
+# Passo 3 — UO
+openipa-pp-cli sede uo --nome "<keyword>" --agent
 ```
 
-Alcuni esempi di strutture che sono AOO, non enti autonomi (i nomi IPA esatti variano — usare sempre `sede aoo --nome` per scoprirli):
+Se il passo 2 trova una AOO e ti servono i contatti (PEC, telefono, indirizzo), recuperali con un secondo step — il campo `domicili` di `sede aoo` è spesso null:
+
+```bash
+openipa-pp-cli aoo cerca <cod_uni_aoo> --agent
+# → mail1 = PEC, tel = telefono, indirizzo = sede
+```
+
+Per una ricerca esaustiva in parallelo su tutti i tipi:
+
+```bash
+openipa-pp-cli enti cerca --nome "<nome>" --agent &
+openipa-pp-cli sede aoo --nome "<keyword>" --tutti --agent &
+openipa-pp-cli sede uo --nome "<keyword>" --agent &
+wait
+```
+
+### Enti che sono AOO, non enti autonomi
+
+Alcune strutture note non sono enti IPA autonomi ma **AOO di un ente padre**: `enti cerca` restituisce 0 risultati per loro.
 
 - **Prefetture** → AOO del Ministero dell'Interno (`m_it`)
 - **Questure** → AOO del Ministero dell'Interno
-- **Provveditorati** → AOO del Ministero dell'Istruzione
+- **Provveditorati / Uffici Scolastici** → AOO del Ministero dell'Istruzione
 
 ```bash
-# esempio: trova il nome IPA esatto e la PEC di una prefettura
-openipa-pp-cli sede aoo --nome "prefettura palermo" --json | \
-  jq '.data[] | {nome: .denominazioneAoo, pec: .domicili[0].domicilioDigitale}'
+# trova nome IPA esatto e contatti (es. prefettura di una provincia)
+openipa-pp-cli sede aoo --nome "prefettura" --tutti --agent | \
+  jq '.data[] | select(.denominazioneAoo | test("<provincia>"; "i")) | {nome: .denominazioneAoo, cod_uni_aoo: .codUniAoo}'
+
+# poi recupera PEC e telefono con:
+openipa-pp-cli aoo cerca <cod_uni_aoo> --agent
 ```
 
 ## Auth Setup

--- a/library/developer-tools/openipa/internal/cli/root.go
+++ b/library/developer-tools/openipa/internal/cli/root.go
@@ -256,6 +256,7 @@ Ricette: README.md o SKILL.md`,
 	// Hand-written: portale IPA endpoints (sede + RTD) — not in public-ws API
 	rootCmd.AddCommand(newSedeCmd(flags))
 	rootCmd.AddCommand(newRtdCmd(flags))
+	rootCmd.AddCommand(newServiziCmd(flags))
 
 	return rootCmd
 }

--- a/library/developer-tools/openipa/internal/cli/sede_aoo.go
+++ b/library/developer-tools/openipa/internal/cli/sede_aoo.go
@@ -6,9 +6,26 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+// normalizeNome replicates the IPA portal's multi-word normalization:
+// "Prefettura di Palermo" → "Prefettura,Palermo" (tokens ≤2 chars dropped, joined by comma).
+func normalizeNome(s string) string {
+	words := strings.Fields(s)
+	kept := words[:0]
+	for _, w := range words {
+		if len(w) > 2 {
+			kept = append(kept, w)
+		}
+	}
+	if len(kept) == 0 {
+		return s
+	}
+	return strings.Join(kept, ",")
+}
 
 func newSedeAooCmd(flags *rootFlags) *cobra.Command {
 	var nome, cf, area, categoria, codiceEnte, codiceAoo string
@@ -29,7 +46,7 @@ func newSedeAooCmd(flags *rootFlags) *cobra.Command {
 			c := newPortaleClient(flags)
 
 			body := map[string]any{
-				"desAoo":            nilIfEmpty(nome),
+				"desAoo":            nilIfEmpty(normalizeNome(nome)),
 				"codiceFiscale":     nilIfEmpty(cf),
 				"area":              nilIfEmpty(area),
 				"codiceCategoria":   nilIfEmpty(categoria),

--- a/library/developer-tools/openipa/internal/cli/sede_aoo.go
+++ b/library/developer-tools/openipa/internal/cli/sede_aoo.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ func normalizeNome(s string) string {
 	words := strings.Fields(s)
 	kept := words[:0]
 	for _, w := range words {
-		if len(w) > 2 {
+		if utf8.RuneCountInString(w) > 2 {
 			kept = append(kept, w)
 		}
 	}

--- a/library/developer-tools/openipa/internal/cli/servizi.go
+++ b/library/developer-tools/openipa/internal/cli/servizi.go
@@ -1,0 +1,37 @@
+// Copyright 2026 aborruso. Licensed under Apache-2.0. See LICENSE.
+// Hand-written addition: servizi command group — preserve on regeneration.
+
+package cli
+
+import "github.com/spf13/cobra"
+
+func newServiziCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "servizi",
+		Short: "Ricerca servizi digitali erogati da enti e UO (portale IPA)",
+		Long: `Ricerca servizi digitali pubblicati sul portale IPA.
+
+Usa questo gruppo per trovare URL e schede di servizi online come Albo Pretorio,
+pagoPA, SUAP, tributi, pratiche edilizie, concorsi, contravvenzioni e appalti.
+
+Workflow tipico:
+  1. servizi tipi              # scopri gli ID delle tipologie ente
+  2. servizi ente --tipologia 1 # cerca servizi ente per tipologia
+  3. servizi tipi --uo          # scopri gli ID delle categorie UO
+  4. servizi uo --categoria 25  # cerca uffici per categoria servizio
+
+Nota: questi dati arrivano dal portale IPA, non dai web service pubblici WS01-WS23.`,
+		Example: `  # Albo pretorio del Comune di Bari
+  openipa-pp-cli servizi ente --nome-ente "Comune di Bari" --nome-servizio "albo" --json
+
+  # Tipologie disponibili per servizi degli enti
+  openipa-pp-cli servizi tipi
+
+  # Categorie disponibili per servizi delle UO
+  openipa-pp-cli servizi tipi --uo`,
+	}
+	cmd.AddCommand(newServiziEnteCmd(flags))
+	cmd.AddCommand(newServiziUoCmd(flags))
+	cmd.AddCommand(newServiziTipiCmd(flags))
+	return cmd
+}

--- a/library/developer-tools/openipa/internal/cli/servizi_ente.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_ente.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -52,7 +51,7 @@ restituire anche Bariano, Baricella o Barisardo; filtra il JSON per
 
 			var tipologiaVal any
 			if tipologia > 0 {
-				tipologiaVal = strconv.Itoa(tipologia)
+				tipologiaVal = tipologia
 			}
 
 			body := map[string]any{

--- a/library/developer-tools/openipa/internal/cli/servizi_ente.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_ente.go
@@ -1,0 +1,106 @@
+// Copyright 2026 aborruso. Licensed under Apache-2.0. See LICENSE.
+// Hand-written addition: servizi ente command — preserve on regeneration.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func newServiziEnteCmd(flags *rootFlags) *cobra.Command {
+	var tipologia int
+	var nomeServizio, nomeEnte, area, categoria, ateco string
+	var pagina int
+	var tutti bool
+
+	cmd := &cobra.Command{
+		Use:   "ente",
+		Short: "Cerca enti per servizio digitale erogato",
+		Long: `Cerca servizi digitali associati agli enti nel portale IPA.
+
+Restituisce, quando disponibile, l'URL del servizio nel campo uri. È utile per
+recuperare Albo Pretorio online, pagoPA, SUAP, tributi, pratiche edilizie,
+concorsi, contravvenzioni, appalti e altri servizi pubblicati dall'ente.
+
+Usa "servizi tipi" per scoprire gli ID da passare a --tipologia. Ad esempio,
+la tipologia 1 è "Accesso agli atti" e comprende spesso l'Albo Pretorio.
+
+Attenzione: --nome-ente è una ricerca testuale ampia. "Comune di Bari" può
+restituire anche Bariano, Baricella o Barisardo; filtra il JSON per
+.denominazioneEnte quando serve una corrispondenza esatta.`,
+		Example: `  # Albo pretorio del Comune di Bari
+  openipa-pp-cli servizi ente --nome-ente "Comune di Bari" --nome-servizio "albo" --json
+
+  # Solo l'URL dell'Albo Pretorio, filtrando la denominazione esatta
+  openipa-pp-cli servizi ente --nome-ente "Comune di Bari" --nome-servizio "albo" --json | \
+    jq -r '.data[] | select(.denominazioneEnte == "Comune di Bari") | .uri'
+
+  # Tutti gli Albi Pretori / accesso agli atti nell'area Bari
+  openipa-pp-cli servizi ente --area "Bari" --tipologia 1 --json
+
+  # Cerca servizi pagoPA
+  openipa-pp-cli servizi ente --nome-servizio "pagopa" --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tipologia == 0 && nomeServizio == "" && nomeEnte == "" && area == "" && categoria == "" && ateco == "" && !flags.dryRun {
+				return fmt.Errorf("almeno un filtro richiesto: --tipologia, --nome-servizio, --nome-ente, --area, --categoria, --ateco")
+			}
+			c := newPortaleClient(flags)
+
+			var tipologiaVal any
+			if tipologia > 0 {
+				tipologiaVal = strconv.Itoa(tipologia)
+			}
+
+			body := map[string]any{
+				"tipologiaServizio":     tipologiaVal,
+				"denominazioneServizio": nilIfEmpty(nomeServizio),
+				"denominazioneEnte":     nilIfEmpty(nomeEnte),
+				"area":                  nilIfEmpty(area),
+				"categoria":             nilIfEmpty(categoria),
+				"attivitaAteco":         nilIfEmpty(ateco),
+			}
+
+			var items json.RawMessage
+			var pag pagResp
+			var status int
+			var err error
+
+			if tutti {
+				items, pag, status, err = fetchAllPages(c, "/api/servizidigitali/ricerca", body, "denominazione")
+			} else {
+				body["paginazione"] = newPaginazione("denominazione", pagina)
+				var raw json.RawMessage
+				raw, status, err = c.PostJSON("/api/servizidigitali/ricerca", body)
+				if err == nil {
+					var r *portaleResp
+					r, err = parsePortaleResp(raw)
+					if err == nil {
+						if r.Risposta == nil {
+							items = json.RawMessage(`[]`)
+						} else {
+							items, pag = r.Risposta.ListaResponse, r.Risposta.Paginazione
+						}
+					}
+				}
+			}
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			return portaleOutput(cmd.OutOrStdout(), flags, "/api/servizidigitali/ricerca", "servizi/ente", status, items, pag)
+		},
+	}
+
+	cmd.Flags().IntVar(&tipologia, "tipologia", 0, "ID tipologia servizio (usa 'servizi tipi' per la lista; 1=Accesso agli atti/Albo Pretorio)")
+	cmd.Flags().StringVar(&nomeServizio, "nome-servizio", "", "Parte del nome del servizio (es. albo, pagopa, SUAP)")
+	cmd.Flags().StringVar(&nomeEnte, "nome-ente", "", "Parte del nome dell'ente; ricerca testuale ampia, non exact match")
+	cmd.Flags().StringVar(&area, "area", "", "Comune o area geografica")
+	cmd.Flags().StringVar(&categoria, "categoria", "", "Codice categoria IPA")
+	cmd.Flags().StringVar(&ateco, "ateco", "", "Codice attività ATECO")
+	cmd.Flags().IntVar(&pagina, "pagina", 1, "Numero di pagina (30 risultati per pagina)")
+	cmd.Flags().BoolVar(&tutti, "tutti", false, "Scarica tutte le pagine")
+	return cmd
+}

--- a/library/developer-tools/openipa/internal/cli/servizi_tipi.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_tipi.go
@@ -47,8 +47,7 @@ spesso l'Albo Pretorio online.`,
 				resource = "servizi/tipi-uo"
 			}
 
-			raw, err := c.Get(path, nil)
-			status := 200
+			raw, status, err := c.GetJSON(path, nil)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
@@ -67,7 +66,7 @@ spesso l'Albo Pretorio online.`,
 				if wrapper.DescrizioneErrore != nil && *wrapper.DescrizioneErrore != "" {
 					msg = *wrapper.DescrizioneErrore
 				}
-				return fmt.Errorf("%s", msg)
+				return fmt.Errorf("%s: %s", path, msg)
 			}
 
 			items := wrapper.Risposta
@@ -81,7 +80,7 @@ spesso l'Albo Pretorio online.`,
 			}
 
 			w := cmd.OutOrStdout()
-			if wantsHumanTable(w, flags) {
+			if wantsHumanTable(w, flags) && flags.selectFields == "" {
 				var list []map[string]any
 				if err := json.Unmarshal(items, &list); err == nil && len(list) > 0 {
 					if err2 := printAutoTable(w, list); err2 == nil {

--- a/library/developer-tools/openipa/internal/cli/servizi_tipi.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_tipi.go
@@ -1,0 +1,114 @@
+// Copyright 2026 aborruso. Licensed under Apache-2.0. See LICENSE.
+// Hand-written addition: servizi tipi command — preserve on regeneration.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newServiziTipiCmd(flags *rootFlags) *cobra.Command {
+	var perUo bool
+
+	cmd := &cobra.Command{
+		Use:   "tipi",
+		Short: "Lista tipologie servizi digitali (ente) o categorie servizi (UO)",
+		Long: `Lista gli ID da usare nelle ricerche dei servizi digitali.
+
+Senza flag mostra le tipologie dei servizi degli enti, da usare con:
+  servizi ente --tipologia <id>
+
+Con --uo mostra le categorie dei servizi delle unità organizzative, da usare con:
+  servizi uo --categoria <id>
+
+Esempio importante: per gli enti, id=1 è "Accesso agli atti" e comprende
+spesso l'Albo Pretorio online.`,
+		Example: `  # Tipologie servizi ente
+  openipa-pp-cli servizi tipi
+
+  # Trova l'ID per Accesso agli atti / Albo Pretorio
+  openipa-pp-cli servizi tipi --json | jq '.data[] | select(.tipo == "Accesso agli atti")'
+
+  # Categorie servizi UO
+  openipa-pp-cli servizi tipi --uo
+
+  # Output compatto con id e tipo
+  openipa-pp-cli servizi tipi --json | jq '.data[] | {id, tipo}'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := newPortaleClient(flags)
+
+			path := "/api/tiposerviziodigitale"
+			resource := "servizi/tipi-ente"
+			if perUo {
+				path = "/api/serviziufficio/tipoServiziUfficio"
+				resource = "servizi/tipi-uo"
+			}
+
+			raw, err := c.Get(path, nil)
+			status := 200
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			// risposta: {"errore":false,"risposta":[...],...}
+			var wrapper struct {
+				Errore            bool            `json:"errore"`
+				Risposta          json.RawMessage `json:"risposta"`
+				DescrizioneErrore *string         `json:"descrizioneErrore"`
+			}
+			if err := json.Unmarshal(raw, &wrapper); err != nil {
+				return fmt.Errorf("parsing risposta tipi: %w", err)
+			}
+			if wrapper.Errore {
+				msg := "portale error"
+				if wrapper.DescrizioneErrore != nil && *wrapper.DescrizioneErrore != "" {
+					msg = *wrapper.DescrizioneErrore
+				}
+				return fmt.Errorf("%s", msg)
+			}
+
+			items := wrapper.Risposta
+			if items == nil {
+				items = json.RawMessage(`[]`)
+			}
+
+			filtered := items
+			if flags.selectFields != "" {
+				filtered = filterFields(filtered, flags.selectFields)
+			}
+
+			w := cmd.OutOrStdout()
+			if wantsHumanTable(w, flags) {
+				var list []map[string]any
+				if err := json.Unmarshal(items, &list); err == nil && len(list) > 0 {
+					if err2 := printAutoTable(w, list); err2 == nil {
+						return nil
+					}
+				}
+			}
+
+			var parsed any
+			envelope := map[string]any{
+				"action":   "get",
+				"resource": resource,
+				"path":     path,
+				"status":   status,
+				"success":  status >= 200 && status < 300,
+			}
+			if err := json.Unmarshal(filtered, &parsed); err == nil {
+				envelope["data"] = parsed
+			}
+			envelopeJSON, err := json.Marshal(envelope)
+			if err != nil {
+				return err
+			}
+			return printOutput(w, json.RawMessage(envelopeJSON), true)
+		},
+	}
+
+	cmd.Flags().BoolVar(&perUo, "uo", false, "Lista categorie servizi per UO invece delle tipologie servizio ente")
+	return cmd
+}

--- a/library/developer-tools/openipa/internal/cli/servizi_uo.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_uo.go
@@ -1,0 +1,89 @@
+// Copyright 2026 aborruso. Licensed under Apache-2.0. See LICENSE.
+// Hand-written addition: servizi uo command — preserve on regeneration.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newServiziUoCmd(flags *rootFlags) *cobra.Command {
+	var categoria int
+	var nomeUo, area string
+	var pagina int
+	var tutti bool
+
+	cmd := &cobra.Command{
+		Use:   "uo",
+		Short: "Cerca unità organizzative per categoria di servizio erogato",
+		Long: `Cerca unità organizzative registrate nel portale IPA in base al servizio erogato.
+
+È utile quando cerchi l'ufficio competente per un servizio, ad esempio
+protocollo, anagrafe, tributi, URP, edilizia privata, gare e appalti.
+
+Usa "servizi tipi --uo" per scoprire gli ID da passare a --categoria.`,
+		Example: `  # Cerca UO che citano protocollo
+  openipa-pp-cli servizi uo --nome-uo "protocollo" --json
+
+  # Cerca UO anagrafiche: categoria 4 = Anagrafico
+  openipa-pp-cli servizi uo --categoria 4 --json
+
+  # Cerca tutte le UO in un'area
+  openipa-pp-cli servizi uo --area "Milano" --tutti --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if categoria == 0 && nomeUo == "" && area == "" && !flags.dryRun {
+				return fmt.Errorf("almeno un filtro richiesto: --categoria, --nome-uo, --area")
+			}
+			c := newPortaleClient(flags)
+
+			var categoriaVal any
+			if categoria > 0 {
+				categoriaVal = categoria
+			}
+
+			body := map[string]any{
+				"categoriaServizio": categoriaVal,
+				"descrizione":       nilIfEmpty(nomeUo),
+				"area":              nilIfEmpty(area),
+			}
+
+			var items json.RawMessage
+			var pag pagResp
+			var status int
+			var err error
+
+			if tutti {
+				items, pag, status, err = fetchAllPages(c, "/api/serviziufficio/ricercaServiziUO", body, "street")
+			} else {
+				body["paginazione"] = newPaginazione("street", pagina)
+				var raw json.RawMessage
+				raw, status, err = c.PostJSON("/api/serviziufficio/ricercaServiziUO", body)
+				if err == nil {
+					var r *portaleResp
+					r, err = parsePortaleResp(raw)
+					if err == nil {
+						if r.Risposta == nil {
+							items = json.RawMessage(`[]`)
+						} else {
+							items, pag = r.Risposta.ListaResponse, r.Risposta.Paginazione
+						}
+					}
+				}
+			}
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			return portaleOutput(cmd.OutOrStdout(), flags, "/api/serviziufficio/ricercaServiziUO", "servizi/uo", status, items, pag)
+		},
+	}
+
+	cmd.Flags().IntVar(&categoria, "categoria", 0, "ID categoria servizio UO (usa 'servizi tipi --uo' per la lista; es. 4=Anagrafico, 25=Protocollo)")
+	cmd.Flags().StringVar(&nomeUo, "nome-uo", "", "Parte del nome della UO o della descrizione servizio (es. protocollo, anagrafe)")
+	cmd.Flags().StringVar(&area, "area", "", "Comune o area geografica")
+	cmd.Flags().IntVar(&pagina, "pagina", 1, "Numero di pagina (30 risultati per pagina)")
+	cmd.Flags().BoolVar(&tutti, "tutti", false, "Scarica tutte le pagine")
+	return cmd
+}

--- a/library/developer-tools/openipa/internal/cli/servizi_uo.go
+++ b/library/developer-tools/openipa/internal/cli/servizi_uo.go
@@ -56,9 +56,9 @@ Usa "servizi tipi --uo" per scoprire gli ID da passare a --categoria.`,
 			var err error
 
 			if tutti {
-				items, pag, status, err = fetchAllPages(c, "/api/serviziufficio/ricercaServiziUO", body, "street")
+				items, pag, status, err = fetchAllPages(c, "/api/serviziufficio/ricercaServiziUO", body, "denominazione")
 			} else {
-				body["paginazione"] = newPaginazione("street", pagina)
+				body["paginazione"] = newPaginazione("denominazione", pagina)
 				var raw json.RawMessage
 				raw, status, err = c.PostJSON("/api/serviziufficio/ricercaServiziUO", body)
 				if err == nil {

--- a/library/developer-tools/openipa/internal/client/client.go
+++ b/library/developer-tools/openipa/internal/client/client.go
@@ -70,6 +70,10 @@ func (c *Client) Get(path string, params map[string]string) (json.RawMessage, er
 	return c.GetWithHeaders(path, params, nil)
 }
 
+func (c *Client) GetJSON(path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do("GET", path, params, nil, nil)
+}
+
 func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {


### PR DESCRIPTION
## servizi command group (WS24/25/26) + sede_aoo normalizeNome

Adds the `servizi` command group for searching digital services published on the IPA portal, plus a normalization fix for the `--nome` field in `sede aoo`.

**API:** IPA (Indice delle Pubbliche Amministrazioni) | **Category:** developer-tools | **Press version:** hand-patch

**Spec:** https://www.indicepa.gov.it

### CLI Shape

```
servizi ente    Search digital services by entity (WS24)
servizi tipi    List available service types (WS25)
servizi uo      Search digital services by organizational unit (WS26)
```

### What This CLI Does

- `servizi ente` — retrieves services for an entity via `cod_amm`, with tabular output of URLs and service pages (WS24)
- `servizi tipi` — lists all available service type categories (WS25)
- `servizi uo` — retrieves services for an organizational unit via `cod_uni_ou` (WS26)
- `sede aoo --nome` — now normalizes multi-word search strings to match the IPA portal behavior (e.g. "Prefettura di Palermo" → "Prefettura,Palermo"), dropping tokens ≤ 2 characters and joining with commas

### Patches recorded

Entries added to `.printing-press-patches.json` per convention.