### PR TITLE
fix(gohighlevel): contacts sync 400s on page 2 — use per-contact searchAfter cursor

### DIFF
--- a/library/sales-and-crm/gohighlevel/.printing-press-patches.json
+++ b/library/sales-and-crm/gohighlevel/.printing-press-patches.json
@@ -11,20 +11,27 @@
       "files": [
         "internal/cli/sync.go"
       ],
-      "findings_addressed": ["F1", "F2"],
+      "findings_addressed": [
+        "F1",
+        "F2"
+      ],
       "patch_count": 10,
       "notes": "Downstream automation (segments refresh, hot follow-up, dedup) needs a local SQLite cache of contacts and tag-application rows for fast SQL queries. Adds POST-list endpoint support (GHL /contacts/search) via a syncFetcher interface, searchAfter cursor pagination (array-shaped cursor JSON-encoded for sync_state.last_cursor), path-key resolution for {locationId} via --global-param/GHL_LOCATION_ID, and per-page derivation of contacts_tags rows from each contact's tags[] array (composite id <contactId>:<tag>, dateUpdated as a coarse tagged_at proxy)."
     },
     {
       "date": "2026-05-20",
       "amend_run_id": "amend-2026-05-20-greptile-715",
-      "summary": "fix(gohighlevel): address Greptile PR #715 review — remove contacts_tags from defaultSyncResources (Issue 1), confirm locationId POST-body path (Issue 2), guard Strategy-2 cursor hasMore on full-page count (Issue 3)",
+      "summary": "fix(gohighlevel): address Greptile PR #715 review \u2014 remove contacts_tags from defaultSyncResources (Issue 1), confirm locationId POST-body path (Issue 2), guard Strategy-2 cursor hasMore on full-page count (Issue 3)",
       "files": [
         "internal/cli/sync.go"
       ],
-      "findings_addressed": ["greptile-715-issue1", "greptile-715-issue2", "greptile-715-issue3"],
+      "findings_addressed": [
+        "greptile-715-issue1",
+        "greptile-715-issue2",
+        "greptile-715-issue3"
+      ],
       "patch_count": 8,
-      "notes": "Issue 1 (P1): contacts_tags was listed in defaultSyncResources(), syncResourcePath(), and syncResourceMethod() as if it were a standalone API resource. It is not — it is derived from every contacts page by deriveContactsTagsFromPage. Removing it from the default list eliminates the second /contacts/search crawl and stops contact JSON blobs from being stored under resource_type='contacts_tags' in the generic resources table. Issue 2 (P1 verify): applyTo(resource, params, false) with isDependent=false propagates both flatGlobal (--param) and trueGlobal (--global-param) into params. locationId from --global-param reaches params[\"locationId\"], which fetchSyncPage reads into the POST body. No bug found; clarifying comment added. Issue 3 (P2): extractSearchAfterCursor Strategy 2 (derive cursor from last contact id) returned hasMore=true unconditionally, causing one extra /contacts/search call when the final page had exactly pageSize.limit items. Fixed by guarding hasMore on len(items) >= pageSize.limit at the call site."
+      "notes": "Issue 1 (P1): contacts_tags was listed in defaultSyncResources(), syncResourcePath(), and syncResourceMethod() as if it were a standalone API resource. It is not \u2014 it is derived from every contacts page by deriveContactsTagsFromPage. Removing it from the default list eliminates the second /contacts/search crawl and stops contact JSON blobs from being stored under resource_type='contacts_tags' in the generic resources table. Issue 2 (P1 verify): applyTo(resource, params, false) with isDependent=false propagates both flatGlobal (--param) and trueGlobal (--global-param) into params. locationId from --global-param reaches params[\"locationId\"], which fetchSyncPage reads into the POST body. No bug found; clarifying comment added. Issue 3 (P2): extractSearchAfterCursor Strategy 2 (derive cursor from last contact id) returned hasMore=true unconditionally, causing one extra /contacts/search call when the final page had exactly pageSize.limit items. Fixed by guarding hasMore on len(items) >= pageSize.limit at the call site."
     },
     {
       "date": "2026-05-20",
@@ -39,8 +46,32 @@
         "internal/store/schema_version_test.go",
         "internal/store/upsert_batch_test.go"
       ],
-      "findings_addressed": ["greptile-715-followup-tags-key", "greptile-715-followup-contacts-tags-partial-failure", "greptile-715-followup-printable-composite-id", "greptile-715-followup-indexed-tag-column", "greptile-715-followup-locations-tags-location-id", "greptile-715-followup-sql-read-only-store", "greptile-715-followup-resource-scoped-location-id", "greptile-715-followup-prune-stale-contact-tags", "greptile-715-followup-env-location-id-post-body", "greptile-715-followup-prune-missing-null-tags"],
+      "findings_addressed": [
+        "greptile-715-followup-tags-key",
+        "greptile-715-followup-contacts-tags-partial-failure",
+        "greptile-715-followup-printable-composite-id",
+        "greptile-715-followup-indexed-tag-column",
+        "greptile-715-followup-locations-tags-location-id",
+        "greptile-715-followup-sql-read-only-store",
+        "greptile-715-followup-resource-scoped-location-id",
+        "greptile-715-followup-prune-stale-contact-tags",
+        "greptile-715-followup-env-location-id-post-body",
+        "greptile-715-followup-prune-missing-null-tags"
+      ],
       "notes": "Adds tags to pageItemKeys so locations_tags extraction stays deterministic if the envelope gains another array, makes contacts_tags derivation collect all per-tag upsert failures instead of returning on the first failed tag, switches the derived id to a printable URL-escaped tag component, adds an indexed contacts_tags.tag column for tag-name queries, injects the resolved locationId into locations_tags rows before typed upsert, opens the sql command with a read-only SQLite handle, lets locations_tags use its own resource-scoped locationId, replaces each contact's derived contacts_tags set so removed tags are pruned from typed and generic tables even when tags is missing or null, and propagates env-resolved GHL_LOCATION_ID into the contacts POST body."
+    },
+    {
+      "date": "2026-05-24",
+      "amend_run_id": "amend-2026-05-24-searchafter-cursor-shape",
+      "summary": "fix(gohighlevel): contacts sync 400s on page 2 \u2014 prefer per-contact searchAfter array over synthesized [id] cursor",
+      "files": [
+        "internal/cli/sync.go"
+      ],
+      "findings_addressed": [
+        "F1-cursor-shape"
+      ],
+      "patch_count": 3,
+      "notes": "extractSearchAfterCursor Strategy 2 synthesized a 1-element []string{id} as the next-page cursor. GHL's /contacts/search returns each contact's searchAfter as a 2-element [timestamp_ms, id] array and requires the same 2-element shape on the next request body \u2014 the 1-element form is rejected with HTTP 400 \"Error occurred while searching for contact\". Hit while building Phase A of the KWCP non-KW production-tiering pipeline: `gohighlevel-pp-cli sync --resources contacts` succeeded on page 1 (100 contacts), failed every subsequent run on page 2. Fix prefers the last contact's own searchAfter array (matches what fetchSyncPage already json.Unmarshals back into the next request body); keeps the id-only fallback as defensive code only with an inline comment noting GHL currently rejects it."
     }
   ]
 }

--- a/library/sales-and-crm/gohighlevel/internal/cli/sync.go
+++ b/library/sales-and-crm/gohighlevel/internal/cli/sync.go
@@ -1290,7 +1290,16 @@ func extractSearchAfterCursor(data json.RawMessage) (string, bool) {
 			}
 		}
 	}
-	// Strategy 2: derive from the last contact's id (GHL pattern).
+	// Strategy 2: pull the last contact's own per-item searchAfter array.
+	// PATCH(amend-2026-05-24: prefer per-contact searchAfter [timestamp_ms, id]
+	// over synthesized [id]) — GHL /contacts/search emits a 2-element
+	// [timestamp_ms, id] searchAfter on each contact in the response and
+	// requires the same 2-element shape on the next request body. The prior
+	// fallback of synthesizing []string{id} produced a 1-element cursor that
+	// the API rejects with HTTP 400 "Error occurred while searching for
+	// contact" on page 2. Use the contact's own array first; keep the
+	// id-only fallback only as defense in case GHL ever stops emitting
+	// per-contact searchAfter.
 	rawContacts, ok := envelope["contacts"]
 	if !ok {
 		return "", false
@@ -1300,6 +1309,19 @@ func extractSearchAfterCursor(data json.RawMessage) (string, bool) {
 		return "", false
 	}
 	last := contacts[len(contacts)-1]
+	// PATCH(amend-2026-05-24: prefer per-contact searchAfter)
+	if rawSA, ok := last["searchAfter"]; ok {
+		// Validate shape: must be a non-empty array. Marshal back to JSON
+		// for storage in sync_state.last_cursor (same encoding fetchSyncPage
+		// expects to json.Unmarshal back into []any).
+		if saArr, ok := rawSA.([]any); ok && len(saArr) > 0 {
+			out, err := json.Marshal(saArr)
+			if err == nil {
+				return string(out), true
+			}
+		}
+	}
+	// PATCH(amend-2026-05-24: id-only fallback — defensive only, GHL rejects 1-element cursors as of 2026-05-24)
 	if id, ok := last["id"].(string); ok && id != "" {
 		out, err := json.Marshal([]string{id})
 		if err == nil {


### PR DESCRIPTION
## Summary

`gohighlevel-pp-cli sync --resources contacts` succeeds on page 1 (100 contacts), then fails on every subsequent page with HTTP 400 `"Error occurred while searching for contact"`. Root cause: `extractSearchAfterCursor` Strategy 2 synthesizes a 1-element `[id]` cursor, but GHL's `/contacts/search` requires the same 2-element `[timestamp_ms, id]` shape it emits per-contact in each response.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1-cursor-shape | sync pagination | bug | Strategy 2 of `extractSearchAfterCursor` emits `[]string{id}` (1-element). GHL emits per-contact `searchAfter: [timestamp_ms, id]` (2-element) and rejects 1-element cursors with HTTP 400. Prefer the contact's own array; keep id-only as defense-only fallback. |

## Changes

`internal/cli/sync.go` — `extractSearchAfterCursor` Strategy 2 now reads `last["searchAfter"]` first and only falls back to `[id]` synthesis if missing. 3 `// PATCH(amend-2026-05-24...)` markers added. `.printing-press-patches.json` updated.

```
 .printing-press-patches.json       | 41 +++++++++++++++++++---
 internal/cli/sync.go               | 24 ++++++++++++-
 2 files changed, 59 insertions(+), 6 deletions(-)
```

## Verification

- `manifest`, `transcendence`, `phase5`, `go mod tidy`, `go vet`, `go build`, `--help`, `--version`, `manuscripts`: **PASS**
- `govulncheck` (golang.org/x/net@v0.43.0 GO-2026-5026) and `verify-skill` (SKILL.md install-section drift): **pre-existing failures on upstream/main**, not introduced by this patch. Confirmed by running `publish validate` on a clean stash of upstream/main and reproducing identical failures.
- Dogfood: hit on real workload — KWCP non-KW production-tiering pipeline (`kwcp_nonkw_production_import.py` Phase A) needed `sync --resources contacts` to populate the local SQLite cache for fast in-memory matching against 13,869 MLS-sourced agents. Reproducer is deterministic: page 1 succeeds, page 2 returns 400 on every retry. Source-dive confirmed Strategy 2's `json.Marshal([]string{id})` emits e.g. `["fGtyf1BozvqzKEI4uImj"]` (1-element); the same response envelope shows `"searchAfter":[1779629940872,"oxX5r5toyVyoRgI1hRMr"]` (2-element) on each individual contact.

## Patch contract

- 3 new `// PATCH(amend-2026-05-24...)` source comments added
- `.printing-press-patches.json` `patches[-1].patch_count: 3` (parity confirmed)

🤖 Generated by /printing-press-amend