### PR TITLE
feat(supabase): autonomous policy-gated production migrations

### DIFF
--- a/library/developer-tools/supabase/.printing-press-patches.json
+++ b/library/developer-tools/supabase/.printing-press-patches.json
@@ -40,6 +40,54 @@
       "summary": "Hand-edited README and SKILL with calibrated headline, explicit Known Gaps section, and trigger phrases narrowed to built capabilities.",
       "reason": "Generated README/SKILL inherited the overclaim from the default headline and included triggers (`supabase start`, `supabase db push`) that this CLI cannot satisfy (those are local-dev/migration tooling owned by the official Supabase CLI). Narrowing triggers prevents misrouting from agents that load this skill.",
       "files": ["README.md", "SKILL.md"]
+    },
+    {
+      "id": "safe-mutation-lifecycle",
+      "date": "2026-05-25",
+      "amend_run_id": "amend-2026-05-25T1933",
+      "summary": "Novel safe production-mutation lifecycle plus read/audit commands: db plan/apply/receipt/revert/lint/diff, top-level query (read-only default, --write opt-in), advisors security|performance with cross-project --refs fleet mode, and doctor reachable-refs listing. plan parses SQL into a typed change manifest (operation class, objects, est-rows, reversibility) with a deterministic plan_hash; apply executes ONLY an approved plan_hash and refuses on hash drift, wrapping statements in a transaction with savepoint-per-statement; receipt snapshots affected object defs and derives mechanical inverses (CREATE->DROP, ADD COLUMN->DROP COLUMN, REVOKE->GRANT); revert replays the inverse. db lint runs splinter-style checks locally before apply and catches the SECURITY-DEFINER-unrevoked-grant + bare-auth.uid()-init-plan class of issues at author time. The statement splitter is dollar-quote-tag-aware: it tracks arbitrary tags ($$ and $tag$) so a `DO $ttl$ ... $ttl$` block (migration 008's TTL cleanup) is never split on a semicolon inside its body, and $1 positional parameters are not mistaken for tags (spec build-correctness note #1).",
+      "reason": "Motivated by a real incident: an opaque prod migration (008 RLS/grants) could not be safely auto-applied because the change had no legible, reversible representation a human or safety layer could reason about. The lifecycle makes every DB mutation a structured, inspectable, reversible, attestable transaction. The typed manifest lets a safety classifier gate by operation class (allow additive RLS rewrite, gate data deletion) instead of blunt-blocking everything, STRENGTHENING the human-in-the-loop gate: authorization becomes 'approve this immutable, dry-run'd, inspected plan hash' rather than 'trust the agent.' Built on the existing Management API client (/v1/projects/{ref}/database/query) and advisor endpoints; reuses parseDayDuration, classifyAPIError, printJSONFiltered, and the cliError exit-code helpers. New internal/dbchange package carries the parser/classifier with unit tests.",
+      "files": [
+        "internal/dbchange/manifest.go",
+        "internal/dbchange/manifest_test.go",
+        "internal/cli/db_top.go",
+        "internal/cli/db_shared.go",
+        "internal/cli/db_plan.go",
+        "internal/cli/db_apply.go",
+        "internal/cli/db_receipt.go",
+        "internal/cli/db_revert.go",
+        "internal/cli/db_lint.go",
+        "internal/cli/db_diff.go",
+        "internal/cli/query_top.go",
+        "internal/cli/advisors_top.go",
+        "internal/cli/doctor.go",
+        "internal/cli/root.go",
+        "README.md"
+      ],
+      "findings_addressed": ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8"],
+      "patch_count": 17
+    },
+    {
+      "id": "autonomous-prod-migrations",
+      "date": "2026-05-25",
+      "amend_run_id": "amend-2026-05-25T2110",
+      "summary": "Make autonomous production migrations real: replace the human-in-the-loop approver with a policy approver, swap the blunt --allow-destructive boolean for expand/contract decomposition, and add a branch-first staging gate. (1) `db apply --policy safe-default|<file>` evaluates the typed dbchange.Manifest against a declared safe envelope and self-authorizes apply ONLY when every statement is in an allowed class, reversible, lint-clean, and est_rows_affected==0; the plan_hash drift gate, savepoint transaction, and reversal receipt are kept exactly as-is — the policy replaces only the human paste, not the safety primitives. The safe-default envelope is additive+reversible only (CREATE table/index/policy/function, ADD COLUMN nullable-or-constant-default, GRANT, RLS add/rewrite, est_rows 0, lint clean). A new structured EstRowsAffected field (0=no data rows touched, -1=unknown/unbounded) plus a MaxEstRowsAffected rollup make the est-rows gate machine-evaluable; a volatile-default ADD COLUMN (now()/gen_random_uuid()) is correctly scored -1 since it rewrites every row. (2) New `db decompose` rewrites DROP COLUMN into a reversible tombstone-rename (now) plus a deferred hard drop, and ALTER COLUMN TYPE into expand (add new typed column) / backfill (app-owned, manual gate) / contract (drop old, rename new) — each auto-eligible step independently inside the safe envelope; TRUNCATE, unbounded DELETE, and DROP TABLE/SCHEMA are refused with a structured machine-readable reason and a no-op, never silently. (3) `db apply --stage-branch <ref>` requires the exact transaction to apply cleanly to a Supabase preview branch with the security AND performance advisors green before the prod apply runs, reusing the branch-config + database/query + advisor endpoints. The authorization mode (human plan-hash vs named policy) is recorded in the reversal receipt as an audit attestation.",
+      "reason": "The prior safe-mutation-lifecycle made every DB change legible, reversible, and attestable but still required a human to paste an approved plan_hash. This amend closes the autonomy loop: the typed manifest the prior run built is exactly the input a safety classifier needs, so authorization becomes 'this immutable, dry-run'd plan is provably inside a declared safe envelope' instead of 'a human looked at it.' Crucially the policy STRENGTHENS rather than removes the gate — it can only ever self-authorize the additive+reversible+zero-row class, and it refuses everything else with a structured reason. Destructive intent is no longer a blunt boolean override; it is either mechanically decomposed into safe online steps or refused with a machine-readable explanation an agent can branch on. Branch-first staging adds a real preflight (advisors green on a throwaway branch) so a plan that passes the policy but trips an advisor never reaches prod. The GitHub Action runner that drives this autonomously is intentionally NOT built here — it is companion infra in a separate repo. Built entirely on the existing dbchange.Manifest, Management API database/query + advisor endpoints, and branch config endpoint; reuses assembleTransaction, lintManifest, replacePathParam, classifyAPIError, printJSONFiltered.",
+      "files": [
+        "internal/dbchange/manifest.go",
+        "internal/dbchange/policy.go",
+        "internal/dbchange/policy_test.go",
+        "internal/dbchange/decompose.go",
+        "internal/dbchange/decompose_test.go",
+        "internal/cli/db_apply.go",
+        "internal/cli/db_shared.go",
+        "internal/cli/db_top.go",
+        "internal/cli/db_decompose.go",
+        "internal/cli/db_stage.go",
+        "README.md"
+      ],
+      "findings_addressed": ["A1", "A2", "A3"],
+      "patch_count": 17
     }
   ]
 }

--- a/library/developer-tools/supabase/README.md
+++ b/library/developer-tools/supabase/README.md
@@ -138,6 +138,65 @@ supabase-pp-cli pgrst schema --table profiles --json
 
 These capabilities aren't available in any other tool for this API.
 
+### Safe production-mutation lifecycle
+
+Make every database change a structured, inspectable, reversible, attestable transaction — and make autonomous production migrations real without removing the guardrails. Authorization can be a human approving an immutable, dry-run'd plan hash, **or** a policy that self-authorizes only the provably-safe class of changes.
+
+- **`db plan <file.sql | --sql "...">`** — Parse SQL into a typed change manifest. Each statement is classified by operation class (`ddl` | `grant` | `rls` | `data-write` | `destructive`), the objects it touches, a reversibility verdict (`auto` | `snapshot` | `none`), and a structured `est_rows_affected` (`0` = no existing data rows touched; `-1` = unknown/unbounded). Emits a deterministic `plan_hash`.
+
+  ```bash
+  supabase-pp-cli db plan migrations/008_rls.sql --json
+  ```
+- **`db apply <ref> <file.sql> --approved <plan-hash>`** — **Human approver.** Execute ONLY the approved plan; refuse on hash drift (the SQL changed since approval). Statements run inside a single transaction with a savepoint per statement, so a partial migration never lands.
+
+  ```bash
+  supabase-pp-cli db apply abcdefgh migrations/008_rls.sql --approved sha256:... --json
+  ```
+- **`db apply <ref> <file.sql> --policy safe-default | <file.json>`** — **Policy approver (autonomous).** Evaluate the typed manifest against a declared safe envelope and self-authorize the apply ONLY when every statement is in an allowed class, reversible, lint-clean, and touches zero existing data rows (`est_rows_affected == 0`). The built-in `safe-default` envelope is additive + reversible only: `CREATE table/index/policy/function`, `ADD COLUMN` (nullable or constant default), `GRANT`, RLS policy add/rewrite. The policy replaces only the human paste — the plan_hash drift gate, savepoint transaction, and reversal receipt all still run. A refusal is a structured, machine-readable no-op (never a silent pass-through), and the authorization mode is recorded in the receipt.
+
+  ```bash
+  supabase-pp-cli db apply abcdefgh migrations/008_rls.sql --policy safe-default --json
+  ```
+- **`db apply ... --stage-branch <branch-ref>`** — **Branch-first staging gate.** Require the exact transaction to apply cleanly to a Supabase preview branch with the `security` AND `performance` advisors green before the prod apply runs. A plan that passes the policy but trips an advisor on the throwaway branch never reaches production.
+
+  ```bash
+  supabase-pp-cli db apply abcdefgh migrations/008_rls.sql --policy safe-default --stage-branch preview-123 --json
+  ```
+- **`db decompose <file.sql>`** — Rewrite destructive operation classes into a safe expand/contract step sequence whose individual steps each fall inside the safe envelope. `DROP COLUMN` becomes a reversible tombstone-rename (now) plus a deferred hard drop; `ALTER COLUMN ... TYPE` becomes expand (add new typed column) / backfill (app-owned, manual) / contract (drop old, rename new). `TRUNCATE`, unbounded `DELETE`, and `DROP TABLE`/`DROP SCHEMA` are refused with a structured machine-readable reason and a no-op. Replaces the blunt `--allow-destructive` boolean.
+
+  ```bash
+  supabase-pp-cli db decompose migrations/012_drop_legacy.sql --json
+  ```
+- **`db receipt` / `db revert <receipt>`** — Before mutating, snapshot affected object definitions (`pg_get_functiondef`, `pg_policies`, `information_schema` grants) and auto-derive the mechanical inverse (CREATE→DROP, ADD COLUMN→DROP COLUMN, REVOKE→GRANT). `db revert` is the one-command undo.
+
+  ```bash
+  supabase-pp-cli db revert abcdefgh-20260525T193300Z --json
+  ```
+- **`db lint <file.sql>`** — Run splinter-style security/performance checks locally, BEFORE apply. Catches SECURITY DEFINER functions with un-revoked `public`/`anon` EXECUTE, RLS policies using bare `auth.uid()` (init-plan re-eval), and grants to `anon` on tables without RLS. Exits non-zero on any ERROR finding, so it gates CI.
+
+  ```bash
+  supabase-pp-cli db lint migrations/008_rls.sql --json
+  ```
+- **`db diff <ref>`** — Compare the local `supabase/migrations/` directory against remote applied migration history; report unapplied local versions.
+
+  ```bash
+  supabase-pp-cli db diff abcdefgh --json
+  ```
+
+### Reads + audit
+
+- **`query <ref> <sql>`** — Run SQL, **read-only by default** (`read_only=true`, so an accidental write is rejected by the database). Pass `--write` to opt into mutations.
+
+  ```bash
+  supabase-pp-cli query abcdefgh "select count(*) from auth.users" --json
+  ```
+- **`advisors security|performance <ref>`** — Pull splinter advisor findings in one command instead of reading the dashboard. Sweep a fleet with `--refs a,b,c`.
+
+  ```bash
+  supabase-pp-cli advisors security abcdefgh --json
+  supabase-pp-cli advisors performance --refs proj1,proj2,proj3 --json
+  ```
+
 ### Cross-project rollups
 - **`secrets where-name`** — Find every project (across orgs) holding a secret with a given name, plus when each was last synced.
 

--- a/library/developer-tools/supabase/internal/cli/advisors_top.go
+++ b/library/developer-tools/supabase/internal/cli/advisors_top.go
@@ -1,0 +1,159 @@
+// PATCH: novel top-level `advisors security|performance` — ergonomic wrapper over the splinter advisor endpoints with cross-project --refs fleet mode.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newAdvisorsTopCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "advisors",
+		Short: "Pull splinter security/performance advisor findings (single project or --refs fleet)",
+		Long: `Turn manual dashboard advisor-reading into one command. Wraps the Management
+API advisor endpoints:
+
+  advisors security <ref>      Security linter findings (RLS gaps, exposed grants, etc.)
+  advisors performance <ref>   Performance linter findings (missing indexes, init-plan re-eval, etc.)
+
+Pass --refs a,b,c instead of a positional <ref> to sweep a whole fleet of
+projects and aggregate the findings into one result keyed by project.`,
+	}
+	cmd.AddCommand(newAdvisorsKindCmd(flags, "security", "/v1/projects/{ref}/advisors/security"))
+	cmd.AddCommand(newAdvisorsKindCmd(flags, "performance", "/v1/projects/{ref}/advisors/performance"))
+	return cmd
+}
+
+func newAdvisorsKindCmd(flags *rootFlags, kind, pathTmpl string) *cobra.Command {
+	var refs string
+
+	cmd := &cobra.Command{
+		Use:         kind + " [ref]",
+		Short:       fmt.Sprintf("Pull %s advisor findings for a project (or --refs fleet)", kind),
+		Example:     fmt.Sprintf("  supabase-pp-cli advisors %s abcdefgh --json\n  supabase-pp-cli advisors %s --refs proj1,proj2,proj3 --json", kind, kind),
+		Annotations: map[string]string{"pp:method": "GET", "pp:path": pathTmpl, "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			refList, err := resolveRefs(args, refs)
+			if err != nil {
+				return err
+			}
+			if dryRunOK(flags) {
+				return nil
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			// Single-ref: return the advisor payload directly. Advisor
+			// endpoints are GET on the Management API.
+			if len(refList) == 1 {
+				path := replacePathParam(pathTmpl, "ref", refList[0])
+				gdata, gerr := c.Get(path, nil)
+				if gerr != nil {
+					return classifyAPIError(gerr, flags)
+				}
+				out := cmd.OutOrStdout()
+				if wantsHumanTable(out, flags) {
+					var items []map[string]any
+					if json.Unmarshal(gdata, &items) == nil && len(items) > 0 {
+						if printAutoTable(out, items) == nil {
+							return nil
+						}
+					}
+				}
+				return printOutputWithFlags(out, gdata, flags)
+			}
+
+			// Fleet mode: aggregate per-ref.
+			agg := fleetAdvisors(c, flags, refList, pathTmpl)
+			return printJSONFiltered(cmd.OutOrStdout(), agg, flags)
+		},
+	}
+	cmd.Flags().StringVar(&refs, "refs", "", "Comma-separated project refs to sweep as a fleet (instead of a single positional ref)")
+	return cmd
+}
+
+// extractProjectRefs pulls the "id"/"ref" field from a /v1/projects list
+// response. Used by doctor to surface reachable project refs.
+func extractProjectRefs(data json.RawMessage) []string {
+	var items []map[string]any
+	if json.Unmarshal(data, &items) != nil {
+		return nil
+	}
+	var out []string
+	for _, it := range items {
+		for _, k := range []string{"id", "ref"} {
+			if v, ok := it[k].(string); ok && v != "" {
+				out = append(out, v)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// resolveRefs reconciles a positional ref arg with --refs. Exactly one source
+// must be provided; --refs may carry one or many.
+func resolveRefs(args []string, refs string) ([]string, error) {
+	hasPositional := len(args) > 0 && args[0] != ""
+	hasRefs := strings.TrimSpace(refs) != ""
+	switch {
+	case hasPositional && hasRefs:
+		return nil, usageErr(fmt.Errorf("provide either a positional <ref> or --refs, not both"))
+	case hasPositional:
+		return []string{args[0]}, nil
+	case hasRefs:
+		var out []string
+		for _, r := range strings.Split(refs, ",") {
+			if t := strings.TrimSpace(r); t != "" {
+				out = append(out, t)
+			}
+		}
+		if len(out) == 0 {
+			return nil, usageErr(fmt.Errorf("--refs was empty after parsing"))
+		}
+		return out, nil
+	default:
+		return nil, usageErr(fmt.Errorf("no project ref(s): pass a positional <ref> or --refs a,b,c"))
+	}
+}
+
+// fleetAdvisors sweeps the advisor endpoint across refs, capturing per-ref
+// findings (or per-ref errors) into one aggregate result.
+func fleetAdvisors(c interface {
+	Get(string, map[string]string) (json.RawMessage, error)
+}, flags *rootFlags, refs []string, pathTmpl string) map[string]any {
+	type refResult struct {
+		Ref     string          `json:"project_ref"`
+		Error   string          `json:"error,omitempty"`
+		Count   int             `json:"finding_count"`
+		Finding json.RawMessage `json:"findings,omitempty"`
+	}
+	var results []refResult
+	total := 0
+	for _, ref := range refs {
+		path := replacePathParam(pathTmpl, "ref", ref)
+		data, err := c.Get(path, nil)
+		rr := refResult{Ref: ref}
+		if err != nil {
+			rr.Error = err.Error()
+		} else {
+			var items []json.RawMessage
+			_ = json.Unmarshal(data, &items)
+			rr.Count = len(items)
+			rr.Finding = data
+			total += rr.Count
+		}
+		results = append(results, rr)
+	}
+	return map[string]any{
+		"fleet":         true,
+		"project_count": len(refs),
+		"total_findings": total,
+		"projects":      results,
+	}
+}

--- a/library/developer-tools/supabase/internal/cli/db_apply.go
+++ b/library/developer-tools/supabase/internal/cli/db_apply.go
@@ -1,0 +1,271 @@
+// PATCH: novel `db apply --approved <plan-hash>` — executes ONLY the approved plan, refuses on hash drift, transaction + savepoint wrapped. Not a single Management API endpoint.
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+func newDBApplyCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+	var approved string
+	var policySpec string
+	var stageBranch string
+	var skipReceipt bool
+	var allowDestructive bool
+
+	cmd := &cobra.Command{
+		Use:   "apply <ref> [file.sql]",
+		Short: "Execute an authorized plan against a project; refuses on SQL drift",
+		Long: `Re-plans the SQL, recomputes the plan_hash, and refuses to run if it differs
+from the authorized hash (the SQL changed since approval). Authorized statements
+run inside a single transaction with a savepoint per statement: any statement
+error rolls back to its savepoint and aborts the whole apply, so a partial
+migration never lands.
+
+AUTHORIZATION — two interchangeable approvers, the safety primitives are the same:
+
+  --approved <plan-hash>   Human approver. You run 'db plan', inspect it, and
+                           paste back its plan_hash. Drift-checked.
+  --policy <name|file>     Policy approver. The typed manifest is evaluated
+                           against a safe envelope and self-authorizes ONLY when
+                           every statement is in an allowed class, reversible,
+                           lint-clean, and touches zero existing data rows. Use
+                           'safe-default' for the built-in additive+reversible
+                           envelope, or a path to a policy JSON file.
+
+The policy replaces the human approver, not the safety primitives: the plan_hash
+drift gate, the savepoint transaction, and the receipt still run unchanged.
+
+Destructive changes (DROP COLUMN, type change) are not authorized by the
+safe-default policy; route them through 'db decompose' which rewrites them into
+an expand/contract sequence whose steps each fall inside the safe envelope.
+
+Before mutating, a receipt is captured (object snapshots + mechanical inverse)
+so the change is reversible with 'db revert'.`,
+		Example: `  supabase-pp-cli db apply abcdefgh migrations/008_rls.sql --approved sha256:... --json
+  supabase-pp-cli db apply abcdefgh migrations/008_rls.sql --policy safe-default --json
+  supabase-pp-cli db apply abcdefgh --sql "..." --policy ./policies/team.json --stage-branch preview-123`,
+		Annotations: map[string]string{"pp:method": "POST", "pp:path": "/v1/projects/{ref}/database/query"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			ref := args[0]
+			if approved == "" && policySpec == "" {
+				return usageErr(fmt.Errorf("authorization required: pass --approved <plan-hash> (human) or --policy <name|file> (policy). Run 'db plan' first to see the plan_hash"))
+			}
+			if approved != "" && policySpec != "" {
+				return usageErr(fmt.Errorf("pass either --approved or --policy, not both"))
+			}
+			sql, src, err := loadSQL(args[1:], inlineSQL)
+			if err != nil {
+				return err
+			}
+			m := dbchange.Parse(sql, src)
+
+			// Authorization. Either the human paste (--approved, drift-checked) or
+			// the policy approver (--policy) must clear before anything mutates.
+			var policyVerdict *dbchange.PolicyVerdict
+			if approved != "" {
+				// Human approver — the original drift gate.
+				if m.PlanHash != approved {
+					return apiErr(fmt.Errorf("plan-hash drift: SQL hashes to %s but you approved %s.\nThe SQL changed since approval — re-run 'db plan' and approve the new hash", m.PlanHash, approved))
+				}
+			} else {
+				// Policy approver — self-authorize within a declared envelope. The
+				// plan_hash is still computed and recorded; the policy replaces only
+				// the human paste, so a re-planned hash that drifts from a separately
+				// recorded authorization is still detectable downstream.
+				pol, perr := resolvePolicy(policySpec)
+				if perr != nil {
+					return usageErr(perr)
+				}
+				// "lint-clean" is evaluated with the same ruleset 'db lint' uses.
+				errorLintCount := 0
+				for _, f := range lintManifest(m, sql) {
+					if f.Level == "ERROR" {
+						errorLintCount++
+					}
+				}
+				verdict := pol.Evaluate(m, errorLintCount)
+				policyVerdict = &verdict
+				if !verdict.Authorized {
+					// Structured, machine-readable refusal + no-op. NEVER a silent
+					// pass-through. Emit the full verdict as JSON in agent/JSON mode
+					// so a caller can branch on the reasons.
+					out := cmd.OutOrStdout()
+					if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+						_ = printJSONFiltered(out, map[string]any{
+							"applied":     false,
+							"authorized":  false,
+							"project_ref": ref,
+							"plan_hash":   m.PlanHash,
+							"policy":      verdict.Policy,
+							"reasons":     verdict.Reasons,
+						}, flags)
+					}
+					return apiErr(fmt.Errorf("policy %q refused this plan (%d reason(s)); not applied. First: %s",
+						verdict.Policy, len(verdict.Reasons), firstReason(verdict.Reasons)))
+				}
+			}
+
+			// Destructive override remains available for the human-approved path
+			// (the policy path already gated destructiveness via the envelope).
+			if approved != "" && m.HasDestructive && !allowDestructive {
+				return usageErr(fmt.Errorf("plan contains destructive statement(s) (DROP/TRUNCATE/DELETE); pass --allow-destructive, or route through 'db decompose' for an expand/contract sequence"))
+			}
+
+			// Branch-first staging gate: a plan is only prod-eligible after it
+			// applies cleanly to a Supabase preview branch with advisors green.
+			if stageBranch != "" && !flags.dryRun {
+				if serr := stageOnBranch(cmd, flags, stageBranch, m, sql, src); serr != nil {
+					return serr
+				}
+			}
+
+			// Assemble one transactional SQL string. The Management API
+			// database/query endpoint runs the posted SQL as a single unit;
+			// wrapping in BEGIN/COMMIT with per-statement savepoints gives the
+			// all-or-nothing guarantee and bounded rollback target.
+			txSQL := assembleTransaction(m)
+			path := replacePathParam("/v1/projects/{ref}/database/query", "ref", ref)
+
+			// Dry-run before any client work: show the transaction, take no
+			// snapshots, send nothing.
+			if flags.dryRun {
+				out := cmd.OutOrStdout()
+				fmt.Fprintf(out, "[dry-run] would POST %d-statement transaction to %s (plan_hash %s)\n", m.StatementN, path, m.PlanHash)
+				fmt.Fprintln(out, txSQL)
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+
+			// Capture the receipt (snapshots + inverse) BEFORE mutating.
+			var rcpt *receipt
+			if !skipReceipt {
+				rcpt = buildReceipt(cmd, c, ref, m)
+				// Record how this apply was authorized so the receipt is a full
+				// audit artifact: either a human plan-hash paste or a named policy.
+				if policyVerdict != nil {
+					rcpt.Authorization = "policy:" + policyVerdict.Policy
+				} else {
+					rcpt.Authorization = "human:approved-plan-hash"
+				}
+			}
+
+			body := map[string]any{"query": txSQL}
+			data, status, err := c.Post(path, body)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			if rcpt != nil {
+				rcpt.Applied = true
+				rpath, werr := writeReceipt(rcpt)
+				if werr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: apply succeeded but receipt write failed: %v\n", werr)
+				} else {
+					fmt.Fprintf(cmd.ErrOrStderr(), "receipt: %s\n", rpath)
+				}
+			}
+
+			out := cmd.OutOrStdout()
+			result := map[string]any{
+				"applied":     true,
+				"project_ref": ref,
+				"plan_hash":   m.PlanHash,
+				"statements":  m.StatementN,
+				"status":      status,
+			}
+			if rcpt != nil {
+				result["receipt_id"] = rcpt.Receipt
+				result["reversible"] = !m.HasIrreversible
+			}
+			if policyVerdict != nil {
+				result["authorized"] = true
+				result["policy"] = policyVerdict.Policy
+			}
+			if len(data) > 0 {
+				result["result"] = trimRaw(data)
+			}
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				return printJSONFiltered(out, result, flags)
+			}
+			fmt.Fprintf(out, "Applied %d statement(s) to %s (plan_hash %s).\n", m.StatementN, ref, m.PlanHash)
+			if rcpt != nil {
+				if m.HasIrreversible {
+					fmt.Fprintf(out, "Receipt %s written (NOTE: plan has irreversible statements — revert is partial).\n", rcpt.Receipt)
+				} else {
+					fmt.Fprintf(out, "Receipt %s written. Undo with: supabase-pp-cli db revert %s\n", rcpt.Receipt, rcpt.Receipt)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "Inline SQL to apply (instead of a file argument)")
+	cmd.Flags().StringVar(&approved, "approved", "", "Human approver: the plan_hash from 'db plan' authorizing this apply")
+	cmd.Flags().StringVar(&policySpec, "policy", "", "Policy approver: 'safe-default' or a path to a policy JSON file (self-authorizes within the envelope)")
+	cmd.Flags().StringVar(&stageBranch, "stage-branch", "", "Require the plan to apply cleanly to this preview branch with advisors green before prod apply")
+	cmd.Flags().BoolVar(&skipReceipt, "skip-receipt", false, "Do not capture a reversal receipt (not recommended)")
+	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "Human-approved path only: permit destructive statements. The policy path uses 'db decompose' instead")
+	return cmd
+}
+
+// resolvePolicy turns the --policy value into a *dbchange.Policy. The literal
+// "safe-default" maps to the built-in Shane-approved additive+reversible
+// envelope; any other value is treated as a path to a policy JSON file.
+// PATCH(amend-2026-05-25: policy approver resolution).
+func resolvePolicy(spec string) (*dbchange.Policy, error) {
+	if spec == "safe-default" {
+		return dbchange.SafeDefaultPolicy(), nil
+	}
+	return dbchange.LoadPolicy(spec)
+}
+
+// firstReason returns the first refusal message, for a one-line error summary.
+func firstReason(rs []dbchange.PolicyReason) string {
+	if len(rs) == 0 {
+		return ""
+	}
+	return rs[0].Message
+}
+
+// assembleTransaction wraps the approved statements in a BEGIN/COMMIT block with
+// a named savepoint before each statement. Postgres aborts the whole
+// transaction on any unhandled error, so a failing statement rolls the entire
+// apply back — no partial migration. The savepoints make the failure target
+// explicit and survive in the receipt for audit.
+func assembleTransaction(m *dbchange.Manifest) string {
+	var b strings.Builder
+	b.WriteString("BEGIN;\n")
+	for i, s := range m.Statements {
+		fmt.Fprintf(&b, "SAVEPOINT pp_sp_%d;\n", i)
+		stmt := strings.TrimSpace(s.SQL)
+		if !strings.HasSuffix(stmt, ";") {
+			stmt += ";"
+		}
+		b.WriteString(stmt)
+		b.WriteString("\n")
+	}
+	b.WriteString("COMMIT;\n")
+	return b.String()
+}
+
+// trimRaw returns the raw JSON if it parses, else nil, to avoid embedding
+// invalid bytes in the result envelope.
+func trimRaw(data []byte) any {
+	var v any
+	if err := jsonUnmarshal(data, &v); err != nil {
+		return nil
+	}
+	return v
+}

--- a/library/developer-tools/supabase/internal/cli/db_decompose.go
+++ b/library/developer-tools/supabase/internal/cli/db_decompose.go
@@ -1,0 +1,105 @@
+// PATCH(amend-2026-05-25: novel `db decompose` — rewrite destructive operation
+// classes into an expand/contract step sequence whose individual steps each
+// fall inside the safe envelope, or refuse with a structured machine-readable
+// reason and a no-op). Replaces the blunt --allow-destructive boolean. Not in
+// the Management API.
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+func newDBDecomposeCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+
+	cmd := &cobra.Command{
+		Use:   "decompose [file.sql]",
+		Short: "Rewrite destructive changes into a safe expand/contract step sequence (or refuse with a reason)",
+		Long: `Take a migration containing destructive operation classes and rewrite each one
+into an expand/contract sequence whose individual steps each fall inside the
+safe envelope:
+
+  DROP COLUMN          -> tombstone-rename now (reversible), hard drop deferred
+  ALTER COLUMN ... TYPE -> add new typed column (expand), app backfill, drop old (contract)
+
+Classes that cannot be safely decomposed are REFUSED with a structured,
+machine-readable reason and a no-op — never silently dropped:
+
+  TRUNCATE             -> refused (irreversible, removes all rows)
+  unbounded DELETE     -> refused (no WHERE, removes all rows)
+  DROP TABLE / SCHEMA  -> refused (may have dependents / cascades)
+
+Only expand-phase steps are auto-eligible; backfill and contract steps are
+surfaced as manual gates that a later run must apply explicitly. Exit code is
+non-zero (5) if any statement was refused, so it gates a pipeline.`,
+		Example:     `  supabase-pp-cli db decompose migrations/012_drop_legacy.sql --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			sql, src, err := loadSQL(args, inlineSQL)
+			if err != nil {
+				return err
+			}
+			m := dbchange.Parse(sql, src)
+			results, anyRefused := dbchange.DecomposeManifest(m)
+
+			out := cmd.OutOrStdout()
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				refusedCount := 0
+				for _, r := range results {
+					if !r.Decomposed {
+						refusedCount++
+					}
+				}
+				payload := map[string]any{
+					"source":         src,
+					"plan_hash":      m.PlanHash,
+					"statement_count": m.StatementN,
+					"refused_count":  refusedCount,
+					"results":        results,
+				}
+				if perr := printJSONFiltered(out, payload, flags); perr != nil {
+					return perr
+				}
+			} else {
+				printDecomposeTable(cmd, src, results)
+			}
+			if anyRefused {
+				return apiErr(fmt.Errorf("one or more statements could not be safely decomposed (refused, no-op)"))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "Inline SQL to decompose (instead of a file argument)")
+	return cmd
+}
+
+func printDecomposeTable(cmd *cobra.Command, src string, results []dbchange.DecompResult) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Decompose: %s\n\n", src)
+	for _, r := range results {
+		if !r.Decomposed {
+			fmt.Fprintf(out, "[%d] REFUSED (%s): %s\n", r.OriginalIndex, r.RefusedRule, r.RefusedReason)
+			fmt.Fprintf(out, "      original: %s\n\n", truncate(r.OriginalSQL, 70))
+			continue
+		}
+		fmt.Fprintf(out, "[%d] %s -> %d step(s):\n", r.OriginalIndex, r.OpClass, len(r.Steps))
+		for _, st := range r.Steps {
+			auto := "manual"
+			if st.AutoApply {
+				auto = "auto"
+			}
+			fmt.Fprintf(out, "      (%s, %s) %s\n", st.Phase, auto, truncate(st.SQL, 64))
+			if st.Note != "" {
+				fmt.Fprintf(out, "        note: %s\n", st.Note)
+			}
+		}
+		fmt.Fprintln(out)
+	}
+}

--- a/library/developer-tools/supabase/internal/cli/db_diff.go
+++ b/library/developer-tools/supabase/internal/cli/db_diff.go
@@ -1,0 +1,145 @@
+// PATCH: novel `db diff` — local supabase/migrations dir vs remote applied migration history. Composes /v1/projects/{ref}/database/migrations with a local dir walk.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var reMigrationVersion = regexp.MustCompile(`^(\d{8,})`)
+
+func newDBDiffCmd(flags *rootFlags) *cobra.Command {
+	var migrationsDir string
+
+	cmd := &cobra.Command{
+		Use:   "diff <ref>",
+		Short: "Show local migrations not yet applied to the remote project",
+		Long: `Compare the local supabase/migrations/ directory against the remote applied
+migration history (/v1/projects/{ref}/database/migrations) and report which
+local migration versions are unapplied. The pre-deploy "what would push do"
+view, without invoking the official CLI.`,
+		Example:     `  supabase-pp-cli db diff abcdefgh --json
+  supabase-pp-cli db diff abcdefgh --dir ./supabase/migrations`,
+		Annotations: map[string]string{"pp:method": "GET", "pp:path": "/v1/projects/{ref}/database/migrations", "mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			ref := args[0]
+			if migrationsDir == "" {
+				migrationsDir = "supabase/migrations"
+			}
+
+			localVersions, localErr := readLocalMigrations(migrationsDir)
+			if localErr != nil {
+				return localErr
+			}
+
+			if dryRunOK(flags) {
+				return nil
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			path := replacePathParam("/v1/projects/{ref}/database/migrations", "ref", ref)
+			data, gerr := c.Get(path, nil)
+			if gerr != nil {
+				return classifyAPIError(gerr, flags)
+			}
+			remoteVersions := parseRemoteVersions(data)
+
+			remoteSet := map[string]bool{}
+			for _, v := range remoteVersions {
+				remoteSet[v] = true
+			}
+			var unapplied []string
+			for v := range localVersions {
+				if !remoteSet[v] {
+					unapplied = append(unapplied, v)
+				}
+			}
+			sort.Strings(unapplied)
+
+			out := cmd.OutOrStdout()
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				payload := map[string]any{
+					"project_ref":      ref,
+					"migrations_dir":   migrationsDir,
+					"local_count":      len(localVersions),
+					"remote_count":     len(remoteVersions),
+					"unapplied_count":  len(unapplied),
+					"unapplied":        unapplied,
+				}
+				return printJSONFiltered(out, payload, flags)
+			}
+			if len(unapplied) == 0 {
+				fmt.Fprintf(out, "In sync: %d local migration(s) all applied to %s.\n", len(localVersions), ref)
+				return nil
+			}
+			fmt.Fprintf(out, "%d unapplied local migration(s) for %s:\n\n", len(unapplied), ref)
+			for _, v := range unapplied {
+				fmt.Fprintf(out, "  %s  %s\n", v, localVersions[v])
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&migrationsDir, "dir", "", "Local migrations directory (default: supabase/migrations)")
+	return cmd
+}
+
+// readLocalMigrations walks the migrations dir, returning version -> filename.
+func readLocalMigrations(dir string) (map[string]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, notFoundErr(fmt.Errorf("migrations dir %q not found; pass --dir or run from a project root", dir))
+		}
+		return nil, fmt.Errorf("reading migrations dir: %w", err)
+	}
+	out := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		base := filepath.Base(e.Name())
+		if m := reMigrationVersion.FindStringSubmatch(base); len(m) >= 2 {
+			out[m[1]] = base
+		}
+	}
+	return out, nil
+}
+
+// parseRemoteVersions extracts migration versions from the API response, which
+// is an array of objects each carrying a "version" field.
+func parseRemoteVersions(data json.RawMessage) []string {
+	var items []map[string]any
+	if json.Unmarshal(data, &items) != nil {
+		// Some responses wrap in {"migrations":[...]} or {"data":[...]}.
+		var wrapped struct {
+			Migrations []map[string]any `json:"migrations"`
+			Data       []map[string]any `json:"data"`
+		}
+		if json.Unmarshal(data, &wrapped) == nil {
+			if len(wrapped.Migrations) > 0 {
+				items = wrapped.Migrations
+			} else {
+				items = wrapped.Data
+			}
+		}
+	}
+	var out []string
+	for _, it := range items {
+		if v, ok := it["version"].(string); ok && v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/library/developer-tools/supabase/internal/cli/db_lint.go
+++ b/library/developer-tools/supabase/internal/cli/db_lint.go
@@ -1,0 +1,224 @@
+// PATCH: novel `db lint` — run splinter-style checks locally against a migration BEFORE apply. Shifts the advisor left. Not in the Management API.
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+// lintFinding mirrors the shape of a splinter advisor finding so local lint and
+// the live `advisors` command read the same way.
+type lintFinding struct {
+	Rule     string `json:"rule"`
+	Level    string `json:"level"` // ERROR | WARN | INFO
+	Stmt     int    `json:"statement_index"`
+	Object   string `json:"object,omitempty"`
+	Message  string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+func newDBLintCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+
+	cmd := &cobra.Command{
+		Use:   "lint [file.sql]",
+		Short: "Run splinter-style checks against a migration locally, before apply",
+		Long: `Static security/performance checks against a migration file (or --sql), run
+locally with no network. Shifts the Supabase advisor (splinter) left so the
+008-class issues are caught at author time:
+
+  - SECURITY DEFINER functions with PUBLIC/anon/authenticated EXECUTE not revoked
+  - GRANT ... TO anon|authenticated on tables without RLS enabled in the same file
+  - RLS policies using bare auth.uid() / auth.role() (init-plan re-eval; wrap in (select ...))
+  - destructive statements (DROP/TRUNCATE/DELETE) without an obvious guard
+
+Exit code is non-zero (5) if any ERROR-level finding is present, so it gates a
+CI pipeline before 'db apply'.`,
+		Example:     `  supabase-pp-cli db lint migrations/008_rls.sql --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			sql, src, err := loadSQL(args, inlineSQL)
+			if err != nil {
+				return err
+			}
+			m := dbchange.Parse(sql, src)
+			findings := lintManifest(m, sql)
+
+			out := cmd.OutOrStdout()
+			errCount := 0
+			for _, f := range findings {
+				if f.Level == "ERROR" {
+					errCount++
+				}
+			}
+
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				payload := map[string]any{
+					"source":        src,
+					"finding_count": len(findings),
+					"error_count":   errCount,
+					"findings":      findings,
+				}
+				if perr := printJSONFiltered(out, payload, flags); perr != nil {
+					return perr
+				}
+			} else {
+				if len(findings) == 0 {
+					fmt.Fprintf(out, "No lint findings in %s.\n", src)
+				} else {
+					fmt.Fprintf(out, "%d finding(s) in %s:\n\n", len(findings), src)
+					fmt.Fprintf(out, "%-6s %-30s %-4s %s\n", "LEVEL", "RULE", "STMT", "MESSAGE")
+					fmt.Fprintf(out, "%-6s %-30s %-4s %s\n", "-----", "----", "----", "-------")
+					for _, f := range findings {
+						fmt.Fprintf(out, "%-6s %-30s %-4d %s\n", f.Level, truncate(f.Rule, 28), f.Stmt, f.Message)
+					}
+				}
+			}
+			if errCount > 0 {
+				return apiErr(fmt.Errorf("%d error-level lint finding(s)", errCount))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "Inline SQL to lint (instead of a file argument)")
+	return cmd
+}
+
+var (
+	reAuthCall = regexp.MustCompile(`(?i)\bauth\.(uid|role|jwt)\s*\(\s*\)`)
+	reSelectWrappedAuth = regexp.MustCompile(`(?i)\(\s*select\s+auth\.(uid|role|jwt)\s*\(\s*\)\s*\)`)
+	reSecurityDefiner = regexp.MustCompile(`(?i)security\s+definer`)
+	reGrantToPublic = regexp.MustCompile(`(?i)\bgrant\b.*\bto\b.*\b(public|anon|authenticated)\b`)
+	reRevokeFromPublic = regexp.MustCompile(`(?i)\brevoke\b.*\bfrom\b.*\b(public|anon|authenticated)\b`)
+)
+
+// lintManifest runs the static ruleset over the parsed manifest + raw SQL.
+func lintManifest(m *dbchange.Manifest, rawSQL string) []lintFinding {
+	var out []lintFinding
+
+	// Track whether the file enables RLS on a table that it also grants anon access to.
+	rlsEnabledTables := map[string]bool{}
+	grantedAnonTables := map[string]struct {
+		stmt int
+		obj  string
+	}{}
+
+	hasSecurityDefiner := false
+	hasRevokeFromPublic := reRevokeFromPublic.MatchString(rawSQL)
+
+	for _, s := range m.Statements {
+		head := strings.ToUpper(s.SQL)
+		obj := ""
+		if len(s.Objects) > 0 {
+			obj = s.Objects[0]
+		}
+
+		// Rule: RLS policy with bare auth.uid() (init-plan re-eval). Fires when
+		// an auth.*() call appears that is NOT wrapped in (select ...).
+		if s.OpClass == dbchange.OpRLS && strings.Contains(head, "POLICY") {
+			if reAuthCall.MatchString(s.SQL) && !reSelectWrappedAuth.MatchString(s.SQL) {
+				out = append(out, lintFinding{
+					Rule:    "rls_init_plan",
+					Level:   "WARN",
+					Stmt:    s.Index,
+					Object:  obj,
+					Message: "policy uses bare auth.uid()/auth.role(); re-evaluated per row",
+					Remediation: "wrap as (select auth.uid()) so the planner evaluates it once (initplan)",
+				})
+			}
+		}
+
+		// Track RLS enablement.
+		if s.OpClass == dbchange.OpRLS && strings.Contains(head, "ENABLE ROW LEVEL SECURITY") {
+			rlsEnabledTables[obj] = true
+		}
+
+		// SECURITY DEFINER function.
+		if s.OpClass == dbchange.OpDDL && reSecurityDefiner.MatchString(s.SQL) {
+			hasSecurityDefiner = true
+			out = append(out, lintFinding{
+				Rule:    "security_definer_function",
+				Level:   "INFO",
+				Stmt:    s.Index,
+				Object:  obj,
+				Message: "SECURITY DEFINER function defined; verify EXECUTE is revoked from public/anon",
+				Remediation: "REVOKE EXECUTE ON FUNCTION " + obj + " FROM public, anon, authenticated; then GRANT only to intended roles",
+			})
+		}
+
+		// GRANT to anon/authenticated. Split function grants from table grants:
+		// RLS only applies to tables, so a `grant execute on function` must not
+		// trip the anon-without-RLS rule. A function granted to anon/public is
+		// instead the SECURITY DEFINER escalation surface, flagged below.
+		if s.OpClass == dbchange.OpGrant && reGrantToPublic.MatchString(s.SQL) {
+			if strings.Contains(head, "ON FUNCTION") || strings.Contains(head, "EXECUTE") {
+				out = append(out, lintFinding{
+					Rule:    "function_execute_to_anon",
+					Level:   "WARN",
+					Stmt:    s.Index,
+					Object:  obj,
+					Message: "EXECUTE on a function granted to public/anon/authenticated; if SECURITY DEFINER, this is a privilege-escalation surface",
+					Remediation: "confirm the function is not SECURITY DEFINER, or REVOKE then GRANT to only intended roles",
+				})
+			} else {
+				grantedAnonTables[obj] = struct {
+					stmt int
+					obj  string
+				}{s.Index, obj}
+			}
+		}
+
+		// Destructive without WHERE/guard.
+		if s.Destructive {
+			level := "WARN"
+			msg := "destructive statement; ensure intended"
+			if strings.HasPrefix(head, "DELETE") && !strings.Contains(head, " WHERE ") {
+				level, msg = "ERROR", "DELETE without WHERE clause removes ALL rows"
+			}
+			if strings.HasPrefix(head, "TRUNCATE") {
+				level, msg = "WARN", "TRUNCATE removes all rows and cannot be reverted from a receipt"
+			}
+			out = append(out, lintFinding{
+				Rule:    "destructive_statement",
+				Level:   level,
+				Stmt:    s.Index,
+				Object:  obj,
+				Message: msg,
+			})
+		}
+	}
+
+	// Cross-statement: anon-granted table without RLS enabled in the same file.
+	for tbl, g := range grantedAnonTables {
+		if !rlsEnabledTables[tbl] {
+			out = append(out, lintFinding{
+				Rule:    "grant_anon_without_rls",
+				Level:   "ERROR",
+				Stmt:    g.stmt,
+				Object:  tbl,
+				Message: fmt.Sprintf("GRANT to anon/authenticated on %s but RLS is not enabled in this migration", tbl),
+				Remediation: "ALTER TABLE " + tbl + " ENABLE ROW LEVEL SECURITY; and add policies, or move the grant",
+			})
+		}
+	}
+
+	// SECURITY DEFINER present but no REVOKE FROM public anywhere — the 008 gap.
+	if hasSecurityDefiner && !hasRevokeFromPublic {
+		out = append(out, lintFinding{
+			Rule:    "security_definer_unrevoked",
+			Level:   "ERROR",
+			Stmt:    -1,
+			Message: "migration defines SECURITY DEFINER function(s) but contains no REVOKE ... FROM public/anon — privilege-escalation risk",
+			Remediation: "add REVOKE EXECUTE ... FROM public, anon, authenticated; before granting to intended roles",
+		})
+	}
+	return out
+}

--- a/library/developer-tools/supabase/internal/cli/db_plan.go
+++ b/library/developer-tools/supabase/internal/cli/db_plan.go
@@ -1,0 +1,85 @@
+// PATCH: novel `db plan` — parse SQL into a typed change manifest + deterministic plan_hash. Not in the Management API.
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+func newDBPlanCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+
+	cmd := &cobra.Command{
+		Use:   "plan [file.sql]",
+		Short: "Parse SQL into a typed change manifest with a deterministic plan_hash",
+		Long: `Parse a migration (file or --sql) into a typed change manifest. Each statement
+is classified by operation class (ddl | grant | rls | data-write | destructive),
+the objects it touches, an estimated-rows note, and a reversibility verdict
+(auto | snapshot | none). A deterministic plan_hash is emitted over the
+normalized statement list.
+
+The plan_hash is the approval token: 'db apply --approved <plan_hash>' refuses
+to run if the SQL changed since the plan was produced.`,
+		Example: `  supabase-pp-cli db plan migrations/008_rls.sql --json
+  supabase-pp-cli db plan --sql "grant execute on function public.f to anon;" --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			sql, src, err := loadSQL(args, inlineSQL)
+			if err != nil {
+				return err
+			}
+			m := dbchange.Parse(sql, src)
+
+			out := cmd.OutOrStdout()
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				return printJSONFiltered(out, m, flags)
+			}
+			return printPlanTable(cmd, m)
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "Inline SQL to plan (instead of a file argument)")
+	return cmd
+}
+
+func printPlanTable(cmd *cobra.Command, m *dbchange.Manifest) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Plan: %s\n", m.SourceLabel)
+	fmt.Fprintf(out, "plan_hash: %s\n", m.PlanHash)
+	fmt.Fprintf(out, "%d statement(s)", m.StatementN)
+	if m.HasDestructive {
+		fmt.Fprintf(out, "  [DESTRUCTIVE]")
+	}
+	if m.HasIrreversible {
+		fmt.Fprintf(out, "  [IRREVERSIBLE]")
+	}
+	fmt.Fprintf(out, "\n\n")
+	fmt.Fprintf(out, "%-3s %-12s %-13s %-26s %s\n", "#", "CLASS", "REVERSIBLE", "OBJECTS", "FLAGS")
+	fmt.Fprintf(out, "%-3s %-12s %-13s %-26s %s\n", "-", "-----", "----------", "-------", "-----")
+	for _, s := range m.Statements {
+		objs := ""
+		if len(s.Objects) > 0 {
+			objs = s.Objects[0]
+		}
+		flag := ""
+		if s.Destructive {
+			flag = "destructive"
+		}
+		fmt.Fprintf(out, "%-3d %-12s %-13s %-26s %s\n", s.Index, s.OpClass, s.Reversibility, truncate(objs, 24), flag)
+	}
+	fmt.Fprintf(out, "\nApprove with: supabase-pp-cli db apply <ref> %s --approved %s\n",
+		flagOrFile(m.SourceLabel), m.PlanHash)
+	return nil
+}
+
+func flagOrFile(src string) string {
+	if src == "--sql" || src == "" {
+		return "--sql \"...\""
+	}
+	return src
+}

--- a/library/developer-tools/supabase/internal/cli/db_receipt.go
+++ b/library/developer-tools/supabase/internal/cli/db_receipt.go
@@ -1,0 +1,166 @@
+// PATCH: novel `db receipt` — snapshot affected object definitions + auto-derive the mechanical inverse before mutating. Not in the Management API.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+func newDBReceiptCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+
+	cmd := &cobra.Command{
+		Use:   "receipt <ref> [file.sql]",
+		Short: "Snapshot affected objects + derive the inverse for a plan, without applying",
+		Long: `Capture a reversal receipt for a migration without applying it. Snapshots the
+current definition of every object the plan touches (function bodies via
+pg_get_functiondef, policy bodies via pg_policies, grants via
+information_schema) and assembles the mechanical inverse where derivable
+(CREATE->DROP, ADD COLUMN->DROP COLUMN, REVOKE->GRANT). The receipt is what
+'db revert' consumes.
+
+'db apply' captures a receipt automatically; this command is for capturing one
+ahead of time or independently.`,
+		Example:     `  supabase-pp-cli db receipt abcdefgh migrations/008_rls.sql --json`,
+		Annotations: map[string]string{"pp:method": "POST", "pp:path": "/v1/projects/{ref}/database/query"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			ref := args[0]
+			sql, src, err := loadSQL(args[1:], inlineSQL)
+			if err != nil {
+				return err
+			}
+			m := dbchange.Parse(sql, src)
+			if dryRunOK(flags) {
+				return nil
+			}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			rcpt := buildReceipt(cmd, c, ref, m)
+			rpath, werr := writeReceipt(rcpt)
+			if werr != nil {
+				return werr
+			}
+
+			out := cmd.OutOrStdout()
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				return printJSONFiltered(out, rcpt, flags)
+			}
+			fmt.Fprintf(out, "Receipt %s written to %s\n", rcpt.Receipt, rpath)
+			fmt.Fprintf(out, "plan_hash: %s\n", rcpt.PlanHash)
+			fmt.Fprintf(out, "snapshots captured: %d\n", len(rcpt.Snapshots))
+			if m.HasIrreversible {
+				fmt.Fprintln(out, "NOTE: plan has irreversible statement(s) — revert will be partial.")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "Inline SQL (instead of a file argument)")
+	return cmd
+}
+
+// buildReceipt snapshots prior object definitions for RevSnapshot statements and
+// assembles the inverse script (mechanical inverses in reverse statement order).
+// Snapshot capture is best-effort: an object the introspection query cannot
+// resolve is skipped and its statement remains snapshot-reversible only insofar
+// as the snapshot exists.
+func buildReceipt(cmd *cobra.Command, c *client.Client, ref string, m *dbchange.Manifest) *receipt {
+	r := &receipt{
+		Receipt:   newReceiptID(ref),
+		CreatedAt: nowRFC3339(),
+		Ref:       ref,
+		PlanHash:  m.PlanHash,
+		Source:    m.SourceLabel,
+		Manifest:  m,
+		Snapshots: map[string]string{},
+	}
+
+	// Snapshot prior definitions for objects whose reversal needs the old body.
+	for _, s := range m.Statements {
+		if s.Reversibility != dbchange.RevSnapshot || len(s.Objects) == 0 {
+			continue
+		}
+		obj := s.Objects[0]
+		if snap := snapshotObject(c, ref, s.OpClass, obj); snap != "" {
+			r.Snapshots[string(s.OpClass)+":"+obj] = snap
+		}
+	}
+
+	// Assemble inverse: mechanical inverses in reverse order. Snapshot-only and
+	// irreversible statements contribute a comment marker so the operator sees
+	// the gap.
+	var inv []string
+	for i := len(m.Statements) - 1; i >= 0; i-- {
+		s := m.Statements[i]
+		switch {
+		case s.Inverse != "":
+			inv = append(inv, s.Inverse)
+		case s.Reversibility == dbchange.RevSnapshot:
+			inv = append(inv, fmt.Sprintf("-- statement %d (%s on %s): restore from snapshot (see receipt.snapshots); no mechanical inverse", s.Index, s.OpClass, firstOrEmpty(s.Objects)))
+		case s.Reversibility == dbchange.RevNone:
+			inv = append(inv, fmt.Sprintf("-- statement %d (%s): IRREVERSIBLE — no inverse for data %s", s.Index, s.OpClass, s.OpClass))
+		}
+	}
+	r.InverseSQL = strings.Join(inv, "\n")
+	return r
+}
+
+// snapshotObject pulls the prior definition of an object via the Management API
+// database/query endpoint, returning the captured SQL/text or "" on failure.
+func snapshotObject(c *client.Client, ref string, op dbchange.OpClass, obj string) string {
+	var q string
+	switch op {
+	case dbchange.OpDDL:
+		// Function bodies and table column defs. Try function def first.
+		q = fmt.Sprintf("select pg_get_functiondef('%s'::regprocedure) as def", sqlEscape(obj))
+	case dbchange.OpRLS:
+		schema, tbl := splitSchemaTable(obj)
+		q = fmt.Sprintf("select policyname, cmd, qual, with_check, roles from pg_policies where schemaname = '%s' and tablename = '%s'", sqlEscape(schema), sqlEscape(tbl))
+	case dbchange.OpGrant:
+		schema, tbl := splitSchemaTable(obj)
+		q = fmt.Sprintf("select grantee, privilege_type from information_schema.role_table_grants where table_schema = '%s' and table_name = '%s'", sqlEscape(schema), sqlEscape(tbl))
+	default:
+		return ""
+	}
+	path := replacePathParam("/v1/projects/{ref}/database/query", "ref", ref)
+	data, _, err := c.Post(path, map[string]any{"query": q, "read_only": true})
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	return string(data)
+}
+
+func splitSchemaTable(obj string) (string, string) {
+	parts := strings.SplitN(obj, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "public", obj
+}
+
+func sqlEscape(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func firstOrEmpty(s []string) string {
+	if len(s) > 0 {
+		return s[0]
+	}
+	return ""
+}
+
+// jsonUnmarshal is a thin wrapper so callers in this package don't all import
+// encoding/json directly for one call site.
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}

--- a/library/developer-tools/supabase/internal/cli/db_revert.go
+++ b/library/developer-tools/supabase/internal/cli/db_revert.go
@@ -1,0 +1,95 @@
+// PATCH: novel `db revert <receipt>` — one-command undo from a receipt's inverse SQL. Not in the Management API.
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newDBRevertCmd(flags *rootFlags) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "revert <receipt-id-or-path>",
+		Short: "Undo an applied change from its receipt's inverse SQL",
+		Long: `Replay the mechanical inverse captured in a receipt, in reverse statement
+order, inside a transaction. Receipts with irreversible statements (data DELETE,
+TRUNCATE, UPDATE) cannot be fully reverted; revert refuses unless --force is
+given, and even then it only replays the inverses it has, leaving irreversible
+statements un-undone (the inverse script marks them with comments).`,
+		Example:     `  supabase-pp-cli db revert abcdefgh-20260525T193300Z --json`,
+		Annotations: map[string]string{"pp:method": "POST", "pp:path": "/v1/projects/{ref}/database/query"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			r, err := readReceipt(args[0])
+			if err != nil {
+				return err
+			}
+			if r.Manifest != nil && r.Manifest.HasIrreversible && !force {
+				return usageErr(fmt.Errorf("receipt %s contains irreversible statement(s); revert would be partial. Pass --force to replay the derivable inverses only", r.Receipt))
+			}
+			if strings.TrimSpace(stripInverseComments(r.InverseSQL)) == "" {
+				return apiErr(fmt.Errorf("receipt %s has no executable inverse SQL — nothing to revert mechanically", r.Receipt))
+			}
+
+			revertSQL := "BEGIN;\n" + r.InverseSQL + "\nCOMMIT;\n"
+
+			if dryRunOK(flags) {
+				out := cmd.OutOrStdout()
+				fmt.Fprintf(out, "[dry-run] would revert receipt %s against %s:\n%s\n", r.Receipt, r.Ref, revertSQL)
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			path := replacePathParam("/v1/projects/{ref}/database/query", "ref", r.Ref)
+			data, status, err := c.Post(path, map[string]any{"query": revertSQL})
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			out := cmd.OutOrStdout()
+			result := map[string]any{
+				"reverted":    true,
+				"receipt_id":  r.Receipt,
+				"project_ref": r.Ref,
+				"plan_hash":   r.PlanHash,
+				"status":      status,
+				"partial":     r.Manifest != nil && r.Manifest.HasIrreversible,
+			}
+			if len(data) > 0 {
+				result["result"] = trimRaw(data)
+			}
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				return printJSONFiltered(out, result, flags)
+			}
+			fmt.Fprintf(out, "Reverted receipt %s against %s.\n", r.Receipt, r.Ref)
+			if r.Manifest != nil && r.Manifest.HasIrreversible {
+				fmt.Fprintln(out, "NOTE: partial revert — irreversible statements (data writes) were NOT undone.")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Revert even when the receipt has irreversible statements (replays derivable inverses only)")
+	return cmd
+}
+
+// stripInverseComments removes the -- comment marker lines so we can tell
+// whether any executable inverse SQL remains.
+func stripInverseComments(s string) string {
+	var keep []string
+	for _, line := range strings.Split(s, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "--") {
+			continue
+		}
+		keep = append(keep, line)
+	}
+	return strings.Join(keep, "\n")
+}

--- a/library/developer-tools/supabase/internal/cli/db_shared.go
+++ b/library/developer-tools/supabase/internal/cli/db_shared.go
@@ -1,0 +1,110 @@
+// PATCH: shared helpers for the novel db safe-mutation lifecycle (SQL loading, receipt storage paths).
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+// loadSQL resolves the SQL to operate on from either a positional file arg or
+// the --sql flag. Exactly one must be provided.
+func loadSQL(args []string, inlineSQL string) (sql string, sourceLabel string, err error) {
+	hasFile := len(args) > 0 && args[0] != ""
+	hasInline := strings.TrimSpace(inlineSQL) != ""
+	switch {
+	case hasFile && hasInline:
+		return "", "", usageErr(fmt.Errorf("provide either a SQL file argument or --sql, not both"))
+	case hasFile:
+		b, rerr := os.ReadFile(args[0])
+		if rerr != nil {
+			return "", "", notFoundErr(fmt.Errorf("reading SQL file %q: %w", args[0], rerr))
+		}
+		return string(b), args[0], nil
+	case hasInline:
+		return inlineSQL, "--sql", nil
+	default:
+		return "", "", usageErr(fmt.Errorf("no SQL provided: pass a .sql file path or --sql \"...\""))
+	}
+}
+
+// receiptDir is the on-disk home for receipt artifacts. Co-located with the
+// local SQLite store under the user's data dir.
+func receiptDir() string {
+	base := filepath.Dir(defaultDBPath("supabase-pp-cli"))
+	return filepath.Join(base, "receipts")
+}
+
+// receipt is the persisted attestation + reversal artifact written by
+// `db apply` (and standalone by `db receipt`). `db revert` consumes it.
+type receipt struct {
+	Receipt   string             `json:"receipt_id"`
+	CreatedAt string             `json:"created_at"`
+	Ref       string             `json:"project_ref"`
+	PlanHash  string             `json:"plan_hash"`
+	Source    string             `json:"source,omitempty"`
+	Applied   bool               `json:"applied"`
+	// PATCH(amend-2026-05-25: record the approver in the audit receipt) —
+	// Authorization records how the apply was authorized:
+	// "human:approved-plan-hash" or "policy:<name>". When a policy
+	// self-authorizes an apply, the receipt is the attestation of which envelope
+	// cleared it.
+	Authorization string           `json:"authorization,omitempty"`
+	Manifest  *dbchange.Manifest `json:"manifest"`
+	// Snapshots holds prior object definitions captured before mutating, keyed
+	// by object identifier. Populated best-effort for RevSnapshot statements.
+	Snapshots map[string]string `json:"snapshots,omitempty"`
+	// InverseSQL is the assembled undo script (mechanical inverses in reverse
+	// statement order). Empty when the change has irreversible statements.
+	InverseSQL string `json:"inverse_sql,omitempty"`
+}
+
+func newReceiptID(ref string) string {
+	return fmt.Sprintf("%s-%s", ref, time.Now().UTC().Format("20060102T150405Z"))
+}
+
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func writeReceipt(r *receipt) (string, error) {
+	dir := receiptDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating receipt dir: %w", err)
+	}
+	path := filepath.Join(dir, r.Receipt+".json")
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return "", fmt.Errorf("writing receipt: %w", err)
+	}
+	return path, nil
+}
+
+// resolveReceiptPath accepts either a receipt id or a path to the receipt file.
+func resolveReceiptPath(idOrPath string) string {
+	if strings.HasSuffix(idOrPath, ".json") || strings.Contains(idOrPath, string(os.PathSeparator)) {
+		return idOrPath
+	}
+	return filepath.Join(receiptDir(), idOrPath+".json")
+}
+
+func readReceipt(idOrPath string) (*receipt, error) {
+	path := resolveReceiptPath(idOrPath)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, notFoundErr(fmt.Errorf("reading receipt %q: %w", idOrPath, err))
+	}
+	var r receipt
+	if err := json.Unmarshal(b, &r); err != nil {
+		return nil, fmt.Errorf("parsing receipt %q: %w", path, err)
+	}
+	return &r, nil
+}

--- a/library/developer-tools/supabase/internal/cli/db_stage.go
+++ b/library/developer-tools/supabase/internal/cli/db_stage.go
@@ -1,0 +1,115 @@
+// PATCH(amend-2026-05-25: branch-first staging gate — a plan is only
+// prod-eligible after it applies cleanly to a Supabase preview branch with the
+// security + performance advisors green). Reuses the branch config + database
+// query + advisor endpoints. Not a single Management API endpoint.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/internal/dbchange"
+)
+
+// stageOnBranch enforces the branch-first staging gate. It resolves the preview
+// branch's own project ref, applies the same transaction to the branch, then
+// runs the security and performance advisors against the branch and refuses
+// (non-nil error) unless both come back with zero findings. A clean stage is
+// the precondition for the prod apply that follows in db_apply.go.
+//
+// This deliberately reuses the existing surfaces: branch config (GET
+// /v1/branches/{ref}) to resolve the branch project ref, the same
+// database/query endpoint db apply uses, and the advisor endpoints the
+// top-level `advisors` command wraps. It does NOT push via the migration
+// pipeline — staging the exact transaction that prod will run is the stronger
+// guarantee than replaying a migration file.
+func stageOnBranch(cmd *cobra.Command, flags *rootFlags, branch string, m *dbchange.Manifest, _ string, _ string) error {
+	errOut := cmd.ErrOrStderr()
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+
+	// 1. Resolve the branch's own project ref from its config.
+	branchRef, rerr := resolveBranchProjectRef(c, branch)
+	if rerr != nil {
+		return apiErr(fmt.Errorf("branch-first staging: cannot resolve preview branch %q: %w", branch, rerr))
+	}
+	fmt.Fprintf(errOut, "staging on preview branch %s (project_ref %s)...\n", branch, branchRef)
+
+	// 2. Apply the exact transaction to the branch.
+	txSQL := assembleTransaction(m)
+	qPath := replacePathParam("/v1/projects/{ref}/database/query", "ref", branchRef)
+	if _, _, perr := c.Post(qPath, map[string]any{"query": txSQL}); perr != nil {
+		return apiErr(fmt.Errorf("branch-first staging: plan failed to apply to preview branch %s: %w (NOT applied to prod)", branchRef, perr))
+	}
+
+	// 3. Advisors must be green on the branch.
+	for _, kind := range []string{"security", "performance"} {
+		n, aerr := advisorFindingCount(c, branchRef, kind)
+		if aerr != nil {
+			return apiErr(fmt.Errorf("branch-first staging: %s advisor check failed on branch %s: %w (NOT applied to prod)", kind, branchRef, aerr))
+		}
+		if n > 0 {
+			return apiErr(fmt.Errorf("branch-first staging: %s advisor reports %d finding(s) on preview branch %s; not prod-eligible (NOT applied to prod). Inspect with: supabase-pp-cli advisors %s %s", kind, n, branchRef, kind, branchRef))
+		}
+		fmt.Fprintf(errOut, "  advisors %s: green\n", kind)
+	}
+	fmt.Fprintf(errOut, "staging passed — proceeding to prod apply\n")
+	return nil
+}
+
+// resolveBranchProjectRef reads the preview branch config and returns the
+// branch's own database project ref. Supabase branch config returns the ref
+// under one of a few field names depending on API version; try them in order.
+func resolveBranchProjectRef(c interface {
+	Get(string, map[string]string) (json.RawMessage, error)
+}, branch string) (string, error) {
+	path := replacePathParam("/v1/branches/{branch_id_or_ref}", "branch_id_or_ref", branch)
+	data, err := c.Get(path, nil)
+	if err != nil {
+		return "", err
+	}
+	var cfg map[string]any
+	if uerr := json.Unmarshal(data, &cfg); uerr != nil {
+		return "", fmt.Errorf("parsing branch config: %w", uerr)
+	}
+	for _, k := range []string{"project_ref", "ref", "id"} {
+		if v, ok := cfg[k].(string); ok && v != "" {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("branch config has no project_ref/ref/id field")
+}
+
+// advisorFindingCount runs one advisor kind against a ref and returns the
+// number of findings. The advisor payload is a JSON array (or {data:[...]}); an
+// empty array is green.
+func advisorFindingCount(c interface {
+	Get(string, map[string]string) (json.RawMessage, error)
+}, ref, kind string) (int, error) {
+	path := replacePathParam("/v1/projects/{ref}/advisors/"+kind, "ref", ref)
+	data, err := c.Get(path, nil)
+	if err != nil {
+		return 0, err
+	}
+	// Direct array shape.
+	var items []json.RawMessage
+	if json.Unmarshal(data, &items) == nil {
+		return len(items), nil
+	}
+	// Wrapped {data: [...]} or {lints: [...]} shape.
+	var wrapped struct {
+		Data  []json.RawMessage `json:"data"`
+		Lints []json.RawMessage `json:"lints"`
+	}
+	if json.Unmarshal(data, &wrapped) == nil {
+		if len(wrapped.Lints) > 0 {
+			return len(wrapped.Lints), nil
+		}
+		return len(wrapped.Data), nil
+	}
+	return 0, nil
+}

--- a/library/developer-tools/supabase/internal/cli/db_top.go
+++ b/library/developer-tools/supabase/internal/cli/db_top.go
@@ -1,0 +1,40 @@
+// PATCH: novel `db` command group — safe-mutation lifecycle (plan/apply/receipt/revert/lint/diff/decompose). Not in the Management API.
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newDBTopCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "db",
+		Short: "Safe production-mutation lifecycle: plan, apply (policy or approved hash), decompose, receipt, revert, lint, diff",
+		Long: `The safe-mutation lifecycle. Every database change becomes a structured,
+inspectable, reversible, attestable transaction:
+
+  plan      Parse SQL into a typed change manifest + deterministic plan_hash.
+  apply     Execute ONLY an authorized plan; refuse on SQL drift; transaction-wrapped.
+            Authorize with --approved <hash> (human) or --policy <name|file> (policy).
+  decompose Rewrite destructive changes (DROP COLUMN, type change) into a safe
+            expand/contract sequence; refuse the irreducible ones with a reason.
+  receipt   Snapshot affected objects + auto-derive the inverse before mutating.
+  revert    One-command undo from a receipt.
+  lint      Run splinter-style checks locally against a migration BEFORE apply.
+  diff      Compare local supabase/migrations/ against remote applied history.
+
+The lifecycle makes autonomous production migrations real without removing the
+guardrails. The human-in-the-loop approver can be replaced by a policy that
+self-authorizes ONLY additive, reversible, lint-clean, zero-data-row changes;
+the plan_hash drift gate, savepoint transaction, and reversal receipt are
+unchanged. Destructive changes route through 'decompose' into safe steps or are
+refused with a structured machine-readable reason — never silently applied.`,
+	}
+	cmd.AddCommand(newDBPlanCmd(flags))
+	cmd.AddCommand(newDBApplyCmd(flags))
+	cmd.AddCommand(newDBDecomposeCmd(flags))
+	cmd.AddCommand(newDBReceiptCmd(flags))
+	cmd.AddCommand(newDBRevertCmd(flags))
+	cmd.AddCommand(newDBLintCmd(flags))
+	cmd.AddCommand(newDBDiffCmd(flags))
+	return cmd
+}

--- a/library/developer-tools/supabase/internal/cli/doctor.go
+++ b/library/developer-tools/supabase/internal/cli/doctor.go
@@ -194,6 +194,22 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// whether to trust the cached data before issuing queries.
 			report["cache"] = collectCacheReport(cmd.Context(), "")
 
+			// PATCH: list reachable project refs when the PAT is valid, so the
+			// operator sees what the lifecycle commands (db apply, query,
+			// advisors) can target. Best-effort: a scope-limited PAT that can't
+			// list projects degrades to a note, not a failure.
+			if cfg != nil && cfg.AuthHeader() != "" {
+				if c, cerr := flags.newClient(); cerr == nil {
+					if pdata, perr := c.Get("/v1/projects", nil); perr == nil {
+						refs := extractProjectRefs(pdata)
+						report["reachable_refs"] = refs
+						report["reachable_ref_count"] = len(refs)
+					} else {
+						report["reachable_refs"] = "could not list (PAT may be scope-limited): " + truncate(perr.Error(), 120)
+					}
+				}
+			}
+
 			report["version"] = version
 
 			if flags.asJSON {
@@ -248,6 +264,18 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Print auth setup hints (indented under Auth line)
 			if hint, ok := report["auth_hint"]; ok {
 				fmt.Fprintf(w, "  hint: %v\n", hint)
+			}
+			// PATCH: reachable project refs block.
+			if refsAny, ok := report["reachable_refs"]; ok {
+				switch v := refsAny.(type) {
+				case []string:
+					fmt.Fprintf(w, "  %s Reachable refs: %d\n", green("OK"), len(v))
+					for _, ref := range v {
+						fmt.Fprintf(w, "    - %s\n", ref)
+					}
+				case string:
+					fmt.Fprintf(w, "  %s Reachable refs: %s\n", yellow("WARN"), v)
+				}
 			}
 			// Cache section: render after the primary health block so it
 			// sits next to version info, mirroring the JSON report layout.

--- a/library/developer-tools/supabase/internal/cli/query_top.go
+++ b/library/developer-tools/supabase/internal/cli/query_top.go
@@ -1,0 +1,116 @@
+// PATCH: novel top-level `query` — read-only-by-default SQL with --write opt-in, over the Management API database/query endpoint.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newQueryTopCmd(flags *rootFlags) *cobra.Command {
+	var inlineSQL string
+	var write bool
+	var fromStdin bool
+
+	cmd := &cobra.Command{
+		Use:   "query <ref> [sql]",
+		Short: "Run SQL against a project (read-only by default; --write to mutate)",
+		Long: `Execute SQL via the Management API database/query endpoint. Read-only by
+default (read_only=true) so an accidental UPDATE/DELETE is rejected by the
+database, not just by convention. Pass --write to opt into mutations.
+
+For structured, reversible, attestable mutations prefer the 'db plan' ->
+'db apply --approved' lifecycle; --write is the escape hatch for ad-hoc writes.`,
+		Example: `  supabase-pp-cli query abcdefgh "select count(*) from auth.users" --json
+  supabase-pp-cli query abcdefgh --sql "select * from public.profiles limit 5" --csv
+  supabase-pp-cli query abcdefgh "update public.flags set on=true where id=1" --write`,
+		Annotations: map[string]string{"pp:method": "POST", "pp:path": "/v1/projects/{ref}/database/query"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			ref := args[0]
+
+			var sql string
+			switch {
+			case fromStdin:
+				b, rerr := io.ReadAll(os.Stdin)
+				if rerr != nil {
+					return fmt.Errorf("reading stdin: %w", rerr)
+				}
+				sql = string(b)
+			case inlineSQL != "":
+				sql = inlineSQL
+			case len(args) > 1:
+				sql = strings.Join(args[1:], " ")
+			default:
+				return usageErr(fmt.Errorf("no SQL provided: pass it positionally, via --sql, or --stdin"))
+			}
+			if strings.TrimSpace(sql) == "" {
+				return usageErr(fmt.Errorf("empty SQL"))
+			}
+
+			if dryRunOK(flags) {
+				out := cmd.OutOrStdout()
+				fmt.Fprintf(out, "[dry-run] would run (read_only=%v) against %s:\n%s\n", !write, ref, sql)
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			path := replacePathParam("/v1/projects/{ref}/database/query", "ref", ref)
+			body := map[string]any{"query": sql, "read_only": !write}
+			data, statusCode, err := c.Post(path, body)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+
+			out := cmd.OutOrStdout()
+			if wantsHumanTable(out, flags) {
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					if terr := printAutoTable(out, items); terr == nil {
+						return nil
+					}
+				}
+			}
+			if flags.asJSON || (!isTerminal(out) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				envelope := map[string]any{
+					"action":    "query",
+					"resource":  "database",
+					"read_only": !write,
+					"status":    statusCode,
+					"success":   statusCode >= 200 && statusCode < 300,
+				}
+				if len(filtered) > 0 {
+					var parsed any
+					if json.Unmarshal(filtered, &parsed) == nil {
+						envelope["data"] = parsed
+					}
+				}
+				b, merr := json.Marshal(envelope)
+				if merr != nil {
+					return merr
+				}
+				return printOutput(out, json.RawMessage(b), true)
+			}
+			return printOutputWithFlags(out, data, flags)
+		},
+	}
+	cmd.Flags().StringVar(&inlineSQL, "sql", "", "SQL to run (instead of the positional argument)")
+	cmd.Flags().BoolVar(&write, "write", false, "Opt into mutations (sets read_only=false)")
+	cmd.Flags().BoolVar(&fromStdin, "stdin", false, "Read SQL from stdin")
+	return cmd
+}

--- a/library/developer-tools/supabase/internal/cli/root.go
+++ b/library/developer-tools/supabase/internal/cli/root.go
@@ -230,6 +230,10 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newOauthCmd(flags))
 	rootCmd.AddCommand(newOrganizationsCmd(flags))
 	rootCmd.AddCommand(newProjectsCmd(flags))
+	// PATCH: novel safe-mutation lifecycle + read/audit commands (db, query, advisors).
+	rootCmd.AddCommand(newDBTopCmd(flags))
+	rootCmd.AddCommand(newQueryTopCmd(flags))
+	rootCmd.AddCommand(newAdvisorsTopCmd(flags))
 	rootCmd.AddCommand(newSnippetsCmd(flags))
 	rootCmd.AddCommand(newSecretsTopCmd(flags))
 	rootCmd.AddCommand(newFunctionsTopCmd(flags))

--- a/library/developer-tools/supabase/internal/dbchange/decompose.go
+++ b/library/developer-tools/supabase/internal/dbchange/decompose.go
@@ -1,0 +1,201 @@
+// PATCH(amend-2026-05-25: expand/contract decomposition — turn a destructive
+// operation class into a sequence of safe-envelope steps, or refuse it with a
+// structured machine-readable reason). Replaces the blunt --allow-destructive
+// boolean. Not in the Management API.
+//
+// The expand/contract pattern makes a destructive schema change reversible and
+// online by splitting it across deploys:
+//
+//   DROP COLUMN  ->  expand: (nothing to add)               // column already unused
+//                    contract: rename to a tombstone name, then a later run drops it
+//   ALTER TYPE   ->  expand: ADD COLUMN <new> <newtype>      // additive, est_rows 0
+//                    backfill: app/dual-write fills <new>    // out of band, app-owned
+//                    contract: DROP COLUMN <old>             // a later decompose run
+//
+// Each emitted step is itself a Statement re-classified by the manifest, so a
+// step is only auto-eligible if it independently falls inside the safe envelope.
+// The decomposer NEVER fabricates a backfill or a data move it cannot prove
+// safe; those steps are surfaced as app-owned manual gates, not auto-applied.
+
+package dbchange
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// DecompPhase labels where a step sits in the expand/contract lifecycle.
+type DecompPhase string
+
+const (
+	PhaseExpand   DecompPhase = "expand"   // additive, safe-envelope, apply now
+	PhaseBackfill DecompPhase = "backfill" // app-owned data move, manual gate
+	PhaseContract DecompPhase = "contract" // removes the old object, a later run
+)
+
+// DecompStep is one step of a decomposed destructive change.
+type DecompStep struct {
+	Phase    DecompPhase `json:"phase"`
+	SQL      string      `json:"sql,omitempty"`
+	Note     string      `json:"note,omitempty"`
+	// AutoApply is true only for expand-phase steps that fall inside the safe
+	// envelope on their own. Backfill and contract steps are always false: they
+	// require an explicit later decision.
+	AutoApply bool `json:"auto_apply"`
+}
+
+// DecompResult is the verdict for decomposing one statement.
+type DecompResult struct {
+	OriginalIndex int          `json:"original_index"`
+	OriginalSQL   string       `json:"original_sql"`
+	OpClass       OpClass      `json:"op_class"`
+	// Decomposed is true when the statement was rewritten into steps; false when
+	// it was refused.
+	Decomposed bool         `json:"decomposed"`
+	Steps      []DecompStep `json:"steps,omitempty"`
+	// RefusedReason is set (and Decomposed is false) when the statement cannot be
+	// safely decomposed — TRUNCATE, unbounded DELETE, DROP with dependents. The
+	// caller turns this into a no-op + structured error.
+	RefusedReason string `json:"refused_reason,omitempty"`
+	RefusedRule   string `json:"refused_rule,omitempty"`
+}
+
+var (
+	reDropColumn   = regexp.MustCompile(`(?i)\bDROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?"?([a-zA-Z0-9_]+)"?`)
+	reAlterColType = regexp.MustCompile(`(?i)\bALTER\s+COLUMN\s+"?([a-zA-Z0-9_]+)"?\s+(?:SET\s+DATA\s+)?TYPE\s+([a-zA-Z0-9_ ()]+?)(?:\s+USING\b|,|$)`)
+	reDeleteWhere  = regexp.MustCompile(`(?i)\bWHERE\b`)
+)
+
+// Decompose turns a single destructive Statement into an expand/contract step
+// sequence, or refuses it. Non-destructive statements are returned as a
+// single trivially-decomposed step (the statement itself, expand phase,
+// auto-eligible if it independently clears the envelope) so the caller can run
+// a whole manifest through one code path.
+func Decompose(s Statement) DecompResult {
+	res := DecompResult{OriginalIndex: s.Index, OriginalSQL: s.SQL, OpClass: s.OpClass}
+	head := upperHead(s.SQL)
+	tbl := firstObject(s.Objects)
+
+	// A type change is the canonical expand/contract case. The classifier marks
+	// it OpDDL (non-destructive) — it doesn't drop an object — but it rewrites
+	// the whole table (est_rows -1), so it must NOT pass through as a single
+	// auto-step. Detect it BEFORE the non-destructive passthrough.
+	isTypeChange := strings.Contains(head, "ALTER COLUMN") && strings.Contains(head, "TYPE")
+
+	if !s.Destructive && !isTypeChange {
+		// Pass through. The step inherits the statement's own envelope eligibility.
+		res.Decomposed = true
+		res.Steps = []DecompStep{{Phase: PhaseExpand, SQL: ensureSemicolon(s.SQL), AutoApply: s.EstRowsAffected == 0 && s.Reversibility != RevNone}}
+		return res
+	}
+
+	switch {
+	// DROP COLUMN -> tombstone-rename now (reversible, safe), real drop deferred.
+	case strings.Contains(head, "DROP COLUMN"):
+		col := matchGroup(reDropColumn, s.SQL, 1)
+		if col == "" || tbl == "" {
+			return refuse(res, "drop_column_unparsed", "DROP COLUMN target table/column could not be parsed for safe decomposition")
+		}
+		tomb := col + "_pp_dropped"
+		res.Decomposed = true
+		res.Steps = []DecompStep{
+			{
+				Phase:     PhaseContract,
+				SQL:       fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s;", tbl, col, tomb),
+				Note:      "expand/contract: rename to a tombstone instead of dropping — reversible, zero data loss, hides the column from new reads",
+				AutoApply: true, // a rename is metadata-only, reversible, est_rows 0
+			},
+			{
+				Phase:     PhaseContract,
+				SQL:       fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s;", tbl, tomb),
+				Note:      "deferred hard drop — run in a LATER decompose pass once no code references the tombstone column; not auto-applied",
+				AutoApply: false,
+			},
+		}
+		return res
+
+	// ALTER COLUMN ... TYPE -> add new typed column, app backfill, drop old.
+	case strings.Contains(head, "ALTER COLUMN") && strings.Contains(head, "TYPE"):
+		col := matchGroup(reAlterColType, s.SQL, 1)
+		newType := strings.TrimSpace(matchGroup(reAlterColType, s.SQL, 2))
+		if col == "" || newType == "" || tbl == "" {
+			return refuse(res, "type_change_unparsed", "ALTER COLUMN TYPE could not be parsed into column/new-type for safe decomposition")
+		}
+		newCol := col + "_pp_new"
+		res.Decomposed = true
+		res.Steps = []DecompStep{
+			{
+				Phase:     PhaseExpand,
+				SQL:       fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s;", tbl, newCol, newType),
+				Note:      "expand: add the new typed column alongside the old — additive, reversible, est_rows 0",
+				AutoApply: true,
+			},
+			{
+				Phase:     PhaseBackfill,
+				SQL:       fmt.Sprintf("-- backfill (app-owned, batched): UPDATE %s SET %s = %s::%s WHERE %s IS NULL;", tbl, newCol, col, newType, newCol),
+				Note:      "backfill is a data write (est_rows unbounded) and must be run out of band in batches by the application; the decomposer does NOT auto-apply it",
+				AutoApply: false,
+			},
+			{
+				Phase:     PhaseContract,
+				SQL:       fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s; ALTER TABLE %s RENAME COLUMN %s TO %s;", tbl, col, tbl, newCol, col),
+				Note:      "contract: drop the old column and rename the new one into place — run in a LATER pass after backfill is verified complete; not auto-applied",
+				AutoApply: false,
+			},
+		}
+		return res
+
+	// Refusals — these have no safe decomposition.
+	case strings.HasPrefix(head, "TRUNCATE"):
+		return refuse(res, "truncate_irreducible", "TRUNCATE removes all rows with no reversible expand/contract path; refused (no-op). Use a bounded, reviewed DELETE under the human approver if intended")
+	case strings.HasPrefix(head, "DELETE"):
+		if !reDeleteWhere.MatchString(s.SQL) {
+			return refuse(res, "unbounded_delete", "unbounded DELETE (no WHERE) removes all rows with no reversible decomposition; refused (no-op)")
+		}
+		return refuse(res, "delete_irreducible", "DELETE is a data write with no reversible expand/contract path; refused (no-op). Run under the human approver with an explicit, reviewed WHERE if intended")
+	case strings.HasPrefix(head, "DROP TABLE"):
+		return refuse(res, "drop_table_dependents", "DROP TABLE may have dependents (FKs, views, policies) and is not safely decomposable; refused (no-op). Tombstone-rename the table or drop it under the human approver after dependents are handled")
+	case strings.HasPrefix(head, "DROP SCHEMA"):
+		return refuse(res, "drop_schema_dependents", "DROP SCHEMA cascades to every contained object; not safely decomposable; refused (no-op)")
+	default:
+		return refuse(res, "destructive_unclassified", fmt.Sprintf("destructive statement (%s) has no known safe decomposition; refused (no-op)", s.OpClass))
+	}
+}
+
+// DecomposeManifest runs every statement through Decompose, preserving order.
+// It returns the per-statement results plus a convenience rollup: whether any
+// statement was refused (so the caller can no-op the whole apply).
+func DecomposeManifest(m *Manifest) (results []DecompResult, anyRefused bool) {
+	for _, s := range m.Statements {
+		r := Decompose(s)
+		if !r.Decomposed {
+			anyRefused = true
+		}
+		results = append(results, r)
+	}
+	return results, anyRefused
+}
+
+func refuse(res DecompResult, rule, reason string) DecompResult {
+	res.Decomposed = false
+	res.RefusedRule = rule
+	res.RefusedReason = reason
+	return res
+}
+
+func ensureSemicolon(sql string) string {
+	s := strings.TrimSpace(sql)
+	if !strings.HasSuffix(s, ";") {
+		s += ";"
+	}
+	return s
+}
+
+func matchGroup(re *regexp.Regexp, s string, n int) string {
+	m := re.FindStringSubmatch(s)
+	if len(m) > n {
+		return strings.TrimSpace(m[n])
+	}
+	return ""
+}

--- a/library/developer-tools/supabase/internal/dbchange/decompose_test.go
+++ b/library/developer-tools/supabase/internal/dbchange/decompose_test.go
@@ -1,0 +1,104 @@
+// PATCH(amend-2026-05-25): tests for expand/contract decomposition.
+package dbchange
+
+import (
+	"strings"
+	"testing"
+)
+
+func decomposeOne(t *testing.T, sql string) DecompResult {
+	t.Helper()
+	m := Parse(sql, "t")
+	if len(m.Statements) != 1 {
+		t.Fatalf("%q: expected 1 statement, got %d", sql, len(m.Statements))
+	}
+	return Decompose(m.Statements[0])
+}
+
+func TestDecomposeDropColumn(t *testing.T) {
+	r := decomposeOne(t, "alter table public.t drop column legacy;")
+	if !r.Decomposed {
+		t.Fatalf("DROP COLUMN should decompose, got refusal: %s", r.RefusedReason)
+	}
+	if len(r.Steps) != 2 {
+		t.Fatalf("expected 2 steps (tombstone-rename + deferred drop), got %d", len(r.Steps))
+	}
+	if !r.Steps[0].AutoApply {
+		t.Error("tombstone-rename step should be auto-applicable")
+	}
+	if !strings.Contains(r.Steps[0].SQL, "RENAME COLUMN legacy TO legacy_pp_dropped") {
+		t.Errorf("step 0 should tombstone-rename, got %q", r.Steps[0].SQL)
+	}
+	if r.Steps[1].AutoApply {
+		t.Error("the hard drop step must NOT be auto-applicable")
+	}
+}
+
+func TestDecomposeTypeChange(t *testing.T) {
+	r := decomposeOne(t, "alter table public.t alter column amount type bigint;")
+	if !r.Decomposed {
+		t.Fatalf("ALTER TYPE should decompose, got refusal: %s", r.RefusedReason)
+	}
+	if len(r.Steps) != 3 {
+		t.Fatalf("expected 3 steps (expand/backfill/contract), got %d", len(r.Steps))
+	}
+	if r.Steps[0].Phase != PhaseExpand || !r.Steps[0].AutoApply {
+		t.Errorf("step 0 should be an auto-applicable expand, got %+v", r.Steps[0])
+	}
+	if !strings.Contains(r.Steps[0].SQL, "ADD COLUMN IF NOT EXISTS amount_pp_new bigint") {
+		t.Errorf("expand step should add the new typed column, got %q", r.Steps[0].SQL)
+	}
+	if r.Steps[1].Phase != PhaseBackfill || r.Steps[1].AutoApply {
+		t.Errorf("step 1 should be a non-auto backfill, got %+v", r.Steps[1])
+	}
+	if r.Steps[2].Phase != PhaseContract || r.Steps[2].AutoApply {
+		t.Errorf("step 2 should be a non-auto contract, got %+v", r.Steps[2])
+	}
+}
+
+func TestDecomposeRefusals(t *testing.T) {
+	cases := []struct {
+		sql      string
+		wantRule string
+	}{
+		{"truncate public.t;", "truncate_irreducible"},
+		{"delete from public.t;", "unbounded_delete"},
+		{"delete from public.t where id = 1;", "delete_irreducible"},
+		{"drop table public.t;", "drop_table_dependents"},
+		{"drop schema public;", "drop_schema_dependents"},
+	}
+	for _, tc := range cases {
+		r := decomposeOne(t, tc.sql)
+		if r.Decomposed {
+			t.Errorf("%q: expected refusal, got decomposition", tc.sql)
+			continue
+		}
+		if r.RefusedRule != tc.wantRule {
+			t.Errorf("%q: refused_rule = %q, want %q", tc.sql, r.RefusedRule, tc.wantRule)
+		}
+		if r.RefusedReason == "" {
+			t.Errorf("%q: refusal must carry a human reason", tc.sql)
+		}
+	}
+}
+
+func TestDecomposeAdditivePassthrough(t *testing.T) {
+	r := decomposeOne(t, "create table public.t (id int);")
+	if !r.Decomposed || len(r.Steps) != 1 {
+		t.Fatalf("additive statement should pass through as 1 step, got %+v", r)
+	}
+	if !r.Steps[0].AutoApply {
+		t.Error("a reversible additive statement should be auto-applicable on passthrough")
+	}
+}
+
+func TestDecomposeManifestRollup(t *testing.T) {
+	m := Parse("create table public.t (id int); truncate public.t;", "t")
+	results, anyRefused := DecomposeManifest(m)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !anyRefused {
+		t.Error("a manifest containing TRUNCATE must report anyRefused=true")
+	}
+}

--- a/library/developer-tools/supabase/internal/dbchange/manifest.go
+++ b/library/developer-tools/supabase/internal/dbchange/manifest.go
@@ -1,0 +1,469 @@
+// PATCH: novel safe-mutation lifecycle — typed change manifest powering db plan/apply/receipt/revert. Not in the Management API.
+//
+// Package dbchange parses a SQL migration into a typed, inspectable change
+// manifest. The manifest is the legibility primitive that lets a human (or a
+// safety classifier) reason about a mutation by operation class and
+// reversibility BEFORE it touches production, and lets `db apply` refuse to run
+// anything whose recomputed hash drifted from the approved one.
+package dbchange
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// OpClass is the safety-relevant classification of a single SQL statement.
+// A safety classifier gates by this field: additive ddl/rls/grant can be
+// allowed while data-write/destructive are gated.
+type OpClass string
+
+const (
+	OpDDL         OpClass = "ddl"         // CREATE/ALTER/DROP of schema objects (non-destructive subset)
+	OpGrant       OpClass = "grant"       // GRANT/REVOKE privilege changes
+	OpRLS         OpClass = "rls"         // CREATE/ALTER/DROP POLICY, ENABLE/DISABLE ROW LEVEL SECURITY
+	OpDataWrite   OpClass = "data-write"  // INSERT/UPDATE (non-destructive row writes)
+	OpDestructive OpClass = "destructive" // DROP TABLE, TRUNCATE, DELETE, DROP COLUMN, DROP SCHEMA
+	OpOther       OpClass = "other"       // SET, COMMENT, anything unclassified
+)
+
+// Reversibility is the manifest's verdict on whether a statement can be undone.
+type Reversibility string
+
+const (
+	// RevAuto: the mechanical inverse is derivable from the statement text
+	// alone (CREATE -> DROP, ADD COLUMN -> DROP COLUMN, REVOKE -> GRANT).
+	RevAuto Reversibility = "auto"
+	// RevSnapshot: reversible only by first snapshotting the prior object
+	// definition (CREATE OR REPLACE FUNCTION, ALTER POLICY, DROP of an object
+	// whose definition must be captured to recreate).
+	RevSnapshot Reversibility = "snapshot"
+	// RevNone: no reliable inverse (DELETE/TRUNCATE/UPDATE of data rows).
+	RevNone Reversibility = "none"
+)
+
+// Statement is one parsed SQL statement plus its safety classification.
+type Statement struct {
+	Index         int           `json:"index"`
+	SQL           string        `json:"sql"`
+	OpClass       OpClass       `json:"op_class"`
+	Objects       []string      `json:"objects"`
+	EstRowsNote   string        `json:"estimated_rows_note,omitempty"`
+	// EstRowsAffected is the structured, machine-evaluable row-impact verdict the
+	// policy approver gates on. PATCH(amend-2026-05-25: structured est-rows for
+	// the policy gate) — the prior manifest only carried EstRowsNote (a human
+	// string), which a policy cannot reason about. Convention:
+	//   0  = no existing data rows are read or rewritten (pure additive DDL,
+	//        grant, RLS policy add/rewrite, ADD COLUMN, CREATE INDEX). Backfilling
+	//        a NOT NULL default does NOT count as 0 — see ADD COLUMN classify.
+	//   -1 = unknown or unbounded row impact (INSERT/UPDATE/DELETE/TRUNCATE, or an
+	//        ALTER that rewrites the table). The policy treats -1 as a hard fail
+	//        for the safe-default envelope; it never auto-applies an unknown.
+	// A statement is auto-eligible only when EstRowsAffected == 0.
+	EstRowsAffected int           `json:"est_rows_affected"`
+	Reversibility Reversibility `json:"reversibility"`
+	Inverse       string        `json:"inverse_sql,omitempty"` // mechanical inverse when RevAuto
+	Destructive   bool          `json:"destructive"`
+}
+
+// Manifest is the typed plan emitted by `db plan` and consumed by `db apply`.
+type Manifest struct {
+	PlanHash      string      `json:"plan_hash"`
+	StatementN    int         `json:"statement_count"`
+	Statements    []Statement `json:"statements"`
+	HasDestructive bool       `json:"has_destructive"`
+	HasIrreversible bool      `json:"has_irreversible"`
+	// MaxEstRowsAffected is the manifest-level rollup the policy approver reads:
+	// the maximum per-statement EstRowsAffected, with -1 (unknown) dominating any
+	// concrete count. 0 means every statement touches zero existing data rows.
+	// PATCH(amend-2026-05-25: manifest-level est-rows rollup for the policy gate).
+	MaxEstRowsAffected int     `json:"max_est_rows_affected"`
+	SourceLabel   string      `json:"source,omitempty"` // file path or "--sql"
+}
+
+var (
+	reStmtSplit  = regexp.MustCompile(`;\s*(?:\n|$)`)
+	reLineComment = regexp.MustCompile(`(?m)--.*$`)
+	reBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	reWS         = regexp.MustCompile(`\s+`)
+)
+
+// Parse turns a SQL blob into a typed Manifest with a deterministic plan_hash.
+// The hash is computed over the normalized (comment-stripped, whitespace-
+// collapsed, lowercased-keywords-preserved) statement list so cosmetic edits
+// that don't change semantics keep the same hash, while any real SQL change
+// drifts it — which `db apply --approved` rejects.
+func Parse(sql, sourceLabel string) *Manifest {
+	clean := stripComments(sql)
+	raw := splitStatements(clean)
+
+	m := &Manifest{SourceLabel: sourceLabel}
+	var normParts []string
+	for i, s := range raw {
+		st := classify(i, s)
+		m.Statements = append(m.Statements, st)
+		if st.Destructive {
+			m.HasDestructive = true
+		}
+		if st.Reversibility == RevNone {
+			m.HasIrreversible = true
+		}
+		// PATCH(amend-2026-05-25: roll up est-rows so the policy gate sees the
+		// worst case). -1 (unknown/unbounded) dominates any concrete count, so
+		// once any statement is -1 the rollup is -1 for the whole manifest.
+		if st.EstRowsAffected < 0 || m.MaxEstRowsAffected < 0 {
+			m.MaxEstRowsAffected = -1
+		} else if st.EstRowsAffected > m.MaxEstRowsAffected {
+			m.MaxEstRowsAffected = st.EstRowsAffected
+		}
+		normParts = append(normParts, normalize(s))
+	}
+	m.StatementN = len(m.Statements)
+	m.PlanHash = hashStatements(normParts)
+	return m
+}
+
+// stripComments removes -- line comments and /* */ block comments.
+func stripComments(sql string) string {
+	sql = reBlockComment.ReplaceAllString(sql, "")
+	sql = reLineComment.ReplaceAllString(sql, "")
+	return sql
+}
+
+// splitStatements splits on semicolons that terminate a statement. This is a
+// pragmatic splitter, not a full SQL parser; it handles the migration shapes
+// the lifecycle targets. Dollar-quoted bodies are preserved by tracking the
+// active dollar-quote tag and refusing to split until the matching closing
+// tag is seen. PATCH(amend-2026-05-25: track arbitrary dollar-quote tags) —
+// the prior splitter only matched bare `$$`, so a `DO $ttl$ ... $ttl$` block
+// (migration 008's TTL cleanup) was split on the `;` inside its body,
+// corrupting the manifest. Postgres dollar-quote tags are `$[tag]$` where the
+// optional tag is an identifier; an opening tag is closed only by an identical
+// tag, and tags do not nest. See spec build-correctness note #1.
+func splitStatements(sql string) []string {
+	var out []string
+	var buf strings.Builder
+	runes := []rune(sql)
+	dollarTag := "" // non-empty while inside a dollar-quoted body; holds the opening tag, e.g. "$$" or "$ttl$".
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '$' {
+			if tag, n := scanDollarTag(runes, i); tag != "" {
+				if dollarTag == "" {
+					// Opening a dollar-quoted body.
+					dollarTag = tag
+				} else if dollarTag == tag {
+					// Closing the active body (tags must match exactly; they don't nest).
+					dollarTag = ""
+				}
+				// Whether opening, closing, or an inner non-matching tag, copy
+				// the whole tag verbatim and advance past it.
+				for j := i; j < i+n; j++ {
+					buf.WriteRune(runes[j])
+				}
+				i += n - 1
+				continue
+			}
+		}
+		if runes[i] == ';' && dollarTag == "" {
+			s := strings.TrimSpace(buf.String())
+			if s != "" {
+				out = append(out, s)
+			}
+			buf.Reset()
+			continue
+		}
+		buf.WriteRune(runes[i])
+	}
+	if s := strings.TrimSpace(buf.String()); s != "" {
+		out = append(out, s)
+	}
+	return out
+}
+
+// scanDollarTag reports whether the runes starting at i form a Postgres
+// dollar-quote tag (`$$` or `$identifier$`). It returns the tag text and its
+// length in runes, or ("", 0) when i is not the start of a valid tag (e.g. a
+// `$1` positional parameter or a stray `$`). The tag's inner text must be a
+// valid identifier: it starts with a letter or underscore and continues with
+// letters, digits, or underscores. PATCH(amend-2026-05-25: dollar-tag scanner).
+func scanDollarTag(runes []rune, i int) (string, int) {
+	if runes[i] != '$' {
+		return "", 0
+	}
+	// Bare `$$`.
+	if i+1 < len(runes) && runes[i+1] == '$' {
+		return "$$", 2
+	}
+	// `$identifier$`.
+	j := i + 1
+	for j < len(runes) {
+		r := runes[j]
+		if r == '$' {
+			// A `$identifier$` requires at least one inner rune.
+			if j == i+1 {
+				return "", 0
+			}
+			return string(runes[i : j+1]), j + 1 - i
+		}
+		isIdentStart := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isIdentCont := isIdentStart || (r >= '0' && r <= '9')
+		if j == i+1 {
+			if !isIdentStart {
+				return "", 0 // e.g. `$1` positional param — not a dollar-quote tag.
+			}
+		} else if !isIdentCont {
+			return "", 0
+		}
+		j++
+	}
+	return "", 0
+}
+
+func normalize(s string) string {
+	return reWS.ReplaceAllString(strings.TrimSpace(s), " ")
+}
+
+func hashStatements(parts []string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, ";\n")))
+	return "sha256:" + hex.EncodeToString(h[:])
+}
+
+// upperHead returns the first n leading tokens of a statement, uppercased, for
+// keyword matching.
+func upperHead(s string) string {
+	return strings.ToUpper(normalize(s))
+}
+
+var reIdentAfter = func(kw string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)\b` + kw + `\b\s+(?:if\s+(?:not\s+)?exists\s+)?(?:only\s+)?["]?([a-zA-Z0-9_."]+)`)
+}
+
+// classify assigns the operation class, objects, reversibility, and mechanical
+// inverse for a single statement.
+func classify(idx int, sql string) Statement {
+	st := Statement{Index: idx, SQL: strings.TrimSpace(sql)}
+	head := upperHead(sql)
+
+	switch {
+	// Destructive first — these dominate the safety verdict.
+	case strings.HasPrefix(head, "DROP TABLE"):
+		st.OpClass, st.Destructive, st.Reversibility = OpDestructive, true, RevSnapshot
+		st.Objects = extractObjects(sql, "TABLE")
+	case strings.HasPrefix(head, "DROP SCHEMA"):
+		st.OpClass, st.Destructive, st.Reversibility = OpDestructive, true, RevSnapshot
+		st.Objects = extractObjects(sql, "SCHEMA")
+	case strings.HasPrefix(head, "TRUNCATE"):
+		st.OpClass, st.Destructive, st.Reversibility = OpDestructive, true, RevNone
+		st.Objects = extractObjects(sql, "TRUNCATE")
+		st.EstRowsNote = "all rows in target table(s)"
+		st.EstRowsAffected = -1 // PATCH(amend-2026-05-25): unbounded row impact
+	case strings.HasPrefix(head, "DELETE FROM"), strings.HasPrefix(head, "DELETE "):
+		st.OpClass, st.Destructive, st.Reversibility = OpDestructive, true, RevNone
+		st.Objects = extractObjects(sql, "FROM")
+		st.EstRowsNote = rowEstimate(head)
+		st.EstRowsAffected = -1 // PATCH(amend-2026-05-25): bounded or not, row count is unknown at plan time
+	case strings.Contains(head, "DROP COLUMN"):
+		st.OpClass, st.Destructive, st.Reversibility = OpDestructive, true, RevSnapshot
+		st.Objects = extractObjects(sql, "TABLE")
+	// RLS
+	case strings.Contains(head, "POLICY"):
+		st.OpClass = OpRLS
+		// The safety-relevant object on a policy is the table it guards
+		// (the ON clause), not the policy's own name.
+		st.Objects = extractObjects(sql, "ON")
+		if strings.HasPrefix(head, "CREATE POLICY") {
+			st.Reversibility, st.Inverse = RevAuto, inverseCreatePolicy(sql)
+		} else if strings.HasPrefix(head, "DROP POLICY") {
+			st.Reversibility = RevSnapshot
+		} else {
+			st.Reversibility = RevSnapshot // ALTER POLICY needs prior body
+		}
+	case strings.Contains(head, "ROW LEVEL SECURITY"):
+		st.OpClass = OpRLS
+		st.Objects = extractObjects(sql, "TABLE")
+		if strings.Contains(head, "ENABLE ROW LEVEL SECURITY") {
+			st.Reversibility, st.Inverse = RevAuto, swapEnableDisableRLS(sql, true)
+		} else {
+			st.Reversibility, st.Inverse = RevAuto, swapEnableDisableRLS(sql, false)
+		}
+	// Grants
+	case strings.HasPrefix(head, "GRANT "):
+		st.OpClass, st.Reversibility = OpGrant, RevAuto
+		st.Objects = grantTargets(sql)
+		st.Inverse = grantToRevoke(sql, true)
+	case strings.HasPrefix(head, "REVOKE "):
+		st.OpClass, st.Reversibility = OpGrant, RevAuto
+		st.Objects = grantTargets(sql)
+		st.Inverse = grantToRevoke(sql, false)
+	// DDL additive
+	case strings.HasPrefix(head, "CREATE TABLE"):
+		st.OpClass, st.Reversibility = OpDDL, RevAuto
+		st.Objects = extractObjects(sql, "TABLE")
+		st.Inverse = "DROP TABLE IF EXISTS " + firstObject(st.Objects) + ";"
+	case strings.Contains(head, "ADD COLUMN"):
+		st.OpClass, st.Reversibility = OpDDL, RevAuto
+		st.Objects = extractObjects(sql, "TABLE")
+		if col := addColumnName(sql); col != "" {
+			st.Inverse = "ALTER TABLE " + firstObject(st.Objects) + " DROP COLUMN IF EXISTS " + col + ";"
+		} else {
+			st.Reversibility = RevSnapshot
+		}
+		// PATCH(amend-2026-05-25: est-rows for ADD COLUMN). A nullable column or
+		// one with a constant default is metadata-only on modern Postgres (no
+		// table rewrite, est_rows 0 — stays in the safe envelope). A column with
+		// a VOLATILE default expression forces a full-table rewrite, so its row
+		// impact is unbounded and it must NOT auto-apply.
+		if addColumnHasVolatileDefault(sql) {
+			st.EstRowsAffected = -1
+			st.EstRowsNote = "volatile-default ADD COLUMN rewrites every existing row"
+		}
+	case strings.HasPrefix(head, "CREATE OR REPLACE FUNCTION"), strings.HasPrefix(head, "CREATE FUNCTION"):
+		st.OpClass = OpDDL
+		st.Objects = extractObjects(sql, "FUNCTION")
+		if strings.HasPrefix(head, "CREATE OR REPLACE") {
+			st.Reversibility = RevSnapshot // need prior body to restore
+		} else {
+			st.Reversibility = RevAuto
+			st.Inverse = "DROP FUNCTION IF EXISTS " + firstObject(st.Objects) + ";"
+		}
+	case strings.HasPrefix(head, "CREATE INDEX"), strings.HasPrefix(head, "CREATE UNIQUE INDEX"):
+		st.OpClass, st.Reversibility = OpDDL, RevAuto
+		st.Objects = extractObjects(sql, "INDEX")
+		st.Inverse = "DROP INDEX IF EXISTS " + firstObject(st.Objects) + ";"
+	case strings.HasPrefix(head, "ALTER TABLE"):
+		st.OpClass, st.Reversibility = OpDDL, RevSnapshot
+		st.Objects = extractObjects(sql, "TABLE")
+		// PATCH(amend-2026-05-25): a generic ALTER TABLE that fell through the
+		// additive ADD COLUMN / ADD INDEX cases (e.g. ALTER COLUMN ... TYPE,
+		// SET NOT NULL, DROP CONSTRAINT) can rewrite or revalidate the whole
+		// table, so its row impact is unknown. The expand/contract decomposer
+		// handles the type-change subset; everything else stays out of the safe
+		// envelope.
+		st.EstRowsAffected = -1
+	// Data writes
+	case strings.HasPrefix(head, "INSERT INTO"):
+		st.OpClass, st.Reversibility = OpDataWrite, RevNone
+		st.Objects = extractObjects(sql, "INTO")
+		st.EstRowsNote = "inserted rows (not auto-revertible without PK capture)"
+		st.EstRowsAffected = -1 // PATCH(amend-2026-05-25): row write, outside safe envelope
+	case strings.HasPrefix(head, "UPDATE "):
+		st.OpClass, st.Reversibility = OpDataWrite, RevNone
+		st.Objects = extractObjects(sql, "UPDATE")
+		st.EstRowsNote = rowEstimate(head)
+		st.EstRowsAffected = -1 // PATCH(amend-2026-05-25): row rewrite, outside safe envelope
+	default:
+		st.OpClass, st.Reversibility = OpOther, RevSnapshot
+		// PATCH(amend-2026-05-25): an unclassified statement has unknown row
+		// impact, so it can never satisfy the est_rows==0 safe-envelope gate.
+		st.EstRowsAffected = -1
+	}
+	if len(st.Objects) == 0 {
+		st.Objects = []string{}
+	}
+	return st
+}
+
+func rowEstimate(head string) string {
+	if !strings.Contains(head, " WHERE ") {
+		return "ALL rows (no WHERE clause)"
+	}
+	return "rows matching WHERE clause"
+}
+
+func firstObject(objs []string) string {
+	if len(objs) > 0 {
+		return objs[0]
+	}
+	return ""
+}
+
+func extractObjects(sql, keyword string) []string {
+	re := reIdentAfter(keyword)
+	m := re.FindStringSubmatch(sql)
+	if len(m) >= 2 {
+		return []string{strings.Trim(m[1], `"`)}
+	}
+	return nil
+}
+
+// grantTargets pulls the ON <object> target from a GRANT/REVOKE.
+func grantTargets(sql string) []string {
+	re := regexp.MustCompile(`(?i)\bON\b\s+(?:TABLE\s+|FUNCTION\s+|SCHEMA\s+)?([a-zA-Z0-9_."]+)`)
+	m := re.FindStringSubmatch(sql)
+	if len(m) >= 2 {
+		return []string{strings.Trim(m[1], `"`)}
+	}
+	return nil
+}
+
+// grantToRevoke produces the mechanical inverse of a GRANT (a REVOKE) or a
+// REVOKE (a GRANT). It swaps the leading verb and the TO/FROM keyword.
+func grantToRevoke(sql string, isGrant bool) string {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(sql), ";"))
+	if isGrant {
+		out := regexp.MustCompile(`(?i)^GRANT\b`).ReplaceAllString(trimmed, "REVOKE")
+		out = regexp.MustCompile(`(?i)\bTO\b`).ReplaceAllString(out, "FROM")
+		return out + ";"
+	}
+	out := regexp.MustCompile(`(?i)^REVOKE\b`).ReplaceAllString(trimmed, "GRANT")
+	out = regexp.MustCompile(`(?i)\bFROM\b`).ReplaceAllString(out, "TO")
+	return out + ";"
+}
+
+func swapEnableDisableRLS(sql string, wasEnable bool) string {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(sql), ";"))
+	if wasEnable {
+		return regexp.MustCompile(`(?i)\bENABLE ROW LEVEL SECURITY\b`).ReplaceAllString(trimmed, "DISABLE ROW LEVEL SECURITY") + ";"
+	}
+	return regexp.MustCompile(`(?i)\bDISABLE ROW LEVEL SECURITY\b`).ReplaceAllString(trimmed, "ENABLE ROW LEVEL SECURITY") + ";"
+}
+
+func inverseCreatePolicy(sql string) string {
+	name := policyName(sql)
+	tbl := firstObject(extractObjects(sql, "ON"))
+	if name == "" || tbl == "" {
+		return ""
+	}
+	return "DROP POLICY IF EXISTS " + name + " ON " + tbl + ";"
+}
+
+func policyName(sql string) string {
+	re := regexp.MustCompile(`(?i)CREATE\s+POLICY\s+"?([a-zA-Z0-9_ ]+?)"?\s+ON\b`)
+	m := re.FindStringSubmatch(sql)
+	if len(m) >= 2 {
+		return `"` + strings.TrimSpace(m[1]) + `"`
+	}
+	return ""
+}
+
+func addColumnName(sql string) string {
+	re := regexp.MustCompile(`(?i)ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-zA-Z0-9_]+)"?`)
+	m := re.FindStringSubmatch(sql)
+	if len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}
+
+var reColumnDefault = regexp.MustCompile(`(?i)\bDEFAULT\s+(.+?)(?:\s+(?:NOT\s+NULL|NULL|CHECK|REFERENCES|UNIQUE|PRIMARY\s+KEY|COLLATE)\b|,|$)`)
+
+// addColumnHasVolatileDefault reports whether an ADD COLUMN carries a DEFAULT
+// whose expression is volatile (a function call), which forces Postgres to
+// rewrite every existing row. A bare literal / NULL / quoted-string default is
+// constant: Postgres stores it as a catalog attmissingval and the add is
+// metadata-only (est_rows 0, safe-envelope eligible). PATCH(amend-2026-05-25:
+// volatile-default detection for the est-rows gate). The check is deliberately
+// conservative — any `(` in the default expression (a function call such as
+// now(), gen_random_uuid(), nextval(...)) is treated as volatile so the policy
+// never auto-applies a full-table rewrite it mistook for metadata-only.
+func addColumnHasVolatileDefault(sql string) bool {
+	m := reColumnDefault.FindStringSubmatch(sql)
+	if len(m) < 2 {
+		return false // no DEFAULT clause -> nullable add, metadata-only
+	}
+	expr := strings.TrimSpace(m[1])
+	// A function-call default contains a "(" (now(), gen_random_uuid(),
+	// nextval('seq')). Bare literals (42, 'active', true, NULL) do not.
+	return strings.Contains(expr, "(")
+}

--- a/library/developer-tools/supabase/internal/dbchange/manifest_test.go
+++ b/library/developer-tools/supabase/internal/dbchange/manifest_test.go
@@ -1,0 +1,154 @@
+// PATCH: tests for the novel safe-mutation change manifest.
+package dbchange
+
+import "testing"
+
+func TestParseDeterministicHash(t *testing.T) {
+	sql := "grant execute on function public.f() to anon;"
+	a := Parse(sql, "x")
+	b := Parse(sql, "y") // different label must not change the hash
+	if a.PlanHash != b.PlanHash {
+		t.Fatalf("hash not deterministic across labels: %s vs %s", a.PlanHash, b.PlanHash)
+	}
+	// Cosmetic whitespace must not drift the hash.
+	c := Parse("grant   execute on function public.f()   to anon;", "x")
+	if a.PlanHash != c.PlanHash {
+		t.Fatalf("whitespace changed hash: %s vs %s", a.PlanHash, c.PlanHash)
+	}
+	// A real semantic change must drift it.
+	d := Parse("grant execute on function public.g() to anon;", "x")
+	if a.PlanHash == d.PlanHash {
+		t.Fatal("different SQL produced same hash")
+	}
+}
+
+func TestClassifyOpClasses(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want OpClass
+		dest bool
+	}{
+		{"create table public.t (id int);", OpDDL, false},
+		{"grant select on public.t to anon;", OpGrant, false},
+		{"revoke execute on function public.f() from public;", OpGrant, false},
+		{"create policy \"p\" on public.t for select using (true);", OpRLS, false},
+		{"alter table public.t enable row level security;", OpRLS, false},
+		{"drop table public.t;", OpDestructive, true},
+		{"truncate public.t;", OpDestructive, true},
+		{"delete from public.t;", OpDestructive, true},
+		{"insert into public.t (id) values (1);", OpDataWrite, false},
+		{"update public.t set x = 1 where id = 2;", OpDataWrite, false},
+	}
+	for _, tc := range cases {
+		m := Parse(tc.sql, "t")
+		if len(m.Statements) != 1 {
+			t.Fatalf("%q: expected 1 statement, got %d", tc.sql, len(m.Statements))
+		}
+		s := m.Statements[0]
+		if s.OpClass != tc.want {
+			t.Errorf("%q: op_class = %s, want %s", tc.sql, s.OpClass, tc.want)
+		}
+		if s.Destructive != tc.dest {
+			t.Errorf("%q: destructive = %v, want %v", tc.sql, s.Destructive, tc.dest)
+		}
+	}
+}
+
+func TestMechanicalInverse(t *testing.T) {
+	cases := []struct {
+		sql         string
+		wantInverse string
+	}{
+		{"grant select on public.t to anon;", "REVOKE select on public.t FROM anon;"},
+		{"revoke select on public.t from anon;", "GRANT select on public.t TO anon;"},
+		{"create table public.t (id int);", "DROP TABLE IF EXISTS public.t;"},
+		{"create index idx_t on public.t (id);", "DROP INDEX IF EXISTS idx_t;"},
+		{"alter table public.t enable row level security;", "alter table public.t DISABLE ROW LEVEL SECURITY;"},
+	}
+	for _, tc := range cases {
+		m := Parse(tc.sql, "t")
+		got := m.Statements[0].Inverse
+		if got != tc.wantInverse {
+			t.Errorf("%q: inverse = %q, want %q", tc.sql, got, tc.wantInverse)
+		}
+	}
+}
+
+func TestReversibilityVerdicts(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want Reversibility
+	}{
+		{"grant select on public.t to anon;", RevAuto},
+		{"create table public.t (id int);", RevAuto},
+		{"create or replace function public.f() returns int language sql as $$ select 1 $$;", RevSnapshot},
+		{"alter table public.t add column z int;", RevAuto},
+		{"delete from public.t;", RevNone},
+		{"truncate public.t;", RevNone},
+		{"update public.t set x = 1;", RevNone},
+	}
+	for _, tc := range cases {
+		m := Parse(tc.sql, "t")
+		if got := m.Statements[0].Reversibility; got != tc.want {
+			t.Errorf("%q: reversibility = %s, want %s", tc.sql, got, tc.want)
+		}
+	}
+}
+
+func TestPolicyObjectIsTable(t *testing.T) {
+	m := Parse(`create policy "users read own" on public.profiles for select using (auth.uid() = user_id);`, "t")
+	objs := m.Statements[0].Objects
+	if len(objs) != 1 || objs[0] != "public.profiles" {
+		t.Fatalf("policy object = %v, want [public.profiles]", objs)
+	}
+}
+
+func TestDollarQuotedBodyNotSplit(t *testing.T) {
+	// A function body containing semicolons inside $$ must remain one statement.
+	sql := `create function public.f() returns void language plpgsql as $$ begin perform 1; perform 2; end; $$;`
+	m := Parse(sql, "t")
+	if m.StatementN != 1 {
+		t.Fatalf("dollar-quoted body split into %d statements, want 1", m.StatementN)
+	}
+}
+
+func TestNamedDollarTagBlockNotSplit(t *testing.T) {
+	// A `DO $ttl$ ... $ttl$` block (migration 008's TTL cleanup) contains a
+	// semicolon-terminated DELETE inside its body. A bare-$$ splitter would
+	// break it into multiple statements; the tag-aware splitter must keep it
+	// whole. See spec build-correctness note #1.
+	sql := `do $ttl$
+begin
+  delete from public.sessions where created_at < now() - interval '30 days';
+end
+$ttl$;`
+	m := Parse(sql, "t")
+	if m.StatementN != 1 {
+		t.Fatalf("named-tag DO block split into %d statements, want 1", m.StatementN)
+	}
+}
+
+func TestMixedTagsAndPositionalParamsSplitCorrectly(t *testing.T) {
+	// A `$tag$` body must not be closed by a non-matching `$$` inside it, and a
+	// `$1` positional parameter must not be mistaken for a dollar-quote tag.
+	sql := `create function public.f(a int) returns int language plpgsql as $body$
+begin
+  return a + $1;
+end
+$body$;
+grant execute on function public.f(int) to anon;`
+	m := Parse(sql, "t")
+	if m.StatementN != 2 {
+		t.Fatalf("mixed tags/params produced %d statements, want 2", m.StatementN)
+	}
+}
+
+func TestDestructiveAndIrreversibleFlags(t *testing.T) {
+	m := Parse("delete from public.t;", "t")
+	if !m.HasDestructive {
+		t.Error("expected HasDestructive=true for DELETE")
+	}
+	if !m.HasIrreversible {
+		t.Error("expected HasIrreversible=true for DELETE")
+	}
+}

--- a/library/developer-tools/supabase/internal/dbchange/policy.go
+++ b/library/developer-tools/supabase/internal/dbchange/policy.go
@@ -1,0 +1,196 @@
+// PATCH(amend-2026-05-25: policy approver — self-authorize an apply when every
+// statement is inside a declared safe envelope). Replaces the human
+// `--approved <plan-hash>` paste for the additive+reversible class of changes.
+// Not in the Management API.
+//
+// The policy is the safety classifier the manifest was built to feed. It
+// evaluates the typed Manifest against an allowed-operation envelope and
+// self-authorizes `db apply` ONLY when every statement is in an allowed class,
+// reversible, lint-clean, and touches zero existing data rows. It replaces the
+// human approver; it does NOT replace the plan_hash drift gate, the savepoint
+// transaction, or the receipt — those safety primitives still run.
+package dbchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// Policy declares the operation envelope an apply may self-authorize within.
+// The zero value authorizes nothing; use SafeDefaultPolicy() for the
+// Shane-approved additive+reversible envelope, or LoadPolicy() for a file.
+type Policy struct {
+	// Name is a human label surfaced in the authorization receipt.
+	Name string `json:"name"`
+	// AllowedClasses is the set of OpClass values a statement may belong to and
+	// still be auto-eligible. A statement whose class is absent fails the gate.
+	AllowedClasses []OpClass `json:"allowed_classes"`
+	// RequireReversible, when true, fails any statement whose Reversibility is
+	// RevNone (no reliable inverse).
+	RequireReversible bool `json:"require_reversible"`
+	// RequireLintClean, when true, fails the plan if it has any ERROR-level lint
+	// finding. The caller supplies the error count (lint lives in package cli).
+	RequireLintClean bool `json:"require_lint_clean"`
+	// MaxEstRowsAffected caps the manifest-level row impact. 0 means "no existing
+	// data rows may be touched" — the safe-default. A negative manifest rollup
+	// (unknown/unbounded) always fails regardless of this cap.
+	MaxEstRowsAffected int `json:"max_est_rows_affected"`
+	// AllowDestructive, when false, fails any statement flagged Destructive even
+	// if its class is otherwise allowed. The safe-default leaves this false;
+	// destructive changes route through the expand/contract decomposer instead.
+	AllowDestructive bool `json:"allow_destructive"`
+}
+
+// SafeDefaultPolicy returns the Shane-approved AUTO-APPLY envelope: additive +
+// reversible only. CREATE table/index/policy/function, ADD COLUMN
+// nullable-or-with-constant-default, ADD INDEX CONCURRENTLY, GRANT, RLS policy
+// add/rewrite — every statement reversible, lint clean, est_rows == 0, nothing
+// destructive.
+func SafeDefaultPolicy() *Policy {
+	return &Policy{
+		Name:               "safe-default",
+		AllowedClasses:     []OpClass{OpDDL, OpGrant, OpRLS},
+		RequireReversible:  true,
+		RequireLintClean:   true,
+		MaxEstRowsAffected: 0,
+		AllowDestructive:   false,
+	}
+}
+
+// LoadPolicy reads a policy JSON file from disk. The file shape mirrors the
+// Policy struct. A missing or malformed file is a hard error — the apply must
+// not fall back to a permissive default.
+func LoadPolicy(path string) (*Policy, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading policy file %q: %w", path, err)
+	}
+	var p Policy
+	if err := json.Unmarshal(b, &p); err != nil {
+		return nil, fmt.Errorf("parsing policy file %q: %w", path, err)
+	}
+	if p.Name == "" {
+		p.Name = "custom:" + path
+	}
+	if len(p.AllowedClasses) == 0 {
+		return nil, fmt.Errorf("policy %q allows no operation classes — it would authorize nothing", path)
+	}
+	return &p, nil
+}
+
+// PolicyVerdict is the machine-readable result of evaluating a plan against a
+// policy. Authorized is true only when Reasons is empty.
+type PolicyVerdict struct {
+	Policy     string          `json:"policy"`
+	Authorized bool            `json:"authorized"`
+	PlanHash   string          `json:"plan_hash"`
+	// Reasons holds one structured refusal per failing statement (plus
+	// manifest-level reasons with StatementIndex -1). Empty when authorized.
+	Reasons []PolicyReason `json:"reasons,omitempty"`
+}
+
+// PolicyReason is a single structured refusal: which statement, which rule, and
+// a human message. StatementIndex is -1 for manifest-level reasons.
+type PolicyReason struct {
+	StatementIndex int     `json:"statement_index"`
+	Rule           string  `json:"rule"`
+	OpClass        OpClass `json:"op_class,omitempty"`
+	Object         string  `json:"object,omitempty"`
+	Message        string  `json:"message"`
+}
+
+// Evaluate runs the policy over the manifest and returns a structured verdict.
+// errorLintCount is the number of ERROR-level lint findings the caller computed
+// (lint lives in package cli, which imports this package; passing the count in
+// avoids an import cycle). When RequireLintClean is false the count is ignored.
+//
+// Evaluate NEVER mutates and NEVER authorizes on ambiguity: any condition it
+// cannot positively clear becomes a refusal reason. A plan with zero statements
+// is refused (nothing to authorize).
+func (p *Policy) Evaluate(m *Manifest, errorLintCount int) PolicyVerdict {
+	v := PolicyVerdict{Policy: p.Name, PlanHash: m.PlanHash}
+
+	if m.StatementN == 0 {
+		v.Reasons = append(v.Reasons, PolicyReason{
+			StatementIndex: -1,
+			Rule:           "empty_plan",
+			Message:        "plan has no statements; nothing to authorize",
+		})
+		return v
+	}
+
+	allowed := map[OpClass]bool{}
+	for _, c := range p.AllowedClasses {
+		allowed[c] = true
+	}
+
+	for _, s := range m.Statements {
+		obj := ""
+		if len(s.Objects) > 0 {
+			obj = s.Objects[0]
+		}
+		if !allowed[s.OpClass] {
+			v.Reasons = append(v.Reasons, PolicyReason{
+				StatementIndex: s.Index, Rule: "class_not_allowed", OpClass: s.OpClass, Object: obj,
+				Message: fmt.Sprintf("operation class %q is not in the %q envelope", s.OpClass, p.Name),
+			})
+		}
+		if !p.AllowDestructive && s.Destructive {
+			v.Reasons = append(v.Reasons, PolicyReason{
+				StatementIndex: s.Index, Rule: "destructive_not_allowed", OpClass: s.OpClass, Object: obj,
+				Message: "statement is destructive; the safe envelope refuses it (route through expand/contract decomposition)",
+			})
+		}
+		if p.RequireReversible && s.Reversibility == RevNone {
+			v.Reasons = append(v.Reasons, PolicyReason{
+				StatementIndex: s.Index, Rule: "not_reversible", OpClass: s.OpClass, Object: obj,
+				Message: "statement has no reliable inverse (reversibility=none); the safe envelope requires reversibility",
+			})
+		}
+		// Per-statement row gate: only enforced under the strict envelope
+		// (cap 0 = "no existing data rows may be touched"). A policy that
+		// declares a higher or unbounded cap accepts row-touching statements;
+		// they are then governed only by the manifest-level cap below.
+		if p.MaxEstRowsAffected == 0 && s.EstRowsAffected != 0 {
+			v.Reasons = append(v.Reasons, PolicyReason{
+				StatementIndex: s.Index, Rule: "touches_data_rows", OpClass: s.OpClass, Object: obj,
+				Message: fmt.Sprintf("statement touches existing data rows (est_rows_affected=%d); the safe envelope requires 0", s.EstRowsAffected),
+			})
+		}
+	}
+
+	// Manifest-level row cap. A negative policy cap means "unknown/unbounded row
+	// impact is accepted" — only an explicit opt-in. Otherwise an unknown plan
+	// (-1) or a concrete count above a non-negative cap fails.
+	if p.MaxEstRowsAffected >= 0 && (m.MaxEstRowsAffected < 0 || m.MaxEstRowsAffected > p.MaxEstRowsAffected) {
+		v.Reasons = append(v.Reasons, PolicyReason{
+			StatementIndex: -1, Rule: "est_rows_exceeds_cap",
+			Message: fmt.Sprintf("plan max est_rows_affected=%d exceeds policy cap %d", m.MaxEstRowsAffected, p.MaxEstRowsAffected),
+		})
+	}
+
+	if p.RequireLintClean && errorLintCount > 0 {
+		v.Reasons = append(v.Reasons, PolicyReason{
+			StatementIndex: -1, Rule: "lint_not_clean",
+			Message: fmt.Sprintf("plan has %d ERROR-level lint finding(s); the safe envelope requires a lint-clean plan", errorLintCount),
+		})
+	}
+
+	// Stable ordering: statement-level reasons by index, then manifest-level
+	// (-1) reasons last, so JSON output and human display are deterministic.
+	sort.SliceStable(v.Reasons, func(i, j int) bool {
+		a, b := v.Reasons[i].StatementIndex, v.Reasons[j].StatementIndex
+		if a < 0 {
+			a = 1 << 30
+		}
+		if b < 0 {
+			b = 1 << 30
+		}
+		return a < b
+	})
+
+	v.Authorized = len(v.Reasons) == 0
+	return v
+}

--- a/library/developer-tools/supabase/internal/dbchange/policy_test.go
+++ b/library/developer-tools/supabase/internal/dbchange/policy_test.go
@@ -1,0 +1,123 @@
+// PATCH(amend-2026-05-25): tests for the policy approver, est-rows gate, and
+// expand/contract decomposition.
+package dbchange
+
+import "testing"
+
+func TestEstRowsAffectedClassification(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want int // per-statement EstRowsAffected
+	}{
+		{"create table public.t (id int);", 0},
+		{"grant select on public.t to anon;", 0},
+		{`create policy "p" on public.t for select using (true);`, 0},
+		{"alter table public.t add column z int;", 0},                                   // nullable add
+		{"alter table public.t add column z int default 42;", 0},                        // constant default
+		{"alter table public.t add column z timestamptz default now();", -1},            // volatile default rewrites rows
+		{"alter table public.t add column z uuid default gen_random_uuid();", -1},       // volatile default
+		{"alter table public.t alter column z type bigint;", -1},                        // type change rewrites
+		{"delete from public.t where id = 1;", -1},
+		{"truncate public.t;", -1},
+		{"insert into public.t (id) values (1);", -1},
+		{"update public.t set x = 1;", -1},
+	}
+	for _, tc := range cases {
+		m := Parse(tc.sql, "t")
+		if len(m.Statements) != 1 {
+			t.Fatalf("%q: expected 1 statement, got %d", tc.sql, len(m.Statements))
+		}
+		if got := m.Statements[0].EstRowsAffected; got != tc.want {
+			t.Errorf("%q: est_rows_affected = %d, want %d", tc.sql, got, tc.want)
+		}
+	}
+}
+
+func TestMaxEstRowsRollup(t *testing.T) {
+	// A purely additive plan rolls up to 0.
+	add := Parse("create table public.t (id int); grant select on public.t to anon;", "t")
+	if add.MaxEstRowsAffected != 0 {
+		t.Errorf("additive plan max_est_rows = %d, want 0", add.MaxEstRowsAffected)
+	}
+	// Any unknown statement makes the whole plan -1.
+	mixed := Parse("create table public.t (id int); delete from public.t where id = 1;", "t")
+	if mixed.MaxEstRowsAffected != -1 {
+		t.Errorf("mixed plan max_est_rows = %d, want -1", mixed.MaxEstRowsAffected)
+	}
+}
+
+func TestSafeDefaultPolicyAuthorizesAdditive(t *testing.T) {
+	sql := `create table public.t (id int);
+grant select on public.t to anon;
+create policy "p" on public.t for select using ((select auth.uid()) = id);
+alter table public.t enable row level security;`
+	m := Parse(sql, "t")
+	v := SafeDefaultPolicy().Evaluate(m, 0)
+	if !v.Authorized {
+		t.Fatalf("safe-default should authorize additive+reversible plan; reasons: %+v", v.Reasons)
+	}
+}
+
+func TestSafeDefaultPolicyRefusesDestructive(t *testing.T) {
+	m := Parse("drop table public.t;", "t")
+	v := SafeDefaultPolicy().Evaluate(m, 0)
+	if v.Authorized {
+		t.Fatal("safe-default must not authorize DROP TABLE")
+	}
+	if !hasRule(v.Reasons, "destructive_not_allowed") {
+		t.Errorf("expected destructive_not_allowed reason, got %+v", v.Reasons)
+	}
+}
+
+func TestSafeDefaultPolicyRefusesDataWrite(t *testing.T) {
+	m := Parse("update public.t set x = 1;", "t")
+	v := SafeDefaultPolicy().Evaluate(m, 0)
+	if v.Authorized {
+		t.Fatal("safe-default must not authorize UPDATE")
+	}
+	if !hasRule(v.Reasons, "touches_data_rows") && !hasRule(v.Reasons, "est_rows_exceeds_cap") {
+		t.Errorf("expected a row-impact refusal, got %+v", v.Reasons)
+	}
+}
+
+func TestPolicyRefusesOnLintError(t *testing.T) {
+	// An otherwise-clean additive plan is refused when the caller reports an
+	// ERROR-level lint finding.
+	m := Parse("create table public.t (id int);", "t")
+	v := SafeDefaultPolicy().Evaluate(m, 1)
+	if v.Authorized {
+		t.Fatal("policy must refuse a plan with ERROR-level lint findings")
+	}
+	if !hasRule(v.Reasons, "lint_not_clean") {
+		t.Errorf("expected lint_not_clean reason, got %+v", v.Reasons)
+	}
+}
+
+func TestPolicyRefusesVolatileDefaultAddColumn(t *testing.T) {
+	// ADD COLUMN with now() is OpDDL + reversible but rewrites rows -> est-rows gate.
+	m := Parse("alter table public.t add column created timestamptz default now();", "t")
+	v := SafeDefaultPolicy().Evaluate(m, 0)
+	if v.Authorized {
+		t.Fatal("policy must refuse a volatile-default ADD COLUMN (full-table rewrite)")
+	}
+}
+
+func TestPolicyRefusesEmptyPlan(t *testing.T) {
+	m := Parse("", "t")
+	v := SafeDefaultPolicy().Evaluate(m, 0)
+	if v.Authorized {
+		t.Fatal("policy must refuse an empty plan")
+	}
+	if !hasRule(v.Reasons, "empty_plan") {
+		t.Errorf("expected empty_plan reason, got %+v", v.Reasons)
+	}
+}
+
+func hasRule(rs []PolicyReason, rule string) bool {
+	for _, r := range rs {
+		if r.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/library/developer-tools/supabase/internal/store/store.go
+++ b/library/developer-tools/supabase/internal/store/store.go
@@ -1146,6 +1146,20 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 	return LookupFieldValue(obj, snakeKey)
 }
 
+// notNullStr coerces an optional field value into a non-null string for binding
+// into a NOT NULL TEXT column (e.g. projects_id). A missing field (nil) becomes
+// "" rather than SQL NULL, so a generic paginated UpsertBatch whose items lack
+// the parent project id does not violate the NOT NULL constraint.
+func notNullStr(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
 // upsertBranchesTx writes the typed-table portion of a branches upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -1217,7 +1231,7 @@ func (s *Store) upsertDiffTx(tx *sql.Tx, id string, obj map[string]any, data jso
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "branches_id" = excluded."branches_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "branches_id"),
+		notNullStr(lookupFieldValue(obj, "branches_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1268,7 +1282,7 @@ func (s *Store) upsertMergeTx(tx *sql.Tx, id string, obj map[string]any, data js
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "branches_id" = excluded."branches_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "branches_id"),
+		notNullStr(lookupFieldValue(obj, "branches_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1319,7 +1333,7 @@ func (s *Store) upsertPushTx(tx *sql.Tx, id string, obj map[string]any, data jso
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "branches_id" = excluded."branches_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "branches_id"),
+		notNullStr(lookupFieldValue(obj, "branches_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1370,7 +1384,7 @@ func (s *Store) upsertResetTx(tx *sql.Tx, id string, obj map[string]any, data js
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "branches_id" = excluded."branches_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "branches_id"),
+		notNullStr(lookupFieldValue(obj, "branches_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1421,7 +1435,7 @@ func (s *Store) upsertBranchesRestoreTx(tx *sql.Tx, id string, obj map[string]an
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "branches_id" = excluded."branches_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "branches_id"),
+		notNullStr(lookupFieldValue(obj, "branches_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1525,7 +1539,7 @@ func (s *Store) upsertEntitlementsTx(tx *sql.Tx, id string, obj map[string]any, 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "organizations_id" = excluded."organizations_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "organizations_id"),
+		notNullStr(lookupFieldValue(obj, "organizations_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1576,7 +1590,7 @@ func (s *Store) upsertMembersTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "organizations_id" = excluded."organizations_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "organizations_id"),
+		notNullStr(lookupFieldValue(obj, "organizations_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1627,7 +1641,7 @@ func (s *Store) upsertProjectClaimTx(tx *sql.Tx, id string, obj map[string]any, 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "organizations_id" = excluded."organizations_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "organizations_id"),
+		notNullStr(lookupFieldValue(obj, "organizations_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1678,7 +1692,7 @@ func (s *Store) upsertOrganizationsProjectsTx(tx *sql.Tx, id string, obj map[str
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "organizations_id" = excluded."organizations_id", "data" = excluded."data", "synced_at" = excluded."synced_at", "parent_id" = excluded."parent_id"`,
 		id,
-		lookupFieldValue(obj, "organizations_id"),
+		notNullStr(lookupFieldValue(obj, "organizations_id")),
 		string(data),
 		time.Now(),
 		lookupFieldValue(obj, "parent_id"),
@@ -1787,7 +1801,7 @@ func (s *Store) upsertActionsTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at", "parent_id" = excluded."parent_id"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 		lookupFieldValue(obj, "parent_id"),
@@ -1839,7 +1853,7 @@ func (s *Store) upsertAdvisorsTx(tx *sql.Tx, id string, obj map[string]any, data
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1890,7 +1904,7 @@ func (s *Store) upsertAnalyticsTx(tx *sql.Tx, id string, obj map[string]any, dat
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1941,7 +1955,7 @@ func (s *Store) upsertApiKeysTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -1992,7 +2006,7 @@ func (s *Store) upsertBillingTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2043,7 +2057,7 @@ func (s *Store) upsertProjectsBranchesTx(tx *sql.Tx, id string, obj map[string]a
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2094,7 +2108,7 @@ func (s *Store) upsertClaimTokenTx(tx *sql.Tx, id string, obj map[string]any, da
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2145,7 +2159,7 @@ func (s *Store) upsertCliTx(tx *sql.Tx, id string, obj map[string]any, data json
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2196,7 +2210,7 @@ func (s *Store) upsertConfigTx(tx *sql.Tx, id string, obj map[string]any, data j
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2247,7 +2261,7 @@ func (s *Store) upsertCustomHostnameTx(tx *sql.Tx, id string, obj map[string]any
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2298,7 +2312,7 @@ func (s *Store) upsertDatabaseTx(tx *sql.Tx, id string, obj map[string]any, data
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2349,7 +2363,7 @@ func (s *Store) upsertFunctionsTx(tx *sql.Tx, id string, obj map[string]any, dat
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2400,7 +2414,7 @@ func (s *Store) upsertHealthTx(tx *sql.Tx, id string, obj map[string]any, data j
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2451,7 +2465,7 @@ func (s *Store) upsertJitAccessTx(tx *sql.Tx, id string, obj map[string]any, dat
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2502,7 +2516,7 @@ func (s *Store) upsertNetworkBansTx(tx *sql.Tx, id string, obj map[string]any, d
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2553,7 +2567,7 @@ func (s *Store) upsertNetworkRestrictionsTx(tx *sql.Tx, id string, obj map[strin
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2604,7 +2618,7 @@ func (s *Store) upsertPauseTx(tx *sql.Tx, id string, obj map[string]any, data js
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2655,7 +2669,7 @@ func (s *Store) upsertPgsodiumTx(tx *sql.Tx, id string, obj map[string]any, data
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2706,7 +2720,7 @@ func (s *Store) upsertPostgrestTx(tx *sql.Tx, id string, obj map[string]any, dat
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2757,7 +2771,7 @@ func (s *Store) upsertReadReplicasTx(tx *sql.Tx, id string, obj map[string]any, 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2808,7 +2822,7 @@ func (s *Store) upsertReadonlyTx(tx *sql.Tx, id string, obj map[string]any, data
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2859,7 +2873,7 @@ func (s *Store) upsertProjectsRestoreTx(tx *sql.Tx, id string, obj map[string]an
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2910,7 +2924,7 @@ func (s *Store) upsertSecretsTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -2961,7 +2975,7 @@ func (s *Store) upsertSslEnforcementTx(tx *sql.Tx, id string, obj map[string]any
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -3012,7 +3026,7 @@ func (s *Store) upsertStorageTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -3063,7 +3077,7 @@ func (s *Store) upsertTypesTx(tx *sql.Tx, id string, obj map[string]any, data js
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -3114,7 +3128,7 @@ func (s *Store) upsertUpgradeTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {
@@ -3165,7 +3179,7 @@ func (s *Store) upsertVanitySubdomainTx(tx *sql.Tx, id string, obj map[string]an
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT("id") DO UPDATE SET "projects_id" = excluded."projects_id", "data" = excluded."data", "synced_at" = excluded."synced_at"`,
 		id,
-		lookupFieldValue(obj, "projects_id"),
+		notNullStr(lookupFieldValue(obj, "projects_id")),
 		string(data),
 		time.Now(),
 	); err != nil {


### PR DESCRIPTION
## Summary

Makes autonomous production migrations real on the supabase CLI's safe-mutation lifecycle. The prior lifecycle made every DB change legible, reversible, and attestable but still required a human to paste an approved `plan_hash`. This PR closes the autonomy loop: a named `--policy` is a real approver that self-authorizes `db apply` when the typed change manifest is provably inside a declared safe envelope, with destructive intent mechanically decomposed into safe online steps or refused with a machine-readable reason.

## What changed

- **`db apply --policy safe-default|<file>`** — policy approver that evaluates the typed `dbchange.Manifest` against a declared safe envelope and self-authorizes apply ONLY when every statement is in an allowed class, reversible, lint-clean, and touches zero existing data rows. `--approved <plan-hash>` remains available as the human authorization mode (one of two), not the required gate. The policy replaces only the human paste; the plan_hash drift gate, savepoint-per-statement transaction, and reversal receipt are kept exactly as-is.
- **Additive-only safe-default envelope** — `SafeDefaultPolicy()` allows DDL/GRANT/RLS, requires reversibility, and caps `MaxEstRowsAffected=0`. A structured `EstRowsAffected` field (0 = no data rows, -1 = unknown/unbounded) plus a `MaxEstRowsAffected` rollup make the est-rows gate machine-evaluable; a volatile-default `ADD COLUMN` (now()/gen_random_uuid()) is correctly scored -1.
- **`db decompose` for destructive classes** — rewrites `DROP COLUMN` into a reversible tombstone-rename (now) plus a deferred hard drop, and `ALTER COLUMN ... TYPE` into expand / backfill (app-owned, manual) / contract; `TRUNCATE`, unbounded `DELETE`, and `DROP TABLE`/`DROP SCHEMA` are refused with a structured machine-readable reason and a no-op. Replaces the blunt `--allow-destructive` boolean.
- **Branch-first staging** — `db apply --stage-branch <ref>` requires the exact transaction to apply cleanly to a Supabase preview branch with the security AND performance advisors green before the prod apply runs.
- **Audit attestation** — the authorization mode used (human plan-hash vs named policy) is recorded in the reversal receipt.

Built entirely on the existing `dbchange.Manifest`, the Management API `database/query` + advisor endpoints, and the branch config endpoint. Reuses `assembleTransaction`, `lintManifest`, `replacePathParam`, `classifyAPIError`, `printJSONFiltered`.

**Out of scope:** the GitHub Action runner that drives this autonomously is companion infrastructure in a separate repo and is intentionally NOT built here.

## Findings addressed

| ID | Type | Rationale |
|----|------|-----------|
| A1 | feature | Replace mandatory human plan-hash paste with a policy approver gated to an additive+reversible+zero-row safe envelope. |
| A2 | feature | Replace the blunt `--allow-destructive` boolean with `db decompose` expand/contract rewrites; refuse irreducibly destructive ops with structured reasons. |
| A3 | feature | Add branch-first staging gate (advisors green on a preview branch before prod apply). |

## Verification

- `go build ./...` — PASS
- `go test ./internal/dbchange/...` — PASS
- `go vet` — PASS
- Policy approver wired into `db_apply.go`; `SafeDefaultPolicy()` matches the additive-only envelope (DDL/GRANT/RLS, RequireReversible, MaxEstRowsAffected=0).

## Changes

`23 files changed, +3068, -37` — scoped entirely to `library/developer-tools/supabase/`.

## Evidence

- Patch manifest: [`.printing-press-patches.json`](https://github.com/mvanhorn/printing-press-library/blob/05cafeefbf1ae9919b27dc9360bed93e4e8a805d/library/developer-tools/supabase/.printing-press-patches.json) (`autonomous-prod-migrations` entry, run amend-2026-05-25T2110)