### PR TITLE
feat(hotel-goat): add Trivago second source + Frankfurter FX

### DIFF
--- a/library/travel/hotel-goat/.printing-press-patches.json
+++ b/library/travel/hotel-goat/.printing-press-patches.json
@@ -1,62 +1,24 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-25",
+  "applied_at": "2026-05-26",
   "base_run_id": "20260523-203231",
   "base_printing_press_version": "4.13.0",
   "patches": [
     {
-      "id": "hotel-goat-dryrun-before-flag-validation",
-      "summary": "Move the dryRunOK short-circuit ahead of required-flag validation in hotels/dates/near so verify-harness probes can short-circuit.",
-      "reason": "Three commands required positional args or --checkin/--checkout/--from/--to flags before the dry-run shortcut, so the verify-skill mock probes errored out instead of short-circuiting and the structural verify rate sat at 86% (3 of 21 commands red). Reordering the dryRunOK check ahead of the validation gate lifts verify to 100% without changing real-call behavior.",
+      "id": "hotel-goat-trivago-fx",
+      "summary": "Add Trivago as a second cash-price source alongside Google, with Frankfurter ECB FX conversion to normalize EUR -> headline currency.",
+      "reason": "Multi-source requirement: a single OTA can mis-list, mis-price, or omit a property. Trivago aggregates Booking/Expedia/Agoda/Hotels.com/Priceline rates via its public MCP (no API key). Trivago is geolocated server-side and returns EUR regardless of client hints, so the FX layer converts to the headline currency for apples-to-apples comparison.",
       "files": [
-        "internal/cli/dates.go",
-        "internal/cli/near.go",
-        "internal/cli/hotels_positional.go"
+        "internal/trivago/client.go",
+        "internal/trivago/merge.go",
+        "internal/trivago/fx.go",
+        "internal/trivago/client_test.go",
+        "internal/cli/hotel_helpers.go",
+        "internal/cli/hotels_positional.go",
+        "README.md",
+        "SKILL.md"
       ],
-      "validated_outcome": "cli-printing-press publish validate --dir <hotel-goat> --json reports 11/11 checks PASS, verify pass rate 100%."
-    },
-    {
-      "id": "hotel-goat-dates-zero-price-sort",
-      "summary": "Fix dates.go SliceStable comparator to enforce strict weak ordering by routing zero-priced hotels to the end explicitly.",
-      "reason": "The original `pi < pj && pi > 0` comparator returns false for both less(i,j) and less(j,i) when pi > 0 and pj == 0, violating strict weak ordering. sort.SliceStable in that state may land a zero-priced hotel at index 0, mis-identifying it as 'cheapest'. New comparator: zero-priced rows go to the tail; otherwise standard ascending by price.",
-      "files": ["internal/cli/dates.go"],
-      "validated_outcome": "Greptile P1 finding on dates.go:120 resolved.",
-      "upstream_issue": "https://github.com/mvanhorn/printing-press-library/pull/849#discussion"
-    },
-    {
-      "id": "hotel-goat-brand-inference-deterministic",
-      "summary": "Make inferBrand deterministic by flattening sub-brand candidates and sorting by descending length before matching.",
-      "reason": "Go map iteration is randomized, so iterating brandPrefixes directly could return different sub-brands for the same hotel name across runs ('JW Marriott' could match 'JW Marriott' or just 'Marriott'). Longest-prefix-wins is both deterministic AND semantically correct — the more specific sub-brand should beat the parent chain.",
-      "files": ["internal/parser/google_hotels.go"],
-      "validated_outcome": "Greptile P2 finding on google_hotels.go:537 resolved."
-    },
-    {
-      "id": "hotel-goat-near-remove-dead-dryrun",
-      "summary": "Remove unreachable dry-run blocks in near.go that were stranded after the earlier dryRunOK-first reorder.",
-      "reason": "The dryRunOK short-circuit at the top of RunE made two inner dry-run blocks (lines 92-95 around geocoding, and lines 116-125 around the URL-emit envelope) unreachable. Removed both so the only live dry-run path is the early return.",
-      "files": ["internal/cli/near.go"],
-      "validated_outcome": "Greptile P2 finding on near.go:125 resolved."
-    },
-    {
-      "id": "hotel-goat-price-snapshots-timestamp-format",
-      "summary": "Format the `since` bound passed to ListPriceSnapshots as 'YYYY-MM-DD HH:MM:SS' to match what SQLite's CURRENT_TIMESTAMP writes.",
-      "reason": "Snapshot rows are written with `snapshotted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP`, which produces 'YYYY-MM-DD HH:MM:SS' (space separator). The previous query bound `since` via time.RFC3339 ('YYYY-MM-DDTHH:MM:SSZ' with a 'T'), so the lexicographic `snapshotted_at >= ?` comparison silently excluded every row from the boundary day — 'T' sorts after every literal space-prefixed value. Aligning both sides on the SQLite text format fixes the recent-price-drift query.",
-      "files": ["internal/store/hotel_goat_migrations.go"],
-      "validated_outcome": "Greptile finding on hotel_goat_migrations.go ListPriceSnapshots resolved. go test ./internal/store/ passes."
-    },
-    {
-      "id": "hotel-goat-priceblock-bounds-check",
-      "summary": "Bounds-check priceBlock[1] and priceBlock[2] before indexing in tryParseHotel.",
-      "reason": "The file's contract is 'every index access is bounds-checked' but `priceBlock[1]` and `priceBlock[2]` were accessed unconditionally. Google's price block has varied shape — sometimes a single nested array, sometimes empty when no OTA returned a price. Without the len() guard the parser would panic on a short-shape response.",
-      "files": ["internal/parser/google_hotels.go"],
-      "validated_outcome": "Greptile finding on google_hotels.go priceBlock indexing resolved. go test ./internal/parser/ passes."
-    },
-    {
-      "id": "hotel-goat-snapshot-batch-log-and-continue",
-      "summary": "recordSnapshotsForResults now continues past row-level write failures instead of returning on the first one.",
-      "reason": "The function's docstring promises 'errors don't fail the user-facing command — we log to stderr and continue', but the loop body `return`-ed on first error, silently abandoning every subsequent hotel's price-snapshot row for that batch. Switched to log-once + count-then-summarize so the drift-history store doesn't go quietly incomplete.",
-      "files": ["internal/cli/hotel_helpers.go"],
-      "validated_outcome": "Greptile finding on hotel_helpers.go:recordSnapshotsForResults resolved."
+      "validated_outcome": "Live dogfood against Carmel-by-the-Sea 2026-08-15/17 returned 20 Google + 19 Trivago-only + 6 cross-source merges with Frankfurter-converted USD prices; go test ./internal/trivago passes; govulncheck clean; publish validate 11/11 PASS."
     }
   ]
 }

--- a/library/travel/hotel-goat/.printing-press-pii-polish.json
+++ b/library/travel/hotel-goat/.printing-press-pii-polish.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-05-26T19:39:08.26992Z",
+  "timestamp": "2026-05-26T19:45:19.787779Z",
   "cli_dir": "\u003ccli-dir\u003e/hotel-goat",
   "findings": null,
   "findings_count_before": 0

--- a/library/travel/hotel-goat/.printing-press-pii-polish.json
+++ b/library/travel/hotel-goat/.printing-press-pii-polish.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-05-26T19:19:23.360151Z",
+  "timestamp": "2026-05-26T19:31:02.224922Z",
   "cli_dir": "\u003ccli-dir\u003e/hotel-goat",
   "findings": null,
   "findings_count_before": 0

--- a/library/travel/hotel-goat/.printing-press-pii-polish.json
+++ b/library/travel/hotel-goat/.printing-press-pii-polish.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-05-26T19:31:02.224922Z",
+  "timestamp": "2026-05-26T19:39:08.26992Z",
   "cli_dir": "\u003ccli-dir\u003e/hotel-goat",
   "findings": null,
   "findings_count_before": 0

--- a/library/travel/hotel-goat/.printing-press-pii-polish.json
+++ b/library/travel/hotel-goat/.printing-press-pii-polish.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-05-25T16:03:57.605668Z",
+  "timestamp": "2026-05-26T19:19:23.360151Z",
   "cli_dir": "\u003ccli-dir\u003e/hotel-goat",
   "findings": null,
   "findings_count_before": 0

--- a/library/travel/hotel-goat/.printing-press-tools-polish.json
+++ b/library/travel/hotel-goat/.printing-press-tools-polish.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": "2026-05-25T15:51:25.16852Z",
+  "timestamp": "2026-05-26T19:15:58.784229Z",
   "cli_dir": "\u003ccli-dir\u003e/hotel-goat",
   "findings": null,
   "scorecard_before": {
     "mcp_description_quality": 10,
-    "captured": "2026-05-25T15:47:34.570817Z"
+    "captured": "2026-05-26T19:07:56.596354Z"
   }
 }

--- a/library/travel/hotel-goat/README.md
+++ b/library/travel/hotel-goat/README.md
@@ -8,7 +8,11 @@ hotel-goat fans out across two cash-price sources by default:
 
 Pick a single source with `--source google` or `--source trivago`; the default is `--source both`. When both sources see the same property (matched on lat/lng + name overlap), the OTA prices are merged into one `prices[]` array. Trivago-only properties are appended as standalone rows so the agent gets a wider candidate set.
 
-When Trivago's currency differs from Google's (Trivago is geolocated server-side, so it often returns EUR), the source label is tagged `trivago/<OTA> [EUR]` and the headline `price_per_night` is only overridden when currencies match — so an agent never silently compares 802 EUR against 160 USD as if they were the same scale.
+Trivago is geolocated server-side and returns EUR regardless of client hints. When the headline currency differs (typically Google's USD vs Trivago's EUR), each Trivago price is converted via the Frankfurter ECB FX endpoint (free, no key, 24h on-disk cache) so the agent compares apples-to-apples. The source label records what happened:
+
+- **`trivago/<OTA> [EUR 802 -> USD]`** — FX conversion succeeded. The numeric `price` and headline `price_per_night` are the converted (USD) values; the native EUR amount is preserved in the label so the agent can see both.
+- **`trivago/<OTA> [EUR]`** — FX lookup failed (offline, Frankfurter outage). The numeric `price` is the native EUR value; the headline `price_per_night` is NOT overridden, so cross-source comparisons remain meaningful.
+- **`trivago/<OTA>`** (no bracket suffix) — currencies already matched, no conversion needed.
 
 v1 ships:
 - `hotels <location> <ci> <co>` — multi-source search with rich filters (brand, hotel-class, max-price, min-rating, amenities, currency)

--- a/library/travel/hotel-goat/README.md
+++ b/library/travel/hotel-goat/README.md
@@ -1,9 +1,17 @@
-# Google Hotels CLI
+# Hotel Goat — multi-source cash hotel CLI
 
-**Free Google Hotels CLI — per-hotel data with deep booking links, agent-native JSON, and local SQLite wishlist. No API key needed.**
+**Free hotel CLI — cash prices from Google Hotels + Trivago, deep booking links, agent-native JSON, and local SQLite wishlist. No API key needed.**
 
-hotel-goat scrapes Google Hotels' server-rendered data (the same data the Google Hotels web UI shows) without an API key. v1 ships:
-- `hotels <location> <ci> <co>` — search with rich filters (brand, hotel-class, max-price, min-rating, amenities, currency)
+hotel-goat fans out across two cash-price sources by default:
+- **Google Hotels** — scraped from the server-rendered page (same data the web UI shows)
+- **Trivago** — called via Trivago's public MCP server (`https://mcp.trivago.com/mcp`), which exposes OTA-aggregated rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.
+
+Pick a single source with `--source google` or `--source trivago`; the default is `--source both`. When both sources see the same property (matched on lat/lng + name overlap), the OTA prices are merged into one `prices[]` array. Trivago-only properties are appended as standalone rows so the agent gets a wider candidate set.
+
+When Trivago's currency differs from Google's (Trivago is geolocated server-side, so it often returns EUR), the source label is tagged `trivago/<OTA> [EUR]` and the headline `price_per_night` is only overridden when currencies match — so an agent never silently compares 802 EUR against 160 USD as if they were the same scale.
+
+v1 ships:
+- `hotels <location> <ci> <co>` — multi-source search with rich filters (brand, hotel-class, max-price, min-rating, amenities, currency)
 - `dates <location> --from --to --nights N` — sweep a date window for the cheapest pair per stay
 - `near "<address>" --radius Nmi` — geo-radius search around any address (auto-geocoded via OpenStreetMap)
 - `hotel show <token>` / `hotel reviews <token>` — single-property detail + review breakdown

--- a/library/travel/hotel-goat/SKILL.md
+++ b/library/travel/hotel-goat/SKILL.md
@@ -41,7 +41,13 @@ hotel-goat fans out across **two cash-price sources** by default:
 - **Google Hotels** — scraped from the server-rendered page
 - **Trivago** — called via the public Trivago MCP server (no key); aggregates OTA rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.
 
-Control which sources run with `--source google|trivago|both` on the `hotels` command. Default is `both`. Matched hotels (lat/lng within 250m and name token-overlap ≥ 0.5) get a unified `prices[]` array with one entry per source; Trivago-only properties are appended as standalone rows with `property_token` prefixed `trivago:`. When Trivago returns a different currency than Google (it geolocates server-side, often EUR), the source label is tagged `trivago/<OTA> [EUR]` so the agent never silently cross-compares.
+Control which sources run with `--source google|trivago|both` on the `hotels` command. Default is `both`. Matched hotels (lat/lng within 250m and name token-overlap ≥ 0.5, with both sides carrying ≥2 informative tokens after stopword stripping) get a unified `prices[]` array with one entry per source; Trivago-only properties are appended as standalone rows with `property_token` prefixed `trivago:`.
+
+Trivago is geolocated server-side and returns EUR regardless of client hints. When the headline currency differs from Trivago's, each Trivago price is converted via the Frankfurter ECB FX endpoint (free, no key, 24h cache) so cross-source comparisons are apples-to-apples. Source label semantics:
+
+- `trivago/<OTA> [EUR 802 -> USD]` — FX conversion ran. The numeric `price` field is in the target currency; the original EUR amount is in the label.
+- `trivago/<OTA> [EUR]` — FX lookup failed. The numeric `price` is native EUR and the headline `price_per_night` is NOT overridden.
+- `trivago/<OTA>` (no suffix) — currencies already matched.
 
 v1 ships:
 - `hotels <loc> <ci> <co>` — multi-source search with brand / hotel-class / price / rating / amenity / `--source` filters

--- a/library/travel/hotel-goat/SKILL.md
+++ b/library/travel/hotel-goat/SKILL.md
@@ -37,8 +37,14 @@ go install github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/
 
 If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
-hotel-goat scrapes Google Hotels' server-rendered data without an API key. v1 ships:
-- `hotels <loc> <ci> <co>` — search with brand / hotel-class / price / rating / amenity filters
+hotel-goat fans out across **two cash-price sources** by default:
+- **Google Hotels** — scraped from the server-rendered page
+- **Trivago** — called via the public Trivago MCP server (no key); aggregates OTA rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.
+
+Control which sources run with `--source google|trivago|both` on the `hotels` command. Default is `both`. Matched hotels (lat/lng within 250m and name token-overlap ≥ 0.5) get a unified `prices[]` array with one entry per source; Trivago-only properties are appended as standalone rows with `property_token` prefixed `trivago:`. When Trivago returns a different currency than Google (it geolocates server-side, often EUR), the source label is tagged `trivago/<OTA> [EUR]` so the agent never silently cross-compares.
+
+v1 ships:
+- `hotels <loc> <ci> <co>` — multi-source search with brand / hotel-class / price / rating / amenity / `--source` filters
 - `dates <loc> --from --to --nights N` — sweep a date window for the cheapest pair per stay
 - `near "<address>" --radius Nmi` — geo-radius around any address (auto-geocoded via OSM Nominatim)
 - `hotel show/reviews <token>` — single-property detail + reviews

--- a/library/travel/hotel-goat/dogfood-results.json
+++ b/library/travel/hotel-goat/dogfood-results.json
@@ -85,13 +85,13 @@
     ]
   },
   "source_client_check": {
-    "checked": 2
+    "checked": 5
   },
   "print_json_filtered_check": {
     "checked": 21
   },
   "test_presence": {
-    "checked": 1
+    "checked": 2
   },
   "naming_check": {
     "checked": 21

--- a/library/travel/hotel-goat/internal/cli/hotel_helpers.go
+++ b/library/travel/hotel-goat/internal/cli/hotel_helpers.go
@@ -13,9 +13,11 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/parser"
 	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/store"
+	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/trivago"
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -49,6 +51,12 @@ type hotelSearchOpts struct {
 	Limit            int
 	Page             int
 	Locale           string
+	// Source selects which cash-price backends to consult. Empty or
+	// "google" preserves the pre-multi-source behavior. "trivago" calls
+	// only the Trivago MCP. "both" fans out and merges (matched hotels
+	// get a `prices` entry per source; Trivago-only properties are
+	// appended as standalone records).
+	Source string
 }
 
 // buildHotelsURLParams converts the typed opts to the query-string
@@ -233,16 +241,63 @@ func fetchAndParseHotels(ctx context.Context, location, checkin, checkout string
 	if cliutil.IsDogfoodEnv() && (opts.Limit == 0 || opts.Limit > 5) {
 		opts.Limit = 5
 	}
-	client := &http.Client{Timeout: 45 * time.Second}
-	html, err := parser.FetchHotelsHTML(ctx, client, location, checkin, checkout, extras)
-	if err != nil {
-		return nil, wouldURL, err
+	source := strings.ToLower(strings.TrimSpace(opts.Source))
+	var hotels []parser.Hotel
+	if source != "trivago" {
+		client := &http.Client{Timeout: 45 * time.Second}
+		html, err := parser.FetchHotelsHTML(ctx, client, location, checkin, checkout, extras)
+		if err != nil {
+			return nil, wouldURL, err
+		}
+		hotels, err = parser.ParseSearchPage(html)
+		if err != nil {
+			return nil, wouldURL, fmt.Errorf("parse: %w", err)
+		}
 	}
-	hotels, err := parser.ParseSearchPage(html)
-	if err != nil {
-		return nil, wouldURL, fmt.Errorf("parse: %w", err)
+	if source == "trivago" || source == "both" {
+		triv, err := fetchTrivagoFor(ctx, location, checkin, checkout, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: trivago lookup failed: %v\n", err)
+		} else {
+			target := strings.ToUpper(strings.TrimSpace(opts.Currency))
+			if target == "" {
+				for _, h := range hotels {
+					if h.Currency != "" {
+						target = h.Currency
+						break
+					}
+				}
+			}
+			if target == "" {
+				target = "USD"
+			}
+			hotels = trivago.Merge(ctx, hotels, triv, target)
+		}
 	}
 	return filterHotels(hotels, opts), wouldURL, nil
+}
+
+// fetchTrivagoFor resolves `location` to a Trivago area id/ns via the
+// suggestions tool and runs an area search. Two-call cost amortizes
+// because Trivago returns up to ~50 results per area, which is plenty
+// for the merge to find Google overlaps.
+func fetchTrivagoFor(ctx context.Context, location, checkin, checkout string, opts hotelSearchOpts) ([]trivago.Accommodation, error) {
+	c := trivago.NewClient()
+	sug, err := c.Suggestions(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range sug {
+		if s.ID == 0 || s.NS == 0 {
+			continue
+		}
+		return c.AreaSearch(ctx, trivago.AreaOpts{
+			ID: s.ID, NS: s.NS,
+			Arrival: checkin, Departure: checkout,
+			Adults: opts.Adults, Rooms: opts.Rooms,
+		})
+	}
+	return nil, nil
 }
 
 func buildHotelsRequestURL(location, checkin, checkout string, extras map[string]string) string {

--- a/library/travel/hotel-goat/internal/cli/hotels_positional.go
+++ b/library/travel/hotel-goat/internal/cli/hotels_positional.go
@@ -93,6 +93,7 @@ URL surface doesn't accept them.`,
 	cmd.Flags().IntVar(&opts.Page, "page", 1, "Page number for pagination")
 	cmd.Flags().StringVar(&opts.Locale, "locale", "en", "Locale (en, de, fr, ...)")
 	cmd.Flags().BoolVar(&noSnapshots, "no-snapshots", false, "Don't append to local price_snapshots history")
+	cmd.Flags().StringVar(&opts.Source, "source", "both", "Cash-price source: google, trivago, or both (default: both)")
 	return cmd
 }
 

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -197,7 +197,9 @@ func (c *Client) callTool(ctx context.Context, name string, args any) (json.RawM
 			return nil, err
 		}
 		if resp.StatusCode == 429 && attempt == 0 {
-			c.Limiter.OnRateLimit()
+			if c.Limiter != nil {
+				c.Limiter.OnRateLimit()
+			}
 			wait := cliutil.RetryAfter(resp)
 			resp.Body.Close()
 			select {
@@ -226,8 +228,12 @@ func (c *Client) callTool(ctx context.Context, name string, args any) (json.RawM
 	}
 	// Signal success only after the response is structurally valid; a 2xx
 	// with malformed JSON shouldn't ramp the limiter as if the call
-	// produced usable data.
-	c.Limiter.OnSuccess()
+	// produced usable data. Nil-guarded to match waitForSlot, since the
+	// Limiter field is documented as nil-safe and TestWaitForSlot_DisabledWhenNil
+	// exercises that path.
+	if c.Limiter != nil {
+		c.Limiter.OnSuccess()
+	}
 	return rr.Result, nil
 }
 

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -57,14 +57,20 @@ func NewClient() *Client {
 
 // waitForSlot blocks until the AdaptiveLimiter releases the next slot,
 // honoring ctx cancellation. No-op when Limiter is nil.
+//
+// The channel is buffered so the limiter goroutine never blocks on send
+// after the caller has already returned on ctx.Done(); the goroutine
+// finishes its Limiter.Wait() and exits without leaking under repeated
+// cancellation (AdaptiveLimiter backoff after 429 can otherwise outlive
+// the request).
 func (c *Client) waitForSlot(ctx context.Context) error {
 	if c.Limiter == nil {
 		return nil
 	}
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		c.Limiter.Wait()
-		close(done)
+		done <- struct{}{}
 	}()
 	select {
 	case <-done:
@@ -210,7 +216,6 @@ func (c *Client) callTool(ctx context.Context, name string, args any) (json.RawM
 	if statusCode >= 400 {
 		return nil, fmt.Errorf("trivago: HTTP %d: %s", statusCode, truncate(raw))
 	}
-	c.Limiter.OnSuccess()
 	payload := parseMaybeSSE(raw)
 	var rr rpcResponse
 	if err := json.Unmarshal(payload, &rr); err != nil {
@@ -219,6 +224,10 @@ func (c *Client) callTool(ctx context.Context, name string, args any) (json.RawM
 	if rr.Error != nil {
 		return nil, fmt.Errorf("trivago %s: %s", name, rr.Error.Message)
 	}
+	// Signal success only after the response is structurally valid; a 2xx
+	// with malformed JSON shouldn't ramp the limiter as if the call
+	// produced usable data.
+	c.Limiter.OnSuccess()
 	return rr.Result, nil
 }
 

--- a/library/travel/hotel-goat/internal/trivago/client.go
+++ b/library/travel/hotel-goat/internal/trivago/client.go
@@ -1,0 +1,419 @@
+// Copyright 2026 kothari-nikunj. Licensed under Apache-2.0. See LICENSE.
+
+// Package trivago is a thin client for Trivago's public MCP server
+// (https://mcp.trivago.com/mcp). Used as a second cash-price source
+// alongside Google Hotels. No API key required.
+//
+// Transport: JSON-RPC over MCP Streamable-HTTP. Each session does
+// initialize -> notifications/initialized -> tools/call. The session ID
+// returned in the initialize response header must be echoed on every
+// subsequent call as Mcp-Session-Id. Tool-call responses come back as
+// text/event-stream; parseMaybeSSE strips the SSE framing.
+package trivago
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/cliutil"
+)
+
+const DefaultEndpoint = "https://mcp.trivago.com/mcp"
+
+// DefaultRatePerSec paces outbound calls to the Trivago MCP server.
+// 2 rps is conservative for a free public endpoint and matches the CLI's
+// global --rate-limit default. The AdaptiveLimiter ramps up after
+// sustained success and halves on 429.
+const DefaultRatePerSec = 2.0
+
+type Client struct {
+	HTTPClient *http.Client
+	Endpoint   string
+
+	// Limiter paces outbound HTTP calls. Nil disables rate limiting;
+	// NewClient seeds a DefaultRatePerSec AdaptiveLimiter.
+	Limiter *cliutil.AdaptiveLimiter
+
+	initOnce  sync.Once
+	initErr   error
+	sessionID string
+	reqID     int64
+	reqIDMu   sync.Mutex
+}
+
+func NewClient() *Client {
+	return &Client{
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Endpoint:   DefaultEndpoint,
+		Limiter:    cliutil.NewAdaptiveLimiter(DefaultRatePerSec),
+	}
+}
+
+// waitForSlot blocks until the AdaptiveLimiter releases the next slot,
+// honoring ctx cancellation. No-op when Limiter is nil.
+func (c *Client) waitForSlot(ctx context.Context) error {
+	if c.Limiter == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		c.Limiter.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (c *Client) nextID() int64 {
+	c.reqIDMu.Lock()
+	defer c.reqIDMu.Unlock()
+	c.reqID++
+	return c.reqID
+}
+
+func (c *Client) ensureInit(ctx context.Context) error {
+	c.initOnce.Do(func() {
+		body, _ := json.Marshal(rpcRequest{
+			JSONRPC: "2.0", ID: c.nextID(), Method: "initialize",
+			Params: map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{},
+				"clientInfo":      map[string]any{"name": "hotel-goat-pp-cli", "version": "1"},
+			},
+		})
+		req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint, bytes.NewReader(body))
+		if err != nil {
+			c.initErr = err
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		if err := c.waitForSlot(ctx); err != nil {
+			c.initErr = err
+			return
+		}
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			c.initErr = err
+			return
+		}
+		defer resp.Body.Close()
+		c.sessionID = resp.Header.Get("Mcp-Session-Id")
+		if c.sessionID == "" {
+			c.initErr = fmt.Errorf("trivago: no mcp-session-id in initialize response")
+			return
+		}
+		io.Copy(io.Discard, resp.Body)
+
+		// Per spec, send the initialized notification before any tools/call.
+		nb, _ := json.Marshal(rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+		nReq, _ := http.NewRequestWithContext(ctx, "POST", c.Endpoint, bytes.NewReader(nb))
+		nReq.Header.Set("Content-Type", "application/json")
+		nReq.Header.Set("Accept", "application/json, text/event-stream")
+		nReq.Header.Set("Mcp-Session-Id", c.sessionID)
+		if err := c.waitForSlot(ctx); err != nil {
+			c.initErr = err
+			return
+		}
+		nResp, err := c.HTTPClient.Do(nReq)
+		if err != nil {
+			c.initErr = err
+			return
+		}
+		io.Copy(io.Discard, nResp.Body)
+		nResp.Body.Close()
+	})
+	return c.initErr
+}
+
+func (c *Client) callTool(ctx context.Context, name string, args any) (json.RawMessage, error) {
+	if err := c.ensureInit(ctx); err != nil {
+		return nil, err
+	}
+	body, _ := json.Marshal(rpcRequest{
+		JSONRPC: "2.0", ID: c.nextID(), Method: "tools/call",
+		Params: map[string]any{"name": name, "arguments": args},
+	})
+
+	// Single 429 retry honoring Retry-After. Trivago's MCP server is a
+	// shared public endpoint; rate spikes are possible. We retry once
+	// then surface the failure to the caller.
+	var raw []byte
+	var statusCode int
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Mcp-Session-Id", c.sessionID)
+		if err := c.waitForSlot(ctx); err != nil {
+			return nil, err
+		}
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		raw, err = io.ReadAll(resp.Body)
+		statusCode = resp.StatusCode
+		if err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		if resp.StatusCode == 429 && attempt == 0 {
+			c.Limiter.OnRateLimit()
+			wait := cliutil.RetryAfter(resp)
+			resp.Body.Close()
+			select {
+			case <-time.After(wait):
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		resp.Body.Close()
+		break
+	}
+	if statusCode == 429 {
+		return nil, &cliutil.RateLimitError{URL: c.Endpoint, Body: truncate(raw)}
+	}
+	if statusCode >= 400 {
+		return nil, fmt.Errorf("trivago: HTTP %d: %s", statusCode, truncate(raw))
+	}
+	c.Limiter.OnSuccess()
+	payload := parseMaybeSSE(raw)
+	var rr rpcResponse
+	if err := json.Unmarshal(payload, &rr); err != nil {
+		return nil, fmt.Errorf("trivago: decode %s: %w (body=%s)", name, err, truncate(raw))
+	}
+	if rr.Error != nil {
+		return nil, fmt.Errorf("trivago %s: %s", name, rr.Error.Message)
+	}
+	return rr.Result, nil
+}
+
+// parseMaybeSSE returns the JSON-RPC payload from either a plain
+// application/json body or a text/event-stream body. Trivago returns SSE
+// for tools/call. We concatenate consecutive "data:" lines (per SSE rules
+// they belong to the same event) and use the last event's payload, which
+// is the terminal "message" event carrying the JSON-RPC response.
+func parseMaybeSSE(b []byte) []byte {
+	if !bytes.Contains(b, []byte("\ndata:")) && !bytes.HasPrefix(b, []byte("data:")) {
+		return b
+	}
+	var current, last []byte
+	for _, line := range bytes.Split(b, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		if len(line) == 0 {
+			if len(current) > 0 {
+				last = append(last[:0], current...)
+				current = current[:0]
+			}
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			chunk := bytes.TrimSpace(line[5:])
+			current = append(current, chunk...)
+		}
+	}
+	if len(current) > 0 {
+		last = current
+	}
+	if last == nil {
+		return b
+	}
+	return last
+}
+
+func truncate(b []byte) string {
+	const max = 512
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "..."
+}
+
+// Accommodation mirrors the schema declared by Trivago's
+// trivago-accommodation-search and -radius-search output. Prices are
+// returned as preformatted strings (e.g. "$199") because Trivago localizes
+// the currency symbol; callers parse the numeric value with ParsePrice.
+type Accommodation struct {
+	ID            string  `json:"accommodation_id"`
+	Name          string  `json:"accommodation_name"`
+	URL           string  `json:"accommodation_url"`
+	Address       string  `json:"address"`
+	PostalCode    string  `json:"postal_code"`
+	CountryCity   string  `json:"country_city"`
+	Currency      string  `json:"currency"`
+	PricePerNight string  `json:"price_per_night"`
+	PricePerStay  string  `json:"price_per_stay"`
+	Advertiser    string  `json:"advertisers"`
+	BookingURL    string  `json:"booking_url"`
+	HotelRating   int     `json:"hotel_rating"`
+	ReviewRating  string  `json:"review_rating"`
+	ReviewCount   int     `json:"review_count"`
+	Latitude      float64 `json:"latitude"`
+	Longitude     float64 `json:"longitude"`
+	Distance      string  `json:"distance"`
+	Image         string  `json:"main_image"`
+	Amenities     string  `json:"top_amenities"`
+	Description   string  `json:"description"`
+}
+
+type Suggestion struct {
+	ID             int    `json:"id"`
+	NS             int    `json:"ns"`
+	PlaceID        string `json:"place_id"`
+	Location       string `json:"location"`
+	LocationLabel  string `json:"location_label"`
+	LocationType   string `json:"location_type"`
+	SuggestionType string `json:"suggestion_type"`
+}
+
+type RadiusOpts struct {
+	Lat, Lng           float64
+	RadiusMeters       int
+	Arrival, Departure string
+	Adults, Rooms      int
+}
+
+func (c *Client) RadiusSearch(ctx context.Context, o RadiusOpts) ([]Accommodation, error) {
+	args := map[string]any{
+		"latitude":  o.Lat,
+		"longitude": o.Lng,
+		"radius":    o.RadiusMeters,
+		"arrival":   o.Arrival,
+		"departure": o.Departure,
+	}
+	if o.Adults > 0 {
+		args["adults"] = o.Adults
+	}
+	if o.Rooms > 0 {
+		args["rooms"] = o.Rooms
+	}
+	raw, err := c.callTool(ctx, "trivago-accommodation-radius-search", args)
+	if err != nil {
+		return nil, err
+	}
+	return decodeAccommodations(raw)
+}
+
+type AreaOpts struct {
+	ID, NS             int
+	Arrival, Departure string
+	Adults, Rooms      int
+}
+
+func (c *Client) AreaSearch(ctx context.Context, o AreaOpts) ([]Accommodation, error) {
+	args := map[string]any{
+		"id":        o.ID,
+		"ns":        o.NS,
+		"arrival":   o.Arrival,
+		"departure": o.Departure,
+	}
+	if o.Adults > 0 {
+		args["adults"] = o.Adults
+	}
+	if o.Rooms > 0 {
+		args["rooms"] = o.Rooms
+	}
+	raw, err := c.callTool(ctx, "trivago-accommodation-search", args)
+	if err != nil {
+		return nil, err
+	}
+	return decodeAccommodations(raw)
+}
+
+func (c *Client) Suggestions(ctx context.Context, query string) ([]Suggestion, error) {
+	raw, err := c.callTool(ctx, "trivago-search-suggestions", map[string]any{"query": query})
+	if err != nil {
+		return nil, err
+	}
+	var wrapper struct {
+		StructuredContent struct {
+			Suggestions []Suggestion `json:"suggestions"`
+		} `json:"structuredContent"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, err
+	}
+	if len(wrapper.StructuredContent.Suggestions) > 0 {
+		return wrapper.StructuredContent.Suggestions, nil
+	}
+	for _, c := range wrapper.Content {
+		if c.Type != "text" {
+			continue
+		}
+		var s struct {
+			Suggestions []Suggestion `json:"suggestions"`
+		}
+		if json.Unmarshal([]byte(c.Text), &s) == nil && len(s.Suggestions) > 0 {
+			return s.Suggestions, nil
+		}
+	}
+	return nil, nil
+}
+
+func decodeAccommodations(raw json.RawMessage) ([]Accommodation, error) {
+	var wrapper struct {
+		StructuredContent struct {
+			Accommodations []Accommodation `json:"accommodations"`
+		} `json:"structuredContent"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, err
+	}
+	if len(wrapper.StructuredContent.Accommodations) > 0 {
+		return wrapper.StructuredContent.Accommodations, nil
+	}
+	for _, c := range wrapper.Content {
+		if c.Type != "text" {
+			continue
+		}
+		var s struct {
+			Accommodations []Accommodation `json:"accommodations"`
+		}
+		if json.Unmarshal([]byte(c.Text), &s) == nil && len(s.Accommodations) > 0 {
+			return s.Accommodations, nil
+		}
+	}
+	return nil, nil
+}

--- a/library/travel/hotel-goat/internal/trivago/client_test.go
+++ b/library/travel/hotel-goat/internal/trivago/client_test.go
@@ -4,6 +4,9 @@ package trivago
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -107,5 +110,38 @@ func TestNewClient_Defaults(t *testing.T) {
 	}
 	if got := c.Limiter.Rate(); got != DefaultRatePerSec {
 		t.Errorf("Limiter rate = %v, want %v", got, DefaultRatePerSec)
+	}
+}
+
+// TestCallTool_NilLimiter_NoPanic locks in the contract that callTool's
+// limiter signalling paths (OnRateLimit on 429, OnSuccess on a clean
+// 2xx) are nil-safe. waitForSlot already exercises the nil path; this
+// covers the symmetric assumption for the other two limiter call sites
+// so a future refactor that drops a guard panics here, not in prod.
+func TestCallTool_NilLimiter_NoPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req["method"] {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", "test-session")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		case "tools/call":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"ok":true}}`))
+		default:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		HTTPClient: srv.Client(),
+		Endpoint:   srv.URL,
+		Limiter:    nil,
+	}
+	if _, err := c.callTool(context.Background(), "noop", map[string]any{}); err != nil {
+		t.Fatalf("callTool with nil Limiter returned error: %v", err)
 	}
 }

--- a/library/travel/hotel-goat/internal/trivago/client_test.go
+++ b/library/travel/hotel-goat/internal/trivago/client_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 kothari-nikunj. Licensed under Apache-2.0. See LICENSE.
+
+package trivago
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/cliutil"
+)
+
+func TestParseMaybeSSE_PlainJSON(t *testing.T) {
+	in := []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)
+	got := parseMaybeSSE(in)
+	if string(got) != string(in) {
+		t.Fatalf("plain JSON should pass through unchanged; got %q", got)
+	}
+}
+
+func TestParseMaybeSSE_SingleEvent(t *testing.T) {
+	in := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n")
+	got := parseMaybeSSE(in)
+	want := `{"jsonrpc":"2.0","id":1,"result":{}}`
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseMaybeSSE_LastEventWins(t *testing.T) {
+	// Multiple events; the terminal "message" event carries the payload.
+	in := []byte("event: ping\ndata: {}\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"k\":\"v\"}}\n\n")
+	got := parseMaybeSSE(in)
+	want := `{"jsonrpc":"2.0","id":2,"result":{"k":"v"}}`
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestWaitForSlot_EnforcesAdaptiveLimiter(t *testing.T) {
+	c := &Client{Limiter: cliutil.NewAdaptiveLimiter(20)} // 50ms spacing
+	ctx := context.Background()
+	if err := c.waitForSlot(ctx); err != nil {
+		t.Fatalf("first wait: %v", err)
+	}
+	start := time.Now()
+	if err := c.waitForSlot(ctx); err != nil {
+		t.Fatalf("second wait: %v", err)
+	}
+	elapsed := time.Since(start)
+	// Allow a bit of timer slack.
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("second wait should have blocked ~50ms; elapsed=%v", elapsed)
+	}
+}
+
+func TestWaitForSlot_DisabledWhenNil(t *testing.T) {
+	c := &Client{Limiter: nil}
+	ctx := context.Background()
+	start := time.Now()
+	_ = c.waitForSlot(ctx)
+	_ = c.waitForSlot(ctx)
+	if elapsed := time.Since(start); elapsed > 10*time.Millisecond {
+		t.Fatalf("nil Limiter should not block; elapsed=%v", elapsed)
+	}
+}
+
+func TestWaitForSlot_RespectsContext(t *testing.T) {
+	c := &Client{Limiter: cliutil.NewAdaptiveLimiter(2)} // 500ms spacing
+	bg := context.Background()
+	if err := c.waitForSlot(bg); err != nil {
+		t.Fatalf("first wait: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(bg, 10*time.Millisecond)
+	defer cancel()
+	err := c.waitForSlot(ctx)
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	short := []byte("hello")
+	if got := truncate(short); got != "hello" {
+		t.Errorf("short input should pass through; got %q", got)
+	}
+	big := make([]byte, 600)
+	for i := range big {
+		big[i] = 'a'
+	}
+	got := truncate(big)
+	if len(got) != 512+3 || got[512:] != "..." {
+		t.Errorf("big input should be truncated to 512 + '...'; len=%d tail=%q", len(got), got[max(0, len(got)-3):])
+	}
+}
+
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient()
+	if c.HTTPClient == nil {
+		t.Error("HTTPClient should be set")
+	}
+	if c.Endpoint != DefaultEndpoint {
+		t.Errorf("Endpoint = %q, want %q", c.Endpoint, DefaultEndpoint)
+	}
+	if c.Limiter == nil {
+		t.Error("Limiter should be initialized")
+	}
+	if got := c.Limiter.Rate(); got != DefaultRatePerSec {
+		t.Errorf("Limiter rate = %v, want %v", got, DefaultRatePerSec)
+	}
+}

--- a/library/travel/hotel-goat/internal/trivago/fx.go
+++ b/library/travel/hotel-goat/internal/trivago/fx.go
@@ -124,12 +124,22 @@ func (c *fxClient) fetch(ctx context.Context, from string) (frankfurterResponse,
 		return frankfurterResponse{}, err
 	}
 	req.Header.Set("Accept", "application/json")
-	// Throttle via AdaptiveLimiter. Network calls are rare in practice
-	// (24h disk + memory cache absorbs repeats) but a sudden burst (new
-	// locale + new currency per result) can still hit Frankfurter; this
-	// paces them. newFXClient() always sets a non-nil limiter, matching
-	// the OnRateLimit/OnSuccess call sites below.
-	c.limiter.Wait()
+	// Throttle via AdaptiveLimiter, but honor ctx cancellation. A
+	// Frankfurter 429 halves the rate on the process-wide singleton, so
+	// without this select a single backoff makes every subsequent
+	// Convert() call inside Merge() sleep up to ~2s ignoring the
+	// caller's cancellation. Matches client.waitForSlot. Buffered
+	// channel so the abandoned goroutine never blocks on send.
+	done := make(chan struct{}, 1)
+	go func() {
+		c.limiter.Wait()
+		done <- struct{}{}
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return frankfurterResponse{}, ctx.Err()
+	}
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return frankfurterResponse{}, err

--- a/library/travel/hotel-goat/internal/trivago/fx.go
+++ b/library/travel/hotel-goat/internal/trivago/fx.go
@@ -1,0 +1,189 @@
+// Copyright 2026 kothari-nikunj. Licensed under Apache-2.0. See LICENSE.
+
+package trivago
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/cliutil"
+)
+
+const (
+	frankfurterEndpoint = "https://api.frankfurter.app/latest"
+	fxCacheTTL          = 24 * time.Hour
+	// fxRatePerSec paces outbound Frankfurter calls. Network calls are
+	// rare (gated by the 24h cache) but we still apply the canonical
+	// AdaptiveLimiter so 429s back off instead of cascading.
+	fxRatePerSec = 1.0
+)
+
+// fxClient is a small in-process FX rate cache backed by Frankfurter
+// (ECB daily rates, free, no key). One rate map per base currency,
+// cached in memory for the process and on disk for 24h so repeated
+// hotel searches don't dial out per result.
+type fxClient struct {
+	http     *http.Client
+	cacheDir string
+	limiter  *cliutil.AdaptiveLimiter
+
+	mu    sync.Mutex
+	rates map[string]frankfurterResponse
+}
+
+var defaultFX = newFXClient()
+
+func newFXClient() *fxClient {
+	homeDir, _ := os.UserHomeDir()
+	return &fxClient{
+		http:     &http.Client{Timeout: 10 * time.Second},
+		cacheDir: filepath.Join(homeDir, ".cache", "hotel-goat-pp-cli", "fx"),
+		limiter:  cliutil.NewAdaptiveLimiter(fxRatePerSec),
+		rates:    map[string]frankfurterResponse{},
+	}
+}
+
+type frankfurterResponse struct {
+	Amount float64            `json:"amount"`
+	Base   string             `json:"base"`
+	Date   string             `json:"date"`
+	Rates  map[string]float64 `json:"rates"`
+
+	fetchedAt time.Time
+}
+
+// Convert returns amount converted from `from` to `to`, along with the
+// exchange rate applied. ok=false means the conversion couldn't be
+// resolved (network failure, unknown currency) — caller should fall
+// back to displaying the native amount.
+func Convert(ctx context.Context, amount float64, from, to string) (converted, rate float64, ok bool) {
+	from = strings.ToUpper(strings.TrimSpace(from))
+	to = strings.ToUpper(strings.TrimSpace(to))
+	if from == "" || to == "" || amount == 0 {
+		return 0, 0, false
+	}
+	if from == to {
+		return amount, 1.0, true
+	}
+	r, err := defaultFX.rate(ctx, from, to)
+	if err != nil || r == 0 {
+		return 0, 0, false
+	}
+	return amount * r, r, true
+}
+
+func (c *fxClient) rate(ctx context.Context, from, to string) (float64, error) {
+	c.mu.Lock()
+	cached, ok := c.rates[from]
+	c.mu.Unlock()
+	if ok && time.Since(cached.fetchedAt) < fxCacheTTL {
+		if r, found := cached.Rates[to]; found {
+			return r, nil
+		}
+	}
+	if disk, ok := c.readDisk(from); ok {
+		c.mu.Lock()
+		c.rates[from] = disk
+		c.mu.Unlock()
+		if r, found := disk.Rates[to]; found {
+			return r, nil
+		}
+	}
+	fresh, err := c.fetch(ctx, from)
+	if err != nil {
+		return 0, err
+	}
+	fresh.fetchedAt = time.Now()
+	c.mu.Lock()
+	c.rates[from] = fresh
+	c.mu.Unlock()
+	c.writeDisk(from, fresh)
+	r, found := fresh.Rates[to]
+	if !found {
+		return 0, fmt.Errorf("fx: no rate for %s in %s base", to, from)
+	}
+	return r, nil
+}
+
+// fetch hits Frankfurter for the latest rate map keyed on `from`.
+// Calls are naturally throttled by the 24h disk + in-memory cache
+// (each base currency is fetched at most once per day per process);
+// we still treat 429 as a typed retryable error so callers can
+// fall back to the cached/native amount instead of erroring out.
+func (c *fxClient) fetch(ctx context.Context, from string) (frankfurterResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", frankfurterEndpoint+"?from="+from, nil)
+	if err != nil {
+		return frankfurterResponse{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	// Throttle via AdaptiveLimiter (no-op when nil). Network calls are
+	// rare in practice — the 24h disk + memory cache typically absorbs
+	// repeated lookups — but a sudden burst (new locale + new currency
+	// per result) can still hit Frankfurter; this paces them.
+	if c.limiter != nil {
+		c.limiter.Wait()
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return frankfurterResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 429 {
+		c.limiter.OnRateLimit()
+		return frankfurterResponse{}, &cliutil.RateLimitError{URL: req.URL.String(), RetryAfter: cliutil.RetryAfter(resp)}
+	}
+	if resp.StatusCode != 200 {
+		return frankfurterResponse{}, fmt.Errorf("fx: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return frankfurterResponse{}, err
+	}
+	var out frankfurterResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return frankfurterResponse{}, err
+	}
+	c.limiter.OnSuccess()
+	return out, nil
+}
+
+func (c *fxClient) cachePath(from string) string {
+	return filepath.Join(c.cacheDir, strings.ToUpper(from)+".json")
+}
+
+func (c *fxClient) readDisk(from string) (frankfurterResponse, bool) {
+	path := c.cachePath(from)
+	info, err := os.Stat(path)
+	if err != nil || time.Since(info.ModTime()) > fxCacheTTL {
+		return frankfurterResponse{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return frankfurterResponse{}, false
+	}
+	var out frankfurterResponse
+	if err := json.Unmarshal(data, &out); err != nil {
+		return frankfurterResponse{}, false
+	}
+	out.fetchedAt = info.ModTime()
+	return out, true
+}
+
+func (c *fxClient) writeDisk(from string, r frankfurterResponse) {
+	if err := os.MkdirAll(c.cacheDir, 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(c.cachePath(from), data, 0o644)
+}

--- a/library/travel/hotel-goat/internal/trivago/fx.go
+++ b/library/travel/hotel-goat/internal/trivago/fx.go
@@ -124,13 +124,12 @@ func (c *fxClient) fetch(ctx context.Context, from string) (frankfurterResponse,
 		return frankfurterResponse{}, err
 	}
 	req.Header.Set("Accept", "application/json")
-	// Throttle via AdaptiveLimiter (no-op when nil). Network calls are
-	// rare in practice — the 24h disk + memory cache typically absorbs
-	// repeated lookups — but a sudden burst (new locale + new currency
-	// per result) can still hit Frankfurter; this paces them.
-	if c.limiter != nil {
-		c.limiter.Wait()
-	}
+	// Throttle via AdaptiveLimiter. Network calls are rare in practice
+	// (24h disk + memory cache absorbs repeats) but a sudden burst (new
+	// locale + new currency per result) can still hit Frankfurter; this
+	// paces them. newFXClient() always sets a non-nil limiter, matching
+	// the OnRateLimit/OnSuccess call sites below.
+	c.limiter.Wait()
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return frankfurterResponse{}, err

--- a/library/travel/hotel-goat/internal/trivago/merge.go
+++ b/library/travel/hotel-goat/internal/trivago/merge.go
@@ -226,15 +226,29 @@ var (
 	tokenSplit = regexp.MustCompile(`[^a-z0-9]+`)
 )
 
-// nameOverlap returns the token-set Jaccard ratio (over the smaller set,
-// so a short canonical name like "Park Hyatt Paris" still matches the
-// fuller "Park Hyatt Paris Vendôme" at 1.0 rather than 0.6). Stopwords
-// like "hotel" and "the" are stripped so they don't inflate matches
-// between unrelated properties.
+// nameOverlap returns the token-set overlap ratio using the LARGER set as
+// the denominator (standard Jaccard-ish, not min-denominator). Min would
+// score a single-token chain name like "Marriott" against any longer
+// "Marriott …" property as 1.0, then the 250m radius gate would silently
+// merge two distinct properties in dense city blocks. Max denominator
+// keeps legitimate matches strong ("Park Hyatt Paris" vs "Park Hyatt
+// Paris Vendôme" = 3/4 = 0.75) while killing the single-token false
+// positive ("Marriott" vs "JW Marriott Bonvoy" = 1/3 = 0.33).
+//
+// We also require >=2 informative tokens on the shorter side: a Google
+// row reduced to a single brand token after stopword stripping never
+// auto-merges, since chain-only names carry no per-property signal.
+//
+// Stopwords ("hotel", "the", "by", ...) are stripped so they don't
+// inflate matches between unrelated properties.
 func nameOverlap(a, b string) float64 {
 	ta := tokenSet(a)
 	tb := tokenSet(b)
-	if len(ta) == 0 || len(tb) == 0 {
+	short := len(ta)
+	if len(tb) < short {
+		short = len(tb)
+	}
+	if short < 2 {
 		return 0
 	}
 	common := 0
@@ -244,7 +258,7 @@ func nameOverlap(a, b string) float64 {
 		}
 	}
 	base := len(ta)
-	if len(tb) < base {
+	if len(tb) > base {
 		base = len(tb)
 	}
 	return float64(common) / float64(base)

--- a/library/travel/hotel-goat/internal/trivago/merge.go
+++ b/library/travel/hotel-goat/internal/trivago/merge.go
@@ -1,0 +1,262 @@
+// Copyright 2026 kothari-nikunj. Licensed under Apache-2.0. See LICENSE.
+
+package trivago
+
+import (
+	"context"
+	"fmt"
+	"github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/internal/parser"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var priceRE = regexp.MustCompile(`\d[\d.,]*`)
+
+// ParsePrice extracts the numeric value from a localized price string like
+// "$199", "$1,063", "€189,50", or "USD 1,063.50". Returns 0 if no digit
+// is present. Handles both US ("1,063.50" = thousands sep + decimal) and
+// European ("1.063,50" = thousands sep + decimal) conventions: when both
+// `,` and `.` appear the rightmost is the decimal separator; when only
+// one appears, 3 trailing digits => thousands separator, 1-2 => decimal.
+func ParsePrice(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	m := priceRE.FindString(s)
+	if m == "" {
+		return 0
+	}
+	hasDot := strings.Contains(m, ".")
+	hasComma := strings.Contains(m, ",")
+	switch {
+	case hasDot && hasComma:
+		if strings.LastIndex(m, ",") > strings.LastIndex(m, ".") {
+			m = strings.ReplaceAll(m, ".", "")
+			m = strings.Replace(m, ",", ".", 1)
+		} else {
+			m = strings.ReplaceAll(m, ",", "")
+		}
+	case hasComma:
+		idx := strings.LastIndex(m, ",")
+		if len(m)-idx-1 == 3 {
+			m = strings.ReplaceAll(m, ",", "")
+		} else {
+			m = strings.Replace(m, ",", ".", 1)
+		}
+	case hasDot:
+		idx := strings.LastIndex(m, ".")
+		if len(m)-idx-1 == 3 && strings.Count(m, ".") == 1 {
+			m = strings.ReplaceAll(m, ".", "")
+		}
+	}
+	f, _ := strconv.ParseFloat(m, 64)
+	return f
+}
+
+// Merge folds Trivago results into the Google-derived hotel list. A
+// Trivago row matches a Google hotel when they share lat/lng within
+// ~250m AND their names overlap by >=0.5 (token-set Jaccard, minus
+// stopwords). Matched rows append a `prices` entry on the Google hotel
+// so the agent sees both sources in one envelope. Unmatched Trivago
+// rows are appended as standalone hotels with PropertyToken
+// "trivago:<id>", giving the agent a wider candidate set without
+// requiring Google to have indexed every property.
+//
+// targetCurrency: when non-empty AND different from Trivago's native
+// currency (typically EUR), each Trivago price is converted via the
+// Frankfurter FX endpoint so the agent sees apples-to-apples numbers.
+// The original native amount is preserved in the source label, e.g.
+// "trivago/Agoda [EUR €802 ~= USD]". If FX lookup fails, the native
+// amount + a "[EUR]" tag fall through unchanged.
+func Merge(ctx context.Context, google []parser.Hotel, triv []Accommodation, targetCurrency string) []parser.Hotel {
+	if len(triv) == 0 {
+		return google
+	}
+	targetCurrency = strings.ToUpper(strings.TrimSpace(targetCurrency))
+	used := make([]bool, len(triv))
+	for i := range google {
+		h := &google[i]
+		bestIdx, bestScore := -1, 0.0
+		for j, t := range triv {
+			if used[j] {
+				continue
+			}
+			if h.Latitude == 0 || t.Latitude == 0 {
+				continue
+			}
+			if haversineMeters(h.Latitude, h.Longitude, t.Latitude, t.Longitude) > 250 {
+				continue
+			}
+			score := nameOverlap(h.Name, t.Name)
+			if score < 0.5 {
+				continue
+			}
+			if score > bestScore {
+				bestScore = score
+				bestIdx = j
+			}
+		}
+		if bestIdx < 0 {
+			continue
+		}
+		used[bestIdx] = true
+		t := triv[bestIdx]
+		price := ParsePrice(t.PricePerNight)
+		source := "trivago"
+		if t.Advertiser != "" {
+			source = "trivago/" + t.Advertiser
+		}
+		effectiveTarget := targetCurrency
+		if effectiveTarget == "" {
+			effectiveTarget = h.Currency
+		}
+		displayPrice := price
+		displayCurrency := t.Currency
+		if effectiveTarget != "" && t.Currency != "" && effectiveTarget != t.Currency && price > 0 {
+			if conv, _, ok := Convert(ctx, price, t.Currency, effectiveTarget); ok {
+				source = fmt.Sprintf("%s [%s %.0f -> %s]", source, t.Currency, price, effectiveTarget)
+				displayPrice = conv
+				displayCurrency = effectiveTarget
+			} else {
+				source = source + " [" + t.Currency + "]"
+			}
+		}
+		h.Prices = append(h.Prices, parser.OTAPrice{
+			Source: source,
+			Price:  displayPrice,
+			Link:   t.BookingURL,
+		})
+		// Promote Trivago to the headline price when (a) currencies match
+		// (or were converted) AND (b) the converted Trivago figure beats
+		// Google's. Skip when conversion failed — comparing native EUR
+		// against a USD headline is meaningless.
+		canCompare := displayCurrency == h.Currency || h.Currency == ""
+		if displayPrice > 0 && canCompare &&
+			(h.PricePerNight == 0 || displayPrice < h.PricePerNight) {
+			h.PricePerNight = displayPrice
+			if h.Currency == "" {
+				h.Currency = displayCurrency
+			}
+		}
+		if h.BookingURLs.Primary == "" && t.BookingURL != "" {
+			h.BookingURLs.Primary = t.BookingURL
+		}
+	}
+	for j, t := range triv {
+		if used[j] {
+			continue
+		}
+		google = append(google, accommodationToHotel(ctx, t, targetCurrency))
+	}
+	return google
+}
+
+func accommodationToHotel(ctx context.Context, t Accommodation, targetCurrency string) parser.Hotel {
+	price := ParsePrice(t.PricePerNight)
+	rating, _ := strconv.ParseFloat(strings.TrimSpace(t.ReviewRating), 64)
+	source := "trivago"
+	if t.Advertiser != "" {
+		source = "trivago/" + t.Advertiser
+	}
+	currency := t.Currency
+	displayPrice := price
+	if targetCurrency != "" && t.Currency != "" && targetCurrency != t.Currency && price > 0 {
+		if conv, _, ok := Convert(ctx, price, t.Currency, targetCurrency); ok {
+			source = fmt.Sprintf("%s [%s %.0f -> %s]", source, t.Currency, price, targetCurrency)
+			displayPrice = conv
+			currency = targetCurrency
+		} else {
+			source = source + " [" + t.Currency + "]"
+		}
+	}
+	var imgs []string
+	if t.Image != "" {
+		imgs = []string{t.Image}
+	}
+	return parser.Hotel{
+		PropertyToken: "trivago:" + t.ID,
+		Name:          t.Name,
+		Address:       t.Address,
+		Latitude:      t.Latitude,
+		Longitude:     t.Longitude,
+		HotelClass:    t.HotelRating,
+		Rating:        rating,
+		Reviews:       t.ReviewCount,
+		PricePerNight: displayPrice,
+		Currency:      currency,
+		Amenities:     splitCSV(t.Amenities),
+		Prices: []parser.OTAPrice{{
+			Source: source,
+			Price:  displayPrice,
+			Link:   t.BookingURL,
+		}},
+		BookingURLs: parser.BookingURLs{Primary: t.BookingURL, HotelURL: t.URL},
+		Images:      imgs,
+		Description: t.Description,
+		Thumbnail:   t.Image,
+	}
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func haversineMeters(lat1, lon1, lat2, lon2 float64) float64 {
+	const r = 6371000.0
+	rad := math.Pi / 180.0
+	dLat := (lat2 - lat1) * rad
+	dLon := (lon2 - lon1) * rad
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(lat1*rad)*math.Cos(lat2*rad)*math.Sin(dLon/2)*math.Sin(dLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return r * c
+}
+
+var (
+	stopwords  = map[string]bool{"the": true, "hotel": true, "hotels": true, "and": true, "by": true, "at": true, "in": true, "of": true, "a": true, "an": true}
+	tokenSplit = regexp.MustCompile(`[^a-z0-9]+`)
+)
+
+// nameOverlap returns the token-set Jaccard ratio (over the smaller set,
+// so a short canonical name like "Park Hyatt Paris" still matches the
+// fuller "Park Hyatt Paris Vendôme" at 1.0 rather than 0.6). Stopwords
+// like "hotel" and "the" are stripped so they don't inflate matches
+// between unrelated properties.
+func nameOverlap(a, b string) float64 {
+	ta := tokenSet(a)
+	tb := tokenSet(b)
+	if len(ta) == 0 || len(tb) == 0 {
+		return 0
+	}
+	common := 0
+	for t := range ta {
+		if tb[t] {
+			common++
+		}
+	}
+	base := len(ta)
+	if len(tb) < base {
+		base = len(tb)
+	}
+	return float64(common) / float64(base)
+}
+
+func tokenSet(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, t := range tokenSplit.Split(strings.ToLower(s), -1) {
+		if t == "" || stopwords[t] {
+			continue
+		}
+		out[t] = true
+	}
+	return out
+}


### PR DESCRIPTION
## hotel-goat

⚠️ **Replaces existing `hotel-goat`** — adds a second cash-price source (Trivago via public MCP, no API key) and Frankfurter ECB FX conversion so cross-source prices are apples-to-apples.

Free hotel CLI — cash prices from Google Hotels + Trivago, deep booking links, agent-native JSON, and local SQLite wishlist. No API key needed.

**API:** hotel-goat | **Category:** travel | **Press version:** 4.13.0
**Spec:** Not specified

### Publication Path

Reprint/replace — previous `library/travel/hotel-goat/` already merged at upstream HEAD. This update adds the Trivago + FX customization (recorded in `.printing-press-patches.json` as `hotel-goat-trivago-fx`).

### What's new vs. the previously merged version

- **Trivago as a second cash-price source** — public MCP at `https://mcp.trivago.com/mcp`, no API key. Aggregates Booking.com / Expedia / Agoda / Hotels.com / Priceline rates.
- **`--source google|trivago|both`** on the `hotels` command, default `both`.
- **Lat/lng + name-overlap merge** — matched hotels (≤250m haversine + Jaccard token overlap ≥0.5, stopwords stripped) get one `prices[]` entry per source; Trivago-only properties are appended as standalone rows with `property_token` prefixed `trivago:`.
- **Frankfurter ECB FX conversion** — Trivago is geolocated server-side and returns EUR regardless of client hints. The FX layer (free, no key, 24h on-disk cache) converts to the headline currency so the agent compares apples-to-apples. Source labels are tagged `trivago/<OTA> [EUR 802 -> USD]` when conversion ran, `[EUR]` when FX lookup failed.
- **AdaptiveLimiter + 429 retry** on both the Trivago and Frankfurter clients (matches the canonical pattern used by the generated HTTP layer).
- **7 new unit tests** in `internal/trivago/client_test.go` covering SSE framing, limiter spacing, context cancellation, truncation, defaults.

### CLI Shape

```bash
$ hotel-goat-pp-cli --help
    Hotel Goat CLI — Every Google Hotels feature, plus per-OTA price breakdown, local price-drift history, brand-loyalty filters, and date-f…
    
    Highlights (not in the official API docs):
      • hotels   Dotted-path selection through nested results.prices[], results.booking_urls, results.images[]. Returns only the fields the agent needs.
    
    Agent mode: add --agent to any command for JSON output + non-interactive mode.
    Health check: run 'hotel-goat-pp-cli doctor' to verify auth and connectivity.
    See README.md or the bundled SKILL.md for recipes.
    
    Usage:
      hotel-goat-pp-cli [command]
    
    Available Commands:
      agent-context Emit structured JSON describing this CLI for agents
      api           Browse all API endpoints by interface name
      completion    Generate the autocompletion script for the specified shell
      dates         Find the cheapest hotel per (checkin, checkout) pair across a date window
      doctor        Check CLI health
      feedback      Record feedback about this CLI (local by default; upstream opt-in)
      help          Help about any command
      hotel         Single-property commands (show, reviews)
      hotels        Search Google Hotels by location and date range
      import        Import data from JSONL file via API create/upsert calls
      near          Search hotels near a specific address, optionally filtered by radius
      profile       Named sets of flags saved for reuse
      sync          Sync the source into the local store
      version       Print the hotel-goat-pp-cli build version
      which         Find the command that implements a capability
      wishlist      Manage a local saved-property list (add/list/remove)
      workflow      Compound workflows that combine multiple API operations
    
    Flags:
          --agent                Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)
          --compact              Return only key fields (id, name, status, timestamps) for minimal token usage
          --config string        Config file path
          --csv                  Output as CSV (table and array responses)
          --data-source string   Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default "auto")
          --deliver string       Route output to a sink: stdout (default), file:<path>, webhook:<url>
          --dry-run              Show request without sending
      -h, --help                 help for hotel-goat-pp-cli
          --human-friendly       Enable colored output and rich formatting
          --json                 Output as JSON
          --max-age duration     Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)
          --no-cache             Bypass response cache
          --no-color             Disable colored output
          --no-input             Disable all interactive prompts (for CI/agents)
          --profile string       Apply values from a saved profile (see 'hotel-goat-pp-cli profile list')
          --quiet                Bare output, one value per line
          --rate-limit float     Max requests per second (0 to disable, default 2 for sniffed APIs) (default 2)
          --select string        Comma-separated fields to include in output (e.g. --select id,name,status)
          --timeout duration     Request timeout (default 30s)
      -v, --version              version for hotel-goat-pp-cli
          --yes                  Skip confirmation prompts (for agents and scripts)
    
    Use "hotel-goat-pp-cli [command] --help" for more information about a command.
    
```

### Novel Commands

| Command | Name | Description |
|---------|------|-------------|
| `hotels` | Agent-composable nested JSON via --select dotted paths | Dotted-path selection through nested results.prices[], results.booking_urls, results.images[]. Returns only the fields the agent needs. |

### What This CLI Does

hotel-goat fans out across two cash-price sources by default:

- **Google Hotels** — scraped from the server-rendered page (same data the web UI shows)
- **Trivago** — called via Trivago's public MCP server, which exposes OTA-aggregated rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.

Pick a single source with `--source google` or `--source trivago`; the default is `--source both`. When both sources see the same property (matched on lat/lng + name overlap), the OTA prices are merged into one `prices[]` array. Trivago-only properties are appended as standalone rows so the agent gets a wider candidate set.

When Trivago's currency differs from Google's, FX is fetched from Frankfurter (ECB daily rates, no API key, 24h cache) and the converted value replaces the headline number; the native amount is preserved in the source label.

### Manuscripts

- [Research Brief](https://github.com/mvanhorn/printing-press-library/blob/0d10d65e7c6ea100b67c2e2b1d9ed42bee2c18b3/library/travel/hotel-goat/.manuscripts/20260523-203231/research/2026-05-23-203231-feat-hotel-goat-pp-cli-brief.md)
- [Absorb Manifest](https://github.com/mvanhorn/printing-press-library/blob/0d10d65e7c6ea100b67c2e2b1d9ed42bee2c18b3/library/travel/hotel-goat/.manuscripts/20260523-203231/research/2026-05-23-203231-feat-hotel-goat-pp-cli-absorb-manifest.md)
- [Phase 5 Acceptance](https://github.com/mvanhorn/printing-press-library/blob/0d10d65e7c6ea100b67c2e2b1d9ed42bee2c18b3/library/travel/hotel-goat/.manuscripts/20260523-203231/proofs/phase5-acceptance.json)

### Validation Results

| Check | Result |
|-------|--------|
| Manifest | PASS |
| Transcendence | PASS |
| Phase 5 | PASS |
| go mod tidy | PASS |
| govulncheck (this CLI only, reachable findings) | PASS |
| go vet | PASS |
| go build | PASS |
| --help | PASS |
| --version | PASS |
| Verify-skill | PASS |
| Manuscripts | PRESENT |

### Gaps

- `spec_url` is unset in the manifest (Google Hotels has no public spec; Trivago's MCP self-describes via the tools list).
