### PR TITLE
fix(icloud): add contacts command group

### DIFF
--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -112,6 +112,16 @@
         "internal/cli/contacts.go",
         "internal/cli/contacts_db.go"
       ]
+    },
+    {
+      "id": "contacts-upsert-cache-completeness",
+      "summary": "UpsertOne re-inserts addresses and URLs (not just phones and emails); merge command nil-guards both GetByAny results; FTS body includes MiddleName; GetByAny prefix LIKE escapes wildcards and pairs with ESCAPE '\\'; analytics countries propagates the unresolved-count Scan error.",
+      "reason": "Greptile PR #872 second-round findings: (1) UpsertOne deleted contact_addresses and contact_urls but only re-inserted phones and emails, so every `contacts update` and `contacts merge --confirm` silently wiped the affected rows in the local cache until the next full sync — most visible on merge, which explicitly aggregates addresses/URLs before writing. Fix: mirror the SyncAll insert loops for addresses and URLs. (2) merge dereferenced primary.Phones / absorbed.Phones without checking the (nil, nil) shape Get returns on sql.ErrNoRows when GetByAny delegates to Get for a full Apple ID not in the local cache — every other write command already guards this. Fix: explicit `if primary == nil` / `if absorbed == nil` returns. (3) UpsertOne's FTS body omitted c.MiddleName, so contacts indexed only by middle name were unsearchable via FTS5 MATCH. (4) GetByAny's UUID-prefix lookup interpolated input directly into LIKE without escaping % and _, so `contacts get %` would match every contact and trip the ambiguous-prefix path instead of returning not-found. Fix: escapeLike(input) + explicit `ESCAPE '\\'` clause. (5) analytics countries swallowed the Scan error on the unresolved-country query — a missing table in an old DB would print 0 instead of erroring.",
+      "files": [
+        "internal/cli/contacts.go",
+        "internal/cli/contacts_db.go",
+        "internal/cli/contacts_analytics.go"
+      ]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -94,6 +94,15 @@
         "internal/cli/root.go"
       ],
       "validated_outcome": "Synced 1,648 contacts; analytics countries returned 47 countries; FTS5 search on 'juan' returned 21 results in 13ms."
+    },
+    {
+      "id": "contacts-argv-injection-fix",
+      "summary": "create/update/delete commands switched from fmt.Sprintf(%q) script interpolation to on-run-argv AppleScript; UpsertOne tx.Exec errors are now propagated; update cache refresh includes MiddleName.",
+      "reason": "Greptile PR #872 flagged three blocking issues: (1) %q produces Go escape sequences (\\n, \\\") that AppleScript parses differently — a double-quote in user-supplied data terminates the string literal and can inject arbitrary AppleScript code. Fix: three contactCreate/Update/DeleteScript constants use 'on run argv / end run'; values are passed as separate process args after '--' and never seen by the AppleScript lexer. (2) UpsertOne swallowed all tx.Exec errors, so a constraint violation or disk-full condition committed a partially-written record silently. Fix: every tx.Exec error is checked and returned. (3) The update command's local cache refresh was missing existing.MiddleName = middle, so the middle name was written to Contacts.app but stale in the SQLite cache until the next full sync.",
+      "files": [
+        "internal/cli/contacts.go",
+        "internal/cli/contacts_db.go"
+      ]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -103,6 +103,15 @@
         "internal/cli/contacts.go",
         "internal/cli/contacts_db.go"
       ]
+    },
+    {
+      "id": "contacts-uuid-merge-duplicates",
+      "summary": "contacts_db.go adds uuid column + GetByAny (prefix lookup); contacts.go adds merge and duplicates commands.",
+      "reason": "Apple contact IDs (UUID:ABPerson) are unwieldy in shell usage. Extracting the bare UUID and storing it separately allows 8-char prefix lookups across all write commands (get/update/delete/merge). The merge command (contacts merge <id1> <id2> [--confirm]) copies phones, emails, URLs, addresses, and note from contact2 into contact1 via AppleScript on-run-argv, deduplicates phones by normalized number and emails by lowercase value in the local store, then deletes contact2. The duplicates command runs four detection strategies (exact name, same-first-prefix-last, same phone, same email) and prints ready-to-paste merge commands with [UUID8] shortcodes.",
+      "files": [
+        "internal/cli/contacts.go",
+        "internal/cli/contacts_db.go"
+      ]
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/.printing-press-patches.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches.json
@@ -82,6 +82,18 @@
       "summary": "fillLastPreviews and printSearchTable slice text via []rune so previews don't split multi-byte UTF-8 runes at the truncation boundary.",
       "reason": "Byte-index truncation (text[:maxLen]) on emoji or CJK previews left a half rune at the end, which both JSON encoders and terminals render as U+FFFD mojibake. Rune-aware slicing keeps the cut at a glyph boundary. Greptile P1 on PR #766.",
       "files": ["internal/cli/messages_db.go", "internal/cli/messages_search.go"]
+    },
+    {
+      "id": "contacts-jxa-sqlite-store",
+      "summary": "contacts.go / contacts_db.go / contacts_analytics.go add a full contacts command group: sync (JXA → SQLite), list, get, search (FTS5), create, update, delete, and analytics subcommands (countries, domains, missing).",
+      "reason": "macOS Contacts requires Full Disk Access for raw SQLite but is fully readable via JXA (JavaScript for Automation) without any special permission. A local SQLite cache (~/Library/Application Support/icloud-pp-cli/contacts.db) is populated once via a single JXA call and makes all subsequent reads instant (<20ms). Phone numbers are resolved to countries via a longest-prefix E.164 dial-code map, enabling the `contacts analytics countries` command that groups contacts by country without any network call.",
+      "files": [
+        "internal/cli/contacts.go",
+        "internal/cli/contacts_analytics.go",
+        "internal/cli/contacts_db.go",
+        "internal/cli/root.go"
+      ],
+      "validated_outcome": "Synced 1,648 contacts; analytics countries returned 47 countries; FTS5 search on 'juan' returned 21 results in 13ms."
     }
   ]
 }

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -622,6 +622,12 @@ func newContactsMergeCmd(f *rootFlags) *cobra.Command {
 			if absorbed == nil {
 				return fmt.Errorf("contact not found: %s", args[1])
 			}
+			// Self-merge would have AppleScript copy values onto the same
+			// scripting object and then `delete p2` — which deletes the
+			// shared contact outright. Refuse before any side effects.
+			if primary.ID == absorbed.ID {
+				return fmt.Errorf("contact 1 and contact 2 resolve to the same contact (%s) — nothing to merge", primary.ID)
+			}
 
 			// Compute what would be added
 			phoneSet := map[string]bool{}

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -1,0 +1,633 @@
+// Copyright 2026 matysanchez. Licensed under Apache-2.0. See LICENSE.
+
+// Package cli — contacts.go
+// contacts command group: sync, list, get, search, create, update, delete.
+// Reads use the local SQLite store (fast). Writes go through Contacts.app
+// via JXA/AppleScript then update the local store.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newContactsCmd(f *rootFlags) *cobra.Command {
+	contacts := &cobra.Command{
+		Use:   "contacts",
+		Short: "Query and manage your Contacts library",
+		Long: `Read and write your macOS Contacts library locally — no network calls required.
+
+Sync once to populate the local SQLite cache, then list/search/get run instantly.
+Write operations (create, update, delete) go through Contacts.app and update the cache.`,
+	}
+
+	contacts.AddCommand(newContactsSyncCmd(f))
+	contacts.AddCommand(newContactsListCmd(f))
+	contacts.AddCommand(newContactsGetCmd(f))
+	contacts.AddCommand(newContactsSearchCmd(f))
+	contacts.AddCommand(newContactsCreateCmd(f))
+	contacts.AddCommand(newContactsUpdateCmd(f))
+	contacts.AddCommand(newContactsDeleteCmd(f))
+	contacts.AddCommand(newContactsAnalyticsCmd(f))
+
+	return contacts
+}
+
+// ── sync ──────────────────────────────────────────────────────────────────────
+
+// jxaSyncScript exports all contacts via JavaScript for Automation (JXA).
+// Single call — much faster than iterating in Go.
+const jxaSyncScript = `
+var app = Application("Contacts");
+var people = app.people();
+var result = people.map(function(p) {
+  var phones = [];
+  try { phones = p.phones().map(function(ph) { return {label: ph.label(), value: ph.value()}; }); } catch(e) {}
+  var emails = [];
+  try { emails = p.emails().map(function(e) { return {label: e.label(), value: e.value()}; }); } catch(e) {}
+  var addresses = [];
+  try { addresses = p.addresses().map(function(a) {
+    return {label: a.label(), street: a.street(), city: a.city(), state: a.state(), zip: a.zip(), country: a.country()};
+  }); } catch(e) {}
+  var urls = [];
+  try { urls = p.urls().map(function(u) { return {label: u.label(), value: u.value()}; }); } catch(e) {}
+  return {
+    id:           p.id(),
+    firstName:    p.firstName(),
+    lastName:     p.lastName(),
+    middleName:   p.middleName(),
+    organization: p.organization(),
+    jobTitle:     p.jobTitle(),
+    note:         p.note(),
+    modifiedAt:   p.modificationDate() ? p.modificationDate().toISOString() : null,
+    phones:       phones,
+    emails:       emails,
+    addresses:    addresses,
+    urls:         urls
+  };
+});
+JSON.stringify(result);
+`
+
+func newContactsSyncCmd(f *rootFlags) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync contacts from Contacts.app into local SQLite cache",
+		Long: `Pulls all contacts from Contacts.app via JavaScript for Automation (JXA)
+and stores them in a local SQLite database for instant querying.
+
+Run sync once before using list, search, or analytics. Re-run after adding
+or importing contacts to pick up changes.`,
+		Example: `  icloud-pp-cli contacts sync
+  icloud-pp-cli contacts sync --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+
+			store, err := openContactStore()
+			if err != nil {
+				return fmt.Errorf("opening contacts store: %w", err)
+			}
+			defer store.Close()
+
+			if !force {
+				last := store.LastSyncedAt()
+				if last != "" {
+					fmt.Fprintf(out, "  %s Last synced: %s\n", yellow(f, out, "i"), last)
+					fmt.Fprintln(out, "  Use --force to re-sync.")
+					count, _ := store.Count()
+					fmt.Fprintf(out, "  %s %s contacts in local store.\n", green(f, out, "✓"), formatInt(int64(count)))
+					return nil
+				}
+			}
+
+			fmt.Fprintln(out, bold(f, out, "Syncing contacts from Contacts.app..."))
+			start := time.Now()
+
+			// Run JXA — single call, returns full JSON array.
+			fmt.Fprintln(out, "  → Fetching contacts via JXA...")
+			raw, err := runOsascriptJS(jxaSyncScript)
+			if err != nil {
+				return fmt.Errorf("JXA sync failed: %w", err)
+			}
+
+			var contacts []jxaContact
+			if err := json.Unmarshal([]byte(raw), &contacts); err != nil {
+				return fmt.Errorf("parsing JXA output: %w", err)
+			}
+			fmt.Fprintf(out, "  → Fetched %s contacts\n", formatInt(int64(len(contacts))))
+
+			fmt.Fprintln(out, "  → Resolving phone countries & indexing...")
+			n, err := store.SyncAll(contacts)
+			if err != nil {
+				return fmt.Errorf("storing contacts: %w", err)
+			}
+
+			elapsed := time.Since(start).Round(time.Millisecond)
+			fmt.Fprintln(out)
+			fmt.Fprintf(out, "%s %s contacts synced in %s\n",
+				green(f, out, "✓"), formatInt(int64(n)), elapsed)
+			fmt.Fprintf(out, "    DB: %s\n", contactsDBPath())
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Re-sync even if already synced")
+	return cmd
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+func newContactsListCmd(f *rootFlags) *cobra.Command {
+	var limit, offset int
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List contacts from local cache",
+		Example: `  icloud-pp-cli contacts list
+  icloud-pp-cli contacts list --limit 100
+  icloud-pp-cli contacts list --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			cs, err := store.List(limit, offset)
+			if err != nil {
+				return err
+			}
+			if len(cs) == 0 {
+				fmt.Fprintln(out, "No contacts in local store. Run: icloud-pp-cli contacts sync")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, cs)
+			}
+			printContactsTable(f, out, cs)
+			total, _ := store.Count()
+			if total > limit+offset {
+				fmt.Fprintf(out, "\n  Showing %d of %s. Use --offset %d for next page.\n",
+					len(cs), formatInt(int64(total)), offset+limit)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 50, "Max contacts to return")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Skip N contacts (for pagination)")
+	return cmd
+}
+
+// ── get ───────────────────────────────────────────────────────────────────────
+
+func newContactsGetCmd(f *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get full details for a contact by UUID",
+		Args:  cobra.ExactArgs(1),
+		Example: `  icloud-pp-cli contacts get "7D7D265B-D6E9-4F41-9E37-2D97AE2C00FC:ABPerson"
+  icloud-pp-cli contacts get "7D7D265B..." --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			c, err := store.Get(args[0])
+			if err != nil {
+				return err
+			}
+			if c == nil {
+				return fmt.Errorf("contact not found: %s", args[0])
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, c)
+			}
+			printContactDetail(f, out, c)
+			return nil
+		},
+	}
+}
+
+// ── search ────────────────────────────────────────────────────────────────────
+
+func newContactsSearchCmd(f *rootFlags) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Full-text search across name, org, phone, and email",
+		Args:  cobra.ExactArgs(1),
+		Example: `  icloud-pp-cli contacts search "juan"
+  icloud-pp-cli contacts search "gmail.com"
+  icloud-pp-cli contacts search "+52"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			cs, err := store.Search(args[0], limit)
+			if err != nil {
+				return fmt.Errorf("search failed: %w\nTip: run 'contacts sync' first", err)
+			}
+			if len(cs) == 0 {
+				fmt.Fprintf(out, "No results for %q\n", args[0])
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, cs)
+			}
+			printContactsTable(f, out, cs)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 25, "Max results")
+	return cmd
+}
+
+// ── create ────────────────────────────────────────────────────────────────────
+
+func newContactsCreateCmd(f *rootFlags) *cobra.Command {
+	var (
+		firstName, lastName, middle string
+		org, jobTitle, note         string
+		phone, email                string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new contact in Contacts.app",
+		Example: `  icloud-pp-cli contacts create --first "Ana" --last "García" --phone "+52 984 100 0000"
+  icloud-pp-cli contacts create --first "Acme" --org "Acme Corp" --email "info@acme.com"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			if firstName == "" && org == "" {
+				return usageErr(fmt.Errorf("--first or --org is required"))
+			}
+
+			// Build AppleScript
+			var sb strings.Builder
+			sb.WriteString("tell application \"Contacts\"\n")
+			sb.WriteString("  set propsRec to {}\n")
+			if firstName != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {first name:%q}\n", firstName))
+			}
+			if lastName != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {last name:%q}\n", lastName))
+			}
+			if middle != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {middle name:%q}\n", middle))
+			}
+			if org != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {organization:%q}\n", org))
+			}
+			if jobTitle != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {job title:%q}\n", jobTitle))
+			}
+			if note != "" {
+				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {note:%q}\n", note))
+			}
+			sb.WriteString("  set newPerson to make new person with properties propsRec\n")
+			if phone != "" {
+				sb.WriteString(fmt.Sprintf("  make new phone at end of phones of newPerson with properties {label:\"mobile\", value:%q}\n", phone))
+			}
+			if email != "" {
+				sb.WriteString(fmt.Sprintf("  make new email at end of emails of newPerson with properties {label:\"work\", value:%q}\n", email))
+			}
+			sb.WriteString("  save\n")
+			sb.WriteString("  return id of newPerson\n")
+			sb.WriteString("end tell\n")
+
+			appleID, err := runOsascript(sb.String())
+			if err != nil {
+				return fmt.Errorf("creating contact: %w", err)
+			}
+			appleID = strings.TrimSpace(appleID)
+
+			// Upsert into local store
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			c := &Contact{
+				ID:           appleID,
+				FirstName:    firstName,
+				LastName:     lastName,
+				MiddleName:   middle,
+				Organization: org,
+				JobTitle:     jobTitle,
+				Note:         note,
+			}
+			if phone != "" {
+				c.Phones = []ContactPhone{{Label: "mobile", Value: phone}}
+			}
+			if email != "" {
+				c.Emails = []ContactEmail{{Label: "work", Value: email}}
+			}
+			if err := store.UpsertOne(c); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: local store update failed: %v\n", err)
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, map[string]string{"id": appleID, "status": "created"})
+			}
+			fmt.Fprintf(out, "%s Created: %s\n", green(f, out, "✓"), c.DisplayName())
+			fmt.Fprintf(out, "   ID: %s\n", appleID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&firstName, "first", "", "First name")
+	cmd.Flags().StringVar(&lastName, "last", "", "Last name")
+	cmd.Flags().StringVar(&middle, "middle", "", "Middle name")
+	cmd.Flags().StringVar(&org, "org", "", "Organization / company")
+	cmd.Flags().StringVar(&jobTitle, "job-title", "", "Job title")
+	cmd.Flags().StringVar(&note, "note", "", "Note")
+	cmd.Flags().StringVar(&phone, "phone", "", "Phone number (e.g. +52 984 100 0000)")
+	cmd.Flags().StringVar(&email, "email", "", "Email address")
+	return cmd
+}
+
+// ── update ────────────────────────────────────────────────────────────────────
+
+func newContactsUpdateCmd(f *rootFlags) *cobra.Command {
+	var (
+		firstName, lastName, middle string
+		org, jobTitle, note         string
+		addPhone, addEmail          string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update fields on an existing contact",
+		Args:  cobra.ExactArgs(1),
+		Example: `  icloud-pp-cli contacts update "UUID:ABPerson" --org "New Corp"
+  icloud-pp-cli contacts update "UUID:ABPerson" --add-phone "+1 555 000 0001"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			id := args[0]
+
+			var sb strings.Builder
+			sb.WriteString("tell application \"Contacts\"\n")
+			sb.WriteString(fmt.Sprintf("  set p to person id %q\n", id))
+			if firstName != "" {
+				sb.WriteString(fmt.Sprintf("  set first name of p to %q\n", firstName))
+			}
+			if lastName != "" {
+				sb.WriteString(fmt.Sprintf("  set last name of p to %q\n", lastName))
+			}
+			if middle != "" {
+				sb.WriteString(fmt.Sprintf("  set middle name of p to %q\n", middle))
+			}
+			if org != "" {
+				sb.WriteString(fmt.Sprintf("  set organization of p to %q\n", org))
+			}
+			if jobTitle != "" {
+				sb.WriteString(fmt.Sprintf("  set job title of p to %q\n", jobTitle))
+			}
+			if note != "" {
+				sb.WriteString(fmt.Sprintf("  set note of p to %q\n", note))
+			}
+			if addPhone != "" {
+				sb.WriteString(fmt.Sprintf("  make new phone at end of phones of p with properties {label:\"mobile\", value:%q}\n", addPhone))
+			}
+			if addEmail != "" {
+				sb.WriteString(fmt.Sprintf("  make new email at end of emails of p with properties {label:\"work\", value:%q}\n", addEmail))
+			}
+			sb.WriteString("  save\n")
+			sb.WriteString("  return \"ok\"\n")
+			sb.WriteString("end tell\n")
+
+			if _, err := runOsascript(sb.String()); err != nil {
+				return fmt.Errorf("updating contact: %w", err)
+			}
+
+			// Refresh local store entry.
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			existing, err := store.Get(id)
+			if err == nil && existing != nil {
+				if firstName != "" {
+					existing.FirstName = firstName
+				}
+				if lastName != "" {
+					existing.LastName = lastName
+				}
+				if org != "" {
+					existing.Organization = org
+				}
+				if jobTitle != "" {
+					existing.JobTitle = jobTitle
+				}
+				if note != "" {
+					existing.Note = note
+				}
+				if addPhone != "" {
+					existing.Phones = append(existing.Phones, ContactPhone{Label: "mobile", Value: addPhone})
+				}
+				if addEmail != "" {
+					existing.Emails = append(existing.Emails, ContactEmail{Label: "work", Value: addEmail})
+				}
+				if err := store.UpsertOne(existing); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: local store update failed: %v\n", err)
+				}
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, map[string]string{"id": id, "status": "updated"})
+			}
+			fmt.Fprintf(out, "%s Updated contact %s\n", green(f, out, "✓"), id)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&firstName, "first", "", "New first name")
+	cmd.Flags().StringVar(&lastName, "last", "", "New last name")
+	cmd.Flags().StringVar(&middle, "middle", "", "New middle name")
+	cmd.Flags().StringVar(&org, "org", "", "New organization")
+	cmd.Flags().StringVar(&jobTitle, "job-title", "", "New job title")
+	cmd.Flags().StringVar(&note, "note", "", "New note")
+	cmd.Flags().StringVar(&addPhone, "add-phone", "", "Add a phone number")
+	cmd.Flags().StringVar(&addEmail, "add-email", "", "Add an email address")
+	return cmd
+}
+
+// ── delete ────────────────────────────────────────────────────────────────────
+
+func newContactsDeleteCmd(f *rootFlags) *cobra.Command {
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a contact from Contacts.app (permanent)",
+		Args:  cobra.ExactArgs(1),
+		Example: `  icloud-pp-cli contacts delete "UUID:ABPerson" --confirm`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			if !confirm {
+				return usageErr(fmt.Errorf("pass --confirm to delete the contact permanently"))
+			}
+			id := args[0]
+
+			script := fmt.Sprintf(`
+tell application "Contacts"
+  set p to person id %q
+  delete p
+  save
+  return "ok"
+end tell`, id)
+
+			if _, err := runOsascript(script); err != nil {
+				return fmt.Errorf("deleting contact: %w", err)
+			}
+
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+			if err := store.Delete(id); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: local store delete failed: %v\n", err)
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, map[string]string{"id": id, "status": "deleted"})
+			}
+			fmt.Fprintf(out, "%s Deleted contact %s\n", red(f, out, "✗"), id)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Required: confirm permanent deletion")
+	return cmd
+}
+
+// ── display helpers ───────────────────────────────────────────────────────────
+
+func printContactsTable(f *rootFlags, out io.Writer, cs []Contact) {
+	tw := newTabWriter(out)
+	fmt.Fprintln(tw, bold(f, out, "Name")+"\t"+bold(f, out, "Phone")+"\t"+bold(f, out, "Email")+"\t"+bold(f, out, "Company"))
+	fmt.Fprintln(tw, strings.Repeat("─", 20)+"\t"+strings.Repeat("─", 18)+"\t"+strings.Repeat("─", 22)+"\t"+strings.Repeat("─", 16))
+	for _, c := range cs {
+		ph := ""
+		if len(c.Phones) > 0 {
+			ph = c.Phones[0].Value
+		}
+		em := ""
+		if len(c.Emails) > 0 {
+			em = c.Emails[0].Value
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			truncate(c.DisplayName(), 28),
+			truncate(ph, 20),
+			truncate(em, 24),
+			truncate(c.Organization, 18),
+		)
+	}
+	tw.Flush()
+}
+
+func printContactDetail(f *rootFlags, out io.Writer, c *Contact) {
+	fmt.Fprintf(out, "\n%s\n", bold(f, out, c.DisplayName()))
+	fmt.Fprintf(out, "  ID:  %s\n", c.ID)
+	if c.Organization != "" {
+		fmt.Fprintf(out, "  Org: %s\n", c.Organization)
+	}
+	if c.JobTitle != "" {
+		fmt.Fprintf(out, "  Job: %s\n", c.JobTitle)
+	}
+	if c.Birthday != "" {
+		fmt.Fprintf(out, "  Born: %s\n", c.Birthday)
+	}
+	if len(c.Phones) > 0 {
+		fmt.Fprintln(out, "  Phones:")
+		for _, ph := range c.Phones {
+			flag := countryFlag(ph.CountryISO)
+			fmt.Fprintf(out, "    %-10s %s  %s %s\n", ph.Label, ph.Value, flag, ph.Country)
+		}
+	}
+	if len(c.Emails) > 0 {
+		fmt.Fprintln(out, "  Emails:")
+		for _, em := range c.Emails {
+			fmt.Fprintf(out, "    %-10s %s\n", em.Label, em.Value)
+		}
+	}
+	if len(c.Addresses) > 0 {
+		fmt.Fprintln(out, "  Addresses:")
+		for _, a := range c.Addresses {
+			parts := filterEmpty(a.Street, a.City, a.State, a.Zip, a.Country)
+			fmt.Fprintf(out, "    %-10s %s\n", a.Label, strings.Join(parts, ", "))
+		}
+	}
+	if len(c.URLs) > 0 {
+		fmt.Fprintln(out, "  URLs:")
+		for _, u := range c.URLs {
+			fmt.Fprintf(out, "    %-10s %s\n", u.Label, u.Value)
+		}
+	}
+	if c.Note != "" {
+		fmt.Fprintf(out, "  Note: %s\n", truncate(c.Note, 80))
+	}
+	if c.ModifiedAt != "" {
+		fmt.Fprintf(out, "  Modified: %s\n", c.ModifiedAt)
+	}
+	fmt.Fprintln(out)
+}
+
+// countryFlag converts ISO2 code to emoji flag (works on macOS Terminal).
+func countryFlag(iso string) string {
+	if len(iso) != 2 {
+		return "  "
+	}
+	r1 := rune(iso[0]-'A') + 0x1F1E6
+	r2 := rune(iso[1]-'A') + 0x1F1E6
+	return string([]rune{r1, r2})
+}
+
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
+}
+
+// ── osascript helpers ─────────────────────────────────────────────────────────
+
+func runOsascript(script string) (string, error) {
+	cmd := exec.Command("osascript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func runOsascriptJS(script string) (string, error) {
+	cmd := exec.Command("osascript", "-l", "JavaScript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -120,16 +120,58 @@ on run argv
 		set p1 to person id (item 1 of argv)
 		set p2 to person id (item 2 of argv)
 		repeat with ph in (get phones of p2)
-			make new phone at end of phones of p1 with properties {label: label of ph, value: value of ph}
+			set v to value of ph
+			set isDup to false
+			repeat with existing in (phones of p1)
+				if value of existing is v then
+					set isDup to true
+					exit repeat
+				end if
+			end repeat
+			if not isDup then
+				make new phone at end of phones of p1 with properties {label: label of ph, value: v}
+			end if
 		end repeat
 		repeat with em in (get emails of p2)
-			make new email at end of emails of p1 with properties {label: label of em, value: value of em}
+			set v to value of em
+			set isDup to false
+			repeat with existing in (emails of p1)
+				if value of existing is v then
+					set isDup to true
+					exit repeat
+				end if
+			end repeat
+			if not isDup then
+				make new email at end of emails of p1 with properties {label: label of em, value: v}
+			end if
 		end repeat
 		repeat with u in (get urls of p2)
-			make new url at end of urls of p1 with properties {label: label of u, value: value of u}
+			set v to value of u
+			set isDup to false
+			repeat with existing in (urls of p1)
+				if value of existing is v then
+					set isDup to true
+					exit repeat
+				end if
+			end repeat
+			if not isDup then
+				make new url at end of urls of p1 with properties {label: label of u, value: v}
+			end if
 		end repeat
 		repeat with addr in (get addresses of p2)
-			make new address at end of addresses of p1 with properties {label: label of addr, street: street of addr, city: city of addr, state: state of addr, zip: zip of addr, country: country of addr}
+			set s to street of addr
+			set c to city of addr
+			set z to zip of addr
+			set isDup to false
+			repeat with existing in (addresses of p1)
+				if (street of existing is s) and (city of existing is c) and (zip of existing is z) then
+					set isDup to true
+					exit repeat
+				end if
+			end repeat
+			if not isDup then
+				make new address at end of addresses of p1 with properties {label: label of addr, street: s, city: c, state: state of addr, zip: z, country: country of addr}
+			end if
 		end repeat
 		set n2 to note of p2
 		if n2 is not missing value and n2 is not "" then

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -35,6 +35,8 @@ Write operations (create, update, delete) go through Contacts.app and update the
 	contacts.AddCommand(newContactsCreateCmd(f))
 	contacts.AddCommand(newContactsUpdateCmd(f))
 	contacts.AddCommand(newContactsDeleteCmd(f))
+	contacts.AddCommand(newContactsMergeCmd(f))
+	contacts.AddCommand(newContactsDuplicatesCmd(f))
 	contacts.AddCommand(newContactsAnalyticsCmd(f))
 
 	return contacts
@@ -105,6 +107,42 @@ on run argv
 		delete p
 		save
 		return "ok"
+	end tell
+end run
+`
+
+// contactMergeScript copies all phones, emails, URLs, and addresses from
+// contact 2 into contact 1, appends contact 2's note, then deletes contact 2.
+// Argv order: id1 (primary), id2 (to absorb).
+const contactMergeScript = `
+on run argv
+	tell application "Contacts"
+		set p1 to person id (item 1 of argv)
+		set p2 to person id (item 2 of argv)
+		repeat with ph in (get phones of p2)
+			make new phone at end of phones of p1 with properties {label: label of ph, value: value of ph}
+		end repeat
+		repeat with em in (get emails of p2)
+			make new email at end of emails of p1 with properties {label: label of em, value: value of em}
+		end repeat
+		repeat with u in (get urls of p2)
+			make new url at end of urls of p1 with properties {label: label of u, value: value of u}
+		end repeat
+		repeat with addr in (get addresses of p2)
+			make new address at end of addresses of p1 with properties {label: label of addr, street: street of addr, city: city of addr, state: state of addr, zip: zip of addr, country: country of addr}
+		end repeat
+		set n2 to note of p2
+		if n2 is not missing value and n2 is not "" then
+			set n1 to note of p1
+			if n1 is missing value or n1 is "" then
+				set note of p1 to n2
+			else
+				set note of p1 to (n1 & return & "---" & return & n2)
+			end if
+		end if
+		delete p2
+		save
+		return id of p1
 	end tell
 end run
 `
@@ -270,7 +308,7 @@ func newContactsGetCmd(f *rootFlags) *cobra.Command {
 			}
 			defer store.Close()
 
-			c, err := store.Get(args[0])
+			c, err := store.GetByAny(args[0])
 			if err != nil {
 				return err
 			}
@@ -416,7 +454,21 @@ func newContactsUpdateCmd(f *rootFlags) *cobra.Command {
   icloud-pp-cli contacts update "UUID:ABPerson" --add-phone "+1 555 000 0001"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := cmd.OutOrStdout()
-			id := args[0]
+
+			// Resolve id (accepts full Apple ID, bare UUID, or UUID prefix)
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			resolved, err := store.GetByAny(args[0])
+			store.Close()
+			if err != nil {
+				return err
+			}
+			if resolved == nil {
+				return fmt.Errorf("contact not found: %s", args[0])
+			}
+			id := resolved.ID // use full Apple ID for AppleScript
 
 			// Pass ID and field values as out-of-band argv — no string interpolation.
 			if _, err := runOsascriptWithArgs(contactUpdateScript,
@@ -425,11 +477,12 @@ func newContactsUpdateCmd(f *rootFlags) *cobra.Command {
 			}
 
 			// Refresh local store entry.
-			store, err := openContactStore()
+			store2, err := openContactStore()
 			if err != nil {
 				return err
 			}
-			defer store.Close()
+			defer store2.Close()
+			store = store2
 
 			existing, err := store.Get(id)
 			if err == nil && existing != nil {
@@ -494,7 +547,21 @@ func newContactsDeleteCmd(f *rootFlags) *cobra.Command {
 			if !confirm {
 				return usageErr(fmt.Errorf("pass --confirm to delete the contact permanently"))
 			}
-			id := args[0]
+
+			// Resolve id (accepts full Apple ID, bare UUID, or UUID prefix)
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			c, err := store.GetByAny(args[0])
+			store.Close()
+			if err != nil {
+				return err
+			}
+			if c == nil {
+				return fmt.Errorf("contact not found: %s", args[0])
+			}
+			id := c.ID // use full Apple ID for AppleScript
 
 			// Pass id as out-of-band argv — prevents injection if the ID ever
 			// contains characters that AppleScript would misparse in a string literal.
@@ -502,12 +569,12 @@ func newContactsDeleteCmd(f *rootFlags) *cobra.Command {
 				return fmt.Errorf("deleting contact: %w", err)
 			}
 
-			store, err := openContactStore()
+			store2, err := openContactStore()
 			if err != nil {
 				return err
 			}
-			defer store.Close()
-			if err := store.Delete(id); err != nil {
+			defer store2.Close()
+			if err := store2.Delete(id); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: local store delete failed: %v\n", err)
 			}
 
@@ -522,13 +589,197 @@ func newContactsDeleteCmd(f *rootFlags) *cobra.Command {
 	return cmd
 }
 
+// ── merge ─────────────────────────────────────────────────────────────────────
+
+func newContactsMergeCmd(f *rootFlags) *cobra.Command {
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   "merge <id1> <id2>",
+		Short: "Merge contact 2 into contact 1, combining all data",
+		Args:  cobra.ExactArgs(2),
+		Example: `  icloud-pp-cli contacts merge 7D7D265B 3E9B2104
+  icloud-pp-cli contacts merge 7D7D265B 3E9B2104 --confirm`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			primary, err := store.GetByAny(args[0])
+			if err != nil {
+				return fmt.Errorf("contact 1: %w", err)
+			}
+			absorbed, err := store.GetByAny(args[1])
+			if err != nil {
+				return fmt.Errorf("contact 2: %w", err)
+			}
+
+			// Compute what would be added
+			phoneSet := map[string]bool{}
+			for _, ph := range primary.Phones {
+				phoneSet[normalizePhone(ph.Value)] = true
+			}
+			var newPhones []ContactPhone
+			for _, ph := range absorbed.Phones {
+				if !phoneSet[normalizePhone(ph.Value)] {
+					newPhones = append(newPhones, ph)
+				}
+			}
+			emailSet := map[string]bool{}
+			for _, em := range primary.Emails {
+				emailSet[strings.ToLower(em.Value)] = true
+			}
+			var newEmails []ContactEmail
+			for _, em := range absorbed.Emails {
+				if !emailSet[strings.ToLower(em.Value)] {
+					newEmails = append(newEmails, em)
+				}
+			}
+
+			// Preview
+			fmt.Fprintf(out, "\n%s  %s\n", bold(f, out, "Primary:"), primary.DisplayName())
+			fmt.Fprintf(out, "    UUID: %s\n", primary.UUID)
+			fmt.Fprintf(out, "%s  %s\n", bold(f, out, "Absorb: "), absorbed.DisplayName())
+			fmt.Fprintf(out, "    UUID: %s\n", absorbed.UUID)
+			fmt.Fprintln(out)
+
+			if len(newPhones) > 0 {
+				fmt.Fprintln(out, "  Phones to add:")
+				for _, ph := range newPhones {
+					fmt.Fprintf(out, "    %-10s %s\n", ph.Label, ph.Value)
+				}
+			} else {
+				fmt.Fprintln(out, "  Phones to add: (none new)")
+			}
+			if len(newEmails) > 0 {
+				fmt.Fprintln(out, "  Emails to add:")
+				for _, em := range newEmails {
+					fmt.Fprintf(out, "    %-10s %s\n", em.Label, em.Value)
+				}
+			} else {
+				fmt.Fprintln(out, "  Emails to add: (none new)")
+			}
+			if len(absorbed.Addresses) > 0 {
+				fmt.Fprintf(out, "  Addresses to add: %d\n", len(absorbed.Addresses))
+			}
+			if absorbed.Note != "" {
+				fmt.Fprintln(out, "  Note: will be appended")
+			}
+			fmt.Fprintln(out)
+
+			if !confirm {
+				fmt.Fprintln(out, yellow(f, out, "  Run with --confirm to execute the merge."))
+				return nil
+			}
+
+			if _, err := runOsascriptWithArgs(contactMergeScript, primary.ID, absorbed.ID); err != nil {
+				return fmt.Errorf("merge in Contacts.app: %w", err)
+			}
+			if _, err := store.MergeIntoStore(primary.ID, absorbed.ID); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: local store merge failed: %v\n", err)
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, map[string]string{
+					"status":     "merged",
+					"primary_id": primary.ID,
+					"removed_id": absorbed.ID,
+				})
+			}
+			fmt.Fprintf(out, "%s Merged %s into %s\n",
+				green(f, out, "✓"), absorbed.DisplayName(), primary.DisplayName())
+			fmt.Fprintf(out, "   Primary UUID: %s\n", primary.UUID)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Required: confirm the merge")
+	return cmd
+}
+
+// ── duplicates ────────────────────────────────────────────────────────────────
+
+func newContactsDuplicatesCmd(f *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "duplicates",
+		Short: "Find potential duplicate contacts (same name, phone, or email)",
+		Example: `  icloud-pp-cli contacts duplicates
+  icloud-pp-cli contacts duplicates --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			pairs, err := store.FindDuplicates()
+			if err != nil {
+				return fmt.Errorf("finding duplicates: %w", err)
+			}
+			if len(pairs) == 0 {
+				fmt.Fprintln(out, green(f, out, "✓")+" No duplicate contacts found.")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, pairs)
+			}
+
+			reasonLabel := map[string]string{
+				"exact_name":   "Exact name match",
+				"similar_name": "Similar name (possible suffix)",
+			}
+
+			fmt.Fprintf(out, "\n%s\n\n", bold(f, out, fmt.Sprintf("Found %d potential duplicate pair(s)", len(pairs))))
+			for i, p := range pairs {
+				label := p.Reason
+				if l, ok := reasonLabel[p.Reason]; ok {
+					label = l
+				} else if strings.HasPrefix(p.Reason, "same_phone:") {
+					label = "Same phone: " + strings.TrimPrefix(p.Reason, "same_phone:")
+				} else if strings.HasPrefix(p.Reason, "same_email:") {
+					label = "Same email: " + strings.TrimPrefix(p.Reason, "same_email:")
+				}
+				fmt.Fprintf(out, "  %d. %s\n", i+1, bold(f, out, label))
+				shortA := p.A.UUID
+				if len(shortA) > 8 {
+					shortA = shortA[:8]
+				}
+				shortB := p.B.UUID
+				if len(shortB) > 8 {
+					shortB = shortB[:8]
+				}
+				phA := ""
+				if len(p.A.Phones) > 0 {
+					phA = "  " + p.A.Phones[0].Value
+				}
+				phB := ""
+				if len(p.B.Phones) > 0 {
+					phB = "  " + p.B.Phones[0].Value
+				}
+				fmt.Fprintf(out, "     [%s]  %-30s%s\n", shortA, truncate(p.A.DisplayName(), 30), phA)
+				fmt.Fprintf(out, "     [%s]  %-30s%s\n", shortB, truncate(p.B.DisplayName(), 30), phB)
+				fmt.Fprintf(out, "     → contacts merge %s %s --confirm\n\n", shortA, shortB)
+			}
+			return nil
+		},
+	}
+}
+
 // ── display helpers ───────────────────────────────────────────────────────────
 
 func printContactsTable(f *rootFlags, out io.Writer, cs []Contact) {
 	tw := newTabWriter(out)
-	fmt.Fprintln(tw, bold(f, out, "Name")+"\t"+bold(f, out, "Phone")+"\t"+bold(f, out, "Email")+"\t"+bold(f, out, "Company"))
-	fmt.Fprintln(tw, strings.Repeat("─", 20)+"\t"+strings.Repeat("─", 18)+"\t"+strings.Repeat("─", 22)+"\t"+strings.Repeat("─", 16))
+	fmt.Fprintln(tw, bold(f, out, "UUID")+"\t"+bold(f, out, "Name")+"\t"+bold(f, out, "Phone")+"\t"+bold(f, out, "Email")+"\t"+bold(f, out, "Company"))
+	fmt.Fprintln(tw, strings.Repeat("─", 8)+"\t"+strings.Repeat("─", 20)+"\t"+strings.Repeat("─", 18)+"\t"+strings.Repeat("─", 22)+"\t"+strings.Repeat("─", 16))
 	for _, c := range cs {
+		short := c.UUID
+		if len(short) > 8 {
+			short = short[:8]
+		}
 		ph := ""
 		if len(c.Phones) > 0 {
 			ph = c.Phones[0].Value
@@ -537,7 +788,8 @@ func printContactsTable(f *rootFlags, out io.Writer, cs []Contact) {
 		if len(c.Emails) > 0 {
 			em = c.Emails[0].Value
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			short,
 			truncate(c.DisplayName(), 28),
 			truncate(ph, 20),
 			truncate(em, 24),
@@ -550,6 +802,9 @@ func printContactsTable(f *rootFlags, out io.Writer, cs []Contact) {
 func printContactDetail(f *rootFlags, out io.Writer, c *Contact) {
 	fmt.Fprintf(out, "\n%s\n", bold(f, out, c.DisplayName()))
 	fmt.Fprintf(out, "  ID:  %s\n", c.ID)
+	if c.UUID != "" {
+		fmt.Fprintf(out, "  UUID: %s\n", c.UUID)
+	}
 	if c.Organization != "" {
 		fmt.Fprintf(out, "  Org: %s\n", c.Organization)
 	}

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -612,9 +612,15 @@ func newContactsMergeCmd(f *rootFlags) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("contact 1: %w", err)
 			}
+			if primary == nil {
+				return fmt.Errorf("contact not found: %s", args[0])
+			}
 			absorbed, err := store.GetByAny(args[1])
 			if err != nil {
 				return fmt.Errorf("contact 2: %w", err)
+			}
+			if absorbed == nil {
+				return fmt.Errorf("contact not found: %s", args[1])
 			}
 
 			// Compute what would be added

--- a/library/media-and-entertainment/icloud/internal/cli/contacts.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts.go
@@ -42,6 +42,73 @@ Write operations (create, update, delete) go through Contacts.app and update the
 
 // ── sync ──────────────────────────────────────────────────────────────────────
 
+// contactCreateScript creates a new contact in Contacts.app.
+// Values are received via "on run argv" so they are never interpolated into the
+// script body — this prevents AppleScript injection via special characters or
+// quote sequences in user-supplied strings.
+// Argv order: firstName, lastName, middleName, org, jobTitle, note, phone, email.
+// Empty string args are accepted and skipped (no field is set).
+const contactCreateScript = `
+on run argv
+	tell application "Contacts"
+		set propsRec to {}
+		if (count of argv) >= 1 and item 1 of argv is not "" then set propsRec to propsRec & {first name: item 1 of argv}
+		if (count of argv) >= 2 and item 2 of argv is not "" then set propsRec to propsRec & {last name: item 2 of argv}
+		if (count of argv) >= 3 and item 3 of argv is not "" then set propsRec to propsRec & {middle name: item 3 of argv}
+		if (count of argv) >= 4 and item 4 of argv is not "" then set propsRec to propsRec & {organization: item 4 of argv}
+		if (count of argv) >= 5 and item 5 of argv is not "" then set propsRec to propsRec & {job title: item 5 of argv}
+		if (count of argv) >= 6 and item 6 of argv is not "" then set propsRec to propsRec & {note: item 6 of argv}
+		set newPerson to make new person with properties propsRec
+		if (count of argv) >= 7 and item 7 of argv is not "" then
+			make new phone at end of phones of newPerson with properties {label: "mobile", value: item 7 of argv}
+		end if
+		if (count of argv) >= 8 and item 8 of argv is not "" then
+			make new email at end of emails of newPerson with properties {label: "work", value: item 8 of argv}
+		end if
+		save
+		return id of newPerson
+	end tell
+end run
+`
+
+// contactUpdateScript updates fields on an existing contact by ID.
+// Argv order: id, firstName, lastName, middleName, org, jobTitle, note, addPhone, addEmail.
+// Empty string args are skipped — only non-empty values overwrite existing fields.
+const contactUpdateScript = `
+on run argv
+	tell application "Contacts"
+		set p to person id (item 1 of argv)
+		if (count of argv) >= 2 and item 2 of argv is not "" then set first name of p to item 2 of argv
+		if (count of argv) >= 3 and item 3 of argv is not "" then set last name of p to item 3 of argv
+		if (count of argv) >= 4 and item 4 of argv is not "" then set middle name of p to item 4 of argv
+		if (count of argv) >= 5 and item 5 of argv is not "" then set organization of p to item 5 of argv
+		if (count of argv) >= 6 and item 6 of argv is not "" then set job title of p to item 6 of argv
+		if (count of argv) >= 7 and item 7 of argv is not "" then set note of p to item 7 of argv
+		if (count of argv) >= 8 and item 8 of argv is not "" then
+			make new phone at end of phones of p with properties {label: "mobile", value: item 8 of argv}
+		end if
+		if (count of argv) >= 9 and item 9 of argv is not "" then
+			make new email at end of emails of p with properties {label: "work", value: item 9 of argv}
+		end if
+		save
+		return "ok"
+	end tell
+end run
+`
+
+// contactDeleteScript deletes a contact by ID.
+// Argv order: id.
+const contactDeleteScript = `
+on run argv
+	tell application "Contacts"
+		set p to person id (item 1 of argv)
+		delete p
+		save
+		return "ok"
+	end tell
+end run
+`
+
 // jxaSyncScript exports all contacts via JavaScript for Automation (JXA).
 // Single call — much faster than iterating in Go.
 const jxaSyncScript = `
@@ -278,40 +345,11 @@ func newContactsCreateCmd(f *rootFlags) *cobra.Command {
 				return usageErr(fmt.Errorf("--first or --org is required"))
 			}
 
-			// Build AppleScript
-			var sb strings.Builder
-			sb.WriteString("tell application \"Contacts\"\n")
-			sb.WriteString("  set propsRec to {}\n")
-			if firstName != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {first name:%q}\n", firstName))
-			}
-			if lastName != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {last name:%q}\n", lastName))
-			}
-			if middle != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {middle name:%q}\n", middle))
-			}
-			if org != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {organization:%q}\n", org))
-			}
-			if jobTitle != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {job title:%q}\n", jobTitle))
-			}
-			if note != "" {
-				sb.WriteString(fmt.Sprintf("  set propsRec to propsRec & {note:%q}\n", note))
-			}
-			sb.WriteString("  set newPerson to make new person with properties propsRec\n")
-			if phone != "" {
-				sb.WriteString(fmt.Sprintf("  make new phone at end of phones of newPerson with properties {label:\"mobile\", value:%q}\n", phone))
-			}
-			if email != "" {
-				sb.WriteString(fmt.Sprintf("  make new email at end of emails of newPerson with properties {label:\"work\", value:%q}\n", email))
-			}
-			sb.WriteString("  save\n")
-			sb.WriteString("  return id of newPerson\n")
-			sb.WriteString("end tell\n")
-
-			appleID, err := runOsascript(sb.String())
+			// Pass values as out-of-band argv — no string interpolation into the
+			// script body, so quotes and backslashes in user data cannot escape
+			// the AppleScript string context.
+			appleID, err := runOsascriptWithArgs(contactCreateScript,
+				firstName, lastName, middle, org, jobTitle, note, phone, email)
 			if err != nil {
 				return fmt.Errorf("creating contact: %w", err)
 			}
@@ -380,38 +418,9 @@ func newContactsUpdateCmd(f *rootFlags) *cobra.Command {
 			out := cmd.OutOrStdout()
 			id := args[0]
 
-			var sb strings.Builder
-			sb.WriteString("tell application \"Contacts\"\n")
-			sb.WriteString(fmt.Sprintf("  set p to person id %q\n", id))
-			if firstName != "" {
-				sb.WriteString(fmt.Sprintf("  set first name of p to %q\n", firstName))
-			}
-			if lastName != "" {
-				sb.WriteString(fmt.Sprintf("  set last name of p to %q\n", lastName))
-			}
-			if middle != "" {
-				sb.WriteString(fmt.Sprintf("  set middle name of p to %q\n", middle))
-			}
-			if org != "" {
-				sb.WriteString(fmt.Sprintf("  set organization of p to %q\n", org))
-			}
-			if jobTitle != "" {
-				sb.WriteString(fmt.Sprintf("  set job title of p to %q\n", jobTitle))
-			}
-			if note != "" {
-				sb.WriteString(fmt.Sprintf("  set note of p to %q\n", note))
-			}
-			if addPhone != "" {
-				sb.WriteString(fmt.Sprintf("  make new phone at end of phones of p with properties {label:\"mobile\", value:%q}\n", addPhone))
-			}
-			if addEmail != "" {
-				sb.WriteString(fmt.Sprintf("  make new email at end of emails of p with properties {label:\"work\", value:%q}\n", addEmail))
-			}
-			sb.WriteString("  save\n")
-			sb.WriteString("  return \"ok\"\n")
-			sb.WriteString("end tell\n")
-
-			if _, err := runOsascript(sb.String()); err != nil {
+			// Pass ID and field values as out-of-band argv — no string interpolation.
+			if _, err := runOsascriptWithArgs(contactUpdateScript,
+				id, firstName, lastName, middle, org, jobTitle, note, addPhone, addEmail); err != nil {
 				return fmt.Errorf("updating contact: %w", err)
 			}
 
@@ -429,6 +438,9 @@ func newContactsUpdateCmd(f *rootFlags) *cobra.Command {
 				}
 				if lastName != "" {
 					existing.LastName = lastName
+				}
+				if middle != "" {
+					existing.MiddleName = middle
 				}
 				if org != "" {
 					existing.Organization = org
@@ -484,15 +496,9 @@ func newContactsDeleteCmd(f *rootFlags) *cobra.Command {
 			}
 			id := args[0]
 
-			script := fmt.Sprintf(`
-tell application "Contacts"
-  set p to person id %q
-  delete p
-  save
-  return "ok"
-end tell`, id)
-
-			if _, err := runOsascript(script); err != nil {
+			// Pass id as out-of-band argv — prevents injection if the ID ever
+			// contains characters that AppleScript would misparse in a string literal.
+			if _, err := runOsascriptWithArgs(contactDeleteScript, id); err != nil {
 				return fmt.Errorf("deleting contact: %w", err)
 			}
 
@@ -610,6 +616,43 @@ func truncate(s string, n int) string {
 
 func runOsascript(script string) (string, error) {
 	cmd := exec.Command("osascript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// runOsascriptWithArgs runs an "on run argv" AppleScript, passing values as
+// separate process arguments after "--" rather than interpolating them into the
+// script body. This is the safe way to pass user-supplied strings to AppleScript:
+// the values are never parsed by the AppleScript lexer, so quotes, backslashes,
+// and other special characters cannot escape the string context or inject code.
+func runOsascriptWithArgs(script string, args ...string) (string, error) {
+	out, err := osascriptRawWithArgs(script, args...)
+	if err == nil {
+		return out, nil
+	}
+	// Contacts.app may not be running (-600). Launch it silently and retry.
+	if strings.Contains(err.Error(), "-600") || strings.Contains(err.Error(), "isn't running") {
+		if launchErr := exec.Command("open", "-a", "Contacts").Run(); launchErr == nil {
+			for i := 0; i < 6; i++ {
+				time.Sleep(500 * time.Millisecond)
+				if out2, err2 := osascriptRawWithArgs(script, args...); err2 == nil {
+					return out2, nil
+				}
+			}
+		}
+	}
+	return "", err
+}
+
+func osascriptRawWithArgs(script string, args ...string) (string, error) {
+	cmdArgs := append([]string{"-e", script, "--"}, args...)
+	cmd := exec.Command("osascript", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_analytics.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_analytics.go
@@ -1,0 +1,206 @@
+// Copyright 2026 matysanchez. Licensed under Apache-2.0. See LICENSE.
+
+// Package cli — contacts_analytics.go
+// contacts analytics subcommands: countries, domains, missing.
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newContactsAnalyticsCmd(f *rootFlags) *cobra.Command {
+	a := &cobra.Command{
+		Use:   "analytics",
+		Short: "Analytics on your contacts (countries, domains, coverage)",
+	}
+	a.AddCommand(newAnalyticsCountriesCmd(f))
+	a.AddCommand(newAnalyticsDomainsCmd(f))
+	a.AddCommand(newAnalyticsMissingCmd(f))
+	return a
+}
+
+// ── countries ─────────────────────────────────────────────────────────────────
+
+func newAnalyticsCountriesCmd(f *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "countries",
+		Short: "Contacts by country, resolved from phone number prefix",
+		Long: `Groups your contacts by country using their phone number's dialing prefix.
+
+A contact may appear in multiple countries if they have numbers from different countries.
+The count column shows unique contacts; phones shows total phone numbers from that country.`,
+		Example: `  icloud-pp-cli contacts analytics countries
+  icloud-pp-cli contacts analytics countries --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			rows, err := store.AnalyticsCountries()
+			if err != nil {
+				return err
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(out, "No phone data found. Run: icloud-pp-cli contacts sync")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, rows)
+			}
+
+			// Count total known-country contacts for percentage
+			total := 0
+			for _, r := range rows {
+				total += r.Count
+			}
+
+			tw := newTabWriter(out)
+			fmt.Fprintln(out, bold(f, out, "Contacts by country (phone prefix)"))
+			fmt.Fprintln(out)
+			header := "  " + bold(f, out, "Flag") + "\t" +
+				bold(f, out, "Country") + "\t" +
+				bold(f, out, "Code") + "\t" +
+				bold(f, out, "Contacts") + "\t" +
+				bold(f, out, "Phones") + "\t" +
+				bold(f, out, "Share")
+			fmt.Fprintln(tw, header)
+			fmt.Fprintln(tw, "  "+strings.Repeat("─", 4)+"\t"+
+				strings.Repeat("─", 30)+"\t"+
+				strings.Repeat("─", 5)+"\t"+
+				strings.Repeat("─", 8)+"\t"+
+				strings.Repeat("─", 6)+"\t"+
+				strings.Repeat("─", 6))
+
+			for _, r := range rows {
+				pct := 0.0
+				if total > 0 {
+					pct = float64(r.Count) / float64(total) * 100
+				}
+				flag := countryFlag(r.ISO)
+				fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\t%.1f%%\n",
+					flag,
+					r.Country,
+					r.Code,
+					formatInt(int64(r.Count)),
+					formatInt(int64(r.Phones)),
+					pct,
+				)
+			}
+			tw.Flush()
+			fmt.Fprintln(out)
+			fmt.Fprintf(out, "  %d countries · %d contacts with known country\n", len(rows), total)
+
+			// Show unresolved count
+			var unresolved int
+			store.db.QueryRow(`
+				SELECT COUNT(DISTINCT contact_id) FROM contact_phones
+				WHERE country IS NULL OR country = ''
+			`).Scan(&unresolved)
+			if unresolved > 0 {
+				fmt.Fprintf(out, "  %s %d contacts have phones with unresolved country (no E.164 prefix)\n",
+					yellow(f, out, "⚠"), unresolved)
+			}
+			return nil
+		},
+	}
+}
+
+// ── domains ───────────────────────────────────────────────────────────────────
+
+func newAnalyticsDomainsCmd(f *rootFlags) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "domains",
+		Short: "Top email domains across your contacts",
+		Example: `  icloud-pp-cli contacts analytics domains
+  icloud-pp-cli contacts analytics domains --limit 50`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			rows, err := store.AnalyticsDomains(limit)
+			if err != nil {
+				return err
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(out, "No email data found. Run: icloud-pp-cli contacts sync")
+				return nil
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, rows)
+			}
+
+			fmt.Fprintln(out, bold(f, out, "Top email domains"))
+			fmt.Fprintln(out)
+			tw := newTabWriter(out)
+			fmt.Fprintln(tw, "  "+bold(f, out, "Domain")+"\t"+bold(f, out, "Contacts"))
+			fmt.Fprintln(tw, "  "+strings.Repeat("─", 30)+"\t"+strings.Repeat("─", 8))
+			for _, r := range rows {
+				fmt.Fprintf(tw, "  %s\t%s\n", r.Domain, formatInt(int64(r.Count)))
+			}
+			tw.Flush()
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 25, "Max domains to show")
+	return cmd
+}
+
+// ── missing ───────────────────────────────────────────────────────────────────
+
+func newAnalyticsMissingCmd(f *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "missing",
+		Short: "Coverage report: contacts missing phone, email, or name",
+		Example: `  icloud-pp-cli contacts analytics missing
+  icloud-pp-cli contacts analytics missing --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			store, err := openContactStore()
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+
+			ms, err := store.AnalyticsMissing()
+			if err != nil {
+				return err
+			}
+
+			if f.asJSON || !isTerminal(out) {
+				return printJSON(out, ms)
+			}
+
+			pct := func(n int) string {
+				if ms.Total == 0 {
+					return "0%"
+				}
+				return fmt.Sprintf("%.1f%%", float64(n)/float64(ms.Total)*100)
+			}
+
+			fmt.Fprintln(out, bold(f, out, "Contact coverage report"))
+			fmt.Fprintln(out)
+			tw := newTabWriter(out)
+			fmt.Fprintf(tw, "  Total contacts\t%s\n", formatInt(int64(ms.Total)))
+			fmt.Fprintln(tw, "  "+strings.Repeat("─", 24)+"\t"+strings.Repeat("─", 14))
+			fmt.Fprintf(tw, "  No phone number\t%s  (%s)\n", formatInt(int64(ms.NoPhone)), pct(ms.NoPhone))
+			fmt.Fprintf(tw, "  No email address\t%s  (%s)\n", formatInt(int64(ms.NoEmail)), pct(ms.NoEmail))
+			fmt.Fprintf(tw, "  No organization\t%s  (%s)\n", formatInt(int64(ms.NoOrg)), pct(ms.NoOrg))
+			fmt.Fprintf(tw, "  No name (first or last)\t%s  (%s)\n", formatInt(int64(ms.NoName)), pct(ms.NoName))
+			tw.Flush()
+			return nil
+		},
+	}
+}

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_analytics.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_analytics.go
@@ -99,10 +99,12 @@ The count column shows unique contacts; phones shows total phone numbers from th
 
 			// Show unresolved count
 			var unresolved int
-			store.db.QueryRow(`
+			if err := store.db.QueryRow(`
 				SELECT COUNT(DISTINCT contact_id) FROM contact_phones
 				WHERE country IS NULL OR country = ''
-			`).Scan(&unresolved)
+			`).Scan(&unresolved); err != nil {
+				return fmt.Errorf("query unresolved-country count: %w", err)
+			}
 			if unresolved > 0 {
 				fmt.Fprintf(out, "  %s %d contacts have phones with unresolved country (no E.164 prefix)\n",
 					yellow(f, out, "⚠"), unresolved)

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
@@ -1,0 +1,829 @@
+// Copyright 2026 matysanchez. Licensed under Apache-2.0. See LICENSE.
+
+// Package cli — contacts_db.go
+// Local SQLite store for Contacts data synced from Contacts.app via JXA.
+// Schema mirrors the Printing Press store pattern: typed columns + sync_state.
+package cli
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// ── store ─────────────────────────────────────────────────────────────────────
+
+type contactStore struct {
+	db *sql.DB
+}
+
+func contactsDBPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Application Support", "icloud-pp-cli", "contacts.db")
+}
+
+func openContactStore() (*contactStore, error) {
+	path := contactsDBPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("creating contacts db dir: %w", err)
+	}
+	db, err := sql.Open("sqlite",
+		path+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening contacts db: %w", err)
+	}
+	db.SetMaxOpenConns(4)
+	s := &contactStore{db: db}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("contacts db migrate: %w", err)
+	}
+	return s, nil
+}
+
+func (s *contactStore) Close() error { return s.db.Close() }
+
+func (s *contactStore) migrate() error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS contacts (
+			id           TEXT PRIMARY KEY,
+			first_name   TEXT,
+			last_name    TEXT,
+			middle_name  TEXT,
+			organization TEXT,
+			job_title    TEXT,
+			note         TEXT,
+			birthday     TEXT,
+			modified_at  TEXT,
+			synced_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_contacts_org      ON contacts(organization)`,
+		`CREATE INDEX IF NOT EXISTS idx_contacts_modified ON contacts(modified_at)`,
+
+		`CREATE TABLE IF NOT EXISTS contact_phones (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			contact_id   TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+			label        TEXT,
+			value        TEXT,
+			normalized   TEXT,
+			country_code TEXT,
+			country_iso  TEXT,
+			country      TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_phones_contact ON contact_phones(contact_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_phones_country ON contact_phones(country_iso)`,
+
+		`CREATE TABLE IF NOT EXISTS contact_emails (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+			label      TEXT,
+			value      TEXT,
+			domain     TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_emails_contact ON contact_emails(contact_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_emails_domain  ON contact_emails(domain)`,
+
+		`CREATE TABLE IF NOT EXISTS contact_addresses (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+			label      TEXT,
+			street     TEXT,
+			city       TEXT,
+			state      TEXT,
+			zip        TEXT,
+			country    TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_addresses_contact ON contact_addresses(contact_id)`,
+
+		`CREATE TABLE IF NOT EXISTS contact_urls (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			contact_id TEXT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+			label      TEXT,
+			value      TEXT
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_urls_contact ON contact_urls(contact_id)`,
+
+		// FTS5 for fast full-text search across name, org, phones, emails, note.
+		// External content table: we manage inserts/deletes manually.
+		`CREATE VIRTUAL TABLE IF NOT EXISTS contacts_fts USING fts5(
+			id UNINDEXED,
+			body,
+			tokenize='unicode61'
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS sync_state (
+			key        TEXT PRIMARY KEY,
+			value      TEXT,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("migrate: %w\nstmt: %s", err, stmt[:min(60, len(stmt))])
+		}
+	}
+	return nil
+}
+
+// ── sync ──────────────────────────────────────────────────────────────────────
+
+// jxaContact is the JSON shape emitted by the JXA sync script.
+type jxaContact struct {
+	ID           string      `json:"id"`
+	FirstName    interface{} `json:"firstName"`
+	LastName     interface{} `json:"lastName"`
+	MiddleName   interface{} `json:"middleName"`
+	Organization interface{} `json:"organization"`
+	JobTitle     interface{} `json:"jobTitle"`
+	Note         interface{} `json:"note"`
+	Birthday     interface{} `json:"birthday"`
+	ModifiedAt   interface{} `json:"modifiedAt"`
+	Phones       []jxaMulti  `json:"phones"`
+	Emails       []jxaMulti  `json:"emails"`
+	Addresses    []jxaAddr   `json:"addresses"`
+	URLs         []jxaMulti  `json:"urls"`
+}
+
+type jxaMulti struct {
+	Label string      `json:"label"`
+	Value interface{} `json:"value"`
+}
+
+type jxaAddr struct {
+	Label   string      `json:"label"`
+	Street  interface{} `json:"street"`
+	City    interface{} `json:"city"`
+	State   interface{} `json:"state"`
+	Zip     interface{} `json:"zip"`
+	Country interface{} `json:"country"`
+}
+
+func str(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+// SyncAll replaces all contact data with the provided JXA-exported list.
+func (s *contactStore) SyncAll(contacts []jxaContact) (int, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// Full replace: delete all child rows first (FK cascade) then contacts.
+	for _, t := range []string{"contact_phones", "contact_emails", "contact_addresses", "contact_urls"} {
+		if _, err := tx.Exec("DELETE FROM " + t); err != nil {
+			return 0, fmt.Errorf("clear %s: %w", t, err)
+		}
+	}
+	if _, err := tx.Exec("DELETE FROM contacts"); err != nil {
+		return 0, fmt.Errorf("clear contacts: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM contacts_fts"); err != nil {
+		return 0, fmt.Errorf("clear contacts_fts: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for i := range contacts {
+		c := &contacts[i]
+		fn := str(c.FirstName)
+		ln := str(c.LastName)
+		mn := str(c.MiddleName)
+		org := str(c.Organization)
+		jt := str(c.JobTitle)
+		note := str(c.Note)
+		bday := str(c.Birthday)
+		mod := str(c.ModifiedAt)
+
+		_, err := tx.Exec(
+			`INSERT INTO contacts (id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			c.ID, fn, ln, mn, org, jt, note, bday, mod, now,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("insert contact %s: %w", c.ID, err)
+		}
+
+		// Phones
+		var phoneTokens []string
+		for _, ph := range c.Phones {
+			v := str(ph.Value)
+			if v == "" {
+				continue
+			}
+			norm := normalizePhone(v)
+			code, iso, country := resolvePhoneCountry(norm)
+			if _, err := tx.Exec(
+				`INSERT INTO contact_phones (contact_id, label, value, normalized, country_code, country_iso, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				c.ID, cleanLabel(ph.Label), v, norm, code, iso, country,
+			); err != nil {
+				return 0, fmt.Errorf("insert phone: %w", err)
+			}
+			phoneTokens = append(phoneTokens, v)
+		}
+
+		// Emails
+		var emailTokens []string
+		for _, em := range c.Emails {
+			v := str(em.Value)
+			if v == "" {
+				continue
+			}
+			domain := ""
+			if at := strings.LastIndex(v, "@"); at >= 0 {
+				domain = strings.ToLower(v[at+1:])
+			}
+			if _, err := tx.Exec(
+				`INSERT INTO contact_emails (contact_id, label, value, domain) VALUES (?, ?, ?, ?)`,
+				c.ID, cleanLabel(em.Label), v, domain,
+			); err != nil {
+				return 0, fmt.Errorf("insert email: %w", err)
+			}
+			emailTokens = append(emailTokens, v)
+		}
+
+		// Addresses
+		for _, addr := range c.Addresses {
+			if _, err := tx.Exec(
+				`INSERT INTO contact_addresses (contact_id, label, street, city, state, zip, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				c.ID, cleanLabel(addr.Label),
+				str(addr.Street), str(addr.City), str(addr.State), str(addr.Zip), str(addr.Country),
+			); err != nil {
+				return 0, fmt.Errorf("insert address: %w", err)
+			}
+		}
+
+		// URLs
+		for _, u := range c.URLs {
+			v := str(u.Value)
+			if v == "" {
+				continue
+			}
+			if _, err := tx.Exec(
+				`INSERT INTO contact_urls (contact_id, label, value) VALUES (?, ?, ?)`,
+				c.ID, cleanLabel(u.Label), v,
+			); err != nil {
+				return 0, fmt.Errorf("insert url: %w", err)
+			}
+		}
+
+		// FTS body
+		body := strings.Join(filterEmpty(fn, ln, mn, org, jt, note,
+			strings.Join(phoneTokens, " "),
+			strings.Join(emailTokens, " ")), " ")
+		if _, err := tx.Exec(
+			`INSERT INTO contacts_fts (id, body) VALUES (?, ?)`,
+			c.ID, body,
+		); err != nil {
+			return 0, fmt.Errorf("insert fts: %w", err)
+		}
+	}
+
+	// Update sync_state
+	if _, err := tx.Exec(
+		`INSERT INTO sync_state (key, value, updated_at) VALUES ('last_synced_at', ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		now,
+	); err != nil {
+		return 0, fmt.Errorf("update sync_state: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(contacts), nil
+}
+
+// ── read ──────────────────────────────────────────────────────────────────────
+
+// Contact is the full contact record returned to CLI commands.
+type Contact struct {
+	ID           string           `json:"id"`
+	FirstName    string           `json:"first_name"`
+	LastName     string           `json:"last_name,omitempty"`
+	MiddleName   string           `json:"middle_name,omitempty"`
+	Organization string           `json:"organization,omitempty"`
+	JobTitle     string           `json:"job_title,omitempty"`
+	Note         string           `json:"note,omitempty"`
+	Birthday     string           `json:"birthday,omitempty"`
+	ModifiedAt   string           `json:"modified_at,omitempty"`
+	SyncedAt     string           `json:"synced_at,omitempty"`
+	Phones       []ContactPhone   `json:"phones,omitempty"`
+	Emails       []ContactEmail   `json:"emails,omitempty"`
+	Addresses    []ContactAddress `json:"addresses,omitempty"`
+	URLs         []ContactURL     `json:"urls,omitempty"`
+}
+
+// DisplayName returns "First Last" or organization as fallback.
+func (c *Contact) DisplayName() string {
+	parts := filterEmpty(c.FirstName, c.LastName)
+	if len(parts) > 0 {
+		return strings.Join(parts, " ")
+	}
+	if c.Organization != "" {
+		return c.Organization
+	}
+	return "(no name)"
+}
+
+type ContactPhone struct {
+	Label       string `json:"label"`
+	Value       string `json:"value"`
+	Country     string `json:"country,omitempty"`
+	CountryISO  string `json:"country_iso,omitempty"`
+	CountryCode string `json:"country_code,omitempty"`
+}
+
+type ContactEmail struct {
+	Label  string `json:"label"`
+	Value  string `json:"value"`
+	Domain string `json:"domain,omitempty"`
+}
+
+type ContactAddress struct {
+	Label   string `json:"label"`
+	Street  string `json:"street,omitempty"`
+	City    string `json:"city,omitempty"`
+	State   string `json:"state,omitempty"`
+	Zip     string `json:"zip,omitempty"`
+	Country string `json:"country,omitempty"`
+}
+
+type ContactURL struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+func (s *contactStore) Count() (int, error) {
+	var n int
+	return n, s.db.QueryRow("SELECT COUNT(*) FROM contacts").Scan(&n)
+}
+
+func (s *contactStore) LastSyncedAt() string {
+	var v sql.NullString
+	s.db.QueryRow("SELECT value FROM sync_state WHERE key = 'last_synced_at'").Scan(&v)
+	if v.Valid {
+		return v.String
+	}
+	return ""
+}
+
+func (s *contactStore) List(limit, offset int) ([]Contact, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(
+		`SELECT id, first_name, last_name, organization, synced_at
+		 FROM contacts
+		 ORDER BY first_name, last_name
+		 LIMIT ? OFFSET ?`, limit, offset,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var cs []Contact
+	for rows.Next() {
+		var c Contact
+		var ln, org, sa sql.NullString
+		if err := rows.Scan(&c.ID, &c.FirstName, &ln, &org, &sa); err != nil {
+			return nil, err
+		}
+		c.LastName = ln.String
+		c.Organization = org.String
+		c.SyncedAt = sa.String
+		cs = append(cs, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range cs {
+		if err := s.loadRelations(&cs[i]); err != nil {
+			return nil, err
+		}
+	}
+	return cs, nil
+}
+
+func (s *contactStore) Get(id string) (*Contact, error) {
+	var c Contact
+	var ln, mn, org, jt, note, bday, mod, sa sql.NullString
+	err := s.db.QueryRow(
+		`SELECT id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at
+		 FROM contacts WHERE id = ?`, id,
+	).Scan(&c.ID, &c.FirstName, &ln, &mn, &org, &jt, &note, &bday, &mod, &sa)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	c.LastName, c.MiddleName, c.Organization = ln.String, mn.String, org.String
+	c.JobTitle, c.Note, c.Birthday = jt.String, note.String, bday.String
+	c.ModifiedAt, c.SyncedAt = mod.String, sa.String
+	return &c, s.loadRelations(&c)
+}
+
+func (s *contactStore) Search(query string, limit int) ([]Contact, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(
+		`SELECT c.id, c.first_name, c.last_name, c.organization, c.synced_at
+		 FROM contacts c
+		 JOIN contacts_fts f ON f.id = c.id
+		 WHERE contacts_fts MATCH ?
+		 ORDER BY rank
+		 LIMIT ?`, query, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fts search: %w", err)
+	}
+	defer rows.Close()
+	var cs []Contact
+	for rows.Next() {
+		var c Contact
+		var ln, org, sa sql.NullString
+		if err := rows.Scan(&c.ID, &c.FirstName, &ln, &org, &sa); err != nil {
+			return nil, err
+		}
+		c.LastName, c.Organization, c.SyncedAt = ln.String, org.String, sa.String
+		cs = append(cs, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range cs {
+		if err := s.loadRelations(&cs[i]); err != nil {
+			return nil, err
+		}
+	}
+	return cs, nil
+}
+
+func (s *contactStore) Delete(id string) error {
+	_, err := s.db.Exec("DELETE FROM contacts WHERE id = ?", id)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec("DELETE FROM contacts_fts WHERE id = ?", id)
+	return err
+}
+
+// UpsertOne inserts or replaces a single contact (used after create/update via AppleScript).
+func (s *contactStore) UpsertOne(c *Contact) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = tx.Exec(
+		`INSERT OR REPLACE INTO contacts (id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.ID, c.FirstName, c.LastName, c.MiddleName, c.Organization, c.JobTitle, c.Note, c.Birthday, c.ModifiedAt, now,
+	)
+	if err != nil {
+		return err
+	}
+	for _, t := range []string{"contact_phones", "contact_emails", "contact_addresses", "contact_urls"} {
+		tx.Exec("DELETE FROM "+t+" WHERE contact_id = ?", c.ID)
+	}
+	tx.Exec("DELETE FROM contacts_fts WHERE id = ?", c.ID)
+
+	var phoneTokens, emailTokens []string
+	for _, ph := range c.Phones {
+		norm := normalizePhone(ph.Value)
+		code, iso, country := resolvePhoneCountry(norm)
+		tx.Exec(`INSERT INTO contact_phones (contact_id, label, value, normalized, country_code, country_iso, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			c.ID, ph.Label, ph.Value, norm, code, iso, country)
+		phoneTokens = append(phoneTokens, ph.Value)
+	}
+	for _, em := range c.Emails {
+		domain := ""
+		if at := strings.LastIndex(em.Value, "@"); at >= 0 {
+			domain = strings.ToLower(em.Value[at+1:])
+		}
+		tx.Exec(`INSERT INTO contact_emails (contact_id, label, value, domain) VALUES (?, ?, ?, ?)`,
+			c.ID, em.Label, em.Value, domain)
+		emailTokens = append(emailTokens, em.Value)
+	}
+
+	body := strings.Join(filterEmpty(c.FirstName, c.LastName, c.Organization, c.JobTitle, c.Note,
+		strings.Join(phoneTokens, " "), strings.Join(emailTokens, " ")), " ")
+	tx.Exec(`INSERT INTO contacts_fts (id, body) VALUES (?, ?)`, c.ID, body)
+
+	return tx.Commit()
+}
+
+func (s *contactStore) loadRelations(c *Contact) error {
+	// phones
+	rows, err := s.db.Query(
+		`SELECT label, value, country_code, country_iso, country FROM contact_phones WHERE contact_id = ?`, c.ID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ph ContactPhone
+		var code, iso, country sql.NullString
+		if err := rows.Scan(&ph.Label, &ph.Value, &code, &iso, &country); err != nil {
+			return err
+		}
+		ph.CountryCode, ph.CountryISO, ph.Country = code.String, iso.String, country.String
+		c.Phones = append(c.Phones, ph)
+	}
+	rows.Close()
+
+	// emails
+	rows, err = s.db.Query(
+		`SELECT label, value, domain FROM contact_emails WHERE contact_id = ?`, c.ID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var em ContactEmail
+		var domain sql.NullString
+		if err := rows.Scan(&em.Label, &em.Value, &domain); err != nil {
+			return err
+		}
+		em.Domain = domain.String
+		c.Emails = append(c.Emails, em)
+	}
+	rows.Close()
+
+	// addresses
+	rows, err = s.db.Query(
+		`SELECT label, street, city, state, zip, country FROM contact_addresses WHERE contact_id = ?`, c.ID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var a ContactAddress
+		var street, city, state, zip, country sql.NullString
+		if err := rows.Scan(&a.Label, &street, &city, &state, &zip, &country); err != nil {
+			return err
+		}
+		a.Street, a.City, a.State, a.Zip, a.Country = street.String, city.String, state.String, zip.String, country.String
+		c.Addresses = append(c.Addresses, a)
+	}
+	rows.Close()
+
+	// urls
+	rows, err = s.db.Query(
+		`SELECT label, value FROM contact_urls WHERE contact_id = ?`, c.ID,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var u ContactURL
+		if err := rows.Scan(&u.Label, &u.Value); err != nil {
+			return err
+		}
+		c.URLs = append(c.URLs, u)
+	}
+	return rows.Err()
+}
+
+// ── analytics queries ─────────────────────────────────────────────────────────
+
+type CountryCount struct {
+	Country string `json:"country"`
+	ISO     string `json:"iso"`
+	Code    string `json:"country_code"`
+	Count   int    `json:"contacts"`
+	Phones  int    `json:"phones"`
+}
+
+func (s *contactStore) AnalyticsCountries() ([]CountryCount, error) {
+	rows, err := s.db.Query(`
+		SELECT country, country_iso, country_code,
+		       COUNT(DISTINCT contact_id) AS contacts,
+		       COUNT(*) AS phones
+		FROM contact_phones
+		WHERE country != '' AND country IS NOT NULL
+		GROUP BY country_iso
+		ORDER BY contacts DESC, phones DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CountryCount
+	for rows.Next() {
+		var r CountryCount
+		var iso, code sql.NullString
+		if err := rows.Scan(&r.Country, &iso, &code, &r.Count, &r.Phones); err != nil {
+			return nil, err
+		}
+		r.ISO = iso.String
+		r.Code = code.String
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+type DomainCount struct {
+	Domain string `json:"domain"`
+	Count  int    `json:"contacts"`
+}
+
+func (s *contactStore) AnalyticsDomains(limit int) ([]DomainCount, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+	rows, err := s.db.Query(`
+		SELECT domain, COUNT(DISTINCT contact_id) AS contacts
+		FROM contact_emails
+		WHERE domain != '' AND domain IS NOT NULL
+		GROUP BY domain
+		ORDER BY contacts DESC
+		LIMIT ?`, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []DomainCount
+	for rows.Next() {
+		var r DomainCount
+		if err := rows.Scan(&r.Domain, &r.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+type MissingStats struct {
+	Total    int `json:"total"`
+	NoPhone  int `json:"no_phone"`
+	NoEmail  int `json:"no_email"`
+	NoOrg    int `json:"no_org"`
+	NoName   int `json:"no_name"`
+}
+
+func (s *contactStore) AnalyticsMissing() (*MissingStats, error) {
+	var ms MissingStats
+	err := s.db.QueryRow(`
+		SELECT
+		  COUNT(*) AS total,
+		  SUM(CASE WHEN id NOT IN (SELECT DISTINCT contact_id FROM contact_phones) THEN 1 ELSE 0 END) AS no_phone,
+		  SUM(CASE WHEN id NOT IN (SELECT DISTINCT contact_id FROM contact_emails) THEN 1 ELSE 0 END) AS no_email,
+		  SUM(CASE WHEN organization IS NULL OR organization = '' THEN 1 ELSE 0 END) AS no_org,
+		  SUM(CASE WHEN (first_name IS NULL OR first_name = '') AND (last_name IS NULL OR last_name = '') THEN 1 ELSE 0 END) AS no_name
+		FROM contacts
+	`).Scan(&ms.Total, &ms.NoPhone, &ms.NoEmail, &ms.NoOrg, &ms.NoName)
+	return &ms, err
+}
+
+// ── phone country resolver ────────────────────────────────────────────────────
+
+type dialEntry struct {
+	prefix  string
+	iso     string
+	country string
+}
+
+// dialPrefixes is sorted longest-first at init time for correct prefix matching.
+var dialPrefixes []dialEntry
+
+func init() {
+	raw := []dialEntry{
+		// 4-digit NANP exceptions (must come before "+1")
+		{"+1242", "BS", "Bahamas"}, {"+1246", "BB", "Barbados"}, {"+1264", "AI", "Anguilla"},
+		{"+1268", "AG", "Antigua and Barbuda"}, {"+1284", "VG", "British Virgin Islands"},
+		{"+1340", "VI", "US Virgin Islands"}, {"+1345", "KY", "Cayman Islands"},
+		{"+1441", "BM", "Bermuda"}, {"+1473", "GD", "Grenada"}, {"+1649", "TC", "Turks and Caicos"},
+		{"+1664", "MS", "Montserrat"}, {"+1670", "MP", "N. Mariana Islands"}, {"+1671", "GU", "Guam"},
+		{"+1684", "AS", "American Samoa"}, {"+1721", "SX", "Sint Maarten"},
+		{"+1758", "LC", "Saint Lucia"}, {"+1767", "DM", "Dominica"},
+		{"+1784", "VC", "St. Vincent and the Grenadines"}, {"+1787", "PR", "Puerto Rico"},
+		{"+1809", "DO", "Dominican Republic"}, {"+1829", "DO", "Dominican Republic"},
+		{"+1849", "DO", "Dominican Republic"}, {"+1868", "TT", "Trinidad and Tobago"},
+		{"+1869", "KN", "Saint Kitts and Nevis"}, {"+1876", "JM", "Jamaica"},
+		{"+1939", "PR", "Puerto Rico"},
+		// 3-digit
+		{"+355", "AL", "Albania"}, {"+356", "MT", "Malta"}, {"+357", "CY", "Cyprus"},
+		{"+358", "FI", "Finland"}, {"+359", "BG", "Bulgaria"}, {"+370", "LT", "Lithuania"},
+		{"+371", "LV", "Latvia"}, {"+372", "EE", "Estonia"}, {"+373", "MD", "Moldova"},
+		{"+374", "AM", "Armenia"}, {"+375", "BY", "Belarus"}, {"+376", "AD", "Andorra"},
+		{"+377", "MC", "Monaco"}, {"+378", "SM", "San Marino"}, {"+380", "UA", "Ukraine"},
+		{"+381", "RS", "Serbia"}, {"+382", "ME", "Montenegro"}, {"+385", "HR", "Croatia"},
+		{"+386", "SI", "Slovenia"}, {"+387", "BA", "Bosnia and Herzegovina"},
+		{"+389", "MK", "North Macedonia"}, {"+420", "CZ", "Czech Republic"},
+		{"+421", "SK", "Slovakia"}, {"+423", "LI", "Liechtenstein"},
+		{"+501", "BZ", "Belize"}, {"+502", "GT", "Guatemala"}, {"+503", "SV", "El Salvador"},
+		{"+504", "HN", "Honduras"}, {"+505", "NI", "Nicaragua"}, {"+506", "CR", "Costa Rica"},
+		{"+507", "PA", "Panama"}, {"+509", "HT", "Haiti"}, {"+590", "GP", "Guadeloupe"},
+		{"+591", "BO", "Bolivia"}, {"+592", "GY", "Guyana"}, {"+593", "EC", "Ecuador"},
+		{"+595", "PY", "Paraguay"}, {"+597", "SR", "Suriname"}, {"+598", "UY", "Uruguay"},
+		{"+673", "BN", "Brunei"}, {"+675", "PG", "Papua New Guinea"}, {"+679", "FJ", "Fiji"},
+		{"+852", "HK", "Hong Kong"}, {"+853", "MO", "Macau"}, {"+855", "KH", "Cambodia"},
+		{"+856", "LA", "Laos"}, {"+880", "BD", "Bangladesh"}, {"+886", "TW", "Taiwan"},
+		{"+960", "MV", "Maldives"}, {"+961", "LB", "Lebanon"}, {"+962", "JO", "Jordan"},
+		{"+963", "SY", "Syria"}, {"+964", "IQ", "Iraq"}, {"+965", "KW", "Kuwait"},
+		{"+966", "SA", "Saudi Arabia"}, {"+967", "YE", "Yemen"}, {"+968", "OM", "Oman"},
+		{"+971", "AE", "United Arab Emirates"}, {"+972", "IL", "Israel"},
+		{"+973", "BH", "Bahrain"}, {"+974", "QA", "Qatar"}, {"+975", "BT", "Bhutan"},
+		{"+976", "MN", "Mongolia"}, {"+977", "NP", "Nepal"}, {"+992", "TJ", "Tajikistan"},
+		{"+993", "TM", "Turkmenistan"}, {"+994", "AZ", "Azerbaijan"}, {"+995", "GE", "Georgia"},
+		{"+996", "KG", "Kyrgyzstan"}, {"+998", "UZ", "Uzbekistan"},
+		// 2-digit
+		{"+20", "EG", "Egypt"}, {"+27", "ZA", "South Africa"}, {"+30", "GR", "Greece"},
+		{"+31", "NL", "Netherlands"}, {"+32", "BE", "Belgium"}, {"+33", "FR", "France"},
+		{"+34", "ES", "Spain"}, {"+36", "HU", "Hungary"}, {"+39", "IT", "Italy"},
+		{"+40", "RO", "Romania"}, {"+41", "CH", "Switzerland"}, {"+43", "AT", "Austria"},
+		{"+44", "GB", "United Kingdom"}, {"+45", "DK", "Denmark"}, {"+46", "SE", "Sweden"},
+		{"+47", "NO", "Norway"}, {"+48", "PL", "Poland"}, {"+49", "DE", "Germany"},
+		{"+51", "PE", "Peru"}, {"+52", "MX", "Mexico"}, {"+53", "CU", "Cuba"},
+		{"+54", "AR", "Argentina"}, {"+55", "BR", "Brazil"}, {"+56", "CL", "Chile"},
+		{"+57", "CO", "Colombia"}, {"+58", "VE", "Venezuela"}, {"+60", "MY", "Malaysia"},
+		{"+61", "AU", "Australia"}, {"+62", "ID", "Indonesia"}, {"+63", "PH", "Philippines"},
+		{"+64", "NZ", "New Zealand"}, {"+65", "SG", "Singapore"}, {"+66", "TH", "Thailand"},
+		{"+81", "JP", "Japan"}, {"+82", "KR", "South Korea"}, {"+84", "VN", "Vietnam"},
+		{"+86", "CN", "China"}, {"+90", "TR", "Turkey"}, {"+91", "IN", "India"},
+		{"+92", "PK", "Pakistan"}, {"+93", "AF", "Afghanistan"}, {"+94", "LK", "Sri Lanka"},
+		{"+95", "MM", "Myanmar"}, {"+98", "IR", "Iran"},
+		// 1-digit (catch-all, must be last)
+		{"+1", "US", "United States / Canada"}, {"+7", "RU", "Russia"},
+	}
+	// Sort longest prefix first so we match most-specific first.
+	sort.Slice(raw, func(i, j int) bool {
+		return len(raw[i].prefix) > len(raw[j].prefix)
+	})
+	dialPrefixes = raw
+}
+
+func normalizePhone(raw string) string {
+	raw = strings.TrimSpace(raw)
+	var b strings.Builder
+	for i, ch := range raw {
+		if ch == '+' && i == 0 {
+			b.WriteRune(ch)
+		} else if ch >= '0' && ch <= '9' {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+// resolvePhoneCountry returns (dialCode, ISO2, countryName) for a normalized phone number.
+func resolvePhoneCountry(normalized string) (code, iso, country string) {
+	if !strings.HasPrefix(normalized, "+") {
+		return "", "", ""
+	}
+	for _, e := range dialPrefixes {
+		if strings.HasPrefix(normalized, e.prefix) {
+			return e.prefix, e.iso, e.country
+		}
+	}
+	return "", "", ""
+}
+
+// cleanLabel converts Apple's internal label format "_$!<Mobile>!$_" → "mobile".
+func cleanLabel(label string) string {
+	if strings.HasPrefix(label, "_$!<") && strings.HasSuffix(label, ">!$_") {
+		label = label[4 : len(label)-4]
+	}
+	return strings.ToLower(strings.TrimSpace(label))
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func filterEmpty(ss ...string) []string {
+	var out []string
+	for _, s := range ss {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
@@ -500,16 +500,24 @@ func (s *contactStore) UpsertOne(c *Contact) error {
 		return err
 	}
 	for _, t := range []string{"contact_phones", "contact_emails", "contact_addresses", "contact_urls"} {
-		tx.Exec("DELETE FROM "+t+" WHERE contact_id = ?", c.ID)
+		if _, err := tx.Exec("DELETE FROM "+t+" WHERE contact_id = ?", c.ID); err != nil {
+			return fmt.Errorf("upsert: delete %s: %w", t, err)
+		}
 	}
-	tx.Exec("DELETE FROM contacts_fts WHERE id = ?", c.ID)
+	if _, err := tx.Exec("DELETE FROM contacts_fts WHERE id = ?", c.ID); err != nil {
+		return fmt.Errorf("upsert: delete fts: %w", err)
+	}
 
 	var phoneTokens, emailTokens []string
 	for _, ph := range c.Phones {
 		norm := normalizePhone(ph.Value)
 		code, iso, country := resolvePhoneCountry(norm)
-		tx.Exec(`INSERT INTO contact_phones (contact_id, label, value, normalized, country_code, country_iso, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-			c.ID, ph.Label, ph.Value, norm, code, iso, country)
+		if _, err := tx.Exec(
+			`INSERT INTO contact_phones (contact_id, label, value, normalized, country_code, country_iso, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			c.ID, ph.Label, ph.Value, norm, code, iso, country,
+		); err != nil {
+			return fmt.Errorf("upsert: insert phone: %w", err)
+		}
 		phoneTokens = append(phoneTokens, ph.Value)
 	}
 	for _, em := range c.Emails {
@@ -517,14 +525,20 @@ func (s *contactStore) UpsertOne(c *Contact) error {
 		if at := strings.LastIndex(em.Value, "@"); at >= 0 {
 			domain = strings.ToLower(em.Value[at+1:])
 		}
-		tx.Exec(`INSERT INTO contact_emails (contact_id, label, value, domain) VALUES (?, ?, ?, ?)`,
-			c.ID, em.Label, em.Value, domain)
+		if _, err := tx.Exec(
+			`INSERT INTO contact_emails (contact_id, label, value, domain) VALUES (?, ?, ?, ?)`,
+			c.ID, em.Label, em.Value, domain,
+		); err != nil {
+			return fmt.Errorf("upsert: insert email: %w", err)
+		}
 		emailTokens = append(emailTokens, em.Value)
 	}
 
 	body := strings.Join(filterEmpty(c.FirstName, c.LastName, c.Organization, c.JobTitle, c.Note,
 		strings.Join(phoneTokens, " "), strings.Join(emailTokens, " ")), " ")
-	tx.Exec(`INSERT INTO contacts_fts (id, body) VALUES (?, ?)`, c.ID, body)
+	if _, err := tx.Exec(`INSERT INTO contacts_fts (id, body) VALUES (?, ?)`, c.ID, body); err != nil {
+		return fmt.Errorf("upsert: insert fts: %w", err)
+	}
 
 	return tx.Commit()
 }

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
@@ -767,7 +767,7 @@ func (s *contactStore) UpsertOne(c *Contact) error {
 		emailTokens = append(emailTokens, em.Value)
 	}
 
-	body := strings.Join(filterEmpty(c.FirstName, c.LastName, c.Organization, c.JobTitle, c.Note,
+	body := strings.Join(filterEmpty(c.FirstName, c.MiddleName, c.LastName, c.Organization, c.JobTitle, c.Note,
 		strings.Join(phoneTokens, " "), strings.Join(emailTokens, " ")), " ")
 	if _, err := tx.Exec(`INSERT INTO contacts_fts (id, body) VALUES (?, ?)`, c.ID, body); err != nil {
 		return fmt.Errorf("upsert: insert fts: %w", err)

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
@@ -62,7 +62,8 @@ func (s *contactStore) migrate() error {
 			note         TEXT,
 			birthday     TEXT,
 			modified_at  TEXT,
-			synced_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+			synced_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+			uuid         TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_contacts_org      ON contacts(organization)`,
 		`CREATE INDEX IF NOT EXISTS idx_contacts_modified ON contacts(modified_at)`,
@@ -129,6 +130,10 @@ func (s *contactStore) migrate() error {
 			return fmt.Errorf("migrate: %w\nstmt: %s", err, stmt[:min(60, len(stmt))])
 		}
 	}
+	// Incremental migrations for existing databases (errors from ALTER TABLE are
+	// ignored — SQLite returns "duplicate column name" when column already exists).
+	s.db.Exec("ALTER TABLE contacts ADD COLUMN uuid TEXT")
+	s.db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_uuid ON contacts(uuid)")
 	return nil
 }
 
@@ -173,6 +178,15 @@ func str(v interface{}) string {
 	return strings.TrimSpace(s)
 }
 
+// extractUUID strips the ":ABPerson" (or similar) suffix from Apple's contact ID,
+// returning the bare UUID that serves as a shorter stable identifier.
+func extractUUID(appleID string) string {
+	if i := strings.LastIndex(appleID, ":"); i >= 0 {
+		return appleID[:i]
+	}
+	return appleID
+}
+
 // SyncAll replaces all contact data with the provided JXA-exported list.
 func (s *contactStore) SyncAll(contacts []jxaContact) (int, error) {
 	tx, err := s.db.Begin()
@@ -208,9 +222,9 @@ func (s *contactStore) SyncAll(contacts []jxaContact) (int, error) {
 		mod := str(c.ModifiedAt)
 
 		_, err := tx.Exec(
-			`INSERT INTO contacts (id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			c.ID, fn, ln, mn, org, jt, note, bday, mod, now,
+			`INSERT INTO contacts (id, uuid, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			c.ID, extractUUID(c.ID), fn, ln, mn, org, jt, note, bday, mod, now,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("insert contact %s: %w", c.ID, err)
@@ -311,6 +325,7 @@ func (s *contactStore) SyncAll(contacts []jxaContact) (int, error) {
 // Contact is the full contact record returned to CLI commands.
 type Contact struct {
 	ID           string           `json:"id"`
+	UUID         string           `json:"uuid,omitempty"`
 	FirstName    string           `json:"first_name"`
 	LastName     string           `json:"last_name,omitempty"`
 	MiddleName   string           `json:"middle_name,omitempty"`
@@ -385,7 +400,7 @@ func (s *contactStore) List(limit, offset int) ([]Contact, error) {
 		limit = 50
 	}
 	rows, err := s.db.Query(
-		`SELECT id, first_name, last_name, organization, synced_at
+		`SELECT id, uuid, first_name, last_name, organization, synced_at
 		 FROM contacts
 		 ORDER BY first_name, last_name
 		 LIMIT ? OFFSET ?`, limit, offset,
@@ -397,10 +412,11 @@ func (s *contactStore) List(limit, offset int) ([]Contact, error) {
 	var cs []Contact
 	for rows.Next() {
 		var c Contact
-		var ln, org, sa sql.NullString
-		if err := rows.Scan(&c.ID, &c.FirstName, &ln, &org, &sa); err != nil {
+		var uuidN, ln, org, sa sql.NullString
+		if err := rows.Scan(&c.ID, &uuidN, &c.FirstName, &ln, &org, &sa); err != nil {
 			return nil, err
 		}
+		c.UUID = uuidN.String
 		c.LastName = ln.String
 		c.Organization = org.String
 		c.SyncedAt = sa.String
@@ -419,21 +435,60 @@ func (s *contactStore) List(limit, offset int) ([]Contact, error) {
 
 func (s *contactStore) Get(id string) (*Contact, error) {
 	var c Contact
-	var ln, mn, org, jt, note, bday, mod, sa sql.NullString
+	var uuidN, ln, mn, org, jt, note, bday, mod, sa sql.NullString
 	err := s.db.QueryRow(
-		`SELECT id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at
+		`SELECT id, uuid, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at
 		 FROM contacts WHERE id = ?`, id,
-	).Scan(&c.ID, &c.FirstName, &ln, &mn, &org, &jt, &note, &bday, &mod, &sa)
+	).Scan(&c.ID, &uuidN, &c.FirstName, &ln, &mn, &org, &jt, &note, &bday, &mod, &sa)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+	c.UUID = uuidN.String
 	c.LastName, c.MiddleName, c.Organization = ln.String, mn.String, org.String
 	c.JobTitle, c.Note, c.Birthday = jt.String, note.String, bday.String
 	c.ModifiedAt, c.SyncedAt = mod.String, sa.String
 	return &c, s.loadRelations(&c)
+}
+
+// GetByAny resolves a contact by full Apple ID, bare UUID, or UUID prefix.
+// Returns an error if the prefix is ambiguous (matches >1 contact).
+func (s *contactStore) GetByAny(input string) (*Contact, error) {
+	// 1. Exact match on Apple ID (e.g. "UUID:ABPerson")
+	if strings.Contains(input, ":") {
+		return s.Get(input)
+	}
+	// 2. Exact UUID match
+	var id string
+	err := s.db.QueryRow("SELECT id FROM contacts WHERE uuid = ?", input).Scan(&id)
+	if err == nil {
+		return s.Get(id)
+	}
+	// 3. UUID prefix match — must be unique
+	rows, err := s.db.Query("SELECT id FROM contacts WHERE uuid LIKE ? || '%' LIMIT 3", input)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var rid string
+		if err := rows.Scan(&rid); err != nil {
+			return nil, err
+		}
+		ids = append(ids, rid)
+	}
+	rows.Close()
+	switch len(ids) {
+	case 0:
+		return nil, fmt.Errorf("no contact found for %q", input)
+	case 1:
+		return s.Get(ids[0])
+	default:
+		return nil, fmt.Errorf("ambiguous prefix %q matches %d contacts — use more characters", input, len(ids))
+	}
 }
 
 func (s *contactStore) Search(query string, limit int) ([]Contact, error) {
@@ -441,7 +496,7 @@ func (s *contactStore) Search(query string, limit int) ([]Contact, error) {
 		limit = 50
 	}
 	rows, err := s.db.Query(
-		`SELECT c.id, c.first_name, c.last_name, c.organization, c.synced_at
+		`SELECT c.id, c.uuid, c.first_name, c.last_name, c.organization, c.synced_at
 		 FROM contacts c
 		 JOIN contacts_fts f ON f.id = c.id
 		 WHERE contacts_fts MATCH ?
@@ -455,10 +510,11 @@ func (s *contactStore) Search(query string, limit int) ([]Contact, error) {
 	var cs []Contact
 	for rows.Next() {
 		var c Contact
-		var ln, org, sa sql.NullString
-		if err := rows.Scan(&c.ID, &c.FirstName, &ln, &org, &sa); err != nil {
+		var uuidN, ln, org, sa sql.NullString
+		if err := rows.Scan(&c.ID, &uuidN, &c.FirstName, &ln, &org, &sa); err != nil {
 			return nil, err
 		}
+		c.UUID = uuidN.String
 		c.LastName, c.Organization, c.SyncedAt = ln.String, org.String, sa.String
 		cs = append(cs, c)
 	}
@@ -482,6 +538,183 @@ func (s *contactStore) Delete(id string) error {
 	return err
 }
 
+// ── duplicates & merge ────────────────────────────────────────────────────────
+
+// DuplicatePair is a pair of contacts that may be duplicates.
+type DuplicatePair struct {
+	Reason string  `json:"reason"`
+	A      Contact `json:"a"`
+	B      Contact `json:"b"`
+}
+
+// FindDuplicates returns candidate duplicate pairs grouped by detection reason.
+// Checks: exact name, same-first-with-prefix-last, same phone, same email.
+func (s *contactStore) FindDuplicates() ([]DuplicatePair, error) {
+	seen := map[string]bool{} // dedup pair keys (idA+idB)
+	var pairs []DuplicatePair
+
+	addPair := func(reason, idA, idB string) {
+		key := idA + "|" + idB
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		a, err := s.Get(idA)
+		if err != nil || a == nil {
+			return
+		}
+		b, err := s.Get(idB)
+		if err != nil || b == nil {
+			return
+		}
+		pairs = append(pairs, DuplicatePair{Reason: reason, A: *a, B: *b})
+	}
+
+	// Exact name match (case-insensitive, non-empty names)
+	rows, err := s.db.Query(`
+		SELECT a.id, b.id
+		FROM contacts a JOIN contacts b ON a.id < b.id
+		WHERE a.first_name != '' AND a.last_name != ''
+		  AND LOWER(a.first_name) = LOWER(b.first_name)
+		  AND LOWER(a.last_name)  = LOWER(b.last_name)
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var idA, idB string
+		if err := rows.Scan(&idA, &idB); err != nil {
+			return nil, err
+		}
+		addPair("exact_name", idA, idB)
+	}
+	rows.Close()
+
+	// Same first name, one last name is a prefix of the other (e.g. "Gomes" vs "Gomes SF")
+	rows, err = s.db.Query(`
+		SELECT a.id, b.id
+		FROM contacts a JOIN contacts b ON a.id < b.id
+		WHERE a.first_name != '' AND b.first_name != ''
+		  AND LOWER(a.first_name) = LOWER(b.first_name)
+		  AND a.last_name != b.last_name
+		  AND (LOWER(b.last_name) LIKE LOWER(a.last_name) || ' %'
+		    OR LOWER(a.last_name) LIKE LOWER(b.last_name) || ' %')
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var idA, idB string
+		if err := rows.Scan(&idA, &idB); err != nil {
+			return nil, err
+		}
+		addPair("similar_name", idA, idB)
+	}
+	rows.Close()
+
+	// Same normalized phone number
+	rows, err = s.db.Query(`
+		SELECT DISTINCT pa.contact_id, pb.contact_id, pa.normalized
+		FROM contact_phones pa
+		JOIN contact_phones pb ON pa.normalized = pb.normalized
+		  AND pa.contact_id < pb.contact_id
+		WHERE pa.normalized != ''
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var idA, idB, norm string
+		if err := rows.Scan(&idA, &idB, &norm); err != nil {
+			return nil, err
+		}
+		addPair("same_phone:"+norm, idA, idB)
+	}
+	rows.Close()
+
+	// Same email address (case-insensitive)
+	rows, err = s.db.Query(`
+		SELECT DISTINCT ea.contact_id, eb.contact_id, LOWER(ea.value)
+		FROM contact_emails ea
+		JOIN contact_emails eb ON LOWER(ea.value) = LOWER(eb.value)
+		  AND ea.contact_id < eb.contact_id
+		WHERE ea.value != ''
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var idA, idB, email string
+		if err := rows.Scan(&idA, &idB, &email); err != nil {
+			return nil, err
+		}
+		addPair("same_email:"+email, idA, idB)
+	}
+	rows.Close()
+
+	return pairs, nil
+}
+
+// MergeIntoStore merges the absorbed contact's data into the primary contact
+// in the local SQLite store. Call this after the Contacts.app merge has already
+// been performed via AppleScript. Deduplicates phones by normalized number and
+// emails by lowercase value; appends all addresses, URLs, and the note.
+func (s *contactStore) MergeIntoStore(primaryID, absorbedID string) (*Contact, error) {
+	primary, err := s.Get(primaryID)
+	if err != nil || primary == nil {
+		return nil, fmt.Errorf("primary contact not found: %s", primaryID)
+	}
+	absorbed, err := s.Get(absorbedID)
+	if err != nil || absorbed == nil {
+		return nil, fmt.Errorf("absorbed contact not found: %s", absorbedID)
+	}
+
+	// Deduplicated phone merge
+	phoneSet := map[string]bool{}
+	for _, ph := range primary.Phones {
+		phoneSet[normalizePhone(ph.Value)] = true
+	}
+	for _, ph := range absorbed.Phones {
+		if norm := normalizePhone(ph.Value); !phoneSet[norm] {
+			primary.Phones = append(primary.Phones, ph)
+			phoneSet[norm] = true
+		}
+	}
+
+	// Deduplicated email merge
+	emailSet := map[string]bool{}
+	for _, em := range primary.Emails {
+		emailSet[strings.ToLower(em.Value)] = true
+	}
+	for _, em := range absorbed.Emails {
+		if !emailSet[strings.ToLower(em.Value)] {
+			primary.Emails = append(primary.Emails, em)
+			emailSet[strings.ToLower(em.Value)] = true
+		}
+	}
+
+	// Append addresses and URLs without dedup (addresses are complex to compare)
+	primary.Addresses = append(primary.Addresses, absorbed.Addresses...)
+	primary.URLs = append(primary.URLs, absorbed.URLs...)
+
+	// Append note (separated by a divider)
+	if absorbed.Note != "" {
+		if primary.Note == "" {
+			primary.Note = absorbed.Note
+		} else {
+			primary.Note = primary.Note + "\n---\n" + absorbed.Note
+		}
+	}
+
+	if err := s.UpsertOne(primary); err != nil {
+		return nil, fmt.Errorf("upsert merged contact: %w", err)
+	}
+	if err := s.Delete(absorbedID); err != nil {
+		return nil, fmt.Errorf("delete absorbed contact from store: %w", err)
+	}
+	return primary, nil
+}
+
 // UpsertOne inserts or replaces a single contact (used after create/update via AppleScript).
 func (s *contactStore) UpsertOne(c *Contact) error {
 	tx, err := s.db.Begin()
@@ -492,9 +725,9 @@ func (s *contactStore) UpsertOne(c *Contact) error {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err = tx.Exec(
-		`INSERT OR REPLACE INTO contacts (id, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		c.ID, c.FirstName, c.LastName, c.MiddleName, c.Organization, c.JobTitle, c.Note, c.Birthday, c.ModifiedAt, now,
+		`INSERT OR REPLACE INTO contacts (id, uuid, first_name, last_name, middle_name, organization, job_title, note, birthday, modified_at, synced_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.ID, extractUUID(c.ID), c.FirstName, c.LastName, c.MiddleName, c.Organization, c.JobTitle, c.Note, c.Birthday, c.ModifiedAt, now,
 	)
 	if err != nil {
 		return err

--- a/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
+++ b/library/media-and-entertainment/icloud/internal/cli/contacts_db.go
@@ -466,8 +466,9 @@ func (s *contactStore) GetByAny(input string) (*Contact, error) {
 	if err == nil {
 		return s.Get(id)
 	}
-	// 3. UUID prefix match — must be unique
-	rows, err := s.db.Query("SELECT id FROM contacts WHERE uuid LIKE ? || '%' LIMIT 3", input)
+	// 3. UUID prefix match — must be unique. Escape SQLite LIKE wildcards
+	// (% and _) in the input so callers can't broaden the match.
+	rows, err := s.db.Query(`SELECT id FROM contacts WHERE uuid LIKE ? || '%' ESCAPE '\' LIMIT 3`, escapeLike(input))
 	if err != nil {
 		return nil, err
 	}
@@ -765,6 +766,22 @@ func (s *contactStore) UpsertOne(c *Contact) error {
 			return fmt.Errorf("upsert: insert email: %w", err)
 		}
 		emailTokens = append(emailTokens, em.Value)
+	}
+	for _, addr := range c.Addresses {
+		if _, err := tx.Exec(
+			`INSERT INTO contact_addresses (contact_id, label, street, city, state, zip, country) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			c.ID, addr.Label, addr.Street, addr.City, addr.State, addr.Zip, addr.Country,
+		); err != nil {
+			return fmt.Errorf("upsert: insert address: %w", err)
+		}
+	}
+	for _, u := range c.URLs {
+		if _, err := tx.Exec(
+			`INSERT INTO contact_urls (contact_id, label, value) VALUES (?, ?, ?)`,
+			c.ID, u.Label, u.Value,
+		); err != nil {
+			return fmt.Errorf("upsert: insert url: %w", err)
+		}
 	}
 
 	body := strings.Join(filterEmpty(c.FirstName, c.MiddleName, c.LastName, c.Organization, c.JobTitle, c.Note,

--- a/library/media-and-entertainment/icloud/internal/cli/root.go
+++ b/library/media-and-entertainment/icloud/internal/cli/root.go
@@ -58,6 +58,7 @@ Pipe any command for automatic JSON output.`,
 
 	root.AddCommand(newPhotosCmd(f))
 	root.AddCommand(newMessagesCmd(f))
+	root.AddCommand(newContactsCmd(f))
 	root.AddCommand(newDoctorCmd(f))
 
 	return root.Execute()


### PR DESCRIPTION
## icloud

Adds a `contacts` command group to `icloud-pp-cli`, giving agents and power users instant access to macOS Contacts data via a local SQLite cache populated from Contacts.app.

**API:** macOS Contacts (local, via JXA) | **Category:** media-and-entertainment | **Press version:** 0.1.3

### CLI Shape

```
contacts sync                  Sync contacts from Contacts.app into local SQLite cache
contacts list                  List contacts from local cache
contacts get <id>              Get full details for a contact by UUID
contacts search <query>        Full-text search across name, org, phone, and email
contacts create                Create a new contact in Contacts.app
contacts update <id>           Update fields on an existing contact
contacts delete <id>           Delete a contact from Contacts.app (permanent)
contacts analytics countries   Contacts by country, resolved from phone number prefix
contacts analytics domains     Top email domains across your contacts
contacts analytics missing     Coverage report: contacts missing phone, email, or name
```

### What This CLI Does

Bridges macOS Contacts.app into a local SQLite store for instant querying. A one-time `contacts sync` pulls all contacts via a single JXA (JavaScript for Automation) call — no Full Disk Access permission required — and stores them in `~/Library/Application Support/icloud-pp-cli/contacts.db` with FTS5 full-text indexing. All subsequent reads (`list`, `search`, `get`, analytics) hit SQLite directly and respond in under 20ms regardless of library size. Write operations (`create`, `update`, `delete`) go through osascript to Contacts.app and update the local cache in the same transaction.

The `contacts analytics countries` command resolves phone numbers to countries via longest-prefix E.164 dial-code matching (100+ prefixes), enabling geographic distribution analysis of your contact network without any network call.

### Validation Results

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `contacts sync` (1,648 contacts) | PASS — synced successfully |
| `contacts analytics countries` | PASS — 47 countries resolved |
| `contacts search "juan"` | PASS — 21 results in 13ms via FTS5 |
| `contacts create / update / delete` | PASS — confirmed via osascript round-trip |
| Patch recorded in `.printing-press-patches.json` | PASS |

### Gaps

- Initial sync takes ~14 minutes for ~1,600 contacts due to JXA bridge overhead. An incremental sync (filter by `modifiedAt` since last sync) is the planned follow-up.
- `contacts send` (iMessage via Contacts) is not included in this PR — that belongs in the `messages` command group.