### PR TITLE
fix(registry): correct roam MCP metadata and clarity display name

### DIFF
--- a/library/marketing/clarity/.printing-press.json
+++ b/library/marketing/clarity/.printing-press.json
@@ -3,7 +3,7 @@
   "generated_at": "2026-05-08T16:22:19.253591Z",
   "printing_press_version": "4.0.1",
   "api_name": "clarity",
-  "display_name": "PP Clarity",
+  "display_name": "Microsoft Clarity",
   "cli_name": "clarity-pp-cli",
   "owner": "user",
   "printer": "cathrynlavery",

--- a/library/productivity/roam/.printing-press.json
+++ b/library/productivity/roam/.printing-press.json
@@ -13,7 +13,10 @@
   "run_id": "20260508-223718",
   "category": "productivity",
   "description": "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output.",
-  "mcp_binary": "roam-pp-cli",
+  "mcp_binary": "roam-pp-mcp",
+  "mcp_tool_count": 85,
+  "mcp_public_tool_count": 85,
+  "mcp_ready": "full",
   "api_version": "1.0.0",
   "auth_type": "bearer",
   "auth_env_vars": [

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -722,6 +722,12 @@ func isStaleAPIValue(prior, displayName, slug string) bool {
 	if prior == titleCaseSlug(slug) {
 		return true
 	}
+	// A "PP "-prefixed prior is a printing-press infix artifact that
+	// leaked into the api label (e.g. "PP Clarity"); a corrected
+	// display_name without that prefix supersedes it.
+	if strings.HasPrefix(prior, "PP ") && !strings.HasPrefix(displayName, "PP ") {
+		return true
+	}
 	if strings.HasSuffix(displayName, " "+prior) && !strings.Contains(prior, " ") {
 		return true
 	}

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -722,10 +722,14 @@ func isStaleAPIValue(prior, displayName, slug string) bool {
 	if prior == titleCaseSlug(slug) {
 		return true
 	}
-	// A "PP "-prefixed prior is a printing-press infix artifact that
-	// leaked into the api label (e.g. "PP Clarity"); a corrected
-	// display_name without that prefix supersedes it.
-	if strings.HasPrefix(prior, "PP ") && !strings.HasPrefix(displayName, "PP ") {
+	// A "PP "-prefixed prior is a printing-press infix artifact when the
+	// prior is exactly "PP " + the tail of the corrected display_name
+	// (e.g. prior="PP Clarity", display="Microsoft Clarity", tail="Clarity").
+	// Scoping to that structural match supersedes the leaked prefix while
+	// leaving a legitimately curated brand that merely starts with "PP "
+	// (e.g. "PP Labs") untouched when the display_name doesn't share its tail.
+	if strings.HasPrefix(prior, "PP ") && !strings.HasPrefix(displayName, "PP ") &&
+		strings.HasSuffix(displayName, strings.TrimPrefix(prior, "PP ")) {
 		return true
 	}
 	if strings.HasSuffix(displayName, " "+prior) && !strings.Contains(prior, " ") {

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -225,6 +225,13 @@ func TestAPIDisplayName(t *testing.T) {
 			slug:  "servicetitan-pricebook",
 			want:  "ServiceTitan Pricebook",
 		},
+		{
+			name:  "PP-prefixed artifact yields to corrected display name",
+			pp:    printingPressManifest{APIName: "clarity", DisplayName: "Microsoft Clarity"},
+			prior: RegistryEntry{API: "PP Clarity"},
+			slug:  "clarity",
+			want:  "Microsoft Clarity",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -232,6 +232,13 @@ func TestAPIDisplayName(t *testing.T) {
 			slug:  "clarity",
 			want:  "Microsoft Clarity",
 		},
+		{
+			name:  "PP-prefixed brand without shared tail is preserved",
+			pp:    printingPressManifest{APIName: "pp-labs", DisplayName: "Acme Widgets"},
+			prior: RegistryEntry{API: "PP Labs"},
+			slug:  "pp-labs",
+			want:  "PP Labs",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Two registry entries were shipping wrong metadata, both traced to `.printing-press.json` drift (not CLI code), plus a generator fix so the clarity correction actually takes effect on regen.

### roam — malformed MCP block

The registry block for `roam` was malformed: `binary: roam-pp-cli` (the CLI binary, not the MCP binary), `tool_count: 0`, `public_tool_count: 0`, no `mcp_ready`.

**This was not a CLI code bug.** The roam CLI and its MCP server both build cleanly, and the MCP server actually serves **85 tools** (verified by booting it and calling `tools/list`). The defect was entirely in `library/productivity/roam/.printing-press.json`:

| Field | Was | Now |
|---|---|---|
| `mcp_binary` | `roam-pp-cli` | `roam-pp-mcp` |
| `mcp_tool_count` | *(absent → 0)* | `85` |
| `mcp_public_tool_count` | *(absent → 0)* | `85` |
| `mcp_ready` | *(absent → omitted)* | `full` |

`.goreleaser.yaml` already builds a separate `roam-pp-mcp` target and `cmd/roam-pp-mcp/main.go` exists — only the manifest field pointed at the wrong binary. The generator copies these straight through, so bad manifest → bad registry block.

### clarity — "PP Clarity" display name

`library/marketing/clarity/.printing-press.json` carried `display_name: "PP Clarity"` — the printing-press `PP` infix leaked into the human-facing label. Corrected to **"Microsoft Clarity"** (the `api_name` and description confirm the API).

The registry generator prefers the prior curated `api` value over the manifest's `display_name`, so the manifest edit alone wouldn't propagate. Taught `isStaleAPIValue` to treat a `"PP "`-prefixed prior as a printing-press artifact that a corrected `display_name` supersedes, with a regression test.

## Scope

Both defects are **one-off** — no other CLI has `mcp_binary == cli_name` or a `"PP "`-prefixed api value (verified by grep across the library), so these are library-side repairs per AGENTS.md, not a template sweep.

## Generated artifacts

`registry.json` and root `README.md` are **not** in this PR — they regenerate post-merge from the edited `.printing-press.json` sources via `generate-registry.yml`. Verified locally with a dry-run regen that both entries come out correct.

## Validation

- `go test ./...` in `tools/generate-registry/` — pass (incl. new `isStaleAPIValue` case)
- Dry-run `go run ./tools/generate-registry/main.go` → `clarity` api = `Microsoft Clarity`, `roam` mcp.binary = `roam-pp-mcp` / tool_count = 85 / mcp_ready = full
- roam `go build ./...` and `go build ./cmd/roam-pp-mcp` — pass
- roam MCP `tools/list` over stdio — 85 tools