### PR TITLE
docs(allrecipes): drop Cloudflare clearance from CLI description

### DIFF
--- a/library/food-and-dining/allrecipes/README.md
+++ b/library/food-and-dining/allrecipes/README.md
@@ -1,6 +1,6 @@
 # Allrecipes CLI
 
-**Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, one-line grocery lists, and Cloudflare clearance.**
+**Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, and one-line grocery lists.**
 
 Search Allrecipes' 250k-recipe corpus from the command line, fetch a full recipe as parsed JSON-LD (ingredients with quantity+unit+name, instructions, nutrition, ratings, Made-It count), aggregate grocery lists from a meal plan, scale recipes, and export to clean markdown. Every recipe you fetch lands in a local SQLite store, which unlocks `pantry` (which recipes can I cook with what I have), `with-ingredient` (reverse index), `top-rated` with Bayesian smoothing (no more 1-review 5-star noise), and `cookbook` (export a category as a personal cookbook). Recipe detail pages are walled by Cloudflare; one-time `auth login --chrome` captures a clearance cookie from your browser — no Allrecipes account needed.
 

--- a/library/food-and-dining/allrecipes/SKILL.md
+++ b/library/food-and-dining/allrecipes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-allrecipes
-description: "Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, one-line grocery lists, and Cloudflare clearance. Trigger phrases: `search Allrecipes for X`, `find a recipe for brownies`, `scale this Allrecipes recipe`, `build a grocery list from these recipes`, `what can I cook with what I have`, `use allrecipes-pp-cli`, `run allrecipes`."
+description: "Every Allrecipes recipe in your terminal — cached as data, with pantry-aware search, Bayesian-smoothed ranking, and one-line grocery lists. Trigger phrases: `search Allrecipes for X`, `find a recipe for brownies`, `scale this Allrecipes recipe`, `build a grocery list from these recipes`, `what can I cook with what I have`, `use allrecipes-pp-cli`, `run allrecipes`."
 author: "Trevin Chow"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/library/food-and-dining/allrecipes/manifest.json
+++ b/library/food-and-dining/allrecipes/manifest.json
@@ -3,7 +3,7 @@
   "name": "allrecipes-pp-mcp",
   "display_name": "Allrecipes",
   "version": "3.8.0",
-  "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, rank by Bayesian-smoothed popularity, and clear Cloudflare with a Chrome session cookie.",
+  "description": "Search and fetch Allrecipes recipes as structured data, scale ingredients, build grocery lists, and rank by Bayesian-smoothed popularity.",
   "author": {
     "name": "CLI Printing Press"
   },


### PR DESCRIPTION
Removes "Cloudflare clearance" from the Allrecipes CLI's headline descriptions. It was listed as a top-level feature in the registry one-liner and the SKILL.md/README taglines, but it's a bot-protection implementation detail — not something a user picks the CLI for — and it reads oddly in a one-line catalog blurb (`…and clear Cloudflare with a Chrome session cookie.`).

The accurate *functional* references stay: the `doctor` command's interstitial diagnosis, the `auth login --chrome` clearance-cookie flow, and the troubleshooting notes all correctly describe how the CLI fetches Cloudflare-walled recipe-detail pages.

### What changed

- **`manifest.json`** — the registry one-liner (source of truth for `registry.json`, which regenerates post-merge). Dropped the trailing `, and clear Cloudflare with a Chrome session cookie.`
- **`SKILL.md`** frontmatter `description` — feature list now ends at `, and one-line grocery lists.`
- **`README.md`** tagline — same trim.

No code touched, so no `.printing-press-patches.json` entry is needed (that manifest is for code-level customizations). `registry.json` and `cli-skills/pp-allrecipes/SKILL.md` are generated artifacts and are intentionally not in this diff — they re-mirror from these sources post-merge.
