### PR TITLE
fix(squarespace): correct printer attribution

### DIFF
--- a/library/commerce/squarespace/.printing-press.json
+++ b/library/commerce/squarespace/.printing-press.json
@@ -7,7 +7,7 @@
   "cli_name": "squarespace-pp-cli",
   "run_id": "20260512-123445",
   "owner": "user",
-  "printer": "zayd",
+  "printer": "zaydiscold",
   "printer_name": "Zayd",
   "spec_path": "spec.json",
   "spec_format": "openapi",

--- a/library/commerce/squarespace/SKILL.md
+++ b/library/commerce/squarespace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pp-squarespace
 description: "Squarespace Commerce plus browser-backed account domains, DNS, email forwarding, and billing reads."
-author: "zayd"
+author: "Zayd"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"

--- a/tools/generate-registry/main.go
+++ b/tools/generate-registry/main.go
@@ -965,17 +965,22 @@ func renderCatalogTable(entries []RegistryEntry) string {
 }
 
 // printerSuffix returns the markdown suffix that visibly credits the
-// printer in the catalog row's description cell. Renders as
-// `<br><sub>Printed by @handle</sub>` when a Printer is set; empty
-// otherwise. Folded into the description cell rather than added as a
-// new column to avoid widening the existing 4-column table (every
-// entry has a description; not every entry has a printer until the
-// backfill follow-up issue ships).
+// printer in the catalog row's description cell. Renders the prose
+// display name when one is set and links it to the GitHub handle stored
+// in Printer; falls back to `@handle` when no display name is present.
+// Folded into the description cell rather than added as a new column to
+// avoid widening the existing 4-column table (every entry has a
+// description; not every entry has a printer until the backfill
+// follow-up issue ships).
 func printerSuffix(e RegistryEntry) string {
 	if e.Printer == "" {
 		return ""
 	}
-	return fmt.Sprintf("<br><sub>Printed by [@%s](https://github.com/%s)</sub>", e.Printer, e.Printer)
+	label := strings.TrimSpace(e.PrinterName)
+	if label == "" {
+		label = "@" + e.Printer
+	}
+	return fmt.Sprintf("<br><sub>Printed by [%s](https://github.com/%s)</sub>", label, e.Printer)
 }
 
 // renderCatalogCounts returns the "N CLIs across M categories." line

--- a/tools/generate-registry/main_test.go
+++ b/tools/generate-registry/main_test.go
@@ -37,6 +37,48 @@ func TestRenderCatalogTable_Golden(t *testing.T) {
 	}
 }
 
+func TestRenderCatalogTable_PrinterDisplayNameLinksToHandle(t *testing.T) {
+	entries := []RegistryEntry{
+		{
+			Name:        "squarespace",
+			Category:    "commerce",
+			API:         "Squarespace",
+			Description: "Manage Squarespace commerce and account workflows.",
+			Path:        "library/commerce/squarespace",
+			Printer:     "zaydiscold",
+			PrinterName: "Zayd",
+		},
+	}
+
+	got := renderCatalogTable(entries)
+
+	if !strings.Contains(got, "Printed by [Zayd](https://github.com/zaydiscold)") {
+		t.Fatalf("catalog should render printer_name as link text and printer as URL handle, got:\n%s", got)
+	}
+	if strings.Contains(got, "Printed by [@zaydiscold]") {
+		t.Fatalf("catalog should not use handle as link text when printer_name is present, got:\n%s", got)
+	}
+}
+
+func TestRenderCatalogTable_PrinterHandleFallback(t *testing.T) {
+	entries := []RegistryEntry{
+		{
+			Name:        "example",
+			Category:    "tools",
+			API:         "Example",
+			Description: "Example workflows.",
+			Path:        "library/tools/example",
+			Printer:     "octocat",
+		},
+	}
+
+	got := renderCatalogTable(entries)
+
+	if !strings.Contains(got, "Printed by [@octocat](https://github.com/octocat)") {
+		t.Fatalf("catalog should fall back to @handle link text when printer_name is absent, got:\n%s", got)
+	}
+}
+
 // TestFormatDescription covers the normalization rules: trim, collapse
 // newlines (a description must fit one table cell), and ensure
 // terminal punctuation. The "?" / "!" branch matters because some


### PR DESCRIPTION
## Summary
- correct Squarespace printer handle from `zayd` to `zaydiscold`
- keep the display attribution as `Zayd` in both `.printing-press.json` and `SKILL.md`
- update the README catalog generator so `printer_name` is rendered as the visible byline while `printer` remains the GitHub link target

## Validation
- `python3 .github/scripts/verify-attribution/verify_attribution.py --base origin/main --head HEAD`
- `python3 .github/scripts/verify-publish-package/verify_publish_package.py --base-ref origin/main`
- `python3 .github/scripts/verify-binary-payload/verify_binary_payload.py --base-ref origin/main`
- `python3 .github/scripts/verify-press-version/verify_press_version.py --base-ref origin/main`
- `go run ./tools/generate-registry/main.go --validate squarespace`
- `(cd tools/generate-registry && go test ./...)`

## Generated artifacts
This PR intentionally does not touch `registry.json` or `cli-skills/pp-*/SKILL.md`; those are regenerated post-merge by the existing workflows.
