### PR TITLE
feat(contact-goat): add local LinkedIn network source

### DIFF
--- a/library/sales-and-crm/contact-goat/.printing-press-patches.json
+++ b/library/sales-and-crm/contact-goat/.printing-press-patches.json
@@ -3,5 +3,21 @@
   "applied_at": "2026-05-08",
   "base_run_id": "2026-04-19T21:05:44.741872Z",
   "base_printing_press_version": "1.3.2",
-  "patches": []
+  "patches": [
+    {
+      "id": "2026-05-28-local-linkedin-network-source",
+      "kind": "code",
+      "summary": "Add a local LinkedIn Network source backed by James/Holger CSV exports on the Mac Mini. The source shells to the linkedin-network CLI JSON output, maps rows into flagshipPerson, and wires local-first results into coverage, prospect, and warm-intro without directly reading SQLite or silently spending Happenstance credits on local-source failure.",
+      "files": [
+        "internal/cli/local_linkedin_network.go",
+        "internal/cli/local_linkedin_network_test.go",
+        "internal/cli/coverage.go",
+        "internal/cli/prospect.go",
+        "internal/cli/warm_intro.go",
+        "internal/cli/flagship_helpers.go",
+        "internal/cli/source_selection.go",
+        "SKILL.md"
+      ]
+    }
+  ]
 }

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-contact-goat
-description: "Super LinkedIn for the terminal. Search, enrich, and map warm-intro paths across LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (cookie-first free quota with bearer-API fallback), and Deepline (paid enrichment). Two Happenstance auth surfaces coexist: Chrome cookie session (free monthly allocation) and HAPPENSTANCE_API_KEY bearer (paid credits, deeper schema). Use when the user asks who they know at a company, how to get a warm intro, who to prospect, or wants cross-source dossiers, network diffs, or waterfall enrichment."
+description: "Super LinkedIn for the terminal. Search, enrich, and map warm-intro paths across the local LinkedIn Network export database, LinkedIn (stickerdaniel/linkedin-mcp-server subprocess), Happenstance (cookie-first free quota with bearer-API fallback), and Deepline (paid enrichment). Use when the user asks who they know at a company, how to get a warm intro, who to prospect, or wants cross-source dossiers, network diffs, or waterfall enrichment."
 author: "Matt Van Horn"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
@@ -49,6 +49,28 @@ Reach for this when the user wants:
 - waterfall enrichment that walks free sources before paid ones
 
 Skip it when the user has a workflow that lives entirely inside LinkedIn Sales Navigator, or when they only need raw LinkedIn scraping with no Happenstance or Deepline overlay (use the LinkedIn MCP directly in that case).
+
+## Local LinkedIn Network First
+
+For Playmaker prospecting, Contact Goat now checks the local LinkedIn Network export database before paid or remote graph sources.
+
+Default local database host/path:
+
+```text
+macmini:/Users/gonkv2/Documents/Agentic Engineering/Playmaker/LinkedIn-Network
+```
+
+The local source reads James and Holger's first-degree LinkedIn exports and emits Contact Goat-shaped rows with `sources: ["local_linkedin_export"]`, `owners`, `relationship`, `rationale`, and `score`.
+
+Useful local-first commands:
+
+```bash
+contact-goat-pp-cli coverage "<company>" --source local --agent
+contact-goat-pp-cli prospect "<query>" --source local --agent
+contact-goat-pp-cli warm-intro "<target>" --sources local --agent
+```
+
+`local` and `ln` are aliases for this source. If the local Mac Mini database or CLI is unavailable, surface that local failure first. Do not silently spend Happenstance credits just because the local source is unavailable.
 
 ## Two Auth Surfaces
 
@@ -104,7 +126,7 @@ The other 12 tools cover the cookie surface (search, friends, feed, notification
    ```
 5. The `--agent` flag sets `--json --compact --no-input --no-color --yes`.
 
-Source routing (cookie vs bearer) is automatic. The auto router prefers the free cookie surface and falls back to the paid bearer surface only when cookie quota is exhausted, logging a "cost spent" notice on stderr. Pass `--source api` to opt into bearer explicitly (richer schema, group-scoped searches), or `--source hp` to force cookies.
+Source routing for Happenstance (cookie vs bearer) is automatic. The auto router prefers the free cookie surface and falls back to the paid bearer surface only when cookie quota is exhausted, logging a "cost spent" notice on stderr. Pass `--source api` to opt into bearer explicitly (richer schema, group-scoped searches), `--source hp` to force cookies, or `--source local` / `--source ln` on supported commands to use the Mac Mini LinkedIn Network source without Happenstance.
 
 ## Enrichment Preflight (read this before running any enrichment command)
 
@@ -148,11 +170,11 @@ Notes:
 
 | Command | What it does |
 |---------|--------------|
-| `coverage <company>` | Who you know at a company across LinkedIn + Happenstance, ranked by relationship strength |
+| `coverage <company>` | Who you know at a company across local LinkedIn exports + LinkedIn + Happenstance, ranked by relationship strength. Use `--source local` or `--source ln` for local-only. |
 | `coverage --location <city>` | Who you know in a city. Bearer-only (cookie surface has no city-search); use `--source api`. |
 | `hp people <query>` | Happenstance graph people-search (1st / 2nd / 3rd degree). `--csv` emits flat CSV with semicolon-joined bridges. |
-| `prospect <query>` | Fan-out search across LinkedIn + Happenstance (+ opt-in Deepline), deduped |
-| `warm-intro <target>` | Mutual connections across sources who could intro you to a target |
+| `prospect <query>` | Fan-out search across local LinkedIn exports + LinkedIn + Happenstance (+ opt-in Deepline), deduped. Use `--source local` or `--source ln` for local-only. |
+| `warm-intro <target>` | Mutual connections across local LinkedIn export owners, LinkedIn, and Happenstance who could intro you to a target. Use `--sources local` for local-only. |
 | `waterfall <target> [--company X]` | Free-sources-first enrichment, falls through to Deepline provider chain. Requires DEEPLINE_API_KEY or --byok. Bare-name targets need --company |
 | `dossier <target> [--enrich-email]` | Unified LinkedIn + Happenstance + (optional) Deepline dossier. --enrich-email requires DEEPLINE_API_KEY |
 | `deepline find-email "<name>" --company <domain>` | Single-call work-email lookup via dropleads_email_finder |

--- a/library/sales-and-crm/contact-goat/internal/cli/coverage.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/coverage.go
@@ -39,18 +39,21 @@ already runs).
 
 Runs the following (in parallel where supported):
 
-  1. Happenstance graph-search (/api/search + /api/dynamo): the real
+  1. Local LinkedIn Network export database on the Mac Mini: James and
+     Holger's first-degree LinkedIn exports, queried locally before paid
+     or remote graph sources.
+  2. Happenstance graph-search (/api/search + /api/dynamo): the real
      people-search the web app uses. Surfaces your 1st-degree (synced
      LinkedIn / Gmail contacts) and 2nd-degree (your friends' networks)
      hits at the target, with referrer rationale.
-  2. LinkedIn search_people scoped to the company name: a name-match
+  3. LinkedIn search_people scoped to the company name: a name-match
      fallback that catches people Happenstance doesn't have synced.
      SKIPPED in --location mode.
 
 Results are deduped across sources and ranked:
-  Happenstance 1st-degree  >  Happenstance 2nd-degree  >  LinkedIn 1st-degree  >  LinkedIn search hit.
+  Local export both-owner  >  Happenstance 1st-degree  >  Happenstance 2nd-degree  >  LinkedIn 1st-degree  >  LinkedIn search hit.
 
-Use --source hp or --source li to isolate one side (company mode only).
+Use --source local, --source hp, or --source li to isolate one side (company mode only).
 JSON output gains a "source_errors" block whenever any upstream call
 errored, so callers can distinguish "empty because nobody is there" from
 "empty because the call failed".`,
@@ -103,6 +106,19 @@ errored, so callers can distinguish "empty because nobody is there" from
 			var results []flagshipPerson
 			var friends []flagshipPerson
 			sourceErrors := map[string]string{}
+
+			// Source 0: local LinkedIn Network export database. This is
+			// free, first-degree, and should be considered before
+			// Happenstance credit-priced paths.
+			if !isLocation && sources[SourceFlagLocal] {
+				hits, err := fetchLocalLinkedInCompany(ctx, company, limit)
+				if err != nil {
+					sourceErrors["local_linkedin"] = err.Error()
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: local LinkedIn Network unavailable: %v\n", err)
+				} else {
+					results = append(results, hits...)
+				}
+			}
 
 			// Source 1: Happenstance graph-search. Routed through SelectSource
 			// (auto-prefers cookie / free quota; falls back to bearer / paid
@@ -232,7 +248,7 @@ errored, so callers can distinguish "empty because nobody is there" from
 		},
 	}
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max people to return")
-	cmd.Flags().StringVar(&sourceFlag, "source", "both", "Sources: li | hp | api | both. hp = cookie/free quota; api = bearer/paid credits; both = LinkedIn + auto-routed Happenstance. Forced to api in --location mode.")
+	cmd.Flags().StringVar(&sourceFlag, "source", "both", "Sources: local | ln | li | hp | api | both. local = Mac Mini LinkedIn exports; hp = cookie/free quota; api = bearer/paid credits; both = local + LinkedIn + Happenstance. Forced to api in --location mode.")
 	cmd.Flags().IntVar(&pollTimeoutSec, "poll-timeout", 0,
 		fmt.Sprintf("Seconds to wait for Happenstance graph-search (0 = use default %ds)",
 			int(client.DefaultPollTimeout.Seconds())))
@@ -453,6 +469,10 @@ func firstSource(tags []string) string {
 // LinkedIn search hits, then graph 3rd-degree (public).
 func scoreForRelationship(rel string) float64 {
 	switch rel {
+	case "linkedin_export_1deg_both":
+		return 9.0
+	case "linkedin_export_1deg_holger", "linkedin_export_1deg_james", "linkedin_export_1deg":
+		return 7.5
 	case "happenstance_friend":
 		return 10.0
 	case string(client.TierFirstDegree): // "1st_degree"

--- a/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/flagship_helpers.go
@@ -40,6 +40,7 @@ type flagshipPerson struct {
 	ImageURL         string      `json:"image_url,omitempty"`
 	ConnectionCount  int         `json:"connection_count,omitempty"`
 	Sources          []string    `json:"sources,omitempty"`
+	Owners           []string    `json:"owners,omitempty"`
 	Rationale        string      `json:"rationale,omitempty"`
 	Relationship     string      `json:"relationship,omitempty"`
 	MutualCount      int         `json:"mutual_count,omitempty"`
@@ -241,6 +242,12 @@ func mergePeople(in []flagshipPerson) []flagshipPerson {
 			// them on so downstream renderers see both.
 			if len(p.Bridges) > 0 && len(existing.Bridges) == 0 {
 				existing.Bridges = p.Bridges
+			}
+			if len(p.Owners) > 0 {
+				existing.Owners = dedupStrings(append(existing.Owners, p.Owners...))
+				if len(existing.Owners) > existing.MutualCount {
+					existing.MutualCount = len(existing.Owners)
+				}
 			}
 			continue
 		}
@@ -653,6 +660,8 @@ func rankPeople(in []flagshipPerson) {
 // ranking flagship results.
 func sourceStrength(tag string) float64 {
 	switch tag {
+	case localLinkedInSourceTag:
+		return 6.0
 	case "hp_friend":
 		return 5.0
 	case "hp_graph_1deg":

--- a/library/sales-and-crm/contact-goat/internal/cli/local_linkedin_network.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/local_linkedin_network.go
@@ -1,0 +1,163 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	localLinkedInSourceTag = "local_linkedin_export"
+	localLinkedInRootEnv   = "CONTACT_GOAT_LINKEDIN_NETWORK_ROOT"
+	localLinkedInHostEnv   = "CONTACT_GOAT_LINKEDIN_NETWORK_HOST"
+	localLinkedInCmdEnv    = "CONTACT_GOAT_LINKEDIN_NETWORK_CMD"
+)
+
+const defaultLocalLinkedInRoot = "/Users/gonkv2/Documents/Agentic Engineering/Playmaker/LinkedIn-Network"
+
+type localLinkedInEnvelope struct {
+	Count   int                   `json:"count"`
+	Results []localLinkedInPerson `json:"results"`
+}
+
+type localLinkedInPerson struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	LinkedInURL       string   `json:"linkedin_url"`
+	Email             string   `json:"email"`
+	Company           string   `json:"company"`
+	Title             string   `json:"title"`
+	Owners            []string `json:"owners"`
+	Relationship      string   `json:"relationship"`
+	Sources           []string `json:"sources"`
+	Rationale         string   `json:"rationale"`
+	Score             float64  `json:"score"`
+	ConnectedOnFirst  string   `json:"connected_on_first"`
+	ConnectedOnLatest string   `json:"connected_on_latest"`
+}
+
+func fetchLocalLinkedInCompany(ctx context.Context, company string, limit int) ([]flagshipPerson, error) {
+	if strings.TrimSpace(company) == "" {
+		return nil, errors.New("local LinkedIn company search requires a company")
+	}
+	return fetchLocalLinkedIn(ctx, []string{"company", company, "--limit", strconv.Itoa(normalizedLimit(limit)), "--format", "json"})
+}
+
+func fetchLocalLinkedInSearch(ctx context.Context, query string, limit int) ([]flagshipPerson, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, errors.New("local LinkedIn search requires a query")
+	}
+	return fetchLocalLinkedIn(ctx, []string{"search", query, "--limit", strconv.Itoa(normalizedLimit(limit)), "--format", "json"})
+}
+
+func fetchLocalLinkedIn(ctx context.Context, args []string) ([]flagshipPerson, error) {
+	raw, err := runLocalLinkedInNetwork(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	var envelope localLinkedInEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("parse local LinkedIn Network response: %w", err)
+	}
+	out := make([]flagshipPerson, 0, len(envelope.Results))
+	for _, p := range envelope.Results {
+		row := localLinkedInToFlagship(p)
+		if row.Name == "" && row.LinkedInURL == "" {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+func localLinkedInToFlagship(p localLinkedInPerson) flagshipPerson {
+	sources := p.Sources
+	if len(sources) == 0 {
+		sources = []string{localLinkedInSourceTag}
+	}
+	return flagshipPerson{
+		Name:         p.Name,
+		LinkedInURL:  p.LinkedInURL,
+		Title:        p.Title,
+		Company:      p.Company,
+		Sources:      sources,
+		Rationale:    p.Rationale,
+		Relationship: p.Relationship,
+		MutualCount:  len(p.Owners),
+		Owners:       p.Owners,
+		Score:        p.Score,
+		Raw:          p,
+	}
+}
+
+func runLocalLinkedInNetwork(ctx context.Context, args ...string) ([]byte, error) {
+	if override := strings.TrimSpace(os.Getenv(localLinkedInCmdEnv)); override != "" {
+		return runCommand(ctx, "", override, args...)
+	}
+
+	root := strings.TrimSpace(os.Getenv(localLinkedInRootEnv))
+	if root == "" {
+		root = defaultLocalLinkedInRoot
+	}
+	if localBin := filepath.Join(root, "linkedin-network"); fileExists(localBin) {
+		return runCommand(ctx, root, localBin, args...)
+	}
+
+	host := strings.TrimSpace(os.Getenv(localLinkedInHostEnv))
+	if host == "" {
+		host = "macmini"
+	}
+	remote := "cd " + shellQuote(root) + " && exec ./linkedin-network " + shellJoin(args)
+	return runCommand(ctx, "", "ssh", host, remote)
+}
+
+func runCommand(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("%s failed: %s", name, msg)
+	}
+	return out, nil
+}
+
+func normalizedLimit(limit int) int {
+	if limit <= 0 {
+		return 25
+	}
+	return limit
+}
+
+func fileExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}
+
+func shellJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/local_linkedin_network_test.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/local_linkedin_network_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 matt-van-horn. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFetchLocalLinkedInCompanyUsesCLIJSON(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "linkedin-network-fake")
+	body := `#!/bin/sh
+if [ "$1" != "company" ]; then
+  echo "unexpected command: $1" >&2
+  exit 2
+fi
+cat <<'JSON'
+{
+  "count": 1,
+  "results": [
+    {
+      "id": "local-1",
+      "name": "Alex Local",
+      "linkedin_url": "https://linkedin.com/in/alex-local",
+      "company": "Acme",
+      "title": "VP Partnerships",
+      "owners": ["Holger", "James"],
+      "relationship": "linkedin_export_1deg_both",
+      "sources": ["local_linkedin_export"],
+      "rationale": "Known by Holger and James via LinkedIn export",
+      "score": 13.2
+    }
+  ]
+}
+JSON
+`
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake local LinkedIn CLI: %v", err)
+	}
+	t.Setenv(localLinkedInCmdEnv, script)
+
+	got, err := fetchLocalLinkedInCompany(context.Background(), "Acme", 5)
+	if err != nil {
+		t.Fatalf("fetchLocalLinkedInCompany returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row.Name != "Alex Local" || row.Company != "Acme" || row.LinkedInURL == "" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+	if row.Relationship != "linkedin_export_1deg_both" {
+		t.Fatalf("relationship = %q", row.Relationship)
+	}
+	if len(row.Owners) != 2 || row.Owners[0] != "Holger" || row.Owners[1] != "James" {
+		t.Fatalf("owners = %#v, want Holger+James", row.Owners)
+	}
+	if row.MutualCount != 2 {
+		t.Fatalf("mutual count = %d, want 2", row.MutualCount)
+	}
+}
+
+func TestParseSourceFlagAcceptsLocalAliases(t *testing.T) {
+	got := parseSourceFlag("ln,li")
+	if !got[SourceFlagLocal] {
+		t.Fatalf("ln should map to %q, got %#v", SourceFlagLocal, got)
+	}
+	if got[SourceFlagLN] {
+		t.Fatalf("raw ln token should be normalized away, got %#v", got)
+	}
+	if !got["li"] {
+		t.Fatalf("li source missing: %#v", got)
+	}
+
+	both := parseSourceFlag("both")
+	for _, want := range []string{SourceFlagLocal, "li", "hp"} {
+		if !both[want] {
+			t.Fatalf("both should include %q, got %#v", want, both)
+		}
+	}
+}
+
+func TestLocalLinkedInRankingStrength(t *testing.T) {
+	if got := sourceStrength(localLinkedInSourceTag); got <= sourceStrength("li_search") {
+		t.Fatalf("local source should outrank raw LinkedIn search, got %.1f", got)
+	}
+	if got := scoreForRelationship("linkedin_export_1deg_both"); got <= scoreForRelationship("linkedin_export_1deg_james") {
+		t.Fatalf("both-owner local relationship should outrank single owner, got %.1f", got)
+	}
+}

--- a/library/sales-and-crm/contact-goat/internal/cli/prospect.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/prospect.go
@@ -59,8 +59,10 @@ Results are deduped across sources and ranked by one of:
 
 			var results []flagshipPerson
 			var friends []flagshipPerson
+			var err error
 
-			// Step A: LinkedIn (free).
+			// Step A0: Local LinkedIn Network export database (free,
+			// first-degree, no credentials).
 			keywords := parsed["freeform"]
 			if keywords == "" {
 				parts := []string{}
@@ -74,17 +76,28 @@ Results are deduped across sources and ranked by one of:
 			if keywords == "" {
 				return usageErr(fmt.Errorf("prospect: unable to derive keywords from %q; provide a phrase or title=...", query))
 			}
+			localOnly := sourceFlag == SourceFlagLocal || sourceFlag == SourceFlagLN
 			liLimit := limit
 			if liLimit <= 0 {
 				liLimit = 25
 			}
-			liHits, err := fetchLinkedInSearchPeople(ctx, keywords, parsed["location"], liLimit)
-			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: LinkedIn search failed: %v\n", err)
+			localHits, localErr := fetchLocalLinkedInSearch(ctx, keywords, liLimit)
+			if localErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: local LinkedIn Network unavailable: %v\n", localErr)
 			} else {
-				for _, p := range liHits {
-					p.Sources = []string{"li_search"}
-					results = append(results, p)
+				results = append(results, localHits...)
+			}
+
+			// Step A: LinkedIn (free).
+			if !localOnly {
+				liHits, err := fetchLinkedInSearchPeople(ctx, keywords, parsed["location"], liLimit)
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: LinkedIn search failed: %v\n", err)
+				} else {
+					for _, p := range liHits {
+						p.Sources = []string{"li_search"}
+						results = append(results, p)
+					}
 				}
 			}
 
@@ -94,62 +107,64 @@ Results are deduped across sources and ranked by one of:
 			//   - SourceAPI (explicit --source api, or auto when cookie is
 			//     unavailable / quota exhausted): run a bearer people-search
 			//     against the parsed keywords (paid: 2 credits per search).
-			cfg, cfgErr := config.Load(flags.configPath)
-			if cfgErr != nil {
-				return configErr(cfgErr)
-			}
-			cookieClient, _ := flags.newClient()
-			cookieAvailable := cookieClient != nil && cookieClient.HasCookieAuth()
-			remaining := UnknownSearchesRemaining
-			if cookieAvailable {
-				remaining = FetchSearchesRemaining(cookieClient, cfg, flags.noCache)
-			}
-			chosen, deferredErr, hardErr := SelectSource(cmd.Context(), sourceFlag, cfg, cookieAvailable, remaining)
-			if hardErr != nil {
-				// Non-fatal here: prospect still has LinkedIn results to show.
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance unavailable: %v\n", hardErr)
-			} else {
-				LogDeferredHint(cmd.ErrOrStderr(), deferredErr)
-				if chosen == SourceCookie {
-					if cookieAvailable {
-						friends, err = fetchHappenstanceFriends(cookieClient)
-						if err != nil {
-							fmt.Fprintf(cmd.ErrOrStderr(), "warning: fetch friends: %v\n", err)
-						} else {
-							for _, f := range friends {
-								if prospectMatches(f, parsed) {
-									f.Sources = []string{"hp_friend"}
-									f.Rationale = fmt.Sprintf("Happenstance friend match (%d connections)", f.ConnectionCount)
-									results = append(results, f)
-								}
-							}
-						}
-					}
-				} else if chosen == SourceAPI {
-					if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
-						currentUUID := ""
+			if !localOnly {
+				cfg, cfgErr := config.Load(flags.configPath)
+				if cfgErr != nil {
+					return configErr(cfgErr)
+				}
+				cookieClient, _ := flags.newClient()
+				cookieAvailable := cookieClient != nil && cookieClient.HasCookieAuth()
+				remaining := UnknownSearchesRemaining
+				if cookieAvailable {
+					remaining = FetchSearchesRemaining(cookieClient, cfg, flags.noCache)
+				}
+				chosen, deferredErr, hardErr := SelectSource(cmd.Context(), sourceFlag, cfg, cookieAvailable, remaining)
+				if hardErr != nil {
+					// Non-fatal here: prospect still has local/LinkedIn results to show.
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance unavailable: %v\n", hardErr)
+				} else {
+					LogDeferredHint(cmd.ErrOrStderr(), deferredErr)
+					if chosen == SourceCookie {
 						if cookieAvailable {
-							currentUUID, _ = fetchCurrentUserUUID(cookieClient)
-						}
-						bres, brerr := BearerSearchAdapter(cmd.Context(), bc, keywords, currentUUID, &api.SearchOptions{IncludeMyConnections: true, IncludeFriendsConnections: true})
-						if brerr != nil {
-							fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance bearer search: %v\n", brerr)
-						} else if bres != nil {
-							for _, p := range bres.People {
-								row := flagshipPerson{
-									Name:      p.Name,
-									Title:     p.CurrentTitle,
-									Company:   p.CurrentCompany,
-									Sources:   []string{"hp_api"},
-									Rationale: bearerRationale(p.Bridges),
-									Score:     bearerScore(p.Bridges, p.Score),
-									Bridges:   bridgesToFlagship(p.Bridges),
+							friends, err = fetchHappenstanceFriends(cookieClient)
+							if err != nil {
+								fmt.Fprintf(cmd.ErrOrStderr(), "warning: fetch friends: %v\n", err)
+							} else {
+								for _, f := range friends {
+									if prospectMatches(f, parsed) {
+										f.Sources = []string{"hp_friend"}
+										f.Rationale = fmt.Sprintf("Happenstance friend match (%d connections)", f.ConnectionCount)
+										results = append(results, f)
+									}
 								}
-								results = append(results, row)
 							}
 						}
-					} else {
-						fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance bearer client: %v\n", berr)
+					} else if chosen == SourceAPI {
+						if bc, berr := flags.newHappenstanceAPIClient(); berr == nil {
+							currentUUID := ""
+							if cookieAvailable {
+								currentUUID, _ = fetchCurrentUserUUID(cookieClient)
+							}
+							bres, brerr := BearerSearchAdapter(cmd.Context(), bc, keywords, currentUUID, &api.SearchOptions{IncludeMyConnections: true, IncludeFriendsConnections: true})
+							if brerr != nil {
+								fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance bearer search: %v\n", brerr)
+							} else if bres != nil {
+								for _, p := range bres.People {
+									row := flagshipPerson{
+										Name:      p.Name,
+										Title:     p.CurrentTitle,
+										Company:   p.CurrentCompany,
+										Sources:   []string{"hp_api"},
+										Rationale: bearerRationale(p.Bridges),
+										Score:     bearerScore(p.Bridges, p.Score),
+										Bridges:   bridgesToFlagship(p.Bridges),
+									}
+									results = append(results, row)
+								}
+							}
+						} else {
+							fmt.Fprintf(cmd.ErrOrStderr(), "warning: Happenstance bearer client: %v\n", berr)
+						}
 					}
 				}
 			}
@@ -253,7 +268,7 @@ Results are deduped across sources and ranked by one of:
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max results to return")
 	cmd.Flags().StringVar(&sortMode, "sort", "relevance", "Sort mode: relevance | network")
 	cmd.Flags().StringVar(&deeplineKey, "deepline-key", "", "Deepline API key (default from $DEEPLINE_API_KEY)")
-	cmd.Flags().StringVar(&sourceFlag, "source", SourceFlagAuto, "Happenstance auth surface: auto | hp | api. auto = cookie/free quota first, bearer fallback")
+	cmd.Flags().StringVar(&sourceFlag, "source", SourceFlagAuto, "Happenstance auth surface: auto | hp | api, or local/ln for local-only. Local LinkedIn exports are always queried first.")
 	return cmd
 }
 

--- a/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/source_selection.go
@@ -83,6 +83,8 @@ const (
 	SourceFlagAuto   = "auto"
 	SourceFlagBoth   = "both" // cross-source commands only (coverage)
 	SourceFlagLI     = "li"   // cross-source commands only (LinkedIn)
+	SourceFlagLocal  = "local"
+	SourceFlagLN     = "ln"
 )
 
 // UnknownSearchesRemaining is the sentinel passed to SelectSource when

--- a/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
+++ b/library/sales-and-crm/contact-goat/internal/cli/warm_intro.go
@@ -48,9 +48,10 @@ When a name is given the CLI resolves it via LinkedIn search_people first.
 Because LinkedIn's MCP does not expose 1st-degree connection lists, this
 command composes warm-intro candidates from three signals:
 
-  1. Happenstance friends you share with the target (strongest signal).
-  2. LinkedIn "People also viewed" sidebar for the target.
-  3. LinkedIn search scoped to the target's current company.
+  1. Local LinkedIn Network export owners (James/Holger first-degree).
+  2. Happenstance friends you share with the target.
+  3. LinkedIn "People also viewed" sidebar for the target.
+  4. LinkedIn search scoped to the target's current company.
 
 Results are ranked by a composite score (source strength + Happenstance
 connection_count + presence in multiple sources).`,
@@ -81,6 +82,25 @@ connection_count + presence in multiple sources).`,
 			var candidates []flagshipPerson
 			var friends []flagshipPerson
 			sourceErrors := map[string]string{}
+
+			// Source 0: local LinkedIn Network export database. Prefer
+			// company when LinkedIn resolution found one; otherwise use the
+			// target string as a weaker local search.
+			if sources[SourceFlagLocal] {
+				var localHits []flagshipPerson
+				var localErr error
+				if resolved.Company != "" {
+					localHits, localErr = fetchLocalLinkedInCompany(ctx, resolved.Company, 25)
+				} else {
+					localHits, localErr = fetchLocalLinkedInSearch(ctx, target, 25)
+				}
+				if localErr != nil {
+					sourceErrors["local_linkedin"] = localErr.Error()
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: local LinkedIn Network unavailable: %v\n", localErr)
+				} else {
+					candidates = append(candidates, localHits...)
+				}
+			}
 
 			// Source 1: Happenstance graph-search at the target's current
 			// company. For each person who comes back:
@@ -285,7 +305,7 @@ connection_count + presence in multiple sources).`,
 	cmd.Flags().StringVar(&targetType, "target-type", "auto", "Target parse mode: auto | url | name")
 	cmd.Flags().IntVar(&limit, "limit", 10, "Max candidates to return")
 	cmd.Flags().BoolVar(&useCached, "use-cached", true, "Persist resolved people into the local store for re-use")
-	cmd.Flags().StringVar(&sourcesFlag, "sources", "li,hp", "Comma-separated sources to query: li,hp,api. Use 'api' to opt into the paid Happenstance bearer surface.")
+	cmd.Flags().StringVar(&sourcesFlag, "sources", "local,li,hp", "Comma-separated sources to query: local,ln,li,hp,api. Use 'api' to opt into the paid Happenstance bearer surface.")
 	return cmd
 }
 
@@ -440,13 +460,18 @@ func parseSourceFlag(csv string) map[string]bool {
 			continue
 		}
 		if tok == "both" {
+			out[SourceFlagLocal] = true
 			out["li"] = true
 			out["hp"] = true
 			continue
 		}
+		if tok == SourceFlagLN {
+			tok = SourceFlagLocal
+		}
 		out[tok] = true
 	}
 	if len(out) == 0 {
+		out[SourceFlagLocal] = true
 		out["li"] = true
 		out["hp"] = true
 	}
@@ -475,6 +500,7 @@ func describeSources(tags []string, connectionCount int) string {
 	li1 := false
 	liSidebar := false
 	liSearch := false
+	localLinkedIn := false
 	hpGraph1 := false
 	hpGraph2 := false
 	for _, t := range tags {
@@ -487,6 +513,8 @@ func describeSources(tags []string, connectionCount int) string {
 			liSidebar = true
 		case "li_search":
 			liSearch = true
+		case localLinkedInSourceTag:
+			localLinkedIn = true
 		case "hp_graph_1deg":
 			hpGraph1 = true
 		case "hp_graph_2deg":
@@ -496,6 +524,9 @@ func describeSources(tags []string, connectionCount int) string {
 	parts := []string{}
 	if hpGraph1 {
 		parts = append(parts, "your direct contact at target company")
+	}
+	if localLinkedIn {
+		parts = append(parts, "James/Holger LinkedIn export")
 	}
 	if hpGraph2 {
 		parts = append(parts, "knows someone at target company")


### PR DESCRIPTION
## Summary
- adds a local LinkedIn Network source for Contact GOAT backed by James/Holger CSV exports on the Mac Mini
- wires local results into coverage, prospect, and warm-intro via CLI JSON shell-out, preserving Happenstance as explicit fallback
- documents local-first usage and records the customization in .printing-press-patches.json

## Verification
- go test ./... from library/sales-and-crm/contact-goat
- python3 .github/scripts/verify-skill/verify_skill.py --dir library/sales-and-crm/contact-goat --json
- contact-goat-pp-cli coverage <known-company> --source local --limit 3 --agent
- contact-goat-pp-cli prospect partnerships --source local --limit 3 --agent
- ssh macmini LinkedIn Network unittest + stats check