### PR TITLE
fix(youtube): parse YouTube URLs in videos-transcript/comments/related/embed

### DIFF
--- a/library/media-and-entertainment/youtube/.printing-press-patches.json
+++ b/library/media-and-entertainment/youtube/.printing-press-patches.json
@@ -65,6 +65,25 @@
         "F3"
       ],
       "patch_count": 1
+    },
+    {
+      "id": "fix-videoarg-commands-parse-urls",
+      "summary": "Route videos-transcript, videos-comments, videos-related, and videos-embed through parseVideoID (with the shared 'could not extract a video ID from %q' usage error) instead of forwarding the raw positional arg, and teach parseVideoID to handle scheme-less YouTube URLs (youtu.be/<id>, www.youtube.com/watch?v=<id>, etc.).",
+      "reason": "Library issue #875: these four commands set videoID := args[0] and passed the raw string straight to InnerTube/the Data API, so every YouTube URL form failed with 'video unavailable' and only a bare 11-char ID worked — even though videos-enrich and videos-links already parsed URLs via parseVideoID. parseVideoID itself gated its URL branch on the presence of '://', so scheme-less copy-paste shapes (youtu.be/<id>, www.youtube.com/watch?v=<id>) fell through to the bare-ID regex and were dropped. The fix normalizes a known YouTube host prefix without a scheme to an absolute URL before parsing (a bare ID never contains '/' or '?', so valid IDs are never rewritten) and aligns all four commands with the established videos-enrich/videos-links pattern, returning a clear exit-2 usage error for unparseable input.",
+      "files": [
+        "internal/cli/videos_links.go",
+        "internal/cli/videos_transcript.go",
+        "internal/cli/videos_comments.go",
+        "internal/cli/videos_related.go",
+        "internal/cli/videos_embed.go",
+        "internal/cli/playlist_enrich_test.go"
+      ],
+      "validated_outcome": "go build ./..., go vet ./..., go test ./..., and gofmt clean on the youtube module. TestParseVideoID extended with 6 scheme-less cases (youtu.be/<id>, youtu.be/<id>?si=..., www.youtube.com/watch?v=<id>, youtube.com/watch?v=<id>, www.youtube.com/embed/<id>, watch?v=<id>&t=...) — all 22 cases pass. Built binary verified: scheme-full and scheme-less watch/youtu.be/embed URLs across all four commands now extract the ID (exit 0); too-short tokens and channel/playlist/user URLs return 'could not extract a video ID from %q' with exit 2.",
+      "findings_addressed": [
+        "F1",
+        "F2",
+        "F3"
+      ]
     }
   ],
   "machine_followups": [

--- a/library/media-and-entertainment/youtube/.printing-press-patches.json
+++ b/library/media-and-entertainment/youtube/.printing-press-patches.json
@@ -78,7 +78,7 @@
         "internal/cli/videos_embed.go",
         "internal/cli/playlist_enrich_test.go"
       ],
-      "validated_outcome": "go build ./..., go vet ./..., go test ./..., and gofmt clean on the youtube module. TestParseVideoID extended with 6 scheme-less cases (youtu.be/<id>, youtu.be/<id>?si=..., www.youtube.com/watch?v=<id>, youtube.com/watch?v=<id>, www.youtube.com/embed/<id>, watch?v=<id>&t=...) — all 22 cases pass. Built binary verified: scheme-full and scheme-less watch/youtu.be/embed URLs across all four commands now extract the ID (exit 0); too-short tokens and channel/playlist/user URLs return 'could not extract a video ID from %q' with exit 2.",
+      "validated_outcome": "go build ./..., go vet ./..., go test ./..., and gofmt clean on the youtube module. TestParseVideoID extended with 8 scheme-less cases (youtu.be/<id>, youtu.be/<id>?si=..., www.youtube.com/watch?v=<id>, youtube.com/watch?v=<id>, www.youtube.com/embed/<id>, watch?v=<id>&t=..., m.youtube.com/watch?v=<id>, plus the scheme-full m.youtube.com variant) — all 24 cases pass. Built binary verified: scheme-full and scheme-less watch/youtu.be/embed URLs across all four commands now extract the ID (exit 0); too-short tokens and channel/playlist/user URLs return 'could not extract a video ID from %q' with exit 2. Greptile P2 follow-up (PR #914): added m.youtube.com test coverage and updated the Use field to '<videoId|url>' plus a URL Example on all four commands so --help advertises URL input.",
       "findings_addressed": [
         "F1",
         "F2",

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
@@ -40,6 +40,15 @@ func TestParseVideoID(t *testing.T) {
 		{"shorts url", "https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"live url", "https://www.youtube.com/live/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"bare id", "dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		// Scheme-less URLs are common copy-paste shapes and must parse too
+		// (library issue #875): without a "://" they used to fall through to
+		// the bare-ID check and fail the 11-char regex.
+		{"scheme-less youtu.be", "youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"scheme-less youtu.be with si param", "youtu.be/dQw4w9WgXcQ?si=yZha3HjrYqLmc5et", "dQw4w9WgXcQ"},
+		{"scheme-less www.youtube.com watch", "www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"scheme-less youtube.com watch", "youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"scheme-less embed", "www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"scheme-less watch with t param", "www.youtube.com/watch?v=dQw4w9WgXcQ&t=10s", "dQw4w9WgXcQ"},
 		{"junk with spaces", "not a video", ""},
 		{"empty", "", ""},
 		// Non-video URLs must return "" so the caller errors clearly rather

--- a/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
+++ b/library/media-and-entertainment/youtube/internal/cli/playlist_enrich_test.go
@@ -49,6 +49,8 @@ func TestParseVideoID(t *testing.T) {
 		{"scheme-less youtube.com watch", "youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"scheme-less embed", "www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"scheme-less watch with t param", "www.youtube.com/watch?v=dQw4w9WgXcQ&t=10s", "dQw4w9WgXcQ"},
+		{"scheme-less m.youtube.com watch", "m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"m.youtube.com watch", "https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
 		{"junk with spaces", "not a video", ""},
 		{"empty", "", ""},
 		// Non-video URLs must return "" so the caller errors clearly rather

--- a/library/media-and-entertainment/youtube/internal/cli/videos_comments.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_comments.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,10 @@ func newYoutubeVideosCommentsCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			videoID := args[0]
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
 
 			if top <= 0 {
 				return usageErr(fmt.Errorf("--top must be > 0"))

--- a/library/media-and-entertainment/youtube/internal/cli/videos_comments.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_comments.go
@@ -39,9 +39,9 @@ func newYoutubeVideosCommentsCmd(flags *rootFlags) *cobra.Command {
 	var order string
 
 	cmd := &cobra.Command{
-		Use:         "videos-comments <videoId>",
+		Use:         "videos-comments <videoId|url>",
 		Short:       "Fetch top comments on a video, ranked by likeCount (uses commentThreads.list, public read-only)",
-		Example:     "  youtube-pp-cli youtube videos-comments dQw4w9WgXcQ --top 10",
+		Example:     "  youtube-pp-cli youtube videos-comments dQw4w9WgXcQ --top 10\n  youtube-pp-cli youtube videos-comments 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' --top 10",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_embed.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_embed.go
@@ -42,7 +42,10 @@ func newYoutubeVideosEmbedCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			videoID := args[0]
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
 
 			validFormats := map[string]bool{"url": true, "iframe": true, "markdown": true, "html": true}
 			if !validFormats[format] {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_embed.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_embed.go
@@ -34,9 +34,9 @@ func newYoutubeVideosEmbedCmd(flags *rootFlags) *cobra.Command {
 	var withTitle bool
 
 	cmd := &cobra.Command{
-		Use:         "videos-embed <videoId>",
+		Use:         "videos-embed <videoId|url>",
 		Short:       "Print embed HTML, iframe, or markdown snippet for a video",
-		Example:     "  youtube-pp-cli youtube videos-embed dQw4w9WgXcQ --format markdown",
+		Example:     "  youtube-pp-cli youtube videos-embed dQw4w9WgXcQ --format markdown\n  youtube-pp-cli youtube videos-embed 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' --format markdown",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_links.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_links.go
@@ -272,6 +272,18 @@ func parseVideoID(in string) string {
 	if in == "" {
 		return ""
 	}
+	// Scheme-less URLs (youtu.be/<id>, www.youtube.com/watch?v=<id>) are common
+	// copy-paste shapes; url.Parse treats them as bare paths and the query/host
+	// extraction below misses the ID. Normalize them to an absolute URL so they
+	// route through the same host/path/query logic as scheme-ful inputs. A bare
+	// 11-char ID never contains "/" or "?", so this never rewrites a valid ID.
+	if !strings.Contains(in, "://") &&
+		(strings.HasPrefix(in, "youtu.be/") ||
+			strings.HasPrefix(in, "youtube.com/") ||
+			strings.HasPrefix(in, "www.youtube.com/") ||
+			strings.HasPrefix(in, "m.youtube.com/")) {
+		in = "https://" + in
+	}
 	if strings.Contains(in, "://") {
 		u, err := url.Parse(in)
 		if err != nil {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_related.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_related.go
@@ -38,9 +38,9 @@ func newYoutubeVideosRelatedCmd(flags *rootFlags) *cobra.Command {
 	var sameChannelOnly bool
 
 	cmd := &cobra.Command{
-		Use:         "videos-related <videoId>",
+		Use:         "videos-related <videoId|url>",
 		Short:       "Find related videos via topic + channel + tag overlap (heuristic; replaces deprecated relatedToVideoId)",
-		Example:     "  youtube-pp-cli youtube videos-related dQw4w9WgXcQ --limit 10",
+		Example:     "  youtube-pp-cli youtube videos-related dQw4w9WgXcQ --limit 10\n  youtube-pp-cli youtube videos-related 'https://youtu.be/dQw4w9WgXcQ' --limit 10",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/library/media-and-entertainment/youtube/internal/cli/videos_related.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_related.go
@@ -46,7 +46,10 @@ func newYoutubeVideosRelatedCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			videoID := args[0]
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
 
 			if dryRunOK(flags) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "GET /youtube/v3/videos?id=%s&part=snippet,topicDetails\n", videoID)

--- a/library/media-and-entertainment/youtube/internal/cli/videos_transcript.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_transcript.go
@@ -115,7 +115,10 @@ func newYoutubeVideosTranscriptCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			videoID := args[0]
+			videoID := parseVideoID(strings.TrimSpace(args[0]))
+			if videoID == "" {
+				return usageErr(fmt.Errorf("could not extract a video ID from %q", args[0]))
+			}
 
 			if dryRunOK(flags) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "POST https://www.youtube.com/youtubei/v1/player (videoId=%s)\n", videoID)

--- a/library/media-and-entertainment/youtube/internal/cli/videos_transcript.go
+++ b/library/media-and-entertainment/youtube/internal/cli/videos_transcript.go
@@ -107,9 +107,9 @@ func newYoutubeVideosTranscriptCmd(flags *rootFlags) *cobra.Command {
 	var noCache bool
 
 	cmd := &cobra.Command{
-		Use:         "videos-transcript <videoId>",
+		Use:         "videos-transcript <videoId|url>",
 		Short:       "Fetch video transcript via InnerTube (no OAuth needed)",
-		Example:     "  youtube-pp-cli youtube videos-transcript dQw4w9WgXcQ --lang en",
+		Example:     "  youtube-pp-cli youtube videos-transcript dQw4w9WgXcQ --lang en\n  youtube-pp-cli youtube videos-transcript 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'",
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {


### PR DESCRIPTION
## Summary

`videos-transcript`, `videos-comments`, `videos-related`, and `videos-embed` only worked when passed a bare 11-character video ID — any YouTube URL form failed. This PR fixes a two-bug root cause behind library issue #875 so all four commands accept the same URL shapes that `videos-enrich` and `videos-links` already did, including scheme-less copy-paste shapes.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1 | arg-parsing | bug | The four video-arg commands set `videoID := args[0]` and forwarded the raw positional arg straight to InnerTube / the Data API, so every URL form returned "video unavailable" and only a bare ID worked. |
| F2 | url-parsing | bug | `parseVideoID` gated its URL branch on the presence of `://`, so scheme-less inputs (`youtu.be/<id>`, `www.youtube.com/watch?v=<id>`) fell through to the bare-ID regex and were dropped. |
| F3 | ux | bug | Unparseable input produced an opaque API failure instead of a clear usage error. |

## Changes

```
 .../youtube/.printing-press-patches.json              | 19 +++++++++++++++++++
 .../youtube/internal/cli/playlist_enrich_test.go      |  9 +++++++++
 .../youtube/internal/cli/videos_comments.go           |  6 +++++-
 .../youtube/internal/cli/videos_embed.go              |  5 ++++-
 .../youtube/internal/cli/videos_links.go              | 12 ++++++++++++
 .../youtube/internal/cli/videos_related.go            |  5 ++++-
 .../youtube/internal/cli/videos_transcript.go         |  5 ++++-
 7 files changed, 57 insertions(+), 4 deletions(-)
```

- Route all four commands through `parseVideoID(strings.TrimSpace(args[0]))` with the shared `could not extract a video ID from %q` usage error (exit 2 on unparseable input), matching the established `videos-enrich`/`videos-links` pattern.
- Normalize a known scheme-less YouTube host prefix (`youtu.be/`, `youtube.com/`, `www.youtube.com/`, `m.youtube.com/`) to an absolute URL before parsing. A bare 11-char ID never contains `/` or `?`, so valid IDs are never rewritten.
- Extend `TestParseVideoID` with six scheme-less cases.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — pass (`TestParseVideoID` now 22 cases, all green)
- `gofmt -l` — clean on all touched files

## Closes

Closes #875