### PR TITLE
feat(stripe): 5 analytics commands (MRR, failures, refunds, disputes)

### DIFF
--- a/library/payments/stripe/.printing-press-patches.json
+++ b/library/payments/stripe/.printing-press-patches.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "applied_at": "2026-05-28",
+  "base_run_id": "20260509-093200",
+  "base_printing_press_version": "4.1.0",
+  "patches": [
+    {
+      "id": "stripe-analytics-commands-port",
+      "summary": "Add five hand-coded analytics commands (mrr-trend, failure-clusters, refund-rate, dispute-win-rate, daily-digest).",
+      "reason": "The generated CLI ships eight transcendence commands (health, dunning-queue, sql, payout-reconcile, customer-360, subs-at-risk, events-since, metadata-grep) but operators still hand-rolled MRR/ARR rollups, failure-pattern grouping, refund-rate trending, dispute outcome ratios, and a one-shot period report via multiple commands + sql. These five additions close those gaps by joining the existing local SQLite mirror via json_extract and the shared transcendence helpers.",
+      "files": [
+        "internal/cli/mrr_trend.go",
+        "internal/cli/failure_clusters.go",
+        "internal/cli/refund_rate.go",
+        "internal/cli/dispute_win_rate.go",
+        "internal/cli/daily_digest.go",
+        "internal/cli/root.go"
+      ],
+      "validated_outcome": "go build, go vet, --help, --dry-run, and --json against both an empty local DB and a seeded local DB all pass. Math validated: 2 USD active subs ($50 + 2x$50 = $150) + 1 EUR yearly trial ($1200/yr = $100/mo) yields the expected per-currency rollup; refund-rate joins refund.charge to charge.invoice.lines.data[0].price.product for --by product; dispute-win-rate partitions on status with reason and amount-band breakdowns.",
+      "deferred_to_upstream": [
+        {
+          "feature": "Generator-level recognition that printed CLIs with subscription + charge + dispute domain models can ship a canonical analytics suite (MRR/ARR, failure clusters, refund rate, dispute outcomes, period digest) out of the box",
+          "reason": "These five commands are a portable analytics pattern any payments-shaped printed CLI would benefit from — Stripe, Lemon Squeezy, Paddle, etc. all expose the same underlying domain. Long-term they belong in the Printing Press analytics-shape catalog, not as per-CLI patches."
+        },
+        {
+          "feature": "Daily-digest subscription MRR currency-mixing limitation: the digest section sums MRR across all currencies into a single mrr_cents field, which is incorrect when the merchant has multi-currency subscriptions. Operators wanting per-currency precision should use mrr-trend.",
+          "reason": "The digest is a single-shot snapshot for USD-primary merchants; preserving currency separation would balloon the section shape. mrr-trend already exposes by_currency for precise per-currency rollups."
+        }
+      ]
+    }
+  ]
+}

--- a/library/payments/stripe/internal/cli/daily_digest.go
+++ b/library/payments/stripe/internal/cli/daily_digest.go
@@ -1,0 +1,658 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: add `daily-digest` analytics command. One-command markdown (or JSON)
+// report for a period: charges, subscriptions, disputes, payouts. Reads from
+// local store only.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/stripe/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+type digestCharges struct {
+	GrossCents       int64                     `json:"gross_cents"`
+	RefundsCents     int64                     `json:"refunds_cents"`
+	NetCents         int64                     `json:"net_cents"`
+	SuccessfulCount  int                       `json:"successful_count"`
+	FailedCount      int                       `json:"failed_count"`
+	SuccessRatePct   float64                   `json:"success_rate_pct"`
+	AOVCents         int64                     `json:"aov_cents"`
+	Days             []digestRevenueDay        `json:"days"`
+	TopFailureCodes  []digestFailureCodeRow    `json:"top_failure_codes,omitempty"`
+}
+
+type digestRevenueDay struct {
+	Date         string `json:"date"`
+	ChargeCount  int    `json:"charge_count"`
+	GrossCents   int64  `json:"gross_cents"`
+	RefundsCents int64  `json:"refunds_cents"`
+	NetCents     int64  `json:"net_cents"`
+}
+
+type digestFailureCodeRow struct {
+	Code  string `json:"code"`
+	Count int    `json:"count"`
+}
+
+type digestSubs struct {
+	MRRCents            int64 `json:"mrr_cents"`
+	ARRCents            int64 `json:"arr_cents"`
+	ActiveSubscribers   int   `json:"active_subscribers"`
+	TrialingSubscribers int   `json:"trialing_subscribers"`
+	NewInWindow         int   `json:"new_in_window"`
+	ChurnedInWindow     int   `json:"churned_in_window"`
+}
+
+type digestDisputes struct {
+	OpenCount   int   `json:"open_count"`
+	OpenTotal   int64 `json:"open_total_cents"`
+	WonInWindow int   `json:"won_in_window"`
+	LostInWindow int  `json:"lost_in_window"`
+}
+
+type digestPayouts struct {
+	NextPayoutCents      int64  `json:"next_payout_cents,omitempty"`
+	NextPayoutArrival    string `json:"next_payout_arrival,omitempty"`
+	LastPayoutCents      int64  `json:"last_payout_cents,omitempty"`
+	LastPayoutArrival    string `json:"last_payout_arrival,omitempty"`
+	LastPayoutStatus     string `json:"last_payout_status,omitempty"`
+}
+
+type dailyDigest struct {
+	From     string          `json:"from"`
+	To       string          `json:"to"`
+	Sections []string        `json:"sections"`
+	Charges  *digestCharges  `json:"charges,omitempty"`
+	Subs     *digestSubs     `json:"subs,omitempty"`
+	Disputes *digestDisputes `json:"disputes,omitempty"`
+	Payouts  *digestPayouts  `json:"payouts,omitempty"`
+}
+
+func newDailyDigestCmd(flags *rootFlags) *cobra.Command {
+	var sinceStr string
+	var fromStr string
+	var toStr string
+	var format string
+	var sections string
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "daily-digest",
+		Short: "One-command period report: charges, subs, disputes, payouts",
+		Long: `Compose a multi-section report for a period — equivalent to running the
+existing customer-360, dunning-queue, and payout-reconcile commands plus a sql
+query for the revenue rollup, but in one shot. Reads from the local SQLite
+mirror only — no API calls. Default format is markdown; pass --json for a
+structured envelope.`,
+		Example: `  # Last 7 days, markdown
+  stripe-pp-cli daily-digest
+
+  # Explicit date range, JSON envelope, charges + subs only
+  stripe-pp-cli daily-digest --from 2026-05-01 --to 2026-05-28 --json --sections charges,subs`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			from, to, err := resolveDigestRange(sinceStr, fromStr, toStr)
+			if err != nil {
+				return usageErr(err)
+			}
+			sectionList := parseSections(sections)
+			if len(sectionList) == 0 {
+				return usageErr(fmt.Errorf("--sections must include at least one of: charges, subs, disputes, payouts"))
+			}
+
+			path := transcendenceDBPath(dbPath)
+			db, err := store.OpenReadOnly(path)
+			if err != nil {
+				return configErr(fmt.Errorf("opening local database (%s): %w\nRun 'stripe-pp-cli sync' first.", path, err))
+			}
+			defer db.Close()
+
+			digest, err := buildDigest(db.DB(), from, to, sectionList)
+			if err != nil {
+				return apiErr(err)
+			}
+
+			switch strings.ToLower(format) {
+			case "json":
+				return printJSONFiltered(cmd.OutOrStdout(), digest, flags)
+			case "md", "markdown", "":
+				_, err := fmt.Fprint(cmd.OutOrStdout(), renderDigestMarkdown(digest))
+				return err
+			default:
+				return usageErr(fmt.Errorf("--format must be md or json (got %q)", format))
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&sinceStr, "since", "7d", "Window ending now (e.g. 7d, 30d). Ignored if --from/--to are set.")
+	cmd.Flags().StringVar(&fromStr, "from", "", "Explicit start date (YYYY-MM-DD). Requires --to.")
+	cmd.Flags().StringVar(&toStr, "to", "", "Explicit end date (YYYY-MM-DD). Requires --from.")
+	cmd.Flags().StringVar(&format, "format", "md", "Output format: md or json")
+	cmd.Flags().StringVar(&sections, "sections", "charges,subs,disputes,payouts", "Comma-separated section list")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/stripe-pp-cli/data.db)")
+
+	// Allow --json shorthand: maps to --format=json. Provided as a separate
+	// flag for ergonomic symmetry with the rest of the CLI; the actual JSON
+	// envelope is the same one printJSONFiltered would emit.
+	cmd.Flags().BoolP("json", "j", false, "Shortcut for --format=json")
+	cmd.PreRunE = func(c *cobra.Command, _ []string) error {
+		if c.Flags().Changed("json") {
+			isJSON, _ := c.Flags().GetBool("json")
+			if isJSON {
+				if err := c.Flags().Set("format", "json"); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+// resolveDigestRange computes the (from, to) UTC date pair. Explicit
+// --from/--to override --since. Validates ordering and bounds.
+func resolveDigestRange(sinceStr, fromStr, toStr string) (time.Time, time.Time, error) {
+	if (fromStr != "") != (toStr != "") {
+		return time.Time{}, time.Time{}, fmt.Errorf("--from and --to must both be set, or neither")
+	}
+	if fromStr != "" {
+		from, err := time.Parse("2006-01-02", fromStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid --from (want YYYY-MM-DD): %w", err)
+		}
+		to, err := time.Parse("2006-01-02", toStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid --to (want YYYY-MM-DD): %w", err)
+		}
+		if to.Before(from) {
+			return time.Time{}, time.Time{}, fmt.Errorf("--from must be on or before --to")
+		}
+		// end-of-day for `to`
+		to = to.Add(24*time.Hour - time.Second)
+		return from, to, nil
+	}
+	since, err := parseHumanDuration(sinceStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid --since: %w", err)
+	}
+	if since == 0 {
+		since = 7 * 24 * time.Hour
+	}
+	now := time.Now().UTC()
+	from := now.Add(-since)
+	return from, now, nil
+}
+
+// parseSections splits a comma-list and lowercases entries, dropping empties.
+func parseSections(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool)
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" || seen[p] {
+			continue
+		}
+		switch p {
+		case "charges", "subs", "subscriptions", "disputes", "payouts":
+			// normalize 'subscriptions' to 'subs' for canonical comparison
+			if p == "subscriptions" {
+				p = "subs"
+			}
+			if !seen[p] {
+				out = append(out, p)
+				seen[p] = true
+			}
+		}
+	}
+	return out
+}
+
+func sectionEnabled(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func buildDigest(db *sql.DB, from, to time.Time, sections []string) (dailyDigest, error) {
+	digest := dailyDigest{
+		From:     from.Format("2006-01-02"),
+		To:       to.Format("2006-01-02"),
+		Sections: sections,
+	}
+	fromTS := from.Unix()
+	toTS := to.Unix()
+
+	if sectionEnabled(sections, "charges") {
+		c, err := buildChargesSection(db, fromTS, toTS, from, to)
+		if err != nil {
+			return digest, err
+		}
+		digest.Charges = &c
+	}
+	if sectionEnabled(sections, "subs") {
+		s, err := buildSubsSection(db, fromTS, toTS)
+		if err != nil {
+			return digest, err
+		}
+		digest.Subs = &s
+	}
+	if sectionEnabled(sections, "disputes") {
+		d, err := buildDisputesSection(db, fromTS, toTS)
+		if err != nil {
+			return digest, err
+		}
+		digest.Disputes = &d
+	}
+	if sectionEnabled(sections, "payouts") {
+		p, err := buildPayoutsSection(db)
+		if err != nil {
+			return digest, err
+		}
+		digest.Payouts = &p
+	}
+	return digest, nil
+}
+
+func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (digestCharges, error) {
+	rs, err := db.Query(`SELECT data FROM resources WHERE resource_type='charges'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) <= ?`, fromTS, toTS)
+	if err != nil {
+		return digestCharges{}, fmt.Errorf("querying charges: %w", err)
+	}
+	defer rs.Close()
+
+	dayMap := make(map[string]*digestRevenueDay)
+	for d := from; !d.After(to); d = d.Add(24 * time.Hour) {
+		key := d.Format("2006-01-02")
+		dayMap[key] = &digestRevenueDay{Date: key}
+	}
+
+	var grossTotal int64
+	successCount := 0
+	failedCount := 0
+	failureCodes := make(map[string]int)
+
+	for rs.Next() {
+		var data string
+		if err := rs.Scan(&data); err != nil {
+			return digestCharges{}, err
+		}
+		raw := json.RawMessage(data)
+		status, _ := jsonGet(raw, "status")
+		amount, _ := jsonGetInt(raw, "amount")
+		ts, _ := jsonGetInt(raw, "created")
+		day := time.Unix(ts, 0).UTC().Format("2006-01-02")
+
+		row := dayMap[day]
+		if row == nil {
+			row = &digestRevenueDay{Date: day}
+			dayMap[day] = row
+		}
+		switch status {
+		case "succeeded":
+			successCount++
+			grossTotal += amount
+			row.ChargeCount++
+			row.GrossCents += amount
+		case "failed":
+			failedCount++
+			code, _ := jsonGet(raw, "failure_code")
+			if code == "" {
+				code = "unknown"
+			}
+			failureCodes[code]++
+		}
+	}
+	if err := rs.Err(); err != nil {
+		return digestCharges{}, err
+	}
+
+	// Refunds within the window
+	refundRows, err := db.Query(`SELECT data FROM resources WHERE resource_type='refunds'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) <= ?`, fromTS, toTS)
+	if err != nil {
+		return digestCharges{}, fmt.Errorf("querying refunds: %w", err)
+	}
+	defer refundRows.Close()
+
+	var refundTotal int64
+	for refundRows.Next() {
+		var data string
+		if err := refundRows.Scan(&data); err != nil {
+			return digestCharges{}, err
+		}
+		raw := json.RawMessage(data)
+		amount, _ := jsonGetInt(raw, "amount")
+		ts, _ := jsonGetInt(raw, "created")
+		day := time.Unix(ts, 0).UTC().Format("2006-01-02")
+		refundTotal += amount
+		if row, ok := dayMap[day]; ok {
+			row.RefundsCents += amount
+		}
+	}
+	if err := refundRows.Err(); err != nil {
+		return digestCharges{}, err
+	}
+
+	days := make([]digestRevenueDay, 0, len(dayMap))
+	for _, row := range dayMap {
+		row.NetCents = row.GrossCents - row.RefundsCents
+		days = append(days, *row)
+	}
+	sort.SliceStable(days, func(i, j int) bool { return days[i].Date < days[j].Date })
+
+	successRate := 0.0
+	denom := successCount + failedCount
+	if denom > 0 {
+		successRate = float64(successCount) / float64(denom) * 100
+	}
+	var aov int64
+	if successCount > 0 {
+		aov = grossTotal / int64(successCount)
+	}
+
+	topCodes := make([]digestFailureCodeRow, 0, len(failureCodes))
+	for code, n := range failureCodes {
+		topCodes = append(topCodes, digestFailureCodeRow{Code: code, Count: n})
+	}
+	sort.SliceStable(topCodes, func(i, j int) bool { return topCodes[i].Count > topCodes[j].Count })
+	if len(topCodes) > 5 {
+		topCodes = topCodes[:5]
+	}
+
+	return digestCharges{
+		GrossCents:      grossTotal,
+		RefundsCents:    refundTotal,
+		NetCents:        grossTotal - refundTotal,
+		SuccessfulCount: successCount,
+		FailedCount:     failedCount,
+		SuccessRatePct:  roundTo(successRate, 2),
+		AOVCents:        aov,
+		Days:            days,
+		TopFailureCodes: topCodes,
+	}, nil
+}
+
+func buildSubsSection(db *sql.DB, fromTS, toTS int64) (digestSubs, error) {
+	rs, err := db.Query(`SELECT id, data FROM resources WHERE resource_type='subscriptions'`)
+	if err != nil {
+		return digestSubs{}, fmt.Errorf("querying subscriptions: %w", err)
+	}
+	defer rs.Close()
+
+	var mrr int64
+	active := 0
+	trialing := 0
+	newSubs := 0
+	churned := 0
+	for rs.Next() {
+		var id, data string
+		_ = id
+		if err := rs.Scan(&id, &data); err != nil {
+			return digestSubs{}, err
+		}
+		raw := json.RawMessage(data)
+		status, _ := jsonGet(raw, "status")
+		created, _ := jsonGetInt(raw, "created")
+		canceled, _ := jsonGetInt(raw, "canceled_at")
+
+		switch status {
+		case "active":
+			active++
+		case "trialing":
+			trialing++
+		}
+		if status == "active" || status == "trialing" {
+			m, _, _ := subscriptionMonthlyMRR(raw)
+			mrr += m
+		}
+		if created >= fromTS && created <= toTS {
+			newSubs++
+		}
+		if canceled > 0 && canceled >= fromTS && canceled <= toTS {
+			churned++
+		}
+	}
+	if err := rs.Err(); err != nil {
+		return digestSubs{}, err
+	}
+
+	return digestSubs{
+		MRRCents:            mrr,
+		ARRCents:            mrr * 12,
+		ActiveSubscribers:   active,
+		TrialingSubscribers: trialing,
+		NewInWindow:         newSubs,
+		ChurnedInWindow:     churned,
+	}, nil
+}
+
+func buildDisputesSection(db *sql.DB, fromTS, toTS int64) (digestDisputes, error) {
+	// Open disputes (regardless of window — open status is the property)
+	openRows, err := db.Query(`SELECT data FROM resources WHERE resource_type='disputes'
+		AND json_extract(data,'$.status') IN ('needs_response','warning_needs_response','under_review','warning_under_review')`)
+	if err != nil {
+		return digestDisputes{}, fmt.Errorf("querying open disputes: %w", err)
+	}
+	defer openRows.Close()
+
+	openCount := 0
+	var openTotal int64
+	for openRows.Next() {
+		var data string
+		if err := openRows.Scan(&data); err != nil {
+			return digestDisputes{}, err
+		}
+		raw := json.RawMessage(data)
+		openCount++
+		if amt, ok := jsonGetInt(raw, "amount"); ok {
+			openTotal += amt
+		}
+	}
+	if err := openRows.Err(); err != nil {
+		return digestDisputes{}, err
+	}
+
+	// Resolved-in-window
+	winRows, err := db.Query(`SELECT data FROM resources WHERE resource_type='disputes'
+		AND json_extract(data,'$.status') IN ('won','lost')
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) <= ?`, fromTS, toTS)
+	if err != nil {
+		return digestDisputes{}, fmt.Errorf("querying resolved disputes: %w", err)
+	}
+	defer winRows.Close()
+
+	won := 0
+	lost := 0
+	for winRows.Next() {
+		var data string
+		if err := winRows.Scan(&data); err != nil {
+			return digestDisputes{}, err
+		}
+		raw := json.RawMessage(data)
+		status, _ := jsonGet(raw, "status")
+		switch status {
+		case "won":
+			won++
+		case "lost":
+			lost++
+		}
+	}
+	if err := winRows.Err(); err != nil {
+		return digestDisputes{}, err
+	}
+
+	return digestDisputes{
+		OpenCount:    openCount,
+		OpenTotal:    openTotal,
+		WonInWindow:  won,
+		LostInWindow: lost,
+	}, nil
+}
+
+func buildPayoutsSection(db *sql.DB) (digestPayouts, error) {
+	rs, err := db.Query(`SELECT data FROM resources WHERE resource_type='payouts'
+		ORDER BY CAST(IFNULL(json_extract(data,'$.arrival_date'),0) AS INTEGER) DESC LIMIT 30`)
+	if err != nil {
+		return digestPayouts{}, fmt.Errorf("querying payouts: %w", err)
+	}
+	defer rs.Close()
+
+	type payout struct {
+		amount  int64
+		arrival int64
+		status  string
+	}
+	var pending, paid []payout
+	for rs.Next() {
+		var data string
+		if err := rs.Scan(&data); err != nil {
+			return digestPayouts{}, err
+		}
+		raw := json.RawMessage(data)
+		amt, _ := jsonGetInt(raw, "amount")
+		arr, _ := jsonGetInt(raw, "arrival_date")
+		st, _ := jsonGet(raw, "status")
+		p := payout{amount: amt, arrival: arr, status: st}
+		switch st {
+		case "pending", "in_transit":
+			pending = append(pending, p)
+		case "paid":
+			paid = append(paid, p)
+		}
+	}
+	if err := rs.Err(); err != nil {
+		return digestPayouts{}, err
+	}
+
+	out := digestPayouts{}
+	if len(pending) > 0 {
+		sort.SliceStable(pending, func(i, j int) bool { return pending[i].arrival < pending[j].arrival })
+		out.NextPayoutCents = pending[0].amount
+		out.NextPayoutArrival = time.Unix(pending[0].arrival, 0).UTC().Format("2006-01-02")
+	}
+	if len(paid) > 0 {
+		// paid list is already DESC by arrival_date thanks to ORDER BY
+		// (skipping `pending` may have lifted later ones up, but `paid` order
+		// among itself is preserved by SQL — re-sort for safety).
+		sort.SliceStable(paid, func(i, j int) bool { return paid[i].arrival > paid[j].arrival })
+		out.LastPayoutCents = paid[0].amount
+		out.LastPayoutArrival = time.Unix(paid[0].arrival, 0).UTC().Format("2006-01-02")
+		out.LastPayoutStatus = paid[0].status
+	}
+	return out, nil
+}
+
+// renderDigestMarkdown produces the human-friendly markdown report.
+// Section ordering: revenue, subscriptions, disputes, payouts.
+func renderDigestMarkdown(d dailyDigest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Stripe Daily Digest\n")
+	fmt.Fprintf(&b, "**Period:** %s -> %s\n\n", d.From, d.To)
+	fmt.Fprintf(&b, "---\n\n")
+
+	if d.Charges != nil {
+		fmt.Fprintf(&b, "## Revenue\n\n")
+		fmt.Fprintf(&b, "| Metric | Value |\n|---|---|\n")
+		fmt.Fprintf(&b, "| Gross | USD %s |\n", centsToDollars(d.Charges.GrossCents))
+		fmt.Fprintf(&b, "| Refunds | USD %s |\n", centsToDollars(d.Charges.RefundsCents))
+		fmt.Fprintf(&b, "| **Net** | **USD %s** |\n", centsToDollars(d.Charges.NetCents))
+		fmt.Fprintf(&b, "| Successful charges | %d |\n", d.Charges.SuccessfulCount)
+		fmt.Fprintf(&b, "| Failed charges | %d |\n", d.Charges.FailedCount)
+		fmt.Fprintf(&b, "| Success rate | %.2f%% |\n", d.Charges.SuccessRatePct)
+		fmt.Fprintf(&b, "| AOV | USD %s |\n\n", centsToDollars(d.Charges.AOVCents))
+
+		if len(d.Charges.Days) > 0 {
+			fmt.Fprintf(&b, "### Day-by-day\n\n| Date | Charges | Gross | Refunds | Net |\n|---|---|---|---|---|\n")
+			for _, row := range d.Charges.Days {
+				fmt.Fprintf(&b, "| %s | %d | USD %s | USD %s | USD %s |\n",
+					row.Date, row.ChargeCount,
+					centsToDollars(row.GrossCents),
+					centsToDollars(row.RefundsCents),
+					centsToDollars(row.NetCents))
+			}
+			fmt.Fprintln(&b)
+		}
+		if len(d.Charges.TopFailureCodes) > 0 {
+			fmt.Fprintf(&b, "### Top failure codes\n\n| Code | Count |\n|---|---|\n")
+			for _, r := range d.Charges.TopFailureCodes {
+				fmt.Fprintf(&b, "| %s | %d |\n", r.Code, r.Count)
+			}
+			fmt.Fprintln(&b)
+		}
+		fmt.Fprintf(&b, "---\n\n")
+	}
+
+	if d.Subs != nil {
+		fmt.Fprintf(&b, "## Subscriptions\n\n| Metric | Value |\n|---|---|\n")
+		fmt.Fprintf(&b, "| MRR | USD %s |\n", centsToDollars(d.Subs.MRRCents))
+		fmt.Fprintf(&b, "| ARR | USD %s |\n", centsToDollars(d.Subs.ARRCents))
+		fmt.Fprintf(&b, "| Active subscribers | %d |\n", d.Subs.ActiveSubscribers)
+		fmt.Fprintf(&b, "| Trialing subscribers | %d |\n", d.Subs.TrialingSubscribers)
+		fmt.Fprintf(&b, "| New in window | %d |\n", d.Subs.NewInWindow)
+		fmt.Fprintf(&b, "| Churned in window | %d |\n\n", d.Subs.ChurnedInWindow)
+		fmt.Fprintf(&b, "---\n\n")
+	}
+
+	if d.Disputes != nil {
+		fmt.Fprintf(&b, "## Disputes\n\n")
+		fmt.Fprintf(&b, "Open: **%d** (total USD %s)\n", d.Disputes.OpenCount, centsToDollars(d.Disputes.OpenTotal))
+		fmt.Fprintf(&b, "Resolved in window: %d won, %d lost\n\n", d.Disputes.WonInWindow, d.Disputes.LostInWindow)
+		fmt.Fprintf(&b, "---\n\n")
+	}
+
+	if d.Payouts != nil {
+		fmt.Fprintf(&b, "## Payouts\n\n")
+		if d.Payouts.NextPayoutCents > 0 {
+			fmt.Fprintf(&b, "Next: USD %s arriving %s\n", centsToDollars(d.Payouts.NextPayoutCents), d.Payouts.NextPayoutArrival)
+		} else {
+			fmt.Fprintf(&b, "Next: _none pending_\n")
+		}
+		if d.Payouts.LastPayoutCents > 0 {
+			fmt.Fprintf(&b, "Last: USD %s on %s (%s)\n\n", centsToDollars(d.Payouts.LastPayoutCents), d.Payouts.LastPayoutArrival, d.Payouts.LastPayoutStatus)
+		} else {
+			fmt.Fprintf(&b, "Last: _none on record_\n\n")
+		}
+	}
+
+	return b.String()
+}
+
+// centsToDollars renders an integer minor-unit amount as a fixed-2-decimal
+// dollar string. Stripe stores amounts as integer cents; this helper is the
+// inverse render for human-readable markdown.
+func centsToDollars(amount int64) string {
+	neg := amount < 0
+	if neg {
+		amount = -amount
+	}
+	dollars := amount / 100
+	cents := amount % 100
+	sign := ""
+	if neg {
+		sign = "-"
+	}
+	return fmt.Sprintf("%s%d.%02d", sign, dollars, cents)
+}

--- a/library/payments/stripe/internal/cli/daily_digest.go
+++ b/library/payments/stripe/internal/cli/daily_digest.go
@@ -457,17 +457,14 @@ func buildSubsSection(db *sql.DB, fromTS, toTS int64) (digestSubs, error) {
 		}
 		if status == "active" || status == "trialing" {
 			// subscriptionMonthlyMRR returns (total monthly-normalized minor
-			// units, primary currency code, per-currency breakdown for
-			// multi-item subs with mixed currencies). Accumulate per-currency
-			// so the markdown renderer can show an honest breakdown instead
-			// of a single label that misrepresents non-USD merchants.
-			m, cur, perCur := subscriptionMonthlyMRR(raw)
+			// units, primary currency code, per-PRODUCT breakdown). The third
+			// return value is NOT per-currency — it's keyed by product ID —
+			// so accumulate using `cur` only. (Subscriptions in Stripe are
+			// settlement-currency-uniform across items; mixed-currency items
+			// inside a single subscription are not a real Stripe shape.)
+			m, cur, _ := subscriptionMonthlyMRR(raw)
 			mrr += m
-			if len(perCur) > 0 {
-				for c, v := range perCur {
-					byCurrency[normalizeCurrencyCode(c)] += v
-				}
-			} else if cur != "" {
+			if cur != "" {
 				byCurrency[normalizeCurrencyCode(cur)] += m
 			}
 		}

--- a/library/payments/stripe/internal/cli/daily_digest.go
+++ b/library/payments/stripe/internal/cli/daily_digest.go
@@ -20,6 +20,11 @@ import (
 )
 
 type digestCharges struct {
+	// GrossCents/RefundsCents/NetCents/AOVCents are face-value sums across ALL
+	// currencies. For multi-currency merchants this is NOT a converted total —
+	// use ByCurrencyCents (and the renderer's per-currency breakdown) to read
+	// honestly. CurrencyLabel reflects the right label to display alongside
+	// the scalar totals.
 	GrossCents       int64                     `json:"gross_cents"`
 	RefundsCents     int64                     `json:"refunds_cents"`
 	NetCents         int64                     `json:"net_cents"`
@@ -27,6 +32,7 @@ type digestCharges struct {
 	FailedCount      int                       `json:"failed_count"`
 	SuccessRatePct   float64                   `json:"success_rate_pct"`
 	AOVCents         int64                     `json:"aov_cents"`
+	ByCurrencyCents  map[string]int64          `json:"by_currency_cents,omitempty"`
 	Days             []digestRevenueDay        `json:"days"`
 	TopFailureCodes  []digestFailureCodeRow    `json:"top_failure_codes,omitempty"`
 }
@@ -59,16 +65,26 @@ type digestSubs struct {
 }
 
 type digestDisputes struct {
-	OpenCount   int   `json:"open_count"`
-	OpenTotal   int64 `json:"open_total_cents"`
-	WonInWindow int   `json:"won_in_window"`
-	LostInWindow int  `json:"lost_in_window"`
+	OpenCount       int              `json:"open_count"`
+	OpenTotal       int64            `json:"open_total_cents"`
+	OpenByCurrency  map[string]int64 `json:"open_by_currency_cents,omitempty"`
+	// WonOpenedInWindow / LostOpenedInWindow count disputes whose `created`
+	// timestamp (when the dispute was OPENED) falls inside the window AND
+	// whose status is currently won/lost. They do NOT count disputes opened
+	// before the window but resolved inside it — Stripe does not expose a
+	// dispute resolution timestamp on the dispute object itself; resolution
+	// dates live in the events log, which this digest does not query.
+	WonOpenedInWindow  int `json:"won_opened_in_window"`
+	LostOpenedInWindow int `json:"lost_opened_in_window"`
+	WindowNote         string `json:"window_note,omitempty"`
 }
 
 type digestPayouts struct {
 	NextPayoutCents      int64  `json:"next_payout_cents,omitempty"`
+	NextPayoutCurrency   string `json:"next_payout_currency,omitempty"`
 	NextPayoutArrival    string `json:"next_payout_arrival,omitempty"`
 	LastPayoutCents      int64  `json:"last_payout_cents,omitempty"`
+	LastPayoutCurrency   string `json:"last_payout_currency,omitempty"`
 	LastPayoutArrival    string `json:"last_payout_arrival,omitempty"`
 	LastPayoutStatus     string `json:"last_payout_status,omitempty"`
 }
@@ -296,6 +312,7 @@ func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (di
 	successCount := 0
 	failedCount := 0
 	failureCodes := make(map[string]int)
+	byCurrency := make(map[string]int64)
 
 	for rs.Next() {
 		var data string
@@ -305,6 +322,7 @@ func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (di
 		raw := json.RawMessage(data)
 		status, _ := jsonGet(raw, "status")
 		amount, _ := jsonGetInt(raw, "amount")
+		currency, _ := jsonGet(raw, "currency")
 		ts, _ := jsonGetInt(raw, "created")
 		day := time.Unix(ts, 0).UTC().Format("2006-01-02")
 
@@ -319,6 +337,8 @@ func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (di
 			grossTotal += amount
 			row.ChargeCount++
 			row.GrossCents += amount
+			// Track per-currency for gross only — refunds tracked separately below.
+			byCurrency[normalizeCurrencyCode(currency)] += amount
 		case "failed":
 			failedCount++
 			code, _ := jsonGet(raw, "failure_code")
@@ -349,12 +369,17 @@ func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (di
 		}
 		raw := json.RawMessage(data)
 		amount, _ := jsonGetInt(raw, "amount")
+		currency, _ := jsonGet(raw, "currency")
 		ts, _ := jsonGetInt(raw, "created")
 		day := time.Unix(ts, 0).UTC().Format("2006-01-02")
 		refundTotal += amount
 		if row, ok := dayMap[day]; ok {
 			row.RefundsCents += amount
 		}
+		// Subtract refund from per-currency gross so the per-currency view
+		// shows NET. If currency is unknown, fall back to the bucket so the
+		// total still reconciles.
+		byCurrency[normalizeCurrencyCode(currency)] -= amount
 	}
 	if err := refundRows.Err(); err != nil {
 		return digestCharges{}, err
@@ -394,6 +419,7 @@ func buildChargesSection(db *sql.DB, fromTS, toTS int64, from, to time.Time) (di
 		FailedCount:     failedCount,
 		SuccessRatePct:  roundTo(successRate, 2),
 		AOVCents:        aov,
+		ByCurrencyCents: byCurrency,
 		Days:            days,
 		TopFailureCodes: topCodes,
 	}, nil
@@ -486,6 +512,7 @@ func buildDisputesSection(db *sql.DB, fromTS, toTS int64) (digestDisputes, error
 
 	openCount := 0
 	var openTotal int64
+	openByCurrency := make(map[string]int64)
 	for openRows.Next() {
 		var data string
 		if err := openRows.Scan(&data); err != nil {
@@ -495,13 +522,15 @@ func buildDisputesSection(db *sql.DB, fromTS, toTS int64) (digestDisputes, error
 		openCount++
 		if amt, ok := jsonGetInt(raw, "amount"); ok {
 			openTotal += amt
+			cur, _ := jsonGet(raw, "currency")
+			openByCurrency[normalizeCurrencyCode(cur)] += amt
 		}
 	}
 	if err := openRows.Err(); err != nil {
 		return digestDisputes{}, err
 	}
 
-	// Resolved-in-window
+	// Resolved-in-window — see WindowNote below for the caveat.
 	winRows, err := db.Query(`SELECT data FROM resources WHERE resource_type='disputes'
 		AND json_extract(data,'$.status') IN ('won','lost')
 		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
@@ -531,11 +560,17 @@ func buildDisputesSection(db *sql.DB, fromTS, toTS int64) (digestDisputes, error
 		return digestDisputes{}, err
 	}
 
+	note := ""
+	if won > 0 || lost > 0 {
+		note = "Counts disputes OPENED in the window that are currently won/lost. Disputes opened earlier but resolved inside the window are not included — Stripe does not expose a resolution timestamp on the dispute object."
+	}
 	return digestDisputes{
-		OpenCount:    openCount,
-		OpenTotal:    openTotal,
-		WonInWindow:  won,
-		LostInWindow: lost,
+		OpenCount:          openCount,
+		OpenTotal:          openTotal,
+		OpenByCurrency:     openByCurrency,
+		WonOpenedInWindow:  won,
+		LostOpenedInWindow: lost,
+		WindowNote:         note,
 	}, nil
 }
 
@@ -548,9 +583,10 @@ func buildPayoutsSection(db *sql.DB) (digestPayouts, error) {
 	defer rs.Close()
 
 	type payout struct {
-		amount  int64
-		arrival int64
-		status  string
+		amount   int64
+		arrival  int64
+		status   string
+		currency string
 	}
 	var pending, paid []payout
 	for rs.Next() {
@@ -562,7 +598,8 @@ func buildPayoutsSection(db *sql.DB) (digestPayouts, error) {
 		amt, _ := jsonGetInt(raw, "amount")
 		arr, _ := jsonGetInt(raw, "arrival_date")
 		st, _ := jsonGet(raw, "status")
-		p := payout{amount: amt, arrival: arr, status: st}
+		cur, _ := jsonGet(raw, "currency")
+		p := payout{amount: amt, arrival: arr, status: st, currency: normalizeCurrencyCode(cur)}
 		switch st {
 		case "pending", "in_transit":
 			pending = append(pending, p)
@@ -578,6 +615,7 @@ func buildPayoutsSection(db *sql.DB) (digestPayouts, error) {
 	if len(pending) > 0 {
 		sort.SliceStable(pending, func(i, j int) bool { return pending[i].arrival < pending[j].arrival })
 		out.NextPayoutCents = pending[0].amount
+		out.NextPayoutCurrency = pending[0].currency
 		out.NextPayoutArrival = time.Unix(pending[0].arrival, 0).UTC().Format("2006-01-02")
 	}
 	if len(paid) > 0 {
@@ -586,10 +624,26 @@ func buildPayoutsSection(db *sql.DB) (digestPayouts, error) {
 		// among itself is preserved by SQL — re-sort for safety).
 		sort.SliceStable(paid, func(i, j int) bool { return paid[i].arrival > paid[j].arrival })
 		out.LastPayoutCents = paid[0].amount
+		out.LastPayoutCurrency = paid[0].currency
 		out.LastPayoutArrival = time.Unix(paid[0].arrival, 0).UTC().Format("2006-01-02")
 		out.LastPayoutStatus = paid[0].status
 	}
 	return out, nil
+}
+
+// digestCurrencyLabel renders the right label for a summed amount: if all
+// entries are in one currency, use that code; if multiple, fall back to
+// "Total (mixed currency)"; if no currency data is known, show a dash.
+func digestCurrencyLabel(byCurrency map[string]int64) string {
+	switch len(byCurrency) {
+	case 1:
+		for c := range byCurrency {
+			return c
+		}
+	case 0:
+		return "—"
+	}
+	return "Total (mixed currency)"
 }
 
 // renderDigestMarkdown produces the human-friendly markdown report.
@@ -601,24 +655,41 @@ func renderDigestMarkdown(d dailyDigest) string {
 	fmt.Fprintf(&b, "---\n\n")
 
 	if d.Charges != nil {
+		curLabel := digestCurrencyLabel(d.Charges.ByCurrencyCents)
 		fmt.Fprintf(&b, "## Revenue\n\n")
 		fmt.Fprintf(&b, "| Metric | Value |\n|---|---|\n")
-		fmt.Fprintf(&b, "| Gross | USD %s |\n", centsToDollars(d.Charges.GrossCents))
-		fmt.Fprintf(&b, "| Refunds | USD %s |\n", centsToDollars(d.Charges.RefundsCents))
-		fmt.Fprintf(&b, "| **Net** | **USD %s** |\n", centsToDollars(d.Charges.NetCents))
+		fmt.Fprintf(&b, "| Gross | %s %s |\n", curLabel, centsToDollars(d.Charges.GrossCents))
+		fmt.Fprintf(&b, "| Refunds | %s %s |\n", curLabel, centsToDollars(d.Charges.RefundsCents))
+		fmt.Fprintf(&b, "| **Net** | **%s %s** |\n", curLabel, centsToDollars(d.Charges.NetCents))
 		fmt.Fprintf(&b, "| Successful charges | %d |\n", d.Charges.SuccessfulCount)
 		fmt.Fprintf(&b, "| Failed charges | %d |\n", d.Charges.FailedCount)
 		fmt.Fprintf(&b, "| Success rate | %.2f%% |\n", d.Charges.SuccessRatePct)
-		fmt.Fprintf(&b, "| AOV | USD %s |\n\n", centsToDollars(d.Charges.AOVCents))
+		fmt.Fprintf(&b, "| AOV | %s %s |\n\n", curLabel, centsToDollars(d.Charges.AOVCents))
+
+		if len(d.Charges.ByCurrencyCents) > 1 {
+			// Multi-currency: render per-currency net breakdown so the scalar
+			// "Mixed currency" totals above are interpretable. Sort by code
+			// so the table is diff-stable across runs.
+			fmt.Fprintf(&b, "Per-currency net (gross − refunds):\n\n| Currency | Net |\n|---|---|\n")
+			codes := make([]string, 0, len(d.Charges.ByCurrencyCents))
+			for c := range d.Charges.ByCurrencyCents {
+				codes = append(codes, c)
+			}
+			sort.Strings(codes)
+			for _, c := range codes {
+				fmt.Fprintf(&b, "| %s | %s |\n", c, centsToDollars(d.Charges.ByCurrencyCents[c]))
+			}
+			fmt.Fprintln(&b)
+		}
 
 		if len(d.Charges.Days) > 0 {
 			fmt.Fprintf(&b, "### Day-by-day\n\n| Date | Charges | Gross | Refunds | Net |\n|---|---|---|---|---|\n")
 			for _, row := range d.Charges.Days {
-				fmt.Fprintf(&b, "| %s | %d | USD %s | USD %s | USD %s |\n",
+				fmt.Fprintf(&b, "| %s | %d | %s %s | %s %s | %s %s |\n",
 					row.Date, row.ChargeCount,
-					centsToDollars(row.GrossCents),
-					centsToDollars(row.RefundsCents),
-					centsToDollars(row.NetCents))
+					curLabel, centsToDollars(row.GrossCents),
+					curLabel, centsToDollars(row.RefundsCents),
+					curLabel, centsToDollars(row.NetCents))
 			}
 			fmt.Fprintln(&b)
 		}
@@ -671,21 +742,46 @@ func renderDigestMarkdown(d dailyDigest) string {
 	}
 
 	if d.Disputes != nil {
+		curLabel := digestCurrencyLabel(d.Disputes.OpenByCurrency)
 		fmt.Fprintf(&b, "## Disputes\n\n")
-		fmt.Fprintf(&b, "Open: **%d** (total USD %s)\n", d.Disputes.OpenCount, centsToDollars(d.Disputes.OpenTotal))
-		fmt.Fprintf(&b, "Resolved in window: %d won, %d lost\n\n", d.Disputes.WonInWindow, d.Disputes.LostInWindow)
+		fmt.Fprintf(&b, "Open: **%d** (total %s %s)\n", d.Disputes.OpenCount, curLabel, centsToDollars(d.Disputes.OpenTotal))
+		fmt.Fprintf(&b, "Opened-in-window status: %d currently won, %d currently lost\n", d.Disputes.WonOpenedInWindow, d.Disputes.LostOpenedInWindow)
+		if d.Disputes.WindowNote != "" {
+			fmt.Fprintf(&b, "_Note:_ %s\n", d.Disputes.WindowNote)
+		}
+		fmt.Fprintln(&b)
+		if len(d.Disputes.OpenByCurrency) > 1 {
+			fmt.Fprintf(&b, "Per-currency open:\n\n| Currency | Open total |\n|---|---|\n")
+			codes := make([]string, 0, len(d.Disputes.OpenByCurrency))
+			for c := range d.Disputes.OpenByCurrency {
+				codes = append(codes, c)
+			}
+			sort.Strings(codes)
+			for _, c := range codes {
+				fmt.Fprintf(&b, "| %s | %s |\n", c, centsToDollars(d.Disputes.OpenByCurrency[c]))
+			}
+			fmt.Fprintln(&b)
+		}
 		fmt.Fprintf(&b, "---\n\n")
 	}
 
 	if d.Payouts != nil {
 		fmt.Fprintf(&b, "## Payouts\n\n")
 		if d.Payouts.NextPayoutCents > 0 {
-			fmt.Fprintf(&b, "Next: USD %s arriving %s\n", centsToDollars(d.Payouts.NextPayoutCents), d.Payouts.NextPayoutArrival)
+			nextCur := d.Payouts.NextPayoutCurrency
+			if nextCur == "" {
+				nextCur = "—"
+			}
+			fmt.Fprintf(&b, "Next: %s %s arriving %s\n", nextCur, centsToDollars(d.Payouts.NextPayoutCents), d.Payouts.NextPayoutArrival)
 		} else {
 			fmt.Fprintf(&b, "Next: _none pending_\n")
 		}
 		if d.Payouts.LastPayoutCents > 0 {
-			fmt.Fprintf(&b, "Last: USD %s on %s (%s)\n\n", centsToDollars(d.Payouts.LastPayoutCents), d.Payouts.LastPayoutArrival, d.Payouts.LastPayoutStatus)
+			lastCur := d.Payouts.LastPayoutCurrency
+			if lastCur == "" {
+				lastCur = "—"
+			}
+			fmt.Fprintf(&b, "Last: %s %s on %s (%s)\n\n", lastCur, centsToDollars(d.Payouts.LastPayoutCents), d.Payouts.LastPayoutArrival, d.Payouts.LastPayoutStatus)
 		} else {
 			fmt.Fprintf(&b, "Last: _none on record_\n\n")
 		}

--- a/library/payments/stripe/internal/cli/daily_digest.go
+++ b/library/payments/stripe/internal/cli/daily_digest.go
@@ -45,12 +45,17 @@ type digestFailureCodeRow struct {
 }
 
 type digestSubs struct {
-	MRRCents            int64 `json:"mrr_cents"`
-	ARRCents            int64 `json:"arr_cents"`
-	ActiveSubscribers   int   `json:"active_subscribers"`
-	TrialingSubscribers int   `json:"trialing_subscribers"`
-	NewInWindow         int   `json:"new_in_window"`
-	ChurnedInWindow     int   `json:"churned_in_window"`
+	// MRRCents is the sum of monthly-normalized recurring revenue across ALL
+	// currencies, in minor units. For multi-currency merchants this is a
+	// face-value sum, not a converted total — use ByCurrencyCents for the
+	// honest per-currency breakdown.
+	MRRCents            int64            `json:"mrr_cents"`
+	ARRCents            int64            `json:"arr_cents"`
+	ByCurrencyCents     map[string]int64 `json:"by_currency_cents,omitempty"`
+	ActiveSubscribers   int              `json:"active_subscribers"`
+	TrialingSubscribers int              `json:"trialing_subscribers"`
+	NewInWindow         int              `json:"new_in_window"`
+	ChurnedInWindow     int              `json:"churned_in_window"`
 }
 
 type digestDisputes struct {
@@ -402,6 +407,7 @@ func buildSubsSection(db *sql.DB, fromTS, toTS int64) (digestSubs, error) {
 	defer rs.Close()
 
 	var mrr int64
+	byCurrency := make(map[string]int64)
 	active := 0
 	trialing := 0
 	newSubs := 0
@@ -424,8 +430,20 @@ func buildSubsSection(db *sql.DB, fromTS, toTS int64) (digestSubs, error) {
 			trialing++
 		}
 		if status == "active" || status == "trialing" {
-			m, _, _ := subscriptionMonthlyMRR(raw)
+			// subscriptionMonthlyMRR returns (total monthly-normalized minor
+			// units, primary currency code, per-currency breakdown for
+			// multi-item subs with mixed currencies). Accumulate per-currency
+			// so the markdown renderer can show an honest breakdown instead
+			// of a single label that misrepresents non-USD merchants.
+			m, cur, perCur := subscriptionMonthlyMRR(raw)
 			mrr += m
+			if len(perCur) > 0 {
+				for c, v := range perCur {
+					byCurrency[normalizeCurrencyCode(c)] += v
+				}
+			} else if cur != "" {
+				byCurrency[normalizeCurrencyCode(cur)] += m
+			}
 		}
 		if created >= fromTS && created <= toTS {
 			newSubs++
@@ -441,11 +459,20 @@ func buildSubsSection(db *sql.DB, fromTS, toTS int64) (digestSubs, error) {
 	return digestSubs{
 		MRRCents:            mrr,
 		ARRCents:            mrr * 12,
+		ByCurrencyCents:     byCurrency,
 		ActiveSubscribers:   active,
 		TrialingSubscribers: trialing,
 		NewInWindow:         newSubs,
 		ChurnedInWindow:     churned,
 	}, nil
+}
+
+func normalizeCurrencyCode(c string) string {
+	c = strings.TrimSpace(c)
+	if c == "" {
+		return "unknown"
+	}
+	return strings.ToUpper(c)
 }
 
 func buildDisputesSection(db *sql.DB, fromTS, toTS int64) (digestDisputes, error) {
@@ -606,13 +633,40 @@ func renderDigestMarkdown(d dailyDigest) string {
 	}
 
 	if d.Subs != nil {
+		// Choose the MRR label honestly. Single-currency merchant gets that
+		// currency code; multi-currency gets a "mixed" label with a per-
+		// currency breakdown table below; absent currency data gets a dash.
+		mrrLabel := "Total (mixed currency)"
+		switch len(d.Subs.ByCurrencyCents) {
+		case 1:
+			for c := range d.Subs.ByCurrencyCents {
+				mrrLabel = c
+			}
+		case 0:
+			mrrLabel = "—"
+		}
 		fmt.Fprintf(&b, "## Subscriptions\n\n| Metric | Value |\n|---|---|\n")
-		fmt.Fprintf(&b, "| MRR | USD %s |\n", centsToDollars(d.Subs.MRRCents))
-		fmt.Fprintf(&b, "| ARR | USD %s |\n", centsToDollars(d.Subs.ARRCents))
+		fmt.Fprintf(&b, "| MRR | %s %s |\n", mrrLabel, centsToDollars(d.Subs.MRRCents))
+		fmt.Fprintf(&b, "| ARR | %s %s |\n", mrrLabel, centsToDollars(d.Subs.ARRCents))
 		fmt.Fprintf(&b, "| Active subscribers | %d |\n", d.Subs.ActiveSubscribers)
 		fmt.Fprintf(&b, "| Trialing subscribers | %d |\n", d.Subs.TrialingSubscribers)
 		fmt.Fprintf(&b, "| New in window | %d |\n", d.Subs.NewInWindow)
 		fmt.Fprintf(&b, "| Churned in window | %d |\n\n", d.Subs.ChurnedInWindow)
+		if len(d.Subs.ByCurrencyCents) > 1 {
+			// Multi-currency: render per-currency monthly breakdown so the
+			// summed MRR row above is interpretable. Sort by code so the
+			// table is diff-stable across runs.
+			fmt.Fprintf(&b, "Per-currency MRR (monthly normalized):\n\n| Currency | MRR |\n|---|---|\n")
+			codes := make([]string, 0, len(d.Subs.ByCurrencyCents))
+			for c := range d.Subs.ByCurrencyCents {
+				codes = append(codes, c)
+			}
+			sort.Strings(codes)
+			for _, c := range codes {
+				fmt.Fprintf(&b, "| %s | %s |\n", c, centsToDollars(d.Subs.ByCurrencyCents[c]))
+			}
+			fmt.Fprintln(&b)
+		}
 		fmt.Fprintf(&b, "---\n\n")
 	}
 

--- a/library/payments/stripe/internal/cli/daily_digest_test.go
+++ b/library/payments/stripe/internal/cli/daily_digest_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: tests for the digest-section helpers added by the amend
+// (digestCurrencyLabel, normalizeCurrencyCode). These cover the
+// single/multi/empty currency-bucket cases that distinguish the
+// "USD" / "Total (mixed currency)" / "—" labels in the markdown
+// renderer.
+
+package cli
+
+import "testing"
+
+func TestNormalizeCurrencyCode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{in: "usd", want: "USD"},
+		{in: "USD", want: "USD"},
+		{in: " eur ", want: "EUR"},
+		{in: "Gbp", want: "GBP"},
+		{in: "", want: "unknown"},
+		{in: "   ", want: "unknown"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := normalizeCurrencyCode(c.in)
+			if got != c.want {
+				t.Errorf("normalizeCurrencyCode(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDigestCurrencyLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]int64
+		want string
+	}{
+		{
+			name: "single currency renders that code",
+			in:   map[string]int64{"USD": 1500},
+			want: "USD",
+		},
+		{
+			name: "multi-currency renders mixed label",
+			in:   map[string]int64{"USD": 1500, "EUR": 800},
+			want: "Total (mixed currency)",
+		},
+		{
+			name: "empty bucket renders dash",
+			in:   map[string]int64{},
+			want: "—",
+		},
+		{
+			name: "nil bucket renders dash",
+			in:   nil,
+			want: "—",
+		},
+		{
+			name: "single non-USD currency",
+			in:   map[string]int64{"EUR": 12000},
+			want: "EUR",
+		},
+		{
+			name: "three currencies still renders mixed label",
+			in:   map[string]int64{"USD": 1000, "EUR": 500, "GBP": 200},
+			want: "Total (mixed currency)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := digestCurrencyLabel(c.in)
+			if got != c.want {
+				t.Errorf("digestCurrencyLabel(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/library/payments/stripe/internal/cli/dispute_win_rate.go
+++ b/library/payments/stripe/internal/cli/dispute_win_rate.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: add `dispute-win-rate` analytics command. Computes historical dispute
+// outcome ratio (won / total resolved) with breakdowns by reason and by
+// amount-band.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/stripe/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+type disputeBucketRow struct {
+	Label       string  `json:"label"`
+	Resolved    int     `json:"resolved"`
+	Won         int     `json:"won"`
+	Lost        int     `json:"lost"`
+	WonRatePct  float64 `json:"won_rate_pct"`
+}
+
+type disputeWinReport struct {
+	Since          string             `json:"since"`
+	By             string             `json:"by"`
+	IncludePending bool               `json:"include_pending"`
+	Resolved       int                `json:"resolved"`
+	Won            int                `json:"won"`
+	Lost           int                `json:"lost"`
+	Pending        int                `json:"pending"`
+	WonRatePct     float64            `json:"won_rate_pct"`
+	ByReason       []disputeBucketRow `json:"by_reason,omitempty"`
+	ByAmountBand   []disputeBucketRow `json:"by_amount_band,omitempty"`
+}
+
+// Amount bands in cents: <$10, $10–100, $100–500, $500–2k, >$2k. Stripe
+// disputes are denominated in the same minor unit as their charge.
+var amountBands = []struct {
+	label string
+	min   int64
+	max   int64
+}{
+	{"<$10", 0, 999},
+	{"$10-$100", 1000, 9999},
+	{"$100-$500", 10000, 49999},
+	{"$500-$2k", 50000, 199999},
+	{">$2k", 200000, 1<<62 - 1},
+}
+
+func newDisputeWinRateCmd(flags *rootFlags) *cobra.Command {
+	var sinceStr string
+	var by string
+	var includePending bool
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "dispute-win-rate",
+		Short: "Historical dispute outcome ratio with reason and amount-band breakdowns",
+		Long: `Walk every dispute since the cutoff. Partition by status: 'won' and 'lost'
+are resolved; the warning_* and needs_response / under_review states are
+pending. won_rate_pct = won / resolved. --by reason adds a per-reason row;
+--by amount-band adds an amount-bucket row. --include-pending widens the
+denominator to all disputes, useful for tracking trajectory.`,
+		Example: `  # Last 90 days, both breakdowns
+  stripe-pp-cli dispute-win-rate --json
+
+  # Last year, reason-only
+  stripe-pp-cli dispute-win-rate --since 365d --by reason --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			since, err := parseHumanDuration(sinceStr)
+			if err != nil {
+				return usageErr(fmt.Errorf("invalid --since: %w", err))
+			}
+			if since == 0 {
+				since = 90 * 24 * time.Hour
+			}
+			by = strings.ToLower(strings.TrimSpace(by))
+			switch by {
+			case "", "all", "reason", "amount-band":
+				// ok
+			default:
+				return usageErr(fmt.Errorf("--by must be one of: reason, amount-band, all (got %q)", by))
+			}
+
+			path := transcendenceDBPath(dbPath)
+			db, err := store.OpenReadOnly(path)
+			if err != nil {
+				return configErr(fmt.Errorf("opening local database (%s): %w\nRun 'stripe-pp-cli sync' first.", path, err))
+			}
+			defer db.Close()
+
+			report, err := computeDisputeWinRate(db.DB(), since, by, includePending)
+			if err != nil {
+				return apiErr(err)
+			}
+			return printJSONFiltered(cmd.OutOrStdout(), report, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&sinceStr, "since", "90d", "Lookback window (e.g. 90d, 365d)")
+	cmd.Flags().StringVar(&by, "by", "all", "Breakdown axis: reason, amount-band, or all (default)")
+	cmd.Flags().BoolVar(&includePending, "include-pending", false, "Include pending disputes in the denominator")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/stripe-pp-cli/data.db)")
+
+	return cmd
+}
+
+// computeDisputeWinRate aggregates dispute outcomes within the window.
+func computeDisputeWinRate(db *sql.DB, since time.Duration, by string, includePending bool) (disputeWinReport, error) {
+	now := time.Now().UTC()
+	cutoff := now.Add(-since).Unix()
+
+	rs, err := db.Query(`SELECT id, data FROM resources WHERE resource_type='disputes'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?`, cutoff)
+	if err != nil {
+		return disputeWinReport{}, fmt.Errorf("querying disputes: %w", err)
+	}
+	defer rs.Close()
+
+	var total bucket
+	pending := 0
+	byReason := make(map[string]*bucket)
+	byBand := make(map[string]*bucket)
+
+	for rs.Next() {
+		var id, data string
+		_ = id
+		if err := rs.Scan(&id, &data); err != nil {
+			return disputeWinReport{}, err
+		}
+		raw := json.RawMessage(data)
+		status, _ := jsonGet(raw, "status")
+		reason, _ := jsonGet(raw, "reason")
+		if reason == "" {
+			reason = "unspecified"
+		}
+		amount, _ := jsonGetInt(raw, "amount")
+		bandLabel := amountBandLabel(amount)
+
+		isWon := status == "won"
+		isLost := status == "lost"
+		isResolved := isWon || isLost
+		isPending := strings.HasPrefix(status, "warning_") || status == "needs_response" || status == "under_review"
+
+		switch {
+		case isWon:
+			total.resolved++
+			total.won++
+			incBucket(byReason, reason, true, false)
+			incBucket(byBand, bandLabel, true, false)
+		case isLost:
+			total.resolved++
+			total.lost++
+			incBucket(byReason, reason, false, true)
+			incBucket(byBand, bandLabel, false, true)
+		case isPending:
+			pending++
+			if includePending {
+				incBucket(byReason, reason, false, false)
+				incBucket(byBand, bandLabel, false, false)
+			}
+		}
+		_ = isResolved
+	}
+	if err := rs.Err(); err != nil {
+		return disputeWinReport{}, err
+	}
+
+	denominator := total.resolved
+	if includePending {
+		denominator += pending
+	}
+	wonPct := 0.0
+	if denominator > 0 {
+		wonPct = float64(total.won) / float64(denominator) * 100
+	}
+
+	report := disputeWinReport{
+		Since:          since.String(),
+		By:             by,
+		IncludePending: includePending,
+		Resolved:       total.resolved,
+		Won:            total.won,
+		Lost:           total.lost,
+		Pending:        pending,
+		WonRatePct:     roundTo(wonPct, 2),
+	}
+
+	if by == "" || by == "all" || by == "reason" {
+		report.ByReason = flattenBuckets(byReason, includePending)
+	}
+	if by == "" || by == "all" || by == "amount-band" {
+		report.ByAmountBand = flattenBucketsOrdered(byBand, amountBandOrder(), includePending)
+	}
+	return report, nil
+}
+
+// incBucket increments the (resolved/won/lost) counts on a label bucket,
+// initializing the entry lazily.
+func incBucket(m map[string]*bucket, label string, won, lost bool) {
+	b, ok := m[label]
+	if !ok {
+		b = &bucket{}
+		m[label] = b
+	}
+	if won {
+		b.resolved++
+		b.won++
+	} else if lost {
+		b.resolved++
+		b.lost++
+	}
+	// pending case (neither won nor lost) widens denominator only.
+}
+
+type bucket struct {
+	resolved int
+	won      int
+	lost     int
+}
+
+// flattenBuckets emits rows in count-desc order. includePending is a hint
+// for documentation only — the buckets already reflect inclusion semantics.
+func flattenBuckets(m map[string]*bucket, _ bool) []disputeBucketRow {
+	out := make([]disputeBucketRow, 0, len(m))
+	for label, b := range m {
+		pct := 0.0
+		if b.resolved > 0 {
+			pct = float64(b.won) / float64(b.resolved) * 100
+		}
+		out = append(out, disputeBucketRow{
+			Label:      label,
+			Resolved:   b.resolved,
+			Won:        b.won,
+			Lost:       b.lost,
+			WonRatePct: roundTo(pct, 2),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Resolved > out[j].Resolved
+	})
+	return out
+}
+
+// flattenBucketsOrdered emits rows in the explicit `order` slice's order
+// (used for amount-band so bands always appear ascending, not by frequency).
+func flattenBucketsOrdered(m map[string]*bucket, order []string, _ bool) []disputeBucketRow {
+	out := make([]disputeBucketRow, 0, len(order))
+	for _, label := range order {
+		b, ok := m[label]
+		if !ok {
+			continue
+		}
+		pct := 0.0
+		if b.resolved > 0 {
+			pct = float64(b.won) / float64(b.resolved) * 100
+		}
+		out = append(out, disputeBucketRow{
+			Label:      label,
+			Resolved:   b.resolved,
+			Won:        b.won,
+			Lost:       b.lost,
+			WonRatePct: roundTo(pct, 2),
+		})
+	}
+	return out
+}
+
+// amountBandLabel maps an amount (in cents) to its band label.
+func amountBandLabel(amount int64) string {
+	for _, b := range amountBands {
+		if amount >= b.min && amount <= b.max {
+			return b.label
+		}
+	}
+	return amountBands[len(amountBands)-1].label
+}
+
+// amountBandOrder returns the canonical band ordering for output.
+func amountBandOrder() []string {
+	out := make([]string, len(amountBands))
+	for i, b := range amountBands {
+		out[i] = b.label
+	}
+	return out
+}

--- a/library/payments/stripe/internal/cli/failure_clusters.go
+++ b/library/payments/stripe/internal/cli/failure_clusters.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: add `failure-clusters` analytics command. Groups failed charges by
+// failure_code, optionally also by payment_method type, and surfaces the top
+// failure patterns. Different from dunning-queue (invoice-level vs charge-level).
+// Ported from an aggregateOperations.declineReasons rollup pattern.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/stripe/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+type failureCluster struct {
+	FailureCode      string   `json:"failure_code"`
+	PaymentMethod    string   `json:"payment_method_type,omitempty"`
+	Count            int      `json:"count"`
+	PercentOfTotal   float64  `json:"percent_of_total"`
+	SampleChargeIDs  []string `json:"sample_charge_ids,omitempty"`
+	TotalAmountCents int64    `json:"total_amount_cents"`
+}
+
+type failureClusterReport struct {
+	Days               int              `json:"window_days"`
+	TotalFailedCharges int              `json:"total_failed_charges"`
+	MinCount           int              `json:"min_count"`
+	ByPaymentMethod    bool             `json:"by_payment_method_type"`
+	Clusters           []failureCluster `json:"clusters"`
+}
+
+func newFailureClustersCmd(flags *rootFlags) *cobra.Command {
+	var days int
+	var minCount int
+	var byPMT bool
+	var dbPath string
+	var sampleSize int
+
+	cmd := &cobra.Command{
+		Use:   "failure-clusters",
+		Short: "Group failed charges by failure_code; surface top failure patterns",
+		Long: `Walk failed charges (resource_type=charges AND status='failed') within the
+window. Bucket by failure_code; optionally also by payment_method type. Clusters
+below --min-count are suppressed so noise doesn't crowd the signal. Sample charge
+IDs are included so an operator can drill into a specific failure cluster.`,
+		Example: `  # Last 30 days, default
+  stripe-pp-cli failure-clusters --json
+
+  # Last 7 days, breakdown by payment-method type
+  stripe-pp-cli failure-clusters --days 7 --by-payment-method-type --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			if days < 1 {
+				return usageErr(fmt.Errorf("--days must be >= 1 (got %d)", days))
+			}
+			if minCount < 1 {
+				return usageErr(fmt.Errorf("--min-count must be >= 1 (got %d)", minCount))
+			}
+
+			path := transcendenceDBPath(dbPath)
+			db, err := store.OpenReadOnly(path)
+			if err != nil {
+				return configErr(fmt.Errorf("opening local database (%s): %w\nRun 'stripe-pp-cli sync' first.", path, err))
+			}
+			defer db.Close()
+
+			report, err := computeFailureClusters(db.DB(), days, minCount, byPMT, sampleSize)
+			if err != nil {
+				return apiErr(err)
+			}
+			return printJSONFiltered(cmd.OutOrStdout(), report, flags)
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 30, "Lookback window in days")
+	cmd.Flags().IntVar(&minCount, "min-count", 3, "Suppress clusters with fewer than N charges")
+	cmd.Flags().BoolVar(&byPMT, "by-payment-method-type", false, "Sub-group each failure_code by payment_method type")
+	cmd.Flags().IntVar(&sampleSize, "sample-size", 5, "Max sample charge IDs to include per cluster")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/stripe-pp-cli/data.db)")
+
+	return cmd
+}
+
+// computeFailureClusters walks failed charges within `days` and aggregates by
+// failure_code (and optionally by payment_method.type as a second axis).
+func computeFailureClusters(db *sql.DB, days, minCount int, byPMT bool, sampleSize int) (failureClusterReport, error) {
+	now := time.Now()
+	cutoff := now.Add(-time.Duration(days) * 24 * time.Hour).Unix()
+
+	rs, err := db.Query(`SELECT id, data FROM resources WHERE resource_type='charges'
+		AND json_extract(data,'$.status') = 'failed'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?`, cutoff)
+	if err != nil {
+		return failureClusterReport{}, fmt.Errorf("querying charges: %w", err)
+	}
+	defer rs.Close()
+
+	// key -> cluster aggregator
+	type agg struct {
+		count   int
+		total   int64
+		samples []string
+		code    string
+		pmType  string
+	}
+	buckets := make(map[string]*agg)
+	totalFailed := 0
+
+	for rs.Next() {
+		var id, data string
+		if err := rs.Scan(&id, &data); err != nil {
+			return failureClusterReport{}, err
+		}
+		raw := json.RawMessage(data)
+		totalFailed++
+
+		code, ok := jsonGet(raw, "failure_code")
+		if !ok || code == "" {
+			code = "unknown"
+		}
+		pmType := ""
+		if byPMT {
+			pmType = extractPaymentMethodType(raw)
+			if pmType == "" {
+				pmType = "unknown"
+			}
+		}
+		key := code
+		if byPMT {
+			key = code + "|" + pmType
+		}
+		b, exists := buckets[key]
+		if !exists {
+			b = &agg{code: code, pmType: pmType}
+			buckets[key] = b
+		}
+		b.count++
+		if amount, ok := jsonGetInt(raw, "amount"); ok {
+			b.total += amount
+		}
+		if len(b.samples) < sampleSize {
+			b.samples = append(b.samples, id)
+		}
+	}
+	if err := rs.Err(); err != nil {
+		return failureClusterReport{}, err
+	}
+
+	clusters := make([]failureCluster, 0, len(buckets))
+	for _, b := range buckets {
+		if b.count < minCount {
+			continue
+		}
+		pct := 0.0
+		if totalFailed > 0 {
+			pct = float64(b.count) / float64(totalFailed) * 100
+		}
+		clusters = append(clusters, failureCluster{
+			FailureCode:      b.code,
+			PaymentMethod:    b.pmType,
+			Count:            b.count,
+			PercentOfTotal:   roundTo(pct, 2),
+			SampleChargeIDs:  b.samples,
+			TotalAmountCents: b.total,
+		})
+	}
+	sort.SliceStable(clusters, func(i, j int) bool {
+		return clusters[i].Count > clusters[j].Count
+	})
+
+	return failureClusterReport{
+		Days:               days,
+		TotalFailedCharges: totalFailed,
+		MinCount:           minCount,
+		ByPaymentMethod:    byPMT,
+		Clusters:           clusters,
+	}, nil
+}
+
+// extractPaymentMethodType pulls payment_method_details.type from a charge JSON
+// blob, defending against a missing or non-object payment_method_details.
+func extractPaymentMethodType(raw json.RawMessage) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	pmd, ok := obj["payment_method_details"]
+	if !ok || string(pmd) == "null" {
+		return ""
+	}
+	var inner map[string]json.RawMessage
+	if err := json.Unmarshal(pmd, &inner); err != nil {
+		return ""
+	}
+	if v, ok := inner["type"]; ok {
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil {
+			return s
+		}
+	}
+	return ""
+}
+
+// roundTo rounds a float to n decimal places. Used to keep percent strings
+// tidy in JSON without forcing a string format.
+func roundTo(v float64, n int) float64 {
+	pow := 1.0
+	for i := 0; i < n; i++ {
+		pow *= 10
+	}
+	// add 0.5 for banker's round-half-up; simple and good enough for percents.
+	if v >= 0 {
+		return float64(int64(v*pow+0.5)) / pow
+	}
+	return float64(int64(v*pow-0.5)) / pow
+}

--- a/library/payments/stripe/internal/cli/mrr_trend.go
+++ b/library/payments/stripe/internal/cli/mrr_trend.go
@@ -182,6 +182,14 @@ func computeMRR(db *sql.DB, primaryCurrency string, includeTrialing bool, byProd
 		snapshot.ARRCents = v * 12
 	}
 	for cur, mrr := range currencyMRR {
+		if cur == primaryCurrency {
+			// Primary currency is already surfaced at the top level via
+			// MRRCents/ARRCents. Emitting it again under ByCurrency contradicts
+			// the documented contract ("others appear under by_currency") and
+			// gives consumers a false positive when they use `len(by_currency)>0`
+			// to detect non-primary currencies.
+			continue
+		}
 		snapshot.ByCurrency = append(snapshot.ByCurrency, mrrCurrencyRow{
 			Currency: cur,
 			MRRCents: mrr,

--- a/library/payments/stripe/internal/cli/mrr_trend.go
+++ b/library/payments/stripe/internal/cli/mrr_trend.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: add `mrr-trend` analytics command. Computes MRR/ARR from active +
+// trialing subscriptions joined to their prices, normalizing each item's
+// (unit_amount * quantity) to monthly via recurring.interval + interval_count.
+// Local-only — reads from the SQLite mirror. Math ported from the
+// normalizeToMonthly + subscriptionMonthlyRevenue + aggregateSubscriptions
+// pattern documented in .printing-press-patches.json.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/stripe/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+// mrrCurrencyRow is the per-currency rollup. Stripe stores unit_amount as
+// integer minor units (cents for USD), and currencies cannot be summed
+// directly — surface them separately.
+type mrrCurrencyRow struct {
+	Currency string `json:"currency"`
+	MRRCents int64  `json:"mrr_cents"`
+	ARRCents int64  `json:"arr_cents"`
+}
+
+// mrrProductRow is the optional per-product rollup. Product name is pulled
+// from the local products table; the id is always present.
+type mrrProductRow struct {
+	ProductID   string `json:"product_id"`
+	ProductName string `json:"product_name,omitempty"`
+	Currency    string `json:"currency"`
+	MRRCents    int64  `json:"mrr_cents"`
+	Subscribers int    `json:"subscribers"`
+}
+
+// mrrSnapshot is the top-level JSON response shape.
+type mrrSnapshot struct {
+	Currency             string           `json:"currency"`
+	MRRCents             int64            `json:"mrr_cents"`
+	ARRCents             int64            `json:"arr_cents"`
+	ActiveSubscriptions  int              `json:"active_subscriptions"`
+	TrialingSubs         int              `json:"trialing"`
+	IncludedTrialing     bool             `json:"included_trialing"`
+	ByCurrency           []mrrCurrencyRow `json:"by_currency"`
+	ByProduct            []mrrProductRow  `json:"by_product,omitempty"`
+}
+
+func newMRRTrendCmd(flags *rootFlags) *cobra.Command {
+	var currency string
+	var includeTrialing bool
+	var byProduct bool
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "mrr-trend",
+		Short: "Compute MRR/ARR from active + trialing subscriptions",
+		Long: `Walk every active (and optionally trialing) subscription, sum each item's
+(unit_amount * quantity) normalized to a monthly figure using recurring.interval
+(day/week/month/year) and recurring.interval_count. MRR is reported per currency;
+the primary --currency value is surfaced at the top level, others appear under
+by_currency. Use --by product to also break down per-product MRR.`,
+		Example: `  # Total MRR/ARR in USD (default)
+  stripe-pp-cli mrr-trend --json
+
+  # Break down per product, exclude trialing
+  stripe-pp-cli mrr-trend --by product --include-trialing=false`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+
+			path := transcendenceDBPath(dbPath)
+			db, err := store.OpenReadOnly(path)
+			if err != nil {
+				return configErr(fmt.Errorf("opening local database (%s): %w\nRun 'stripe-pp-cli sync' first.", path, err))
+			}
+			defer db.Close()
+
+			snapshot, err := computeMRR(db.DB(), strings.ToLower(currency), includeTrialing, byProduct)
+			if err != nil {
+				return apiErr(err)
+			}
+			return printJSONFiltered(cmd.OutOrStdout(), snapshot, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&currency, "currency", "USD", "Primary currency for top-level mrr_cents/arr_cents (others shown in by_currency)")
+	cmd.Flags().BoolVar(&includeTrialing, "include-trialing", true, "Include trialing subscriptions in MRR")
+	cmd.Flags().BoolVar(&byProduct, "by", false, "When true, populate by_product breakdown (equivalent to --by product)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/stripe-pp-cli/data.db)")
+
+	// Allow --by product (string form) for symmetry with refund-rate/dispute-win-rate.
+	// We parse it manually because cobra's bool flag form expects --by alone.
+	cmd.Flags().Lookup("by").NoOptDefVal = "true"
+
+	return cmd
+}
+
+// computeMRR walks subscriptions and aggregates monthly recurring revenue.
+// includeTrialing=true sums status IN ('active','trialing'); false sums only 'active'.
+// byProduct=true populates the by_product slice (requires a join to the local
+// products table for display names).
+func computeMRR(db *sql.DB, primaryCurrency string, includeTrialing bool, byProduct bool) (mrrSnapshot, error) {
+	statuses := "'active'"
+	if includeTrialing {
+		statuses = "'active','trialing'"
+	}
+	q := fmt.Sprintf(`SELECT id, data FROM resources WHERE resource_type='subscriptions'
+		AND json_extract(data,'$.status') IN (%s)`, statuses)
+	rs, err := db.Query(q)
+	if err != nil {
+		return mrrSnapshot{}, fmt.Errorf("querying subscriptions: %w", err)
+	}
+	defer rs.Close()
+
+	currencyMRR := make(map[string]int64)
+	// productKey = productID + "|" + currency (currencies cannot be summed)
+	productMRR := make(map[string]int64)
+	productCurrency := make(map[string]string)
+	productSubs := make(map[string]int)
+	activeCount := 0
+	trialingCount := 0
+
+	productCache := make(map[string]string) // productID -> name
+
+	for rs.Next() {
+		var id, data string
+		if err := rs.Scan(&id, &data); err != nil {
+			return mrrSnapshot{}, err
+		}
+		raw := json.RawMessage(data)
+
+		status, _ := jsonGet(raw, "status")
+		switch status {
+		case "active":
+			activeCount++
+		case "trialing":
+			trialingCount++
+		}
+
+		monthly, currency, byProd := subscriptionMonthlyMRR(raw)
+		if monthly == 0 || currency == "" {
+			continue
+		}
+		currencyMRR[currency] += monthly
+
+		if byProduct {
+			for productID, amt := range byProd {
+				key := productID + "|" + currency
+				productMRR[key] += amt
+				productCurrency[key] = currency
+				productSubs[key]++
+
+				// Lazy product-name lookup. Empty name on miss is fine.
+				if _, hit := productCache[productID]; !hit && productID != "" {
+					productCache[productID] = lookupProductName(db, productID)
+				}
+			}
+		}
+	}
+	if err := rs.Err(); err != nil {
+		return mrrSnapshot{}, err
+	}
+
+	snapshot := mrrSnapshot{
+		Currency:            primaryCurrency,
+		ActiveSubscriptions: activeCount,
+		TrialingSubs:        trialingCount,
+		IncludedTrialing:    includeTrialing,
+		ByCurrency:          make([]mrrCurrencyRow, 0, len(currencyMRR)),
+	}
+	if v, ok := currencyMRR[primaryCurrency]; ok {
+		snapshot.MRRCents = v
+		snapshot.ARRCents = v * 12
+	}
+	for cur, mrr := range currencyMRR {
+		snapshot.ByCurrency = append(snapshot.ByCurrency, mrrCurrencyRow{
+			Currency: cur,
+			MRRCents: mrr,
+			ARRCents: mrr * 12,
+		})
+	}
+	sort.SliceStable(snapshot.ByCurrency, func(i, j int) bool {
+		return snapshot.ByCurrency[i].MRRCents > snapshot.ByCurrency[j].MRRCents
+	})
+
+	if byProduct {
+		for key, mrr := range productMRR {
+			parts := strings.SplitN(key, "|", 2)
+			pid := parts[0]
+			cur := productCurrency[key]
+			row := mrrProductRow{
+				ProductID:   pid,
+				ProductName: productCache[pid],
+				Currency:    cur,
+				MRRCents:    mrr,
+				Subscribers: productSubs[key],
+			}
+			snapshot.ByProduct = append(snapshot.ByProduct, row)
+		}
+		sort.SliceStable(snapshot.ByProduct, func(i, j int) bool {
+			return snapshot.ByProduct[i].MRRCents > snapshot.ByProduct[j].MRRCents
+		})
+	}
+	return snapshot, nil
+}
+
+// subscriptionMonthlyMRR walks ALL items on a subscription (unlike subs_at_risk's
+// subscriptionMRR which only takes the first item) and returns the total MRR,
+// the currency, and a per-product breakdown. Returns currency = "" when no
+// item has a valid recurring price.
+func subscriptionMonthlyMRR(raw json.RawMessage) (int64, string, map[string]int64) {
+	var sub map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &sub); err != nil {
+		return 0, "", nil
+	}
+	itemsRaw, ok := sub["items"]
+	if !ok {
+		return 0, "", nil
+	}
+	var items map[string]json.RawMessage
+	if err := json.Unmarshal(itemsRaw, &items); err != nil {
+		return 0, "", nil
+	}
+	dataRaw, ok := items["data"]
+	if !ok {
+		return 0, "", nil
+	}
+	var arr []map[string]json.RawMessage
+	if err := json.Unmarshal(dataRaw, &arr); err != nil {
+		return 0, "", nil
+	}
+
+	var totalMonthly int64
+	currency := ""
+	byProduct := make(map[string]int64)
+
+	for _, item := range arr {
+		var qty int64 = 1
+		if q, ok := item["quantity"]; ok {
+			_ = json.Unmarshal(q, &qty)
+		}
+		priceRaw, ok := item["price"]
+		if !ok {
+			continue
+		}
+		var price map[string]json.RawMessage
+		if err := json.Unmarshal(priceRaw, &price); err != nil {
+			continue
+		}
+		var unit int64
+		if v, ok := price["unit_amount"]; ok {
+			_ = json.Unmarshal(v, &unit)
+		}
+		if unit == 0 {
+			continue
+		}
+		var cur string
+		if v, ok := price["currency"]; ok {
+			_ = json.Unmarshal(v, &cur)
+		}
+		if cur == "" {
+			cur = "usd"
+		}
+		if currency == "" {
+			currency = strings.ToLower(cur)
+		}
+		// Recurring info; without it, treat as non-recurring (skip).
+		recRaw, ok := price["recurring"]
+		if !ok || string(recRaw) == "null" {
+			continue
+		}
+		var rec map[string]json.RawMessage
+		if err := json.Unmarshal(recRaw, &rec); err != nil {
+			continue
+		}
+		var interval string
+		if v, ok := rec["interval"]; ok {
+			_ = json.Unmarshal(v, &interval)
+		}
+		var intervalCount int64 = 1
+		if v, ok := rec["interval_count"]; ok {
+			_ = json.Unmarshal(v, &intervalCount)
+		}
+		if intervalCount <= 0 {
+			intervalCount = 1
+		}
+
+		monthly := normalizeToMonthlyCents(unit*qty, interval, intervalCount)
+		if monthly == 0 {
+			continue
+		}
+		totalMonthly += monthly
+
+		// Product id may be a string or an embedded object.
+		pid := ""
+		if v, ok := price["product"]; ok {
+			var s string
+			if json.Unmarshal(v, &s) == nil {
+				pid = s
+			} else {
+				var obj map[string]json.RawMessage
+				if json.Unmarshal(v, &obj) == nil {
+					if idRaw, ok := obj["id"]; ok {
+						_ = json.Unmarshal(idRaw, &pid)
+					}
+				}
+			}
+		}
+		if pid == "" {
+			pid = "untagged"
+		}
+		byProduct[pid] += monthly
+	}
+	return totalMonthly, currency, byProduct
+}
+
+// normalizeToMonthlyCents normalizes a gross-per-period amount (in minor units)
+// to a monthly figure, matching the Baremetrics / ProfitWell convention:
+// month → as-is, year → /12, week → *4.33, day → *30. Returns 0 for unknown
+// intervals so callers can skip silently.
+func normalizeToMonthlyCents(gross int64, interval string, intervalCount int64) int64 {
+	if gross <= 0 || intervalCount <= 0 {
+		return 0
+	}
+	switch interval {
+	case "month":
+		return gross / intervalCount
+	case "year":
+		return gross / (12 * intervalCount)
+	case "week":
+		// 52 weeks ÷ 12 months ≈ 4.33 weeks per month.
+		// Integer math: (gross * 433) / (100 * intervalCount).
+		return (gross * 433) / (100 * intervalCount)
+	case "day":
+		// ~30 days per month.
+		return (gross * 30) / intervalCount
+	default:
+		return 0
+	}
+}
+
+// lookupProductName fetches a product's display name from the local store.
+// Returns "" on any miss so the caller can fall back to the id.
+func lookupProductName(db *sql.DB, productID string) string {
+	var data string
+	if err := db.QueryRow(
+		`SELECT data FROM resources WHERE resource_type='products' AND id=?`, productID,
+	).Scan(&data); err != nil {
+		return ""
+	}
+	if name, ok := jsonGet(json.RawMessage(data), "name"); ok {
+		return name
+	}
+	return ""
+}

--- a/library/payments/stripe/internal/cli/refund_rate.go
+++ b/library/payments/stripe/internal/cli/refund_rate.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Chris Rodriguez and contributors. Licensed under Apache-2.0. See LICENSE.
+
+// PATCH: add `refund-rate` analytics command. Computes daily refund-rate
+// trending over a window, optionally grouped by product, customer, or
+// payment-method type, with threshold-flagging. Refund -> charge join is
+// via the refund.charge field.
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/stripe/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+type refundRateDay struct {
+	Date              string  `json:"date"`
+	Group             string  `json:"group,omitempty"`
+	SucceededCharges  int     `json:"succeeded_charges"`
+	RefundedCharges   int     `json:"refunded_charges"`
+	RefundRatePct     float64 `json:"refund_rate_pct"`
+	OverThreshold     bool    `json:"over_threshold"`
+}
+
+type refundRateReport struct {
+	Window         string          `json:"window"`
+	From           string          `json:"from"`
+	To             string          `json:"to"`
+	By             string          `json:"by"`
+	ThresholdPct   float64         `json:"threshold_pct"`
+	OverThreshold  int             `json:"days_over_threshold"`
+	Days           []refundRateDay `json:"days"`
+}
+
+func newRefundRateCmd(flags *rootFlags) *cobra.Command {
+	var windowStr string
+	var by string
+	var thresholdPct float64
+	var dbPath string
+
+	cmd := &cobra.Command{
+		Use:   "refund-rate",
+		Short: "Daily refund-rate trending with optional grouping and threshold flagging",
+		Long: `Compute per-day refund rate (refunded_charges / succeeded_charges) within
+the window. Optional --by groups by product (via charge -> invoice_item -> price
+-> product, falling back to "untagged"), customer, or payment_method type. Days
+where the rate exceeds --threshold-pct are flagged with over_threshold=true.`,
+		Example: `  # Last 7 days, global
+  stripe-pp-cli refund-rate --json
+
+  # Last 30 days, by product, flag days >5%
+  stripe-pp-cli refund-rate --window 30d --by product --threshold-pct 5 --json`,
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			window, err := parseHumanDuration(windowStr)
+			if err != nil {
+				return usageErr(fmt.Errorf("invalid --window: %w", err))
+			}
+			if window == 0 {
+				window = 7 * 24 * time.Hour
+			}
+			by = strings.ToLower(strings.TrimSpace(by))
+			switch by {
+			case "", "global", "product", "customer", "payment_method":
+				// ok
+			default:
+				return usageErr(fmt.Errorf("--by must be one of: product, customer, payment_method (got %q)", by))
+			}
+
+			path := transcendenceDBPath(dbPath)
+			db, err := store.OpenReadOnly(path)
+			if err != nil {
+				return configErr(fmt.Errorf("opening local database (%s): %w\nRun 'stripe-pp-cli sync' first.", path, err))
+			}
+			defer db.Close()
+
+			report, err := computeRefundRate(db.DB(), window, by, thresholdPct)
+			if err != nil {
+				return apiErr(err)
+			}
+			return printJSONFiltered(cmd.OutOrStdout(), report, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&windowStr, "window", "7d", "Lookback window (e.g. 7d, 30d, 168h)")
+	cmd.Flags().StringVar(&by, "by", "", "Grouping: product, customer, or payment_method (default: global)")
+	cmd.Flags().Float64Var(&thresholdPct, "threshold-pct", 5.0, "Flag days where refund rate exceeds this percentage")
+	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/stripe-pp-cli/data.db)")
+
+	return cmd
+}
+
+// computeRefundRate aggregates charges and refunds by day (and optionally
+// by group dimension) within the window. Refund→charge join is via the
+// charge_id field on the refund record.
+func computeRefundRate(db *sql.DB, window time.Duration, by string, thresholdPct float64) (refundRateReport, error) {
+	now := time.Now().UTC()
+	from := now.Add(-window)
+	fromTS := from.Unix()
+	toTS := now.Unix()
+
+	// Pull charges (succeeded only — refund rate denominator is charges that
+	// actually went through). Build a map of charge_id -> (day, group_label).
+	chargeRows, err := db.Query(`SELECT id, data FROM resources WHERE resource_type='charges'
+		AND json_extract(data,'$.status') = 'succeeded'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) <= ?`, fromTS, toTS)
+	if err != nil {
+		return refundRateReport{}, fmt.Errorf("querying charges: %w", err)
+	}
+	defer chargeRows.Close()
+
+	type chargeMeta struct {
+		day   string
+		group string
+	}
+	chargeMetaByID := make(map[string]chargeMeta)
+	dayGroupCharges := make(map[string]int) // key = day + "|" + group
+
+	for chargeRows.Next() {
+		var id, data string
+		if err := chargeRows.Scan(&id, &data); err != nil {
+			return refundRateReport{}, err
+		}
+		raw := json.RawMessage(data)
+		ts, _ := jsonGetInt(raw, "created")
+		day := time.Unix(ts, 0).UTC().Format("2006-01-02")
+		group := chargeGroupLabel(db, raw, by)
+		chargeMetaByID[id] = chargeMeta{day: day, group: group}
+		key := day + "|" + group
+		dayGroupCharges[key]++
+	}
+	if err := chargeRows.Err(); err != nil {
+		return refundRateReport{}, err
+	}
+
+	// Pull refunds in window. Each refund's charge_id is the join key.
+	refundRows, err := db.Query(`SELECT data FROM resources WHERE resource_type='refunds'
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) >= ?
+		AND CAST(IFNULL(json_extract(data,'$.created'),0) AS INTEGER) <= ?`, fromTS, toTS)
+	if err != nil {
+		return refundRateReport{}, fmt.Errorf("querying refunds: %w", err)
+	}
+	defer refundRows.Close()
+
+	dayGroupRefunds := make(map[string]int)
+	for refundRows.Next() {
+		var data string
+		if err := refundRows.Scan(&data); err != nil {
+			return refundRateReport{}, err
+		}
+		raw := json.RawMessage(data)
+		chargeID, _ := jsonGet(raw, "charge")
+		meta, hit := chargeMetaByID[chargeID]
+		if !hit {
+			// Charge isn't in this window (older than window OR missing from mirror).
+			// Use the refund's own created timestamp + unknown group as a fallback.
+			ts, _ := jsonGetInt(raw, "created")
+			meta = chargeMeta{
+				day:   time.Unix(ts, 0).UTC().Format("2006-01-02"),
+				group: "untagged",
+			}
+		}
+		key := meta.day + "|" + meta.group
+		dayGroupRefunds[key]++
+	}
+	if err := refundRows.Err(); err != nil {
+		return refundRateReport{}, err
+	}
+
+	// Emit one row per (day, group) where there was at least one charge.
+	out := make([]refundRateDay, 0, len(dayGroupCharges))
+	for key, charges := range dayGroupCharges {
+		parts := strings.SplitN(key, "|", 2)
+		day, group := parts[0], parts[1]
+		refunds := dayGroupRefunds[key]
+		pct := 0.0
+		if charges > 0 {
+			pct = float64(refunds) / float64(charges) * 100
+		}
+		out = append(out, refundRateDay{
+			Date:             day,
+			Group:            group,
+			SucceededCharges: charges,
+			RefundedCharges:  refunds,
+			RefundRatePct:    roundTo(pct, 2),
+			OverThreshold:    pct > thresholdPct,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Date != out[j].Date {
+			return out[i].Date < out[j].Date
+		}
+		return out[i].Group < out[j].Group
+	})
+
+	overCount := 0
+	for _, d := range out {
+		if d.OverThreshold {
+			overCount++
+		}
+	}
+
+	return refundRateReport{
+		Window:        window.String(),
+		From:          from.Format("2006-01-02"),
+		To:            now.Format("2006-01-02"),
+		By:            by,
+		ThresholdPct:  thresholdPct,
+		OverThreshold: overCount,
+		Days:          out,
+	}, nil
+}
+
+// chargeGroupLabel computes a charge's group label based on the --by axis.
+// Returns "global" for empty/global, otherwise the customer id, payment-method
+// type, or product id (via charge -> invoice -> line.price.product walking).
+// Falls back to "untagged" when the join can't complete.
+func chargeGroupLabel(db *sql.DB, raw json.RawMessage, by string) string {
+	switch by {
+	case "", "global":
+		return "global"
+	case "customer":
+		if v, ok := jsonGet(raw, "customer"); ok && v != "" {
+			return v
+		}
+		return "untagged"
+	case "payment_method":
+		t := extractPaymentMethodType(raw)
+		if t == "" {
+			return "untagged"
+		}
+		return t
+	case "product":
+		// charges have an optional 'invoice' pointer; invoices have lines with prices.
+		invoiceID, _ := jsonGet(raw, "invoice")
+		if invoiceID == "" {
+			return "untagged"
+		}
+		var invData string
+		if err := db.QueryRow(
+			`SELECT data FROM resources WHERE resource_type='invoices' AND id=?`, invoiceID,
+		).Scan(&invData); err != nil {
+			return "untagged"
+		}
+		pid := firstProductFromInvoice(json.RawMessage(invData))
+		if pid == "" {
+			return "untagged"
+		}
+		return pid
+	}
+	return "global"
+}
+
+// firstProductFromInvoice extracts the product id of the invoice's first
+// line item's price. Stripe's invoice line shape: lines.data[].price.product.
+// Returns "" if the path can't be walked.
+func firstProductFromInvoice(raw json.RawMessage) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	linesRaw, ok := obj["lines"]
+	if !ok || string(linesRaw) == "null" {
+		return ""
+	}
+	var lines map[string]json.RawMessage
+	if err := json.Unmarshal(linesRaw, &lines); err != nil {
+		return ""
+	}
+	dataRaw, ok := lines["data"]
+	if !ok {
+		return ""
+	}
+	var arr []map[string]json.RawMessage
+	if err := json.Unmarshal(dataRaw, &arr); err != nil || len(arr) == 0 {
+		return ""
+	}
+	first := arr[0]
+	priceRaw, ok := first["price"]
+	if !ok || string(priceRaw) == "null" {
+		return ""
+	}
+	var price map[string]json.RawMessage
+	if err := json.Unmarshal(priceRaw, &price); err != nil {
+		return ""
+	}
+	if v, ok := price["product"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil {
+			return s
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(v, &inner) == nil {
+			if idRaw, ok := inner["id"]; ok {
+				var id string
+				if json.Unmarshal(idRaw, &id) == nil {
+					return id
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/library/payments/stripe/internal/cli/root.go
+++ b/library/payments/stripe/internal/cli/root.go
@@ -278,6 +278,13 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newSubsAtRiskCmd(flags))
 	rootCmd.AddCommand(newEventsSinceCmd(flags))
 	rootCmd.AddCommand(newMetadataGrepCmd(flags))
+	// PATCH: register five hand-coded analytics commands.
+	// See .printing-press-patches.json entry id=stripe-analytics-commands-port.
+	rootCmd.AddCommand(newMRRTrendCmd(flags))
+	rootCmd.AddCommand(newFailureClustersCmd(flags))
+	rootCmd.AddCommand(newRefundRateCmd(flags))
+	rootCmd.AddCommand(newDisputeWinRateCmd(flags))
+	rootCmd.AddCommand(newDailyDigestCmd(flags))
 	rootCmd.AddCommand(newVersionCliCmd())
 
 	return rootCmd


### PR DESCRIPTION
## Summary

Add five hand-coded transcendence commands on top of the already-published `stripe-pp-cli`. All five read from the existing local SQLite mirror using the shared transcendence helpers — no new dependencies, no generator-touch points, no changes to crodorg's primary authorship on `.printing-press.json`.

## Findings

| ID | Command | Type | What it does |
|---|---|---|---|
| F1 | `mrr-trend` | feature | MRR/ARR from active + trialing subs, normalized to monthly via `recurring.interval` + `interval_count`. Supports `--by` product breakdown and multi-currency `by_currency` rollup. |
| F2 | `failure-clusters` | feature | Groups failed charges by `failure_code`, optionally also by `payment_method` type. Surfaces top failure patterns; complement to `dunning-queue` (invoice-level). |
| F3 | `refund-rate` | feature | Daily refund-rate trending per `--by` axis (product, customer, payment_method, or global) with threshold flagging. |
| F4 | `dispute-win-rate` | feature | Historical won / total-resolved ratio with breakdowns by reason and amount-band. `--include-pending` widens the denominator. |
| F5 | `daily-digest` | feature | One-command markdown (or JSON) period report: charges, subs, disputes, payouts. Replaces a multi-command + `sql` workflow with one invocation. |

## Changes

```
 .../payments/stripe/.printing-press-patches.json   |  32 +
 .../payments/stripe/internal/cli/daily_digest.go   | 658 +++++++++++++++++++++
 .../stripe/internal/cli/dispute_win_rate.go        | 297 ++++++++++
 .../stripe/internal/cli/failure_clusters.go        | 226 +++++++
 library/payments/stripe/internal/cli/mrr_trend.go  | 364 ++++++++++++
 .../payments/stripe/internal/cli/refund_rate.go    | 314 ++++++++++
 library/payments/stripe/internal/cli/root.go       |   7 +
 7 files changed, 1898 insertions(+)
```

## Verification

- Build: PASS (`go build ./...`)
- `go vet`: PASS
- `cli-printing-press publish validate`: PASS (11/11 checks)
- `--help`, `--version`: PASS
- `--dry-run --agent` on all five new commands: exit 0
- Functional tests on a seeded local SQLite mirror:
  - `mrr-trend` correctly sums 2 active USD subs ($50 + 2×$50 = $150) and 1 trialing EUR yearly (€1200/yr ÷ 12 = €100/mo), surfaces primary currency at top level and others under `by_currency`; `--by` produces accurate `by_product` rollup with product names from the local products table.
  - `failure-clusters` aggregates 6 failed charges (3 `card_declined` + 3 `insufficient_funds`) into 2 clusters at default `--min-count 3`; `--by-payment-method-type` correctly sub-groups by `payment_method_details.type`.
  - `refund-rate --by product` walks the refund → charge → invoice.lines[0].price.product join and falls back to `untagged` for refunds whose charge has no invoice pointer.
  - `dispute-win-rate` correctly partitions 4 disputes into 2 won + 1 lost + 1 pending → `won_rate_pct: 66.67`; `--by all` emits both `by_reason` and `by_amount_band` breakdowns in canonical order.
  - `daily-digest` renders a 4-section markdown report (revenue, subs, disputes, payouts) with a day-by-day revenue table and a top-failure-codes table.

## Patch contract

- `.printing-press-patches.json` carries a single `patches[0]` entry, id `stripe-analytics-commands-port`, with `base_run_id` and `base_printing_press_version` copied from `.printing-press.json` (v4.1.0, run 20260509-093200).
- Inline `// PATCH:` header comments on each new file and at the command-registration site in `root.go`.
- The `deferred_to_upstream` field documents two future supersession paths: (1) a Printing-Press generator-level analytics-shape catalog that any payments-domain CLI could pick up; (2) a known limitation in `daily-digest` where multi-currency MRR sums to a single `mrr_cents` field — operators wanting per-currency precision should use `mrr-trend` directly.

## Evidence

- Patch record: https://github.com/sdhilip200/printing-press-library/blob/5ce42c3f9a549c4864305309befb06bfa5c10a1b/library/payments/stripe/.printing-press-patches.json
- Per-finding rationale lives in the patch record above and the Findings table earlier in this PR body.

## Hygiene

- AI/Automation disclosure: **Human-reviewed**.
- `creator.handle` in `.printing-press.json` is unchanged (`crodorg`). This PR ships hand-coded local customizations only, not a regeneration.

