### PR TITLE
fix(wavespeed): preserve completed run output before downloads

### DIFF
--- a/library/ai/wavespeed/.printing-press-patches.json
+++ b/library/ai/wavespeed/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-27",
+  "applied_at": "2026-05-28",
   "base_run_id": "20260527-214905",
   "base_printing_press_version": "4.18.1",
   "patches": [
@@ -49,6 +49,16 @@
         "internal/client/client.go"
       ],
       "validated_outcome": "go test ./... passed after the publish-review fixes, including mixed --set/--input-kv and echoed-input URL filtering."
+    },
+    {
+      "id": "wavespeed-run-download-recovery",
+      "summary": "Hardened run --download so completed prediction payloads print before download attempts and CDN downloads do not receive API credentials.",
+      "reason": "WaveSpeed completed predictions can include public CDN outputs plus API management URLs; attaching credentials to CDN requests or failing before printing the paid result loses the successful generation URL.",
+      "files": [
+        "internal/cli/run.go",
+        "internal/cli/run_test.go"
+      ],
+      "validated_outcome": "Regression tests cover positional --download path parsing, CDN downloads without Authorization, skipped prediction management URLs, and non-fatal post-success download warnings."
     }
   ]
 }

--- a/library/ai/wavespeed/internal/cli/run.go
+++ b/library/ai/wavespeed/internal/cli/run.go
@@ -150,8 +150,15 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 
+			var downloadSpec string
+			var plannedDownloads []downloadedFile
+			if cmd.Flags().Changed("download") {
+				downloadSpec = runDownloadSpec(opts, project, cmd.Flags().Changed("download-dir"))
+				plannedDownloads = planRunDownloads(unwrapWaveSpeedData(result), downloadSpec)
+			}
+
 			status := extractPredictionStatus(result)
-			output := runOutputEnvelope(pricing, result, nil)
+			output := runOutputEnvelope(pricing, result, plannedDownloads)
 			if err := printOutputWithFlags(cmd.OutOrStdout(), output, flags); err != nil {
 				return err
 			}
@@ -159,14 +166,13 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				return apiErr(fmt.Errorf("prediction finished with status %q", status))
 			}
 			if cmd.Flags().Changed("download") {
-				downloadSpec := runDownloadSpec(opts, project, cmd.Flags().Changed("download-dir"))
 				downloads, err := downloadRunOutputs(cmd.Context(), c, unwrapWaveSpeedData(result), downloadSpec)
+				for _, item := range downloads {
+					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
+				}
 				if err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: download failed: %v\n", err)
 					return nil
-				}
-				for _, item := range downloads {
-					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
 				}
 			}
 			return nil
@@ -1436,15 +1442,10 @@ type downloadedFile struct {
 }
 
 func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMessage, spec string) ([]downloadedFile, error) {
-	urls := collectURLStrings(data)
-	if len(urls) == 0 {
-		return nil, nil
-	}
-	if spec == "" || spec == "true" {
-		spec = "."
-	}
-	downloads := make([]downloadedFile, 0, len(urls))
-	for i, rawURL := range urls {
+	planned := planRunDownloads(data, spec)
+	downloads := make([]downloadedFile, 0, len(planned))
+	for _, item := range planned {
+		rawURL := item.URL
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 		if err != nil {
 			return downloads, fmt.Errorf("building download request: %w", err)
@@ -1462,7 +1463,7 @@ func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMess
 				err = fmt.Errorf("downloading %s returned HTTP %d", rawURL, resp.StatusCode)
 				return
 			}
-			outPath := downloadOutputPath(spec, rawURL, i, len(urls))
+			outPath := item.Path
 			if err = os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 				err = fmt.Errorf("creating download dir: %w", err)
 				return
@@ -1478,13 +1479,31 @@ func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMess
 				err = fmt.Errorf("writing %s: %w", outPath, err)
 				return
 			}
-			downloads = append(downloads, downloadedFile{URL: rawURL, Path: outPath})
+			downloads = append(downloads, item)
 		}()
 		if err != nil {
 			return downloads, err
 		}
 	}
 	return downloads, nil
+}
+
+func planRunDownloads(data json.RawMessage, spec string) []downloadedFile {
+	urls := collectURLStrings(data)
+	if len(urls) == 0 {
+		return nil
+	}
+	if spec == "" || spec == "true" {
+		spec = "."
+	}
+	downloads := make([]downloadedFile, 0, len(urls))
+	for i, rawURL := range urls {
+		downloads = append(downloads, downloadedFile{
+			URL:  rawURL,
+			Path: downloadOutputPath(spec, rawURL, i, len(urls)),
+		})
+	}
+	return downloads
 }
 
 func addDownloadRequestHeaders(ctx context.Context, c *client.Client, req *http.Request) error {
@@ -1582,7 +1601,7 @@ func collectURLStrings(data json.RawMessage) []string {
 				if isEchoedInputContainerKey(key) {
 					continue
 				}
-				if isManagementURLContainer(key, item) {
+				if isPredictionManagementURL(key, item) {
 					continue
 				}
 				walk(item)
@@ -1602,23 +1621,22 @@ func isEchoedInputContainerKey(key string) bool {
 	}
 }
 
-func isManagementURLContainer(key string, item any) bool {
+func isPredictionManagementURL(key string, item any) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "urls", "links", "_links":
+	case "get", "self", "status", "result", "cancel", "delete":
 	default:
 		return false
 	}
-	items, ok := item.(map[string]any)
-	if !ok {
+	rawURL, ok := item.(string)
+	if !ok || !strings.HasPrefix(rawURL, "http") {
 		return false
 	}
-	for key := range items {
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "get", "self", "status", "result", "cancel", "delete":
-			return true
-		}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
 	}
-	return false
+	path := strings.ToLower(parsed.Path)
+	return strings.Contains(path, "/predictions/")
 }
 
 func outputFilename(rawURL string, index int) string {

--- a/library/ai/wavespeed/internal/cli/run.go
+++ b/library/ai/wavespeed/internal/cli/run.go
@@ -166,7 +166,7 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				return apiErr(fmt.Errorf("prediction finished with status %q", status))
 			}
 			if cmd.Flags().Changed("download") {
-				downloads, err := downloadRunOutputs(cmd.Context(), c, unwrapWaveSpeedData(result), downloadSpec)
+				downloads, err := downloadPlannedRunOutputs(cmd.Context(), c, plannedDownloads)
 				for _, item := range downloads {
 					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
 				}
@@ -1442,7 +1442,10 @@ type downloadedFile struct {
 }
 
 func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMessage, spec string) ([]downloadedFile, error) {
-	planned := planRunDownloads(data, spec)
+	return downloadPlannedRunOutputs(ctx, c, planRunDownloads(data, spec))
+}
+
+func downloadPlannedRunOutputs(ctx context.Context, c *client.Client, planned []downloadedFile) ([]downloadedFile, error) {
 	downloads := make([]downloadedFile, 0, len(planned))
 	for _, item := range planned {
 		rawURL := item.URL

--- a/library/ai/wavespeed/internal/cli/run.go
+++ b/library/ai/wavespeed/internal/cli/run.go
@@ -72,7 +72,7 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 		Example: `  wavespeed-pp-cli run wavespeed-ai/flux-dev -p "a studio product photo" --wait
   wavespeed-pp-cli run hero -i size=1024 -i enable_base64_output=false --price --wait --download ./outputs/{index}.{ext}
   wavespeed-pp-cli run --model-id wavespeed-ai/flux-dev --prompt "agent-friendly MCP call" --price-only`,
-		Args:        cobra.MaximumNArgs(1),
+		Args:        validateRunArgs(&opts),
 		Annotations: map[string]string{"pp:method": "POST", "pp:path": "/{model_id}"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			project, err := loadWavespeedProjectConfig()
@@ -80,11 +80,16 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				return usageErr(err)
 			}
 
+			modelArgs, downloadArg := splitRunArgs(cmd, args, &opts)
+			if downloadArg != "" {
+				opts.download = downloadArg
+			}
+
 			modelToken := ""
 			if cmd.Flags().Changed("model-id") {
 				modelToken = opts.modelID
-			} else if len(args) > 0 {
-				modelToken = args[0]
+			} else if len(modelArgs) > 0 {
+				modelToken = modelArgs[0]
 			} else {
 				modelToken = project.DefaultModel
 			}
@@ -145,25 +150,24 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 
-			var downloads []downloadedFile
-			if cmd.Flags().Changed("download") {
-				downloadSpec := runDownloadSpec(opts, project, cmd.Flags().Changed("download-dir"))
-				downloads, err = downloadRunOutputs(cmd.Context(), c, unwrapWaveSpeedData(result), downloadSpec)
-				if err != nil {
-					return err
-				}
-				for _, item := range downloads {
-					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
-				}
-			}
-
 			status := extractPredictionStatus(result)
-			output := runOutputEnvelope(pricing, result, downloads)
+			output := runOutputEnvelope(pricing, result, nil)
 			if err := printOutputWithFlags(cmd.OutOrStdout(), output, flags); err != nil {
 				return err
 			}
 			if isFailedPredictionStatus(status) {
 				return apiErr(fmt.Errorf("prediction finished with status %q", status))
+			}
+			if cmd.Flags().Changed("download") {
+				downloadSpec := runDownloadSpec(opts, project, cmd.Flags().Changed("download-dir"))
+				downloads, err := downloadRunOutputs(cmd.Context(), c, unwrapWaveSpeedData(result), downloadSpec)
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: download failed: %v\n", err)
+					return nil
+				}
+				for _, item := range downloads {
+					fmt.Fprintf(cmd.ErrOrStderr(), "downloaded %s\n", item.Path)
+				}
 			}
 			return nil
 		},
@@ -185,6 +189,40 @@ func newRunCmd(flags *rootFlags) *cobra.Command {
 	installRunModelHelp(cmd, flags, &opts)
 
 	return cmd
+}
+
+func validateRunArgs(opts *runCommandOptions) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		allowed := 1
+		if acceptsDownloadPathArg(cmd, opts) && !cmd.Flags().Changed("model-id") {
+			allowed = 2
+		}
+		if len(args) <= allowed {
+			return nil
+		}
+		extra := args[allowed]
+		if acceptsDownloadPathArg(cmd, opts) {
+			return fmt.Errorf("accepts at most %d arg(s), received %d; unexpected extra arg %q (if this is a download path, pass it immediately after --download or use --download=%s)", allowed, len(args), extra, extra)
+		}
+		return fmt.Errorf("accepts at most %d arg(s), received %d; unexpected extra arg %q", allowed, len(args), extra)
+	}
+}
+
+func splitRunArgs(cmd *cobra.Command, args []string, opts *runCommandOptions) ([]string, string) {
+	if !acceptsDownloadPathArg(cmd, opts) || len(args) == 0 {
+		return args, ""
+	}
+	if cmd.Flags().Changed("model-id") {
+		return nil, args[0]
+	}
+	if len(args) >= 2 {
+		return args[:1], args[1]
+	}
+	return args, ""
+}
+
+func acceptsDownloadPathArg(cmd *cobra.Command, opts *runCommandOptions) bool {
+	return cmd.Flags().Changed("download") && opts.download == "true"
 }
 
 func installRunModelHelp(cmd *cobra.Command, flags *rootFlags, opts *runCommandOptions) {
@@ -1411,6 +1449,9 @@ func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMess
 		if err != nil {
 			return downloads, fmt.Errorf("building download request: %w", err)
 		}
+		if err := addDownloadRequestHeaders(ctx, c, req); err != nil {
+			return downloads, err
+		}
 		resp, err := c.DoRaw(req)
 		if err != nil {
 			return downloads, fmt.Errorf("downloading %s: %w", rawURL, err)
@@ -1444,6 +1485,34 @@ func downloadRunOutputs(ctx context.Context, c *client.Client, data json.RawMess
 		}
 	}
 	return downloads, nil
+}
+
+func addDownloadRequestHeaders(ctx context.Context, c *client.Client, req *http.Request) error {
+	if c == nil || c.Config == nil || !sameHost(req.URL, c.BaseURL) {
+		return nil
+	}
+	auth, err := c.AuthHeader(ctx)
+	if err != nil {
+		return err
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	for k, v := range c.Config.Headers {
+		req.Header.Set(k, v)
+	}
+	return nil
+}
+
+func sameHost(target *url.URL, baseURL string) bool {
+	if target == nil {
+		return false
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(target.Host, base.Host)
 }
 
 func downloadOutputPath(spec, rawURL string, index, total int) string {
@@ -1513,6 +1582,9 @@ func collectURLStrings(data json.RawMessage) []string {
 				if isEchoedInputContainerKey(key) {
 					continue
 				}
+				if isManagementURLContainer(key, item) {
+					continue
+				}
 				walk(item)
 			}
 		}
@@ -1528,6 +1600,25 @@ func isEchoedInputContainerKey(key string) bool {
 	default:
 		return false
 	}
+}
+
+func isManagementURLContainer(key string, item any) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "urls", "links", "_links":
+	default:
+		return false
+	}
+	items, ok := item.(map[string]any)
+	if !ok {
+		return false
+	}
+	for key := range items {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "get", "self", "status", "result", "cancel", "delete":
+			return true
+		}
+	}
+	return false
 }
 
 func outputFilename(rawURL string, index int) string {

--- a/library/ai/wavespeed/internal/cli/run_test.go
+++ b/library/ai/wavespeed/internal/cli/run_test.go
@@ -154,13 +154,14 @@ func TestCollectURLStringsSkipsEchoedInputs(t *testing.T) {
 			],
 			"urls": {
 				"get": "https://api.wavespeed.ai/api/v3/predictions/pred-123/result",
-				"cancel": "https://api.wavespeed.ai/api/v3/predictions/pred-123/cancel"
+				"cancel": "https://api.wavespeed.ai/api/v3/predictions/pred-123/cancel",
+				"result": "https://cdn.example.com/from-result-key.mp4"
 			}
 		}
 	}`)
 
 	got := collectURLStrings(raw)
-	want := []string{"https://example.com/generated.png", "https://example.com/generated.mp4"}
+	want := []string{"https://example.com/generated.png", "https://example.com/generated.mp4", "https://cdn.example.com/from-result-key.mp4"}
 	if len(got) != len(want) {
 		t.Fatalf("urls = %#v", got)
 	}
@@ -220,6 +221,9 @@ func TestRunWaitDownloadPrintsResultAndDownloadsCDNWithoutAuth(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"status": "completed"`) || !strings.Contains(stdout, cdn.URL+`/generated.png`) {
 		t.Fatalf("stdout did not preserve completed result: %s", stdout)
+	}
+	if !strings.Contains(stdout, `"downloads"`) || !strings.Contains(stdout, `"path": "`+outPath+`"`) {
+		t.Fatalf("stdout did not include planned download mapping: %s", stdout)
 	}
 	if !strings.Contains(stderr, "downloaded "+outPath) {
 		t.Fatalf("stderr missing download confirmation: %s", stderr)
@@ -281,11 +285,72 @@ func TestRunDownloadFailureWarnsAfterPrintingCompletedResult(t *testing.T) {
 	if !strings.Contains(stdout, `"status": "completed"`) || !strings.Contains(stdout, cdn.URL+`/generated.png`) {
 		t.Fatalf("stdout did not include completed result before warning: %s", stdout)
 	}
+	if !strings.Contains(stdout, `"downloads"`) || !strings.Contains(stdout, `"path": "`+outPath+`"`) {
+		t.Fatalf("stdout did not include planned download mapping before warning: %s", stdout)
+	}
 	if !strings.Contains(stderr, "warning: download failed: downloading "+cdn.URL+"/generated.png returned HTTP 401") {
 		t.Fatalf("stderr missing download warning: %s", stderr)
 	}
 	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
 		t.Fatalf("download path exists after failed download: err=%v", err)
+	}
+}
+
+func TestRunDownloadFailureReportsPartialSuccesses(t *testing.T) {
+	t.Chdir(t.TempDir())
+	outTemplate := filepath.Join(t.TempDir(), "{index}.{ext}")
+
+	okCDN := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("first"))
+	}))
+	defer okCDN.Close()
+
+	failCDN := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer failCDN.Close()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/google/nano-banana-2/edit":
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-789","status":"created"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/predictions/pred-789/result":
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-789","status":"completed","outputs":["` + okCDN.URL + `/first.png","` + failCDN.URL + `/second.png"]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	stdout, stderr, err := executeRootForTest(t, []string{
+		"--json",
+		"run",
+		"google/nano-banana-2/edit",
+		"--prompt", "edit this",
+		"--wait",
+		"--poll-interval", "1ms",
+		"--download", outTemplate,
+	}, api.URL)
+	if err != nil {
+		t.Fatalf("partial download failure should be non-fatal, got %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	firstPath := filepath.Join(filepath.Dir(outTemplate), "1.png")
+	secondPath := filepath.Join(filepath.Dir(outTemplate), "2.png")
+	if !strings.Contains(stdout, firstPath) || !strings.Contains(stdout, secondPath) {
+		t.Fatalf("stdout missing planned download paths: %s", stdout)
+	}
+	if !strings.Contains(stderr, "downloaded "+firstPath) {
+		t.Fatalf("stderr missing partial success confirmation: %s", stderr)
+	}
+	if !strings.Contains(stderr, "warning: download failed: downloading "+failCDN.URL+"/second.png returned HTTP 401") {
+		t.Fatalf("stderr missing partial failure warning: %s", stderr)
+	}
+	if got, err := os.ReadFile(firstPath); err != nil || string(got) != "first" {
+		t.Fatalf("first download = %q, %v", string(got), err)
+	}
+	if _, err := os.Stat(secondPath); !os.IsNotExist(err) {
+		t.Fatalf("second download path exists after failed download: err=%v", err)
 	}
 }
 

--- a/library/ai/wavespeed/internal/cli/run_test.go
+++ b/library/ai/wavespeed/internal/cli/run_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -147,7 +151,11 @@ func TestCollectURLStringsSkipsEchoedInputs(t *testing.T) {
 			"outputs": [
 				"https://example.com/generated.png",
 				{"video": "https://example.com/generated.mp4"}
-			]
+			],
+			"urls": {
+				"get": "https://api.wavespeed.ai/api/v3/predictions/pred-123/result",
+				"cancel": "https://api.wavespeed.ai/api/v3/predictions/pred-123/cancel"
+			}
 		}
 	}`)
 
@@ -161,6 +169,139 @@ func TestCollectURLStringsSkipsEchoedInputs(t *testing.T) {
 			t.Fatalf("urls = %#v", got)
 		}
 	}
+}
+
+func TestRunWaitDownloadPrintsResultAndDownloadsCDNWithoutAuth(t *testing.T) {
+	t.Chdir(t.TempDir())
+	outPath := filepath.Join(t.TempDir(), "generated.png")
+
+	var cdnAuth string
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cdnAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	defer cdn.Close()
+
+	var api *httptest.Server
+	var postAuth string
+	var resultAuth string
+	resultRequests := 0
+	api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/google/nano-banana-2/edit":
+			postAuth = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-123","status":"created"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/predictions/pred-123/result":
+			resultRequests++
+			resultAuth = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-123","status":"completed","outputs":["` + cdn.URL + `/generated.png"],"urls":{"get":"` + api.URL + `/predictions/pred-123/result"}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	stdout, stderr, err := executeRootForTest(t, []string{
+		"--json",
+		"--timeout", "5s",
+		"run",
+		"google/nano-banana-2/edit",
+		"-p", "edit this",
+		"--images", "https://example.com/input.png",
+		"-i", "aspect_ratio=1:1",
+		"--wait",
+		"--poll-interval", "1ms",
+		"--download", outPath,
+	}, api.URL)
+	if err != nil {
+		t.Fatalf("run returned error: %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, `"status": "completed"`) || !strings.Contains(stdout, cdn.URL+`/generated.png`) {
+		t.Fatalf("stdout did not preserve completed result: %s", stdout)
+	}
+	if !strings.Contains(stderr, "downloaded "+outPath) {
+		t.Fatalf("stderr missing download confirmation: %s", stderr)
+	}
+	if cdnAuth != "" {
+		t.Fatalf("cdn download received auth header %q", cdnAuth)
+	}
+	if postAuth != "Bearer test-key" || resultAuth != "Bearer test-key" {
+		t.Fatalf("api auth headers post=%q result=%q", postAuth, resultAuth)
+	}
+	if resultRequests != 1 {
+		t.Fatalf("prediction result endpoint was called %d times, want only polling call", resultRequests)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, []byte("png-bytes")) {
+		t.Fatalf("downloaded file = %q", string(got))
+	}
+}
+
+func TestRunDownloadFailureWarnsAfterPrintingCompletedResult(t *testing.T) {
+	t.Chdir(t.TempDir())
+	outPath := filepath.Join(t.TempDir(), "generated.png")
+
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer cdn.Close()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/google/nano-banana-2/edit":
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-456","status":"created"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/predictions/pred-456/result":
+			_, _ = w.Write([]byte(`{"data":{"id":"pred-456","status":"completed","outputs":["` + cdn.URL + `/generated.png"]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	stdout, stderr, err := executeRootForTest(t, []string{
+		"--json",
+		"run",
+		"--model-id", "google/nano-banana-2/edit",
+		"--prompt", "edit this",
+		"--images", "https://example.com/input.png",
+		"--set", "aspect_ratio=1:1",
+		"--wait",
+		"--poll-interval", "1ms",
+		"--download", outPath,
+	}, api.URL)
+	if err != nil {
+		t.Fatalf("download failure should be non-fatal, got %v\nstdout=%s\nstderr=%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, `"status": "completed"`) || !strings.Contains(stdout, cdn.URL+`/generated.png`) {
+		t.Fatalf("stdout did not include completed result before warning: %s", stdout)
+	}
+	if !strings.Contains(stderr, "warning: download failed: downloading "+cdn.URL+"/generated.png returned HTTP 401") {
+		t.Fatalf("stderr missing download warning: %s", stderr)
+	}
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Fatalf("download path exists after failed download: err=%v", err)
+	}
+}
+
+func executeRootForTest(t *testing.T, args []string, baseURL string) (string, string, error) {
+	t.Helper()
+	t.Setenv("WAVESPEED_API_KEY", "test-key")
+	t.Setenv("WAVESPEED_BASE_URL", baseURL)
+	t.Setenv("WAVESPEED_CONFIG", filepath.Join(t.TempDir(), "missing-config.toml"))
+
+	cmd := RootCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func TestReadRunInputsMediaConvenienceFlags(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes three `wavespeed-pp-cli run --wait --download` issues observed after a successful paid generation:

- prints the completed prediction payload/output URLs before attempting downloads
- treats post-success download failures as stderr warnings instead of fatal errors
- avoids sending WaveSpeed API credentials to public CDN download hosts
- accepts `run <model-id> ... --download <path>` with the positional model form
- skips prediction management URLs in `urls`/`links` containers when collecting downloadable outputs

## Validation
- `make`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...`

Note: I did not run a live paid WaveSpeed generation because `WAVESPEED_API_KEY` was not present in the environment. The regression tests use httptest servers to verify the API host still receives auth and the CDN host does not.
