### PR TITLE
fix(chrome-history): quote skill description frontmatter

### DIFF
--- a/library/productivity/chrome-history/SKILL.md
+++ b/library/productivity/chrome-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pp-chrome-history
-description: Query your local Chrome browsing history — search, topic clusters (Chrome's own Journeys), time/productivity reports, session timelines, downloads, and a behavioral profile — all read-only and on-device. Trigger phrases: "what have I been browsing", "search my chrome history", "what was that page I saw", "my browsing journeys / topics", "what did I download in chrome", "what sites do I visit most", "my browsing time report", "my browsing profile", "what was I researching last week", "use chrome-history", "run chrome-history-pp-cli".
+description: "Query your local Chrome browsing history — search, topic clusters (Chrome's own Journeys), time/productivity reports, session timelines, downloads, and a behavioral profile — all read-only and on-device. Trigger phrases: `what have I been browsing`, `search my chrome history`, `what was that page I saw`, `my browsing journeys / topics`, `what did I download in chrome`, `what sites do I visit most`, `my browsing time report`, `my browsing profile`, `what was I researching last week`, `use chrome-history`, `run chrome-history-pp-cli`."
 ---
 
 # pp-chrome-history


### PR DESCRIPTION
## Summary
- quote the chrome-history skill description frontmatter so the skills installer can parse it
- switch embedded trigger phrases to backticks inside the quoted YAML string

## Why
Before this change, `npx -y skills@latest add mvanhorn/printing-press-library/cli-skills/pp-chrome-history -g -y` cloned the repo but reported `No skills found`. The unquoted description contains `Trigger phrases:`, which makes the frontmatter invalid for the skill installer.

## Validation
- `git diff --check`
- `go test ./...` from `tools/generate-skills`
- `npx -y skills@latest add /Users/kieran/printing-press/chrome-history-skill-fix/library/productivity/chrome-history -g -y` now reports `Found 1 skill` and installs `pp-chrome-history`