### PR TITLE
fix(lawhub): conform CLI to canonical cobra constructor convention

### DIFF
--- a/library/education/lawhub/.printing-press-patches.json
+++ b/library/education/lawhub/.printing-press-patches.json
@@ -1,7 +1,21 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-15",
+  "applied_at": "2026-05-29",
   "base_run_id": "20260515-014700",
   "base_printing_press_version": "manual-go-cobra",
-  "patches": []
+  "patches": [
+    {
+      "id": "conform-cobra-constructor-convention",
+      "summary": "Renamed every command constructor to the canonical newXxxCmd form and rebuilt the root command via one-per-line rootCmd.AddCommand(newXxxCmd()) calls.",
+      "reason": "The non-standard shape (xxxCmd() constructors and cmd.AddCommand(...) inside func rootCmd()) forced verify_skill.py into its glob-order-dependent legacy fallback, which mis-resolved the colliding `list`/`show` leaves and produced a platform-dependent false positive ('questions list expects 1-1 positional args') that failed verify-skills CI on Linux while passing on macOS. Conforming to the convention routes resolution through the deterministic command-tree walker.",
+      "files": [
+        "internal/cli/root.go",
+        "internal/cli/questions.go",
+        "internal/cli/auth.go",
+        "internal/cli/sync_go.go",
+        "internal/cli/version.go"
+      ],
+      "validated_outcome": "go build/vet pass, 13 tests pass, and verify_skill.py reports 0 errors (only the pre-existing `auth login` false-positive warnings remain)."
+    }
+  ]
 }

--- a/library/education/lawhub/.printing-press.json
+++ b/library/education/lawhub/.printing-press.json
@@ -9,6 +9,12 @@
     "handle": "nolan",
     "name": "Nolan McCafferty"
   },
+  "contributors": [
+    {
+      "handle": "tmchow",
+      "name": "Trevin Chow"
+    }
+  ],
   "description": "Local-first LSAT practice analytics from authenticated LawHub score metadata, with SQLite, weakness reports, question notes, and safe review links back to LawHub.",
   "category": "education",
   "spec_format": "internal",

--- a/library/education/lawhub/internal/cli/auth.go
+++ b/library/education/lawhub/internal/cli/auth.go
@@ -169,7 +169,7 @@ func discoverUserIDFromPage(p *rod.Page) string {
 	return ""
 }
 
-func loginCmd() *cobra.Command {
+func newLoginCmd() *cobra.Command {
 	return loginCobra("login")
 }
 
@@ -253,9 +253,13 @@ func resolveCDPWebSocket(cdpURL string) (string, error) {
 	return v.WebSocketDebuggerURL, nil
 }
 
-func authCmd() *cobra.Command {
+func newAuthCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "auth", Short: "Manage LawHub session"}
-	cmd.AddCommand(loginCobra("login"), authImportFileCmd(), authStatusCmd(), authPathCmd(), authLogoutCmd())
+	cmd.AddCommand(loginCobra("login"))
+	cmd.AddCommand(newAuthImportFileCmd())
+	cmd.AddCommand(newAuthStatusCmd())
+	cmd.AddCommand(newAuthPathCmd())
+	cmd.AddCommand(newAuthLogoutCmd())
 	return cmd
 }
 
@@ -309,7 +313,7 @@ func authPing() map[string]any {
 	return out
 }
 
-func authImportFileCmd() *cobra.Command {
+func newAuthImportFileCmd() *cobra.Command {
 	return &cobra.Command{Use: "import-file <storage-state.json>", Short: "Import Playwright/browser-use storage state", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 		in := args[0]
 		f, err := os.Open(in)
@@ -342,7 +346,7 @@ func authImportFileCmd() *cobra.Command {
 	}}
 }
 
-func authStatusCmd() *cobra.Command {
+func newAuthStatusCmd() *cobra.Command {
 	var live bool
 	c := &cobra.Command{Use: "status", Short: "Show saved session status", RunE: func(cmd *cobra.Command, args []string) error {
 		st := readAccount()
@@ -358,13 +362,13 @@ func authStatusCmd() *cobra.Command {
 	return c
 }
 
-func authPathCmd() *cobra.Command {
+func newAuthPathCmd() *cobra.Command {
 	return &cobra.Command{Use: "path", Short: "Print auth/session paths", RunE: func(cmd *cobra.Command, args []string) error {
 		return emit(map[string]any{"secure_dir": cfg.SecureDir, "session_file": sessionPath(), "account_file": accountPath()})
 	}}
 }
 
-func authLogoutCmd() *cobra.Command {
+func newAuthLogoutCmd() *cobra.Command {
 	return &cobra.Command{Use: "logout", Short: "Delete saved LawHub session", RunE: func(cmd *cobra.Command, args []string) error {
 		removed := []string{}
 		for _, p := range []string{sessionPath(), accountPath()} {

--- a/library/education/lawhub/internal/cli/questions.go
+++ b/library/education/lawhub/internal/cli/questions.go
@@ -7,13 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func questionsCmd() *cobra.Command {
+func newQuestionsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "questions", Short: "Question metadata and review notes"}
-	cmd.AddCommand(questionsListCmd(), questionsShowCmd(), questionsNoteCmd())
+	cmd.AddCommand(newQuestionsListCmd())
+	cmd.AddCommand(newQuestionsShowCmd())
+	cmd.AddCommand(newQuestionsNoteCmd())
 	return cmd
 }
 
-func questionsListCmd() *cobra.Command {
+func newQuestionsListCmd() *cobra.Command {
 	var limit int
 	var attempt, qtype string
 	var incorrect, flagged, unanswered bool
@@ -72,7 +74,7 @@ func questionsListCmd() *cobra.Command {
 	return c
 }
 
-func questionsShowCmd() *cobra.Command {
+func newQuestionsShowCmd() *cobra.Command {
 	return &cobra.Command{Use: "show <id>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 		db, _, err := openDB()
 		if err != nil {
@@ -90,7 +92,7 @@ func questionsShowCmd() *cobra.Command {
 	}}
 }
 
-func questionsNoteCmd() *cobra.Command {
+func newQuestionsNoteCmd() *cobra.Command {
 	var note, whyPicked, whyCorrect, nextTime string
 	c := &cobra.Command{Use: "note <id>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 		parts := []string{}

--- a/library/education/lawhub/internal/cli/root.go
+++ b/library/education/lawhub/internal/cli/root.go
@@ -52,15 +52,15 @@ func homeJoin(parts ...string) string {
 }
 
 func Execute() {
-	root := rootCmd()
+	root := newRootCmd()
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func rootCmd() *cobra.Command {
-	cmd := &cobra.Command{
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
 		Use:          app,
 		Short:        "LawHub/LSAC practice-test analytics CLI",
 		Long:         "Standalone local CLI for LawHub LSAT practice-test analytics. SQLite is the source of truth.",
@@ -73,18 +73,28 @@ func rootCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.PersistentFlags().StringVar(&cfg.DataDir, "data-dir", homeJoin(".local", "share", app), "data directory")
-	cmd.PersistentFlags().StringVar(&cfg.ConfigDir, "config-dir", homeJoin(".config", app), "config directory")
-	cmd.PersistentFlags().StringVar(&cfg.SecureDir, "secure-dir", homeJoin(".openclaw", "secure", "lawhub"), "secure session directory")
-	cmd.PersistentFlags().BoolVar(&cfg.JSON, "json", false, "JSON output")
-	cmd.PersistentFlags().BoolVar(&cfg.Compact, "compact", false, "compact JSON")
-	cmd.PersistentFlags().BoolVar(&cfg.Agent, "agent", false, "agent mode: compact JSON, no prompts where possible")
-	cmd.PersistentFlags().StringVar(&cfg.Select, "select", "", "comma-separated fields to include in JSON output")
-	cmd.PersistentFlags().StringVar(&cfg.UserID, "user-id", "", "LawHub user id override (advanced; normally discovered at login)")
-	cmd.SetVersionTemplate(app + " {{ .Version }}\n")
+	rootCmd.PersistentFlags().StringVar(&cfg.DataDir, "data-dir", homeJoin(".local", "share", app), "data directory")
+	rootCmd.PersistentFlags().StringVar(&cfg.ConfigDir, "config-dir", homeJoin(".config", app), "config directory")
+	rootCmd.PersistentFlags().StringVar(&cfg.SecureDir, "secure-dir", homeJoin(".openclaw", "secure", "lawhub"), "secure session directory")
+	rootCmd.PersistentFlags().BoolVar(&cfg.JSON, "json", false, "JSON output")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Compact, "compact", false, "compact JSON")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Agent, "agent", false, "agent mode: compact JSON, no prompts where possible")
+	rootCmd.PersistentFlags().StringVar(&cfg.Select, "select", "", "comma-separated fields to include in JSON output")
+	rootCmd.PersistentFlags().StringVar(&cfg.UserID, "user-id", "", "LawHub user id override (advanced; normally discovered at login)")
+	rootCmd.SetVersionTemplate(app + " {{ .Version }}\n")
 
-	cmd.AddCommand(doctorCmd(), summaryCmd(), attemptsCmd(), testsCmd(), questionsCmd(), weaknessCmd(), reviewCmd(), syncCmd(), loginCmd(), authCmd(), versionCmd())
-	return cmd
+	rootCmd.AddCommand(newDoctorCmd())
+	rootCmd.AddCommand(newSummaryCmd())
+	rootCmd.AddCommand(newAttemptsCmd())
+	rootCmd.AddCommand(newTestsCmd())
+	rootCmd.AddCommand(newQuestionsCmd())
+	rootCmd.AddCommand(newWeaknessCmd())
+	rootCmd.AddCommand(newReviewCmd())
+	rootCmd.AddCommand(newSyncCmd())
+	rootCmd.AddCommand(newLoginCmd())
+	rootCmd.AddCommand(newAuthCmd())
+	rootCmd.AddCommand(newVersionCmd())
+	return rootCmd
 }
 
 func openDB() (*sql.DB, string, error) { return store.Open(cfg.DataDir) }
@@ -122,7 +132,7 @@ func mustCounts(db *sql.DB) map[string]int {
 	return out
 }
 
-func doctorCmd() *cobra.Command {
+func newDoctorCmd() *cobra.Command {
 	var live bool
 	c := &cobra.Command{Use: "doctor", Short: "Check local state", RunE: func(cmd *cobra.Command, args []string) error {
 		db, dbPath, err := openDB()
@@ -179,7 +189,7 @@ func queryAttempts(db *sql.DB, limit int) ([]Attempt, error) {
 	return out, rows.Err()
 }
 
-func summaryCmd() *cobra.Command {
+func newSummaryCmd() *cobra.Command {
 	var limit, minCount int
 	cmd := &cobra.Command{Use: "summary", Short: "CLI-native LSAT analytics summary", RunE: func(cmd *cobra.Command, args []string) error {
 		db, _, err := openDB()
@@ -242,7 +252,7 @@ func asInt(v any) int64 {
 	return 0
 }
 
-func attemptsCmd() *cobra.Command {
+func newAttemptsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "attempts", Short: "Manage attempts"}
 	var limit int
 	list := &cobra.Command{Use: "list", Short: "List attempts", RunE: func(cmd *cobra.Command, args []string) error {
@@ -345,7 +355,7 @@ func queryMaps(db *sql.DB, q string, args ...any) ([]map[string]any, error) {
 	return out, rows.Err()
 }
 
-func testsCmd() *cobra.Command {
+func newTestsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "tests", Short: "Manage tests"}
 	cmd.AddCommand(&cobra.Command{Use: "list", RunE: func(cmd *cobra.Command, args []string) error {
 		db, _, err := openDB()
@@ -362,7 +372,7 @@ func testsCmd() *cobra.Command {
 	return cmd
 }
 
-func weaknessCmd() *cobra.Command {
+func newWeaknessCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "weakness", Short: "Weakness analytics"}
 	var min int
 	r := &cobra.Command{Use: "report", RunE: func(cmd *cobra.Command, args []string) error {
@@ -421,7 +431,7 @@ func questionTypeWeakness(db *sql.DB, min int) ([]WeaknessRow, error) {
 	return out, rows.Err()
 }
 
-func reviewCmd() *cobra.Command {
+func newReviewCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "review", Short: "Open LawHub review pages"}
 	var section, question int
 	var printURL bool
@@ -469,8 +479,10 @@ func openURL(url string) error {
 	}
 }
 
-func syncCmd() *cobra.Command {
+func newSyncCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "sync", Short: "Sync LawHub data"}
-	cmd.AddCommand(syncBrowserCmd(), syncHistoryCmd(), syncReportMetadataCmd())
+	cmd.AddCommand(newSyncBrowserCmd())
+	cmd.AddCommand(newSyncHistoryCmd())
+	cmd.AddCommand(newSyncReportMetadataCmd())
 	return cmd
 }

--- a/library/education/lawhub/internal/cli/sync_go.go
+++ b/library/education/lawhub/internal/cli/sync_go.go
@@ -173,7 +173,7 @@ func sectionType(id, fallback string) string {
 	return fallback
 }
 
-func syncBrowserCmd() *cobra.Command {
+func newSyncBrowserCmd() *cobra.Command {
 	var wait int
 	c := &cobra.Command{Use: "browser", RunE: func(cmd *cobra.Command, args []string) error {
 		b, p, err := browserPage()
@@ -208,7 +208,7 @@ func syncBrowserCmd() *cobra.Command {
 	return c
 }
 
-func syncHistoryCmd() *cobra.Command {
+func newSyncHistoryCmd() *cobra.Command {
 	var module string
 	var pageSize int
 	c := &cobra.Command{Use: "history", RunE: func(cmd *cobra.Command, args []string) error {
@@ -393,7 +393,7 @@ func upsertReportQuestions(db *sql.DB, attemptID string, rows []reportRow) int {
 	return updated
 }
 
-func syncReportMetadataCmd() *cobra.Command {
+func newSyncReportMetadataCmd() *cobra.Command {
 	var attempt string
 	var wait int
 	c := &cobra.Command{Use: "report-metadata", RunE: func(cmd *cobra.Command, args []string) error {

--- a/library/education/lawhub/internal/cli/version.go
+++ b/library/education/lawhub/internal/cli/version.go
@@ -12,7 +12,7 @@ func versionInfo() map[string]string {
 	return map[string]string{"version": version, "commit": commit, "date": date}
 }
 
-func versionCmd() *cobra.Command {
+func newVersionCmd() *cobra.Command {
 	return &cobra.Command{Use: "version", Short: "Print version information", RunE: func(cmd *cobra.Command, args []string) error {
 		return emit(versionInfo())
 	}}


### PR DESCRIPTION
## Summary

Fixes a **platform-dependent false positive** in the `verify-skills` check that has been failing on unrelated PRs whenever a full-library scan runs. The failure looks like:

```
[positional-args] lawhub-pp-cli questions list: got 0 positional args; Use: "list" expects 1–1
```

It only reproduces on Linux (CI), which is why `verify_skill.py --dir library/education/lawhub/` passes locally on macOS — making it confusing to track down.

## Root cause

`verify_skill.py` resolves command paths two ways:

1. **Primary (deterministic):** walk the cobra command tree, keyed off the standard `func newXxxCmd()` constructors registered via `rootCmd.AddCommand(newXxxCmd())`.
2. **Legacy fallback:** when a CLI doesn't follow that convention, scan `internal/cli/*.go` in `glob()` order and read `Args:` from a 500-char text window.

lawhub is an older-style CLI: its constructors were named `questionsListCmd()` (no `new` prefix) and the tree was wired with `cmd.AddCommand(...)` inside `func rootCmd()`. That forced the **legacy fallback**, whose file-iteration order is filesystem-dependent. There are three colliding `list` leaves (`attempts list`, `tests list`, `questions list`); on Linux the iteration order made the fallback grab a neighboring command's `cobra.ExactArgs(1)` and wrongly conclude `questions list` needs a positional arg. The SKILL.md recipe `questions list --incorrect` (0 args) is correct — the verifier was wrong.

## Fix

Conform lawhub to the canonical CLI shape so resolution uses the deterministic walker (and is therefore platform-independent):

- Renamed every command constructor to the `newXxxCmd` form.
- Rebuilt the root command as `func newRootCmd()` with a local `rootCmd` var and **one `rootCmd.AddCommand(newXxxCmd())` per line** (the verifier's child-matcher only captures the first arg per `.AddCommand(...)`).
- Split the `questions`, `auth`, and `sync` sub-command registrations to one-per-line as well.

No runtime behavior change — these are constructor renames and call-site regrouping only. Recorded in `.printing-press-patches.json`.

## Validation

| Check | Result |
|---|---|
| `go build ./...` | ✅ pass |
| `go vet ./...` | ✅ clean |
| `go test ./...` | ✅ 13 pass |
| `verify_skill.py --dir library/education/lawhub/` | ✅ 0 errors (only the pre-existing `auth login` false-positive warnings remain) |

## Rebasing other PRs

This is intended to land first; once it's on `main`, in-flight PRs that were red on the lawhub `verify-skills` step just need a rebase/merge of `main` to go green. No changes to `registry.json` or `cli-skills/` (regenerated post-merge as usual).