### PR TITLE
fix(npm): tailor the not-on-PATH fix to the user's platform and shell

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - When `go install` writes a CLI to a directory that isn't on `PATH`, print the exact, copy-pasteable fix for the detected platform and shell instead of a single Unix-flavored hint. macOS zsh gets a `~/.zshrc` line, macOS bash gets `~/.bash_profile` (login shells don't read `.bashrc`), Linux bash gets `~/.bashrc`, fish gets `fish_add_path`, Windows gets the persistent PowerShell `[Environment]::SetEnvironmentVariable(... "User")` command plus a GUI fallback (and never the truncating `setx` footgun), and Git Bash gets a POSIX-translated path. The previous message printed `$(go env GOPATH)/bin` shell syntax that was wrong on Windows and imprecise on fish.
 
+## 0.1.10
+
+- Fix `install` / `uninstall` failing at the skill step on Windows with `ENOENT`. The process runner invoked `npx` through `node:child_process.execFile`, which does not resolve the `npx.cmd` shim Windows requires; it now uses `cross-spawn`, so the `npx skills …` install/remove step runs on Windows the same as on macOS and Linux. (#864)
+
+## 0.1.9
+
+- Catalog hints now match how the tool was invoked. The `list` and `search` usage lines and each entry's `install:` hint previously hardcoded the long `npx -y @mvanhorn/printing-press-library …` prefix; they now detect an `npx` run versus a globally-installed `printing-press-library` binary and print the shorter `printing-press-library …` form when that's how you're running it. (#749)
+
 ## 0.1.8
 
 - Avoid treating one-character queries or the shared `-pp-cli` binary suffix as searchable content, so queries like `a`, `t`, `pp`, or `cli` no longer match broad slices of the catalog while full binary-name queries still resolve to the intended CLI.

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.11
+
+- When `go install` writes a CLI to a directory that isn't on `PATH`, print the exact, copy-pasteable fix for the detected platform and shell instead of a single Unix-flavored hint. macOS zsh gets a `~/.zshrc` line, macOS bash gets `~/.bash_profile` (login shells don't read `.bashrc`), Linux bash gets `~/.bashrc`, fish gets `fish_add_path`, Windows gets the persistent PowerShell `[Environment]::SetEnvironmentVariable(... "User")` command plus a GUI fallback (and never the truncating `setx` footgun), and Git Bash gets a POSIX-translated path. The previous message printed `$(go env GOPATH)/bin` shell syntax that was wrong on Windows and imprecise on fish.
+
 ## 0.1.8
 
 - Avoid treating one-character queries or the shared `-pp-cli` binary suffix as searchable content, so queries like `a`, `t`, `pp`, or `cli` no longer match broad slices of the catalog while full binary-name queries still resolve to the intended CLI.

--- a/npm/README.md
+++ b/npm/README.md
@@ -132,7 +132,7 @@ More bundles will be added over time. To suggest one, open an issue at the [prin
 
 - Node.js 20+
 - Go 1.26.3 or newer (for `go install`)
-- `$(go env GOPATH)/bin` on `$PATH` (usually `$HOME/go/bin`) so installed CLIs are runnable
+- The Go install directory on your `PATH` so installed CLIs are runnable by name — `$(go env GOPATH)/bin` (usually `$HOME/go/bin`) on macOS/Linux, or `%USERPROFILE%\go\bin` on Windows. Go does not add this to `PATH` for you. If it's missing, `install` prints the exact, copy-pasteable line to add for your platform and shell (zsh/bash/fish, PowerShell, cmd, or Git Bash).
 
 ## Migration from @mvanhorn/printing-press
 

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -1,5 +1,6 @@
 import { BUNDLES, isBundle } from "../bundles.js";
 import { detectGo, goInstall, goInstallDir, type GoDetection, type GoInstallDir } from "../go.js";
+import { pathFixInstructions } from "../pathfix.js";
 import { commandOnPath, type RunResult } from "../process.js";
 import {
   cliBinaryName,
@@ -31,6 +32,10 @@ interface InstallDeps {
   stdout: (message: string) => void;
   stderr: (message: string) => void;
   platform: NodeJS.Platform;
+  /** Login shell (Unix) or Git Bash marker (Windows); drives the per-shell PATH fix. */
+  shell?: string;
+  /** Home directory, used to prefer the portable `$HOME/go/bin` form in PATH instructions. */
+  home?: string;
 }
 
 interface InstallSummary {
@@ -70,6 +75,8 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
     platform: process.platform,
+    shell: process.env.SHELL,
+    home: process.env.HOME ?? process.env.USERPROFILE,
     ...overrides,
   };
 
@@ -147,14 +154,15 @@ async function installOne(
       return { ok: false, name: entry.name, error: "go install failed" };
     }
 
-    const installedPath = await resolveInstalledPath(binary, deps);
+    const installed = await resolveInstalledPath(binary, deps);
+    const installedPath = installed?.binaryPath ?? null;
     const pathBinaryPath = await deps.commandOnPath(binary);
 
     if (!pathBinaryPath) {
       // `go install` succeeded, but `which`/`where` cannot find the binary —
-      // PATH does not include the directory go install wrote to. Tell the user
-      // exactly which directory to add when we know it.
-      deps.stderr(installedPath ? installedNotOnPathMessage(binary, installedPath) : pathMessage(binary));
+      // PATH does not include the directory go install wrote to. Print the exact,
+      // copy-pasteable PATH fix for this platform and shell.
+      deps.stderr(notOnPathMessage(binary, installed, deps));
       return { ok: false, name: entry.name, error: "binary not on PATH" };
     }
 
@@ -325,21 +333,24 @@ function goMissingMessage(platform: NodeJS.Platform): string {
   return `Go is required to install Printing Press CLIs. ${installHint}`;
 }
 
-function pathMessage(binary: string): string {
-  return `${binary} was installed, but it is not on PATH. Add $(go env GOPATH)/bin, usually $HOME/go/bin, to PATH and retry.`;
+interface InstalledPath {
+  /** Directory `go install` wrote to (GOBIN or GOPATH/bin). */
+  binDir: string;
+  /** Full path to the installed binary (binDir + binary + platform suffix). */
+  binaryPath: string;
 }
 
 async function resolveInstalledPath(
   binary: string,
   deps: InstallDeps,
-): Promise<string | null> {
+): Promise<InstalledPath | null> {
   const info = await deps.goInstallDir();
   if (!info.binDir) {
     return null;
   }
   const sep = deps.platform === "win32" ? "\\" : "/";
   const suffix = deps.platform === "win32" ? ".exe" : "";
-  return `${info.binDir}${sep}${binary}${suffix}`;
+  return { binDir: info.binDir, binaryPath: `${info.binDir}${sep}${binary}${suffix}` };
 }
 
 function memoize<T>(fn: () => Promise<T>): () => Promise<T> {
@@ -367,9 +378,20 @@ function shadowMessage(binary: string, installedPath: string, shadowedBy: string
   );
 }
 
-function installedNotOnPathMessage(binary: string, installedPath: string): string {
-  return (
-    `WARNING: installed ${binary} at ${installedPath}, but its directory is not on PATH. ` +
-    `Add it to PATH (e.g. $(go env GOPATH)/bin, usually $HOME/go/bin) and retry, or invoke the binary by absolute path.`
-  );
+function notOnPathMessage(
+  binary: string,
+  installed: InstalledPath | null,
+  deps: InstallDeps,
+): string {
+  const head = installed
+    ? `WARNING: installed ${binary} at ${installed.binaryPath}, but its directory is not on PATH.`
+    : `WARNING: ${binary} was installed, but it is not on PATH.`;
+  const fix = pathFixInstructions({
+    binDir: installed?.binDir ?? null,
+    platform: deps.platform,
+    shell: deps.shell,
+    home: deps.home,
+  });
+  const tail = installed ? `\n\nOr run it directly: ${installed.binaryPath}` : "";
+  return `${head}\n${fix}${tail}`;
 }

--- a/npm/src/pathfix.ts
+++ b/npm/src/pathfix.ts
@@ -1,0 +1,118 @@
+/**
+ * Platform- and shell-aware instructions for putting the Go install directory on
+ * PATH. `go install` writes to $(go env GOPATH)/bin (default ~/go/bin), which Go
+ * never adds to PATH itself — so a freshly installed CLI is unusable by name until
+ * the user wires up PATH. This builds the exact, copy-pasteable fix for the
+ * detected (platform, shell) rather than a single Unix-flavored hint that is wrong
+ * on Windows and imprecise on fish.
+ *
+ * Pure and dependency-free so the full (platform × shell) matrix is unit-testable.
+ */
+
+export interface PathFixContext {
+  /** Resolved `go install` directory (GOBIN or GOPATH/bin). Null when `go env` couldn't resolve it. */
+  binDir: string | null;
+  platform: NodeJS.Platform;
+  /** process.env.SHELL — the login shell on Unix; set under Git Bash/MSYS on Windows. */
+  shell?: string;
+  /** process.env.HOME ?? process.env.USERPROFILE — used to prefer the portable $HOME/go/bin form. */
+  home?: string;
+}
+
+type ShellKind = "zsh" | "bash" | "fish" | "gitbash" | "windows" | "unknown";
+
+function detectShell(platform: NodeJS.Platform, shell?: string): ShellKind {
+  const s = (shell ?? "").toLowerCase();
+  if (platform === "win32") {
+    // The only Windows shell we can reliably detect from a Node grandchild of npx
+    // is Git Bash / MSYS, which sets SHELL to a bash path. pwsh vs cmd is not
+    // reliably distinguishable here, so we emit a combined Windows block instead
+    // of guessing and printing the wrong syntax.
+    return s.includes("bash") ? "gitbash" : "windows";
+  }
+  if (s.includes("zsh")) return "zsh";
+  if (s.includes("fish")) return "fish";
+  if (s.includes("bash")) return "bash";
+  return "unknown";
+}
+
+/**
+ * The PATH entry to print for a Unix shell: the portable `$HOME/go/bin` form when
+ * the dir is the default (so it survives a GOPATH reset), else the literal path.
+ * fish passes its own `nullFallback` because its command-substitution syntax
+ * `(...)` differs from bash's `$(...)`.
+ */
+function unixPathEntry(
+  binDir: string | null,
+  home?: string,
+  nullFallback = "$(go env GOPATH)/bin",
+): string {
+  if (!binDir) return nullFallback;
+  if (home && binDir === `${home}/go/bin`) return "$HOME/go/bin";
+  return binDir;
+}
+
+/** C:\Users\you\go\bin -> /c/Users/you/go/bin (Git Bash / MSYS path form). */
+function toPosixPath(winPath: string): string {
+  const m = winPath.match(/^([A-Za-z]):[\\/](.*)$/);
+  if (!m) return winPath.replace(/\\/g, "/");
+  return `/${m[1]!.toLowerCase()}/${m[2]!.replace(/\\/g, "/")}`;
+}
+
+function rcFile(kind: "zsh" | "bash", platform: NodeJS.Platform): string {
+  if (kind === "zsh") return "~/.zshrc";
+  // bash login shells on macOS read .bash_profile, not .bashrc; Linux desktop
+  // terminals start interactive non-login shells that read .bashrc.
+  return platform === "darwin" ? "~/.bash_profile" : "~/.bashrc";
+}
+
+/**
+ * Returns a copy-pasteable instruction block (no leading/trailing newline) telling
+ * the user how to add `binDir` to PATH for their detected platform and shell.
+ */
+export function pathFixInstructions(ctx: PathFixContext): string {
+  const kind = detectShell(ctx.platform, ctx.shell);
+
+  if (kind === "windows") {
+    const dir = ctx.binDir ?? "%USERPROFILE%\\go\\bin";
+    return [
+      "PowerShell (persistent — recommended), then open a new terminal:",
+      `    [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";${dir}", "User")`,
+      "",
+      "Current session only:",
+      `    $env:Path += ";${dir}"        # PowerShell`,
+      `    set PATH=%PATH%;${dir}        # cmd.exe`,
+      "",
+      'Or via the GUI: press Win, search "environment variables", open',
+      `"Edit environment variables for your account", and add ${dir} to Path.`,
+    ].join("\n");
+  }
+
+  if (kind === "gitbash") {
+    const posix = ctx.binDir ? toPosixPath(ctx.binDir) : "$(go env GOPATH)/bin";
+    return [
+      "Add it to PATH (Git Bash):",
+      `    echo 'export PATH="${posix}:$PATH"' >> ~/.bashrc && source ~/.bashrc`,
+    ].join("\n");
+  }
+
+  if (kind === "fish") {
+    const entry = unixPathEntry(ctx.binDir, ctx.home, "(go env GOPATH)/bin");
+    return ["Add it to PATH (fish):", `    fish_add_path ${entry}`].join("\n");
+  }
+
+  const entry = unixPathEntry(ctx.binDir, ctx.home);
+  if (kind === "unknown") {
+    return [
+      "Add it to PATH by adding this line to your shell's startup file",
+      "(e.g. ~/.zshrc or ~/.bashrc), then restart your shell:",
+      `    export PATH="${entry}:$PATH"`,
+    ].join("\n");
+  }
+
+  const file = rcFile(kind, ctx.platform);
+  return [
+    `Add it to PATH (${kind}):`,
+    `    echo 'export PATH="${entry}:$PATH"' >> ${file} && source ${file}`,
+  ].join("\n");
+}

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -187,6 +187,7 @@ test("not-on-PATH warning is PowerShell-flavored on Windows", async () => {
     installSkill: async () => ok(),
     stderr: (message) => stderr.push(message),
     platform: "win32",
+    shell: undefined,
     home: "C:\\Users\\you",
   });
 

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -152,6 +152,50 @@ test("install command stops when binary is not on PATH", async () => {
   assert.match(stderr.join("\n"), /not on PATH/);
 });
 
+test("not-on-PATH warning is zsh-flavored on macOS", async () => {
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/amosclaw/go/bin"),
+    commandOnPath: async () => null,
+    installSkill: async () => ok(),
+    stderr: (message) => stderr.push(message),
+    platform: "darwin",
+    shell: "/bin/zsh",
+    home: "/Users/amosclaw",
+  });
+
+  assert.equal(await command(["espn"]), 1);
+  const out = stderr.join("\n");
+  assert.match(out, /installed espn-pp-cli at \/Users\/amosclaw\/go\/bin\/espn-pp-cli/);
+  assert.match(out, /~\/\.zshrc/);
+  assert.match(out, /export PATH="\$HOME\/go\/bin:\$PATH"/);
+});
+
+test("not-on-PATH warning is PowerShell-flavored on Windows", async () => {
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("C:\\Users\\you\\go\\bin"),
+    commandOnPath: async () => null,
+    installSkill: async () => ok(),
+    stderr: (message) => stderr.push(message),
+    platform: "win32",
+    home: "C:\\Users\\you",
+  });
+
+  assert.equal(await command(["espn"]), 1);
+  const out = stderr.join("\n");
+  assert.match(out, /SetEnvironmentVariable/);
+  assert.doesNotMatch(out, /setx/);
+});
+
 test("install command reports skill install failure without hiding binary", async () => {
   const stderr: string[] = [];
   const command = createInstallCommand({

--- a/npm/tests/pathfix.test.ts
+++ b/npm/tests/pathfix.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { pathFixInstructions, type PathFixContext } from "../src/pathfix.js";
+
+const MAC_HOME = "/Users/amosclaw";
+const MAC_BIN = `${MAC_HOME}/go/bin`;
+const WIN_BIN = "C:\\Users\\you\\go\\bin";
+
+function ctx(overrides: Partial<PathFixContext>): PathFixContext {
+  return { binDir: MAC_BIN, platform: "darwin", home: MAC_HOME, ...overrides };
+}
+
+test("macOS zsh recommends ~/.zshrc with the portable $HOME form", () => {
+  const out = pathFixInstructions(ctx({ shell: "/bin/zsh" }));
+  assert.match(out, /\(zsh\)/);
+  assert.match(out, /~\/\.zshrc/);
+  assert.match(out, /export PATH="\$HOME\/go\/bin:\$PATH"/);
+  assert.match(out, /source ~\/\.zshrc/);
+});
+
+test("macOS bash recommends ~/.bash_profile, not ~/.bashrc", () => {
+  const out = pathFixInstructions(ctx({ shell: "/bin/bash" }));
+  assert.match(out, /~\/\.bash_profile/);
+  assert.doesNotMatch(out, /\.bashrc/);
+});
+
+test("Linux bash recommends ~/.bashrc", () => {
+  const out = pathFixInstructions(
+    ctx({ platform: "linux", shell: "/usr/bin/bash", home: "/home/dev", binDir: "/home/dev/go/bin" }),
+  );
+  assert.match(out, /~\/\.bashrc/);
+  assert.doesNotMatch(out, /\.bash_profile/);
+});
+
+test("fish uses fish_add_path, never bash export syntax", () => {
+  const out = pathFixInstructions(ctx({ shell: "/opt/homebrew/bin/fish" }));
+  assert.match(out, /fish_add_path \$HOME\/go\/bin/);
+  assert.doesNotMatch(out, /export PATH/);
+});
+
+test("custom GOPATH prints the literal dir, not $HOME/go/bin", () => {
+  const out = pathFixInstructions(ctx({ shell: "/bin/zsh", binDir: "/opt/tools/bin" }));
+  assert.match(out, /export PATH="\/opt\/tools\/bin:\$PATH"/);
+  assert.doesNotMatch(out, /\$HOME\/go\/bin/);
+});
+
+test("unknown Unix shell falls back to generic guidance", () => {
+  const out = pathFixInstructions(ctx({ shell: "/bin/ksh" }));
+  assert.match(out, /shell's startup file/);
+  assert.match(out, /export PATH="\$HOME\/go\/bin:\$PATH"/);
+});
+
+test("Windows (no detectable shell) gives the persistent SetEnvironmentVariable command", () => {
+  const out = pathFixInstructions({ binDir: WIN_BIN, platform: "win32", home: "C:\\Users\\you" });
+  assert.match(out, /SetEnvironmentVariable/);
+  assert.match(out, /"User"\)/);
+  assert.ok(out.includes(WIN_BIN), "includes the literal Windows bin dir");
+  assert.match(out, /environment variables/i); // GUI fallback present
+  assert.doesNotMatch(out, /setx/); // never recommend the truncating setx footgun
+});
+
+test("Windows Git Bash translates the path to POSIX form and edits ~/.bashrc", () => {
+  const out = pathFixInstructions({
+    binDir: WIN_BIN,
+    platform: "win32",
+    shell: "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    home: "C:\\Users\\you",
+  });
+  assert.match(out, /Git Bash/);
+  assert.match(out, /\/c\/Users\/you\/go\/bin/);
+  assert.match(out, /~\/\.bashrc/);
+});
+
+test("missing binDir falls back to $(go env GOPATH)/bin on Unix", () => {
+  const out = pathFixInstructions({ binDir: null, platform: "darwin", shell: "/bin/zsh" });
+  assert.match(out, /\$\(go env GOPATH\)\/bin/);
+});
+
+test("missing binDir falls back to %USERPROFILE%\\go\\bin on Windows", () => {
+  const out = pathFixInstructions({ binDir: null, platform: "win32" });
+  assert.ok(out.includes("%USERPROFILE%\\go\\bin"));
+});


### PR DESCRIPTION
## Summary

`npx -y @mvanhorn/printing-press-library install <cli>` runs `go install`, which drops the binary in `$(go env GOPATH)/bin` (usually `~/go/bin`) — a directory Go never adds to `PATH` itself. When it's missing, the installer printed **one Unix-flavored hint regardless of OS or shell**:

```
WARNING: installed espn-pp-cli at …/go/bin/espn-pp-cli, but its directory is not on PATH.
Add it to PATH (e.g. $(go env GOPATH)/bin, usually $HOME/go/bin) and retry…
```

That `$(go env GOPATH)/bin` is broken shell syntax on Windows (a meaningful share of installs) and imprecise for fish. The installer now detects the platform and shell and prints the exact, copy-pasteable line to fix it.

## Before → after

macOS zsh now gets a line you can paste as-is:

```
Add it to PATH (zsh):
    echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
```

Windows now gets the persistent, registry-backed command instead of `$()` syntax that does nothing in PowerShell or cmd:

```
PowerShell (persistent — recommended), then open a new terminal:
    [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path","User") + ";C:\Users\you\go\bin", "User")
```

## What it emits per environment

| Platform / shell | Instruction |
|---|---|
| macOS zsh | `export … >> ~/.zshrc` |
| macOS bash | `~/.bash_profile` (login shells don't read `.bashrc`) |
| Linux bash | `~/.bashrc` |
| fish (any OS) | `fish_add_path` |
| Windows PowerShell / cmd | persistent `[Environment]::SetEnvironmentVariable(… "User")` + GUI fallback |
| Windows Git Bash | POSIX-translated path appended to `~/.bashrc` |
| unknown shell | generic `export` line with file guidance |

## Design decisions

- **No silent dotfile mutation.** `npx -y` is consent to run the wrapper, not to rewrite `~/.zshrc`. The fix stays a printed instruction the user pastes — never an automatic edit. Behavior is otherwise unchanged: warn, exit non-zero, don't touch the shell config.
- **Windows persistent `PATH` is registry-based, not an rc-append**, so it gets the PowerShell `SetEnvironmentVariable(… "User")` form plus a GUI fallback — and deliberately avoids `setx`, which truncates at 1024 chars and corrupts a merged User+System `PATH`.
- **Parent-shell detection on Windows is unreliable** from a Node grandchild of npx, so rather than guess PowerShell vs cmd we print the correct PowerShell form (callable from both) plus the GUI path. Git Bash is the one case we can detect (it sets `SHELL`).

The matrix lives in a new pure `pathFixInstructions()` helper, so every `(platform × shell)` combination is unit-tested rather than hand-verified.

## Tests

12 new tests — the full `pathfix` matrix (zsh, macOS vs Linux bash, fish, Windows PowerShell, Git Bash, custom GOPATH, missing bin dir) plus two `install` integration tests asserting the warning is platform-correct end-to-end. Full suite: **73 passing**. Includes the `npm/package.json` `0.1.10 → 0.1.11` bump that `verify-npm-version-bump.yml` requires for `npm/**` changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
