### PR TITLE
ci: publish discovery skill to ClawHub

### DIFF
--- a/.github/workflows/publish-clawhub-discovery-skill.yml
+++ b/.github/workflows/publish-clawhub-discovery-skill.yml
@@ -39,6 +39,12 @@ jobs:
             exit 0
           fi
 
+          if ! git cat-file -e "$BEFORE_SHA^{commit}" || ! git cat-file -e "$AFTER_SHA^{commit}"; then
+            echo "Could not resolve push boundary; publishing defensively."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if git diff --quiet "$BEFORE_SHA" "$AFTER_SHA" -- skills/printing-press-library; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/publish-clawhub-discovery-skill.yml
+++ b/.github/workflows/publish-clawhub-discovery-skill.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Checkout library
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check whether discovery skill changed
         id: changes
         shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -31,7 +34,12 @@ jobs:
             exit 0
           fi
 
-          if git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- skills/printing-press-library; then
+          if [ -z "${BEFORE_SHA:-}" ] || [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$BEFORE_SHA" "$AFTER_SHA" -- skills/printing-press-library; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -127,18 +135,35 @@ jobs:
 
           target = os.environ["VERSION"]
           raw = Path("/tmp/clawhub-existing.json").read_text(encoding="utf-8")
-          # clawhub may print progress lines before the JSON object; strip them.
-          start = raw.find("{")
-          if start == -1:
+          # clawhub may print progress lines before the JSON payload; strip them.
+          starts = [idx for idx in (raw.find("{"), raw.find("[")) if idx != -1]
+          if not starts:
               print("::error::clawhub inspect did not return JSON", file=sys.stderr)
               print(raw, file=sys.stderr)
               sys.exit(1)
-          data = json.loads(raw[start:])
-          versions = [item.get("version") for item in data.get("versions") or []]
-          if target in versions:
+
+          payload = raw[min(starts):]
+          try:
+              data = json.loads(payload)
+          except json.JSONDecodeError as exc:
+              print(f"::error::Could not parse clawhub inspect JSON: {exc}", file=sys.stderr)
+              print(payload, file=sys.stderr)
+              sys.exit(1)
+
+          if isinstance(data, dict):
+              version_items = data.get("versions") or []
+          elif isinstance(data, list):
+              version_items = data
+          else:
+              print(f"::error::Unexpected clawhub inspect JSON root: {type(data).__name__}", file=sys.stderr)
+              sys.exit(1)
+
+          versions = [item.get("version") for item in version_items if isinstance(item, dict)]
+          version_strings = [version for version in versions if isinstance(version, str) and version]
+          if target in version_strings:
               print(f"::error::ClawHub version {target} already exists for printing-press-library. Bump version: in skills/printing-press-library/SKILL.md before publishing.", file=sys.stderr)
               sys.exit(1)
-          print(f"ClawHub version {target} is new. Existing versions: {', '.join(versions) or 'none'}")
+          print(f"ClawHub version {target} is new. Existing versions: {', '.join(version_strings) or 'none'}")
           PY
 
       - name: Publish discovery skill to ClawHub

--- a/.github/workflows/publish-clawhub-discovery-skill.yml
+++ b/.github/workflows/publish-clawhub-discovery-skill.yml
@@ -1,0 +1,158 @@
+name: Publish discovery skill to ClawHub
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/printing-press-library/**'
+      - '.github/workflows/publish-clawhub-discovery-skill.yml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish printing-press-library skill
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout library
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Check whether discovery skill changed
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- skills/printing-press-library; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Extract ClawHub version from skill frontmatter
+        if: steps.changes.outputs.changed == 'true'
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          from pathlib import Path
+          import re
+          import sys
+
+          skill = Path('skills/printing-press-library/SKILL.md')
+          if not skill.is_file():
+              print(f'::error::Missing {skill}', file=sys.stderr)
+              sys.exit(1)
+
+          text = skill.read_text(encoding='utf-8')
+          match = re.match(r'^---\n(.*?)\n---\n', text, re.S)
+          if not match:
+              print('::error::SKILL.md must start with YAML frontmatter containing version:', file=sys.stderr)
+              sys.exit(1)
+
+          version = None
+          for line in match.group(1).splitlines():
+              if re.match(r'^version\s*:', line):
+                  version = line.split(':', 1)[1].strip().strip('"\'')
+                  break
+
+          if not version:
+              print('::error::ClawHub publish requires a semver frontmatter field: version: x.y.z', file=sys.stderr)
+              sys.exit(1)
+
+          if not re.match(r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$', version):
+              print(f'::error::Invalid semver for ClawHub: {version}', file=sys.stderr)
+              sys.exit(1)
+
+          print(f'version={version}')
+          PY
+
+      - name: Authenticate ClawHub CLI
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          CLAW_TOKEN: ${{ secrets.CLAW_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${CLAW_TOKEN:-}" ]; then
+            echo "::error::Missing CLAW_TOKEN repository secret"
+            exit 1
+          fi
+          npx -y clawhub@0.18.0 --no-input login --token "$CLAW_TOKEN"
+          npx -y clawhub@0.18.0 --no-input whoami
+
+      - name: Ensure ClawHub version is new
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          npx -y clawhub@0.18.0 --no-input inspect printing-press-library --versions --limit 200 --json > /tmp/clawhub-existing.json 2>/tmp/clawhub-existing.err
+          rc=$?
+          set -e
+
+          if [ "$rc" -ne 0 ]; then
+            if grep -qi "Skill not found" /tmp/clawhub-existing.err /tmp/clawhub-existing.json 2>/dev/null; then
+              echo "Skill is not published yet; initial publish will create version $VERSION."
+              exit 0
+            fi
+            echo "::error::Could not inspect existing ClawHub versions"
+            cat /tmp/clawhub-existing.err || true
+            cat /tmp/clawhub-existing.json || true
+            exit "$rc"
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          target = os.environ["VERSION"]
+          raw = Path("/tmp/clawhub-existing.json").read_text(encoding="utf-8")
+          # clawhub may print progress lines before the JSON object; strip them.
+          start = raw.find("{")
+          if start == -1:
+              print("::error::clawhub inspect did not return JSON", file=sys.stderr)
+              print(raw, file=sys.stderr)
+              sys.exit(1)
+          data = json.loads(raw[start:])
+          versions = [item.get("version") for item in data.get("versions") or []]
+          if target in versions:
+              print(f"::error::ClawHub version {target} already exists for printing-press-library. Bump version: in skills/printing-press-library/SKILL.md before publishing.", file=sys.stderr)
+              sys.exit(1)
+          print(f"ClawHub version {target} is new. Existing versions: {', '.join(versions) or 'none'}")
+          PY
+
+      - name: Publish discovery skill to ClawHub
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx -y clawhub@0.18.0 --no-input skill publish skills/printing-press-library \
+            --slug printing-press-library \
+            --name "Printing Press Library" \
+            --version "${{ steps.version.outputs.version }}" \
+            --changelog "Publish Printing Press Library discovery skill from ${GITHUB_SHA}" \
+            --clawscan-note "Catalog/discovery skill only. It may instruct agents to run npx @mvanhorn/printing-press-library commands and install focused pp-* skills, but this package itself does not include executable code or credentials."
+
+      - name: Skip publish
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No changes under skills/printing-press-library; skipping ClawHub publish."

--- a/.github/workflows/verify-clawhub-discovery-version.yml
+++ b/.github/workflows/verify-clawhub-discovery-version.yml
@@ -1,0 +1,124 @@
+name: Verify ClawHub discovery skill version
+
+on:
+  pull_request:
+    paths:
+      - 'skills/printing-press-library/**'
+      - '.github/workflows/verify-clawhub-discovery-version.yml'
+      - '.github/workflows/publish-clawhub-discovery-skill.yml'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Require discovery skill semver bump
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout library
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify version bump
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF" --depth=1
+
+          python3 - <<'PY'
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          base_ref = "origin/" + __import__("os").environ.get("BASE_REF", "main")
+          skill_path = Path("skills/printing-press-library/SKILL.md")
+
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+              text=True,
+          ).splitlines()
+
+          skill_changed = any(
+              path == "skills/printing-press-library/SKILL.md"
+              or path.startswith("skills/printing-press-library/")
+              for path in changed
+          )
+          if not skill_changed:
+              print("No changes under skills/printing-press-library; version bump not required.")
+              raise SystemExit(0)
+
+          if not skill_path.is_file():
+              print(f"::error::Missing {skill_path}", file=sys.stderr)
+              raise SystemExit(1)
+
+          semver_re = re.compile(
+              r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+              r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+              r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+          )
+
+          def extract_version_from_text(text: str, source: str) -> str:
+              match = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+              if not match:
+                  print(f"::error::{source} must start with YAML frontmatter containing version:", file=sys.stderr)
+                  raise SystemExit(1)
+              for line in match.group(1).splitlines():
+                  if re.match(r"^version\s*:", line):
+                      version = line.split(":", 1)[1].strip().strip("\"'")
+                      if not semver_re.match(version):
+                          print(f"::error::Invalid semver in {source}: {version}", file=sys.stderr)
+                          raise SystemExit(1)
+                      return version
+              print(f"::error::Missing version: in {source}", file=sys.stderr)
+              raise SystemExit(1)
+
+          def version_at(ref: str, path: str) -> str | None:
+              result = subprocess.run(
+                  ["git", "show", f"{ref}:{path}"],
+                  text=True,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.DEVNULL,
+              )
+              if result.returncode != 0:
+                  return None
+              return extract_version_from_text(result.stdout, f"{ref}:{path}")
+
+          def semver_key(version: str):
+              match = semver_re.match(version)
+              assert match
+              major, minor, patch = (int(match.group(i)) for i in range(1, 4))
+              prerelease = match.group(4)
+              # Stable releases sort after their prereleases for the same core.
+              pre_key = (1,) if prerelease is None else (0, tuple(prerelease.split(".")))
+              return (major, minor, patch, pre_key)
+
+          head_version = extract_version_from_text(skill_path.read_text(encoding="utf-8"), str(skill_path))
+          base_version = version_at(base_ref, str(skill_path))
+
+          if base_version is None:
+              print(f"Initial ClawHub discovery skill version: {head_version}")
+              raise SystemExit(0)
+
+          if head_version == base_version:
+              print(
+                  "::error::skills/printing-press-library changed but version did not. "
+                  f"Bump version: in {skill_path} from {base_version} before merge.",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          if semver_key(head_version) <= semver_key(base_version):
+              print(
+                  "::error::skills/printing-press-library version must increase. "
+                  f"Base={base_version}, head={head_version}.",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          print(f"ClawHub discovery skill version bump OK: {base_version} -> {head_version}")
+          PY

--- a/.github/workflows/verify-clawhub-discovery-version.yml
+++ b/.github/workflows/verify-clawhub-discovery-version.yml
@@ -94,7 +94,16 @@ jobs:
               major, minor, patch = (int(match.group(i)) for i in range(1, 4))
               prerelease = match.group(4)
               # Stable releases sort after their prereleases for the same core.
-              pre_key = (1,) if prerelease is None else (0, tuple(prerelease.split(".")))
+              if prerelease is None:
+                  pre_key = (1,)
+              else:
+                  parts = []
+                  for identifier in prerelease.split("."):
+                      if identifier.isdigit():
+                          parts.append((0, int(identifier)))
+                      else:
+                          parts.append((1, identifier))
+                  pre_key = (0, tuple(parts))
               return (major, minor, patch, pre_key)
 
           head_version = extract_version_from_text(skill_path.read_text(encoding="utf-8"), str(skill_path))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,18 @@ Every CLI in `library/` **must** ship a `library/<category>/<slug>/SKILL.md`. Th
 
 When adding a new CLI, ship a library SKILL.md alongside the generated code. If you need to change SKILL.md *shape* (frontmatter fields, structure, sections), make that change in `cli-printing-press`'s `internal/generator/templates/skill.md.tmpl` and regenerate the affected CLIs — don't hand-shape it here.
 
+## ClawHub discovery skill release
+
+The root catalog/discovery skill lives at `skills/printing-press-library/SKILL.md`. Its frontmatter `version:` is the source of truth for ClawHub publishing.
+
+Any PR that changes `skills/printing-press-library/**` must bump that frontmatter version using semver:
+
+- patch: wording, examples, install command fixes
+- minor: new workflow, new supported harness, substantial discovery behavior
+- major: breaking discovery/install behavior, renamed skill, incompatible assumptions
+
+Do not tie this version to `npm/package.json`. The ClawHub discovery skill and npm installer release independently. The PR-time `verify-clawhub-discovery-version.yml` workflow enforces that the version increases before merge; the post-merge publish workflow verifies that the target version does not already exist on ClawHub before publishing.
+
 ## NPM installer surface
 
 `@mvanhorn/printing-press` lives in `npm/`. The `printing-press` command reads the live `registry.json`, resolves a catalog name to its published Go module path, runs `go install`, and installs the matching `cli-skills/pp-<name>` skill with `skills@latest`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,42 @@ Three to try first:
 - flight-goat (Kayak nonstop search plus sniffed Google Flights). _"Non-stop flights over 8 hours from Seattle for 4 people, Dec 24 to Jan 1, cheapest first."_ Two sources, one query.
 - sentry-pp-cli (local SQLite mirror, SQL across orgs and projects). _"Every issue first seen in the last release whose error rate is climbing across two projects."_ Compound queries the Sentry API can't answer.
 
+## Agent-native discovery
+
+If you use OpenClaw, Hermes, Claude Code, Codex, Cursor, or another harness that supports agent skills, install the Printing Press Library discovery skill first. It helps your agent search the catalog, choose the right focused `pp-*` skill, and defer CLI binary setup until the focused skill says it is needed.
+
+OpenClaw users can install the published skill from ClawHub:
+
+```bash
+clawhub install printing-press-library
+```
+
+Humans and agents on Vercel Agent Skills-compatible harnesses can install the same discovery skill from this repo:
+
+```bash
+npx skills add mvanhorn/printing-press-library/skills/printing-press-library -g -y
+```
+
+Or from the repo root by selecting the catalog skill explicitly:
+
+```bash
+npx skills add mvanhorn/printing-press-library -g -y --skill printing-press-library
+```
+
+Hermes users can install it through Hermes:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/skills/printing-press-library --force
+```
+
+Once you know the specific tool you want, install the focused skill directly, for example:
+
+```bash
+npx skills add mvanhorn/printing-press-library/cli-skills/pp-espn -g -y
+```
+
+The existing npm installer remains the right path for humans, scripts, and CLI-first setup.
+
 ## Discover and install
 
 The fastest way to start — install four hand-picked CLIs and skills in one command:

--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: printing-press-library
+description: Discover and install Printing Press Library CLIs and focused agent skills.
+version: 0.1.0
+metadata:
+  openclaw:
+    emoji: "🖨️"
+    homepage: https://github.com/mvanhorn/printing-press-library
+    requires:
+      anyBins:
+        - npx
+        - npm
+        - hermes
+        - clawhub
+---
+
+# Printing Press Library
+
+Use this skill when a user asks for a CLI, agent skill, API wrapper, scraper, automation tool, or data source that may exist in the Printing Press Library.
+
+The library is an open-source catalog of focused CLIs and matching agent skills generated from `mvanhorn/cli-printing-press`. This skill is the catalog front door. Do not install a random long-tail skill just because it exists. First identify the right tool, then install the focused skill or CLI only when it is useful for the task.
+
+## Default workflow
+
+1. Clarify the user goal only if needed.
+   - If the request names a service or website, search for that directly.
+   - If the request describes a job instead of a service, search by capability and domain.
+
+2. Search the catalog.
+   - Use the GitHub repo, local clone, or npm package docs if available.
+   - Relevant local paths when the repo is cloned:
+     - `registry.json`
+     - `library/<category>/<slug>/README.md`
+     - `library/<category>/<slug>/SKILL.md`
+     - `cli-skills/pp-<slug>/SKILL.md`
+
+3. Prefer a focused `pp-*` skill before installing or running a CLI.
+   - Focused skills include usage guidance, auth notes, examples, and install instructions.
+   - The CLI binary should be installed only when the task actually needs execution.
+
+4. Verify before claiming success.
+   - If installing a skill, verify the destination harness can see it.
+   - If installing a CLI, run its `--help` or an equivalent harmless command.
+   - If using a credentialed CLI, confirm required environment variables without printing secrets.
+
+## Install paths
+
+### OpenClaw / ClawHub
+
+OpenClaw users should install this discovery skill from ClawHub:
+
+```bash
+clawhub install printing-press-library
+```
+
+To install a focused skill from ClawHub if it is published there:
+
+```bash
+clawhub install <skill-slug>
+```
+
+If a focused skill is not on ClawHub, use the Vercel Agent Skills-compatible GitHub path below.
+
+### Vercel Agent Skills-compatible harnesses
+
+Install this discovery skill globally:
+
+```bash
+npx skills add mvanhorn/printing-press-library/skills/printing-press-library -g -y
+```
+
+Or select it explicitly from the repo root:
+
+```bash
+npx skills add mvanhorn/printing-press-library -g -y --skill printing-press-library
+```
+
+Install a focused per-CLI skill globally:
+
+```bash
+npx skills add mvanhorn/printing-press-library/cli-skills/pp-<slug> -g -y
+```
+
+Example:
+
+```bash
+npx skills add mvanhorn/printing-press-library/cli-skills/pp-espn -g -y
+```
+
+### Hermes
+
+Install this discovery skill:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/skills/printing-press-library --force
+```
+
+Install a focused per-CLI skill:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-<slug> --force
+```
+
+### CLI-first install
+
+For humans, scripts, and CLI-first usage, use the npm installer:
+
+```bash
+npx -y @mvanhorn/printing-press-library install <slug>
+```
+
+That path installs the CLI and the matching skill using the library installer.
+
+## Search tactics
+
+Use whichever source is available:
+
+```bash
+# From a local clone
+python3 - <<'PY'
+import json
+from pathlib import Path
+q = 'espn'
+registry = json.loads(Path('registry.json').read_text())
+for item in registry:
+    haystack = json.dumps(item).lower()
+    if q.lower() in haystack:
+        print(item.get('slug') or item.get('name'), item.get('title') or item.get('description', ''))
+PY
+```
+
+```bash
+# Broad repo text search when local tools are available
+rg -i "<service-or-capability>" registry.json library cli-skills
+```
+
+If the registry shape differs, inspect `registry.json` first instead of guessing. Generated catalogs move; facts beat vibes.
+
+## Selection rules
+
+Prefer a candidate when:
+
+- It names the target service directly.
+- Its README/SKILL examples match the user's requested job.
+- It has documented auth and setup requirements the user can satisfy.
+- It supports the user's OS/runtime.
+
+Avoid a candidate when:
+
+- It is only vaguely adjacent to the task.
+- It requires credentials the user does not have.
+- It is a scraper for a site where the user's task needs official-account data and the skill cannot authenticate.
+- A safer built-in API/tool already solves the task.
+
+## Safety and credentials
+
+- Never print API keys, cookies, tokens, or session headers.
+- Do not ask the user to paste secrets into chat if a local secret manager or environment file is available.
+- Treat third-party CLIs as code execution. Install only the focused tool needed for the task.
+- Do not publish, post, email, buy, book, or mutate external state unless the user explicitly approves that action.
+
+## README behavior on ClawHub
+
+ClawHub renders `SKILL.md` (or `skill.md`) as the skill readme. A separate `README.md` in the skill folder is not the published readme. Put user-facing ClawHub documentation in this file.


### PR DESCRIPTION
## Summary
- Add a root-level Printing Press Library discovery skill for OpenClaw/ClawHub, Hermes, and Vercel Agent Skills-compatible harnesses.
- Add a ClawHub publish workflow scoped only to `skills/printing-press-library`, using `CLAW_TOKEN` and duplicate-version preflight.
- Add PR-time semver bump verification for discovery skill changes.
- Document agent-native install paths while preserving existing CLI/npm install docs.

## Test plan
- Ruby YAML parse for both new workflow files.
- `git diff --check` clean.
- Local version extraction reports `0.1.0`.
- Local ClawHub inspect preflight confirms initial publish path for `printing-press-library`.

## Notes
- This intentionally publishes only the curated discovery skill, not the generated `cli-skills/pp-*` fleet.
- ClawHub versions are immutable, so future changes must bump `skills/printing-press-library/SKILL.md` frontmatter `version:`.