### PR TITLE
fix(splitwise): paginate expense sync past the 100-row first page

### DIFF
--- a/library/payments/splitwise/.printing-press-patches.json
+++ b/library/payments/splitwise/.printing-press-patches.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "applied_at": "2026-05-28",
+  "applied_at": "2026-05-30",
   "base_run_id": "20260528-002755",
   "base_printing_press_version": "4.19.0",
   "patches": [
@@ -13,6 +13,22 @@
       ],
       "validated_outcome": "Publish live gate (dogfood --live --level full) get-group error_path passes; full matrix 115/115.",
       "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/2327"
+    },
+    {
+      "id": "splitwise-sync-offset-pagination-past-first-page",
+      "summary": "Make offset-paginated sync advance past the first page when the API returns no has_more/cursor signal.",
+      "reason": "Splitwise /get_expenses paginates by offset and returns a bare {\"expenses\":[...]} envelope with no has_more field, so extractPageItems returns hasMore=false. The sync loop's natural-end check (!hasMore) fired after the first 100 rows even under --full --max-pages 0, so the 43 oldest of 143 expenses never reached the local store — breaking debts --aged (age_days:null) and under-counting spend. Added an offset-paginator full-page fallback mirroring the existing page-int fallback: when cursorType==\"offset\", nextCursor is empty, and the page is full, synthesize hasMore and the next offset so the loop continues until a short/empty page.",
+      "files": [
+        "internal/cli/sync.go",
+        "internal/cli/sync_offset_pagination_test.go"
+      ],
+      "validated_outcome": "New TestSyncGetExpenses_PaginatesPastFirstPage syncs all 143 rows (fails at 100 without the fix); go build/vet/test, govulncheck, and verify-skill all pass.",
+      "deferred_to_upstream": [
+        {
+          "feature": "Offset-class paginator support in the sync loop template (sync.go.tmpl) that does not rely on an envelope has_more/cursor field to advance.",
+          "reason": "Generator-shaped: 13 published CLIs use cursorType==\"offset\" and 12 besides splitwise lack this fallback, so any offset endpoint that omits has_more truncates at one page. The template should emit the offset full-page fallback alongside the existing page-int one."
+        }
+      ]
     }
   ]
 }

--- a/library/payments/splitwise/internal/cli/sync.go
+++ b/library/payments/splitwise/internal/cli/sync.go
@@ -505,6 +505,23 @@ func syncResource(ctx context.Context, c interface {
 			hasMore = true
 		}
 
+		// PATCH(amend-2026-05-30: paginate offset APIs past the first page) —
+		// Offset paginator fallback: when the API paginates by ?offset=N and
+		// returns a bare item-array envelope with no body has_more/cursor
+		// signal (Splitwise's {"expenses":[...]} shape), a full page must be
+		// treated as "there may be more" so the loop advances the offset
+		// instead of stopping at pageSize.limit. Without this, get-expenses
+		// hard-caps at 100 even under --full --max-pages 0: extractPageItems
+		// returns hasMore=false, the natural-end check (`!hasMore`) fires after
+		// page 1, and the offset-advance branch below is never reached. Mirrors
+		// the page-int fallback above; guards on cursorType so it only affects
+		// offset-class paginators.
+		if pageSize.cursorType == "offset" && nextCursor == "" && len(items) >= pageSize.limit {
+			currentOffset, _ := strconv.Atoi(cursor)
+			nextCursor = strconv.Itoa(currentOffset + pageSize.limit)
+			hasMore = true
+		}
+
 		if len(items) == 0 {
 			if isEmptyPageResponse(data) {
 				break

--- a/library/payments/splitwise/internal/cli/sync_offset_pagination_test.go
+++ b/library/payments/splitwise/internal/cli/sync_offset_pagination_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
+)
+
+// offsetPageClient is a fake sync client that emulates Splitwise's
+// /get_expenses endpoint: it paginates by ?offset=N&limit=M and returns a
+// bare {"expenses":[...]} envelope with no has_more / next-cursor signal.
+// It serves `total` synthetic expenses across as many pages as the offset
+// walk requires.
+type offsetPageClient struct {
+	total          int
+	requestedPages int
+}
+
+func (c *offsetPageClient) RateLimit() float64 { return 0 }
+
+func (c *offsetPageClient) Get(_ context.Context, _ string, params map[string]string) (json.RawMessage, error) {
+	c.requestedPages++
+
+	limit, _ := strconv.Atoi(params["limit"])
+	if limit <= 0 {
+		limit = 100
+	}
+	offset, _ := strconv.Atoi(params["offset"])
+
+	remaining := c.total - offset
+	if remaining < 0 {
+		remaining = 0
+	}
+	n := limit
+	if remaining < limit {
+		n = remaining
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`{"expenses":[`)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		// Each expense needs an extractable integer primary key so the
+		// upsert path lands a row.
+		fmt.Fprintf(&sb, `{"id":%d,"description":"e%d","deleted_at":null}`, offset+i+1, offset+i+1)
+	}
+	sb.WriteString(`]}`)
+	return json.RawMessage(sb.String()), nil
+}
+
+// TestSyncGetExpenses_PaginatesPastFirstPage pins the offset-paginator fix:
+// /get_expenses returns no has_more signal, so before the fix the sync loop
+// broke after the first 100 rows even under --full --max-pages 0. The fake
+// account here has 143 expenses; all 143 must reach the local store.
+func TestSyncGetExpenses_PaginatesPastFirstPage(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	client := &offsetPageClient{total: 143}
+
+	userParams, err := parseSyncUserParams(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("parseSyncUserParams: %v", err)
+	}
+
+	// full=true clears any resume cursor; maxPages=0 means unlimited.
+	res := syncResource(
+		context.Background(),
+		client,
+		db,
+		"get-expenses",
+		"",    // sinceTS
+		true,  // full
+		0,     // maxPages (0 = unlimited)
+		false, // latestOnly
+		userParams,
+		io.Discard,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncResource returned error: %v", res.Err)
+	}
+
+	if res.Count != 143 {
+		t.Fatalf("synced count = %d, want 143 (offset pagination must walk past the 100-row first page)", res.Count)
+	}
+
+	// The fake account spans two pages (100 + 43); a third request returns an
+	// empty page that terminates the walk.
+	if client.requestedPages < 2 {
+		t.Fatalf("requested pages = %d, want >= 2 (the loop must advance the offset beyond page 1)", client.requestedPages)
+	}
+
+	var rows int
+	if err := db.DB().QueryRow(
+		`SELECT COUNT(*) FROM resources WHERE resource_type = ?`,
+		"get-expenses",
+	).Scan(&rows); err != nil {
+		t.Fatalf("count stored rows: %v", err)
+	}
+	if rows != 143 {
+		t.Fatalf("stored rows = %d, want 143 (the 43 oldest expenses must reach the local store)", rows)
+	}
+}

--- a/library/payments/splitwise/internal/cli/sync_offset_pagination_test.go
+++ b/library/payments/splitwise/internal/cli/sync_offset_pagination_test.go
@@ -99,10 +99,13 @@ func TestSyncGetExpenses_PaginatesPastFirstPage(t *testing.T) {
 		t.Fatalf("synced count = %d, want 143 (offset pagination must walk past the 100-row first page)", res.Count)
 	}
 
-	// The fake account spans two pages (100 + 43); a third request returns an
-	// empty page that terminates the walk.
-	if client.requestedPages < 2 {
-		t.Fatalf("requested pages = %d, want >= 2 (the loop must advance the offset beyond page 1)", client.requestedPages)
+	// The fake account spans exactly two pages (100 + 43). After the second
+	// request, len(items)=43 < pageSize.limit triggers the natural-end check
+	// and the loop exits without issuing a third request. Pinning to == 2
+	// catches both "stopped too early" (page 1 only) and "never stops"
+	// (sticky-offset infinite loop) regressions.
+	if client.requestedPages != 2 {
+		t.Fatalf("requested pages = %d, want 2 (loop must advance past page 1 and stop after the short second page)", client.requestedPages)
 	}
 
 	var rows int


### PR DESCRIPTION
## Summary

The splitwise `sync` get-expenses path hard-capped at 100 expenses and never stored more, even with `--full --max-pages 0`. On an account with 143 expenses, the 43 oldest never reached the local SQLite store — so `debts --aged` returned `age_days:null` for friends whose only open-balance expense predated the 100-row window, and `spend` totals under-counted. This fix makes offset-paginated sync advance past the first page.

## Root cause

Splitwise's `/get_expenses` paginates by `offset`/`limit` and returns a bare `{"expenses":[...]}` envelope with **no `has_more` field and no cursor**. In `internal/cli/sync.go`:

- `extractPaginationFromEnvelope` finds no cursor and no `has_more`, so it returns `("", false)`.
- The sync loop's natural-end check `if !hasMore || len(items) < pageSize.limit { break }` then fires after the very first page of 100 — regardless of `--max-pages 0`.
- The offset-advance branch lower in the loop (`nextCursor = offset + limit`) was never reached, because the loop already broke on `!hasMore`.

The generator already handles the analogous case for integer-`?page=N` paginators (the page-int fallback that synthesizes `hasMore` on a full page), but not for the offset class.

## Fix

Add an offset-paginator full-page fallback that mirrors the existing page-int fallback: when `cursorType == "offset"`, `nextCursor == ""`, and the page is full (`len(items) >= pageSize.limit`), synthesize `hasMore=true` and `nextCursor = offset + limit` so the loop advances. It still terminates naturally on the first short/empty page (143 → page 1 of 100, page 2 of 43, stop).

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1 | sync / pagination | bug | get-expenses offset sync stopped after 100 rows because the API emits no `has_more`; downstream `debts --aged` and `spend` were wrong for pre-window expenses |

## Changes

```
 .../splitwise/.printing-press-patches.json         |  18 +++++++++++++++++-
 .../splitwise/internal/cli/sync.go                 |  16 ++++++++++++++++
 .../internal/cli/sync_offset_pagination_test.go    | 118 ++++++++++++++++++++++
 3 files changed, 152 insertions(+), 1 deletion(-)
```

## Verification

| Check | Result |
|-------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS |
| `govulncheck ./...` | PASS (0 reachable) |
| `verify_skill.py` | PASS |
| New regression test | `TestSyncGetExpenses_PaginatesPastFirstPage` syncs all 143 rows; reverting the fix drops it to exactly 100 (reproduces the reported symptom) |

## Generator-shaped (upstream)

This is a template-level defect, not splitwise-specific. 13 published CLIs use `cursorType=="offset"` and 12 besides splitwise lack this fallback, so any offset endpoint that omits `has_more` truncates at one page. The local patch lands here first (users install from this repo); the generalized fix belongs in the sync-loop template (`sync.go.tmpl`) alongside the existing page-int fallback. Recorded under `deferred_to_upstream` in `.printing-press-patches.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
