### PR TITLE
feat(npm): add reinstall command as an alias for update

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.12
 
-- Add a `reinstall` command as an alias for `update`. `reinstall <name>` rebuilds one CLI's binary from the latest catalog code and re-adds its skill; `reinstall` with no name does the same for every Printing Press CLI already on `PATH`. The mechanics are identical to `update` (both run `go install …@latest` and re-add the skill) — this just exposes the verb users reach for when a binary or skill needs a clean refresh.
+- Add a `reinstall` command as an alias for `update`. `reinstall <name>` rebuilds one CLI's binary from the latest catalog code and re-adds its skill; `reinstall` with no name does the same for every Printing Press CLI already on `PATH`. The mechanics are identical to `update` (both run `go install …@latest` and re-add the skill) — this just exposes the verb users reach for when a binary or skill needs a clean refresh. The shared "no CLIs found on PATH" message is now verb-neutral so it reads correctly under either command.
 
 ## 0.1.11
 

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.12
+
+- Add a `reinstall` command as an alias for `update`. `reinstall <name>` rebuilds one CLI's binary from the latest catalog code and re-adds its skill; `reinstall` with no name does the same for every Printing Press CLI already on `PATH`. The mechanics are identical to `update` (both run `go install …@latest` and re-add the skill) — this just exposes the verb users reach for when a binary or skill needs a clean refresh.
+
 ## 0.1.11
 
 - When `go install` writes a CLI to a directory that isn't on `PATH`, print the exact, copy-pasteable fix for the detected platform and shell instead of a single Unix-flavored hint. macOS zsh gets a `~/.zshrc` line, macOS bash gets `~/.bash_profile` (login shells don't read `.bashrc`), Linux bash gets `~/.bashrc`, fish gets `fish_add_path`, Windows gets the persistent PowerShell `[Environment]::SetEnvironmentVariable(... "User")` command plus a GUI fallback (and never the truncating `setx` footgun), and Git Bash gets a POSIX-translated path. The previous message printed `$(go env GOPATH)/bin` shell syntax that was wrong on Windows and imprecise on fish.

--- a/npm/README.md
+++ b/npm/README.md
@@ -91,10 +91,13 @@ npx -y @mvanhorn/printing-press-library search sports
 npx -y @mvanhorn/printing-press-library list --category travel
 npx -y @mvanhorn/printing-press-library list --installed
 npx -y @mvanhorn/printing-press-library update espn
+npx -y @mvanhorn/printing-press-library reinstall espn
 npx -y @mvanhorn/printing-press-library uninstall espn --yes
 ```
 
 `list` shows the public catalog by default. Use `list --installed` when you only want CLIs already present on your machine.
+
+`reinstall` is an alias for `update`: `reinstall <name>` rebuilds one CLI from the latest catalog code and re-adds its skill, while `reinstall` with no name refreshes every Printing Press CLI already on your `PATH`. Reach for it when a binary or skill needs a clean refresh — `install <name>` overwrites in place too, so either works.
 
 ## Options
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/cli.ts
+++ b/npm/src/cli.ts
@@ -12,6 +12,10 @@ type CommandHandler = (args: string[]) => Promise<number>;
 const COMMANDS: Record<string, CommandHandler> = {
   install: installCommand,
   update: updateCommand,
+  // `reinstall` is an alias for `update`: both rebuild the binary from the
+  // latest catalog code (`go install …@latest`) and re-add the skill. It exists
+  // because "reinstall" is the verb users reach for; the mechanics are identical.
+  reinstall: updateCommand,
   list: listCommand,
   search: searchCommand,
   uninstall: uninstallCommand,
@@ -56,6 +60,7 @@ Usage:
 Commands:
   install <name|bundle>...  Install one or more Printing Press CLIs (and skills)
   update [name]             Refresh one installed CLI, or all installed CLIs
+  reinstall [name]          Reinstall one CLI (or all installed); alias for update
   list                      List available Printing Press CLIs
   search <query>            Search the Printing Press catalog
   uninstall <name>          Remove a Printing Press CLI and skill
@@ -67,6 +72,7 @@ Examples:
   printing-press-library install starter-pack
   printing-press-library install espn linear dub
   printing-press-library install espn --cli-only
+  printing-press-library reinstall espn
   printing-press-library list
   printing-press-library search sports
   printing-press-library list --installed

--- a/npm/src/commands/update.ts
+++ b/npm/src/commands/update.ts
@@ -40,7 +40,7 @@ export function createUpdateCommand(overrides: Partial<UpdateDeps> = {}) {
     }
 
     if (installed.length === 0) {
-      deps.stdout("Nothing to update; no Printing Press CLIs were found on PATH.");
+      deps.stdout("No Printing Press CLIs found on PATH to refresh.");
       return 0;
     }
 

--- a/npm/src/commands/update.ts
+++ b/npm/src/commands/update.ts
@@ -83,7 +83,7 @@ function parseUpdateArgs(args: string[]):
         installArgs.push(value);
       }
     } else if (arg.startsWith("-")) {
-      return { error: `Unknown update option: ${arg}` };
+      return { error: `Unknown option: ${arg}` };
     } else if (!name) {
       name = arg;
     } else {

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -4,6 +4,7 @@ import { createListCommand } from "../src/commands/list.js";
 import { createSearchCommand, searchRegistry } from "../src/commands/search.js";
 import { createUninstallCommand } from "../src/commands/uninstall.js";
 import { createUpdateCommand } from "../src/commands/update.js";
+import { run } from "../src/cli.js";
 import { CLI_COMMAND_NAME, commandPrefixForInvocation, NPX_COMMAND_PREFIX } from "../src/constants.js";
 import type { RunResult } from "../src/process.js";
 import type { Registry } from "../src/registry.js";
@@ -211,6 +212,37 @@ test("update command refreshes detected installed CLIs", async () => {
 
   assert.equal(await command(["--agent", "claude-code"]), 0);
   assert.deepEqual(installs, [["espn", "--agent", "claude-code"]]);
+});
+
+test("reinstall dispatches to the update handler rather than the unknown-command path", async () => {
+  // `reinstall --bogus` fails in the update arg parser before any network call,
+  // which proves the alias routes to `update` (and not to "Unknown command").
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (message) => errors.push(String(message));
+  let code: number;
+  try {
+    code = await run(["reinstall", "--bogus-flag"]);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(code, 1);
+  assert.doesNotMatch(errors.join("\n"), /Unknown command/);
+  assert.match(errors.join("\n"), /Unknown option: --bogus-flag/);
+});
+
+test("help lists the reinstall command", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (message) => lines.push(String(message));
+  try {
+    assert.equal(await run(["--help"]), 0);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.match(lines.join("\n"), /reinstall \[name\]/);
 });
 
 test("uninstall command requires --yes", async () => {


### PR DESCRIPTION
## Summary

`reinstall` is now a command on the installer. Before this, the only ways to force-refresh an installed CLI were to know that `install <name>` happens to overwrite in place, or that `update` is mechanically a reinstall — neither is the verb you reach for when a binary or skill has gone stale. `reinstall <name>` rebuilds one CLI's binary from the latest catalog code and re-adds its skill; `reinstall` with no name does the same for every Printing Press CLI already on your `PATH`.

It routes to the existing `update` handler instead of duplicating logic, because the operation is genuinely identical — both run `go install …@latest` and re-add the skill. As part of that, the shared arg-parser's `Unknown update option` error becomes the command-agnostic `Unknown option`, so it reads correctly whether the user typed `update` or `reinstall`.

| Command | Effect |
|---|---|
| `reinstall <name>` | Rebuild one CLI's binary + re-add its skill (to latest) |
| `reinstall` | Same, for every Printing Press CLI found on `PATH` |

## Verification

`npm test` passes 75/75 (includes two new tests: alias routes to the update handler rather than the unknown-command path, and `--help` lists the command). Built-binary smoke test:

```
$ printing-press-library --help
  …
  update [name]             Refresh one installed CLI, or all installed CLIs
  reinstall [name]          Reinstall one CLI (or all installed); alias for update
  …

$ printing-press-library reinstall --bogus
Unknown option: --bogus        # routed to update parser, not "Unknown command"; exit 1
```

## Release note

Bumps the npm package to `0.1.12` (required for `npm/src/**` changes). On merge to `main` this auto-tags and publishes `0.1.12` via the OIDC pipeline — no CLI/catalog/skill changes are involved.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
