### PR TITLE
fix(skill): set Hermes category for library skill

### DIFF
--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -22,7 +22,7 @@ metadata:
       - agent-skill
       - tool-discovery
       - install
-    category: software-development
+    category: productivity
   openclaw:
     emoji: "🖨️"
     homepage: https://github.com/mvanhorn/printing-press-library

--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -10,8 +10,19 @@ tags:
   - agent-skill
   - tool-discovery
   - install
-version: 0.1.2
+version: 0.1.3
 metadata:
+  hermes:
+    tags:
+      - cli
+      - api-wrapper
+      - scraper
+      - data-source
+      - automation
+      - agent-skill
+      - tool-discovery
+      - install
+    category: software-development
   openclaw:
     emoji: "🖨️"
     homepage: https://github.com/mvanhorn/printing-press-library


### PR DESCRIPTION
## Summary
- add supported Hermes skill metadata for the root Printing Press Library skill
- set `metadata.hermes.category` to `productivity`
- mirror the existing routeability tags under `metadata.hermes.tags`
- bump the skill version from `0.1.2` to `0.1.3`

## Why `productivity`
Hermes' skills docs support `metadata.hermes.category`, and this discovery skill is intentionally broad: it helps agents find and install CLIs, API wrappers, scrapers, automation tools, data-source tools, and focused agent skills for getting work done.

Although some library entries are developer-facing, the root discovery skill is not only a software-development tool. A large share of the catalog is productivity/assistant-oriented, and `productivity` is the better top-level category for a general assistant skill that expands what the agent can do for user tasks. The narrower technical intent remains captured by `metadata.hermes.tags` such as `cli`, `api-wrapper`, `scraper`, `automation`, `agent-skill`, and `tool-discovery`.

Omitting category would make the skill less discoverable in Hermes' category-oriented listing, so an explicit broad category is preferable.

## Verification
- Parsed `skills/printing-press-library/SKILL.md` frontmatter with Ruby YAML
- Verified:
  - `name == printing-press-library`
  - `version == 0.1.3`
  - `metadata.hermes.category == productivity`
  - `metadata.hermes.tags` includes `tool-discovery`
  - existing OpenClaw metadata remains present
