### PR TITLE
feat(splitwise): add forecast command for upcoming-obligations projection

### DIFF
--- a/library/payments/splitwise/.printing-press-patches/splitwise-forecast-upcoming-obligations.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-forecast-upcoming-obligations.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-forecast-upcoming-obligations",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add an offline `forecast` command that projects upcoming shared obligations from recurring spending patterns over the synced expense store.",
+  "reason": "Splitwise tracks past expenses but offers no forward view of what shared bills are coming due. This was the third of three analytics commands #949 deferred to follow-up PRs (after `net` and `audit`). `forecast` clusters expenses by normalized description, applies a self-contained regularity gate, and projects each regular charge's next expected date/amount, flagging overdue ones. Built only on helpers present on main (loadExpenses, loadGroups, expenseDeleted, normalizeRecurringKey, parseFlexibleDate, parseAmount, round2, mostCommonString, flags.printJSON, openSplitwiseStore) with a local settlement-description check, so it does not depend on the unmerged #949 branch.",
+  "files": [
+    "internal/cli/splitwise_forecast.go",
+    "internal/cli/splitwise_forecast_test.go",
+    "internal/cli/root.go"
+  ],
+  "validated_outcome": "New TestComputeForecast_* and TestLooksLikeSettlement pass; go build/vet/test, govulncheck (0 reachable), and verify_skill all pass. forecast --help / --dry-run smoke clean."
+}

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -230,6 +230,16 @@ splitwise-pp-cli net
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
 
+### See what's coming — `forecast`
+
+**Project next month's recurring shared obligations:**
+
+```bash
+splitwise-pp-cli forecast
+```
+
+Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -183,6 +183,14 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   splitwise-pp-cli recurring --agent
   ```
+- **`forecast`** — Project upcoming shared obligations from recurring spending patterns. Finds charges with a regular cadence and reports the next expected date and amount for anything due inside the window (default 35 days) or already overdue.
+
+  _Use to budget for next month's shared bills, or catch a regular charge that's overdue and unlogged._
+
+  ```bash
+  splitwise-pp-cli forecast --agent
+  splitwise-pp-cli forecast --days 60 --json
+  ```
 
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -184,6 +184,7 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 - **`forecast`** — Project upcoming shared obligations from recurring spending patterns. Finds charges with a regular cadence and reports the next expected date and amount for anything due inside the window (default 35 days) or already overdue.
+  Forecast reads from your synced local store; on large accounts, results can be incomplete until a full sync.
 
   _Use to budget for next month's shared bills, or catch a regular charge that's overdue and unlogged._
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -101,6 +101,7 @@ These capabilities aren't available in any other tool for this API.
 
 ### Upcoming-obligations forecast
 - **`forecast`** — Project your next shared obligations from recurring spending patterns over your synced history. Clusters expenses by normalized description, finds the ones with a regular cadence (>= 3 dated occurrences, mean cadence 2-400 days, largest gap <= 3x the smallest), and projects the next expected date and amount. Returns charges whose next occurrence falls inside the window (default 35 days) or is already overdue, sorted by expected date.
+  Reads from your synced local store; on large accounts, results can be incomplete until a full sync.
 
   _Use to answer "what shared bills are coming up?" or "what should I budget for next month?" — and to catch a regular charge that's overdue and hasn't been logged yet._
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -99,6 +99,39 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Upcoming-obligations forecast
+- **`forecast`** — Project your next shared obligations from recurring spending patterns over your synced history. Clusters expenses by normalized description, finds the ones with a regular cadence (>= 3 dated occurrences, mean cadence 2-400 days, largest gap <= 3x the smallest), and projects the next expected date and amount. Returns charges whose next occurrence falls inside the window (default 35 days) or is already overdue, sorted by expected date.
+
+  _Use to answer "what shared bills are coming up?" or "what should I budget for next month?" — and to catch a regular charge that's overdue and hasn't been logged yet._
+
+  ```bash
+  splitwise-pp-cli forecast --agent
+  splitwise-pp-cli forecast --days 60 --limit 20 --json
+  ```
+
+  Output shape (`--agent` / `--json`):
+
+  ```json
+  {
+    "as_of": "2026-05-30",
+    "window_days": 35,
+    "upcoming": [
+      {
+        "description": "Rent",
+        "group": "Roommates",
+        "last_date": "2026-05-01",
+        "expected_date": "2026-06-01",
+        "expected_amount": 1850.00,
+        "cadence_days": 30,
+        "occurrences": 6,
+        "overdue": false
+      }
+    ]
+  }
+  ```
+
+  Payments and settlement rows (`settle all balances`, `settle up`, `payment`, `paid via …`) are excluded. Read-only; never posts.
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -298,6 +298,16 @@ splitwise-pp-cli net
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
 
+### See what's coming — `forecast`
+
+**Project next month's recurring shared obligations:**
+
+```bash
+splitwise-pp-cli forecast
+```
+
+Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -264,6 +264,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNetCmd(flags))
 	rootCmd.AddCommand(newSplitCmd(flags))
 	rootCmd.AddCommand(newRecurringCmd(flags))
+	rootCmd.AddCommand(newForecastCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -1,0 +1,257 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type forecastEntry struct {
+	Description    string  `json:"description"`
+	Group          string  `json:"group"`
+	LastDate       string  `json:"last_date"`
+	ExpectedDate   string  `json:"expected_date"`
+	ExpectedAmount float64 `json:"expected_amount"`
+	CadenceDays    int     `json:"cadence_days"`
+	Occurrences    int     `json:"occurrences"`
+	Overdue        bool    `json:"overdue"`
+}
+
+func looksLikeSettlement(desc string) bool {
+	d := strings.ToLower(strings.TrimSpace(desc))
+	switch d {
+	case "settle all balances", "settle up", "payment":
+		return true
+	}
+	return strings.HasPrefix(d, "paid via ")
+}
+
+// computeForecast projects upcoming obligations. groupNames maps group_id -> display name
+// (with 0 -> "Non-group"). now is the reference time. windowDays is the forecast window.
+// limit caps the returned slice (apply after sorting). Returns entries sorted by
+// expected_date ascending.
+func computeForecast(expenses []Expense, groupNames map[int]string, now time.Time, windowDays, limit int) []forecastEntry {
+	type cluster struct {
+		dates      []time.Time
+		costs      []float64
+		labels     map[string]int
+		groupCount map[int]int
+	}
+
+	clusters := make(map[string]*cluster)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) || looksLikeSettlement(e.Description) {
+			continue
+		}
+		key := normalizeRecurringKey(e.Description)
+		if key == "" {
+			continue
+		}
+		if clusters[key] == nil {
+			clusters[key] = &cluster{
+				dates:      make([]time.Time, 0),
+				costs:      make([]float64, 0),
+				labels:     make(map[string]int),
+				groupCount: make(map[int]int),
+			}
+		}
+		c := clusters[key]
+		if t, ok := parseFlexibleDate(e.Date); ok {
+			c.dates = append(c.dates, t)
+			c.costs = append(c.costs, parseAmount(e.Cost))
+		}
+		label := strings.TrimSpace(e.Description)
+		if label == "" {
+			label = key
+		}
+		c.labels[label]++
+		c.groupCount[e.GroupID]++
+	}
+
+	result := make([]forecastEntry, 0)
+	windowEnd := now.AddDate(0, 0, windowDays)
+	for key, c := range clusters {
+		if len(c.dates) < 3 {
+			continue
+		}
+		sort.Slice(c.dates, func(i, j int) bool { return c.dates[i].Before(c.dates[j]) })
+
+		gaps := make([]float64, 0, len(c.dates)-1)
+		totalGap := 0.0
+		for i := 1; i < len(c.dates); i++ {
+			gap := c.dates[i].Sub(c.dates[i-1]).Hours() / 24
+			gaps = append(gaps, gap)
+			totalGap += gap
+		}
+		if len(gaps) == 0 {
+			continue
+		}
+		cadence := int(math.Round(totalGap / float64(len(gaps))))
+		if cadence < 2 || cadence > 400 {
+			continue
+		}
+		if len(gaps) >= 2 {
+			minGap := gaps[0]
+			maxGap := gaps[0]
+			for _, gap := range gaps[1:] {
+				if gap < minGap {
+					minGap = gap
+				}
+				if gap > maxGap {
+					maxGap = gap
+				}
+			}
+			if minGap <= 0 {
+				continue
+			}
+			if maxGap > 3.0*minGap {
+				continue
+			}
+		}
+
+		lastDate := c.dates[len(c.dates)-1]
+		expectedDate := lastDate.AddDate(0, 0, cadence)
+		overdue := expectedDate.Before(now)
+		if !overdue {
+			if expectedDate.After(windowEnd) || expectedDate.Before(now) {
+				continue
+			}
+		}
+
+		totalCost := 0.0
+		for _, cost := range c.costs {
+			totalCost += cost
+		}
+		expectedAmount := 0.0
+		if len(c.costs) > 0 {
+			expectedAmount = round2(totalCost / float64(len(c.costs)))
+		}
+
+		groupID := 0
+		bestCount := -1
+		for id, count := range c.groupCount {
+			if count > bestCount || (count == bestCount && id < groupID) {
+				groupID = id
+				bestCount = count
+			}
+		}
+		groupName := ""
+		if groupID == 0 {
+			groupName = groupNames[0]
+		} else if name, ok := groupNames[groupID]; ok && strings.TrimSpace(name) != "" {
+			groupName = strings.TrimSpace(name)
+		} else {
+			groupName = fmt.Sprintf("Group %d", groupID)
+		}
+
+		result = append(result, forecastEntry{
+			Description:    mostCommonString(c.labels, key),
+			Group:          groupName,
+			LastDate:       lastDate.Format("2006-01-02"),
+			ExpectedDate:   expectedDate.Format("2006-01-02"),
+			ExpectedAmount: expectedAmount,
+			CadenceDays:    cadence,
+			Occurrences:    len(c.dates),
+			Overdue:        overdue,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ExpectedDate == result[j].ExpectedDate {
+			return result[i].Description < result[j].Description
+		}
+		return result[i].ExpectedDate < result[j].ExpectedDate
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+// pp:data-source local
+func newForecastCmd(flags *rootFlags) *cobra.Command {
+	days := 35
+	limit := 50
+
+	cmd := &cobra.Command{
+		Use:         "forecast",
+		Short:       "Project upcoming shared obligations from recurring spending patterns",
+		Example:     "  splitwise-pp-cli forecast --agent\n  splitwise-pp-cli forecast --days 60 --limit 20 --json",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would forecast upcoming obligations")
+				return nil
+			}
+			if days < 1 {
+				return usageErr(fmt.Errorf("--days must be >= 1"))
+			}
+			if limit < 1 {
+				return usageErr(fmt.Errorf("--limit must be >= 1"))
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-expenses")
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
+
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			groups, err := loadGroups(db)
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC()
+			groupNames := make(map[int]string)
+			groupNames[0] = "Non-group"
+			for _, g := range groups {
+				groupNames[g.ID] = strings.TrimSpace(g.Name)
+			}
+
+			entries := computeForecast(expenses, groupNames, now, days, limit)
+			if entries == nil {
+				entries = make([]forecastEntry, 0)
+			}
+			view := struct {
+				AsOf       string          `json:"as_of"`
+				WindowDays int             `json:"window_days"`
+				Upcoming   []forecastEntry `json:"upcoming"`
+			}{
+				AsOf:       now.Format("2006-01-02"),
+				WindowDays: days,
+				Upcoming:   entries,
+			}
+
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, view)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "As of %s, forecast window %d days:\n", view.AsOf, days)
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tGROUP\tEXPECTED\tAMOUNT\tCADENCE\tLAST\tOCCURRENCES\tOVERDUE")
+			for _, row := range view.Upcoming {
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%.2f\t%d\t%s\t%d\t%t\n", row.Description, row.Group, row.ExpectedDate, row.ExpectedAmount, row.CadenceDays, row.LastDate, row.Occurrences, row.Overdue)
+			}
+			return tw.Flush()
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 35, "Forecast window in days")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum upcoming entries to return")
+	return cmd
+}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -64,13 +64,13 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		if t, ok := parseFlexibleDate(e.Date); ok {
 			c.dates = append(c.dates, t)
 			c.costs = append(c.costs, parseAmount(e.Cost))
+			label := strings.TrimSpace(e.Description)
+			if label == "" {
+				label = key
+			}
+			c.labels[label]++
+			c.groupCount[e.GroupID]++
 		}
-		label := strings.TrimSpace(e.Description)
-		if label == "" {
-			label = key
-		}
-		c.labels[label]++
-		c.groupCount[e.GroupID]++
 	}
 
 	result := make([]forecastEntry, 0)
@@ -118,7 +118,7 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		expectedDate := lastDate.AddDate(0, 0, cadence)
 		overdue := expectedDate.Before(now)
 		if !overdue {
-			if expectedDate.After(windowEnd) || expectedDate.Before(now) {
+			if expectedDate.After(windowEnd) {
 				continue
 			}
 		}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -74,7 +74,8 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 	}
 
 	result := make([]forecastEntry, 0)
-	windowEnd := now.AddDate(0, 0, windowDays)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	windowEnd := today.AddDate(0, 0, windowDays)
 	for key, c := range clusters {
 		if len(c.dates) < 3 {
 			continue
@@ -95,28 +96,27 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		if cadence < 2 || cadence > 400 {
 			continue
 		}
-		if len(gaps) >= 2 {
-			minGap := gaps[0]
-			maxGap := gaps[0]
-			for _, gap := range gaps[1:] {
-				if gap < minGap {
-					minGap = gap
-				}
-				if gap > maxGap {
-					maxGap = gap
-				}
+		// Invariant: len(c.dates) >= 3 implies len(gaps) >= 2.
+		minGap := gaps[0]
+		maxGap := gaps[0]
+		for _, gap := range gaps[1:] {
+			if gap < minGap {
+				minGap = gap
 			}
-			if minGap <= 0 {
-				continue
+			if gap > maxGap {
+				maxGap = gap
 			}
-			if maxGap > 3.0*minGap {
-				continue
-			}
+		}
+		if minGap <= 0 {
+			continue
+		}
+		if maxGap > 3.0*minGap {
+			continue
 		}
 
 		lastDate := c.dates[len(c.dates)-1]
 		expectedDate := lastDate.AddDate(0, 0, cadence)
-		overdue := expectedDate.Before(now)
+		overdue := expectedDate.Before(today)
 		if !overdue {
 			if expectedDate.After(windowEnd) {
 				continue

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -99,6 +99,50 @@ func TestComputeForecastOverdueIncluded(t *testing.T) {
 	}
 }
 
+func TestComputeForecastDueTodayAtMiddayNotOverdue(t *testing.T) {
+	now := time.Date(2026, 6, 1, 14, 30, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-06-01")
+	}
+	if got[0].Overdue {
+		t.Fatalf("Overdue = true, want false")
+	}
+}
+
+func TestComputeForecastYesterdayAtMiddayOverdue(t *testing.T) {
+	now := time.Date(2026, 6, 2, 14, 30, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-06-01")
+	}
+	if !got[0].Overdue {
+		t.Fatalf("Overdue = false, want true")
+	}
+}
+
 func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	groups := map[int]string{0: "Non-group", 1: "Trip"}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -133,3 +133,32 @@ func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
 		t.Fatalf("ExpectedAmount = %.2f, want 50.00", got[0].ExpectedAmount)
 	}
 }
+
+func TestComputeForecastUndatedExpensesDoNotAffectAttribution(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Dinner", GroupID: 10, Cost: "10.00", Date: "2026-03-01"},
+		{Description: "Dinner", GroupID: 10, Cost: "20.00", Date: "2026-04-01"},
+		{Description: "Dinner", GroupID: 10, Cost: "30.00", Date: "2026-05-01"},
+		{Description: "Bogus label", GroupID: 999, Cost: "999.00", Date: "not-a-date"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Home", 999: "ShouldNotWin"}
+
+	got := computeForecast(expenses, groups, now, 40, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row.Description != "Dinner" {
+		t.Fatalf("Description = %q, want %q", row.Description, "Dinner")
+	}
+	if row.Group != "Home" {
+		t.Fatalf("Group = %q, want %q", row.Group, "Home")
+	}
+	if row.Occurrences != 3 {
+		t.Fatalf("Occurrences = %d, want 3", row.Occurrences)
+	}
+	if row.ExpectedAmount != 20.00 {
+		t.Fatalf("ExpectedAmount = %.2f, want 20.00", row.ExpectedAmount)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLooksLikeSettlement(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want bool
+	}{
+		{name: "settle all balances", desc: "Settle all balances", want: true},
+		{name: "settle up", desc: " settle up ", want: true},
+		{name: "payment", desc: "payment", want: true},
+		{name: "paid via", desc: "paid via Venmo", want: true},
+		{name: "non-settlement", desc: "Dinner", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeSettlement(tc.desc); got != tc.want {
+				t.Fatalf("looksLikeSettlement(%q) = %v, want %v", tc.desc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeForecastMonthlyInsideWindow(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row.Description != "Rent" {
+		t.Fatalf("Description = %q, want %q", row.Description, "Rent")
+	}
+	if row.Group != "Roommates" {
+		t.Fatalf("Group = %q, want %q", row.Group, "Roommates")
+	}
+	if row.ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", row.ExpectedDate, "2026-06-01")
+	}
+	if row.Overdue {
+		t.Fatalf("Overdue = true, want false")
+	}
+	if row.CadenceDays != 30 {
+		t.Fatalf("CadenceDays = %d, want 30", row.CadenceDays)
+	}
+	if row.ExpectedAmount != 115.00 {
+		t.Fatalf("ExpectedAmount = %.2f, want 115.00", row.ExpectedAmount)
+	}
+}
+
+func TestComputeForecastIrregularExcluded(t *testing.T) {
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-01"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-03"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-05"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-02-14"},
+	}
+	groups := map[int]string{0: "Non-group"}
+
+	got := computeForecast(expenses, groups, now, 90, 50)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestComputeForecastOverdueIncluded(t *testing.T) {
+	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Utilities", GroupID: 0, Cost: "90", Date: "2026-01-01"},
+		{Description: "Utilities", GroupID: 0, Cost: "100", Date: "2026-01-31"},
+		{Description: "Utilities", GroupID: 0, Cost: "110", Date: "2026-03-02"},
+	}
+	groups := map[int]string{0: "Non-group"}
+
+	got := computeForecast(expenses, groups, now, 20, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if !got[0].Overdue {
+		t.Fatalf("Overdue = false, want true")
+	}
+	if got[0].ExpectedDate != "2026-04-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-04-01")
+	}
+}
+
+func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	groups := map[int]string{0: "Non-group", 1: "Trip"}
+
+	onlyFiltered := []Expense{
+		{Description: "Settle all balances", GroupID: 1, Cost: "10", Date: "2026-01-01"},
+		{Description: "paid via Venmo", GroupID: 1, Cost: "10", Date: "2026-02-01"},
+		{Description: "Payment", GroupID: 1, Cost: "10", Date: "2026-03-01", Payment: true},
+	}
+	got := computeForecast(onlyFiltered, groups, now, 60, 50)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+
+	mixed := []Expense{
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-02-01"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-03-03"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-04-02"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-05-02"},
+		{Description: "Settle all balances", GroupID: 1, Cost: "999", Date: "2026-05-10"},
+		{Description: "paid via Venmo", GroupID: 1, Cost: "888", Date: "2026-05-12"},
+		{Description: "Internet", GroupID: 1, Cost: "777", Date: "2026-05-14", Payment: true},
+	}
+	got = computeForecast(mixed, groups, now, 40, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Description != "Internet" {
+		t.Fatalf("Description = %q, want Internet", got[0].Description)
+	}
+	if got[0].ExpectedAmount != 50 {
+		t.Fatalf("ExpectedAmount = %.2f, want 50.00", got[0].ExpectedAmount)
+	}
+}


### PR DESCRIPTION
## Summary

Splitwise tracks past expenses but offers no forward view of what shared bills are coming due. This adds a new offline `forecast` command that projects your next shared obligations from recurring spending patterns over the synced expense store — answering "what shared bills are coming up?" and surfacing a regular charge that's overdue and hasn't been logged.

This is the third of the three new feature commands that #949 explicitly deferred to separate follow-up PRs ("`net` cross-group debt netting, `audit` anomaly/data-quality, `forecast` upcoming obligations … will land as separate follow-up PRs"), after `net` (#958) and `audit` (#959). Expect a merge conflict with #949, #958, and #959 on `root.go` (AddCommand), `SKILL.md`, `README.md`, and `.printing-press-patches.json` — that's by design; this PR is intentionally **not** stacked on any unmerged branch and the conflicts resolve trivially at merge.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| F1 | analytics command | feature | The CLI surfaces `recurring` (what repeats) but nothing forward-looking. `forecast` clusters expenses by normalized description, applies a self-contained regularity gate, and projects each regular charge's next expected date + amount, flagging anything overdue — so an agent can budget the next cycle or catch an unlogged recurring bill. |

## Changes

```
 .../splitwise/.printing-press-patches.json         |  11 +
 library/payments/splitwise/README.md               |   8 +
 library/payments/splitwise/SKILL.md                |  33 +++
 library/payments/splitwise/internal/cli/root.go    |   1 +
 .../splitwise/internal/cli/splitwise_forecast.go   | 257 +++++++++++++++++++++
 .../internal/cli/splitwise_forecast_test.go        | 135 +++++++++++
 6 files changed, 445 insertions(+)
```

**What `forecast` does**

- Reads from the local store (`loadExpenses` + `loadGroups`) with the usual `hintIfUnsynced` / `hintIfStale` staleness nudges. Read-only — never posts.
- Skips payments (`e.Payment`), deleted expenses (`expenseDeleted`), and settlement rows via a **local** `looksLikeSettlement` check (lowercased description in {`settle all balances`, `settle up`, `payment`} or prefix `paid via `) — it does **not** call `isSettlementDescription` (that's #949-only).
- Clusters by `normalizeRecurringKey(e.Description)`. For each cluster it tracks per-occurrence dates (`parseFlexibleDate`) and costs (`parseAmount`), the most-common label (`mostCommonString`), and the most-common group id (resolved to a name via the `group_id -> name` map, `0 -> "Non-group"`).
- **Self-contained regularity gate** (no `recurringCadence`): requires >= 3 dated occurrences; computes the mean cadence (rounded days) and requires it in `[2, 400]`; with >= 2 gaps requires the largest gap <= 3x the smallest and skips a cluster with a non-positive min gap.
- `expected_date = last_date + cadence`. A cluster is included when `expected_date` falls inside the window `[now, now+days]` **or** is already overdue (`expected_date < now`); `overdue` is set accordingly.
- Structured output under `--agent` / `--json` (and any non-TTY), human tabwriter table otherwise — emitted via `flags.printJSON`, **not** `emitStructured` (#949-only):
  `{ as_of, window_days, upcoming: [{description, group, last_date, expected_date, expected_amount, cadence_days, occurrences, overdue}] }`, sorted by `expected_date` ascending.
- Flags: `--days` (forecast window, default 35), `--limit` (default 50, caps `upcoming`).

The projection is factored into a pure `computeForecast(expenses, groupNames, now, windowDays, limit) []forecastEntry` so it is unit-tested without cobra.

Built only on helpers present on the current `origin/main`: `loadExpenses`, `loadGroups`, `expenseDeleted`, `normalizeRecurringKey`, `parseFlexibleDate`, `parseAmount`, `round2`, `mostCommonString`, `flags.printJSON`, `openSplitwiseStore`, `dryRunOK`, `hintIfUnsynced` / `hintIfStale`. (No `emitStructured` / `recurringCadence` / `isSettlementDescription` — those live on the unmerged #949 branch.) `splitwise_recurring.go` is untouched.

## Verification

| Check | Result |
|-------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (incl. new `TestComputeForecast*` + `TestLooksLikeSettlement`) |
| `govulncheck ./...` | PASS (0 reachable) |
| `verify_skill.py --dir library/payments/splitwise/` | PASS (flag-names, flag-commands, positional-args, unknown-command) |
| `forecast --help` / `--version` | PASS |
| `forecast --dry-run` | PASS ("would forecast upcoming obligations") |

Tests cover: a regular monthly charge whose next date lands in the window is forecast with the right `expected_date` / `expected_amount`; an irregular cluster (gaps 2,2,40) is excluded; an overdue regular charge is flagged `overdue: true` and still included; payments + settlements (`Settle all balances`, `paid via Venmo`, `Payment` with `payment:true`) are filtered out of both an all-settlement cluster and a mixed one.

## Evidence

- Patch manifest entry: `library/payments/splitwise/.printing-press-patches.json` → `splitwise-forecast-upcoming-obligations`
