### PR TITLE
fix(verify-attribution): exempt wholly-retired CLIs from the attribution gate

### DIFF
--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -329,6 +329,15 @@ def run(base: str, head: str) -> int:
             failures.extend(validate_new_cli(head, change))
             continue
 
+        # A wholly-retired CLI (its .printing-press.json deleted at head) is not
+        # an attribution flip. Deleting SKILL.md drops its author to None, which
+        # the change detector records as an attribution change, and the rest of
+        # the deleted tree counts as a surface change -- so without this exemption
+        # every CLI retirement trips the attribution-vs-surface gate. Retirement
+        # is a legitimate operation; skip the gate when the manifest is gone.
+        if not path_exists(head, f"{change.root}/.printing-press.json"):
+            continue
+
         if change.attribution_changes and change.surface_changes:
             detail = "; ".join(change.attribution_changes)
             surface = ", ".join(change.surface_changes[:5])


### PR DESCRIPTION
The attribution guard (`verify_attribution.py`) cannot distinguish a CLI **retirement** from an attribution **flip**: deleting a CLI drops its `SKILL.md` author to `None` (an attribution change) and removes its tree (a surface change), so the "attribution change + surface change" rule blocks *every* retirement.

This exempts a CLI whose `.printing-press.json` is gone at head — a wholesale retirement is a legitimate operation, not an ownership change. Partial edits that keep the manifest are unaffected.

This is the enabling fix for **#966** (retiring `substack-creator` after its surface was consolidated into `substack` in #964). Must merge before #966 can pass CI (the Verify job overlays verifier scripts from base).