### PR TITLE
fix(here-now): brand name here.now in renamed-resource descriptions

### DIFF
--- a/library/cloud/here-now/.printing-press-patches.json
+++ b/library/cloud/here-now/.printing-press-patches.json
@@ -8,48 +8,82 @@
       "id": "novel-feature-implementations",
       "summary": "Implemented the 7 transcendence commands (publish dir, publish resume, claims/expiring/redeem, drives sync/diff, usage) in hand-authored files; generated newNovel*Cmd stubs delegate to them.",
       "reason": "The generator scaffolds novel features as TODO stubs; real logic must be hand-written. Logic lives in separate files (here_now_novel.go, store/here_now_store.go, publish_dir.go, claims_redeem.go) so it survives regen as whole hand-authored units.",
-      "files": ["internal/cli/here_now_novel.go", "internal/cli/publish_dir.go", "internal/cli/claims_redeem.go", "internal/store/here_now_store.go"],
+      "files": [
+        "internal/cli/here_now_novel.go",
+        "internal/cli/publish_dir.go",
+        "internal/cli/claims_redeem.go",
+        "internal/store/here_now_store.go"
+      ],
       "validated_outcome": "All 7 commands verified live against https://here.now: anonymous publish produces a live site (HTTP 200, marker matched), claim vault + redeem work, drives sync sha256-diff uploads only drift, usage reports free-plan metrics. Full live dogfood: 161/161."
     },
     {
       "id": "root-novel-reparenting",
       "summary": "Re-parented sites stale under sites, publish dir/resume under publish, drives sync/diff under drives in root.go; removed the standalone singular 'drive' group.",
       "reason": "Generator registered novel subcommands as top-level and created a confusing singular 'drive' group adjacent to the 'drives' resource group. regen-merge re-injects AddCommand calls, so this re-parenting must be re-applied or merged on a fresh generate.",
-      "files": ["internal/cli/root.go"]
+      "files": [
+        "internal/cli/root.go"
+      ]
     },
     {
       "id": "publish-dir-password-wiring",
       "summary": "Wired the --password flag on `publish dir` into the publish-create request body (it was declared but never sent).",
       "reason": "Security defect found in Phase 4.95 review: `publish dir --password secret` silently published an unprotected public site. Added Password to publishCreateReq and the request body.",
-      "files": ["internal/cli/here_now_novel.go"],
+      "files": [
+        "internal/cli/here_now_novel.go"
+      ],
       "validated_outcome": "go test passes; password now propagates to POST /api/v1/publish per the spec's password field."
     },
     {
       "id": "publish-resume-notfound-exit",
       "summary": "`publish resume <unknown-slug>` now returns a typed not-found error (non-zero exit) instead of a soft exit-0 message.",
       "reason": "Dogfood error_path probe expects a non-zero exit for an invalid argument; an unknown slug is a genuine not-found, not a no-op. (An already-finalized slug still returns exit 0 as a legitimate no-op.)",
-      "files": ["internal/cli/publish_resume.go"],
+      "files": [
+        "internal/cli/publish_resume.go"
+      ],
       "validated_outcome": "`publish resume nonexistent --db <tmp>` exits 4; full dogfood error_path passes."
     },
     {
       "id": "profile-resource-example-hyphenation",
       "summary": "Corrected generated Example strings from `profile_resource` to `profile-resource` across the 6 profile_resource command files (and README/SKILL).",
       "reason": "x-pp-resource=profile_resource was authored with an underscore to avoid the reserved 'profile' template collision, but Cobra normalizes the group name to hyphenated 'profile-resource'. The generated Example strings kept the underscore, so dogfood's happy_path probe could not run them ('missing runnable example').",
-      "files": ["internal/cli/profile_resource_get-profile.go", "internal/cli/profile_resource_list-profile-sites.go", "internal/cli/profile_resource_add-profile-site.go", "internal/cli/profile_resource_patch-profile.go", "internal/cli/profile_resource_patch-profile-username.go", "internal/cli/profile_resource_remove-profile-site.go"],
+      "files": [
+        "internal/cli/profile_resource_get-profile.go",
+        "internal/cli/profile_resource_list-profile-sites.go",
+        "internal/cli/profile_resource_add-profile-site.go",
+        "internal/cli/profile_resource_patch-profile.go",
+        "internal/cli/profile_resource_patch-profile-username.go",
+        "internal/cli/profile_resource_remove-profile-site.go"
+      ],
       "validated_outcome": "`profile-resource get-profile --help` exits 0; full dogfood happy_path passes 161/161."
     },
     {
       "id": "docs-command-accuracy",
       "summary": "Fixed README/SKILL/research.json prose referencing nonexistent commands: `auth login` -> here-now-auth request-agent-code/verify-agent-code + auth set-token; `sites claim` -> claims redeem; `sites refresh-uploads` -> publish uploads refresh-site-urls / publish resume. Also dropped the unimplementable cross-site Site Data search feature.",
       "reason": "Phase 4.9 doc audit found troubleshooting/auth prose telling users to run commands the CLI does not expose. Site Data search was dropped because the here.now API cannot enumerate a site's collections.",
-      "files": ["README.md", "SKILL.md"]
+      "files": [
+        "README.md",
+        "SKILL.md"
+      ]
     },
     {
       "id": "dependent-typed-upsert-parent-id-fallback",
       "summary": "upsertFilesTx/upsertDataTx fall back to parent_id when the NOT NULL parent column (drives_id / publishes_id) is absent on a synced item, via a nil-safe isEmptyFieldValue helper.",
       "reason": "Dependent-resource sync injects the parent key as parent_id, not drives_id/publishes_id; the NOT NULL constraint rolled back the typed insert and left parent_id unpopulated, failing TestUpsertBatch_SetsFilesParentID and TestUpsertBatch_SetsDataParentID. This is a generator template bug in a DO-NOT-EDIT file, patched locally; flagged for upstream.",
-      "files": ["internal/store/store.go"],
+      "files": [
+        "internal/store/store.go"
+      ],
       "validated_outcome": "go test ./... passes; both TestUpsertBatch_Sets{Files,Data}ParentID green; library copy builds and store tests pass post-promote."
+    },
+    {
+      "id": "here-now-brand-deslug-in-renamed-resource-descriptions",
+      "summary": "Brand name 'here now' (space-mangled) -> 'here.now' in the fallback descriptions for the framework-collision-renamed resources (here-now-analytics, here-now-auth).",
+      "reason": "When a resource name collides with a reserved framework command, the generator renames it (analytics->here-now-analytics, auth->here-now-auth) and de-slugs the new name for a fallback description, turning 'here-now-auth' into 'Manage here now auth'. That mangles the brand. Corrected the 4 rendered strings.",
+      "files": [
+        "internal/cli/here-now-auth.go",
+        "internal/mcp/tools.go",
+        "README.md",
+        "SKILL.md"
+      ]
     }
   ],
   "upstream_tracking": [
@@ -70,6 +104,11 @@
     },
     {
       "issue": "Dependent-resource typed upsert (upsertFilesTx/upsertDataTx) rolls back on the parent-id NOT NULL constraint when sync injects parent_id instead of drives_id/publishes_id (TestUpsertBatch_Sets{Files,Data}ParentID). Generator template bug in internal/store/store.go.",
+      "status": "to-file-in-retro",
+      "affected_cli": "library/cloud/here-now"
+    },
+    {
+      "issue": "generator de-slugs collision-renamed resource names into space-separated fallback descriptions, mangling brand names that contain non-alphanumerics (here.now -> 'here now'). Should use the narrative display_name, or skip de-slugging for renamed resources.",
       "status": "to-file-in-retro",
       "affected_cli": "library/cloud/here-now"
     }

--- a/library/cloud/here-now/README.md
+++ b/library/cloud/here-now/README.md
@@ -271,13 +271,13 @@ Manage handle
 
 ### here-now-analytics
 
-Manage here now analytics
+Manage here.now analytics
 
 - **`here-now-pp-cli here-now-analytics`** - Returns aggregate analytics across all Sites owned by the authenticated paid account.
 
 ### here-now-auth
 
-Manage here now auth
+Manage here.now auth
 
 - **`here-now-pp-cli here-now-auth request-agent-code`** - Starts the agent-assisted API key flow by emailing a one-time code to the user.
 - **`here-now-pp-cli here-now-auth verify-agent-code`** - Completes agent-assisted sign-in. If the email is new, the account is created.

--- a/library/cloud/here-now/SKILL.md
+++ b/library/cloud/here-now/SKILL.md
@@ -127,11 +127,11 @@ These capabilities aren't available in any other tool for this API.
 - `here-now-pp-cli handle get` — Get account subdomain handle
 - `here-now-pp-cli handle update` — Update account subdomain handle
 
-**here-now-analytics** — Manage here now analytics
+**here-now-analytics** — Manage here.now analytics
 
 - `here-now-pp-cli here-now-analytics` — Returns aggregate analytics across all Sites owned by the authenticated paid account.
 
-**here-now-auth** — Manage here now auth
+**here-now-auth** — Manage here.now auth
 
 - `here-now-pp-cli here-now-auth request-agent-code` — Starts the agent-assisted API key flow by emailing a one-time code to the user.
 - `here-now-pp-cli here-now-auth verify-agent-code` — Completes agent-assisted sign-in. If the email is new, the account is created.

--- a/library/cloud/here-now/internal/cli/here-now-auth.go
+++ b/library/cloud/here-now/internal/cli/here-now-auth.go
@@ -10,7 +10,7 @@ import (
 func newHereNowAuthCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "here-now-auth",
-		Short:       "Manage here now auth",
+		Short:       "Manage here.now auth",
 		Hidden:      true,
 		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE:        parentNoSubcommandRunE(flags),

--- a/library/cloud/here-now/internal/mcp/tools.go
+++ b/library/cloud/here-now/internal/mcp/tools.go
@@ -470,13 +470,13 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 			},
 			{
 				"name":        "here-now-analytics",
-				"description": "Manage here now analytics",
+				"description": "Manage here.now analytics",
 				"endpoints":   []string{"get-account"},
 				"searchable":  true,
 			},
 			{
 				"name":        "here-now-auth",
-				"description": "Manage here now auth",
+				"description": "Manage here.now auth",
 				"endpoints":   []string{"request-agent-code", "verify-agent-code"},
 				"searchable":  true,
 			},


### PR DESCRIPTION
## Fix brand name `here.now` in renamed-resource descriptions

Follow-up to #965. Four strings rendered the product brand as `here now` (space-mangled) instead of `here.now`.

**Root cause:** when a resource name collides with a reserved framework command, the generator renames it (`analytics` → `here-now-analytics`, `auth` → `here-now-auth`) and builds a fallback description by **de-slugging** the new name — turning `here-now-auth` into `"Manage here now auth"`. That mangles the brand. The fix corrects the 4 rendered strings. Everything that *should* stay hyphenated — binary `here-now-pp-cli`, the `library/cloud/here-now` path, env var `HERENOW_API_KEY`, the command names `here-now-analytics`/`here-now-auth`, the install slug — is untouched.

### Changes
- `internal/cli/here-now-auth.go` — command `Short`: `Manage here now auth` → `Manage here.now auth`
- `internal/mcp/tools.go` — two MCP tool `description`s → `here.now`
- `README.md`, `SKILL.md` — the rendered lines derived from the above
- `.printing-press-patches.json` — records the generated-file edits + flags the generator de-slug issue upstream

### Validation
- `go build ./...` PASS · `go vet ./...` PASS · `go test ./...` PASS · `gofmt` clean
- `verify-skill` PASS
- Zero remaining space-mangled `here now` across the CLI tree

No `registry.json` or `cli-skills/` changes.
