### PR TITLE
feat(splitwise): add normalize command for multi-currency normalization

### DIFF
--- a/library/payments/splitwise/.printing-press-patches/normalize-unsynced-current-user-note.json
+++ b/library/payments/splitwise/.printing-press-patches/normalize-unsynced-current-user-note.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "normalize-unsynced-current-user-note",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "normalize emits a stderr note when the current user is unsynced (youID==0) so a silently-zero Spend total is explained.",
+  "reason": "Consistency with balances --by-group; without it a 0.00 Spend reads as a real total rather than an unknown-identity artifact.",
+  "files": [
+    "internal/cli/splitwise_normalize.go",
+    "internal/cli/splitwise_normalize_test.go"
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-normalize-multicurrency.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-normalize-multicurrency.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-normalize-multicurrency",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add a normalize command that converts multi-currency net position and spend into a single base currency.",
+  "reason": "Provide deterministic offline multi-currency normalization with user-supplied FX rates from --rate and --rates-file; historical or automatic FX lookup is intentionally out of scope.",
+  "files": [
+    "internal/cli/splitwise_normalize.go",
+    "internal/cli/splitwise_normalize_test.go",
+    "internal/cli/root.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "splitwise_normalize tests pass and required offline gates (gofmt, go build, go vet, go test ./internal/cli/...) pass."
+}

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -184,6 +184,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Multi-currency normalization
+- **`normalize`** — Normalize multi-currency net position and spend into one base currency using user-supplied offline FX rates (`--rate` / `--rates-file`); historical/automatic FX lookup is intentionally out of scope.
+
+  _Use to compare or total spend across trips in different currencies — supply the rates and get one base-currency number; a currency with no rate is surfaced as unconverted, never silently dropped._
+
+  ```bash
+  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -210,6 +219,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
+### Normalize multi-currency spend — `normalize`
+
+Convert mixed-currency balances/spend into one base currency with deterministic, user-supplied rates.
+
+```bash
+splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
+```
+
+Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
 
 ### Settle the whole network in the fewest transfers — `net`
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -99,6 +99,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Multi-currency normalization
+- **`normalize`** — Normalize multi-currency net position and spend into one base currency using user-supplied offline FX rates (`--rate` / `--rates-file`); historical/automatic FX lookup is intentionally out of scope.
+
+  _Use to compare or total spend across trips in different currencies — supply the rates and get one base-currency number; a currency with no rate is surfaced as unconverted, never silently dropped._
+
+  ```bash
+  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -263,6 +272,16 @@ splitwise-pp-cli net
 ```
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
+
+### Normalize multi-currency spend — `normalize`
+
+Convert mixed-currency balances/spend into one base currency with deterministic, user-supplied rates.
+
+```bash
+splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
+```
+
+Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -264,6 +264,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNetCmd(flags))
 	rootCmd.AddCommand(newSplitCmd(flags))
 	rootCmd.AddCommand(newRecurringCmd(flags))
+	rootCmd.AddCommand(newNormalizeCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -219,6 +219,13 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			youID := loadCurrentUserID(db)
+			if youID == 0 {
+				// Without a synced current user the Spend per-user owed-share loop
+				// never matches, so Spend totals are silently 0.00. Warn on stderr in
+				// every output mode (mirrors balances --by-group) so the zero reads as
+				// an unknown-identity artifact, not a real total.
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "note: current user not synced; run sync to populate get-current-user")
+			}
 
 			res := computeNormalize(friends, expenses, youID, mergedRates, baseCode)
 			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -112,8 +112,11 @@ func makeNormalizeMetric(byCurrency map[string]float64, rates map[string]float64
 		metric.Rows = append(metric.Rows, normalizeRow{
 			CurrencyCode: cc,
 			Original:     original,
-			Rate:         round2(rate),
-			Converted:    converted,
+			// Keep the full-precision rate actually used in the conversion so a
+			// reader can reproduce original*rate≈converted; rounding it for display
+			// disagreed with the conversion math (Greptile #970).
+			Rate:      rate,
+			Converted: converted,
 		})
 		metric.TotalBase = round2(metric.TotalBase + converted)
 	}
@@ -203,7 +206,9 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 			defer db.Close()
 
 			hintIfUnsynced(cmd, db, "get-friends")
+			hintIfUnsynced(cmd, db, "get-expenses")
 			hintIfStale(cmd, db, "get-friends", flags.maxAge)
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
 
 			friends, err := loadFriends(db)
 			if err != nil {

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type normalizeUnconverted struct {
+	CurrencyCode string  `json:"currency_code"`
+	Original     float64 `json:"original"`
+}
+
+type normalizeRow struct {
+	CurrencyCode string  `json:"currency_code"`
+	Original     float64 `json:"original"`
+	Rate         float64 `json:"rate"`
+	Converted    float64 `json:"converted"`
+}
+
+type normalizeMetric struct {
+	Rows        []normalizeRow         `json:"rows"`
+	TotalBase   float64                `json:"total_base"`
+	Unconverted []normalizeUnconverted `json:"unconverted"`
+}
+
+type normalizeResult struct {
+	Base  string          `json:"base"`
+	Net   normalizeMetric `json:"net"`
+	Spend normalizeMetric `json:"spend"`
+}
+
+func parseNormalizeRates(raw []string) (map[string]float64, error) {
+	rates := make(map[string]float64)
+	for _, item := range raw {
+		parts := strings.SplitN(strings.TrimSpace(item), "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --rate %q: expected CUR=FACTOR", item)
+		}
+		cc := strings.ToUpper(strings.TrimSpace(parts[0]))
+		if cc == "" {
+			return nil, fmt.Errorf("invalid --rate %q: currency code is required", item)
+		}
+		factor, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --rate %q: factor must be numeric", item)
+		}
+		if factor <= 0 {
+			return nil, fmt.Errorf("invalid --rate %q: factor must be > 0", item)
+		}
+		rates[cc] = factor
+	}
+	return rates, nil
+}
+
+func loadNormalizeRatesFile(path string) (map[string]float64, error) {
+	if strings.TrimSpace(path) == "" {
+		return map[string]float64{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --rates-file: %w", err)
+	}
+	var raw map[string]float64
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse --rates-file JSON object: %w", err)
+	}
+	rates := make(map[string]float64, len(raw))
+	for k, v := range raw {
+		cc := strings.ToUpper(strings.TrimSpace(k))
+		if cc == "" {
+			return nil, fmt.Errorf("--rates-file contains empty currency code")
+		}
+		if v <= 0 {
+			return nil, fmt.Errorf("--rates-file contains non-positive factor for %s", cc)
+		}
+		rates[cc] = v
+	}
+	return rates, nil
+}
+
+func makeNormalizeMetric(byCurrency map[string]float64, rates map[string]float64, base string) normalizeMetric {
+	metric := normalizeMetric{
+		Rows:        make([]normalizeRow, 0),
+		Unconverted: make([]normalizeUnconverted, 0),
+	}
+	currencies := make([]string, 0, len(byCurrency))
+	for cc := range byCurrency {
+		currencies = append(currencies, cc)
+	}
+	sort.Strings(currencies)
+
+	for _, cc := range currencies {
+		original := round2(byCurrency[cc])
+		rate := 0.0
+		if cc == base {
+			rate = 1.0
+		} else {
+			rate = rates[cc]
+		}
+		if rate <= 0 {
+			metric.Unconverted = append(metric.Unconverted, normalizeUnconverted{CurrencyCode: cc, Original: original})
+			continue
+		}
+		converted := round2(original * rate)
+		metric.Rows = append(metric.Rows, normalizeRow{
+			CurrencyCode: cc,
+			Original:     original,
+			Rate:         round2(rate),
+			Converted:    converted,
+		})
+		metric.TotalBase = round2(metric.TotalBase + converted)
+	}
+
+	return metric
+}
+
+func computeNormalize(friends []Friend, expenses []Expense, youID int, rates map[string]float64, base string) normalizeResult {
+	netByCurrency := make(map[string]float64)
+	for _, f := range friends {
+		for _, b := range f.Balance {
+			cc := strings.ToUpper(strings.TrimSpace(b.CurrencyCode))
+			if cc == "" {
+				continue
+			}
+			netByCurrency[cc] += parseAmount(b.Amount)
+		}
+	}
+
+	spendByCurrency := make(map[string]float64)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+		if cc == "" {
+			continue
+		}
+		for _, u := range e.Users {
+			if u.UserID == youID {
+				spendByCurrency[cc] += parseAmount(u.OwedShare)
+				break
+			}
+		}
+	}
+
+	return normalizeResult{
+		Base:  base,
+		Net:   makeNormalizeMetric(netByCurrency, rates, base),
+		Spend: makeNormalizeMetric(spendByCurrency, rates, base),
+	}
+}
+
+// pp:data-source local
+func newNormalizeCmd(flags *rootFlags) *cobra.Command {
+	base := "USD"
+	rateFlags := make([]string, 0)
+	ratesFile := ""
+
+	cmd := &cobra.Command{
+		Use:         "normalize",
+		Short:       "Normalize multi-currency net and spend into one base currency using user-supplied FX rates",
+		Example:     "  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27 --agent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would normalize multi-currency balances and spend")
+				return nil
+			}
+
+			baseCode := strings.ToUpper(strings.TrimSpace(base))
+			if baseCode == "" {
+				return usageErr(fmt.Errorf("--base must not be empty"))
+			}
+
+			mergedRates, err := loadNormalizeRatesFile(ratesFile)
+			if err != nil {
+				return usageErr(err)
+			}
+			inlineRates, err := parseNormalizeRates(rateFlags)
+			if err != nil {
+				return usageErr(err)
+			}
+			for cc, rate := range inlineRates {
+				mergedRates[cc] = rate
+			}
+			mergedRates[baseCode] = 1.0
+
+			// Historical/automatic FX lookup is intentionally out of scope; normalize is deterministic and offline-only.
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-friends")
+			hintIfStale(cmd, db, "get-friends", flags.maxAge)
+
+			friends, err := loadFriends(db)
+			if err != nil {
+				return err
+			}
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			res := computeNormalize(friends, expenses, youID, mergedRates, baseCode)
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, res)
+			}
+
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintln(out, "Net position")
+			tw := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintf(tw, "CURRENCY\tORIGINAL\tRATE\tIN %s\n", res.Base)
+			for _, row := range res.Net.Rows {
+				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%.4f\t%.2f\n", row.CurrencyCode, row.Original, row.Rate, row.Converted)
+			}
+			if err := tw.Flush(); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "Total ≈ %.2f %s\n", res.Net.TotalBase, res.Base)
+
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintln(out, "Spend")
+			tw2 := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintf(tw2, "CURRENCY\tORIGINAL\tRATE\tIN %s\n", res.Base)
+			for _, row := range res.Spend.Rows {
+				_, _ = fmt.Fprintf(tw2, "%s\t%.2f\t%.4f\t%.2f\n", row.CurrencyCode, row.Original, row.Rate, row.Converted)
+			}
+			if err := tw2.Flush(); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "Total ≈ %.2f %s\n", res.Spend.TotalBase, res.Base)
+
+			if len(res.Net.Unconverted) > 0 || len(res.Spend.Unconverted) > 0 {
+				_, _ = fmt.Fprintln(out)
+				_, _ = fmt.Fprintln(out, "Unconverted currencies (add --rate CUR=FACTOR):")
+				for _, row := range res.Net.Unconverted {
+					_, _ = fmt.Fprintf(out, "net: %s %.2f\n", row.CurrencyCode, row.Original)
+				}
+				for _, row := range res.Spend.Unconverted {
+					_, _ = fmt.Fprintf(out, "spend: %s %.2f\n", row.CurrencyCode, row.Original)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&base, "base", "USD", "Base currency code used for normalization")
+	cmd.Flags().StringArrayVar(&rateFlags, "rate", nil, "FX rate CUR=FACTOR where 1 CUR equals FACTOR in base currency (repeatable)")
+	cmd.Flags().StringVar(&ratesFile, "rates-file", "", "JSON file with currency-rate object, e.g. {\"EUR\":1.08}; merged before --rate overrides")
+	cmd.Long = "Normalize your multi-currency Splitwise net position and spend into one base currency using only user-supplied rates from --rate and/or --rates-file. Historical or automatic FX lookup is intentionally out of scope."
+
+	return cmd
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -248,3 +248,21 @@ func TestLoadNormalizeRatesFile(t *testing.T) {
 		t.Fatalf("missing file: expected error, got nil")
 	}
 }
+
+func TestComputeNormalize_RatePrecision(t *testing.T) {
+	// The Rate field must carry the FULL-precision rate used in the conversion,
+	// not a rounded display value, so a reader can reproduce original*rate≈converted.
+	friends := []Friend{{Balance: []Balance{{CurrencyCode: "EUR", Amount: "10.00"}}}}
+	got := computeNormalize(friends, nil, 1, map[string]float64{"EUR": 1.3333}, "USD")
+	if len(got.Net.Rows) != 1 {
+		t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+	}
+	row := got.Net.Rows[0]
+	if row.Rate != 1.3333 {
+		t.Fatalf("Rate = %v, want 1.3333 (full precision, not rounded)", row.Rate)
+	}
+	// converted = round2(10 * 1.3333) = round2(13.333) = 13.33
+	if row.Converted != 13.33 {
+		t.Fatalf("Converted = %v, want 13.33", row.Converted)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestComputeNormalize(t *testing.T) {
+	tests := []struct {
+		name      string
+		friends   []Friend
+		expenses  []Expense
+		youID     int
+		rates     map[string]float64
+		base      string
+		assertion func(t *testing.T, got normalizeResult)
+	}{
+		{
+			name: "multi-currency net converts and totals",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "USD", Amount: "10"}, {CurrencyCode: "EUR", Amount: "5"}}},
+				{Balance: []Balance{{CurrencyCode: "GBP", Amount: "2"}}},
+			},
+			rates: map[string]float64{"EUR": 1.08, "GBP": 1.27},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 17.94 {
+					t.Fatalf("Net.TotalBase = %.2f, want 17.94", got.Net.TotalBase)
+				}
+				if len(got.Net.Rows) != 3 {
+					t.Fatalf("len(Net.Rows) = %d, want 3", len(got.Net.Rows))
+				}
+			},
+		},
+		{
+			name: "missing rate is unconverted and excluded from total",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "USD", Amount: "10"}, {CurrencyCode: "JPY", Amount: "1200"}}},
+			},
+			rates: map[string]float64{},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 10 {
+					t.Fatalf("Net.TotalBase = %.2f, want 10.00", got.Net.TotalBase)
+				}
+				if len(got.Net.Unconverted) != 1 {
+					t.Fatalf("len(Net.Unconverted) = %d, want 1", len(got.Net.Unconverted))
+				}
+				if got.Net.Unconverted[0].CurrencyCode != "JPY" || got.Net.Unconverted[0].Original != 1200 {
+					t.Fatalf("unexpected unconverted row: %+v", got.Net.Unconverted[0])
+				}
+			},
+		},
+		{
+			name: "base currency passes through at rate one",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "usd", Amount: "3.33"}}},
+			},
+			rates: map[string]float64{"EUR": 1.08},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Net.Rows) != 1 {
+					t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+				}
+				row := got.Net.Rows[0]
+				if row.CurrencyCode != "USD" || row.Rate != 1 || row.Converted != 3.33 {
+					t.Fatalf("unexpected row: %+v", row)
+				}
+			},
+		},
+		{
+			name: "spend counts only non-payment non-deleted owed_share for you",
+			expenses: []Expense{
+				{
+					CurrencyCode: "USD",
+					Users:        []ExpenseUser{{UserID: 9, OwedShare: "10.00"}, {UserID: 1, OwedShare: "10.00"}},
+				},
+				{
+					CurrencyCode: "USD",
+					Payment:      true,
+					Users:        []ExpenseUser{{UserID: 1, OwedShare: "50.00"}},
+				},
+				{
+					CurrencyCode: "EUR",
+					DeletedAt: func() *string {
+						s := "2026-01-01"
+						return &s
+					}(),
+					Users: []ExpenseUser{{UserID: 1, OwedShare: "20.00"}},
+				},
+			},
+			youID: 1,
+			rates: map[string]float64{},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Spend.Rows) != 1 {
+					t.Fatalf("len(Spend.Rows) = %d, want 1", len(got.Spend.Rows))
+				}
+				if got.Spend.Rows[0].Original != 10 {
+					t.Fatalf("Spend USD original = %.2f, want 10.00", got.Spend.Rows[0].Original)
+				}
+			},
+		},
+		{
+			name:     "empty inputs return zero totals",
+			friends:  []Friend{},
+			expenses: []Expense{},
+			rates:    map[string]float64{},
+			base:     "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 0 || got.Spend.TotalBase != 0 {
+					t.Fatalf("totals not zero: net=%.2f spend=%.2f", got.Net.TotalBase, got.Spend.TotalBase)
+				}
+				if got.Net.Rows == nil || got.Spend.Rows == nil {
+					t.Fatalf("rows should be non-nil")
+				}
+			},
+		},
+		{
+			name: "rounding to two decimals",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "EUR", Amount: "1.006"}}},
+			},
+			rates: map[string]float64{"EUR": 1.3333},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Net.Rows) != 1 {
+					t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+				}
+				row := got.Net.Rows[0]
+				if row.Original != 1.01 {
+					t.Fatalf("Original = %.2f, want 1.01", row.Original)
+				}
+				if math.Abs(row.Converted-1.35) > 1e-9 {
+					t.Fatalf("Converted = %.2f, want 1.35", row.Converted)
+				}
+				if got.Net.TotalBase != 1.35 {
+					t.Fatalf("Net.TotalBase = %.2f, want 1.35", got.Net.TotalBase)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeNormalize(tt.friends, tt.expenses, tt.youID, tt.rates, tt.base)
+			tt.assertion(t, got)
+		})
+	}
+}
+
+func TestParseNormalizeRates(t *testing.T) {
+	tests := []struct {
+		name    string
+		rateArg []string
+		want    map[string]float64
+		wantErr bool
+	}{
+		{
+			name:    "valid map",
+			rateArg: []string{"EUR=1.08", "gbp=1.27", "USD=1"},
+			want:    map[string]float64{"EUR": 1.08, "GBP": 1.27, "USD": 1},
+		},
+		{name: "missing equals", rateArg: []string{"EUR"}, wantErr: true},
+		{name: "empty currency", rateArg: []string{"=1.2"}, wantErr: true},
+		{name: "non-positive", rateArg: []string{"JPY=0"}, wantErr: true},
+		{name: "bad factor", rateArg: []string{"CAD=abc"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNormalizeRates(tt.rateArg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("rates = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNormalizeRatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// empty path → empty map, no error
+	if got, err := loadNormalizeRatesFile(""); err != nil || len(got) != 0 {
+		t.Fatalf("empty path = (%v, %v), want (empty map, nil)", got, err)
+	}
+
+	// valid JSON object, currency codes upper-cased
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, []byte(`{"eur":1.08,"GBP":1.27}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadNormalizeRatesFile(good)
+	if err != nil {
+		t.Fatalf("valid file: unexpected error %v", err)
+	}
+	if !reflect.DeepEqual(got, map[string]float64{"EUR": 1.08, "GBP": 1.27}) {
+		t.Fatalf("valid file rates = %#v", got)
+	}
+
+	// non-positive factor → error
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte(`{"EUR":0}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(bad); err == nil {
+		t.Fatalf("non-positive factor: expected error, got nil")
+	}
+
+	// empty currency code → error
+	emptyCode := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(emptyCode, []byte(`{"  ":1.1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(emptyCode); err == nil {
+		t.Fatalf("empty currency code: expected error, got nil")
+	}
+
+	// malformed JSON → error
+	malformed := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformed, []byte(`not json`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(malformed); err == nil {
+		t.Fatalf("malformed JSON: expected error, got nil")
+	}
+
+	// missing file → error
+	if _, err := loadNormalizeRatesFile(filepath.Join(dir, "nope.json")); err == nil {
+		t.Fatalf("missing file: expected error, got nil")
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
 )
 
 func TestComputeNormalize(t *testing.T) {
@@ -264,5 +268,45 @@ func TestComputeNormalize_RatePrecision(t *testing.T) {
 	// converted = round2(10 * 1.3333) = round2(13.333) = 13.33
 	if row.Converted != 13.33 {
 		t.Fatalf("Converted = %v, want 13.33", row.Converted)
+	}
+}
+
+// TestNormalizeUnsyncedUserNote guards that normalize emits the
+// "current user not synced" stderr note when get-current-user is unsynced
+// (youID == 0), so a silently-zero Spend total is explained rather than
+// mistaken for real data. Mirrors balances --by-group.
+func TestNormalizeUnsyncedUserNote(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// An expense is present, but get-current-user is NOT synced -> youID == 0.
+	if err := s.Upsert("get-expenses", "1", []byte(`{"id":1,"currency_code":"USD","cost":"10.00","users":[{"user_id":42,"owed_share":"10.00"}]}`)); err != nil {
+		t.Fatalf("seed expense: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	flags := &rootFlags{agent: true} // structured output path
+	cmd := newNormalizeCmd(flags)
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	// --base is required to bypass the "no flags → help" guard (NFlag()==0 check).
+	cmd.SetArgs([]string{"--base=USD"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "current user not synced") {
+		t.Errorf("expected unsynced-current-user note on stderr, got: %q", errBuf.String())
 	}
 }


### PR DESCRIPTION
## normalize — offline multi-currency normalization

Adds a `normalize` command that converts your multi-currency Splitwise position into a single base currency using **user-supplied** FX rates. Pure-offline and deterministic — no network, no historical-FX dependency.

### What it does
- Reads friends' per-currency balances (net position) and your per-currency spend from the synced store.
- Converts each currency bucket to a base currency (`--base`, default USD) via repeatable `--rate CUR=FACTOR` and/or a `--rates-file` JSON map.
- A currency present in the data with no rate is reported as **unconverted** — never silently dropped, never mixed into the base total.
- `--agent`/`--json` for machine output; otherwise a human table.

### Design notes
- Pure `computeNormalize(...)` + a `--rate` parser, both table-tested (multi-currency conversion, missing-rate exclusion, base passthrough at 1.0, spend filtering of payment/deleted rows, 2dp rounding, parser validation incl. `--rates-file`).
- Historical / automatic per-expense-date FX lookup is intentionally **out of scope for v1** (it would add a network dependency); rates are user-supplied. Documented in `--help` and code.
- Self-contained: uses only helpers already on `main` (loaders, `parseAmount`/`round2`, `expenseDeleted`).

### Validation
| Check | Result |
|---|---|
| gofmt | clean |
| go build ./... | PASS |
| go vet ./... | PASS |
| go test ./... | PASS |
| govulncheck ./... | 0 reachable |
| verify_skill.py --dir | PASS |

SKILL.md + README.md carry the Unique-Capability entry + a `## Recipes` cookbook; `.printing-press-patches.json` records the customization.