### PR TITLE
feat(splitwise): add report command for trip/period export (md/csv/json)

### DIFF
--- a/library/payments/splitwise/.printing-press-patches/report-csv-truncation-stderr-note.json
+++ b/library/payments/splitwise/.printing-press-patches/report-csv-truncation-stderr-note.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "report-csv-truncation-stderr-note",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "report --format csv emits a stderr note when --limit truncates rows, matching json/md/summary.",
+  "reason": "renderReportCSV ignored res.Truncated, so a capped CSV looked complete with no in-band or stderr signal.",
+  "files": [
+    "internal/cli/splitwise_report.go",
+    "internal/cli/splitwise_report_test.go"
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-report-export.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-report-export.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-report-export",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add an offline report command that exports trip/period spending to Markdown, CSV, or JSON.",
+  "reason": "Provide deterministic, read-only trip/period report export from the local store with single-currency output (most-common by default, or explicit --currency) so mixed currencies are never incorrectly combined; PDF is intentionally out of scope for v1. Markdown table cells escape pipes/newlines from user descriptions. Uses a self-contained resolveReportGroup so report does not depend on any other novel command.",
+  "files": [
+    "internal/cli/splitwise_report.go",
+    "internal/cli/splitwise_report_test.go",
+    "internal/cli/root.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "Required offline gates pass: gofmt, go build, go vet, go test ./..., govulncheck (0 reachable), verify-skill."
+}

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -184,6 +184,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Trip & period reports
+- **`report`** — Export an offline trip/period spend report as Markdown, CSV, or JSON. Report output is single-currency: default is the most common filtered currency, other currencies are excluded and counted, and `--currency` pins one explicitly.
+
+  _Use to hand someone a trip summary, or to archive a period's shared spend — totals, per-person paid/owed/net, per-category breakdown, and the expense list, in a format you can paste or commit._
+
+  ```bash
+  splitwise-pp-cli report --group "Tahoe Trip" --format md
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -210,6 +219,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
+### Export a trip/period report — `report`
+
+Generate a deterministic offline report for a group/trip or date range.
+
+```bash
+splitwise-pp-cli report --group "Tahoe Trip" --format md
+splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv
+splitwise-pp-cli report --agent
+```
 
 ### Settle the whole network in the fewest transfers — `net`
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -99,6 +99,38 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Trip & period reports
+- **`report`** — Export an offline trip/period spend report as Markdown, CSV, or JSON. Single-currency only: defaults to the most common filtered currency, excludes other currencies with an explicit excluded count, and supports `--currency` to pin one. PDF is intentionally out of scope in v1.
+
+  Output shape (`--agent` / `--json`):
+
+  ```json
+  {
+    "scope": "group:Tahoe Trip",
+    "currency": "USD",
+    "period_start": "2025-01-10",
+    "period_end": "2025-02-01",
+    "expense_count": 12,
+    "excluded_other_currency": 0,
+    "total_cost": 1840.00,
+    "your_paid": 920.00,
+    "your_owed": 613.33,
+    "your_net": 306.67,
+    "people": [
+      { "user_id": 1, "name": "You", "paid": 920.00, "owed": 613.33, "net": 306.67 }
+    ],
+    "categories": [
+      { "name": "Lodging", "total": 1200.00, "count": 2 }
+    ],
+    "expenses": [
+      { "id": 9001, "date": "2025-01-10", "description": "Cabin", "cost": 1200.00, "currency_code": "USD", "payer": "You" }
+    ],
+    "truncated": false
+  }
+  ```
+
+  Payment and deleted rows are excluded. Single-currency: other-currency expenses are excluded and counted in `excluded_other_currency`. Read-only; never posts.
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -263,6 +295,17 @@ splitwise-pp-cli net
 ```
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
+
+### Export a trip/period report — `report`
+
+Build a deterministic offline report from synced expenses for a trip/group or date window.
+
+```bash
+splitwise-pp-cli report --group "Tahoe Trip" --format md
+splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv
+splitwise-pp-cli report --agent
+```
+
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -264,6 +264,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNetCmd(flags))
 	rootCmd.AddCommand(newSplitCmd(flags))
 	rootCmd.AddCommand(newRecurringCmd(flags))
+	rootCmd.AddCommand(newReportCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -145,6 +145,11 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 			switch format {
 			case "csv":
 				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportCSV(res))
+				if res.Truncated {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"note: CSV truncated to %d of %d expense row(s); use --limit 0 for all rows\n",
+						len(res.Expenses), res.ExpenseCount)
+				}
 				return nil
 			case "md":
 				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportMarkdown(res))

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -19,7 +19,6 @@ type reportOpts struct {
 	Until      string
 	Currency   string
 	Limit      int
-	Scope      string
 }
 
 type reportPerson struct {
@@ -129,13 +128,10 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 			}
 			youID := loadCurrentUserID(db)
 
-			scope := "all"
 			if strings.TrimSpace(groupRef) != "" {
-				_, groupName, ok := resolveReportGroup(groupRef, groups)
-				if !ok {
+				if _, _, ok := resolveReportGroup(groupRef, groups); !ok {
 					return usageErr(fmt.Errorf("no group matches %q; run sync first", groupRef))
 				}
-				scope = "group:" + groupName
 			}
 
 			res := computeReport(expenses, groups, youID, reportOpts{
@@ -144,7 +140,6 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 				Until:      until,
 				Currency:   currency,
 				Limit:      limit,
-				Scope:      scope,
 			})
 
 			switch format {
@@ -201,23 +196,28 @@ func resolveReportGroup(input string, groups []Group) (int, string, bool) {
 
 func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpts) reportResult {
 	res := reportResult{
-		Scope:      strings.TrimSpace(opts.Scope),
+		Scope:      "all",
 		People:     make([]reportPerson, 0),
 		Categories: make([]reportCategory, 0),
 		Expenses:   make([]reportExpenseRow, 0),
-	}
-	if res.Scope == "" {
-		res.Scope = "all"
 	}
 
 	var groupID int
 	groupFilter := false
 	if strings.TrimSpace(opts.GroupInput) != "" {
 		id, name, ok := resolveReportGroup(opts.GroupInput, groups)
+		groupFilter = true
 		if ok {
-			groupFilter = true
 			groupID = id
 			res.Scope = "group:" + name
+		} else {
+			// GroupInput was given but matches no group. Filter to nothing rather
+			// than silently falling through to an unfiltered report — no expense has
+			// a negative group id, so this yields an empty, correctly-scoped report
+			// even if this pure function is called without the command's
+			// pre-validation. (Greptile #971)
+			groupID = -1
+			res.Scope = "group:" + strings.TrimSpace(opts.GroupInput) + " (no match)"
 		}
 	}
 
@@ -253,7 +253,11 @@ func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpt
 			}
 		}
 		if hasUntil {
-			if !ok || t.After(untilT.Add(24*time.Hour-time.Nanosecond)) {
+			// --until is inclusive of the whole named day: extend the bound to just
+			// before the next midnight so a same-day timestamp with a time component
+			// (e.g. "2025-12-31T18:00") still matches.
+			endOfUntil := untilT.Add(24*time.Hour - time.Nanosecond)
+			if !ok || t.After(endOfUntil) {
 				continue
 			}
 		}

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -1,0 +1,566 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type reportOpts struct {
+	GroupInput string
+	Since      string
+	Until      string
+	Currency   string
+	Limit      int
+	Scope      string
+}
+
+type reportPerson struct {
+	UserID int     `json:"user_id"`
+	Name   string  `json:"name"`
+	Paid   float64 `json:"paid"`
+	Owed   float64 `json:"owed"`
+	Net    float64 `json:"net"`
+}
+
+type reportCategory struct {
+	Name  string  `json:"name"`
+	Total float64 `json:"total"`
+	Count int     `json:"count"`
+}
+
+type reportExpenseRow struct {
+	ID           int     `json:"id"`
+	Date         string  `json:"date"`
+	Description  string  `json:"description"`
+	Cost         float64 `json:"cost"`
+	CurrencyCode string  `json:"currency_code"`
+	Payer        string  `json:"payer"`
+}
+
+type reportResult struct {
+	Scope                 string             `json:"scope"`
+	Currency              string             `json:"currency"`
+	PeriodStart           string             `json:"period_start"`
+	PeriodEnd             string             `json:"period_end"`
+	ExpenseCount          int                `json:"expense_count"`
+	ExcludedOtherCurrency int                `json:"excluded_other_currency"`
+	TotalCost             float64            `json:"total_cost"`
+	YourPaid              float64            `json:"your_paid"`
+	YourOwed              float64            `json:"your_owed"`
+	YourNet               float64            `json:"your_net"`
+	People                []reportPerson     `json:"people"`
+	Categories            []reportCategory   `json:"categories"`
+	Expenses              []reportExpenseRow `json:"expenses"`
+	Truncated             bool               `json:"truncated"`
+}
+
+func newReportCmd(flags *rootFlags) *cobra.Command {
+	var groupRef string
+	var since string
+	var until string
+	var currency string
+	var format string
+	limit := 100
+
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Export an offline trip/period spend report (md/csv/json; PDF out of scope in v1)",
+		Example: "  splitwise-pp-cli report --group \"Tahoe Trip\" --format md\n" +
+			"  splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would compute report")
+				return nil
+			}
+
+			format = strings.ToLower(strings.TrimSpace(format))
+			if format != "" && format != "md" && format != "csv" && format != "json" {
+				return usageErr(fmt.Errorf("invalid --format value %q: must be md, csv, or json", format))
+			}
+
+			if strings.TrimSpace(since) != "" {
+				if _, err := time.Parse("2006-01-02", strings.TrimSpace(since)); err != nil {
+					return usageErr(fmt.Errorf("invalid --since %q: %w", since, err))
+				}
+			}
+			if strings.TrimSpace(until) != "" {
+				if _, err := time.Parse("2006-01-02", strings.TrimSpace(until)); err != nil {
+					return usageErr(fmt.Errorf("invalid --until %q: %w", until, err))
+				}
+			}
+			if strings.TrimSpace(since) != "" && strings.TrimSpace(until) != "" {
+				sv, _ := time.Parse("2006-01-02", strings.TrimSpace(since))
+				uv, _ := time.Parse("2006-01-02", strings.TrimSpace(until))
+				if uv.Before(sv) {
+					return usageErr(fmt.Errorf("--until must be on/after --since"))
+				}
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-expenses")
+			hintIfUnsynced(cmd, db, "get-groups")
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
+			hintIfStale(cmd, db, "get-groups", flags.maxAge)
+
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			groups, err := loadGroups(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			scope := "all"
+			if strings.TrimSpace(groupRef) != "" {
+				_, groupName, ok := resolveReportGroup(groupRef, groups)
+				if !ok {
+					return usageErr(fmt.Errorf("no group matches %q; run sync first", groupRef))
+				}
+				scope = "group:" + groupName
+			}
+
+			res := computeReport(expenses, groups, youID, reportOpts{
+				GroupInput: groupRef,
+				Since:      since,
+				Until:      until,
+				Currency:   currency,
+				Limit:      limit,
+				Scope:      scope,
+			})
+
+			switch format {
+			case "csv":
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportCSV(res))
+				return nil
+			case "md":
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportMarkdown(res))
+				return nil
+			case "json":
+				return flags.printJSON(cmd, res)
+			default:
+				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+					return flags.printJSON(cmd, res)
+				}
+				return printReportSummary(cmd, res)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&groupRef, "group", "", "Group name or id")
+	cmd.Flags().StringVar(&since, "since", "", "Include expenses on/after YYYY-MM-DD")
+	cmd.Flags().StringVar(&until, "until", "", "Include expenses on/before YYYY-MM-DD")
+	cmd.Flags().StringVar(&currency, "currency", "", "Single currency code (default picks most common and excludes others)")
+	cmd.Flags().StringVar(&format, "format", "", "Output format: md|csv|json (PDF is out of scope in v1)")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Max expense rows in output (<=0 means all)")
+	return cmd
+}
+
+// resolveReportGroup maps a --group reference (numeric id or exact, case-insensitive
+// name) to its group id and display name. Self-contained so `report` does not depend on
+// any other novel command's resolver; prefers an exact match and never substring-guesses.
+func resolveReportGroup(input string, groups []Group) (int, string, bool) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return 0, "", false
+	}
+	if isAllDigits(trimmed) {
+		id, _ := strconv.Atoi(trimmed)
+		for _, g := range groups {
+			if g.ID == id {
+				return g.ID, strings.TrimSpace(g.Name), true
+			}
+		}
+		return 0, "", false
+	}
+	for _, g := range groups {
+		if strings.EqualFold(strings.TrimSpace(g.Name), trimmed) {
+			return g.ID, strings.TrimSpace(g.Name), true
+		}
+	}
+	return 0, "", false
+}
+
+func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpts) reportResult {
+	res := reportResult{
+		Scope:      strings.TrimSpace(opts.Scope),
+		People:     make([]reportPerson, 0),
+		Categories: make([]reportCategory, 0),
+		Expenses:   make([]reportExpenseRow, 0),
+	}
+	if res.Scope == "" {
+		res.Scope = "all"
+	}
+
+	var groupID int
+	groupFilter := false
+	if strings.TrimSpace(opts.GroupInput) != "" {
+		id, name, ok := resolveReportGroup(opts.GroupInput, groups)
+		if ok {
+			groupFilter = true
+			groupID = id
+			res.Scope = "group:" + name
+		}
+	}
+
+	var sinceT time.Time
+	hasSince := false
+	if strings.TrimSpace(opts.Since) != "" {
+		if t, err := time.Parse("2006-01-02", strings.TrimSpace(opts.Since)); err == nil {
+			sinceT = t
+			hasSince = true
+		}
+	}
+	var untilT time.Time
+	hasUntil := false
+	if strings.TrimSpace(opts.Until) != "" {
+		if t, err := time.Parse("2006-01-02", strings.TrimSpace(opts.Until)); err == nil {
+			untilT = t
+			hasUntil = true
+		}
+	}
+
+	filtered := make([]Expense, 0)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		if groupFilter && e.GroupID != groupID {
+			continue
+		}
+		t, ok := parseSplitwiseDate(e.Date)
+		if hasSince {
+			if !ok || t.Before(sinceT) {
+				continue
+			}
+		}
+		if hasUntil {
+			if !ok || t.After(untilT.Add(24*time.Hour-time.Nanosecond)) {
+				continue
+			}
+		}
+		filtered = append(filtered, e)
+	}
+
+	currency := strings.ToUpper(strings.TrimSpace(opts.Currency))
+	if currency == "" {
+		freq := make(map[string]int)
+		for _, e := range filtered {
+			cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+			if cc == "" {
+				continue
+			}
+			freq[cc]++
+		}
+		maxCount := 0
+		for cc, n := range freq {
+			if n > maxCount || (n == maxCount && (currency == "" || cc < currency)) {
+				currency = cc
+				maxCount = n
+			}
+		}
+	}
+	res.Currency = currency
+
+	kept := make([]Expense, 0, len(filtered))
+	for _, e := range filtered {
+		cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+		if currency != "" && cc != currency {
+			res.ExcludedOtherCurrency++
+			continue
+		}
+		kept = append(kept, e)
+	}
+
+	type personAgg struct {
+		name string
+		paid float64
+		owed float64
+	}
+	type catAgg struct {
+		total float64
+		count int
+	}
+	people := make(map[int]*personAgg)
+	cats := make(map[string]*catAgg)
+
+	var minDate *time.Time
+	var maxDate *time.Time
+
+	for _, e := range kept {
+		cost := round2(parseAmount(e.Cost))
+		res.TotalCost = round2(res.TotalCost + cost)
+		res.ExpenseCount++
+
+		if t, ok := parseSplitwiseDate(e.Date); ok {
+			td := t.UTC()
+			if minDate == nil || td.Before(*minDate) {
+				cpy := td
+				minDate = &cpy
+			}
+			if maxDate == nil || td.After(*maxDate) {
+				cpy := td
+				maxDate = &cpy
+			}
+		}
+
+		catName := strings.TrimSpace(e.Category.Name)
+		if catName == "" {
+			catName = "Uncategorized"
+		}
+		if _, ok := cats[catName]; !ok {
+			cats[catName] = &catAgg{}
+		}
+		cats[catName].total = round2(cats[catName].total + cost)
+		cats[catName].count++
+
+		payerName := ""
+		paidPositive := 0
+		maxPaid := 0.0
+		for _, u := range e.Users {
+			paid := round2(parseAmount(u.PaidShare))
+			owed := round2(parseAmount(u.OwedShare))
+			name := strings.TrimSpace(strings.TrimSpace(u.User.FirstName) + " " + strings.TrimSpace(u.User.LastName))
+			if name == "" {
+				name = fmt.Sprintf("user %d", u.UserID)
+			}
+			if _, ok := people[u.UserID]; !ok {
+				people[u.UserID] = &personAgg{name: name}
+			}
+			if people[u.UserID].name == "" {
+				people[u.UserID].name = name
+			}
+			people[u.UserID].paid = round2(people[u.UserID].paid + paid)
+			people[u.UserID].owed = round2(people[u.UserID].owed + owed)
+
+			if u.UserID == youID {
+				res.YourPaid = round2(res.YourPaid + paid)
+				res.YourOwed = round2(res.YourOwed + owed)
+			}
+
+			if paid > 0 {
+				paidPositive++
+			}
+			if paid > maxPaid {
+				maxPaid = paid
+				payerName = name
+			}
+		}
+		if paidPositive >= 2 {
+			payerName = "multiple"
+		}
+		if payerName == "" {
+			// No participant has a positive paid_share — distinct from a genuine
+			// 2+-payer split, so don't mislabel it "multiple".
+			payerName = "-"
+		}
+
+		ds := strings.TrimSpace(e.Date)
+		if t, ok := parseSplitwiseDate(e.Date); ok {
+			ds = t.UTC().Format("2006-01-02")
+		}
+		res.Expenses = append(res.Expenses, reportExpenseRow{
+			ID:           e.ID,
+			Date:         ds,
+			Description:  strings.TrimSpace(e.Description),
+			Cost:         cost,
+			CurrencyCode: strings.ToUpper(strings.TrimSpace(e.CurrencyCode)),
+			Payer:        payerName,
+		})
+	}
+	res.YourNet = round2(res.YourPaid - res.YourOwed)
+
+	if minDate != nil {
+		res.PeriodStart = minDate.Format("2006-01-02")
+	}
+	if maxDate != nil {
+		res.PeriodEnd = maxDate.Format("2006-01-02")
+	}
+
+	for id, a := range people {
+		name := strings.TrimSpace(a.name)
+		if name == "" {
+			name = fmt.Sprintf("user %d", id)
+		}
+		res.People = append(res.People, reportPerson{
+			UserID: id,
+			Name:   name,
+			Paid:   round2(a.paid),
+			Owed:   round2(a.owed),
+			Net:    round2(a.paid - a.owed),
+		})
+	}
+	sort.Slice(res.People, func(i, j int) bool {
+		if res.People[i].Net != res.People[j].Net {
+			return res.People[i].Net > res.People[j].Net
+		}
+		if res.People[i].Name != res.People[j].Name {
+			return res.People[i].Name < res.People[j].Name
+		}
+		return res.People[i].UserID < res.People[j].UserID
+	})
+
+	for name, a := range cats {
+		res.Categories = append(res.Categories, reportCategory{Name: name, Total: round2(a.total), Count: a.count})
+	}
+	sort.Slice(res.Categories, func(i, j int) bool {
+		if res.Categories[i].Total != res.Categories[j].Total {
+			return res.Categories[i].Total > res.Categories[j].Total
+		}
+		return res.Categories[i].Name < res.Categories[j].Name
+	})
+
+	sort.Slice(res.Expenses, func(i, j int) bool {
+		if res.Expenses[i].Date != res.Expenses[j].Date {
+			return res.Expenses[i].Date < res.Expenses[j].Date
+		}
+		return res.Expenses[i].ID < res.Expenses[j].ID
+	})
+
+	if opts.Limit > 0 && len(res.Expenses) > opts.Limit {
+		res.Expenses = res.Expenses[:opts.Limit]
+		res.Truncated = true
+	}
+
+	return res
+}
+
+func renderReportMarkdown(r reportResult) string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "# Report — %s\n\n", r.Scope)
+	_, _ = fmt.Fprintf(&b, "Period: %s to %s  | Currency: %s  | Expenses: %d  | Total: %.2f  | Your net: %.2f\n\n", valueOrDash(r.PeriodStart), valueOrDash(r.PeriodEnd), valueOrDash(r.Currency), r.ExpenseCount, r.TotalCost, r.YourNet)
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(&b, "Excluded %d expense(s) in other currencies.\n\n", r.ExcludedOtherCurrency)
+	}
+
+	b.WriteString("## By person\n\n")
+	b.WriteString("| Name | Paid | Owed | Net |\n")
+	b.WriteString("| --- | ---: | ---: | ---: |\n")
+	for _, p := range r.People {
+		_, _ = fmt.Fprintf(&b, "| %s | %.2f | %.2f | %.2f |\n", mdCell(p.Name), p.Paid, p.Owed, p.Net)
+	}
+	b.WriteString("\n## By category\n\n")
+	b.WriteString("| Category | Total | Count |\n")
+	b.WriteString("| --- | ---: | ---: |\n")
+	for _, c := range r.Categories {
+		_, _ = fmt.Fprintf(&b, "| %s | %.2f | %d |\n", mdCell(c.Name), c.Total, c.Count)
+	}
+	b.WriteString("\n## Expenses\n\n")
+	b.WriteString("| ID | Date | Description | Cost | Currency | Payer |\n")
+	b.WriteString("| ---: | --- | --- | ---: | --- | --- |\n")
+	for _, e := range r.Expenses {
+		_, _ = fmt.Fprintf(&b, "| %d | %s | %s | %.2f | %s | %s |\n", e.ID, e.Date, mdCell(e.Description), e.Cost, e.CurrencyCode, mdCell(e.Payer))
+	}
+	if r.Truncated {
+		_, _ = fmt.Fprintf(&b, "\nShowing first %d expense row(s) of %d.\n", len(r.Expenses), r.ExpenseCount)
+	}
+	return b.String()
+}
+
+// mdCell escapes a user-controlled value for a Markdown table cell: a literal
+// pipe would inject an extra column and a newline would split the row. Splitwise
+// descriptions frequently contain '|', so this keeps the rendered table well-formed.
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+func renderReportCSV(r reportResult) string {
+	var b bytes.Buffer
+	w := csv.NewWriter(&b)
+	_ = w.Write([]string{"id", "date", "description", "cost", "currency", "payer"})
+	for _, e := range r.Expenses {
+		_ = w.Write([]string{
+			strconv.Itoa(e.ID),
+			e.Date,
+			e.Description,
+			fmt.Sprintf("%.2f", e.Cost),
+			e.CurrencyCode,
+			e.Payer,
+		})
+	}
+	w.Flush()
+	return b.String()
+}
+
+func printReportSummary(cmd *cobra.Command, r reportResult) error {
+	out := cmd.OutOrStdout()
+	tw := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "scope\t%s\n", r.Scope)
+	_, _ = fmt.Fprintf(tw, "period\t%s to %s\n", valueOrDash(r.PeriodStart), valueOrDash(r.PeriodEnd))
+	_, _ = fmt.Fprintf(tw, "currency\t%s\n", valueOrDash(r.Currency))
+	_, _ = fmt.Fprintf(tw, "expense_count\t%d\n", r.ExpenseCount)
+	_, _ = fmt.Fprintf(tw, "total\t%.2f\n", r.TotalCost)
+	_, _ = fmt.Fprintf(tw, "your_net\t%.2f\n", r.YourNet)
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(tw, "excluded_other_currency\t%d\n", r.ExcludedOtherCurrency)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out)
+	twPeople := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(twPeople, "PERSON\tPAID\tOWED\tNET")
+	for i, p := range r.People {
+		if i >= 8 {
+			break
+		}
+		_, _ = fmt.Fprintf(twPeople, "%s\t%.2f\t%.2f\t%.2f\n", p.Name, p.Paid, p.Owed, p.Net)
+	}
+	if err := twPeople.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out)
+	twCat := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(twCat, "CATEGORY\tTOTAL\tCOUNT")
+	for i, c := range r.Categories {
+		if i >= 8 {
+			break
+		}
+		_, _ = fmt.Fprintf(twCat, "%s\t%.2f\t%d\n", c.Name, c.Total, c.Count)
+	}
+	if err := twCat.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "\n%d expenses — use --format md for the full report\n", r.ExpenseCount)
+	if r.Truncated {
+		_, _ = fmt.Fprintf(out, "rows capped at %d; use --limit 0 for all rows\n", len(r.Expenses))
+	}
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(out, "note: excluded %d expense(s) in other currencies\n", r.ExcludedOtherCurrency)
+	}
+	return nil
+}
+
+func valueOrDash(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+func TestComputeReport_TableDriven(t *testing.T) {
+	expenses := []Expense{
+		{
+			ID:           101,
+			GroupID:      10,
+			Description:  "Lunch",
+			Cost:         "40.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-10T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Food"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "40.00", OwedShare: "20.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "0", OwedShare: "20.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           102,
+			GroupID:      10,
+			Description:  "Cab",
+			Cost:         "20.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-11T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Transport"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "10.00", OwedShare: "10.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "10.00", OwedShare: "10.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           103,
+			GroupID:      10,
+			Description:  "Museum",
+			Cost:         "30.00",
+			CurrencyCode: "EUR",
+			Date:         "2025-01-12T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Entertainment"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "0", OwedShare: "15.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "30.00", OwedShare: "15.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           104,
+			GroupID:      11,
+			Description:  "Hotel",
+			Cost:         "80.00",
+			CurrencyCode: "USD",
+			Date:         "2025-02-01T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Lodging"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "80.00", OwedShare: "40.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 3, PaidShare: "0", OwedShare: "40.00", User: NestedUser{ID: 3, FirstName: ""}},
+			},
+		},
+		{
+			ID:           105,
+			GroupID:      10,
+			Description:  "Settlement",
+			Cost:         "10.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-15T12:00:00Z",
+			Payment:      true,
+			Category:     Category{Name: ""},
+		},
+		{
+			ID:           106,
+			GroupID:      10,
+			Description:  "Deleted Meal",
+			Cost:         "10.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-16T12:00:00Z",
+			Payment:      false,
+			DeletedAt:    ptr("2025-01-17T00:00:00Z"),
+			Category:     Category{Name: "Food"},
+		},
+	}
+
+	groups := []Group{{ID: 10, Name: "Tahoe Trip"}, {ID: 11, Name: "Ski Weekend"}}
+
+	tests := []struct {
+		name   string
+		opts   reportOpts
+		assert func(t *testing.T, got reportResult)
+	}{
+		{
+			name: "group date payment deleted and currency default",
+			opts: reportOpts{GroupInput: "Tahoe Trip", Since: "2025-01-10", Until: "2025-01-31", Limit: 100},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Scope != "group:Tahoe Trip" {
+					t.Fatalf("Scope=%q", got.Scope)
+				}
+				if got.Currency != "USD" {
+					t.Fatalf("Currency=%q, want USD", got.Currency)
+				}
+				if got.ExcludedOtherCurrency != 1 {
+					t.Fatalf("ExcludedOtherCurrency=%d, want 1", got.ExcludedOtherCurrency)
+				}
+				if got.ExpenseCount != 2 {
+					t.Fatalf("ExpenseCount=%d, want 2", got.ExpenseCount)
+				}
+				if got.TotalCost != 60 {
+					t.Fatalf("TotalCost=%.2f, want 60", got.TotalCost)
+				}
+				if got.YourPaid != 50 || got.YourOwed != 30 || got.YourNet != 20 {
+					t.Fatalf("your totals paid=%.2f owed=%.2f net=%.2f", got.YourPaid, got.YourOwed, got.YourNet)
+				}
+				if got.PeriodStart != "2025-01-10" || got.PeriodEnd != "2025-01-11" {
+					t.Fatalf("period=%s..%s", got.PeriodStart, got.PeriodEnd)
+				}
+				if len(got.People) != 2 {
+					t.Fatalf("len(People)=%d, want 2", len(got.People))
+				}
+				if got.People[0].Name != "You Person" || got.People[0].Net != 20 {
+					t.Fatalf("people[0]=%+v", got.People[0])
+				}
+				if got.People[1].Name != "Alex Kim" || got.People[1].Net != -20 {
+					t.Fatalf("people[1]=%+v", got.People[1])
+				}
+				if len(got.Categories) != 2 {
+					t.Fatalf("len(Categories)=%d, want 2", len(got.Categories))
+				}
+				if got.Categories[0].Name != "Food" || got.Categories[0].Total != 40 || got.Categories[0].Count != 1 {
+					t.Fatalf("categories[0]=%+v", got.Categories[0])
+				}
+				if got.Categories[1].Name != "Transport" || got.Categories[1].Total != 20 || got.Categories[1].Count != 1 {
+					t.Fatalf("categories[1]=%+v", got.Categories[1])
+				}
+				if len(got.Expenses) != 2 {
+					t.Fatalf("len(Expenses)=%d, want 2", len(got.Expenses))
+				}
+				if got.Expenses[0].ID != 101 || got.Expenses[0].Payer != "You Person" {
+					t.Fatalf("expense[0]=%+v", got.Expenses[0])
+				}
+				if got.Expenses[1].ID != 102 || got.Expenses[1].Payer != "multiple" {
+					t.Fatalf("expense[1]=%+v", got.Expenses[1])
+				}
+			},
+		},
+		{
+			name: "explicit currency and limit with fallback user name",
+			opts: reportOpts{Currency: "USD", Limit: 1},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Scope != "all" {
+					t.Fatalf("Scope=%q, want all", got.Scope)
+				}
+				if got.Currency != "USD" {
+					t.Fatalf("Currency=%q, want USD", got.Currency)
+				}
+				if got.ExcludedOtherCurrency != 1 {
+					t.Fatalf("ExcludedOtherCurrency=%d, want 1", got.ExcludedOtherCurrency)
+				}
+				if got.ExpenseCount != 3 {
+					t.Fatalf("ExpenseCount=%d, want 3", got.ExpenseCount)
+				}
+				if got.Truncated != true || len(got.Expenses) != 1 {
+					t.Fatalf("Truncated=%v len(Expenses)=%d", got.Truncated, len(got.Expenses))
+				}
+				if got.People[0].Name != "You Person" || got.People[2].Name != "user 3" {
+					t.Fatalf("people ordering/fallback: %+v", got.People)
+				}
+				if got.PeriodStart != "2025-01-10" || got.PeriodEnd != "2025-02-01" {
+					t.Fatalf("period=%s..%s", got.PeriodStart, got.PeriodEnd)
+				}
+			},
+		},
+		{
+			name: "limit zero means all",
+			opts: reportOpts{Limit: 0},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Truncated {
+					t.Fatalf("Truncated=true, want false")
+				}
+				if len(got.Expenses) != got.ExpenseCount {
+					t.Fatalf("len(Expenses)=%d ExpenseCount=%d", len(got.Expenses), got.ExpenseCount)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeReport(expenses, groups, 1, tc.opts)
+			tc.assert(t, got)
+		})
+	}
+}
+
+func TestRenderReportMarkdown(t *testing.T) {
+	r := reportResult{
+		Scope:                 "group:Tahoe Trip",
+		Currency:              "USD",
+		PeriodStart:           "2025-01-10",
+		PeriodEnd:             "2025-01-11",
+		ExpenseCount:          2,
+		ExcludedOtherCurrency: 1,
+		TotalCost:             60,
+		YourNet:               20,
+		People:                []reportPerson{{Name: "You Person", Paid: 50, Owed: 30, Net: 20}},
+		Categories:            []reportCategory{{Name: "Food", Total: 40, Count: 1}},
+		Expenses:              []reportExpenseRow{{ID: 101, Date: "2025-01-10", Description: "Lunch", Cost: 40, CurrencyCode: "USD", Payer: "You Person"}},
+	}
+
+	md := renderReportMarkdown(r)
+	mustContain := []string{
+		"# Report — group:Tahoe Trip",
+		"## By person",
+		"## By category",
+		"## Expenses",
+		"| You Person | 50.00 | 30.00 | 20.00 |",
+		"| Food | 40.00 | 1 |",
+		"Excluded 1 expense(s) in other currencies.",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q\n%s", want, md)
+		}
+	}
+}
+
+func TestRenderReportCSV_EscapingAndRows(t *testing.T) {
+	r := reportResult{Expenses: []reportExpenseRow{
+		{ID: 101, Date: "2025-01-10", Description: "Simple", Cost: 40, CurrencyCode: "USD", Payer: "You Person"},
+		{ID: 102, Date: "2025-01-11", Description: "Taxi, \"airport\"", Cost: 20, CurrencyCode: "USD", Payer: "multiple"},
+	}}
+
+	out := renderReportCSV(r)
+	rows, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+	if err != nil {
+		t.Fatalf("csv parse: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows=%d, want 3", len(rows))
+	}
+	head := strings.Join(rows[0], ",")
+	if head != "id,date,description,cost,currency,payer" {
+		t.Fatalf("header=%q", head)
+	}
+	if rows[2][2] != "Taxi, \"airport\"" {
+		t.Fatalf("escaped description mismatch: %q", rows[2][2])
+	}
+}
+
+func TestRenderReportMarkdown_EscapesPipes(t *testing.T) {
+	r := reportResult{
+		Scope:    "all",
+		Currency: "USD",
+		People:   []reportPerson{{Name: "A | B", Paid: 1, Owed: 0, Net: 1}},
+		Expenses: []reportExpenseRow{
+			{ID: 1, Date: "2025-01-10", Description: "Dinner | drinks\nlate", Cost: 50, CurrencyCode: "USD", Payer: "You"},
+		},
+	}
+	md := renderReportMarkdown(r)
+	if !strings.Contains(md, `Dinner \| drinks late`) {
+		t.Fatalf("description pipe/newline not escaped:\n%s", md)
+	}
+	if strings.Contains(md, "Dinner | drinks") {
+		t.Fatalf("raw unescaped pipe leaked into markdown:\n%s", md)
+	}
+	if !strings.Contains(md, `A \| B`) {
+		t.Fatalf("person-name pipe not escaped:\n%s", md)
+	}
+	// The expense data row must remain a single 6-cell row (7 structural pipes),
+	// regardless of pipes inside the (now-escaped) description.
+	for _, line := range strings.Split(md, "\n") {
+		if strings.HasPrefix(line, "| 1 | 2025-01-10 |") {
+			if structural := strings.Count(line, "|") - strings.Count(line, `\|`); structural != 7 {
+				t.Fatalf("expense row has %d structural pipes, want 7: %q", structural, line)
+			}
+		}
+	}
+}
+
+func TestComputeReport_CurrencyTieBreak(t *testing.T) {
+	// 1 USD + 1 EUR is a tie; the default currency picks the alphabetically-first
+	// code (EUR) deterministically, and the USD expense is excluded (not mixed).
+	expenses := []Expense{
+		{ID: 1, Description: "u", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", Users: []ExpenseUser{{UserID: 1, PaidShare: "10", OwedShare: "10"}}},
+		{ID: 2, Description: "e", Cost: "20", CurrencyCode: "EUR", Date: "2025-01-02", Users: []ExpenseUser{{UserID: 1, PaidShare: "20", OwedShare: "20"}}},
+	}
+	got := computeReport(expenses, nil, 1, reportOpts{Limit: 0})
+	if got.Currency != "EUR" {
+		t.Fatalf("tie-break currency=%q want EUR", got.Currency)
+	}
+	if got.ExpenseCount != 1 || got.ExcludedOtherCurrency != 1 {
+		t.Fatalf("expense_count=%d excluded=%d want 1/1", got.ExpenseCount, got.ExcludedOtherCurrency)
+	}
+}
+
+func TestComputeReport_NoPayer(t *testing.T) {
+	// No participant has a positive paid_share -> payer "-", distinct from a
+	// genuine 2+-payer "multiple".
+	expenses := []Expense{
+		{ID: 1, Description: "x", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", Users: []ExpenseUser{
+			{UserID: 1, PaidShare: "0", OwedShare: "5", User: NestedUser{ID: 1, FirstName: "A"}},
+			{UserID: 2, PaidShare: "0", OwedShare: "5", User: NestedUser{ID: 2, FirstName: "B"}},
+		}},
+	}
+	got := computeReport(expenses, nil, 1, reportOpts{Limit: 0})
+	if len(got.Expenses) != 1 || got.Expenses[0].Payer != "-" {
+		t.Fatalf("payer=%q want '-'", got.Expenses[0].Payer)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -1,9 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
 )
 
 func TestComputeReport_TableDriven(t *testing.T) {
@@ -330,3 +336,61 @@ func TestComputeReport_UnresolvableGroupYieldsEmpty(t *testing.T) {
 }
 
 func ptr(s string) *string { return &s }
+
+// TestReportCSVTruncationWarnsOnStderr verifies that when --limit truncates
+// the expense list, the CSV output path emits a note on stderr (matching
+// json/md/summary) while stdout remains valid, parseable CSV.
+func TestReportCSVTruncationWarnsOnStderr(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Seed 3 same-currency expenses so --limit 1 truncates (2 dropped).
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+		body := fmt.Sprintf(
+			`{"id":%d,"currency_code":"USD","cost":"10.00","date":"2025-01-0%d","description":"expense%d","users":[{"user_id":42,"owed_share":"10.00","paid_share":"10.00","user":{"id":42,"first_name":"You","last_name":"Person"}}]}`,
+			i, i, i,
+		)
+		if err := s.Upsert("get-expenses", id, []byte(body)); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	cmd := newReportCmd(&rootFlags{})
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--format", "csv", "--limit", "1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+
+	// Assertion that will FAIL before the fix: stderr must contain "truncated".
+	if !strings.Contains(errBuf.String(), "truncated") {
+		t.Errorf("expected CSV truncation note on stderr, got: %q", errBuf.String())
+	}
+	// stdout must still be valid CSV with the expected header.
+	if !strings.Contains(out.String(), "id,date,description") {
+		t.Errorf("expected CSV header on stdout, got: %q", out.String())
+	}
+	// Confirm stdout is parseable CSV.
+	rows, parseErr := csv.NewReader(strings.NewReader(out.String())).ReadAll()
+	if parseErr != nil {
+		t.Errorf("stdout is not valid CSV: %v\nraw: %q", parseErr, out.String())
+	}
+	// header + 1 data row (limit=1)
+	if len(rows) != 2 {
+		t.Errorf("expected 2 CSV rows (header+1 data), got %d", len(rows))
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -313,4 +313,20 @@ func TestComputeReport_NoPayer(t *testing.T) {
 	}
 }
 
+func TestComputeReport_UnresolvableGroupYieldsEmpty(t *testing.T) {
+	// A --group that matches no group must NOT silently fall through to an
+	// unfiltered report; the pure function filters to nothing and scopes the label.
+	expenses := []Expense{
+		{ID: 1, Description: "x", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", GroupID: 7, Users: []ExpenseUser{{UserID: 1, PaidShare: "10", OwedShare: "10"}}},
+	}
+	groups := []Group{{ID: 7, Name: "Real Group"}}
+	got := computeReport(expenses, groups, 1, reportOpts{GroupInput: "Nonexistent Group", Limit: 0})
+	if got.ExpenseCount != 0 || len(got.Expenses) != 0 {
+		t.Fatalf("expense_count=%d len=%d, want 0/0 (unresolvable group must filter to nothing)", got.ExpenseCount, len(got.Expenses))
+	}
+	if !strings.Contains(got.Scope, "no match") {
+		t.Fatalf("scope=%q, want it to flag the unmatched group", got.Scope)
+	}
+}
+
 func ptr(s string) *string { return &s }


### PR DESCRIPTION
## report — offline trip/period spend report

Adds a read-only `report` command that exports a trip/period spending report from the synced store as **Markdown, CSV, or JSON**.

### What it does
- Filters by `--group` (exact name or id), `--since`/`--until` window, and `--currency`; caps rows with `--limit`.
- Produces: a summary (period, totals, your paid/owed/net), per-person paid/owed/net, a per-category breakdown, and the expense list (with payer).
- `--format md|csv|json`; without `--format`, follows the usual JSON-vs-human rule.

### Design notes
- **Single-currency by design** — mixing currencies without conversion is wrong, so the report defaults to the most common currency in scope and **excludes** other-currency expenses, counting them in `excluded_other_currency` (never silently dropped, never mixed). Pin one with `--currency`.
- Markdown table cells **escape `|` and newlines** from user descriptions so a description like `Dinner | drinks` can't corrupt the table; CSV uses `encoding/csv`.
- Pure `computeReport(...)` + pure md/csv renderers, table-tested (group/date filtering, currency exclusion + tie-break, per-person/per-category aggregation, payer selection incl. no-payer, `--limit`/truncation, markdown pipe-escaping, CSV escaping).
- Self-contained `resolveReportGroup` (exact-match, no substring guessing) — `report` does not depend on any other novel command.
- PDF is intentionally **out of scope for v1** (would add a dependency).

### Validation
| Check | Result |
|---|---|
| gofmt | clean |
| go build ./... | PASS |
| go vet ./... | PASS |
| go test ./... | PASS |
| govulncheck ./... | 0 reachable |
| verify_skill.py --dir | PASS |

SKILL.md + README.md carry the Unique-Capability entry (with the JSON output shape) + a `## Recipes` cookbook; `.printing-press-patches.json` records the customization.