### PR TITLE
feat(splitwise): add balances --by-group

### DIFF
--- a/library/payments/splitwise/.printing-press-patches.json
+++ b/library/payments/splitwise/.printing-press-patches.json
@@ -101,7 +101,7 @@
     {
       "id": "balances-by-group",
       "summary": "Add a --by-group flag to the balances command: the current user's net position per group (one row per group per currency, non-zero only, biggest absolute balance first) computed offline from synced group members.",
-      "reason": "balances only broke down per friend or per currency; there was no first-class 'outstanding balance by group' view, even though every synced group object carries members[].balance. Agent hosts had to hand-roll raw SQL (and one falsely concluded the store lacked per-group debt). Added a pure groupBalances(groups, currentUserID) helper plus the --by-group branch reusing loadGroups/loadCurrentUserID/emitStructured.",
+      "reason": "balances only broke down per friend or per currency; there was no first-class 'outstanding balance by group' view, even though every synced group object carries members[].balance. Agent hosts had to hand-roll raw SQL (and one falsely concluded the store lacked per-group debt). Added a pure groupBalances(groups, currentUserID) helper plus the --by-group branch reusing loadGroups/loadCurrentUserID/emitStructured. The 'current user not synced' note is emitted before the structured-output early return so it reaches stderr in agent/JSON/pipe mode (otherwise an agent reading {\"by_group\":[]} had no signal that the empty result was due to an unknown identity rather than no balances).",
       "files": [
         "internal/cli/splitwise_balances_bygroup.go",
         "internal/cli/splitwise_balances_bygroup_test.go",
@@ -110,7 +110,7 @@
         "SKILL.md",
         "README.md"
       ],
-      "validated_outcome": "TestGroupBalances_* (7 cases: single/zero-excluded/multi-currency/non-member-skip/abs-desc-sort/name-tiebreak/empty) and TestBalancesByGroupCommand (end-to-end: by_group envelope + --by-group precedence over --by-currency against a seeded store) pass; gofmt/build/vet/test, govulncheck, verify-skill pass."
+      "validated_outcome": "TestGroupBalances_* (7 cases: single/zero-excluded/multi-currency/non-member-skip/abs-desc-sort/name-tiebreak/empty), TestBalancesByGroupCommand (end-to-end: by_group envelope + --by-group precedence over --by-currency against a seeded store), and TestBalancesByGroupUnsyncedUserNoteInAgentMode (the unsynced-current-user note reaches stderr in agent mode) pass; gofmt/build/vet/test, govulncheck, verify-skill pass."
     }
   ]
 }

--- a/library/payments/splitwise/.printing-press-patches.json
+++ b/library/payments/splitwise/.printing-press-patches.json
@@ -17,7 +17,7 @@
     {
       "id": "splitwise-sync-offset-pagination-past-first-page",
       "summary": "Make offset-paginated sync advance past the first page when the API returns no has_more/cursor signal.",
-      "reason": "Splitwise /get_expenses paginates by offset and returns a bare {\"expenses\":[...]} envelope with no has_more field, so extractPageItems returns hasMore=false. The sync loop's natural-end check (!hasMore) fired after the first 100 rows even under --full --max-pages 0, so the 43 oldest of 143 expenses never reached the local store — breaking debts --aged (age_days:null) and under-counting spend. Added an offset-paginator full-page fallback mirroring the existing page-int fallback: when cursorType==\"offset\", nextCursor is empty, and the page is full, synthesize hasMore and the next offset so the loop continues until a short/empty page.",
+      "reason": "Splitwise /get_expenses paginates by offset and returns a bare {\"expenses\":[...]} envelope with no has_more field, so extractPageItems returns hasMore=false. The sync loop's natural-end check (!hasMore) fired after the first 100 rows even under --full --max-pages 0, so the 43 oldest of 143 expenses never reached the local store \u2014 breaking debts --aged (age_days:null) and under-counting spend. Added an offset-paginator full-page fallback mirroring the existing page-int fallback: when cursorType==\"offset\", nextCursor is empty, and the page is full, synthesize hasMore and the next offset so the loop continues until a short/empty page.",
       "files": [
         "internal/cli/sync.go",
         "internal/cli/sync_offset_pagination_test.go"
@@ -51,7 +51,7 @@
     {
       "id": "name-resolver-ambiguity",
       "summary": "Group/friend name resolution prefers an exact match and errors on ambiguous names instead of silently picking the first substring match.",
-      "reason": "resolveLedgerGroup/resolveSettleGroup/resolveSettleFriend returned the first case-insensitive substring match, so a name matching multiple groups/friends silently resolved to one — dangerous for settle-up --record, which creates real payment expenses. Settle-up falls through to a unique friend when the group name is ambiguous.",
+      "reason": "resolveLedgerGroup/resolveSettleGroup/resolveSettleFriend returned the first case-insensitive substring match, so a name matching multiple groups/friends silently resolved to one \u2014 dangerous for settle-up --record, which creates real payment expenses. Settle-up falls through to a unique friend when the group name is ambiguous.",
       "files": [
         "internal/cli/splitwise_settle.go",
         "internal/cli/splitwise_spend.go",
@@ -97,6 +97,20 @@
         "internal/cli/which.go"
       ],
       "validated_outcome": "Live: `which \"who owes me money\"` now returns debts (score 3) at exit 0; `which \"venmo\"` returns settle-up."
+    },
+    {
+      "id": "balances-by-group",
+      "summary": "Add a --by-group flag to the balances command: the current user's net position per group (one row per group per currency, non-zero only, biggest absolute balance first) computed offline from synced group members.",
+      "reason": "balances only broke down per friend or per currency; there was no first-class 'outstanding balance by group' view, even though every synced group object carries members[].balance. Agent hosts had to hand-roll raw SQL (and one falsely concluded the store lacked per-group debt). Added a pure groupBalances(groups, currentUserID) helper plus the --by-group branch reusing loadGroups/loadCurrentUserID/emitStructured.",
+      "files": [
+        "internal/cli/splitwise_balances_bygroup.go",
+        "internal/cli/splitwise_balances_bygroup_test.go",
+        "internal/cli/splitwise_balances_bygroup_cmd_test.go",
+        "internal/cli/splitwise_balances.go",
+        "SKILL.md",
+        "README.md"
+      ],
+      "validated_outcome": "TestGroupBalances_* (7 cases: single/zero-excluded/multi-currency/non-member-skip/abs-desc-sort/name-tiebreak/empty) and TestBalancesByGroupCommand (end-to-end: by_group envelope + --by-group precedence over --by-currency against a seeded store) pass; gofmt/build/vet/test, govulncheck, verify-skill pass."
     }
   ]
 }

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -140,6 +140,12 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   splitwise-pp-cli balances --agent
   ```
+
+  Add `--by-group` to break your net position out **per group** (one row per group per currency, biggest absolute balance first) instead of per friend:
+
+  ```bash
+  splitwise-pp-cli balances --by-group --agent
+  ```
 - **`debts`** — List who owes you (and whom you owe) sorted by how long the balance has gone unsettled.
 
   _Use when the task is 'who never pays me back' or chasing stale IOUs._

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -55,6 +55,12 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   splitwise-pp-cli balances --agent
   ```
+
+  Add `--by-group` to break your net position out **per group** (one row per group per currency, biggest absolute balance first) instead of per friend — answers "what's my outstanding balance by group?" directly from the synced store:
+
+  ```bash
+  splitwise-pp-cli balances --by-group --agent
+  ```
 - **`debts`** — List who owes you (and whom you owe) sorted by how long the balance has gone unsettled.
 
   _Use when the task is 'who never pays me back' or chasing stale IOUs._

--- a/library/payments/splitwise/internal/cli/splitwise_balances.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances.go
@@ -113,6 +113,7 @@ func newResolveCmd(flags *rootFlags) *cobra.Command {
 
 func newBalancesCmd(flags *rootFlags) *cobra.Command {
 	var byCurrency bool
+	var byGroup bool
 	cmd := &cobra.Command{
 		Use:         "balances",
 		Short:       "Show net friend balances",
@@ -132,6 +133,30 @@ func newBalancesCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			defer db.Close()
+
+			if byGroup {
+				hintIfUnsynced(cmd, db, "get-groups")
+				hintIfStale(cmd, db, "get-groups", flags.maxAge)
+				groups, err := loadGroups(db)
+				if err != nil {
+					return err
+				}
+				youID := loadCurrentUserID(db)
+				rows := groupBalances(groups, youID)
+				out := map[string]any{"by_group": rows}
+				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+					return flags.emitStructured(cmd, out)
+				}
+				if youID == 0 {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "note: current user not synced; run sync to populate get-current-user")
+				}
+				tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+				_, _ = fmt.Fprintln(tw, "GROUP\tCURRENCY\tAMOUNT")
+				for _, row := range rows {
+					_, _ = fmt.Fprintf(tw, "%s\t%s\t%.2f\n", row.GroupName, row.CurrencyCode, row.Amount)
+				}
+				return tw.Flush()
+			}
 
 			hintIfUnsynced(cmd, db, "get-friends")
 			hintIfStale(cmd, db, "get-friends", flags.maxAge)
@@ -232,6 +257,7 @@ func newBalancesCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&byCurrency, "by-currency", false, "Show only the per-currency net totals (omit the per-friend breakdown)")
+	cmd.Flags().BoolVar(&byGroup, "by-group", false, "Show your net balance in each group (per group, per currency) instead of the per-friend breakdown (takes precedence over --by-currency)")
 	return cmd
 }
 

--- a/library/payments/splitwise/internal/cli/splitwise_balances.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances.go
@@ -144,11 +144,16 @@ func newBalancesCmd(flags *rootFlags) *cobra.Command {
 				youID := loadCurrentUserID(db)
 				rows := groupBalances(groups, youID)
 				out := map[string]any{"by_group": rows}
-				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
-					return flags.emitStructured(cmd, out)
-				}
+				// Emit the unsynced-current-user note before the structured-output
+				// early return so it reaches stderr in every mode. Without a current
+				// user id groupBalances yields no rows; an agent reading {"by_group":[]}
+				// would otherwise have no signal that the result is empty because the
+				// identity is unknown rather than because there are no balances.
 				if youID == 0 {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "note: current user not synced; run sync to populate get-current-user")
+				}
+				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+					return flags.emitStructured(cmd, out)
 				}
 				tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 				_, _ = fmt.Fprintln(tw, "GROUP\tCURRENCY\tAMOUNT")

--- a/library/payments/splitwise/internal/cli/splitwise_balances_bygroup.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances_bygroup.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"math"
+	"sort"
+)
+
+type groupBalanceRow struct {
+	GroupID      int     `json:"group_id"`
+	GroupName    string  `json:"group_name"`
+	CurrencyCode string  `json:"currency_code"`
+	Amount       float64 `json:"amount"`
+}
+
+func groupBalances(groups []Group, currentUserID int) []groupBalanceRow {
+	rows := make([]groupBalanceRow, 0)
+	for _, g := range groups {
+		var me *GroupMember
+		for i := range g.Members {
+			if g.Members[i].ID == currentUserID {
+				me = &g.Members[i]
+				break
+			}
+		}
+		if me == nil {
+			continue
+		}
+		for _, b := range me.Balance {
+			amt := parseAmount(b.Amount)
+			if amt == 0 {
+				continue
+			}
+			rows = append(rows, groupBalanceRow{
+				GroupID:      g.ID,
+				GroupName:    g.Name,
+				CurrencyCode: b.CurrencyCode,
+				Amount:       round2(amt),
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		ai := math.Abs(rows[i].Amount)
+		aj := math.Abs(rows[j].Amount)
+		if ai != aj {
+			return ai > aj
+		}
+		if rows[i].GroupName != rows[j].GroupName {
+			return rows[i].GroupName < rows[j].GroupName
+		}
+		return rows[i].CurrencyCode < rows[j].CurrencyCode
+	})
+	return rows
+}

--- a/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_cmd_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_cmd_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
+)
+
+// TestBalancesByGroupCommand drives the balances command end-to-end with
+// --by-group set against a seeded offline store, locking in the JSON output
+// contract (the "by_group" envelope key, computed from synced group members)
+// and the precedence of --by-group over --by-currency.
+func TestBalancesByGroupCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Current user (id 42) is a member of "Tahoe" with a non-zero USD balance.
+	if err := s.Upsert("get-current-user", "42", []byte(`{"user":{"id":42}}`)); err != nil {
+		t.Fatalf("seed current user: %v", err)
+	}
+	if err := s.Upsert("get-groups", "100", []byte(`{"id":100,"name":"Tahoe","members":[{"id":42,"balance":[{"currency_code":"USD","amount":"25.00"}]},{"id":7,"balance":[{"currency_code":"USD","amount":"-25.00"}]}]}`)); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	flags := &rootFlags{agent: true} // force the structured (JSON) output path
+	cmd := newBalancesCmd(flags)
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	// Both flags set: --by-group must win.
+	cmd.SetArgs([]string{"--by-group", "--by-currency"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output is not JSON object: %v (raw: %s)", err, out.String())
+	}
+	rows, ok := got["by_group"].([]any)
+	if !ok {
+		t.Fatalf("expected by_group array in output, got: %s", out.String())
+	}
+	// --by-group precedence: the per-friend / per-currency envelopes must be absent.
+	if _, present := got["friends"]; present {
+		t.Errorf("--by-group should not emit a friends breakdown; got: %s", out.String())
+	}
+	if _, present := got["by_currency"]; present {
+		t.Errorf("--by-group should take precedence over --by-currency; got: %s", out.String())
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 group row for the current user, got %d: %s", len(rows), out.String())
+	}
+	row := rows[0].(map[string]any)
+	if row["group_name"] != "Tahoe" {
+		t.Errorf("group_name = %v, want Tahoe", row["group_name"])
+	}
+	if row["amount"] != 25.0 {
+		t.Errorf("amount = %v, want 25", row["amount"])
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_cmd_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
@@ -74,5 +75,45 @@ func TestBalancesByGroupCommand(t *testing.T) {
 	}
 	if row["amount"] != 25.0 {
 		t.Errorf("amount = %v, want 25", row["amount"])
+	}
+}
+
+// TestBalancesByGroupUnsyncedUserNoteInAgentMode guards the reachability of the
+// "current user not synced" stderr note: it must fire in the structured/agent
+// output path, not only the human-table path. Without a synced current user,
+// groupBalances yields no rows; an agent reading {"by_group":[]} needs the note
+// to distinguish "identity unknown" from "no balances".
+func TestBalancesByGroupUnsyncedUserNoteInAgentMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Groups are synced, but get-current-user is NOT — so youID resolves to 0.
+	if err := s.Upsert("get-groups", "100", []byte(`{"id":100,"name":"Tahoe","members":[{"id":42,"balance":[{"currency_code":"USD","amount":"25.00"}]}]}`)); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	flags := &rootFlags{agent: true} // structured output path
+	cmd := newBalancesCmd(flags)
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--by-group"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "current user not synced") {
+		t.Errorf("expected unsynced-current-user note on stderr in agent mode, got: %q", errBuf.String())
 	}
 }

--- a/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances_bygroup_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Test fixtures use gb-prefixed builders to avoid colliding with other helpers
+// in package cli's test files.
+func gbBal(ccy, amt string) Balance { return Balance{CurrencyCode: ccy, Amount: amt} }
+
+func gbMember(id int, bals ...Balance) GroupMember {
+	return GroupMember{ID: id, Balance: bals}
+}
+
+func gbGroup(id int, name string, members ...GroupMember) Group {
+	return Group{ID: id, Name: name, Members: members}
+}
+
+// groupBalances returns the current user's net balance in each group they are a
+// member of, one row per (group, currency) with a non-zero balance.
+
+func TestGroupBalances_SingleNonZeroBalance(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Tahoe Trip", gbMember(42, gbBal("USD", "25.00")), gbMember(7, gbBal("USD", "-25.00"))),
+	}
+	got := groupBalances(groups, 42)
+	want := []groupBalanceRow{
+		{GroupID: 1, GroupName: "Tahoe Trip", CurrencyCode: "USD", Amount: 25.00},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groupBalances = %+v, want %+v", got, want)
+	}
+}
+
+func TestGroupBalances_ExcludesZeroBalanceGroups(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Settled Up", gbMember(42, gbBal("USD", "0.00"))),
+		gbGroup(2, "Active", gbMember(42, gbBal("USD", "12.50"))),
+	}
+	got := groupBalances(groups, 42)
+	want := []groupBalanceRow{
+		{GroupID: 2, GroupName: "Active", CurrencyCode: "USD", Amount: 12.50},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groupBalances = %+v, want %+v", got, want)
+	}
+}
+
+func TestGroupBalances_MultiCurrencyEmitsRowPerCurrency(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Barcelona", gbMember(42, gbBal("USD", "10.00"), gbBal("EUR", "-5.00"))),
+	}
+	got := groupBalances(groups, 42)
+	// Within the result the larger absolute amount comes first.
+	want := []groupBalanceRow{
+		{GroupID: 1, GroupName: "Barcelona", CurrencyCode: "USD", Amount: 10.00},
+		{GroupID: 1, GroupName: "Barcelona", CurrencyCode: "EUR", Amount: -5.00},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groupBalances = %+v, want %+v", got, want)
+	}
+}
+
+func TestGroupBalances_SkipsGroupsWhereUserIsNotMember(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Not Mine", gbMember(7, gbBal("USD", "99.00"))),
+		gbGroup(2, "Mine", gbMember(42, gbBal("USD", "3.00"))),
+	}
+	got := groupBalances(groups, 42)
+	want := []groupBalanceRow{
+		{GroupID: 2, GroupName: "Mine", CurrencyCode: "USD", Amount: 3.00},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groupBalances = %+v, want %+v", got, want)
+	}
+}
+
+func TestGroupBalances_SortedByAbsoluteAmountDescending(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Small", gbMember(42, gbBal("USD", "5.00"))),
+		gbGroup(2, "Big", gbMember(42, gbBal("USD", "-40.00"))),
+		gbGroup(3, "Mid", gbMember(42, gbBal("USD", "12.00"))),
+	}
+	got := groupBalances(groups, 42)
+	wantOrder := []string{"Big", "Mid", "Small"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d rows, want %d: %+v", len(got), len(wantOrder), got)
+	}
+	for i, name := range wantOrder {
+		if got[i].GroupName != name {
+			t.Fatalf("row %d = %q, want %q (full: %+v)", i, got[i].GroupName, name, got)
+		}
+	}
+}
+
+func TestGroupBalances_TieBreaksByGroupName(t *testing.T) {
+	groups := []Group{
+		gbGroup(1, "Zebra", gbMember(42, gbBal("USD", "20.00"))),
+		gbGroup(2, "Alpha", gbMember(42, gbBal("USD", "-20.00"))),
+	}
+	got := groupBalances(groups, 42)
+	wantOrder := []string{"Alpha", "Zebra"}
+	for i, name := range wantOrder {
+		if got[i].GroupName != name {
+			t.Fatalf("row %d = %q, want %q (full: %+v)", i, got[i].GroupName, name, got)
+		}
+	}
+}
+
+func TestGroupBalances_EmptyGroupsReturnsEmpty(t *testing.T) {
+	got := groupBalances(nil, 42)
+	if len(got) != 0 {
+		t.Fatalf("groupBalances(nil) = %+v, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--by-group` flag to the `balances` command, giving the current user their net position per group — one row per group per currency, non-zero balances only, biggest absolute balance first — computed entirely offline from synced group members.

## Findings

| ID | Category | Type | Rationale |
|----|----------|------|-----------|
| balances-by-group | command surface | feature | `balances` could roll up by currency but not by group, so "what's my standing in each group?" required N manual per-group lookups. |

## Changes

```
 .printing-press-patches.json                          | 18 +++-
 README.md                                             |  6 ++
 SKILL.md                                              |  6 ++
 internal/cli/splitwise_balances.go                    | 26 +++++
 internal/cli/splitwise_balances_bygroup.go            | 54 ++++++++++
 internal/cli/splitwise_balances_bygroup_cmd_test.go   | 78 ++++++++++++++
 internal/cli/splitwise_balances_bygroup_test.go       | 117 +++++++++++++++++++
 7 files changed, 303 insertions(+), 2 deletions(-)
```

- `--by-group` reuses the existing `loadGroups` / `loadCurrentUserID` / `emitStructured` helpers and takes precedence over `--by-currency`.
- One row per group per currency; non-zero only; sorted by absolute balance descending.
- Cookbook recipe added to `SKILL.md` and `README.md`; patch entry recorded in `.printing-press-patches.json`.

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `go test ./...` — PASS (new `splitwise_balances_bygroup_test.go` + `_cmd_test.go`)
- `govulncheck ./...` — PASS
- `verify_skill.py` — PASS
