### PR TITLE
fix(cli): keep skill install after PATH warning

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.14
+
+- Treat "installed but not on PATH" as a warning instead of aborting `install`. `go install` can succeed while the current agent or gateway process cannot discover `$GOPATH/bin`; the installer now prints the platform-specific PATH fix, continues installing the focused `pp-*` skill, and reports a successful install with a `pathWarning: "not_on_path"` field in JSON output. This avoids half-installed agent setups where the binary exists but the matching skill was skipped.
+- Suppress stale-binary shadow warnings when the earlier PATH hit resolves to the same file as the freshly installed Go binary, such as a `~/.local/bin/<tool>` symlink pointing at `~/go/bin/<tool>`.
+- Document that agent/gateway sessions may need a restart after PATH changes, and that a PATH-visible symlink can be a practical bridge in environments that already expose `~/.local/bin`.
+
 ## 0.1.13
 
 - Speed up `update` (and `update` with no name) by refreshing detected CLIs concurrently instead of one at a time. The cost of a bulk update is dominated by per-CLI network round-trips — the go-proxy `@latest` resolution (~1s each, even when nothing changed, because the build cache can't shortcut it) plus the skill fetch — which serialized into ~30s for a dozen CLIs. These are independent, so they now run with bounded concurrency, and the catalog detection sweep (a `which`/`where` probe per catalog entry) is parallelized the same way. Each install's output is buffered and replayed in catalog order (preserving stdout/stderr ordering within each CLI), so concurrent runs don't interleave into scrambled lines. A failed PATH probe degrades to "not installed" instead of aborting the run. No command, flag, or output-shape changes — same behavior, less waiting.

--- a/npm/README.md
+++ b/npm/README.md
@@ -135,7 +135,13 @@ More bundles will be added over time. To suggest one, open an issue at the [prin
 
 - Node.js 20+
 - Go 1.26.3 or newer (for `go install`)
-- The Go install directory on your `PATH` so installed CLIs are runnable by name — `$(go env GOPATH)/bin` (usually `$HOME/go/bin`) on macOS/Linux, or `%USERPROFILE%\go\bin` on Windows. Go does not add this to `PATH` for you. If it's missing, `install` prints the exact, copy-pasteable line to add for your platform and shell (zsh/bash/fish, PowerShell, cmd, or Git Bash).
+- The Go install directory on your `PATH` so installed CLIs are runnable by name — `$(go env GOPATH)/bin` (usually `$HOME/go/bin`) on macOS/Linux, or `%USERPROFILE%\go\bin` on Windows. Go does not add this to `PATH` for you. If it's missing, `install` still installs the focused skill, then prints the exact, copy-pasteable line to add for your platform and shell (zsh/bash/fish, PowerShell, cmd, or Git Bash).
+
+Agent and gateway environments often run with a frozen or sanitized `PATH`. Updating `.zshrc`, `.bashrc`, or the Windows user environment may not affect an already-running agent process until you restart that session or gateway. If your harness already includes a user bin directory such as `~/.local/bin`, a symlink from the Go-installed binary into that directory is also a reasonable bridge:
+
+```bash
+ln -sf "$(go env GOPATH)/bin/<tool>" "$HOME/.local/bin/<tool>"
+```
 
 ## Migration from @mvanhorn/printing-press
 

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.11",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.11",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -42,7 +42,9 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "check-lock-version": "node scripts/check-lock-version.mjs",
     "clean": "rm -rf dist",
+    "preversion": "npm run check-lock-version",
     "test": "npm run build && node --test \"dist/tests/**/*.test.js\"",
     "prepublishOnly": "npm test && npm run build"
   },

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/scripts/check-lock-version.mjs
+++ b/npm/scripts/check-lock-version.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const [pkgRaw, lockRaw] = await Promise.all([
+  readFile(new URL("../package.json", import.meta.url), "utf8"),
+  readFile(new URL("../package-lock.json", import.meta.url), "utf8"),
+]);
+
+const pkg = JSON.parse(pkgRaw);
+const lock = JSON.parse(lockRaw);
+const rootPackage = lock.packages?.[""];
+const lockVersions = [
+  ["package-lock.json version", lock.version],
+  ["package-lock.json packages[\"\"] version", rootPackage?.version],
+];
+
+const mismatches = lockVersions.filter(([, version]) => version !== pkg.version);
+if (mismatches.length > 0) {
+  for (const [label, version] of mismatches) {
+    console.error(`${label} is ${version ?? "missing"}, expected ${pkg.version}`);
+  }
+  console.error("Run `npm install --package-lock-only` before bumping the npm package version.");
+  process.exit(1);
+}

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -221,7 +221,9 @@ async function installOne(
       deps.stdout(`  shadowed by: ${summary.shadowedBy} (earlier in PATH)`);
     }
     if (summary.pathWarning === "not_on_path") {
-      deps.stdout("  warning: binary is not on PATH; add the Go install directory above or run the binary by full path");
+      deps.stdout(
+        "  warning: binary is not on PATH; run it by full path or add the Go install directory to PATH (see stderr for platform-specific instructions)",
+      );
     }
     if (summary.skill) {
       deps.stdout(`  skill: ${summary.skill}`);

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -1,4 +1,5 @@
 import { BUNDLES, isBundle } from "../bundles.js";
+import { realpath } from "node:fs/promises";
 import { detectGo, goInstall, goInstallDir, type GoDetection, type GoInstallDir } from "../go.js";
 import { pathFixInstructions } from "../pathfix.js";
 import { commandOnPath, type RunResult } from "../process.js";
@@ -28,6 +29,7 @@ interface InstallDeps {
   goInstall: (modulePath: string, ref: string, env?: NodeJS.ProcessEnv) => Promise<RunResult>;
   goInstallDir: () => Promise<GoInstallDir>;
   commandOnPath: (binary: string) => Promise<string | null>;
+  realpath: (path: string) => Promise<string | null>;
   installSkill: (skillName: string, agents: string[]) => Promise<RunResult>;
   stdout: (message: string) => void;
   stderr: (message: string) => void;
@@ -54,6 +56,8 @@ interface InstallSummary {
   installedPath?: string;
   /** Set when an older binary earlier in PATH would shadow the freshly installed one. */
   shadowedBy?: string;
+  /** Set when the binary was installed but is not currently discoverable by name. */
+  pathWarning?: "not_on_path";
 }
 
 interface InstallOutcome {
@@ -71,6 +75,13 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     goInstall: (modulePath, ref, env) => goInstall(modulePath, { ref, env }),
     goInstallDir: () => goInstallDir(),
     commandOnPath: (binary) => commandOnPath(binary),
+    realpath: async (path) => {
+      try {
+        return await realpath(path);
+      } catch {
+        return null;
+      }
+    },
     installSkill: (skillName, agents) => installSkill(skillName, { agents }),
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
@@ -161,9 +172,9 @@ async function installOne(
     if (!pathBinaryPath) {
       // `go install` succeeded, but `which`/`where` cannot find the binary —
       // PATH does not include the directory go install wrote to. Print the exact,
-      // copy-pasteable PATH fix for this platform and shell.
+      // copy-pasteable PATH fix for this platform and shell, but keep going so
+      // the matching focused skill is still installed.
       deps.stderr(notOnPathMessage(binary, installed, deps));
-      return { ok: false, name: entry.name, error: "binary not on PATH" };
     }
 
     summary.binary = binary;
@@ -171,9 +182,12 @@ async function installOne(
     if (installedPath) {
       summary.installedPath = installedPath;
     }
-    summary.binaryPath = pathBinaryPath;
+    summary.binaryPath = installedPath ?? pathBinaryPath ?? undefined;
+    if (!pathBinaryPath) {
+      summary.pathWarning = "not_on_path";
+    }
 
-    if (installedPath && !samePath(installedPath, pathBinaryPath, deps.platform)) {
+    if (installedPath && pathBinaryPath && !(await sameInstalledBinary(installedPath, pathBinaryPath, deps))) {
       // `which`/`where` resolved to a different binary than `go install` wrote.
       // The older binary earlier in PATH will shadow the freshly built one.
       summary.shadowedBy = pathBinaryPath;
@@ -205,6 +219,9 @@ async function installOne(
     }
     if (summary.shadowedBy) {
       deps.stdout(`  shadowed by: ${summary.shadowedBy} (earlier in PATH)`);
+    }
+    if (summary.pathWarning === "not_on_path") {
+      deps.stdout("  warning: binary is not on PATH; add the Go install directory above or run the binary by full path");
     }
     if (summary.skill) {
       deps.stdout(`  skill: ${summary.skill}`);
@@ -369,6 +386,14 @@ function samePath(a: string, b: string, platform: NodeJS.Platform): boolean {
     return platform === "win32" ? stripped.toLowerCase() : stripped;
   };
   return norm(a) === norm(b);
+}
+
+async function sameInstalledBinary(a: string, b: string, deps: InstallDeps): Promise<boolean> {
+  if (samePath(a, b, deps.platform)) {
+    return true;
+  }
+  const [realA, realB] = await Promise.all([deps.realpath(a), deps.realpath(b)]);
+  return !!realA && !!realB && samePath(realA, realB, deps.platform);
 }
 
 function shadowMessage(binary: string, installedPath: string, shadowedBy: string): string {

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -130,9 +130,10 @@ test("install command surfaces go install failure when @latest fails", async () 
   assert.match(stderr.join("\n"), /go install failed/);
 });
 
-test("install command stops when binary is not on PATH", async () => {
+test("install command warns but still installs skill when binary is not on PATH", async () => {
   const skillCalls: string[] = [];
   const stderr: string[] = [];
+  const stdout: string[] = [];
   const command = createInstallCommand({
     fetchRegistry: async () => registry,
     resolveModulePath: async () => null,
@@ -144,12 +145,14 @@ test("install command stops when binary is not on PATH", async () => {
       skillCalls.push("skill");
       return ok();
     },
+    stdout: (message) => stdout.push(message),
     stderr: (message) => stderr.push(message),
   });
 
-  assert.equal(await command(["espn"]), 1);
-  assert.deepEqual(skillCalls, []);
+  assert.equal(await command(["espn"]), 0);
+  assert.deepEqual(skillCalls, ["skill"]);
   assert.match(stderr.join("\n"), /not on PATH/);
+  assert.match(stdout.join("\n"), /warning: binary is not on PATH/);
 });
 
 test("not-on-PATH warning is zsh-flavored on macOS", async () => {
@@ -162,13 +165,14 @@ test("not-on-PATH warning is zsh-flavored on macOS", async () => {
     goInstallDir: async () => goBinDir("/Users/amosclaw/go/bin"),
     commandOnPath: async () => null,
     installSkill: async () => ok(),
+    stdout: () => {},
     stderr: (message) => stderr.push(message),
     platform: "darwin",
     shell: "/bin/zsh",
     home: "/Users/amosclaw",
   });
 
-  assert.equal(await command(["espn"]), 1);
+  assert.equal(await command(["espn"]), 0);
   const out = stderr.join("\n");
   assert.match(out, /installed espn-pp-cli at \/Users\/amosclaw\/go\/bin\/espn-pp-cli/);
   assert.match(out, /~\/\.zshrc/);
@@ -185,13 +189,14 @@ test("not-on-PATH warning is PowerShell-flavored on Windows", async () => {
     goInstallDir: async () => goBinDir("C:\\Users\\you\\go\\bin"),
     commandOnPath: async () => null,
     installSkill: async () => ok(),
+    stdout: () => {},
     stderr: (message) => stderr.push(message),
     platform: "win32",
     shell: undefined,
     home: "C:\\Users\\you",
   });
 
-  assert.equal(await command(["espn"]), 1);
+  assert.equal(await command(["espn"]), 0);
   const out = stderr.join("\n");
   assert.match(out, /SetEnvironmentVariable/);
   assert.doesNotMatch(out, /setx/);
@@ -548,6 +553,54 @@ test("install command includes shadow info in JSON output", async () => {
   assert.equal(json.shadowedBy, "/opt/homebrew/bin/espn-pp-cli");
 });
 
+test("install command includes PATH warning in JSON output", async () => {
+  const stdout: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => null,
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: () => {},
+  });
+
+  assert.equal(await command(["espn", "--json"]), 0);
+  const json = JSON.parse(stdout[0]!);
+  assert.equal(json.ok, true);
+  assert.equal(json.binaryPath, "/Users/example/go/bin/espn-pp-cli");
+  assert.equal(json.installedPath, "/Users/example/go/bin/espn-pp-cli");
+  assert.equal(json.pathWarning, "not_on_path");
+  assert.equal(json.skill, "pp-espn");
+});
+
+test("install command does not warn when PATH hit is a symlink to the freshly installed binary", async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async () => ok(),
+    goInstallDir: async () => goBinDir("/Users/example/go/bin"),
+    commandOnPath: async () => "/Users/example/.local/bin/espn-pp-cli",
+    realpath: async (path) =>
+      path === "/Users/example/.local/bin/espn-pp-cli"
+        ? "/Users/example/go/bin/espn-pp-cli"
+        : path,
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn"]), 0);
+  assert.doesNotMatch(stderr.join("\n"), /shadow/);
+  assert.doesNotMatch(stdout.join("\n"), /shadowed by/);
+  assert.match(stdout.join("\n"), /binary: \/Users\/example\/go\/bin\/espn-pp-cli/);
+});
+
 test("install command falls back to PATH match when go env returns no install dir", async () => {
   const stdout: string[] = [];
   const stderr: string[] = [];
@@ -614,7 +667,7 @@ test("install command points at the install dir when nothing is on PATH", async 
     stderr: (message) => stderr.push(message),
   });
 
-  assert.equal(await command(["espn"]), 1);
+  assert.equal(await command(["espn"]), 0);
   // The error message names the specific path the user needs to add to PATH.
   assert.match(stderr.join("\n"), /\/Users\/example\/go\/bin\/espn-pp-cli/);
 });

--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -10,7 +10,7 @@ tags:
   - agent-skill
   - tool-discovery
   - install
-version: 0.2.0
+version: 0.2.1
 metadata:
   hermes:
     tags:
@@ -62,6 +62,8 @@ The library is an open-source catalog of focused CLIs and matching agent skills 
    - The install command installs both the CLI and the matching focused agent skill.
    - `install <slug>` is idempotent: re-running it on an already-installed tool refreshes the Go binary and overwrites/re-adds the focused skill in place.
    - Behind the scenes, the installer uses `go install <module>@latest` for the CLI and the Vercel Agent Skills-compatible `skills` CLI to install the focused `pp-*` skill globally from this repo.
+   - If the Go binary installs successfully but is not on the current process `PATH`, treat that as a warning, not a failed skill install. The installer should still install the focused skill and print platform-specific PATH instructions.
+   - In agent/gateway environments, shell startup files may not affect the already-running process. Restart the session/gateway after PATH changes, or use a PATH-visible user bin directory such as `~/.local/bin` when that is already exposed by the harness.
    - In OpenClaw, this same install command installs the focused skill for OpenClaw; do not replace it with a separate repo-path skill install unless the user explicitly asks for skill-only installation.
    - Pass `--cli-only` or `--skill-only` only when the user explicitly wants just one side.
 
@@ -124,6 +126,12 @@ npx -y skills@latest add mvanhorn/printing-press-library/cli-skills/pp-<slug> -g
 So the catalog installer is still the right top-level command: it installs the CLI, then installs the focused skill globally using the same agent-skills mechanism rather than asking the agent to hand-roll a separate skill install path.
 
 The install operation is idempotent and works as a reinstall for one tool. Re-running `install <slug>` uses `go install <module>@latest` for the binary and re-adds the focused skill non-interactively, overwriting the existing install in place. No uninstall-first step is needed.
+
+If install warns that the binary directory is not on `PATH`, the binary and focused skill can still be installed successfully. Follow the printed platform-specific PATH instructions, then restart the running agent session or gateway if it inherits a fixed environment. On Unix-like systems where the harness already exposes `~/.local/bin`, a symlink can be a practical bridge:
+
+```bash
+ln -sf "$(go env GOPATH)/bin/<tool>" "$HOME/.local/bin/<tool>"
+```
 
 Use `update` when the user asks to refresh or reinstall existing tools:
 


### PR DESCRIPTION
## Summary

- Treat a Go binary that installs outside the current PATH as a warning instead of aborting before the focused skill is added.
- Add pathWarning: "not_on_path" to successful JSON output when this happens.
- Make shadow detection symlink-aware so a PATH-visible symlink to the freshly installed Go binary does not produce a stale-binary warning.
- Document agent/gateway PATH behavior and symlink fallback guidance in the npm README and Printing Press Library discovery skill.
- Bump npm package to 0.1.14 and discovery skill to 0.2.1.

## Testing

- npm test