### PR TITLE
fix(cli): address installer review follow-up

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.15
+
+- Add a version-lifecycle guard for npm releases: `preversion` now checks that `package-lock.json` is in sync before the bump, and `version` refreshes/checks the lockfile after `package.json` changes so future release commits cannot accidentally leave the lockfile version stale.
+- Make the installer shadow-warning JSON test hermetic by explicitly stubbing `realpath` in the stale-binary case.
+
 ## 0.1.14
 
 - Treat "installed but not on PATH" as a warning instead of aborting `install`. `go install` can succeed while the current agent or gateway process cannot discover `$GOPATH/bin`; the installer now prints the platform-specific PATH fix, continues installing the focused `pp-*` skill, and reports a successful install with a `pathWarning: "not_on_path"` field in JSON output. This avoids half-installed agent setups where the binary exists but the matching skill was skipped.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -45,6 +45,7 @@
     "check-lock-version": "node scripts/check-lock-version.mjs",
     "clean": "rm -rf dist",
     "preversion": "npm run check-lock-version",
+    "version": "npm install --package-lock-only && npm run check-lock-version",
     "test": "npm run build && node --test \"dist/tests/**/*.test.js\"",
     "prepublishOnly": "npm test && npm run build"
   },

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -540,6 +540,7 @@ test("install command includes shadow info in JSON output", async () => {
     goInstall: async () => ok(),
     goInstallDir: async () => goBinDir("/Users/ada/go/bin"),
     commandOnPath: async () => "/opt/homebrew/bin/espn-pp-cli",
+    realpath: async (path) => path,
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
     stderr: () => {},

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -496,6 +496,7 @@ test("install command warns loudly when a stale binary earlier in PATH shadows t
     goInstall: async () => ok(),
     goInstallDir: async () => goBinDir("/Users/ada/go/bin"),
     commandOnPath: async () => "/opt/homebrew/bin/espn-pp-cli",
+    realpath: async (path) => path,
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
     stderr: (message) => stderr.push(message),


### PR DESCRIPTION
## Summary

- Make the shadow JSON test hermetic by stubbing realpath explicitly.
- Add an npm version lifecycle hook that refreshes/checks package-lock after package.json is bumped and before npm creates its version commit/tag.

This is the tiny follow-up from Greptile's second pass on #985, which merged before the final hygiene commit attached.

## Testing

- npm run check-lock-version
- npm test
- git diff --check origin/main..HEAD