### PR TITLE
fix(skills): unblock PP skills in Hermes by removing config-file literal from generated header

### DIFF
--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """verify_skill.py — validate that SKILL.md matches the shipped CLI source.
 
-Four checks run in sequence:
+Five checks run in sequence:
 
+  0. skill-guard-literals — SKILL.md references no agent-config filename
+     literal (AGENTS.md, CLAUDE.md, .cursorrules, .clinerules). Hermes'
+     skills guard flags those as CRITICAL persistence, hard-blocking install
+     of the generated cli-skills/pp-*/SKILL.md mirror.
   1. flag-names — every `--flag` used on a `<cli_binary> ...` invocation in
      SKILL.md is declared as a cobra flag somewhere in internal/cli/*.go.
      Flags on lines that invoke other tools (npx installers, gh, go,
@@ -33,6 +37,7 @@ USAGE
     python3 verify_skill.py --dir <cli-dir> --json
     python3 verify_skill.py --dir <cli-dir> --only flag-names
     python3 verify_skill.py --dir <cli-dir> --only unknown-command
+    python3 verify_skill.py --dir <cli-dir> --only skill-guard-literals
     python3 verify_skill.py --dir <cli-dir> --strict  # treat known-FPs as failures
 
 Exit codes:

--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -951,6 +951,42 @@ def derive_cli_binary(cli_dir: Path) -> str:
     return cli_dir.name + "-pp-cli"
 
 
+# Agent-config filename literals that Hermes' skills guard (and similar
+# scanners) flag as CRITICAL "persistence" (agent_config_mod) findings. A
+# single match yields a DANGEROUS verdict that hard-blocks install of the
+# mirrored cli-skills/pp-*/SKILL.md (--force cannot override). The library
+# SKILL.md is the source of truth for the mirror body, so guarding it here —
+# PR-time, per CLI — keeps these literals off the install surface. The
+# generator header is guarded separately by a unit test in
+# tools/generate-skills/main_test.go. See
+# docs/plans/2026-06-01-001-fix-hermes-skills-guard-false-positive-plan.md.
+AGENT_CONFIG_LITERALS = ("AGENTS.md", "CLAUDE.md", ".cursorrules", ".clinerules")
+
+
+def check_skill_guard_literals(
+    cli_dir: Path, skill: Path, cli_binary: str, report: Report
+) -> None:
+    text = skill.read_text(encoding="utf-8", errors="replace")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        lower = line.lower()
+        for literal in AGENT_CONFIG_LITERALS:
+            if literal.lower() in lower:
+                report.findings.append(
+                    Finding(
+                        check="skill-guard-literals",
+                        severity="error",
+                        command=cli_binary,
+                        detail=(
+                            f"SKILL.md references the agent-config literal {literal!r}, "
+                            "which Hermes' skills guard flags as CRITICAL persistence and "
+                            "hard-blocks install of the generated mirror. Name the doc/section "
+                            "without the filename."
+                        ),
+                        evidence=f"SKILL.md:{lineno}: {line.strip()}",
+                    )
+                )
+
+
 def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     skill = cli_dir / "SKILL.md"
     if not skill.exists():
@@ -963,7 +999,16 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     cli_binary = derive_cli_binary(cli_dir)
     report = Report(cli_dir=str(cli_dir), skill_path=str(skill))
 
-    checks = only or {"flag-names", "flag-commands", "positional-args", "unknown-command"}
+    checks = only or {
+        "flag-names",
+        "flag-commands",
+        "positional-args",
+        "unknown-command",
+        "skill-guard-literals",
+    }
+    if "skill-guard-literals" in checks:
+        report.checks_run.append("skill-guard-literals")
+        check_skill_guard_literals(cli_dir, skill, cli_binary, report)
     if "flag-names" in checks:
         report.checks_run.append("flag-names")
         check_flag_names(cli_dir, skill, cli_binary, report)
@@ -1040,7 +1085,13 @@ def main():
     p.add_argument("--dir", required=True, help="CLI directory (contains SKILL.md + internal/cli/)")
     p.add_argument(
         "--only",
-        choices=["flag-names", "flag-commands", "positional-args", "unknown-command"],
+        choices=[
+            "flag-names",
+            "flag-commands",
+            "positional-args",
+            "unknown-command",
+            "skill-guard-literals",
+        ],
         action="append",
         help="Run only the named check(s). Pass multiple times to include multiple.",
     )

--- a/.github/scripts/verify-skill/verify_skill_test.py
+++ b/.github/scripts/verify-skill/verify_skill_test.py
@@ -1,0 +1,67 @@
+"""Tests for verify_skill.py's skill-guard-literals check.
+
+Run from this directory:
+
+    python3 -m unittest verify_skill_test
+
+The check guards against agent-config filename literals (AGENTS.md, CLAUDE.md,
+.cursorrules, .clinerules) in a library SKILL.md. Hermes' skills guard flags
+those as CRITICAL persistence findings, which hard-block install of the
+generated cli-skills/pp-*/SKILL.md mirror. See
+docs/plans/2026-06-01-001-fix-hermes-skills-guard-false-positive-plan.md.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_skill
+
+
+def _check(skill_text: str) -> verify_skill.Report:
+    with tempfile.TemporaryDirectory() as d:
+        cli_dir = Path(d)
+        skill = cli_dir / "SKILL.md"
+        skill.write_text(skill_text, encoding="utf-8")
+        report = verify_skill.Report(cli_dir=str(cli_dir), skill_path=str(skill))
+        verify_skill.check_skill_guard_literals(cli_dir, skill, "thing-pp-cli", report)
+        return report
+
+
+class SkillGuardLiteralsTest(unittest.TestCase):
+    def test_clean_skill_passes(self):
+        report = _check("---\nname: pp-thing\n---\n\n# Thing\n\nNormal prose, no config files.\n")
+        self.assertFalse(report.has_real_failures())
+        self.assertEqual(report.findings, [])
+
+    def test_agents_md_fails(self):
+        report = _check("# Thing\n\nSee AGENTS.md for the contract.\n")
+        self.assertTrue(report.has_real_failures())
+        self.assertEqual(report.findings[0].check, "skill-guard-literals")
+        self.assertIn("AGENTS.md", report.findings[0].detail)
+        self.assertIn("SKILL.md:3", report.findings[0].evidence)
+
+    def test_each_literal_is_caught(self):
+        for literal in verify_skill.AGENT_CONFIG_LITERALS:
+            with self.subTest(literal=literal):
+                report = _check(f"# Thing\n\nmentions {literal} somewhere\n")
+                self.assertTrue(
+                    report.has_real_failures(),
+                    f"{literal} should be flagged",
+                )
+
+    def test_case_insensitive_match(self):
+        # Hermes' scanner matches case-insensitively; so must the guard.
+        report = _check("# Thing\n\nsee agents.md in the root\n")
+        self.assertTrue(report.has_real_failures())
+
+    def test_multiple_literals_report_each_occurrence(self):
+        report = _check("# Thing\n\nSee AGENTS.md\n\nand CLAUDE.md too\n")
+        details = " ".join(f.detail for f in report.findings)
+        self.assertIn("AGENTS.md", details)
+        self.assertIn("CLAUDE.md", details)
+        self.assertEqual(len(report.findings), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify-skill/verify_skill_test.py
+++ b/.github/scripts/verify-skill/verify_skill_test.py
@@ -63,5 +63,37 @@ class SkillGuardLiteralsTest(unittest.TestCase):
         self.assertEqual(len(report.findings), 2)
 
 
+class SkillGuardLiteralsRunChecksTest(unittest.TestCase):
+    """Exercises the full run_checks path so the check's registration in the
+    default set (and in checks_run) is covered, not just the function in
+    isolation."""
+
+    def _cli_dir(self, tmp: str, skill_text: str) -> Path:
+        cli_dir = Path(tmp)
+        (cli_dir / "internal" / "cli").mkdir(parents=True)
+        (cli_dir / "internal" / "cli" / "root.go").write_text(
+            "package cli\n", encoding="utf-8"
+        )
+        (cli_dir / "SKILL.md").write_text(skill_text, encoding="utf-8")
+        return cli_dir
+
+    def test_default_set_runs_and_flags_literal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cli_dir = self._cli_dir(tmp, "# Thing\n\nSee AGENTS.md for the contract.\n")
+            report = verify_skill.run_checks(cli_dir, only=None)
+        self.assertIn("skill-guard-literals", report.checks_run)
+        self.assertTrue(report.has_real_failures())
+        self.assertTrue(
+            any(f.check == "skill-guard-literals" for f in report.findings)
+        )
+
+    def test_only_isolation_registers_check(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cli_dir = self._cli_dir(tmp, "# Thing\n\nClean prose, no config files.\n")
+            report = verify_skill.run_checks(cli_dir, only={"skill-guard-literals"})
+        self.assertEqual(report.checks_run, ["skill-guard-literals"])
+        self.assertFalse(report.has_real_failures())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/generate-skills/main.go
+++ b/tools/generate-skills/main.go
@@ -25,7 +25,7 @@ const generatedHeaderFmt = "<!-- GENERATED FILE — DO NOT EDIT.\n" +
 	"     This file is a verbatim mirror of %s,\n" +
 	"     regenerated post-merge by tools/generate-skills/. Hand-edits here are\n" +
 	"     silently overwritten on the next regen. Edit the library/ source instead.\n" +
-	"     See AGENTS.md \"Generated artifacts: registry.json, cli-skills/\". -->\n"
+	"     See the repository agent guide, section \"Generated artifacts: registry.json, cli-skills/\". -->\n"
 const generatedHeaderPrefix = "<!-- GENERATED FILE — DO NOT EDIT"
 
 type PrintManifest struct {

--- a/tools/generate-skills/main_test.go
+++ b/tools/generate-skills/main_test.go
@@ -395,6 +395,22 @@ func TestInjectGeneratedHeader_WithFrontmatter(t *testing.T) {
 	}
 }
 
+// TestInjectGeneratedHeader_NoAgentConfigLiteral guards against reintroducing a
+// literal agent-config filename into the generated header. Hermes' skills guard
+// (and similar scanners) flag the substrings AGENTS.md, CLAUDE.md, .cursorrules,
+// and .clinerules as CRITICAL "persistence" findings, which hard-block install of
+// every mirrored cli-skills/pp-*/SKILL.md. The header must point at the docs
+// without naming the file. See docs/plans/2026-06-01-001-fix-hermes-skills-guard-false-positive-plan.md.
+func TestInjectGeneratedHeader_NoAgentConfigLiteral(t *testing.T) {
+	src := []byte("---\nname: pp-thing\ndescription: \"hi\"\n---\n\n# Body\n")
+	got := string(injectGeneratedHeader(src, "library/productivity/thing/SKILL.md"))
+	for _, literal := range []string{"AGENTS.md", "CLAUDE.md", ".cursorrules", ".clinerules"} {
+		if strings.Contains(got, literal) {
+			t.Errorf("generated header must not contain the scanner-tripping literal %q (flags every mirror DANGEROUS in Hermes), got:\n%s", literal, got)
+		}
+	}
+}
+
 func TestInjectGeneratedHeader_NoFrontmatter(t *testing.T) {
 	src := []byte("# Plain skill\n\nNo frontmatter at all.\n")
 	got := injectGeneratedHeader(src, "library/productivity/plain/SKILL.md")


### PR DESCRIPTION
## What

Removes a false positive that hard-blocks every focused PP skill from installing in Hermes.

The generated `cli-skills/pp-*/SKILL.md` header (emitted by `tools/generate-skills/main.go`) contained the literal `AGENTS.md`. Hermes' skills guard flags that as a CRITICAL `agent_config_mod` (persistence) finding, yielding a DANGEROUS verdict — which for a community source is a hard block that `--force` cannot override. So `hermes skills install mvanhorn/printing-press-library/cli-skills/pp-<name>` failed for every CLI.

This reweords the header to name the docs section without the filename, and adds two guards so the literal can't return.

## Changes

- `tools/generate-skills/main.go` — reword the header's doc pointer; no longer emits `AGENTS.md`.
- `tools/generate-skills/main_test.go` — regression test asserting the generated header carries none of `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / `.clinerules`.
- `.github/scripts/verify-skill/verify_skill.py` — new `skill-guard-literals` check (runs per-CLI in `verify-skills.yml`) that fails when a library `SKILL.md` references one of those literals — the other path a literal could reach the install surface.
- `.github/scripts/verify-skill/verify_skill_test.py` — unit tests for the check.

## Verification

Ran the actual Hermes skills guard (`NousResearch/hermes-agent` `tools/skills_guard.py`) against the regenerated mirrors:

| | Before | After |
|---|---|---|
| Verdict | DANGEROUS | SAFE |
| Install | blocked (`--force` can't override) | allowed |

- All 211 current library CLIs pass the new `skill-guard-literals` check (no false positives).
- `go build` / `go vet` / `go test` (generate-skills) and the verify-skill unit tests pass.

The `cli-skills/pp-*/SKILL.md` mirrors are intentionally not in this diff — `generate-skills.yml` regenerates them post-merge from the new header.
