### PR TITLE
fix(patches): per-patch directory layout + post-merge normalizer

### DIFF
--- a/.github/scripts/normalize-patches/normalize.py
+++ b/.github/scripts/normalize-patches/normalize.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Normalize legacy single-array .printing-press-patches.json into a per-patch directory.
+
+Why this exists
+---------------
+`.printing-press-patches.json` is a single JSON array (`patches: [...]`). Every
+PR that customizes the *same* published CLI appends one object to that one
+array, so any two in-flight PRs on the same CLI conflict on this file at merge
+time — a structural conflict unrelated to the actual code change
+(mvanhorn/cli-printing-press#2496).
+
+The fix is to store one patch per file under a directory:
+
+    library/<cat>/<slug>/.printing-press-patches/
+      <id>.json     one self-contained patch per file
+      _meta.json    only when the CLI carries global (non-per-patch) lists
+      .gitkeep      present even at zero patches (git won't track an empty dir)
+
+Two PRs adding different patches now write different files, which git never
+conflicts on.
+
+Because the Printing Press is distributed and versioned, old binaries/skills
+keep emitting the single-array file indefinitely. So this is not a one-shot
+migration: it runs post-merge on `main` (.github/workflows/normalize-patches.yml)
+to convert whatever old-format files land, and the same script is used for the
+one-time targeted sweep of existing high-churn CLIs.
+
+Usage
+-----
+    normalize.py [--root DIR] [--check] [CLI_DIR ...]
+
+  * With no CLI_DIR args, scans --root (default: library) for every
+    .printing-press-patches.json and normalizes each.
+  * With CLI_DIR args, normalizes exactly those directories (the targeted-sweep
+    path); each must be a library/<cat>/<slug> directory.
+  * --check makes no writes and exits 1 if any directory would change. Used by
+    the idempotency test and as a dry run.
+
+Idempotency is a hard requirement: running twice yields zero diff. The
+normalize_test.py suite enforces it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+LEGACY_FILENAME = ".printing-press-patches.json"
+PATCHES_DIRNAME = ".printing-press-patches"
+META_FILENAME = "_meta.json"
+GITKEEP_FILENAME = ".gitkeep"
+
+SCHEMA_VERSION = 2
+
+# Top-level keys that are provenance the per-patch files inherit, not CLI-global
+# data. Everything else at the top level (deferred_to_upstream, upstream_tracking,
+# machine_followups, …) is CLI-global and is preserved in _meta.json.
+PROVENANCE_KEYS = ("applied_at", "base_run_id", "base_printing_press_version")
+STD_TOP_KEYS = {"schema_version", "patches", *PROVENANCE_KEYS}
+
+# Order the well-known fields first in each emitted patch file for readability;
+# any other original keys follow in their original order.
+PATCH_KEY_ORDER = ("schema_version", "id", *PROVENANCE_KEYS)
+
+
+def slugify(value: str) -> str:
+    """Filesystem-safe kebab slug. Used for patch filenames only; the original
+    `id` value is preserved verbatim inside the file."""
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-{2,}", "-", value).strip("-")
+    return value[:60].strip("-")
+
+
+def patch_filename(patch: dict, index: int, taken: set[str]) -> str:
+    """Deterministic filename for a patch. Prefers a slug of its `id`; falls back
+    to a slug of `summary`, then `patch-NN`. Dedups against names already taken."""
+    raw_id = patch.get("id")
+    base = ""
+    if isinstance(raw_id, str):
+        base = slugify(raw_id)
+    if not base and isinstance(patch.get("summary"), str):
+        base = slugify(patch["summary"])
+    if not base:
+        base = f"patch-{index + 1:02d}"
+
+    name = base
+    suffix = 2
+    while f"{name}.json" in taken:
+        name = f"{base}-{suffix}"
+        suffix += 1
+    taken.add(f"{name}.json")
+    return f"{name}.json"
+
+
+def build_patch_object(patch: dict, top: dict) -> dict:
+    """Return the self-contained per-patch object: schema_version + inherited
+    provenance + every original key, with well-known keys ordered first."""
+    out: dict = {"schema_version": SCHEMA_VERSION}
+
+    # Ensure an `id` is present (synthesized callers pass it through the original
+    # dict, but a patch may legitimately lack one — keep whatever is there).
+    if patch.get("id") is not None:
+        out["id"] = patch["id"]
+
+    # Inherit provenance from the top level when the patch doesn't carry its own.
+    for key in PROVENANCE_KEYS:
+        if patch.get(key) is not None:
+            out[key] = patch[key]
+        elif top.get(key) is not None:
+            out[key] = top[key]
+
+    # Append every remaining original key in its original order.
+    for key, val in patch.items():
+        if key not in out:
+            out[key] = val
+
+    # Reorder so PATCH_KEY_ORDER comes first, then the rest as inserted.
+    ordered = {k: out[k] for k in PATCH_KEY_ORDER if k in out}
+    for k, v in out.items():
+        if k not in ordered:
+            ordered[k] = v
+    return ordered
+
+
+def desired_files(legacy_data: dict, existing_dir: dict[str, dict] | None) -> dict[str, str]:
+    """Compute the full desired content of the patches dir as {filename: text}.
+
+    existing_dir maps already-present <name>.json -> parsed object (the inflow /
+    merge case where a dir already exists alongside an incoming legacy file). On
+    a plain migration it is None/empty.
+    """
+    existing_dir = existing_dir or {}
+    files: dict[str, str] = {}
+
+    # Preserve any files already in the dir verbatim (dir is source of truth on
+    # merge); their names are reserved so incoming patches can't collide.
+    taken = set(existing_dir.keys())
+    existing_ids = {
+        obj.get("id")
+        for obj in existing_dir.values()
+        if isinstance(obj, dict) and obj.get("id") is not None
+    }
+    for name, obj in existing_dir.items():
+        if name in (META_FILENAME, GITKEEP_FILENAME):
+            continue
+        files[name] = dumps(obj)
+
+    patches = legacy_data.get("patches") or []
+    if isinstance(patches, list):
+        for index, patch in enumerate(patches):
+            if not isinstance(patch, dict):
+                continue
+            # On merge, an incoming patch whose id already lives in the dir is a
+            # duplicate (old-Press branch re-emitting a converted patch) — skip.
+            if patch.get("id") is not None and patch["id"] in existing_ids:
+                continue
+            name = patch_filename(patch, index, taken)
+            files[name] = dumps(build_patch_object(patch, legacy_data))
+
+    # CLI-global lists (everything at the top level that isn't provenance or the
+    # patches array) live in _meta.json. This is the one shared file that
+    # remains, and it changes rarely.
+    global_keys = {k: v for k, v in legacy_data.items() if k not in STD_TOP_KEYS}
+    existing_meta = existing_dir.get(META_FILENAME) or {}
+    if global_keys or existing_meta:
+        meta: dict = {"schema_version": SCHEMA_VERSION}
+        # Existing meta wins for scalar collisions; lists are unioned.
+        for key, val in {**global_keys, **{k: v for k, v in existing_meta.items() if k != "schema_version"}}.items():
+            if isinstance(global_keys.get(key), list) and isinstance(existing_meta.get(key), list):
+                merged = list(existing_meta[key])
+                for item in global_keys[key]:
+                    if item not in merged:
+                        merged.append(item)
+                meta[key] = merged
+            else:
+                meta[key] = val
+        files[META_FILENAME] = dumps(meta)
+
+    return files
+
+
+def dumps(obj: dict) -> str:
+    return json.dumps(obj, indent=2, ensure_ascii=False) + "\n"
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def normalize_dir(cli_dir: Path, check: bool) -> tuple[bool, list[str]]:
+    """Normalize one CLI directory. Returns (changed, errors)."""
+    errors: list[str] = []
+    legacy = cli_dir / LEGACY_FILENAME
+    patches_dir = cli_dir / PATCHES_DIRNAME
+
+    has_legacy = legacy.is_file()
+    has_dir = patches_dir.is_dir()
+    if not has_legacy and not has_dir:
+        return (False, errors)
+
+    legacy_data: dict = {}
+    if has_legacy:
+        try:
+            legacy_data = read_json(legacy)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{legacy}: unparseable, skipped ({exc})")
+            return (False, errors)
+        if not isinstance(legacy_data, dict):
+            errors.append(f"{legacy}: top level is not an object, skipped")
+            return (False, errors)
+
+    existing: dict[str, dict] = {}
+    if has_dir:
+        for f in sorted(patches_dir.glob("*.json")):
+            try:
+                existing[f.name] = read_json(f)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"{f}: unparseable, skipped ({exc})")
+                return (False, errors)
+
+    desired = desired_files(legacy_data, existing if has_dir else None)
+
+    # Compute the target on-disk state of the dir: desired *.json + .gitkeep,
+    # nothing else. .gitkeep guarantees the dir survives at zero patches.
+    target: dict[str, str | None] = dict(desired)
+    target[GITKEEP_FILENAME] = ""
+
+    # Determine current on-disk state of the dir.
+    current: dict[str, str] = {}
+    if has_dir:
+        for f in sorted(patches_dir.iterdir()):
+            if f.is_file():
+                current[f.name] = f.read_text()
+
+    changed = False
+
+    # Files to write or rewrite.
+    writes = {n: t for n, t in target.items() if current.get(n) != t}
+    # Stray files in the dir not in target (besides ones we manage) get removed
+    # only if they are .json we'd be replacing the legacy source of — to stay
+    # conservative we remove only *.json no longer desired plus an obsolete
+    # legacy file. We never touch unknown non-json files.
+    deletes = [n for n in current if n.endswith(".json") and n not in target]
+
+    if writes or deletes or has_legacy:
+        changed = True
+
+    if check or not changed:
+        return (changed, errors)
+
+    patches_dir.mkdir(exist_ok=True)
+    for name, text in writes.items():
+        (patches_dir / name).write_text(text)
+    for name in deletes:
+        (patches_dir / name).unlink()
+    if has_legacy:
+        legacy.unlink()
+
+    return (changed, errors)
+
+
+def discover(root: Path) -> list[Path]:
+    dirs: set[Path] = set()
+    for legacy in root.rglob(LEGACY_FILENAME):
+        dirs.add(legacy.parent)
+    for d in root.rglob(PATCHES_DIRNAME):
+        if d.is_dir():
+            dirs.add(d.parent)
+    return sorted(dirs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", default="library", help="Library root to scan when no CLI_DIR is given (default: library)")
+    parser.add_argument("--check", action="store_true", help="Report changes without writing; exit 1 if any dir would change")
+    parser.add_argument("dirs", nargs="*", help="Specific library/<cat>/<slug> directories to normalize")
+    args = parser.parse_args(argv)
+
+    if args.dirs:
+        targets = [Path(d) for d in args.dirs]
+    else:
+        targets = discover(Path(args.root))
+
+    any_changed = False
+    all_errors: list[str] = []
+    for cli_dir in targets:
+        changed, errors = normalize_dir(cli_dir, args.check)
+        all_errors.extend(errors)
+        if changed:
+            any_changed = True
+            print(f"{'would change' if args.check else 'normalized'}: {cli_dir}")
+
+    for err in all_errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+
+    if all_errors:
+        return 2
+    if args.check and any_changed:
+        return 1
+    if not any_changed:
+        print("No patches files needed normalization.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/normalize-patches/normalize_test.py
+++ b/.github/scripts/normalize-patches/normalize_test.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Tests for normalize.py. Run from this directory: python3 -m unittest normalize_test"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import normalize
+
+
+def write(path: Path, obj) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2) + "\n")
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+class NormalizeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.cli = self.root / "library" / "cat" / "slug"
+        self.cli.mkdir(parents=True)
+        self.legacy = self.cli / normalize.LEGACY_FILENAME
+        self.pdir = self.cli / normalize.PATCHES_DIRNAME
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def run_norm(self, check: bool = False):
+        return normalize.normalize_dir(self.cli, check=check)
+
+    # --- core migration ---------------------------------------------------
+
+    def test_explodes_multi_patch_array(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "applied_at": "2026-05-21",
+            "base_run_id": "RUN-1",
+            "base_printing_press_version": "4.9.0",
+            "patches": [
+                {"id": "alpha", "summary": "A", "reason": "ra"},
+                {"id": "beta", "summary": "B", "reason": "rb"},
+            ],
+        })
+        changed, errors = self.run_norm()
+        self.assertTrue(changed)
+        self.assertEqual(errors, [])
+        self.assertFalse(self.legacy.exists(), "legacy file removed")
+        self.assertTrue((self.pdir / "alpha.json").exists())
+        self.assertTrue((self.pdir / "beta.json").exists())
+        self.assertTrue((self.pdir / normalize.GITKEEP_FILENAME).exists())
+
+        alpha = read(self.pdir / "alpha.json")
+        self.assertEqual(alpha["schema_version"], 2)
+        self.assertEqual(alpha["id"], "alpha")
+        # inherited provenance
+        self.assertEqual(alpha["applied_at"], "2026-05-21")
+        self.assertEqual(alpha["base_run_id"], "RUN-1")
+        self.assertEqual(alpha["base_printing_press_version"], "4.9.0")
+        self.assertEqual(alpha["reason"], "ra")
+        # well-known keys ordered first
+        self.assertEqual(
+            list(alpha.keys())[:5],
+            ["schema_version", "id", "applied_at", "base_run_id", "base_printing_press_version"],
+        )
+
+    def test_idempotent(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "applied_at": "2026-05-21",
+            "base_run_id": "RUN-1",
+            "base_printing_press_version": "4.9.0",
+            "patches": [{"id": "alpha", "summary": "A"}],
+        })
+        self.run_norm()
+        before = {p.name: p.read_text() for p in self.pdir.iterdir()}
+        # Second pass must be a no-op.
+        changed, errors = self.run_norm()
+        self.assertFalse(changed)
+        self.assertEqual(errors, [])
+        after = {p.name: p.read_text() for p in self.pdir.iterdir()}
+        self.assertEqual(before, after)
+        # --check agrees there is nothing to do.
+        changed_check, _ = self.run_norm(check=True)
+        self.assertFalse(changed_check)
+
+    def test_empty_array_yields_gitkeep_only(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "applied_at": "2026-05-21",
+            "base_run_id": "RUN-1",
+            "base_printing_press_version": "4.9.0",
+            "patches": [],
+        })
+        changed, errors = self.run_norm()
+        self.assertTrue(changed)
+        self.assertEqual(errors, [])
+        self.assertFalse(self.legacy.exists())
+        entries = sorted(p.name for p in self.pdir.iterdir())
+        self.assertEqual(entries, [normalize.GITKEEP_FILENAME])
+
+    def test_patch_inherits_only_missing_provenance(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "applied_at": "2026-05-21",
+            "base_run_id": "RUN-1",
+            "base_printing_press_version": "4.9.0",
+            "patches": [{"id": "alpha", "applied_at": "2026-06-01"}],
+        })
+        self.run_norm()
+        alpha = read(self.pdir / "alpha.json")
+        # patch's own applied_at wins over the top-level one
+        self.assertEqual(alpha["applied_at"], "2026-06-01")
+
+    # --- edge cases the real data showed ---------------------------------
+
+    def test_id_less_patch_gets_synthesized_filename(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "patches": [
+                {"summary": "Fix the products parser for wall connectors"},
+                {"summary": "Fix the products parser for wall connectors"},  # collision
+            ],
+        })
+        changed, errors = self.run_norm()
+        self.assertTrue(changed)
+        self.assertEqual(errors, [])
+        names = sorted(p.name for p in self.pdir.glob("*.json"))
+        self.assertEqual(
+            names,
+            ["fix-the-products-parser-for-wall-connectors-2.json",
+             "fix-the-products-parser-for-wall-connectors.json"],
+        )
+
+    def test_global_lists_go_to_meta(self) -> None:
+        write(self.legacy, {
+            "schema_version": 1,
+            "applied_at": "2026-05-21",
+            "base_run_id": "RUN-1",
+            "base_printing_press_version": "4.9.0",
+            "patches": [{"id": "alpha"}],
+            "deferred_to_upstream": [{"item": "x"}],
+            "upstream_tracking": ["https://example/issue/1"],
+        })
+        changed, errors = self.run_norm()
+        self.assertTrue(changed)
+        self.assertEqual(errors, [])
+        meta = read(self.pdir / normalize.META_FILENAME)
+        self.assertEqual(meta["schema_version"], 2)
+        self.assertEqual(meta["deferred_to_upstream"], [{"item": "x"}])
+        self.assertEqual(meta["upstream_tracking"], ["https://example/issue/1"])
+        # provenance does NOT leak into meta (it is per-patch)
+        self.assertNotIn("base_run_id", meta)
+
+    # --- inflow / merge case ---------------------------------------------
+
+    def test_merges_incoming_legacy_into_existing_dir(self) -> None:
+        # Dir already has alpha (converted earlier); an old-Press branch lands a
+        # legacy file re-adding alpha plus a new gamma.
+        self.pdir.mkdir()
+        write(self.pdir / "alpha.json", {"schema_version": 2, "id": "alpha", "summary": "A"})
+        (self.pdir / normalize.GITKEEP_FILENAME).write_text("")
+        write(self.legacy, {
+            "schema_version": 1,
+            "patches": [
+                {"id": "alpha", "summary": "A-dup"},  # dup id -> skipped
+                {"id": "gamma", "summary": "G"},       # new -> added
+            ],
+        })
+        changed, errors = self.run_norm()
+        self.assertTrue(changed)
+        self.assertEqual(errors, [])
+        self.assertFalse(self.legacy.exists())
+        # alpha preserved from the dir (not overwritten by the dup)
+        self.assertEqual(read(self.pdir / "alpha.json")["summary"], "A")
+        self.assertEqual(read(self.pdir / "gamma.json")["summary"], "G")
+
+    # --- robustness -------------------------------------------------------
+
+    def test_unparseable_legacy_is_reported_not_destroyed(self) -> None:
+        self.legacy.write_text("{ not json")
+        changed, errors = self.run_norm()
+        self.assertFalse(changed)
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(self.legacy.exists(), "bad file left intact for a human")
+        self.assertFalse(self.pdir.exists())
+
+    def test_no_patches_artifacts_is_noop(self) -> None:
+        changed, errors = self.run_norm()
+        self.assertFalse(changed)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -40,6 +40,7 @@ PATCHES_DIR = ".printing-press-patches"
 def patches_present(cli_dir: Path) -> bool:
     return (cli_dir / PATCHES_LEGACY_FILE).is_file() or (cli_dir / PATCHES_DIR).is_dir()
 
+
 PRINTER_SENTINELS = {"", "USER", "user", "unknown", "UNKNOWN", "changeme", "CHANGE_ME"}
 
 

--- a/.github/scripts/verify-publish-package/verify_publish_package.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package.py
@@ -20,7 +20,6 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 ROOT_ARTIFACTS = (
     ".printing-press.json",
-    ".printing-press-patches.json",
     "AGENTS.md",
     "README.md",
     "SKILL.md",
@@ -29,6 +28,17 @@ ROOT_ARTIFACTS = (
     "LICENSE",
     "NOTICE",
 )
+
+# The patches index ships in one of two shapes (mvanhorn/cli-printing-press#2496):
+# the legacy single-array file, or the per-patch directory it is being migrated to.
+# CI tolerates either through the transition; the post-merge normalize-patches
+# workflow converts the legacy file to the directory on main.
+PATCHES_LEGACY_FILE = ".printing-press-patches.json"
+PATCHES_DIR = ".printing-press-patches"
+
+
+def patches_present(cli_dir: Path) -> bool:
+    return (cli_dir / PATCHES_LEGACY_FILE).is_file() or (cli_dir / PATCHES_DIR).is_dir()
 
 PRINTER_SENTINELS = {"", "USER", "user", "unknown", "UNKNOWN", "changeme", "CHANGE_ME"}
 
@@ -157,15 +167,18 @@ def validate_required_artifacts(cli_dir: Path, manifest: dict | None) -> list[Pr
                         "new library CLI is missing AGENTS.md. Re-run the publish skill with a current Printing Press build so reviewers and future agents get the generated per-CLI operating guide.",
                     )
                 )
-            elif artifact == ".printing-press-patches.json":
-                problems.append(
-                    Problem(
-                        path,
-                        "new library CLI is missing .printing-press-patches.json. Fresh prints should include the empty patch index; hand-authored customizations are recorded there per the shape documented in AGENTS.md.",
-                    )
-                )
             else:
                 problems.append(Problem(path, f"new library CLI is missing required publish artifact {artifact}"))
+
+    if not patches_present(cli_dir):
+        problems.append(
+            Problem(
+                cli_dir / PATCHES_DIR,
+                "new library CLI is missing its patches index. Fresh prints should include "
+                f"{PATCHES_DIR}/ (with .gitkeep) — or the legacy {PATCHES_LEGACY_FILE} — per the "
+                "shape documented in AGENTS.md. Hand-authored customizations are recorded there.",
+            )
+        )
 
     cli_name = manifest.get("cli_name") if manifest else None
     if isinstance(cli_name, str) and cli_name:
@@ -337,42 +350,41 @@ def validate_patch_manifest(
     cli_dir: Path,
     changed_files: set[str] | None,
 ) -> list[Problem]:
-    """Validate `.printing-press-patches.json` minimally.
+    """Validate the patches index minimally, in either supported shape.
+
+    The index ships as the legacy single-array `.printing-press-patches.json`
+    or the per-patch `.printing-press-patches/` directory it is migrating to
+    (mvanhorn/cli-printing-press#2496). CI tolerates both.
 
     CI's role for the patches manifest is to catch the structural class of
-    bugs that would silently break downstream readers (the file is unparseable
-    JSON, or `patches` is set to something other than an array). Everything
-    else about the manifest's shape — per-patch fields, referenced-file
-    existence, inline source-marker pairing — is the authoring contract
-    described in this repo's AGENTS.md and is enforced by agent diligence
-    and code review, not by CI.
-
-    Rationale: the bi-directional source-marker / patches-entry pairing
-    that this verifier previously enforced added two commits to every
-    in-session customization PR (add the entry, add the matching marker)
-    without catching a class of bug git history + the manifest doesn't
-    already surface. AGENTS.md remains the source of truth for what
-    belongs in a well-formed patches entry.
+    bugs that would silently break downstream readers (a file is unparseable
+    JSON, the legacy `patches` is set to something other than an array, or a
+    per-patch file is not a JSON object). Everything else about the manifest's
+    shape — per-patch fields, referenced-file existence — is the authoring
+    contract described in this repo's AGENTS.md and is enforced by agent
+    diligence and code review, not by CI.
 
     The `changed_files` parameter is kept for API stability with the
-    surrounding caller but is unused — the two remaining checks (parse +
-    array-shape) are cheap and don't need diff-scoping.
+    surrounding caller but is unused — the remaining checks are cheap and
+    don't need diff-scoping.
     """
     del changed_files  # unused; kept for caller-API stability
     problems: list[Problem] = []
-    patch_path = cli_dir / ".printing-press-patches.json"
-    if not patch_path.exists():
-        return problems
 
-    manifest = read_json(patch_path, problems)
-    if manifest is None:
-        return problems
+    legacy_path = cli_dir / PATCHES_LEGACY_FILE
+    if legacy_path.exists():
+        manifest = read_json(legacy_path, problems)
+        if manifest is not None:
+            patches = manifest.get("patches", [])
+            if patches is not None and not isinstance(patches, list):
+                problems.append(Problem(legacy_path, "patches must be an array"))
 
-    patches = manifest.get("patches", [])
-    if patches is None:
-        patches = []
-    if not isinstance(patches, list):
-        problems.append(Problem(patch_path, "patches must be an array"))
+    patches_dir = cli_dir / PATCHES_DIR
+    if patches_dir.is_dir():
+        # read_json appends a problem when a file isn't a JSON object, which is
+        # exactly the structural check we want per patch file.
+        for patch_file in sorted(patches_dir.glob("*.json")):
+            read_json(patch_file, problems)
 
     return problems
 

--- a/.github/scripts/verify-publish-package/verify_publish_package_test.py
+++ b/.github/scripts/verify-publish-package/verify_publish_package_test.py
@@ -302,6 +302,57 @@ class PublishPackageVerifierTest(unittest.TestCase):
             msg="malformed JSON should still surface as a problem",
         )
 
+    def test_patches_directory_shape_passes(self) -> None:
+        """The per-patch directory layout (mvanhorn/cli-printing-press#2496) is
+        accepted alongside the legacy single-array file. A dir of well-formed
+        per-patch objects + .gitkeep, with no legacy file, validates clean.
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "legacy"
+        self.write(
+            "library/cloud/legacy/.printing-press.json",
+            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
+        )
+        self.write("library/cloud/legacy/.printing-press-patches/.gitkeep", "")
+        self.write(
+            "library/cloud/legacy/.printing-press-patches/alpha.json",
+            json.dumps({"schema_version": 2, "id": "alpha", "summary": "A", "reason": "ra"}),
+        )
+
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertEqual([], problems, msg=f"got {[p.message for p in problems]}")
+
+    def test_patches_directory_with_non_object_file_fails(self) -> None:
+        """A per-patch file that isn't a JSON object would break dir readers,
+        so read_json surfaces it as a structural problem.
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "legacy"
+        self.write(
+            "library/cloud/legacy/.printing-press.json",
+            json.dumps({"schema_version": 1, "api_name": "legacy", "cli_name": "legacy-pp-cli"}),
+        )
+        self.write("library/cloud/legacy/.printing-press-patches/.gitkeep", "")
+        self.write(
+            "library/cloud/legacy/.printing-press-patches/bad.json",
+            json.dumps(["not", "an", "object"]),
+        )
+
+        problems = verifier.validate_patch_manifest(cli_dir, changed_files=None)
+        self.assertNotEqual([], problems, msg="non-object patch file should surface a problem")
+
+    def test_new_cli_with_patches_dir_satisfies_presence(self) -> None:
+        """A new CLI shipping the directory shape (no legacy file) is not flagged
+        as missing its patches index by the required-artifacts check.
+        """
+        cli_dir = self.tmp / "library" / "cloud" / "bad"
+        self.write("library/cloud/bad/.printing-press.json", '{"api_name": "bad", "cli_name": "bad-pp-cli"}')
+        self.write("library/cloud/bad/.printing-press-patches/.gitkeep", "")
+
+        problems = verifier.validate_required_artifacts(cli_dir, manifest=None)
+        self.assertFalse(
+            any("patches index" in p.message for p in problems),
+            msg="dir-form patches index must satisfy the presence check",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/normalize-patches.yml
+++ b/.github/workflows/normalize-patches.yml
@@ -1,0 +1,133 @@
+name: Normalize patches manifests
+
+# Converts any legacy single-array .printing-press-patches.json that lands on
+# main into the per-patch directory layout (.printing-press-patches/<id>.json),
+# committing the result back with [skip ci].
+#
+# Why post-merge instead of a PR check: the single-array file conflicts on every
+# concurrent same-CLI PR (mvanhorn/cli-printing-press#2496). The directory layout
+# fixes that structurally, but the Printing Press is distributed and versioned —
+# older binaries/skills keep emitting the single-array file indefinitely. Rather
+# than reject those PRs (which would force users to upgrade tooling they may not
+# control) or push fixups onto untrusted PR branches (pull_request_target / fork
+# write exposure this repo deliberately avoids), we accept the legacy file at PR
+# time and normalize it here, on main, after merge. Open old-format PRs therefore
+# self-heal with no author action.
+#
+# Why diff-scoped (not a full-library sweep on every run): converting a CLI
+# deletes its legacy file, which conflicts with any *other* open PR still editing
+# that legacy file. Scoping to the CLI(s) a merge actually touched keeps the blast
+# radius to exactly where a conversion was already due, and leaves dormant CLIs
+# (and their open PRs) untouched until they are next modified. A deliberate full
+# or targeted sweep is available via workflow_dispatch.
+#
+# This is the same post-merge generated-artifact pattern this repo already uses
+# for registry.json and cli-skills/.
+#
+# Source of truth for the conversion: .github/scripts/normalize-patches/normalize.py
+# (idempotent; the same script powers manual sweeps).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'library/**/.printing-press-patches.json'
+      - '.github/scripts/normalize-patches/**'
+      - '.github/workflows/normalize-patches.yml'
+  workflow_dispatch:
+    inputs:
+      dirs:
+        description: 'Space-separated library/<cat>/<slug> dirs to normalize. Empty = full library sweep.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  normalize:
+    name: Normalize and commit
+    runs-on: ubuntu-latest
+    # Share one push lane with generate-registry.yml / generate-skills.yml. All
+    # three commit back to main after a library/** change; serializing avoids
+    # non-fast-forward push failures. The three touch disjoint paths
+    # (.printing-press-patches/ vs registry.json+README.md vs cli-skills/), so
+    # the rebase-before-push below is conflict-free in practice.
+    concurrency:
+      group: generated-artifact-push-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Write access on the same branch we push to. GITHUB_TOKEN's default
+          # ref is the merge commit; check out main explicitly so the final push
+          # targets it. fetch-depth 2 so the push diff can resolve the parent.
+          ref: main
+          fetch-depth: 2
+          # Admin-scoped PAT so the post-commit push bypasses the main-branch
+          # ruleset (default GITHUB_TOKEN cannot bypass).
+          token: ${{ secrets.ADMIN_PUSH_PAT }}
+      - name: Resolve target directories
+        id: targets
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          DISPATCH_DIRS: ${{ github.event.inputs.dirs }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Empty input → full sweep (--root library); otherwise the given dirs.
+            echo "args=${DISPATCH_DIRS}" >> "$GITHUB_OUTPUT"
+            echo "mode=dispatch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # push: scope to CLI dirs whose legacy patches file changed in this push.
+          # PRs land on main as a single commit here, so HEAD~1 is the reliable
+          # base; github.event.before is preferred when its commit is present in
+          # the (shallow) checkout, else we fall back rather than crash. A missed
+          # conversion is not data loss — the next patches push for that CLI
+          # catches it, and a workflow_dispatch sweep is the backstop.
+          BASE="HEAD~1"
+          if [ -n "${BEFORE:-}" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+             && git rev-parse --verify --quiet "${BEFORE}^{commit}" >/dev/null; then
+            BASE="$BEFORE"
+          fi
+          dirs="$(git diff --name-only "$BASE" HEAD -- 'library/**/.printing-press-patches.json' \
+                  | xargs -r -n1 dirname | sort -u | tr '\n' ' ')"
+          echo "args=${dirs}" >> "$GITHUB_OUTPUT"
+          echo "mode=push" >> "$GITHUB_OUTPUT"
+      - name: Normalize legacy patches files
+        env:
+          ARGS: ${{ steps.targets.outputs.args }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ARGS// }" ]; then
+            if [ "${{ steps.targets.outputs.mode }}" = "dispatch" ]; then
+              echo "Full-library sweep."
+              python3 .github/scripts/normalize-patches/normalize.py --root library
+            else
+              echo "No changed patches files to normalize."
+            fi
+          else
+            echo "Normalizing: $ARGS"
+            # shellcheck disable=SC2086
+            python3 .github/scripts/normalize-patches/normalize.py $ARGS
+          fi
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          git add -A -- library
+          if git diff --cached --quiet; then
+            echo "No patches normalization changes; nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # [skip ci] suppresses a re-trigger of this workflow on its own commit.
+          git commit -m "chore(patches): normalize patches manifests to per-patch dirs [skip ci]"
+          # Defense-in-depth against the cross-workflow race with the sibling
+          # generated-artifact workflows — the concurrency group serializes most
+          # runs; the rebase handles a sibling landing between checkout and push.
+          # Paths are disjoint, so the rebase is conflict-free.
+          git pull --rebase origin main
+          git push

--- a/.github/workflows/normalize-patches.yml
+++ b/.github/workflows/normalize-patches.yml
@@ -67,52 +67,69 @@ jobs:
           # Admin-scoped PAT so the post-commit push bypasses the main-branch
           # ruleset (default GITHUB_TOKEN cannot bypass).
           token: ${{ secrets.ADMIN_PUSH_PAT }}
-      - name: Resolve target directories
-        id: targets
+      - name: Normalize legacy patches files
         env:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE: ${{ github.event.before }}
           DISPATCH_DIRS: ${{ github.event.inputs.dirs }}
         run: |
           set -euo pipefail
+
+          # Collect candidate target dirs. workflow_dispatch with an empty input
+          # means a full-library sweep; otherwise it is the operator-supplied list.
+          # On push, scope to CLI dirs whose legacy patches file changed.
+          raw=""
+          full_sweep=false
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            # Empty input → full sweep (--root library); otherwise the given dirs.
-            echo "args=${DISPATCH_DIRS}" >> "$GITHUB_OUTPUT"
-            echo "mode=dispatch" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # push: scope to CLI dirs whose legacy patches file changed in this push.
-          # PRs land on main as a single commit here, so HEAD~1 is the reliable
-          # base; github.event.before is preferred when its commit is present in
-          # the (shallow) checkout, else we fall back rather than crash. A missed
-          # conversion is not data loss — the next patches push for that CLI
-          # catches it, and a workflow_dispatch sweep is the backstop.
-          BASE="HEAD~1"
-          if [ -n "${BEFORE:-}" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
-             && git rev-parse --verify --quiet "${BEFORE}^{commit}" >/dev/null; then
-            BASE="$BEFORE"
-          fi
-          dirs="$(git diff --name-only "$BASE" HEAD -- 'library/**/.printing-press-patches.json' \
-                  | xargs -r -n1 dirname | sort -u | tr '\n' ' ')"
-          echo "args=${dirs}" >> "$GITHUB_OUTPUT"
-          echo "mode=push" >> "$GITHUB_OUTPUT"
-      - name: Normalize legacy patches files
-        env:
-          ARGS: ${{ steps.targets.outputs.args }}
-        run: |
-          set -euo pipefail
-          if [ -z "${ARGS// }" ]; then
-            if [ "${{ steps.targets.outputs.mode }}" = "dispatch" ]; then
-              echo "Full-library sweep."
-              python3 .github/scripts/normalize-patches/normalize.py --root library
+            if [ -z "${DISPATCH_DIRS// /}" ]; then
+              full_sweep=true
             else
-              echo "No changed patches files to normalize."
+              raw="$DISPATCH_DIRS"
             fi
           else
-            echo "Normalizing: $ARGS"
-            # shellcheck disable=SC2086
-            python3 .github/scripts/normalize-patches/normalize.py $ARGS
+            # PRs land on main as a single commit, so HEAD~1 is the reliable base;
+            # github.event.before is preferred when present in the (shallow)
+            # checkout, else fall back rather than crash. A missed conversion is
+            # not data loss — the next patches push for that CLI catches it, and a
+            # workflow_dispatch sweep is the backstop.
+            BASE="HEAD~1"
+            if [ -n "${BEFORE:-}" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+               && git rev-parse --verify --quiet "${BEFORE}^{commit}" >/dev/null; then
+              BASE="$BEFORE"
+            fi
+            raw="$(git diff --name-only "$BASE" HEAD -- 'library/**/.printing-press-patches.json' \
+                   | xargs -r -n1 dirname | sort -u)"
           fi
+
+          if [ "$full_sweep" = true ]; then
+            echo "Full-library sweep."
+            python3 .github/scripts/normalize-patches/normalize.py --root library
+            exit 0
+          fi
+
+          # Validate every candidate before use. Each must be a library/<cat>/<slug>
+          # directory; this rejects shell metacharacters, globs, and out-of-scope
+          # paths a workflow_dispatch caller could otherwise inject. set -f disables
+          # globbing while we split the unquoted list; validated tokens are then
+          # passed to the script as a quoted array (no word-splitting downstream).
+          set -f
+          targets=()
+          for d in $raw; do
+            if ! printf '%s' "$d" | grep -Eq '^library/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+              echo "::error::refusing unsafe or out-of-scope target: $d"
+              exit 1
+            fi
+            targets+=("$d")
+          done
+          set +f
+
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "No changed patches files to normalize."
+            exit 0
+          fi
+          printf 'Normalizing %d dir(s):\n' "${#targets[@]}"
+          printf '  %s\n' "${targets[@]}"
+          python3 .github/scripts/normalize-patches/normalize.py "${targets[@]}"
       - name: Commit if changed
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,10 @@ This repo is **the published library repo**: finished printed CLIs are copied he
 
 When deciding where a change belongs:
 
-- **A broken published CLI gets patched here first, regardless of root cause.** If a CLI on `main` is shipping a real defect — migration fails, command panics, build breaks, sync blocks — fix it in `library/<cat>/<slug>/` and record the change in `.printing-press-patches.json`. Users install from this repo; leaving the published artifact broken while an upstream change works its way through generation is not an acceptable wait. If the same defect also reproduces in other published CLIs (quick `grep` across `library/**/internal/...`), it's a genuine multi-CLI template bug — fix the generator in parallel, but the local patch still lands first.
+- **A broken published CLI gets patched here first, regardless of root cause.** If a CLI on `main` is shipping a real defect — migration fails, command panics, build breaks, sync blocks — fix it in `library/<cat>/<slug>/` and record the change in `.printing-press-patches/`. Users install from this repo; leaving the published artifact broken while an upstream change works its way through generation is not an acceptable wait. If the same defect also reproduces in other published CLIs (quick `grep` across `library/**/internal/...`), it's a genuine multi-CLI template bug — fix the generator in parallel, but the local patch still lands first.
 - **Distinguish single-CLI manifestation from multi-CLI template bug.** Template bugs that only fire under rare spec shapes (high endpoint-to-table aggregation, unusual auth flows, exotic parameter naming) can look generator-template in form but show up in exactly one CLI — those are one-off published-library repairs, not upstream work. Reserve "fix the generator" for defects that reproduce across multiple published CLIs, broken codegen for a whole spec class, or pipeline issues (dogfood, verify, MCP emission, scoring, publish, AST patch).
 - **Published catalog behavior belongs here.** Registry metadata, npm installer behavior, generated skill mirrors, per-CLI README/SKILL polish, and one-off repairs to an already-published CLI live in this repo.
-- **How to record a hand-edit.** When you patch a generated CLI in `library/`, mark each changed site with a `// PATCH(...)` source comment and add an entry to `.printing-press-patches.json` per the dedicated section below. If the fix is also generator-shaped and you have a local `cli-printing-press` checkout, make the generator change in parallel; if you do not, open or draft an upstream issue carrying the affected CLI path, the generated code pattern, the expected generator behavior, and a pointer to the patch you applied here.
+- **How to record a hand-edit.** When you patch a generated CLI in `library/`, add a `<id>.json` entry under `.printing-press-patches/` per the dedicated section below (an inline `// PATCH(...)` source comment is an optional navigation aid, not required). If the fix is also generator-shaped and you have a local `cli-printing-press` checkout, make the generator change in parallel; if you do not, open or draft an upstream issue carrying the affected CLI path, the generated code pattern, the expected generator behavior, and a pointer to the patch you applied here.
 - **Do not rerun broad generation casually from this repo.** Regeneration is owned by the generator pipeline. The `printing-press patch` workflow from the generator repo is an alternative to a hand-edit when you have a local generator checkout and the change fits its AST-patch model.
 - **When working cross-repo, obey both repos' instructions.** Start in this repo for published artifacts, switch to the local `cli-printing-press` checkout for generator changes if one is available, and keep commits scoped so generated output and generator logic are not mixed accidentally.
 - **Vulnerability gates are split by lifecycle.** The generator/publish flow in `cli-printing-press` should block newly printed CLIs on reachable `govulncheck` findings before they enter this repo. This public library keeps a clean baseline when practical, but it is a catalog of many independent CLIs — do not turn every unrelated PR into a full-library dependency-freshness campaign.
@@ -76,7 +76,7 @@ Treat the change as a **new CLI / reprint** (subject to this rule) if any of the
 
 The following are **not** new CLI / reprint changes and are fine to land via a normal hand-authored PR from this repo:
 
-- Bug fixes or behavior tweaks in an already-published CLI's `internal/cli/*.go`, `internal/client/*.go`, etc. Record any code-level customization in `.printing-press-patches.json` per the convention below.
+- Bug fixes or behavior tweaks in an already-published CLI's `internal/cli/*.go`, `internal/client/*.go`, etc. Record any code-level customization in `.printing-press-patches/` per the convention below.
 - README/SKILL.md polish on an already-published CLI (edit `library/<cat>/<slug>/SKILL.md`, never the `cli-skills/` mirror).
 - AST-level patches via `printing-press patch` from the generator repo.
 - `tools/sweep-canonical/` runs that retrofit canonical shape across all entries.
@@ -115,7 +115,7 @@ When any of these fire, **the right move is not to fix the PR by adding more sec
 
 ### CI gates for new-CLI / reprint shape
 
-The `verify-library-conventions.yml` workflow runs `verify_publish_package.py` on every PR that touches `library/**`. For PRs that **add** a `library/<cat>/<slug>/.printing-press.json` (the classifier for new-CLI submissions), it hard-fails on missing publish artifacts (`.printing-press-patches.json`, `AGENTS.md`, `README.md`, `SKILL.md`, `go.mod`, `.goreleaser.yaml`, `LICENSE`, `NOTICE`, `cmd/<cli_name>/main.go`), missing `.manuscripts/<run-id>/{research,proofs}/`, missing `run_id` / `printer` / `printing_press_version` in the manifest, missing `novel_features`, and missing MCP artifacts (`manifest.json`, `tools-manifest.json`) when MCP is advertised. It also emits advisory notices when the PR body lacks `### Publication Path` or `### Novel Commands`. Don't try to placate the verifier file by file — if it fires, you've drifted off the publish flow; re-run the publish skill.
+The `verify-library-conventions.yml` workflow runs `verify_publish_package.py` on every PR that touches `library/**`. For PRs that **add** a `library/<cat>/<slug>/.printing-press.json` (the classifier for new-CLI submissions), it hard-fails on missing publish artifacts (the patches index — either `.printing-press-patches/` or the legacy `.printing-press-patches.json` — `AGENTS.md`, `README.md`, `SKILL.md`, `go.mod`, `.goreleaser.yaml`, `LICENSE`, `NOTICE`, `cmd/<cli_name>/main.go`), missing `.manuscripts/<run-id>/{research,proofs}/`, missing `run_id` / `printer` / `printing_press_version` in the manifest, missing `novel_features`, and missing MCP artifacts (`manifest.json`, `tools-manifest.json`) when MCP is advertised. It also emits advisory notices when the PR body lacks `### Publication Path` or `### Novel Commands`. Don't try to placate the verifier file by file — if it fires, you've drifted off the publish flow; re-run the publish skill.
 
 ## Automated code review with Greptile
 
@@ -195,40 +195,45 @@ A printed CLI's attribution is a single permanent **`creator`** plus a multi-val
 - **When you fix or improve a published CLI, add yourself to `contributors[]`** in that CLI's `.printing-press.json`. From a local `cli-printing-press` checkout, `cli-printing-press contributors add --dir library/<cat>/<slug>` does this idempotently (skips the creator and anyone already listed). A reprinter is listed first (`--front`). Plain regen/sync never appends a contributor — accrual is a deliberate action.
 - **Do not hand-edit attribution from a contribution PR beyond adding your own contributor entry.** The library-wide migration and contributor backfill are owned by `tools/sweep-canonical` (`-backfill-contributors`), which derives contributors from git history with a bot/regen/rename denylist and surfaces a human-reviewable table before writing — see the next section.
 
-## `.printing-press-patches.json` records library-side customizations
+## `.printing-press-patches/` records library-side customizations
 
-If you modify a published CLI under `library/<cat>/<slug>/` beyond what the generator produced, **catalog the change in `.printing-press-patches.json`** at the CLI's root (parallel to `.printing-press.json`). SKILL.md / README.md edits are owned by `tools/sweep-canonical/` or direct edit and don't need a patch manifest; this convention is for code-level customizations.
+If you modify a published CLI under `library/<cat>/<slug>/` beyond what the generator produced, **catalog the change as one file per patch under `.printing-press-patches/`** at the CLI's root (parallel to `.printing-press.json`). SKILL.md / README.md edits are owned by `tools/sweep-canonical/` or direct edit and don't need a patch entry; this convention is for code-level customizations.
 
-Minimum shape:
+```
+library/<cat>/<slug>/.printing-press-patches/
+  <id>.json     one self-contained patch per file
+  _meta.json    only when the CLI carries CLI-global lists (see below)
+  .gitkeep      present even at zero patches (git won't track an empty dir)
+```
+
+Each `<id>.json` is a single self-contained patch object:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "id": "short-identifier",
   "applied_at": "YYYY-MM-DD",
   "base_run_id": "<copy from .printing-press.json>",
   "base_printing_press_version": "<copy from .printing-press.json>",
-  "patches": [
-    {
-      "id": "short-identifier",
-      "summary": "What changed (one sentence).",
-      "reason": "Why this customization was needed (one or two sentences).",
-      "files": ["internal/cli/foo.go"],
-      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-    }
-  ]
+  "summary": "What changed (one sentence).",
+  "reason": "Why this customization was needed (one or two sentences).",
+  "files": ["internal/cli/foo.go"],
+  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+  "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
 }
 ```
 
-Optional top-level fields the kalshi example uses when relevant: `upstream_tracking[]`, `deferred_to_upstream[]`.
+The filename is `slugify(id).json`. **One PR = one new file**, so two concurrent PRs on the same CLI write different files and never conflict on patch metadata — the whole point of the directory layout ([mvanhorn/cli-printing-press#2496](https://github.com/mvanhorn/cli-printing-press/issues/2496)). CLI-global lists that don't belong to any single patch (`upstream_tracking`, `deferred_to_upstream`, …) live in `_meta.json`; that is the one remaining shared file and it changes rarely.
 
-This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the manifest is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short — if you find yourself writing tables of field renames or SQL transformations, that detail belongs in the commit message, not here. A fresh print from the generator overwrites this tree, and the manifest is what survives that overwrite.
+**Why this is not the legacy single-array file.** This used to be a single `.printing-press-patches.json` with a `patches: [...]` array that every PR appended to — a guaranteed merge conflict between any two same-CLI PRs. That shape is now **converted automatically**: the post-merge `normalize-patches.yml` workflow (source: `.github/scripts/normalize-patches/normalize.py`) explodes any legacy single-array file that lands on `main` into this directory. Older Printing Press versions still emit the single file, and CI tolerates it on PRs — you don't have to convert it yourself, the normalizer does it after merge. New work should write the directory form directly.
+
+Each `<id>.json` is an **index entry**, not a second copy of the diff. Diffs live in `git`; the entry tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short — tables of field renames or SQL transformations belong in the commit message, not here. A fresh print from the generator overwrites this tree, and these entries are what survive that overwrite.
 
 **Inline `// PATCH:` source comments are optional, not required.** Earlier guidance asked agents to mark each changed site in source alongside the manifest entry; `verify_publish_package.py` enforced a bidirectional pairing that doubled the commit count on every in-session customization without surfacing a class of bug git history and the manifest didn't already cover. The pairing requirement is gone; if you find a marker helpful as a navigation aid for yourself, fine, but the CI no longer cares whether you add one.
 
-**Delete stale workaround entries.** A `reason` field that describes a verifier or pipeline bug (e.g. *"the package verifier currently treats X as Y; this entry exists to silence the false positive"*) is a placeholder, not a real customization. When the underlying bug is fixed, delete the entry — leaving it behind makes future contributors think there's a hand-edit to preserve when there isn't.
+**Delete stale workaround entries.** A `reason` field that describes a verifier or pipeline bug (e.g. *"the package verifier currently treats X as Y; this entry exists to silence the false positive"*) is a placeholder, not a real customization. When the underlying bug is fixed, delete the file — leaving it behind makes future contributors think there's a hand-edit to preserve when there isn't.
 
-A worked example lives at `library/payments/kalshi/.printing-press-patches.json`.
+A worked example lives at `library/payments/kalshi/.printing-press-patches/`.
 
 ## CLI `root.go` shape
 


### PR DESCRIPTION
## Patches manifest: per-patch directory layout + post-merge normalizer

`.printing-press-patches.json` is a single JSON array (`patches: [...]`). Every PR that customizes the *same* published CLI appends a new object to that one array, so **any two in-flight PRs on the same CLI conflict on this file at merge time** — a structural conflict unrelated to the actual code change. This bit us repeatedly (e.g. #989 vs #924 on tesla; #943/#949 on splitwise). Tracked upstream as [mvanhorn/cli-printing-press#2496](https://github.com/mvanhorn/cli-printing-press/issues/2496).

This PR lands the **conflict-free per-patch directory layout** and the machinery to migrate to it **without a flag day** — older Printing Press versions keep emitting the single-array file indefinitely, so the old shape has to be tolerated through a sunset window, not rejected.

### Target shape

```
library/<cat>/<slug>/.printing-press-patches/
  <id>.json     one self-contained patch per file (its own applied_at + base_* provenance)
  _meta.json    only when the CLI carries CLI-global lists (upstream_tracking, deferred_to_upstream, …)
  .gitkeep      present even at zero patches (git won't track an empty dir)
```

Two PRs adding different patches now write different files → git never conflicts. The directory's value is preserved exactly as `printing-press-reprint` consumes it (an unordered set of `reason`/`validated_outcome` entries).

### What's in this PR (all backward-compatible — nothing is converted yet)

- **`.github/scripts/normalize-patches/normalize.py`** (+ `normalize_test.py`) — idempotent exploder converting a legacy single-array file into the directory. Validated against **all 203 live files (963 patches): idempotent, zero errors**. Handles the real-data edge cases: 10 id-less patches (synthesized stable filenames), 68 empty scaffolds, ~18 files with CLI-global lists.
- **`.github/workflows/normalize-patches.yml`** — post-merge converter, mirroring the `generate-registry` `[skip ci]` pattern and sharing its push-lane concurrency group. **Diff-scoped on push** (converts only the CLI a merge actually touched, so open PRs on *other* CLIs are never disrupted); full or targeted sweep via `workflow_dispatch`. Post-merge (not a PR check) so it never pushes to untrusted PR branches.
- **`verify_publish_package.py`** (+ tests) — accepts **either** the directory or the legacy file through the transition.
- **`AGENTS.md`** — documents the directory shape and the normalizer.

### Why post-merge + tolerant instead of a hard gate

The Printing Press is distributed and versioned; we can't assume the old format is gone. So legacy files are accepted at PR time and **self-heal after merge** (open old-format PRs need no author action). The generator-side changes (emit the directory natively, bump `min-binary-version` so current skills produce the new shape, flip a patches-shape gate to finally reject legacy) are a follow-up in `cli-printing-press`, sequenced to land **after** this tolerance is on `main`. Full sunset plan: cli-printing-press#2496.

### Testing

```
$ python3 -m unittest normalize_test          # 9 passed
$ python3 -m unittest verify_publish_package_test  # 13 passed (3 new dir-shape cases)
$ python3 .github/scripts/normalize-patches/normalize.py --check --root library  # 203 would-convert, 0 errors
$ python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main     # no findings
```

Refs mvanhorn/cli-printing-press#2496
