### PR TITLE
fix(skills): remove leading bytes before frontmatter in supabase and gravitus SKILL.md

### DIFF
--- a/library/developer-tools/supabase/SKILL.md
+++ b/library/developer-tools/supabase/SKILL.md
@@ -1,4 +1,3 @@
-<!-- // PATCH: hand-edited headline + Known Gaps section + narrowed trigger phrases vs generated defaults; aligned with README/SKILL contract. -->
 ---
 name: pp-supabase
 description: "The full Supabase Management API (108 endpoints) plus a local SQLite cache of orgs, projects, functions, branches, and secret names — powering cross-project queries no live API answers in one call, with Auth Admin lookup, PostgREST schema introspection, and Storage usage rollup on top. Trigger phrases: `supabase auth admin lookup`, `supabase secret name audit`, `supabase branches drift`, `supabase project estate rollup`, `supabase storage usage`, `supabase pgrst schema`, `use supabase`, `run supabase`. Anti-triggers: `supabase start` (use the official supabase CLI), `supabase db push` (official CLI), `supabase gen types` (official CLI), supabase realtime subscribe (WebSocket — out of scope)."

--- a/library/other/gravitus/SKILL.md
+++ b/library/other/gravitus/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: pp-gravitus
 description: "The only CLI that syncs your Gravitus strength data into your training dashboard. Trigger phrases: `sync my Gravitus workouts`, `load my lifting data into the dashboard`, `find my plateau lifts`, `export my Gravitus data`, `check my personal records`, `use gravitus`, `run gravitus-pp-cli`."
 author: "mvanhorn"


### PR DESCRIPTION
## Summary

Two published CLIs fail to install their skill via `npx -y @mvanhorn/printing-press install <name>` (and the underlying `npx skills@latest add ...`):

> No valid skills found. Skills require a SKILL.md with name and description.

The binary installs fine in both cases — only the skill doc fails.

> ⚠️ **Depends on #996 — merge that first.** See "Sequencing" below.

## Root cause

`skills@latest add` requires the YAML frontmatter `---` at the **very top** of `SKILL.md` and does **not** skip leading content. Two `library/**/SKILL.md` sources had bytes before the opening fence:

| CLI | Leading bytes before `---` |
|---|---|
| `developer-tools/supabase` | a `<!-- // PATCH … -->` comment line |
| `other/gravitus` | a UTF-8 BOM (`EF BB BF`) |

This also defeated the mirror generator's frontmatter detection (`frontmatterEnd()` in `tools/generate-skills/main.go` only recognizes frontmatter when the file starts with `---\n`), so its `GENERATED FILE` header was prepended at the top, stacking *more* bytes before `---`. Mirrors that install correctly (figma, stripe, slack, …) have `---` on line 1.

## Fix

Both source `SKILL.md` files now start with `---`:

- **supabase** — removed the leading inline `// PATCH` comment. The customization it described is already recorded in `library/developer-tools/supabase/.printing-press-patches.json` (`readme-skill-calibrated-tagline`), and inline `// PATCH` comments are optional per AGENTS.md, so nothing is lost.
- **gravitus** — stripped the UTF-8 BOM.

With the sources fixed, they install directly **and** the generator injects its header after the frontmatter, so the regenerated mirrors also start with `---`.

## Sequencing (depends on #996)

The `Guard CLI attribution` check reads the SKILL.md `author:` with the same strict `\A---` match. Against the **base** version of these files (BOM/comment present) it reads the author as `None`; after this fix it reads the real value — so it reports a phantom attribution change and gates the PR, even though the author never changed. `verify-library-conventions.yml` deliberately runs the **base-branch** copy of the guard, so the guard fix can't take effect in this same PR. #996 lands that guard hardening on `main` first; once merged, this PR's attribution check passes. Until then the `Verify` job is expected to be red on the attribution step only.

## Validation

- `verify_skill.py --dir library/developer-tools/supabase/` and `--dir library/other/gravitus/` → all checks pass
- Ran `tools/generate-skills` locally: regenerated `pp-supabase` / `pp-gravitus` mirrors now start with `---` on line 1; the other 210 mirrors are byte-identical (idempotent)
- Verified the fixed skill installs cleanly end-to-end with `skills add`

## Scope notes

- Diff is **two `library/` SKILL.md files only**. Regenerated `cli-skills/pp-*/SKILL.md` mirrors are intentionally **not** included — regenerated post-merge by `generate-skills.yml`.
- No `.printing-press.json` added → not a new-CLI/reprint submission.
- A library-wide sweep confirmed these are the **only** two `library/**/SKILL.md` files that don't begin with `---`.