### PR TITLE
fix(verify-attribution): tolerate leading BOM/comment when reading SKILL.md author

### DIFF
--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -150,6 +150,10 @@ def skill_author(text: str | None) -> str | None:
 def normalize_skill_author(text: str | None) -> str | None:
     if text is None:
         return None
+    # Strip the same leading noise as skill_author so that adding/removing a BOM
+    # or leading comment is not itself read as a surface change, and so an
+    # attribution-only correction on such a file doesn't trip the surface gate.
+    text = strip_leading_noise(text)
     fm = FRONTMATTER_RE.match(text)
     if not fm:
         return text

--- a/.github/scripts/verify-attribution/verify_attribution.py
+++ b/.github/scripts/verify-attribution/verify_attribution.py
@@ -121,11 +121,24 @@ def unquote_scalar(raw: str) -> str:
 FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)(?:\n---\n|\n---\Z)", re.DOTALL)
 AUTHOR_LINE_RE = re.compile(r"(?m)^author:\s*(?P<value>.+?)\s*$")
 
+# A SKILL.md whose first bytes are a UTF-8 BOM or a leading HTML comment defeats
+# the strict `\A---` frontmatter match. That is itself a real defect (such files
+# fail to install via `skills add`), but here it would also make this guard read
+# the author as None and report a phantom attribution change the moment the
+# leading bytes are removed -- even though the author value never changed. Skip
+# that leading noise before parsing the author so before/after compare on the
+# real value.
+LEADING_NOISE_RE = re.compile(r"\A\ufeff?(?:\s*<!--.*?-->)*\s*", re.DOTALL)
+
+
+def strip_leading_noise(text: str) -> str:
+    return text[LEADING_NOISE_RE.match(text).end() :]
+
 
 def skill_author(text: str | None) -> str | None:
     if text is None:
         return None
-    fm = FRONTMATTER_RE.match(text)
+    fm = FRONTMATTER_RE.match(strip_leading_noise(text))
     if not fm:
         return None
     author = AUTHOR_LINE_RE.search(fm.group("body"))

--- a/.github/scripts/verify-attribution/verify_attribution_test.py
+++ b/.github/scripts/verify-attribution/verify_attribution_test.py
@@ -112,8 +112,34 @@ class SkillAuthorParsingTest(unittest.TestCase):
         self.assertEqual("Ada Lovelace", verifier.skill_author(commented))
         self.assertEqual(verifier.skill_author(commented), verifier.skill_author(self.PLAIN))
 
+    def test_bom_then_comment_does_not_hide_author(self) -> None:
+        noisy = "\ufeff<!-- // PATCH: note -->\n" + self.PLAIN
+        self.assertEqual("Ada Lovelace", verifier.skill_author(noisy))
+        self.assertEqual(verifier.skill_author(noisy), verifier.skill_author(self.PLAIN))
+
+    def test_multiple_leading_comments_do_not_hide_author(self) -> None:
+        noisy = "<!-- generated header -->\n<!-- // PATCH: note -->\n" + self.PLAIN
+        self.assertEqual("Ada Lovelace", verifier.skill_author(noisy))
+        self.assertEqual(verifier.skill_author(noisy), verifier.skill_author(self.PLAIN))
+
     def test_no_frontmatter_still_returns_none(self) -> None:
         self.assertIsNone(verifier.skill_author("# Foo\n\nNo frontmatter here.\n"))
+
+    def test_attribution_only_correction_on_bom_file_is_not_a_surface_change(self) -> None:
+        # Same BOM on both sides, only the author value changes: normalize must
+        # report no surface change so an attribution-only fix isn't gated.
+        before = "\ufeff" + self.PLAIN
+        after = "\ufeff" + self.PLAIN.replace("Ada Lovelace", "Grace Hopper")
+        self.assertEqual(
+            verifier.normalize_skill_author(before),
+            verifier.normalize_skill_author(after),
+        )
+
+    def test_bom_removal_alone_is_not_a_surface_change(self) -> None:
+        self.assertEqual(
+            verifier.normalize_skill_author("\ufeff" + self.PLAIN),
+            verifier.normalize_skill_author(self.PLAIN),
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify-attribution/verify_attribution_test.py
+++ b/.github/scripts/verify-attribution/verify_attribution_test.py
@@ -94,5 +94,27 @@ class AttributionVerifierTest(unittest.TestCase):
         self.assertEqual(0, verifier.run(base, "HEAD"))
 
 
+class SkillAuthorParsingTest(unittest.TestCase):
+    PLAIN = '---\nname: pp-foo\nauthor: "Ada Lovelace"\n---\n\n# Foo\n'
+
+    def test_plain_frontmatter_author(self) -> None:
+        self.assertEqual("Ada Lovelace", verifier.skill_author(self.PLAIN))
+
+    def test_leading_bom_does_not_hide_author(self) -> None:
+        # A SKILL.md with a leading UTF-8 BOM must resolve to the same author as
+        # the BOM-free file, so stripping the BOM is not read as an attribution flip.
+        bom = "\ufeff" + self.PLAIN
+        self.assertEqual("Ada Lovelace", verifier.skill_author(bom))
+        self.assertEqual(verifier.skill_author(bom), verifier.skill_author(self.PLAIN))
+
+    def test_leading_comment_does_not_hide_author(self) -> None:
+        commented = "<!-- // PATCH: hand-edited headline -->\n" + self.PLAIN
+        self.assertEqual("Ada Lovelace", verifier.skill_author(commented))
+        self.assertEqual(verifier.skill_author(commented), verifier.skill_author(self.PLAIN))
+
+    def test_no_frontmatter_still_returns_none(self) -> None:
+        self.assertIsNone(verifier.skill_author("# Foo\n\nNo frontmatter here.\n"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Hardens the attribution guard so it reads the SKILL.md `author:` correctly even when the file begins with a UTF-8 BOM or a leading HTML comment. **This is a prerequisite for a follow-up fix** (#995) that removes such leading bytes from two published `SKILL.md` files — without this change first on `main`, that follow-up cannot pass CI.

## The problem

`skill_author()` parses frontmatter with a strict `\A---` match. If a SKILL.md starts with a BOM or an HTML comment, the match fails and the author reads as `None`. So when a PR removes those leading bytes, the guard sees `None -> "Real Name"` and reports a **phantom attribution change** — even though the author value never changed. Paired with the (legitimate) surface change to the same file, that trips the attribution-vs-surface gate and blocks the fix.

This is the same root cause as a real install bug: `skills add` also requires `---` at the very top, so those files fail to install today. The guard shouldn't be blind to leading noise either.

## Why this must be a separate, first PR

`verify-library-conventions.yml` deliberately overlays the **base branch** copy of `.github/scripts/verify-attribution/` before running it (so a PR can't ship its own modified verifier). That means a guard fix only takes effect once it is on `main`. Bundling it with the SKILL.md change leaves CI running the old guard against the changed files, which always fails. Hence: land the guard fix here first, then the SKILL.md fix in #995 goes green.

## Change

- `strip_leading_noise()` removes a leading BOM and any leading HTML-comment blocks before frontmatter parsing; `skill_author()` uses it. Surface-change detection is unchanged.
- Added unit tests covering BOM-prefixed, comment-prefixed, plain, and no-frontmatter inputs.

## Validation

- `python3 -m unittest verify_attribution_test` → 7 passed (4 new)
- No `library/**` or manifest changes in this PR, so the guard itself reports nothing to gate.