### PR TITLE
feat(splitwise): consolidated feature roundup (audit, forecast, normalize, report, fairness, MCP & CLI polish)

### DIFF
--- a/library/payments/splitwise/.printing-press-patches/fairness-carrier-role-paid-owes-nothing.json
+++ b/library/payments/splitwise/.printing-press-patches/fairness-carrier-role-paid-owes-nothing.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "fairness-carrier-role-paid-owes-nothing",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "fairness --by contribution classifies a member who paid but owes nothing as carrier, not rider.",
+  "reason": "classifyRole defaults a nil CarryRatio to rider; a payer excluded from the split has an unbounded carry ratio and is a pure carrier.",
+  "files": [
+    "internal/cli/splitwise_fairness.go",
+    "internal/cli/splitwise_fairness_test.go"
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/mcp-list-tool-byte-pagination.json
+++ b/library/payments/splitwise/.printing-press-patches/mcp-list-tool-byte-pagination.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 2,
+  "id": "mcp-list-tool-byte-pagination",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "GET list MCP tools byte-budget-paginate by default (PaginateByBytes/ListFromResponse/PaginateBody in internal/cli); the 5 no-native-paging list tools gain client offset/limit params. Stops get-groups_list's ~118KB firehose.",
+  "reason": "makeAPIHandler returned raw list bodies with no size control, so get-groups_list (~118,973 chars) exceeded the host token budget. Added a shared byte-budget pager in internal/cli (the CLI owns output shaping). The pager runs ONLY for GET tools that do not page natively (paginatesNatively(bindings) is false): endpoints with native offset/limit (get-expenses, get-notifications) are left untouched so their API-paginated response keeps its native schema and full-collection total rather than being re-wrapped in the {total,...,items} envelope. maxBytes default 24KB, PP_MCP_MAX_BYTES override. For the client-paged tools, offset/limit are marked consumed in knownArgs (same paginatesNatively gate) so the generic args-forwarding loop does not append them to the upstream query string; without that guard a client cursor leaked to an endpoint that accepts it natively (e.g. /get_comments?offset=N), making the API return a partial slice that PaginateBody then mis-totaled.",
+  "known_limitation": "List detection at the MCP call site uses lone-top-level-array auto-detection (listField=\"\"). A GET 200 body carrying a SIBLING top-level array (e.g. an errors:[] companion) would fail auto-detect and pass through unpaginated. Not the case for the 5 targeted GET list success shapes ({groups|friends|categories|comments|currencies}:[...] are lone-array envelopes). Closed in Increment 2, where the generator passes the spec-derived listField per tool so detection never depends on the array-count heuristic.",
+  "files": [
+    "internal/cli/pagination.go",
+    "internal/cli/pagination_test.go",
+    "internal/mcp/tools.go",
+    "internal/mcp/pagination_wiring_test.go"
+  ],
+  "validated_outcome": "PaginateByBytes/ListFromResponse/PaginateBody (15 cases) + mcpIntArg/bindingHasName/paginatesNatively pass; get-groups_list returns a {total,offset,returned,next_offset,items} page under the byte budget instead of ~118KB; the 5 no-native list tools expose offset/limit while get-expenses/notifications keep their native API response untouched (pager gated off for natively-paged tools); the client cursor no longer leaks into the upstream query string; gofmt/build/vet/test, govulncheck, verify-skill pass.",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/2515",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator: emit listField + offset/limit params + the shared PaginateByBytes/ListFromResponse/PaginateBody helpers into every printed CLI's list tools; reconcile native-paged endpoints; add CLI --agent/--max-bytes routing through the same pager.",
+      "reason": "Generator-shaped (#2515). Increment 2 — developed in cli-printing-press-private, promoted to a public PR closing #2515. Design: workshop hub splitwise-list-pagination-design.md."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/mcp-numeric-param-scientific-notation.json
+++ b/library/payments/splitwise/.printing-press-patches/mcp-numeric-param-scientific-notation.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 2,
+  "id": "mcp-numeric-param-scientific-notation",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "MCP path/query params no longer render large integer IDs in scientific notation (get-friend 1925035 was building /get_friend/1.925035e+06 and 403ing).",
+  "reason": "makeAPIHandler stringified MCP arguments with fmt.Sprintf(\"%v\", v). JSON numbers arrive as float64, and %v prints a large integer-valued float in scientific notation, so a numeric path id (id 1925035 -> 1.925035e+06) or numeric query filter (group_id/friend_id/limit/offset) was corrupted — get-friend/get-expense/get-group/get-user and the delete/update endpoints all break for real Splitwise IDs (>1e6). Added formatMCPParamValue which uses strconv.FormatFloat('f', -1) for float64 (minimal decimal, no exponent) and falls back to %v otherwise. Fixing the path also resolved the 403 (it was Splitwise rejecting the malformed id, not a permission restriction).",
+  "files": [
+    "internal/mcp/tools.go",
+    "internal/mcp/format_param_test.go"
+  ],
+  "validated_outcome": "TestFormatMCPParamValue pins 1925035.0->\"1925035\", 28.48->\"28.48\"; driving the live get-friend_get tool with id=1925035 now returns the friend (path /get_friend/1925035). gofmt/build/vet/test, govulncheck, verify-skill pass.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator fix: command_endpoint MCP handler template (makeAPIHandler) must format numeric path/query params without scientific notation.",
+      "reason": "Generator-shaped — tools.go is generated DO-NOT-EDIT; every printed CLI whose API has numeric path/query params (IDs, limits, offsets) over ~1e6 is affected. The %v-on-float64 should be FormatFloat('f') in the template. Filed as a cli-printing-press retro."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/mcp-sql-tool-schema-description.json
+++ b/library/payments/splitwise/.printing-press-patches/mcp-sql-tool-schema-description.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "mcp-sql-tool-schema-description",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "The sql MCP tool's query-param description now documents the real store schema (single resources table keyed by resource_type, JSON data, json_extract) instead of the false 'Tables match resource names'.",
+  "reason": "The local store keeps every synced record in ONE resources(resource_type, id, data, ...) table with the record JSON in `data` — there are no per-resource tables. The generated description claimed 'Tables match resource names', so MCP hosts tried FROM groups / FROM get_groups and got 'no such table', burning queries before stumbling onto the resources/json_extract pattern. Extracted the description to a sqlQueryParamDesc constant naming resources/resource_type/json_extract with a worked example.",
+  "files": [
+    "internal/mcp/tools.go",
+    "internal/mcp/sql_description_test.go"
+  ],
+  "validated_outcome": "TestSQLToolParamDescribesRealSchema pins resources/resource_type/json_extract present and 'Tables match resource names' absent; gofmt/build/vet/test, govulncheck, verify-skill pass.",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/2516",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator fix: the sql tool template must describe the real resources/resource_type/json_extract schema, not 'Tables match resource names'.",
+      "reason": "Generator-shaped — tools.go is generated DO-NOT-EDIT; every store-backed printed CLI ships the same misleading sql-tool description that sends MCP hosts to non-existent per-resource tables. Filed as a cli-printing-press retro."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/mcp-tool-appname-discovery.json
+++ b/library/payments/splitwise/.printing-press-patches/mcp-tool-appname-discovery.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 2,
+  "id": "mcp-tool-appname-discovery",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Front-load the 'Splitwise' app name into the context/search/sql MCP tool descriptions so a deferred-tool host (Cowork) searching the tool surface by app name finds the connector.",
+  "reason": "No MCP tool name carries the app name (they are resource/verb-based: get-groups_list, search, sql, context), and the entry-point tools' descriptions didn't mention it. A host that discovers tools by app-name keyword (Cowork: query='splitwise') got no hit and wrongly concluded no connector was installed, pivoting to the public MCP install registry. Extracted contextToolDesc/searchToolDesc/sqlToolDesc constants leading with 'Splitwise'.",
+  "files": [
+    "internal/mcp/tools.go",
+    "internal/mcp/discoverability_test.go"
+  ],
+  "validated_outcome": "TestEntryPointToolsAreDiscoverableByAppName pins 'Splitwise' present in the context/search/sql tool descriptions; gofmt/build/vet/test, govulncheck, verify-skill pass. (Improves app-name discoverability; a host-side cold-start/lazy-index component may remain.)",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/2553",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator fix: front-load the API/app name into generated MCP tool descriptions (at minimum the context/search/sql entry-point tools).",
+      "reason": "Generator-shaped — every printed CLI's MCP tool surface is resource/verb-based with the API name absent, so deferred-tool hosts that search by app name miss the connector. Filed as a cli-printing-press retro."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/mcp-version-startup-banner.json
+++ b/library/payments/splitwise/.printing-press-patches/mcp-version-startup-banner.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 2,
+  "id": "mcp-version-startup-banner",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "The MCP server now reports the real build version (via cli.Version() instead of a hardcoded \"1.0.0\") and writes a startup banner to stderr on load, so a host's MCP log identifies which build is running.",
+  "reason": "cmd/splitwise-pp-mcp/main.go passed a literal \"1.0.0\" to NewMCPServer (ignoring the ldflags-injected internal/cli.version the CLI uses) and logged nothing on stdio startup, so there was no way to tell which build Claude Desktop loaded when dogfooding multiple builds. Added cli.Version() accessor, wired it into NewMCPServer, and added startupBanner(version, transport) printed to stderr. Because goreleaser already injects internal/cli.version into all binaries, published MCP builds now report their real release version for free.",
+  "files": [
+    "internal/cli/root.go",
+    "cmd/splitwise-pp-mcp/main.go",
+    "cmd/splitwise-pp-mcp/main_test.go"
+  ],
+  "validated_outcome": "TestStartupBannerIncludesVersionAndTransport passes; a plain build prints 'splitwise-pp-mcp 1.0.0 starting (transport=stdio)' to stderr, and an ldflags build (-X internal/cli.version=...) prints the injected version; gofmt/build/vet/test, govulncheck, verify-skill pass.",
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/2554",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator fix: the MCP main template must report the real build version (wire NewMCPServer to the ldflags-injected internal/cli.version) and write a startup banner to stderr.",
+      "reason": "Generator-shaped — every printed CLI's MCP main hardcodes \"1.0.0\" and is silent on stdio startup, so no host log identifies the running build. Filed as a cli-printing-press retro."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/multiword-positional-names.json
+++ b/library/payments/splitwise/.printing-press-patches/multiword-positional-names.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 2,
+  "id": "multiword-positional-names",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Name-positional commands settle-up, resolve, split, and ledger rejoin multi-word names from multiple positional args instead of reading only args[0], so a name the MCP command-mirror whitespace-split (args:\"EDCO 2021\" -> [\"EDCO\",\"2021\"]) resolves correctly. joinNameArgs is defined canonically here in splitwise_settle.go.",
+  "reason": "settle-up/resolve/split/ledger read input from args[0] only, so a multi-word group/friend name split into several positionals (cobratree SplitShellArgs whitespace-splits the args string when the agent doesn't inner-quote) was truncated to the first token, then substring-matched several groups and errored as ambiguous (observed dogfooding settle_up on 'EDCO 2021'). Added shared joinNameArgs(args) used by all four (split and ledger added after Greptile flagged them as carrying the same defect). The fairness nudge command (not present on this base) carries the same fix on its own PR.",
+  "files": [
+    "internal/cli/splitwise_settle.go",
+    "internal/cli/splitwise_balances.go",
+    "internal/cli/splitwise_split.go",
+    "internal/cli/splitwise_spend.go",
+    "internal/cli/splitwise_settle_input_test.go"
+  ],
+  "validated_outcome": "TestJoinNameArgs, TestSettleResolvesMultiWordGroupName, TestLedgerResolvesMultiWordGroupName, and TestNameCommandsAcceptMultiWordPositionals (the last guards the cobra Args validator accepts 2+ positionals for settle-up, resolve, split, and ledger) pass; gofmt/build/vet/test, govulncheck, verify-skill pass.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator/cobratree: a command taking a multi-word positional name should not require the agent to inner-quote it in the MCP command-mirror args string (the SplitShellArgs whitespace-split is the root cause).",
+      "reason": "Generator-shaped — related to the cobratree command-mirror discoverability gap (cli-printing-press#2517). The library-side joinNameArgs is the local mitigation."
+    }
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/normalize-unsynced-current-user-note.json
+++ b/library/payments/splitwise/.printing-press-patches/normalize-unsynced-current-user-note.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "normalize-unsynced-current-user-note",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "normalize emits a stderr note when the current user is unsynced (youID==0) so a silently-zero Spend total is explained.",
+  "reason": "Consistency with balances --by-group; without it a 0.00 Spend reads as a real total rather than an unknown-identity artifact.",
+  "files": [
+    "internal/cli/splitwise_normalize.go",
+    "internal/cli/splitwise_normalize_test.go"
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/report-csv-truncation-stderr-note.json
+++ b/library/payments/splitwise/.printing-press-patches/report-csv-truncation-stderr-note.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "report-csv-truncation-stderr-note",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "report --format csv emits a stderr note when --limit truncates rows, matching json/md/summary.",
+  "reason": "renderReportCSV ignored res.Truncated, so a capped CSV looked complete with no in-band or stderr signal.",
+  "files": [
+    "internal/cli/splitwise_report.go",
+    "internal/cli/splitwise_report_test.go"
+  ]
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-audit-data-quality-and-cost-outliers.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-audit-data-quality-and-cost-outliers.json
@@ -5,7 +5,7 @@
   "base_run_id": "20260528-002755",
   "base_printing_press_version": "4.19.0",
   "summary": "Add an audit command that scans synced expenses for likely duplicates and per-category cost outliers.",
-  "reason": "Splitwise has no built-in data-quality check, so double-entered charges (repeated identical 'Settle all balances' rows) and anomalous expenses go unnoticed. audit reads the local expense store (skipping payments and deleted expenses), clusters exact duplicates by normalized description + cost + date + group, and flags per-category cost outliers above mean + 3*stddev (only for categories with >= 5 samples). Read-only; --limit caps findings per type.",
+  "reason": "Splitwise has no built-in data-quality check, so double-entered charges (repeated identical 'Settle all balances' rows) and anomalous expenses go unnoticed. audit reads the local expense store (skipping payments and deleted expenses), clusters exact duplicates by normalized description + cost + date + group, and flags per-category cost outliers using a two-sided robust modified z-score (|z| > 3.5 vs. category median/MAD; flags items far above OR below the median, only for categories with >= 5 samples). Read-only; --limit caps findings per type.",
   "files": [
     "internal/cli/splitwise_audit.go",
     "internal/cli/splitwise_audit_test.go",

--- a/library/payments/splitwise/.printing-press-patches/splitwise-audit-data-quality-and-cost-outliers.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-audit-data-quality-and-cost-outliers.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-audit-data-quality-and-cost-outliers",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add an audit command that scans synced expenses for likely duplicates and per-category cost outliers.",
+  "reason": "Splitwise has no built-in data-quality check, so double-entered charges (repeated identical 'Settle all balances' rows) and anomalous expenses go unnoticed. audit reads the local expense store (skipping payments and deleted expenses), clusters exact duplicates by normalized description + cost + date + group, and flags per-category cost outliers above mean + 3*stddev (only for categories with >= 5 samples). Read-only; --limit caps findings per type.",
+  "files": [
+    "internal/cli/splitwise_audit.go",
+    "internal/cli/splitwise_audit_test.go",
+    "internal/cli/root.go"
+  ],
+  "validated_outcome": "go build/vet/test pass; runAudit unit tests cover duplicate clustering with description normalization, cost-outlier detection, normal-expense exclusion, small-category skip, and payment/deleted exclusion; verify-skill passes; audit --agent ran against a live 113-expense store and surfaced real outliers."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-fairness-command.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-fairness-command.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-fairness-command",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add the `fairness` analytics command (risk / contribution / collectability lenses); render day-ages as readable durations (humanizeDays + shared ageCell) in the fairness and debts human tables while JSON keeps raw *_days for analytics tools.",
+  "reason": "Hand-built offline-analytics command over the synced store, completing the net/audit/forecast set. Surfaces who carries the group, a 0-100 collection-risk score with nudge/chase/write-off action tiers, and contribution (carry-ratio) and collectability (debt age, settle latency) lenses. Empty-history members are surfaced separately and never scored as riders/risk. Outstanding-balance holders are never windowed away by --since. Reuses existing helpers (Friend.Balance sign, SimplifiedDebts, parseSplitwiseDate, round2, loaders); no generator change. The ageCell/humanizeDays display helpers are shared with the debts AGE column for consistent human rendering.",
+  "files": [
+    "internal/cli/splitwise_fairness.go",
+    "internal/cli/splitwise_fairness_test.go",
+    "internal/cli/splitwise_balances.go",
+    "internal/cli/root.go"
+  ],
+  "validated_outcome": "TestComputeFairness* table-driven suite (risk-score formula pinned at 90 for the write-off anchor, episode latency 19/15, multi-currency, group-scope via SimplifiedDebts) passes; TestHumanizeDays + TestAgeCell pin the readable-duration rendering; TestComputeFairnessSinceKeepsOutstandingDebtor pins that --since cannot hide an open debt; gofmt, go build/vet/test, govulncheck, and verify-skill all pass; live dogfood on a real account ran all three lenses."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-fairness-nudge.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-fairness-nudge.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-fairness-nudge",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add fairness nudge as a write action that posts a reminder comment on a shared expense, accepting multi-word friend names.",
+  "reason": "Splitwise has no send-reminder API; comment creation is the API-native nudge path. The command is preview-by-default and only posts with --send so reminder writes are explicit and safe. The default message quotes the friend's owed share, not the expense total. The Args validator is cobra.MinimumNArgs(1) (not ExactArgs(1)) and the friend name is rejoined with an inline strings.TrimSpace(strings.Join(args, \" \")) so a quoted multi-word friend name whitespace-split by the MCP command-mirror resolves to the full name instead of substring-matching on the first token. The inline join can be refactored to call joinNameArgs once the multiword settle/resolve patch lands that helper in the cli package.",
+  "files": [
+    "internal/cli/splitwise_fairness.go",
+    "internal/cli/splitwise_fairness_nudge.go",
+    "internal/cli/splitwise_fairness_nudge_test.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "Added failing-first tests for pure nudge target/message helpers plus a multi-word-positional Args test, then passed gofmt, go build, go vet, go test ./internal/cli/... with preview-only default and --send comment posting."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-fairness-projected-settle-date.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-fairness-projected-settle-date.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-fairness-projected-settle-date",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add projected settle-date fields to fairness output and collectability table projection rendering.",
+  "reason": "Collectability now projects when an open debt is expected to settle by combining current debt age with historical average settle latency; JSON includes raw `projected_days_out` and ISO `projected_settle_date`. Gated on outstanding>0 so a settled $0 balance never gets a projection (dogfood caught it firing for settled people).",
+  "files": [
+    "internal/cli/splitwise_fairness.go",
+    "internal/cli/splitwise_fairness_test.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "Added failing-first tests for projectSettle and computeFairness projection behavior (incl. a settled-debtor regression), then passed gofmt, go build, go vet, go test ./internal/cli/... with projected-days/date wired into collectability human + JSON output."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-forecast-upcoming-obligations.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-forecast-upcoming-obligations.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-forecast-upcoming-obligations",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add an offline `forecast` command that projects upcoming shared obligations from recurring spending patterns over the synced expense store.",
+  "reason": "Splitwise tracks past expenses but offers no forward view of what shared bills are coming due. This was the third of three analytics commands #949 deferred to follow-up PRs (after `net` and `audit`). `forecast` clusters expenses by normalized description, applies a self-contained regularity gate, and projects each regular charge's next expected date/amount, flagging overdue ones. Built only on helpers present on main (loadExpenses, loadGroups, expenseDeleted, normalizeRecurringKey, parseFlexibleDate, parseAmount, round2, mostCommonString, flags.printJSON, openSplitwiseStore) with a local settlement-description check, so it does not depend on the unmerged #949 branch.",
+  "files": [
+    "internal/cli/splitwise_forecast.go",
+    "internal/cli/splitwise_forecast_test.go",
+    "internal/cli/root.go"
+  ],
+  "validated_outcome": "New TestComputeForecast_* and TestLooksLikeSettlement pass; go build/vet/test, govulncheck (0 reachable), and verify_skill all pass. forecast --help / --dry-run smoke clean."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-normalize-multicurrency.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-normalize-multicurrency.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-normalize-multicurrency",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add a normalize command that converts multi-currency net position and spend into a single base currency.",
+  "reason": "Provide deterministic offline multi-currency normalization with user-supplied FX rates from --rate and --rates-file; historical or automatic FX lookup is intentionally out of scope.",
+  "files": [
+    "internal/cli/splitwise_normalize.go",
+    "internal/cli/splitwise_normalize_test.go",
+    "internal/cli/root.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "splitwise_normalize tests pass and required offline gates (gofmt, go build, go vet, go test ./internal/cli/...) pass."
+}

--- a/library/payments/splitwise/.printing-press-patches/splitwise-report-export.json
+++ b/library/payments/splitwise/.printing-press-patches/splitwise-report-export.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 2,
+  "id": "splitwise-report-export",
+  "applied_at": "2026-05-30",
+  "base_run_id": "20260528-002755",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Add an offline report command that exports trip/period spending to Markdown, CSV, or JSON.",
+  "reason": "Provide deterministic, read-only trip/period report export from the local store with single-currency output (most-common by default, or explicit --currency) so mixed currencies are never incorrectly combined; PDF is intentionally out of scope for v1. Markdown table cells escape pipes/newlines from user descriptions. Uses a self-contained resolveReportGroup so report does not depend on any other novel command.",
+  "files": [
+    "internal/cli/splitwise_report.go",
+    "internal/cli/splitwise_report_test.go",
+    "internal/cli/root.go",
+    "SKILL.md",
+    "README.md"
+  ],
+  "validated_outcome": "Required offline gates pass: gofmt, go build, go vet, go test ./..., govulncheck (0 reachable), verify-skill."
+}

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -207,7 +207,7 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli split "Tahoe Trip" --amount 84 --equal --agent
   ```
 - **`net`** — Net balances across all groups into the fewest direct transfers to settle your whole account (plan-only; `--record` planned).
-- **`audit`** — Scan synced expenses offline for likely duplicates (same description, cost, date, and group) and per-category cost outliers (above mean + 3σ); read-only, `--limit` caps findings per type (default 50).
+- **`audit`** — Scan synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; high-side threshold > 3.5); read-only, `--limit` caps findings per type (default 50).
 
 ## Recipes
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -183,6 +183,14 @@ These capabilities aren't available in any other tool for this API.
   ```bash
   splitwise-pp-cli recurring --agent
   ```
+- **`forecast`** — Project upcoming shared obligations from recurring spending patterns. Finds charges with a regular cadence and reports the next expected date and amount for anything due inside the window (default 35 days) or already overdue.
+
+  _Use to budget for next month's shared bills, or catch a regular charge that's overdue and unlogged._
+
+  ```bash
+  splitwise-pp-cli forecast --agent
+  splitwise-pp-cli forecast --days 60 --json
+  ```
 
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -184,6 +184,7 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 - **`forecast`** — Project upcoming shared obligations from recurring spending patterns. Finds charges with a regular cadence and reports the next expected date and amount for anything due inside the window (default 35 days) or already overdue.
+  Forecast reads from your synced local store; on large accounts, results can be incomplete until a full sync.
 
   _Use to budget for next month's shared bills, or catch a regular charge that's overdue and unlogged._
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -207,6 +207,7 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli split "Tahoe Trip" --amount 84 --equal --agent
   ```
 - **`net`** — Net balances across all groups into the fewest direct transfers to settle your whole account (plan-only; `--record` planned).
+- **`audit`** — Scan synced expenses offline for likely duplicates (same description, cost, date, and group) and per-category cost outliers (above mean + 3σ); read-only, `--limit` caps findings per type (default 50).
 
 ## Recipes
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -222,6 +222,16 @@ splitwise-pp-cli net
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
 
+### Catch bad data before you settle — `audit`
+
+**Find likely duplicate expenses and per-category cost outliers:**
+
+```bash
+splitwise-pp-cli audit
+```
+
+Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -323,7 +323,7 @@ Per person: paid, owed, net, carry-ratio, and a carrier/even/rider role. Informa
 splitwise-pp-cli fairness --by collectability
 ```
 
-Sorted by debt age, with average settle latency and days since they last settled.
+Sorted by debt age, with average settle latency and days since they last settled; `--by collectability` now also shows a projected settle date (raw `projected_days_out` in JSON).
 
 **Scope to one friend, or one group/trip:**
 
@@ -345,6 +345,24 @@ Human tables print ages as `4y 3mo 8d`; JSON keeps raw `*_days` integers so tool
 ```bash
 splitwise-pp-cli fairness --by risk --write-off-days 730 --ghost-days 90
 ```
+
+### Nudge a friend to pay — `fairness nudge`
+
+Splitwise has no send-reminder endpoint, so this command posts a comment on a shared unsettled expense; Splitwise then notifies participants per their own notification settings.
+
+Preview only by default:
+
+```bash
+splitwise-pp-cli fairness nudge "Alex"
+```
+
+Actually post the reminder comment:
+
+```bash
+splitwise-pp-cli fairness nudge "Alex" --send
+```
+
+Optional flags: `--message` to override reminder text, `--expense-id` to force a specific expense, and `--send` to post (otherwise preview only). Reachability caveat: this CLI's synced `Friend` shape does not include email/registration status, so v1 does not pre-gate on confirmed-account status.
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -241,6 +241,16 @@ splitwise-pp-cli audit
 
 Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
 
+### See what's coming — `forecast`
+
+**Project next month's recurring shared obligations:**
+
+```bash
+splitwise-pp-cli forecast
+```
+
+Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -297,6 +297,55 @@ splitwise-pp-cli forecast
 
 Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
 
+### Collect what you're owed — the `fairness` cookbook
+
+`fairness` turns your synced ledger into an action list. Default lens is **risk** (who to chase, worst first).
+
+**Who should I chase, and what should I just write off?**
+
+```bash
+splitwise-pp-cli fairness --by risk
+```
+
+Ranks everyone who owes you by a 0–100 collection-risk score with a per-row action: 🟢 on track · 🟡 nudge · 🟠 chase · 🔴 write-off (old **and** gone quiet). The footer totals at-risk vs. write-off dollars.
+
+**Who carries the group (fronts cash) vs. who free-rides?**
+
+```bash
+splitwise-pp-cli fairness --by contribution
+```
+
+Per person: paid, owed, net, carry-ratio, and a carrier/even/rider role. Informational — Splitwise settles regardless of who pays.
+
+**Who's slow to settle / a live collection risk?**
+
+```bash
+splitwise-pp-cli fairness --by collectability
+```
+
+Sorted by debt age, with average settle latency and days since they last settled.
+
+**Scope to one friend, or one group/trip:**
+
+```bash
+splitwise-pp-cli fairness --friend "Alex"
+splitwise-pp-cli fairness --group "Tahoe Trip"
+```
+
+**Agent mode — the action list as JSON (raw day-counts for your own math):**
+
+```bash
+splitwise-pp-cli fairness --by risk --agent
+```
+
+Human tables print ages as `4y 3mo 8d`; JSON keeps raw `*_days` integers so tools convert themselves.
+
+**Tune the write-off threshold** (default: 365 days old + 180 days silent):
+
+```bash
+splitwise-pp-cli fairness --by risk --write-off-days 730 --ghost-days 90
+```
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -202,6 +202,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
   ```
 
+### Trip & period reports
+- **`report`** — Export an offline trip/period spend report as Markdown, CSV, or JSON. Report output is single-currency: default is the most common filtered currency, other currencies are excluded and counted, and `--currency` pins one explicitly.
+
+  _Use to hand someone a trip summary, or to archive a period's shared spend — totals, per-person paid/owed/net, per-category breakdown, and the expense list, in a format you can paste or commit._
+
+  ```bash
+  splitwise-pp-cli report --group "Tahoe Trip" --format md
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -238,6 +247,16 @@ splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
 ```
 
 Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
+
+### Export a trip/period report — `report`
+
+Generate a deterministic offline report for a group/trip or date range.
+
+```bash
+splitwise-pp-cli report --group "Tahoe Trip" --format md
+splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv
+splitwise-pp-cli report --agent
+```
 
 ### Settle the whole network in the fewest transfers — `net`
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -193,6 +193,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli forecast --days 60 --json
   ```
 
+### Multi-currency normalization
+- **`normalize`** — Normalize multi-currency net position and spend into one base currency using user-supplied offline FX rates (`--rate` / `--rates-file`); historical/automatic FX lookup is intentionally out of scope.
+
+  _Use to compare or total spend across trips in different currencies — supply the rates and get one base-currency number; a currency with no rate is surfaced as unconverted, never silently dropped._
+
+  ```bash
+  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -220,6 +229,15 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
+### Normalize multi-currency spend — `normalize`
+
+Convert mixed-currency balances/spend into one base currency with deterministic, user-supplied rates.
+
+```bash
+splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
+```
+
+Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
 
 ### Settle the whole network in the fewest transfers — `net`
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -243,7 +243,7 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli split "Tahoe Trip" --amount 84 --equal --agent
   ```
 - **`net`** — Net balances across all groups into the fewest direct transfers to settle your whole account (plan-only; `--record` planned).
-- **`audit`** — Scan synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; high-side threshold > 3.5); read-only, `--limit` caps findings per type (default 50).
+- **`audit`** — Scan synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; two-sided threshold |z| > 3.5, flagging items far above OR below the category median); read-only, `--limit` caps findings per type (default 50).
 
 ## Recipes
 
@@ -285,7 +285,7 @@ Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum s
 splitwise-pp-cli audit
 ```
 
-Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
+Flags repeated near-identical expenses (same description, cost, date, currency, and group) and expenses far from their category baseline (either unusually expensive or unusually cheap) using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
 
 ### See what's coming — `forecast`
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -211,6 +211,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli report --group "Tahoe Trip" --format md
   ```
 
+### Fairness & collection risk
+- **`fairness`** — Score who carries the group, who's a collection risk, and who to chase or write off — offline, from your synced history.
+
+  _Turns "who still owes me, and will I ever see it" into an action list: nudge, chase, or write off (debt that is old **and** gone quiet). `--by contribution` shows who fronts cash vs. free-rides; `--by collectability` ranks by debt age and settle latency. New group members with no history are surfaced separately, never flagged as risks._
+
+  ```bash
+  splitwise-pp-cli fairness --by risk --agent
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -132,7 +132,7 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Data-quality audit
-- **`audit`** — Scan your synced expenses offline for likely duplicates (same description, cost, date, and group) and per-category cost outliers (cost above mean + 3σ), grouped by finding type.
+- **`audit`** — Scan your synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; high-side threshold > 3.5), grouped by finding type.
 
   _Use before reporting or settling to catch double-entered charges (e.g. repeated "Settle all balances" rows) and surface unusually large expenses an agent or user should review. Read-only; never mutates. `--limit` caps findings per type (default 50)._
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -273,6 +273,16 @@ splitwise-pp-cli net
 
 Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum set of real-world transfers, separated per currency, and reports how many transfers it saved vs. settling each group on its own. Add `--agent` for JSON.
 
+### Catch bad data before you settle — `audit`
+
+**Find likely duplicate expenses and per-category cost outliers:**
+
+```bash
+splitwise-pp-cli audit
+```
+
+Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -101,6 +101,7 @@ These capabilities aren't available in any other tool for this API.
 
 ### Upcoming-obligations forecast
 - **`forecast`** — Project your next shared obligations from recurring spending patterns over your synced history. Clusters expenses by normalized description, finds the ones with a regular cadence (>= 3 dated occurrences, mean cadence 2-400 days, largest gap <= 3x the smallest), and projects the next expected date and amount. Returns charges whose next occurrence falls inside the window (default 35 days) or is already overdue, sorted by expected date.
+  Reads from your synced local store; on large accounts, results can be incomplete until a full sync.
 
   _Use to answer "what shared bills are coming up?" or "what should I budget for next month?" — and to catch a regular charge that's overdue and hasn't been logged yet._
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -397,6 +397,54 @@ splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 202
 splitwise-pp-cli report --agent
 ```
 
+### Collect what you're owed — the `fairness` cookbook
+
+`fairness` turns your synced ledger into an action list. Default lens is **risk** (who to chase, worst first).
+
+**Who should I chase, and what should I just write off?**
+
+```bash
+splitwise-pp-cli fairness --by risk
+```
+
+Ranks everyone who owes you by a 0–100 collection-risk score with a per-row action: 🟢 on track · 🟡 nudge · 🟠 chase · 🔴 write-off (old **and** gone quiet). The footer totals at-risk vs. write-off dollars.
+
+**Who carries the group (fronts cash) vs. who free-rides?**
+
+```bash
+splitwise-pp-cli fairness --by contribution
+```
+
+Per person: paid, owed, net, carry-ratio, and a carrier/even/rider role. Informational — Splitwise settles regardless of who pays, so this is for when you still care who fronts the money.
+
+**Who's slow to settle / a live collection risk?**
+
+```bash
+splitwise-pp-cli fairness --by collectability
+```
+
+Sorted by debt age, with average settle latency and days since they last settled.
+
+**Scope to one friend, or one group/trip:**
+
+```bash
+splitwise-pp-cli fairness --friend "Alex"
+splitwise-pp-cli fairness --group "Tahoe Trip"
+```
+
+**Agent mode — the action list as JSON (raw day-counts for your own math):**
+
+```bash
+splitwise-pp-cli fairness --by risk --agent
+```
+
+Human tables print ages as `4y 3mo 8d`; JSON keeps raw `*_days` integers so tools convert themselves.
+
+**Tune the write-off threshold** (default: 365 days old + 180 days silent):
+
+```bash
+splitwise-pp-cli fairness --by risk --write-off-days 730 --ghost-days 90
+```
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -99,6 +99,39 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli recurring --agent
   ```
 
+### Upcoming-obligations forecast
+- **`forecast`** — Project your next shared obligations from recurring spending patterns over your synced history. Clusters expenses by normalized description, finds the ones with a regular cadence (>= 3 dated occurrences, mean cadence 2-400 days, largest gap <= 3x the smallest), and projects the next expected date and amount. Returns charges whose next occurrence falls inside the window (default 35 days) or is already overdue, sorted by expected date.
+
+  _Use to answer "what shared bills are coming up?" or "what should I budget for next month?" — and to catch a regular charge that's overdue and hasn't been logged yet._
+
+  ```bash
+  splitwise-pp-cli forecast --agent
+  splitwise-pp-cli forecast --days 60 --limit 20 --json
+  ```
+
+  Output shape (`--agent` / `--json`):
+
+  ```json
+  {
+    "as_of": "2026-05-30",
+    "window_days": 35,
+    "upcoming": [
+      {
+        "description": "Rent",
+        "group": "Roommates",
+        "last_date": "2026-05-01",
+        "expected_date": "2026-06-01",
+        "expected_amount": 1850.00,
+        "cadence_days": 30,
+        "occurrences": 6,
+        "overdue": false
+      }
+    ]
+  }
+  ```
+
+  Payments and settlement rows (`settle all balances`, `settle up`, `payment`, `paid via …`) are excluded. Read-only; never posts.
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -133,6 +133,16 @@ These capabilities aren't available in any other tool for this API.
 
   Payments and settlement rows (`settle all balances`, `settle up`, `payment`, `paid via …`) are excluded. Read-only; never posts.
 
+### Multi-currency normalization
+- **`normalize`** — Normalize multi-currency net position and spend into one base currency using user-supplied offline FX rates (`--rate` / `--rates-file`); historical/automatic FX lookup is intentionally out of scope.
+
+  _Use to compare or total spend across trips in different currencies — supply the rates and get one base-currency number; a currency with no rate is surfaced as unconverted, never silently dropped._
+
+  ```bash
+  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
+  ```
+
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 
@@ -326,6 +336,16 @@ splitwise-pp-cli forecast
 ```
 
 Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
+
+### Normalize multi-currency spend — `normalize`
+
+Convert mixed-currency balances/spend into one base currency with deterministic, user-supplied rates.
+
+```bash
+splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
+```
+
+Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -131,6 +131,15 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli net --agent
   ```
 
+### Data-quality audit
+- **`audit`** — Scan your synced expenses offline for likely duplicates (same description, cost, date, and group) and per-category cost outliers (cost above mean + 3σ), grouped by finding type.
+
+  _Use before reporting or settling to catch double-entered charges (e.g. repeated "Settle all balances" rows) and surface unusually large expenses an agent or user should review. Read-only; never mutates. `--limit` caps findings per type (default 50)._
+
+  ```bash
+  splitwise-pp-cli audit --agent
+  ```
+
 ## Command Reference
 
 **add-user-to-group** — Manage add user to group

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -317,6 +317,16 @@ splitwise-pp-cli audit
 
 Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
 
+### See what's coming — `forecast`
+
+**Project next month's recurring shared obligations:**
+
+```bash
+splitwise-pp-cli forecast
+```
+
+Detects regular charges (rent, utilities, subscriptions) from your synced history and projects the upcoming ones, flagging anything overdue or due soon. Set the window with `--days N` (default 35), add `--agent` for JSON.
+
 ### Net position for an agent
 
 ```bash

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -216,9 +216,9 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ### Data-quality audit
-- **`audit`** — Scan your synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; high-side threshold > 3.5), grouped by finding type.
+- **`audit`** — Scan your synced expenses offline for likely duplicates (same description, cost, currency, date, and group) and per-category cost outliers (robust modified z-score using median/MAD; two-sided threshold |z| > 3.5, flagging items far above OR below the category median), grouped by finding type.
 
-  _Use before reporting or settling to catch double-entered charges (e.g. repeated "Settle all balances" rows) and surface unusually large expenses an agent or user should review. Read-only; never mutates. `--limit` caps findings per type (default 50)._
+  _Use before reporting or settling to catch double-entered charges (e.g. repeated "Settle all balances" rows) and surface unusually expensive or unusually cheap entries (likely data-quality errors) an agent or user should review. Read-only; never mutates. `--limit` caps findings per type (default 50)._
 
   ```bash
   splitwise-pp-cli audit --agent
@@ -365,7 +365,7 @@ Nets each friend's balances (cancelling A→B→C→A cycles) into the minimum s
 splitwise-pp-cli audit
 ```
 
-Flags repeated near-identical expenses (same description, cost, date, currency, and group) and unusually large expenses vs. their category baseline using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
+Flags repeated near-identical expenses (same description, cost, date, currency, and group) and expenses far from their category baseline (either unusually expensive or unusually cheap) using a robust median/MAD score. Use `--limit N` to cap findings per type, `--agent` for JSON.
 
 ### See what's coming — `forecast`
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -142,6 +142,37 @@ These capabilities aren't available in any other tool for this API.
   splitwise-pp-cli normalize --base USD --rate EUR=1.08 --agent
   ```
 
+### Trip & period reports
+- **`report`** — Export an offline trip/period spend report as Markdown, CSV, or JSON. Single-currency only: defaults to the most common filtered currency, excludes other currencies with an explicit excluded count, and supports `--currency` to pin one. PDF is intentionally out of scope in v1.
+
+  Output shape (`--agent` / `--json`):
+
+  ```json
+  {
+    "scope": "group:Tahoe Trip",
+    "currency": "USD",
+    "period_start": "2025-01-10",
+    "period_end": "2025-02-01",
+    "expense_count": 12,
+    "excluded_other_currency": 0,
+    "total_cost": 1840.00,
+    "your_paid": 920.00,
+    "your_owed": 613.33,
+    "your_net": 306.67,
+    "people": [
+      { "user_id": 1, "name": "You", "paid": 920.00, "owed": 613.33, "net": 306.67 }
+    ],
+    "categories": [
+      { "name": "Lodging", "total": 1200.00, "count": 2 }
+    ],
+    "expenses": [
+      { "id": 9001, "date": "2025-01-10", "description": "Cabin", "cost": 1200.00, "currency_code": "USD", "payer": "You" }
+    ],
+    "truncated": false
+  }
+  ```
+
+  Payment and deleted rows are excluded. Single-currency: other-currency expenses are excluded and counted in `excluded_other_currency`. Read-only; never posts.
 
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
@@ -346,6 +377,17 @@ splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27
 ```
 
 Add `--agent` for JSON output in automation flows. A currency with no `--rate` is listed as unconverted (not mixed into the total); pin rates with repeated `--rate CUR=FACTOR` or a `--rates-file`.
+
+### Export a trip/period report — `report`
+
+Build a deterministic offline report from synced expenses for a trip/group or date window.
+
+```bash
+splitwise-pp-cli report --group "Tahoe Trip" --format md
+splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv
+splitwise-pp-cli report --agent
+```
+
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -174,6 +174,15 @@ These capabilities aren't available in any other tool for this API.
 
   Payment and deleted rows are excluded. Single-currency: other-currency expenses are excluded and counted in `excluded_other_currency`. Read-only; never posts.
 
+### Fairness & collection risk
+- **`fairness`** — Score who carries the group, who's a collection risk, and who to chase or write off — offline, from your synced history.
+
+  _Turns "who still owes me, and will I ever see it" into an action list: nudge, chase, or write off (debt that is old **and** gone quiet). `--by contribution` shows who fronts cash vs. free-rides; `--by collectability` ranks by debt age and settle latency. New group members with no history are surfaced separately, never flagged as risks._
+
+  ```bash
+  splitwise-pp-cli fairness --by risk --agent
+  ```
+
 ### Reconcile and settle
 - **`settle-up`** — Compute the minimum set of transfers that zeroes out balances in a group, then optionally record the payments.
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -423,7 +423,7 @@ Per person: paid, owed, net, carry-ratio, and a carrier/even/rider role. Informa
 splitwise-pp-cli fairness --by collectability
 ```
 
-Sorted by debt age, with average settle latency and days since they last settled.
+Sorted by debt age, with average settle latency and days since they last settled; `--by collectability` now also shows a projected settle date (raw `projected_days_out` in JSON).
 
 **Scope to one friend, or one group/trip:**
 
@@ -445,6 +445,24 @@ Human tables print ages as `4y 3mo 8d`; JSON keeps raw `*_days` integers so tool
 ```bash
 splitwise-pp-cli fairness --by risk --write-off-days 730 --ghost-days 90
 ```
+
+### Nudge a friend to pay — `fairness nudge`
+
+Splitwise has no send-reminder endpoint, so this command posts a comment on a shared unsettled expense; Splitwise then notifies participants per their own notification settings.
+
+Preview only by default:
+
+```bash
+splitwise-pp-cli fairness nudge "Alex"
+```
+
+Actually post the reminder comment:
+
+```bash
+splitwise-pp-cli fairness nudge "Alex" --send
+```
+
+Optional flags: `--message` to override reminder text, `--expense-id` to force a specific expense, and `--send` to post (otherwise preview only). Reachability caveat: this CLI's synced `Friend` shape does not include email/registration status, so v1 does not pre-gate on confirmed-account status.
 
 ### Net position for an agent
 

--- a/library/payments/splitwise/cmd/splitwise-pp-mcp/main.go
+++ b/library/payments/splitwise/cmd/splitwise-pp-mcp/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/cli"
 	mcptools "github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/mcp"
 )
 
@@ -24,9 +25,11 @@ const (
 )
 
 func main() {
+	buildVersion := cli.Version()
+
 	s := server.NewMCPServer(
 		"Splitwise",
-		"1.0.0",
+		buildVersion,
 		server.WithToolCapabilities(false),
 	)
 
@@ -36,7 +39,11 @@ func main() {
 	addr := flag.String("addr", defaultHTTPAddr, "bind address for http transport (host:port or :port)")
 	flag.Parse()
 
-	switch strings.ToLower(*transport) {
+	// Startup banner to stderr so the host's MCP log identifies the running build.
+	resolvedTransport := strings.ToLower(*transport)
+	fmt.Fprintln(os.Stderr, startupBanner(buildVersion, resolvedTransport))
+
+	switch resolvedTransport {
 	case "stdio":
 		if err := server.ServeStdio(s); err != nil {
 			fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
@@ -53,6 +60,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown --transport %q (supported: stdio, http)\n", *transport)
 		os.Exit(2)
 	}
+}
+
+// startupBanner is the one line the MCP server writes to stderr on load. It lands
+// in the host's MCP log (e.g. Claude Desktop) and identifies exactly which build
+// is running.
+func startupBanner(version, transport string) string {
+	return fmt.Sprintf("splitwise-pp-mcp %s starting (transport=%s)", version, transport)
 }
 
 // defaultTransport reads PP_MCP_TRANSPORT env when set, otherwise falls back

--- a/library/payments/splitwise/cmd/splitwise-pp-mcp/main_test.go
+++ b/library/payments/splitwise/cmd/splitwise-pp-mcp/main_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStartupBannerIncludesVersionAndTransport pins the startup line the MCP
+// server writes to stderr on load: it must carry the binary name, the build
+// version, and the selected transport so the line in a host's MCP log
+// (e.g. Claude Desktop) identifies exactly which build is running.
+func TestStartupBannerIncludesVersionAndTransport(t *testing.T) {
+	got := startupBanner("4.20.0-next.4", "stdio")
+	for _, want := range []string{"splitwise-pp-mcp", "4.20.0-next.4", "stdio"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startupBanner missing %q; got %q", want, got)
+		}
+	}
+}

--- a/library/payments/splitwise/internal/cli/pagination.go
+++ b/library/payments/splitwise/internal/cli/pagination.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// PageResult is the byte-budgeted page envelope returned for list responses.
+type PageResult struct {
+	Items      []json.RawMessage `json:"items"`
+	Total      int               `json:"total"`
+	Offset     int               `json:"offset"`
+	Returned   int               `json:"returned"`
+	NextOffset *int              `json:"next_offset,omitempty"`
+	Truncated  bool              `json:"truncated,omitempty"`
+}
+
+// PaginateByBytes returns items[offset:] up to the point where adding the next
+// item's serialized length would exceed maxBytes. ALWAYS returns >=1 item when
+// items remain (a single oversized item is returned alone with Truncated=true) so
+// callers always make progress. A positive limit caps the count first; the byte
+// budget trims further. NextOffset is set (to the next unreturned index) iff items
+// remain beyond this page.
+func PaginateByBytes(items []json.RawMessage, offset, limit, maxBytes int) PageResult {
+	total := len(items)
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+
+	end := total
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+
+	page := make([]json.RawMessage, 0)
+	used := 0
+	truncated := false
+	i := offset
+	for i < end {
+		sz := len(items[i])
+		if len(page) == 0 {
+			page = append(page, items[i])
+			used += sz
+			i++
+			if sz > maxBytes {
+				truncated = true
+				break
+			}
+			continue
+		}
+		if used+sz > maxBytes {
+			break
+		}
+		page = append(page, items[i])
+		used += sz
+		i++
+	}
+
+	res := PageResult{
+		Items:     page,
+		Total:     total,
+		Offset:    offset,
+		Returned:  len(page),
+		Truncated: truncated,
+	}
+	if i < total {
+		next := i
+		res.NextOffset = &next
+	}
+	return res
+}
+
+// ListFromResponse locates the list within a response body: a bare [...] array, or
+// an array field of an object. If listField is non-empty it is used directly;
+// otherwise the LONE array-valued field is auto-detected (more than one array field
+// is ambiguous -> not a list). Returns (items, true) on success, (nil, false)
+// otherwise (caller passes the body through unchanged).
+func ListFromResponse(body json.RawMessage, listField string) ([]json.RawMessage, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var items []json.RawMessage
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, false
+		}
+		return items, true
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return nil, false
+		}
+
+		if listField != "" {
+			raw, ok := obj[listField]
+			if !ok {
+				return nil, false
+			}
+			var items []json.RawMessage
+			if err := json.Unmarshal(raw, &items); err != nil {
+				return nil, false
+			}
+			return items, true
+		}
+
+		var detected []json.RawMessage
+		found := 0
+		for _, raw := range obj {
+			v := bytes.TrimSpace(raw)
+			if len(v) == 0 || v[0] != '[' {
+				continue
+			}
+			var items []json.RawMessage
+			if err := json.Unmarshal(raw, &items); err != nil {
+				continue
+			}
+			detected = items
+			found++
+			if found > 1 {
+				return nil, false
+			}
+		}
+		if found == 1 {
+			return detected, true
+		}
+		return nil, false
+	default:
+		return nil, false
+	}
+}
+
+// PaginateBody locates a list in body and returns the byte-budgeted page envelope
+// as JSON bytes plus paginated=true. When body is not a detectable list it returns
+// (nil, false).
+func PaginateBody(body json.RawMessage, offset, limit, maxBytes int, listField string) ([]byte, bool) {
+	items, ok := ListFromResponse(body, listField)
+	if !ok {
+		return nil, false
+	}
+
+	paged := PaginateByBytes(items, offset, limit, maxBytes)
+	out, err := json.Marshal(paged)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}

--- a/library/payments/splitwise/internal/cli/pagination_test.go
+++ b/library/payments/splitwise/internal/cli/pagination_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// raws builds a []json.RawMessage from literal JSON fragments; each `{"n":1}` is 7 bytes.
+func raws(parts ...string) []json.RawMessage {
+	out := make([]json.RawMessage, len(parts))
+	for i, p := range parts {
+		out[i] = json.RawMessage(p)
+	}
+	return out
+}
+
+func TestPaginateByBytes_AllFitOnePage(t *testing.T) {
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`, `{"c":3}`), 0, 0, 1000)
+	if got.Total != 3 || got.Returned != 3 || got.Offset != 0 || got.NextOffset != nil || got.Truncated {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_SpansPages(t *testing.T) {
+	// 5 items x 7 bytes; budget 16 fits 2 (7,14); 3rd (21) overflows.
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`, `{"c":3}`, `{"d":4}`, `{"e":5}`), 0, 0, 16)
+	if got.Returned != 2 || got.NextOffset == nil || *got.NextOffset != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_ExactBudgetBoundary(t *testing.T) {
+	// budget 14 fits exactly 2 (7+7=14, not > 14).
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`, `{"c":3}`), 0, 0, 14)
+	if got.Returned != 2 || got.NextOffset == nil || *got.NextOffset != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_OversizedSingleItem(t *testing.T) {
+	// First item (17 bytes) exceeds budget 10 -> returned alone, truncated, next points past it.
+	got := PaginateByBytes(raws(`{"big":"xxxxxxx"}`, `{"a":1}`), 0, 0, 10)
+	if got.Returned != 1 || !got.Truncated || got.NextOffset == nil || *got.NextOffset != 1 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_OffsetMidList(t *testing.T) {
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`, `{"c":3}`, `{"d":4}`, `{"e":5}`), 2, 0, 1000)
+	if got.Offset != 2 || got.Returned != 3 || got.NextOffset != nil {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_OffsetPastEnd(t *testing.T) {
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`), 10, 0, 1000)
+	if got.Total != 2 || got.Returned != 0 || got.NextOffset != nil {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateByBytes_LimitCapsCount(t *testing.T) {
+	got := PaginateByBytes(raws(`{"a":1}`, `{"b":2}`, `{"c":3}`, `{"d":4}`), 0, 2, 1000)
+	if got.Returned != 2 || got.NextOffset == nil || *got.NextOffset != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestListFromResponse_BareArray(t *testing.T) {
+	items, ok := ListFromResponse(json.RawMessage(`[{"a":1},{"b":2}]`), "")
+	if !ok || len(items) != 2 {
+		t.Fatalf("ok=%v items=%d", ok, len(items))
+	}
+}
+
+func TestListFromResponse_EnvelopeAutoDetect(t *testing.T) {
+	items, ok := ListFromResponse(json.RawMessage(`{"groups":[{"a":1}]}`), "")
+	if !ok || len(items) != 1 {
+		t.Fatalf("ok=%v items=%d", ok, len(items))
+	}
+}
+
+func TestListFromResponse_ExplicitField(t *testing.T) {
+	items, ok := ListFromResponse(json.RawMessage(`{"groups":[{"a":1},{"b":2}],"meta":1}`), "groups")
+	if !ok || len(items) != 2 {
+		t.Fatalf("ok=%v items=%d", ok, len(items))
+	}
+}
+
+func TestListFromResponse_MultipleArraysAmbiguous(t *testing.T) {
+	_, ok := ListFromResponse(json.RawMessage(`{"a":[1],"b":[2]}`), "")
+	if ok {
+		t.Fatalf("expected ok=false for ambiguous multi-array")
+	}
+}
+
+func TestListFromResponse_SingleObjectPassthrough(t *testing.T) {
+	_, ok := ListFromResponse(json.RawMessage(`{"id":5,"name":"x"}`), "")
+	if ok {
+		t.Fatalf("expected ok=false for non-list object")
+	}
+}
+
+func TestListFromResponse_NonJSON(t *testing.T) {
+	_, ok := ListFromResponse(json.RawMessage(`not json`), "")
+	if ok {
+		t.Fatalf("expected ok=false for non-JSON")
+	}
+}
+
+func TestPaginateBody_PaginatesEnvelopeList(t *testing.T) {
+	body := json.RawMessage(`{"groups":[{"a":1},{"b":2},{"c":3},{"d":4},{"e":5}]}`)
+	out, paginated := PaginateBody(body, 0, 0, 16, "")
+	if !paginated {
+		t.Fatalf("expected paginated=true")
+	}
+	var got PageResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Total != 5 || got.Returned != 2 || got.NextOffset == nil || *got.NextOffset != 2 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestPaginateBody_PassthroughForNonList(t *testing.T) {
+	out, paginated := PaginateBody(json.RawMessage(`{"id":5}`), 0, 0, 16, "")
+	if paginated || out != nil {
+		t.Fatalf("expected passthrough: paginated=%v out=%s", paginated, out)
+	}
+}

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -266,6 +266,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newRecurringCmd(flags))
 	rootCmd.AddCommand(newAuditCmd(flags))
 	rootCmd.AddCommand(newForecastCmd(flags))
+	rootCmd.AddCommand(newNormalizeCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -19,6 +19,10 @@ import (
 
 var version = "1.0.0"
 
+// Version returns the build version (set via -ldflags at release; "1.0.0" in a
+// plain go build). Exposed so the MCP server can report the same version as the CLI.
+func Version() string { return version }
+
 type rootFlags struct {
 	asJSON     bool
 	compact    bool

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -267,6 +267,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newAuditCmd(flags))
 	rootCmd.AddCommand(newForecastCmd(flags))
 	rootCmd.AddCommand(newNormalizeCmd(flags))
+	rootCmd.AddCommand(newReportCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -272,6 +272,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newForecastCmd(flags))
 	rootCmd.AddCommand(newNormalizeCmd(flags))
 	rootCmd.AddCommand(newReportCmd(flags))
+	rootCmd.AddCommand(newFairnessCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -265,6 +265,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newSplitCmd(flags))
 	rootCmd.AddCommand(newRecurringCmd(flags))
 	rootCmd.AddCommand(newAuditCmd(flags))
+	rootCmd.AddCommand(newForecastCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/root.go
+++ b/library/payments/splitwise/internal/cli/root.go
@@ -264,6 +264,7 @@ See README.md or the bundled SKILL.md for recipes.`,
 	rootCmd.AddCommand(newNetCmd(flags))
 	rootCmd.AddCommand(newSplitCmd(flags))
 	rootCmd.AddCommand(newRecurringCmd(flags))
+	rootCmd.AddCommand(newAuditCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newAddUserToGroupPromotedCmd(flags))
 	rootCmd.AddCommand(newCreateCommentPromotedCmd(flags))

--- a/library/payments/splitwise/internal/cli/splitwise_audit.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit.go
@@ -218,8 +218,12 @@ func detectCostOutliers(expenses []Expense) []auditCostOutlier {
 		}
 		for idx, e := range items {
 			v := values[idx]
+			// Two-sided: flag items far from the category median in EITHER
+			// direction. An unusually cheap entry (a $1 item in an $80-median
+			// category) is as likely a data-quality error as an unusually
+			// expensive one.
 			modifiedZ := 0.6745 * (v - categoryMedian) / mad
-			if modifiedZ > 3.5 {
+			if math.Abs(modifiedZ) > 3.5 {
 				out = append(out, auditCostOutlier{
 					ExpenseID:      e.ID,
 					Description:    strings.TrimSpace(e.Description),

--- a/library/payments/splitwise/internal/cli/splitwise_audit.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type auditDuplicateCluster struct {
+	Description  string  `json:"description"`
+	Cost         float64 `json:"cost"`
+	CurrencyCode string  `json:"currency_code"`
+	Date         string  `json:"date"`
+	GroupID      int     `json:"group_id"`
+	ExpenseIDs   []int   `json:"expense_ids"`
+	Count        int     `json:"count"`
+}
+
+type auditCostOutlier struct {
+	ExpenseID    int     `json:"expense_id"`
+	Description  string  `json:"description"`
+	Cost         float64 `json:"cost"`
+	CurrencyCode string  `json:"currency_code"`
+	Category     string  `json:"category"`
+	Date         string  `json:"date"`
+	CategoryMean float64 `json:"category_mean"`
+}
+
+type auditResult struct {
+	Duplicates      []auditDuplicateCluster `json:"duplicates"`
+	Outliers        []auditCostOutlier      `json:"outliers"`
+	ScannedExpenses int                     `json:"scanned_expenses"`
+}
+
+func newAuditCmd(flags *rootFlags) *cobra.Command {
+	limit := 50
+	cmd := &cobra.Command{
+		Use:         "audit",
+		Short:       "Audit synced expenses for likely duplicates and per-category cost outliers",
+		Example:     "  splitwise-pp-cli audit --agent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would audit synced expenses")
+				return nil
+			}
+			if limit < 1 {
+				return usageErr(fmt.Errorf("--limit must be >= 1"))
+			}
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			hintIfUnsynced(cmd, db, "get-expenses")
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			res := runAudit(expenses, limit)
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, res)
+			}
+
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintf(tw, "LIKELY DUPLICATES (%d)\n", len(res.Duplicates))
+			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tCOST\tCURRENCY\tDATE\tGROUP\tCOUNT\tIDS")
+			for _, row := range res.Duplicates {
+				ids := make([]string, 0, len(row.ExpenseIDs))
+				for _, id := range row.ExpenseIDs {
+					ids = append(ids, fmt.Sprintf("%d", id))
+				}
+				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%d\t%d\t%s\n", row.Description, row.Cost, row.CurrencyCode, row.Date, row.GroupID, row.Count, strings.Join(ids, ","))
+			}
+			_, _ = fmt.Fprintln(tw)
+			_, _ = fmt.Fprintf(tw, "COST OUTLIERS (%d)\n", len(res.Outliers))
+			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tCOST\tCURRENCY\tCATEGORY\tDATE\tCAT_MEAN\tID")
+			for _, row := range res.Outliers {
+				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\t%.2f\t%d\n", row.Description, row.Cost, row.CurrencyCode, row.Category, row.Date, row.CategoryMean, row.ExpenseID)
+			}
+			_, _ = fmt.Fprintf(tw, "\nScanned %d expenses.\n", res.ScannedExpenses)
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum findings to report per finding type")
+	return cmd
+}
+
+func runAudit(expenses []Expense, limit int) auditResult {
+	filtered := make([]Expense, 0, len(expenses))
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	if limit < 1 {
+		limit = 1
+	}
+
+	duplicates := detectDuplicateClusters(filtered)
+	outliers := detectCostOutliers(filtered)
+	if len(duplicates) > limit {
+		duplicates = duplicates[:limit]
+	}
+	if len(outliers) > limit {
+		outliers = outliers[:limit]
+	}
+	return auditResult{
+		Duplicates:      duplicates,
+		Outliers:        outliers,
+		ScannedExpenses: len(filtered),
+	}
+}
+
+func auditNormalizeDescription(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+func auditDateKey(date string) string {
+	t := strings.TrimSpace(date)
+	if len(t) >= 10 {
+		return t[:10]
+	}
+	return t
+}
+
+func detectDuplicateClusters(expenses []Expense) []auditDuplicateCluster {
+	type key struct {
+		Description string
+		Cost        string
+		Date        string
+		GroupID     int
+	}
+	clusters := make(map[key][]Expense)
+	for _, e := range expenses {
+		cost := fmt.Sprintf("%.2f", round2(parseAmount(e.Cost)))
+		k := key{
+			Description: auditNormalizeDescription(e.Description),
+			Cost:        cost,
+			Date:        auditDateKey(e.Date),
+			GroupID:     e.GroupID,
+		}
+		clusters[k] = append(clusters[k], e)
+	}
+	out := make([]auditDuplicateCluster, 0)
+	for k, items := range clusters {
+		if len(items) < 2 {
+			continue
+		}
+		ids := make([]int, 0, len(items))
+		for _, it := range items {
+			ids = append(ids, it.ID)
+		}
+		sort.Ints(ids)
+		out = append(out, auditDuplicateCluster{
+			Description:  strings.TrimSpace(items[0].Description),
+			Cost:         round2(parseAmount(items[0].Cost)),
+			CurrencyCode: strings.TrimSpace(items[0].CurrencyCode),
+			Date:         k.Date,
+			GroupID:      k.GroupID,
+			ExpenseIDs:   ids,
+			Count:        len(items),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count == out[j].Count {
+			if out[i].Description == out[j].Description {
+				return out[i].Date < out[j].Date
+			}
+			return out[i].Description < out[j].Description
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}
+
+func detectCostOutliers(expenses []Expense) []auditCostOutlier {
+	byCategory := make(map[string][]Expense)
+	for _, e := range expenses {
+		category := strings.TrimSpace(e.Category.Name)
+		if category == "" {
+			category = "Uncategorized"
+		}
+		byCategory[category] = append(byCategory[category], e)
+	}
+
+	out := make([]auditCostOutlier, 0)
+	for category, items := range byCategory {
+		n := len(items)
+		if n < 5 {
+			continue
+		}
+		sum := 0.0
+		values := make([]float64, 0, n)
+		for _, e := range items {
+			v := parseAmount(e.Cost)
+			values = append(values, v)
+			sum += v
+		}
+		mean := sum / float64(n)
+
+		ss := 0.0
+		for _, v := range values {
+			d := v - mean
+			ss += d * d
+		}
+		stddev := math.Sqrt(ss / float64(n-1))
+		if stddev == 0 {
+			continue
+		}
+		cutoff := mean + (3 * stddev)
+		for idx, e := range items {
+			v := values[idx]
+			if v > cutoff {
+				out = append(out, auditCostOutlier{
+					ExpenseID:    e.ID,
+					Description:  strings.TrimSpace(e.Description),
+					Cost:         round2(v),
+					CurrencyCode: strings.TrimSpace(e.CurrencyCode),
+					Category:     category,
+					Date:         auditDateKey(e.Date),
+					CategoryMean: round2(mean),
+				})
+			}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cost == out[j].Cost {
+			if out[i].Category == out[j].Category {
+				return out[i].ExpenseID < out[j].ExpenseID
+			}
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Cost > out[j].Cost
+	})
+	return out
+}

--- a/library/payments/splitwise/internal/cli/splitwise_audit.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit.go
@@ -21,18 +21,20 @@ type auditDuplicateCluster struct {
 }
 
 type auditCostOutlier struct {
-	ExpenseID    int     `json:"expense_id"`
-	Description  string  `json:"description"`
-	Cost         float64 `json:"cost"`
-	CurrencyCode string  `json:"currency_code"`
-	Category     string  `json:"category"`
-	Date         string  `json:"date"`
-	CategoryMean float64 `json:"category_mean"`
+	ExpenseID      int     `json:"expense_id"`
+	Description    string  `json:"description"`
+	Cost           float64 `json:"cost"`
+	CurrencyCode   string  `json:"currency_code"`
+	Category       string  `json:"category"`
+	Date           string  `json:"date"`
+	CategoryMedian float64 `json:"category_median"`
 }
 
 type auditResult struct {
 	Duplicates      []auditDuplicateCluster `json:"duplicates"`
+	DuplicatesTotal int                     `json:"duplicates_total"`
 	Outliers        []auditCostOutlier      `json:"outliers"`
+	OutliersTotal   int                     `json:"outliers_total"`
 	ScannedExpenses int                     `json:"scanned_expenses"`
 }
 
@@ -67,7 +69,7 @@ func newAuditCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
-			_, _ = fmt.Fprintf(tw, "LIKELY DUPLICATES (%d)\n", len(res.Duplicates))
+			_, _ = fmt.Fprintf(tw, "LIKELY DUPLICATES (%d of %d)\n", len(res.Duplicates), res.DuplicatesTotal)
 			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tCOST\tCURRENCY\tDATE\tGROUP\tCOUNT\tIDS")
 			for _, row := range res.Duplicates {
 				ids := make([]string, 0, len(row.ExpenseIDs))
@@ -77,10 +79,10 @@ func newAuditCmd(flags *rootFlags) *cobra.Command {
 				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%d\t%d\t%s\n", row.Description, row.Cost, row.CurrencyCode, row.Date, row.GroupID, row.Count, strings.Join(ids, ","))
 			}
 			_, _ = fmt.Fprintln(tw)
-			_, _ = fmt.Fprintf(tw, "COST OUTLIERS (%d)\n", len(res.Outliers))
-			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tCOST\tCURRENCY\tCATEGORY\tDATE\tCAT_MEAN\tID")
+			_, _ = fmt.Fprintf(tw, "COST OUTLIERS (%d of %d)\n", len(res.Outliers), res.OutliersTotal)
+			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tCOST\tCURRENCY\tCATEGORY\tDATE\tCAT_MEDIAN\tID")
 			for _, row := range res.Outliers {
-				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\t%.2f\t%d\n", row.Description, row.Cost, row.CurrencyCode, row.Category, row.Date, row.CategoryMean, row.ExpenseID)
+				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\t%.2f\t%d\n", row.Description, row.Cost, row.CurrencyCode, row.Category, row.Date, row.CategoryMedian, row.ExpenseID)
 			}
 			_, _ = fmt.Fprintf(tw, "\nScanned %d expenses.\n", res.ScannedExpenses)
 			return tw.Flush()
@@ -104,6 +106,8 @@ func runAudit(expenses []Expense, limit int) auditResult {
 
 	duplicates := detectDuplicateClusters(filtered)
 	outliers := detectCostOutliers(filtered)
+	duplicatesTotal := len(duplicates)
+	outliersTotal := len(outliers)
 	if len(duplicates) > limit {
 		duplicates = duplicates[:limit]
 	}
@@ -112,7 +116,9 @@ func runAudit(expenses []Expense, limit int) auditResult {
 	}
 	return auditResult{
 		Duplicates:      duplicates,
+		DuplicatesTotal: duplicatesTotal,
 		Outliers:        outliers,
+		OutliersTotal:   outliersTotal,
 		ScannedExpenses: len(filtered),
 	}
 }
@@ -131,21 +137,21 @@ func auditDateKey(date string) string {
 
 func detectDuplicateClusters(expenses []Expense) []auditDuplicateCluster {
 	type key struct {
-		Description string
-		Cost        string
+		Description  string
+		Cost         string
 		CurrencyCode string
-		Date        string
-		GroupID     int
+		Date         string
+		GroupID      int
 	}
 	clusters := make(map[key][]Expense)
 	for _, e := range expenses {
 		cost := fmt.Sprintf("%.2f", round2(parseAmount(e.Cost)))
 		k := key{
-			Description: auditNormalizeDescription(e.Description),
-			Cost:        cost,
+			Description:  auditNormalizeDescription(e.Description),
+			Cost:         cost,
 			CurrencyCode: strings.TrimSpace(e.CurrencyCode),
-			Date:        auditDateKey(e.Date),
-			GroupID:     e.GroupID,
+			Date:         auditDateKey(e.Date),
+			GroupID:      e.GroupID,
 		}
 		clusters[k] = append(clusters[k], e)
 	}
@@ -197,36 +203,31 @@ func detectCostOutliers(expenses []Expense) []auditCostOutlier {
 		if n < 5 {
 			continue
 		}
-		sum := 0.0
 		values := make([]float64, 0, n)
 		for _, e := range items {
-			v := parseAmount(e.Cost)
-			values = append(values, v)
-			sum += v
+			values = append(values, parseAmount(e.Cost))
 		}
-		mean := sum / float64(n)
-
-		ss := 0.0
+		categoryMedian := median(values)
+		absDeviations := make([]float64, 0, n)
 		for _, v := range values {
-			d := v - mean
-			ss += d * d
+			absDeviations = append(absDeviations, math.Abs(v-categoryMedian))
 		}
-		stddev := math.Sqrt(ss / float64(n-1))
-		if stddev == 0 {
+		mad := median(absDeviations)
+		if mad == 0 {
 			continue
 		}
-		cutoff := mean + (3 * stddev)
 		for idx, e := range items {
 			v := values[idx]
-			if v > cutoff {
+			modifiedZ := 0.6745 * (v - categoryMedian) / mad
+			if modifiedZ > 3.5 {
 				out = append(out, auditCostOutlier{
-					ExpenseID:    e.ID,
-					Description:  strings.TrimSpace(e.Description),
-					Cost:         round2(v),
-					CurrencyCode: strings.TrimSpace(e.CurrencyCode),
-					Category:     category,
-					Date:         auditDateKey(e.Date),
-					CategoryMean: round2(mean),
+					ExpenseID:      e.ID,
+					Description:    strings.TrimSpace(e.Description),
+					Cost:           round2(v),
+					CurrencyCode:   strings.TrimSpace(e.CurrencyCode),
+					Category:       category,
+					Date:           auditDateKey(e.Date),
+					CategoryMedian: round2(categoryMedian),
 				})
 			}
 		}
@@ -242,4 +243,15 @@ func detectCostOutliers(expenses []Expense) []auditCostOutlier {
 		return out[i].Cost > out[j].Cost
 	})
 	return out
+}
+
+func median(values []float64) float64 {
+	cpy := append([]float64(nil), values...)
+	sort.Float64s(cpy)
+	n := len(cpy)
+	mid := n / 2
+	if n%2 == 1 {
+		return cpy[mid]
+	}
+	return (cpy[mid-1] + cpy[mid]) / 2
 }

--- a/library/payments/splitwise/internal/cli/splitwise_audit.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit.go
@@ -43,10 +43,7 @@ func newAuditCmd(flags *rootFlags) *cobra.Command {
 		Short:       "Audit synced expenses for likely duplicates and per-category cost outliers",
 		Example:     "  splitwise-pp-cli audit --agent",
 		Annotations: map[string]string{"mcp:read-only": "true"},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
-				return cmd.Help()
-			}
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if dryRunOK(flags) {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would audit synced expenses")
 				return nil
@@ -136,6 +133,7 @@ func detectDuplicateClusters(expenses []Expense) []auditDuplicateCluster {
 	type key struct {
 		Description string
 		Cost        string
+		CurrencyCode string
 		Date        string
 		GroupID     int
 	}
@@ -145,6 +143,7 @@ func detectDuplicateClusters(expenses []Expense) []auditDuplicateCluster {
 		k := key{
 			Description: auditNormalizeDescription(e.Description),
 			Cost:        cost,
+			CurrencyCode: strings.TrimSpace(e.CurrencyCode),
 			Date:        auditDateKey(e.Date),
 			GroupID:     e.GroupID,
 		}
@@ -163,7 +162,7 @@ func detectDuplicateClusters(expenses []Expense) []auditDuplicateCluster {
 		out = append(out, auditDuplicateCluster{
 			Description:  strings.TrimSpace(items[0].Description),
 			Cost:         round2(parseAmount(items[0].Cost)),
-			CurrencyCode: strings.TrimSpace(items[0].CurrencyCode),
+			CurrencyCode: k.CurrencyCode,
 			Date:         k.Date,
 			GroupID:      k.GroupID,
 			ExpenseIDs:   ids,

--- a/library/payments/splitwise/internal/cli/splitwise_audit_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit_test.go
@@ -8,16 +8,16 @@ func TestRunAudit(t *testing.T) {
 	expenses := []Expense{
 		{ID: 1, GroupID: 10, Description: "Settle all balances", Cost: "12.50", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z", Category: Category{Name: "Meals"}},
 		{ID: 2, GroupID: 10, Description: "  settle ALL   balances ", Cost: "12.50", CurrencyCode: "USD", Date: "2026-05-20T19:30:00Z", Category: Category{Name: "Meals"}},
-		{ID: 3, GroupID: 10, Description: "Coffee", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-21T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 4, GroupID: 10, Description: "Snack", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-22T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 3, GroupID: 10, Description: "Coffee", Cost: "9.90", CurrencyCode: "USD", Date: "2026-05-21T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 4, GroupID: 10, Description: "Snack", Cost: "9.95", CurrencyCode: "USD", Date: "2026-05-22T10:00:00Z", Category: Category{Name: "Meals"}},
 		{ID: 5, GroupID: 10, Description: "Brunch", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-23T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 6, GroupID: 10, Description: "Lunch", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-24T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 7, GroupID: 10, Description: "Dinner", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-25T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 8, GroupID: 10, Description: "Groceries", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-26T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 9, GroupID: 10, Description: "Tea", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-27T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 10, GroupID: 10, Description: "Sandwich", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-28T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 11, GroupID: 10, Description: "Pizza", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-29T10:00:00Z", Category: Category{Name: "Meals"}},
-		{ID: 12, GroupID: 10, Description: "Soup", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-30T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 6, GroupID: 10, Description: "Lunch", Cost: "10.05", CurrencyCode: "USD", Date: "2026-05-24T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 7, GroupID: 10, Description: "Dinner", Cost: "10.10", CurrencyCode: "USD", Date: "2026-05-25T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 8, GroupID: 10, Description: "Groceries", Cost: "10.15", CurrencyCode: "USD", Date: "2026-05-26T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 9, GroupID: 10, Description: "Tea", Cost: "9.85", CurrencyCode: "USD", Date: "2026-05-27T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 10, GroupID: 10, Description: "Sandwich", Cost: "9.80", CurrencyCode: "USD", Date: "2026-05-28T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 11, GroupID: 10, Description: "Pizza", Cost: "10.20", CurrencyCode: "USD", Date: "2026-05-29T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 12, GroupID: 10, Description: "Soup", Cost: "10.25", CurrencyCode: "USD", Date: "2026-05-30T10:00:00Z", Category: Category{Name: "Meals"}},
 		{ID: 13, GroupID: 10, Description: "Luxury tasting", Cost: "10000.00", CurrencyCode: "USD", Date: "2026-05-31T10:00:00Z", Category: Category{Name: "Meals"}},
 		{ID: 14, GroupID: 20, Description: "Small one", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Travel"}},
 		{ID: 15, GroupID: 20, Description: "Small two", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-02T10:00:00Z", Category: Category{Name: "Travel"}},
@@ -36,6 +36,9 @@ func TestRunAudit(t *testing.T) {
 	if len(res.Duplicates) != 1 {
 		t.Fatalf("duplicates len = %d, want 1", len(res.Duplicates))
 	}
+	if res.DuplicatesTotal != 1 {
+		t.Fatalf("duplicates total = %d, want 1", res.DuplicatesTotal)
+	}
 	dup := res.Duplicates[0]
 	if dup.Count != 2 {
 		t.Fatalf("duplicate count = %d, want 2", dup.Count)
@@ -44,20 +47,27 @@ func TestRunAudit(t *testing.T) {
 		t.Fatalf("duplicate IDs = %v, want [1 2]", dup.ExpenseIDs)
 	}
 
-	if len(res.Outliers) != 1 {
-		t.Fatalf("outliers len = %d, want 1", len(res.Outliers))
+	if len(res.Outliers) == 0 {
+		t.Fatalf("outliers len = %d, want >= 1", len(res.Outliers))
 	}
-	if res.Outliers[0].ExpenseID != 13 {
-		t.Fatalf("outlier expense_id = %d, want 13", res.Outliers[0].ExpenseID)
+	if res.OutliersTotal < 1 {
+		t.Fatalf("outliers total = %d, want >= 1", res.OutliersTotal)
 	}
 
+	foundWhale := false
 	for _, o := range res.Outliers {
+		if o.ExpenseID == 13 {
+			foundWhale = true
+		}
 		if o.ExpenseID == 3 || o.ExpenseID == 4 || o.ExpenseID == 5 || o.ExpenseID == 6 || o.ExpenseID == 7 || o.ExpenseID == 8 || o.ExpenseID == 9 || o.ExpenseID == 10 || o.ExpenseID == 11 || o.ExpenseID == 12 {
 			t.Fatalf("normal meal expense was incorrectly flagged as outlier: %d", o.ExpenseID)
 		}
 		if o.Category == "Travel" {
 			t.Fatalf("small-category travel outlier should have been skipped: %+v", o)
 		}
+	}
+	if !foundWhale {
+		t.Fatalf("expected whale expense 13 to be flagged, got outliers: %+v", res.Outliers)
 	}
 }
 
@@ -98,5 +108,53 @@ func TestDetectDuplicateClustersSameCurrencyStillClusters(t *testing.T) {
 	}
 	if clusters[0].Count != 2 {
 		t.Fatalf("cluster count = %d, want 2", clusters[0].Count)
+	}
+}
+
+func TestDetectCostOutliersFlagsWhaleInSmallCategory(t *testing.T) {
+	expenses := []Expense{
+		{ID: 1, Description: "A", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 2, Description: "B", Cost: "10.25", CurrencyCode: "USD", Date: "2026-05-02T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 3, Description: "C", Cost: "9.95", CurrencyCode: "USD", Date: "2026-05-03T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 4, Description: "D", Cost: "10.10", CurrencyCode: "USD", Date: "2026-05-04T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 5, Description: "E", Cost: "10.05", CurrencyCode: "USD", Date: "2026-05-05T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 6, Description: "F", Cost: "10.15", CurrencyCode: "USD", Date: "2026-05-06T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 7, Description: "G", Cost: "9.90", CurrencyCode: "USD", Date: "2026-05-07T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 8, Description: "H", Cost: "10.20", CurrencyCode: "USD", Date: "2026-05-08T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 9, Description: "I", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-09T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 10, Description: "Whale", Cost: "100000.00", CurrencyCode: "USD", Date: "2026-05-10T10:00:00Z", Category: Category{Name: "Meals"}},
+	}
+	outliers := detectCostOutliers(expenses)
+	if len(outliers) != 1 {
+		t.Fatalf("outliers len = %d, want 1", len(outliers))
+	}
+	if outliers[0].ExpenseID != 10 {
+		t.Fatalf("outlier expense_id = %d, want 10", outliers[0].ExpenseID)
+	}
+}
+
+func TestDetectCostOutliersSkipsMADZero(t *testing.T) {
+	expenses := []Expense{
+		{ID: 1, Description: "A", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 2, Description: "B", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-02T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 3, Description: "C", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-03T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 4, Description: "D", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-04T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 5, Description: "E", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-05T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 6, Description: "F", Cost: "100000.00", CurrencyCode: "USD", Date: "2026-05-06T10:00:00Z", Category: Category{Name: "Meals"}},
+	}
+	outliers := detectCostOutliers(expenses)
+	if len(outliers) != 0 {
+		t.Fatalf("outliers len = %d, want 0 when MAD == 0", len(outliers))
+	}
+}
+
+func TestMedian(t *testing.T) {
+	odd := median([]float64{5, 1, 9})
+	if odd != 5 {
+		t.Fatalf("median odd = %v, want 5", odd)
+	}
+	even := median([]float64{10, 2, 6, 4})
+	if even != 5 {
+		t.Fatalf("median even = %v, want 5", even)
 	}
 }

--- a/library/payments/splitwise/internal/cli/splitwise_audit_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit_test.go
@@ -133,6 +133,27 @@ func TestDetectCostOutliersFlagsWhaleInSmallCategory(t *testing.T) {
 	}
 }
 
+func TestDetectCostOutliersFlagsUnusuallyCheapItem(t *testing.T) {
+	expenses := []Expense{
+		{ID: 1, Description: "A", Cost: "80.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 2, Description: "B", Cost: "82.00", CurrencyCode: "USD", Date: "2026-05-02T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 3, Description: "C", Cost: "78.00", CurrencyCode: "USD", Date: "2026-05-03T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 4, Description: "D", Cost: "81.00", CurrencyCode: "USD", Date: "2026-05-04T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 5, Description: "E", Cost: "79.00", CurrencyCode: "USD", Date: "2026-05-05T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 6, Description: "F", Cost: "80.50", CurrencyCode: "USD", Date: "2026-05-06T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 7, Description: "G", Cost: "79.50", CurrencyCode: "USD", Date: "2026-05-07T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 8, Description: "H", Cost: "80.00", CurrencyCode: "USD", Date: "2026-05-08T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 9, Description: "Misfiled $1 dinner", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-09T10:00:00Z", Category: Category{Name: "Meals"}},
+	}
+	outliers := detectCostOutliers(expenses)
+	if len(outliers) != 1 {
+		t.Fatalf("outliers len = %d, want 1 (the $1 misfiled item)", len(outliers))
+	}
+	if outliers[0].ExpenseID != 9 {
+		t.Fatalf("outlier expense_id = %d, want 9", outliers[0].ExpenseID)
+	}
+}
+
 func TestDetectCostOutliersSkipsMADZero(t *testing.T) {
 	expenses := []Expense{
 		{ID: 1, Description: "A", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Meals"}},

--- a/library/payments/splitwise/internal/cli/splitwise_audit_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import "testing"
+
+func TestRunAudit(t *testing.T) {
+	sp := func(s string) *string { return &s }
+
+	expenses := []Expense{
+		{ID: 1, GroupID: 10, Description: "Settle all balances", Cost: "12.50", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 2, GroupID: 10, Description: "  settle ALL   balances ", Cost: "12.50", CurrencyCode: "USD", Date: "2026-05-20T19:30:00Z", Category: Category{Name: "Meals"}},
+		{ID: 3, GroupID: 10, Description: "Coffee", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-21T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 4, GroupID: 10, Description: "Snack", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-22T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 5, GroupID: 10, Description: "Brunch", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-23T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 6, GroupID: 10, Description: "Lunch", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-24T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 7, GroupID: 10, Description: "Dinner", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-25T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 8, GroupID: 10, Description: "Groceries", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-26T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 9, GroupID: 10, Description: "Tea", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-27T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 10, GroupID: 10, Description: "Sandwich", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-28T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 11, GroupID: 10, Description: "Pizza", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-29T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 12, GroupID: 10, Description: "Soup", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-30T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 13, GroupID: 10, Description: "Luxury tasting", Cost: "10000.00", CurrencyCode: "USD", Date: "2026-05-31T10:00:00Z", Category: Category{Name: "Meals"}},
+		{ID: 14, GroupID: 20, Description: "Small one", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Travel"}},
+		{ID: 15, GroupID: 20, Description: "Small two", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-02T10:00:00Z", Category: Category{Name: "Travel"}},
+		{ID: 16, GroupID: 20, Description: "Small three", Cost: "1.00", CurrencyCode: "USD", Date: "2026-05-03T10:00:00Z", Category: Category{Name: "Travel"}},
+		{ID: 17, GroupID: 20, Description: "Huge travel", Cost: "1000000.00", CurrencyCode: "USD", Date: "2026-05-04T10:00:00Z", Category: Category{Name: "Travel"}},
+		{ID: 18, GroupID: 10, Description: "Payment record", Cost: "999.00", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z", Payment: true, Category: Category{Name: "Meals"}},
+		{ID: 19, GroupID: 10, Description: "Deleted record", Cost: "999.00", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z", DeletedAt: sp("2026-01-01"), Category: Category{Name: "Meals"}},
+	}
+
+	res := runAudit(expenses, 50)
+
+	if res.ScannedExpenses != 17 {
+		t.Fatalf("ScannedExpenses = %d, want 17", res.ScannedExpenses)
+	}
+
+	if len(res.Duplicates) != 1 {
+		t.Fatalf("duplicates len = %d, want 1", len(res.Duplicates))
+	}
+	dup := res.Duplicates[0]
+	if dup.Count != 2 {
+		t.Fatalf("duplicate count = %d, want 2", dup.Count)
+	}
+	if len(dup.ExpenseIDs) != 2 || dup.ExpenseIDs[0] != 1 || dup.ExpenseIDs[1] != 2 {
+		t.Fatalf("duplicate IDs = %v, want [1 2]", dup.ExpenseIDs)
+	}
+
+	if len(res.Outliers) != 1 {
+		t.Fatalf("outliers len = %d, want 1", len(res.Outliers))
+	}
+	if res.Outliers[0].ExpenseID != 13 {
+		t.Fatalf("outlier expense_id = %d, want 13", res.Outliers[0].ExpenseID)
+	}
+
+	for _, o := range res.Outliers {
+		if o.ExpenseID == 3 || o.ExpenseID == 4 || o.ExpenseID == 5 || o.ExpenseID == 6 || o.ExpenseID == 7 || o.ExpenseID == 8 || o.ExpenseID == 9 || o.ExpenseID == 10 || o.ExpenseID == 11 || o.ExpenseID == 12 {
+			t.Fatalf("normal meal expense was incorrectly flagged as outlier: %d", o.ExpenseID)
+		}
+		if o.Category == "Travel" {
+			t.Fatalf("small-category travel outlier should have been skipped: %+v", o)
+		}
+	}
+}
+
+func TestRunAuditSingletonNotDuplicate(t *testing.T) {
+	expenses := []Expense{
+		{ID: 100, GroupID: 1, Description: "Solo expense", Cost: "8.00", CurrencyCode: "USD", Date: "2026-05-01T10:00:00Z", Category: Category{Name: "Misc"}},
+	}
+	res := runAudit(expenses, 50)
+	if len(res.Duplicates) != 0 {
+		t.Fatalf("duplicates len = %d, want 0", len(res.Duplicates))
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_audit_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_audit_test.go
@@ -70,3 +70,33 @@ func TestRunAuditSingletonNotDuplicate(t *testing.T) {
 		t.Fatalf("duplicates len = %d, want 0", len(res.Duplicates))
 	}
 }
+
+func TestDetectDuplicateClustersCurrencyIsolation(t *testing.T) {
+	expenses := []Expense{
+		{ID: 1, GroupID: 42, Description: "Team lunch", Cost: "50.00", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z"},
+		{ID: 2, GroupID: 42, Description: "team   lunch", Cost: "50.00", CurrencyCode: "EUR", Date: "2026-05-20T19:00:00Z"},
+	}
+
+	clusters := detectDuplicateClusters(expenses)
+	if len(clusters) != 0 {
+		t.Fatalf("clusters len = %d, want 0 for mixed currency", len(clusters))
+	}
+}
+
+func TestDetectDuplicateClustersSameCurrencyStillClusters(t *testing.T) {
+	expenses := []Expense{
+		{ID: 10, GroupID: 42, Description: "Team lunch", Cost: "50.00", CurrencyCode: "USD", Date: "2026-05-20T10:00:00Z"},
+		{ID: 11, GroupID: 42, Description: "team   lunch", Cost: "50.00", CurrencyCode: "USD", Date: "2026-05-20T19:00:00Z"},
+	}
+
+	clusters := detectDuplicateClusters(expenses)
+	if len(clusters) != 1 {
+		t.Fatalf("clusters len = %d, want 1", len(clusters))
+	}
+	if clusters[0].CurrencyCode != "USD" {
+		t.Fatalf("cluster currency = %q, want USD", clusters[0].CurrencyCode)
+	}
+	if clusters[0].Count != 2 {
+		t.Fatalf("cluster count = %d, want 2", clusters[0].Count)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_balances.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -382,18 +381,10 @@ func newDebtsCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
-			_, _ = fmt.Fprintln(tw, "FRIEND\tCURRENCY\tAMOUNT\tDIRECTION\tOLDEST EXPENSE\tAGE DAYS")
+			_, _ = fmt.Fprintln(tw, "FRIEND\tCURRENCY\tAMOUNT\tDIRECTION\tOLDEST EXPENSE\tAGE")
 			for _, row := range results {
-				// AgeDays is a *int: nil means the oldest contributing expense
-				// is outside the synced window, so the age is genuinely unknown.
-				// Render the dereferenced value, and a "-" placeholder for nil —
-				// printing the pointer with %d would emit the address for known
-				// ages and a misleading 0 for unknown ones.
-				ageCell := "-"
-				if row.AgeDays != nil {
-					ageCell = strconv.Itoa(*row.AgeDays)
-				}
-				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", row.Name, row.CurrencyCode, row.Amount, row.Direction, row.OldestExpenseDate, ageCell)
+				ageStr := ageCell(row.AgeDays)
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", row.Name, row.CurrencyCode, row.Amount, row.Direction, row.OldestExpenseDate, ageStr)
 			}
 			return tw.Flush()
 		},

--- a/library/payments/splitwise/internal/cli/splitwise_balances.go
+++ b/library/payments/splitwise/internal/cli/splitwise_balances.go
@@ -31,7 +31,7 @@ func newResolveCmd(flags *rootFlags) *cobra.Command {
 			if dryRunOK(flags) {
 				target := "name"
 				if len(args) > 0 {
-					target = strings.TrimSpace(args[0])
+					target = joinNameArgs(args)
 				}
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "would resolve %s\n", target)
 				return nil
@@ -39,7 +39,7 @@ func newResolveCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return usageErr(errors.New("name argument is required"))
 			}
-			name := strings.TrimSpace(args[0])
+			name := joinNameArgs(args)
 
 			db, err := openSplitwiseStore(cmd.Context())
 			if err != nil {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -225,7 +225,7 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&writeOffDays, "write-off-days", 365, "Days after which old debt may be written off")
 	cmd.Flags().IntVar(&ghostDays, "ghost-days", 180, "Days of inactivity considered ghosted")
 	cmd.Flags().IntVar(&minEpisodes, "min-episodes", 1, "Minimum closed episodes required for avg latency")
-	cmd.Flags().StringVar(&since, "since", "", "Only include activity on/after YYYY-MM-DD")
+	cmd.Flags().StringVar(&since, "since", "", "Window contribution (paid/owed) to on/after YYYY-MM-DD; collectability and debt age always use full history")
 	return cmd
 }
 
@@ -351,13 +351,19 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 			if !member {
 				continue
 			}
+			matchedAny = true
+			// Collectability signals (debt age / settle latency / last-settled /
+			// ghost) use FULL history -- a debt's age is an absolute fact, not
+			// scoped by --since; only the contribution numbers below are windowed,
+			// so --since can never suppress an old debt's write_off tier.
+			if d, ok := parseSplitwiseDate(e.Date); ok {
+				events = append(events, subjectEvent{date: d, payment: e.Payment})
+			}
 			if opts.hasSince {
-				t, ok := parseSplitwiseDate(e.Date)
-				if !ok || t.Before(opts.since) {
+				if t, ok := parseSplitwiseDate(e.Date); !ok || t.Before(opts.since) {
 					continue
 				}
 			}
-			matchedAny = true
 			if !e.Payment {
 				p.Paid += parseAmount(row.PaidShare)
 				p.Owed += parseAmount(row.OwedShare)
@@ -365,9 +371,6 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 				if parseAmount(row.PaidShare) > 0 {
 					p.PayerCount++
 				}
-			}
-			if d, ok := parseSplitwiseDate(e.Date); ok {
-				events = append(events, subjectEvent{date: d, payment: e.Payment})
 			}
 		}
 

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -387,7 +387,7 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 			r := round2(p.Paid / p.Owed)
 			p.CarryRatio = &r
 		}
-		p.Role = classifyRole(p.HasHistory, p.CarryRatio)
+		p.Role = roleForContribution(p.HasHistory, p.Paid, p.Owed, p.CarryRatio)
 
 		ep := episodeMetrics(now, events, opts.minEpisodes)
 		p.DebtAgeDays = ep.debtAgeDays
@@ -593,6 +593,18 @@ func classifyRole(hasHistory bool, ratio *float64) string {
 		return "carrier"
 	}
 	return "even"
+}
+
+// roleForContribution wraps classifyRole to correct the one case classifyRole
+// cannot see: a member who paid into the group while owing nothing (excluded
+// from the split) has a nil CarryRatio, which classifyRole defaults to "rider".
+// That member is a pure carrier — an unbounded carry ratio — not a rider.
+func roleForContribution(hasHistory bool, paid, owed float64, ratio *float64) string {
+	role := classifyRole(hasHistory, ratio)
+	if role == "rider" && owed == 0 && paid > 0 {
+		return "carrier"
+	}
+	return role
 }
 
 func clampDays(v int) int {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -1,0 +1,672 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type fairnessOpts struct {
+	by                      string
+	writeOffDays, ghostDays int
+	minEpisodes             int
+	currency                string
+	since                   time.Time
+	hasSince                bool
+	friendID                int
+	groupID                 int
+	groupScoped             bool
+}
+
+type fairnessPerson struct {
+	UserID                int                `json:"user_id"`
+	Name                  string             `json:"name"`
+	HasHistory            bool               `json:"has_history"`
+	Paid                  float64            `json:"paid"`
+	Owed                  float64            `json:"owed"`
+	Net                   float64            `json:"net"`
+	CarryRatio            *float64           `json:"carry_ratio"`
+	ExpenseCount          int                `json:"expense_count"`
+	PayerCount            int                `json:"payer_count"`
+	Role                  string             `json:"role"`
+	OutstandingByCurrency map[string]float64 `json:"outstanding_by_currency"`
+	OutstandingTotal      float64            `json:"outstanding_total"`
+	DebtAgeDays           *int               `json:"debt_age_days"`
+	LastSettledDays       *int               `json:"last_settled_days"`
+	AvgLatencyDays        *float64           `json:"avg_latency_days"`
+	RiskScore             *float64           `json:"risk_score"`
+	RiskTier              string             `json:"risk_tier"`
+	Action                string             `json:"action"`
+}
+
+type fairnessResult struct {
+	By            string           `json:"by"`
+	Scope         string           `json:"scope"`
+	People        []fairnessPerson `json:"people"`
+	AtRiskTotal   float64          `json:"at_risk_total"`
+	WriteOffTotal float64          `json:"write_off_total"`
+	NewMembers    int              `json:"new_members"`
+	GroupCaveat   bool             `json:"group_caveat,omitempty"`
+}
+
+type subjectEvent struct {
+	date    time.Time
+	payment bool
+}
+
+type episodeState struct {
+	debtAgeDays      *int
+	lastSettledDays  *int
+	avgLatencyDays   *float64
+	lastActivityDays int
+}
+
+type fairnessSubject struct {
+	id   int
+	name string
+}
+
+// pp:data-source local
+func newFairnessCmd(flags *rootFlags) *cobra.Command {
+	var by string
+	var friendRef string
+	var groupRef string
+	var currency string
+	var writeOffDays int
+	var ghostDays int
+	var minEpisodes int
+	var since string
+
+	cmd := &cobra.Command{
+		Use:         "fairness",
+		Short:       "Score who carries the group, who's a collection risk, and who to chase or write off",
+		Example:     "  splitwise-pp-cli fairness --by risk --agent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would compute fairness")
+				return nil
+			}
+			if by != "risk" && by != "contribution" && by != "collectability" {
+				return usageErr(fmt.Errorf("invalid --by value %q: must be risk, contribution, or collectability", by))
+			}
+			if friendRef != "" && groupRef != "" {
+				return usageErr(errors.New("--friend and --group are mutually exclusive"))
+			}
+			if writeOffDays <= 0 {
+				return usageErr(fmt.Errorf("--write-off-days must be >= 1"))
+			}
+			if ghostDays <= 0 {
+				return usageErr(fmt.Errorf("--ghost-days must be >= 1"))
+			}
+			if minEpisodes < 1 {
+				return usageErr(fmt.Errorf("--min-episodes must be >= 1"))
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-friends")
+			hintIfUnsynced(cmd, db, "get-groups")
+			hintIfUnsynced(cmd, db, "get-expenses")
+			hintIfStale(cmd, db, "get-friends", flags.maxAge)
+			hintIfStale(cmd, db, "get-groups", flags.maxAge)
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
+
+			friends, err := loadFriends(db)
+			if err != nil {
+				return err
+			}
+			groups, err := loadGroups(db)
+			if err != nil {
+				return err
+			}
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			opts := fairnessOpts{by: by, writeOffDays: writeOffDays, ghostDays: ghostDays, minEpisodes: minEpisodes, currency: strings.TrimSpace(currency)}
+			if strings.TrimSpace(since) != "" {
+				t, err := time.Parse("2006-01-02", strings.TrimSpace(since))
+				if err != nil {
+					return usageErr(fmt.Errorf("invalid --since %q: %w", since, err))
+				}
+				opts.since = t
+				opts.hasSince = true
+			}
+
+			scope := "all-friends"
+			if strings.TrimSpace(friendRef) != "" {
+				id, name, ok := resolveFairnessFriend(friendRef, friends)
+				if !ok {
+					return usageErr(fmt.Errorf("no friend matches %q; run sync first", friendRef))
+				}
+				opts.friendID = id
+				scope = "friend:" + name
+			}
+			if strings.TrimSpace(groupRef) != "" {
+				id, name, ok := resolveFairnessGroup(groupRef, groups)
+				if !ok {
+					return usageErr(fmt.Errorf("no group matches %q; run sync first", groupRef))
+				}
+				opts.groupID = id
+				opts.groupScoped = true
+				scope = "group:" + name
+			}
+
+			result := computeFairness(youID, friends, groups, expenses, time.Now().UTC(), opts)
+			if result.Scope == "" {
+				result.Scope = scope
+			}
+
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, result)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Fairness — %s (by %s)\n", result.Scope, result.By)
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+			switch result.By {
+			case "risk":
+				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE(d)\tLAST SETTLED(d)\tTIER\tACTION")
+				for _, p := range result.People {
+					age := "-"
+					if p.DebtAgeDays != nil {
+						age = strconv.Itoa(*p.DebtAgeDays)
+					}
+					last := "-"
+					if p.LastSettledDays != nil {
+						last = strconv.Itoa(*p.LastSettledDays)
+					}
+					_, _ = fmt.Fprintf(tw, "%s %s\t%.2f\t%s\t%s\t%s\t%s\n", tierGlyph(p.RiskTier), p.Name, p.OutstandingTotal, age, last, p.RiskTier, p.Action)
+				}
+			case "contribution":
+				_, _ = fmt.Fprintln(tw, "WHO\tPAID\tOWED\tNET\tRATIO\tROLE")
+				for _, p := range result.People {
+					ratio := "-"
+					if p.CarryRatio != nil {
+						ratio = fmt.Sprintf("%.2f", *p.CarryRatio)
+					}
+					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%.2f\t%.2f\t%s\t%s\n", p.Name, p.Paid, p.Owed, p.Net, ratio, p.Role)
+				}
+			case "collectability":
+				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE(d)\tLAST SETTLED(d)\tAVG LATENCY(d)")
+				for _, p := range result.People {
+					age := "-"
+					if p.DebtAgeDays != nil {
+						age = strconv.Itoa(*p.DebtAgeDays)
+					}
+					last := "-"
+					if p.LastSettledDays != nil {
+						last = strconv.Itoa(*p.LastSettledDays)
+					}
+					avg := "-"
+					if p.AvgLatencyDays != nil {
+						avg = fmt.Sprintf("%.2f", *p.AvgLatencyDays)
+					}
+					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\n", p.Name, p.OutstandingTotal, age, last, avg)
+				}
+			}
+			if err := tw.Flush(); err != nil {
+				return err
+			}
+			if result.By == "risk" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "At risk: %.2f  ·  Write-off candidates: %.2f  ·  New members: %d\n", result.AtRiskTotal, result.WriteOffTotal, result.NewMembers)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&friendRef, "friend", "", "Friend name or id")
+	cmd.Flags().StringVar(&groupRef, "group", "", "Group name or id")
+	cmd.Flags().StringVar(&by, "by", "risk", "Lens: risk|contribution|collectability")
+	cmd.Flags().StringVar(&currency, "currency", "", "Currency code filter")
+	cmd.Flags().IntVar(&writeOffDays, "write-off-days", 365, "Days after which old debt may be written off")
+	cmd.Flags().IntVar(&ghostDays, "ghost-days", 180, "Days of inactivity considered ghosted")
+	cmd.Flags().IntVar(&minEpisodes, "min-episodes", 1, "Minimum closed episodes required for avg latency")
+	cmd.Flags().StringVar(&since, "since", "", "Only include activity on/after YYYY-MM-DD")
+	return cmd
+}
+
+func computeFairness(youID int, friends []Friend, groups []Group, expenses []Expense, now time.Time, opts fairnessOpts) fairnessResult {
+	result := fairnessResult{By: opts.by, Scope: "all-friends", People: make([]fairnessPerson, 0)}
+	if result.By == "" {
+		result.By = "risk"
+	}
+
+	subjects := make([]fairnessSubject, 0)
+	outstanding := make(map[int]map[string]float64)
+
+	if opts.groupScoped {
+		for _, g := range groups {
+			if g.ID != opts.groupID {
+				continue
+			}
+			result.Scope = "group:" + strings.TrimSpace(g.Name)
+			result.GroupCaveat = true
+			for _, m := range g.Members {
+				if m.ID == youID {
+					continue
+				}
+				name := strings.TrimSpace(strings.TrimSpace(m.FirstName) + " " + strings.TrimSpace(m.LastName))
+				if name == "" {
+					name = fmt.Sprintf("user %d", m.ID)
+				}
+				subjects = append(subjects, fairnessSubject{id: m.ID, name: name})
+			}
+			for _, d := range g.SimplifiedDebts {
+				if d.To != youID || d.From == youID {
+					continue
+				}
+				if opts.currency != "" && !strings.EqualFold(strings.TrimSpace(d.CurrencyCode), opts.currency) {
+					continue
+				}
+				amt := parseAmount(d.Amount)
+				if amt <= 0 {
+					continue
+				}
+				if outstanding[d.From] == nil {
+					outstanding[d.From] = make(map[string]float64)
+				}
+				cc := strings.ToUpper(strings.TrimSpace(d.CurrencyCode))
+				outstanding[d.From][cc] = round2(outstanding[d.From][cc] + amt)
+			}
+			break
+		}
+	} else {
+		for _, f := range friends {
+			if opts.friendID != 0 && f.ID != opts.friendID {
+				continue
+			}
+			name := friendDisplayName(f)
+			if name == "" {
+				name = fmt.Sprintf("friend %d", f.ID)
+			}
+			if opts.friendID != 0 {
+				result.Scope = "friend:" + name
+			}
+			subjects = append(subjects, fairnessSubject{id: f.ID, name: name})
+			for _, b := range f.Balance {
+				if opts.currency != "" && !strings.EqualFold(strings.TrimSpace(b.CurrencyCode), opts.currency) {
+					continue
+				}
+				amt := parseAmount(b.Amount)
+				if amt <= 0 {
+					continue
+				}
+				if outstanding[f.ID] == nil {
+					outstanding[f.ID] = make(map[string]float64)
+				}
+				cc := strings.ToUpper(strings.TrimSpace(b.CurrencyCode))
+				outstanding[f.ID][cc] = round2(outstanding[f.ID][cc] + amt)
+			}
+		}
+	}
+
+	if len(subjects) == 0 {
+		return result
+	}
+
+	type rawStats struct {
+		person           fairnessPerson
+		lastActivityDays int
+	}
+
+	raw := make([]rawStats, 0, len(subjects))
+	maxOut := 0.0
+	for _, s := range subjects {
+		p := fairnessPerson{UserID: s.id, Name: s.name, OutstandingByCurrency: make(map[string]float64), RiskTier: "new", Action: "no history yet — nothing to collect"}
+		if currencies := outstanding[s.id]; currencies != nil {
+			for cc, amt := range currencies {
+				if amt > 0 {
+					p.OutstandingByCurrency[cc] = round2(amt)
+					p.OutstandingTotal += amt
+				}
+			}
+			p.OutstandingTotal = round2(p.OutstandingTotal)
+		}
+
+		matchedAny := false
+		events := make([]subjectEvent, 0)
+		for _, e := range expenses {
+			if expenseDeleted(e.DeletedAt) {
+				continue
+			}
+			if opts.groupScoped && e.GroupID != opts.groupID {
+				continue
+			}
+			if opts.currency != "" && !strings.EqualFold(strings.TrimSpace(e.CurrencyCode), opts.currency) {
+				continue
+			}
+			member := false
+			var row ExpenseUser
+			for _, u := range e.Users {
+				if u.UserID == s.id {
+					row = u
+					member = true
+					break
+				}
+			}
+			if !member {
+				continue
+			}
+			if opts.hasSince {
+				t, ok := parseSplitwiseDate(e.Date)
+				if !ok || t.Before(opts.since) {
+					continue
+				}
+			}
+			matchedAny = true
+			if !e.Payment {
+				p.Paid += parseAmount(row.PaidShare)
+				p.Owed += parseAmount(row.OwedShare)
+				p.ExpenseCount++
+				if parseAmount(row.PaidShare) > 0 {
+					p.PayerCount++
+				}
+			}
+			if d, ok := parseSplitwiseDate(e.Date); ok {
+				events = append(events, subjectEvent{date: d, payment: e.Payment})
+			}
+		}
+
+		p.HasHistory = matchedAny
+		p.Paid = round2(p.Paid)
+		p.Owed = round2(p.Owed)
+		p.Net = round2(p.Paid - p.Owed)
+		if p.Owed > 0 {
+			r := round2(p.Paid / p.Owed)
+			p.CarryRatio = &r
+		}
+		p.Role = classifyRole(p.HasHistory, p.CarryRatio)
+
+		ep := episodeMetrics(now, events, opts.minEpisodes)
+		p.DebtAgeDays = ep.debtAgeDays
+		p.LastSettledDays = ep.lastSettledDays
+		p.AvgLatencyDays = ep.avgLatencyDays
+
+		if !p.HasHistory {
+			result.NewMembers++
+		}
+		if p.HasHistory && p.OutstandingTotal > 0 && p.OutstandingTotal > maxOut {
+			maxOut = p.OutstandingTotal
+		}
+		raw = append(raw, rawStats{person: p, lastActivityDays: ep.lastActivityDays})
+	}
+
+	if maxOut <= 0 {
+		maxOut = 1
+	}
+
+	for i := range raw {
+		p := &raw[i].person
+		if !p.HasHistory {
+			continue
+		}
+		if p.OutstandingTotal <= 0 {
+			p.RiskTier = "settled"
+			p.Action = ""
+			continue
+		}
+
+		debtAge := 0.0
+		if p.DebtAgeDays != nil {
+			debtAge = float64(*p.DebtAgeDays)
+		}
+		// lastActivityDays was derived once in episodeMetrics (large sentinel when the
+		// subject has no parseable-date events, pinning ghostScore to its max).
+		lastActivity := float64(raw[i].lastActivityDays)
+		ageScore := clampUnit(debtAge/float64(opts.writeOffDays)) * 40
+		ghostScore := clampUnit(lastActivity/float64(opts.ghostDays)) * 30
+		latScore := 10.0
+		if p.AvgLatencyDays != nil {
+			latScore = clampUnit(*p.AvgLatencyDays/float64(opts.ghostDays)) * 20
+		}
+		magScore := clampUnit(p.OutstandingTotal/maxOut) * 10
+		score := round2(ageScore + ghostScore + latScore + magScore)
+		p.RiskScore = &score
+
+		if p.DebtAgeDays != nil && *p.DebtAgeDays >= opts.writeOffDays && lastActivity >= float64(opts.ghostDays) {
+			p.RiskTier = "write_off"
+			p.Action = "consider writing off — old and gone quiet"
+		} else if score >= 60 {
+			p.RiskTier = "chase"
+			p.Action = "follow up directly"
+		} else if score >= 30 {
+			p.RiskTier = "nudge"
+			p.Action = "send a reminder"
+		} else {
+			p.RiskTier = "on_track"
+			p.Action = ""
+		}
+	}
+
+	people := make([]fairnessPerson, 0)
+	for _, row := range raw {
+		p := row.person
+		switch result.By {
+		case "risk":
+			if p.HasHistory && p.OutstandingTotal > 0 {
+				people = append(people, p)
+				result.AtRiskTotal += p.OutstandingTotal
+				if p.RiskTier == "write_off" {
+					result.WriteOffTotal += p.OutstandingTotal
+				}
+			}
+		case "collectability", "contribution":
+			if p.HasHistory {
+				people = append(people, p)
+			}
+		default:
+			if p.HasHistory && p.OutstandingTotal > 0 {
+				people = append(people, p)
+			}
+		}
+	}
+	result.AtRiskTotal = round2(result.AtRiskTotal)
+	result.WriteOffTotal = round2(result.WriteOffTotal)
+
+	switch result.By {
+	case "risk":
+		sort.Slice(people, func(i, j int) bool {
+			si := 0.0
+			sj := 0.0
+			if people[i].RiskScore != nil {
+				si = *people[i].RiskScore
+			}
+			if people[j].RiskScore != nil {
+				sj = *people[j].RiskScore
+			}
+			if si != sj {
+				return si > sj
+			}
+			if people[i].OutstandingTotal != people[j].OutstandingTotal {
+				return people[i].OutstandingTotal > people[j].OutstandingTotal
+			}
+			return people[i].Name < people[j].Name
+		})
+	case "collectability":
+		sort.Slice(people, func(i, j int) bool {
+			if people[i].DebtAgeDays == nil && people[j].DebtAgeDays != nil {
+				return false
+			}
+			if people[i].DebtAgeDays != nil && people[j].DebtAgeDays == nil {
+				return true
+			}
+			if people[i].DebtAgeDays != nil && people[j].DebtAgeDays != nil && *people[i].DebtAgeDays != *people[j].DebtAgeDays {
+				return *people[i].DebtAgeDays > *people[j].DebtAgeDays
+			}
+			if people[i].OutstandingTotal != people[j].OutstandingTotal {
+				return people[i].OutstandingTotal > people[j].OutstandingTotal
+			}
+			return people[i].Name < people[j].Name
+		})
+	case "contribution":
+		sort.Slice(people, func(i, j int) bool {
+			if people[i].Net != people[j].Net {
+				return people[i].Net > people[j].Net
+			}
+			return people[i].Name < people[j].Name
+		})
+	}
+
+	result.People = people
+	return result
+}
+
+func clampUnit(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+func episodeMetrics(now time.Time, events []subjectEvent, minEpisodes int) episodeState {
+	sort.Slice(events, func(i, j int) bool { return events[i].date.Before(events[j].date) })
+	var openStart *time.Time
+	var lastPayment *time.Time
+	latencies := make([]float64, 0)
+	for _, e := range events {
+		if !e.payment {
+			if openStart == nil {
+				d := e.date
+				openStart = &d
+			}
+			continue
+		}
+		if openStart != nil {
+			days := e.date.Sub(*openStart).Hours() / 24
+			if days < 0 {
+				days = 0
+			}
+			latencies = append(latencies, days)
+			openStart = nil
+		}
+		d := e.date
+		lastPayment = &d
+	}
+
+	st := episodeState{lastActivityDays: 100000}
+	if len(events) > 0 {
+		last := events[len(events)-1].date
+		st.lastActivityDays = clampDays(int(now.Sub(last).Hours() / 24))
+	}
+	if openStart != nil {
+		d := clampDays(int(now.Sub(*openStart).Hours() / 24))
+		st.debtAgeDays = &d
+	}
+	if lastPayment != nil {
+		d := clampDays(int(now.Sub(*lastPayment).Hours() / 24))
+		st.lastSettledDays = &d
+	}
+	if len(latencies) >= minEpisodes {
+		total := 0.0
+		for _, v := range latencies {
+			total += v
+		}
+		avg := round2(total / float64(len(latencies)))
+		st.avgLatencyDays = &avg
+	}
+	return st
+}
+
+func classifyRole(hasHistory bool, ratio *float64) string {
+	if !hasHistory {
+		return "new"
+	}
+	if ratio == nil || *ratio < 0.90 {
+		return "rider"
+	}
+	if *ratio > 1.10 {
+		return "carrier"
+	}
+	return "even"
+}
+
+func clampDays(v int) int {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func resolveFairnessFriend(input string, friends []Friend) (int, string, bool) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return 0, "", false
+	}
+	if isAllDigits(trimmed) {
+		id, _ := strconv.Atoi(trimmed)
+		for _, f := range friends {
+			if f.ID == id {
+				name := friendDisplayName(f)
+				if name == "" {
+					name = fmt.Sprintf("friend %d", f.ID)
+				}
+				return f.ID, name, true
+			}
+		}
+		return 0, "", false
+	}
+	for _, f := range friends {
+		if strings.EqualFold(friendDisplayName(f), trimmed) {
+			name := friendDisplayName(f)
+			if name == "" {
+				name = fmt.Sprintf("friend %d", f.ID)
+			}
+			return f.ID, name, true
+		}
+	}
+	return 0, "", false
+}
+
+func resolveFairnessGroup(input string, groups []Group) (int, string, bool) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return 0, "", false
+	}
+	if isAllDigits(trimmed) {
+		id, _ := strconv.Atoi(trimmed)
+		for _, g := range groups {
+			if g.ID == id {
+				return g.ID, strings.TrimSpace(g.Name), true
+			}
+		}
+		return 0, "", false
+	}
+	for _, g := range groups {
+		if strings.EqualFold(strings.TrimSpace(g.Name), trimmed) {
+			return g.ID, strings.TrimSpace(g.Name), true
+		}
+	}
+	return 0, "", false
+}
+
+func tierGlyph(tier string) string {
+	switch tier {
+	case "write_off":
+		return "🔴"
+	case "chase":
+		return "🟠"
+	case "nudge":
+		return "🟡"
+	default:
+		return "🟢"
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -40,6 +41,8 @@ type fairnessPerson struct {
 	DebtAgeDays           *int               `json:"debt_age_days"`
 	LastSettledDays       *int               `json:"last_settled_days"`
 	AvgLatencyDays        *float64           `json:"avg_latency_days"`
+	ProjectedDaysOut      *int               `json:"projected_days_out"`
+	ProjectedSettleDate   *string            `json:"projected_settle_date"`
 	RiskScore             *float64           `json:"risk_score"`
 	RiskTier              string             `json:"risk_tier"`
 	Action                string             `json:"action"`
@@ -197,7 +200,7 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%.2f\t%.2f\t%s\t%s\n", p.Name, p.Paid, p.Owed, p.Net, ratio, p.Role)
 				}
 			case "collectability":
-				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE\tLAST SETTLED\tAVG LATENCY(d)")
+				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE\tLAST SETTLED\tAVG LATENCY(d)\tPROJECTED")
 				for _, p := range result.People {
 					age := ageCell(p.DebtAgeDays)
 					last := ageCell(p.LastSettledDays)
@@ -205,7 +208,15 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 					if p.AvgLatencyDays != nil {
 						avg = fmt.Sprintf("%.2f", *p.AvgLatencyDays)
 					}
-					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\n", p.Name, p.OutstandingTotal, age, last, avg)
+					projected := "-"
+					if p.ProjectedDaysOut != nil {
+						if *p.ProjectedDaysOut >= 0 {
+							projected = humanizeDays(*p.ProjectedDaysOut) + " out"
+						} else {
+							projected = humanizeDays(-*p.ProjectedDaysOut) + " overdue"
+						}
+					}
+					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%s\t%s\t%s\t%s\n", p.Name, p.OutstandingTotal, age, last, avg, projected)
 				}
 			}
 			if err := tw.Flush(); err != nil {
@@ -226,6 +237,7 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&ghostDays, "ghost-days", 180, "Days of inactivity considered ghosted")
 	cmd.Flags().IntVar(&minEpisodes, "min-episodes", 1, "Minimum closed episodes required for avg latency")
 	cmd.Flags().StringVar(&since, "since", "", "Window contribution (paid/owed) to on/after YYYY-MM-DD; collectability and debt age always use full history")
+	cmd.AddCommand(newFairnessNudgeCmd(flags))
 	return cmd
 }
 
@@ -393,6 +405,14 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 		p.DebtAgeDays = ep.debtAgeDays
 		p.LastSettledDays = ep.lastSettledDays
 		p.AvgLatencyDays = ep.avgLatencyDays
+		// Project a settle date only for people who actually owe right now. The
+		// episode model can leave an "open" episode (and thus a debtAge) for a
+		// fully-settled person whose most recent shared expense wasn't followed by
+		// a payment record; projecting a settle date for someone who owes 0 is
+		// noise ("overdue by 2459d" for a $0 balance), so gate on outstanding>0.
+		if p.OutstandingTotal > 0 {
+			p.ProjectedDaysOut, p.ProjectedSettleDate = projectSettle(p.DebtAgeDays, p.AvgLatencyDays, now)
+		}
 
 		if !p.HasHistory {
 			result.NewMembers++
@@ -531,6 +551,15 @@ func clampUnit(x float64) float64 {
 		return 1
 	}
 	return x
+}
+
+func projectSettle(debtAgeDays *int, avgLatencyDays *float64, now time.Time) (*int, *string) {
+	if debtAgeDays == nil || avgLatencyDays == nil {
+		return nil, nil
+	}
+	daysOut := int(math.Round(*avgLatencyDays)) - *debtAgeDays
+	iso := now.AddDate(0, 0, daysOut).Format("2006-01-02")
+	return &daysOut, &iso
 }
 
 func episodeMetrics(now time.Time, events []subjectEvent, minEpisodes int) episodeState {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -181,16 +181,10 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
 			switch result.By {
 			case "risk":
-				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE(d)\tLAST SETTLED(d)\tTIER\tACTION")
+				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE\tLAST SETTLED\tTIER\tACTION")
 				for _, p := range result.People {
-					age := "-"
-					if p.DebtAgeDays != nil {
-						age = strconv.Itoa(*p.DebtAgeDays)
-					}
-					last := "-"
-					if p.LastSettledDays != nil {
-						last = strconv.Itoa(*p.LastSettledDays)
-					}
+					age := ageCell(p.DebtAgeDays)
+					last := ageCell(p.LastSettledDays)
 					_, _ = fmt.Fprintf(tw, "%s %s\t%.2f\t%s\t%s\t%s\t%s\n", tierGlyph(p.RiskTier), p.Name, p.OutstandingTotal, age, last, p.RiskTier, p.Action)
 				}
 			case "contribution":
@@ -203,16 +197,10 @@ func newFairnessCmd(flags *rootFlags) *cobra.Command {
 					_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%.2f\t%.2f\t%s\t%s\n", p.Name, p.Paid, p.Owed, p.Net, ratio, p.Role)
 				}
 			case "collectability":
-				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE(d)\tLAST SETTLED(d)\tAVG LATENCY(d)")
+				_, _ = fmt.Fprintln(tw, "WHO\tOUTSTANDING\tAGE\tLAST SETTLED\tAVG LATENCY(d)")
 				for _, p := range result.People {
-					age := "-"
-					if p.DebtAgeDays != nil {
-						age = strconv.Itoa(*p.DebtAgeDays)
-					}
-					last := "-"
-					if p.LastSettledDays != nil {
-						last = strconv.Itoa(*p.LastSettledDays)
-					}
+					age := ageCell(p.DebtAgeDays)
+					last := ageCell(p.LastSettledDays)
 					avg := "-"
 					if p.AvgLatencyDays != nil {
 						avg = fmt.Sprintf("%.2f", *p.AvgLatencyDays)
@@ -383,7 +371,12 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 			}
 		}
 
-		p.HasHistory = matchedAny
+		// A positive outstanding balance is a current fact from Friend.Balance /
+		// SimplifiedDebts and is NOT date-filtered. A debtor whose every in-scope
+		// expense predates --since must still count as "has history" — otherwise
+		// they'd be miscounted as a new member and dropped from every view,
+		// silently hiding a real (often old) outstanding debt.
+		p.HasHistory = matchedAny || p.OutstandingTotal > 0
 		p.Paid = round2(p.Paid)
 		p.Owed = round2(p.Owed)
 		p.Net = round2(p.Paid - p.Owed)
@@ -656,6 +649,57 @@ func resolveFairnessGroup(input string, groups []Group) (int, string, bool) {
 		}
 	}
 	return 0, "", false
+}
+
+// humanizeDays renders an integer day count as a readable duration for the
+// human table (e.g. 1558 -> "4y 3mo 8d", 19 -> "2w 5d", 5 -> "5d"). Display aid
+// only: the JSON output keeps the raw `*_days` integers so agents and analytics
+// tools do their own (calendar-accurate) conversion. Uses approximate units —
+// year=365d, month=30d, week=7d — fine for a readability hint and deterministic
+// without needing the start date.
+func humanizeDays(days int) string {
+	if days < 0 {
+		days = 0
+	}
+	switch {
+	case days < 7:
+		return fmt.Sprintf("%dd", days)
+	case days < 30:
+		w, d := days/7, days%7
+		if d == 0 {
+			return fmt.Sprintf("%dw", w)
+		}
+		return fmt.Sprintf("%dw %dd", w, d)
+	case days < 365:
+		mo, d := days/30, days%30
+		if d == 0 {
+			return fmt.Sprintf("%dmo", mo)
+		}
+		return fmt.Sprintf("%dmo %dd", mo, d)
+	default:
+		y := days / 365
+		rem := days % 365
+		mo, d := rem/30, rem%30
+		parts := []string{fmt.Sprintf("%dy", y)}
+		if mo > 0 {
+			parts = append(parts, fmt.Sprintf("%dmo", mo))
+		}
+		if d > 0 {
+			parts = append(parts, fmt.Sprintf("%dd", d))
+		}
+		return strings.Join(parts, " ")
+	}
+}
+
+// ageCell renders a *int day-age for a human table: "-" when the age is unknown
+// (nil — e.g. the contributing expense is outside the synced window), otherwise
+// the friendly humanizeDays form. Shared by the `fairness` and `debts` reports so
+// their AGE columns render identically; JSON keeps the raw `*_days` integer.
+func ageCell(days *int) string {
+	if days == nil {
+		return "-"
+	}
+	return humanizeDays(*days)
 }
 
 func tierGlyph(tier string) string {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness.go
@@ -447,6 +447,11 @@ func computeFairness(youID int, friends []Friend, groups []Group, expenses []Exp
 		lastActivity := float64(raw[i].lastActivityDays)
 		ageScore := clampUnit(debtAge/float64(opts.writeOffDays)) * 40
 		ghostScore := clampUnit(lastActivity/float64(opts.ghostDays)) * 30
+		// latScore: 0-20 points when average settle latency is known; a neutral
+		// 10 (the midpoint) when fewer than --min-episodes closed cycles exist.
+		// This intentionally caps the achievable risk score at 90 for
+		// unknown-latency debtors -- they get the benefit of the doubt versus a
+		// confirmed slow payer (score 100).
 		latScore := 10.0
 		if p.AvgLatencyDays != nil {
 			latScore = clampUnit(*p.AvgLatencyDays/float64(opts.ghostDays)) * 20

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
@@ -17,6 +17,10 @@ func newFairnessNudgeCmd(flags *rootFlags) *cobra.Command {
 		Use:   "nudge <friend>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Send a friendly payment reminder to a friend who owes you",
+		// CLI-only write action: keep nudge off the MCP surface so an agent can't
+		// auto-post reminders, and so it is never grouped under the read-only
+		// fairness parent tool.
+		Annotations: map[string]string{"mcp:hidden": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dryRunOK(flags) {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would send a nudge")
@@ -49,6 +53,13 @@ func newFairnessNudgeCmd(flags *rootFlags) *cobra.Command {
 				overrideTarget, found := findExpenseByID(expenses, overrideExpenseID)
 				if !found {
 					return usageErr(fmt.Errorf("no expense matches --expense-id %d", overrideExpenseID))
+				}
+				// Apply the same guards selectNudgeExpense uses, so a manual
+				// --expense-id can't post a wrong-amount reminder (friend not on the
+				// expense → message quotes the total) or a doomed comment (deleted /
+				// payment row → opaque API error).
+				if problem := nudgeExpenseProblem(overrideTarget, friendID); problem != "" {
+					return usageErr(fmt.Errorf("--expense-id %d is not a valid nudge target: %s", overrideExpenseID, problem))
 				}
 				target = overrideTarget
 				ok = true
@@ -214,4 +225,24 @@ func findExpenseByID(expenses []Expense, id int) (Expense, bool) {
 		}
 	}
 	return Expense{}, false
+}
+
+// nudgeExpenseProblem returns a human-readable reason the expense is not a valid
+// nudge target for friendID, or "" if it is. Mirrors the guards selectNudgeExpense
+// applies so a manual --expense-id override can't post a wrong-amount reminder
+// (friend not on the expense → message would quote the total cost) or a doomed
+// comment (a deleted or payment/settlement row).
+func nudgeExpenseProblem(e Expense, friendID int) string {
+	if expenseDeleted(e.DeletedAt) {
+		return "that expense is deleted"
+	}
+	if e.Payment {
+		return "that expense is a payment/settlement record, not a shared charge"
+	}
+	for _, u := range e.Users {
+		if u.UserID == friendID && parseAmount(u.OwedShare) > 0 {
+			return ""
+		}
+	}
+	return "that friend has no positive owed share on that expense"
 }

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newFairnessNudgeCmd(flags *rootFlags) *cobra.Command {
+	var customMessage string
+	var overrideExpenseID int
+	var send bool
+
+	cmd := &cobra.Command{
+		Use:   "nudge <friend>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Send a friendly payment reminder to a friend who owes you",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would send a nudge")
+				return nil
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			friends, err := loadFriends(db)
+			if err != nil {
+				return err
+			}
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			friendID, friendName, ok := resolveFairnessFriend(args[0], friends)
+			if !ok {
+				return usageErr(fmt.Errorf("no friend matches %q; run sync first", args[0]))
+			}
+
+			target, ok := selectNudgeExpense(expenses, friendID, youID)
+			if cmd.Flags().Changed("expense-id") {
+				overrideTarget, found := findExpenseByID(expenses, overrideExpenseID)
+				if !found {
+					return usageErr(fmt.Errorf("no expense matches --expense-id %d", overrideExpenseID))
+				}
+				target = overrideTarget
+				ok = true
+			}
+			if !ok {
+				return fmt.Errorf("no shared unsettled expense found to comment on")
+			}
+
+			msg := buildNudgeMessage(friendName, friendID, target, customMessage)
+			result := map[string]any{
+				"friend":     friendName,
+				"friend_id":  friendID,
+				"expense_id": target.ID,
+				"message":    msg,
+				"sent":       false,
+			}
+
+			if !send || flags.dryRun {
+				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+					return flags.printJSON(cmd, result)
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "friend: %s (id %d)\n", friendName, friendID)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "target expense: %d | %s | %s %s\n", target.ID, strings.TrimSpace(target.Description), strings.TrimSpace(target.Cost), strings.TrimSpace(target.CurrencyCode))
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "message: %s\n", msg)
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "preview only — re-run with --send to post the reminder comment")
+				return nil
+			}
+
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+			data, status, err := c.PostWithParams(
+				cmd.Context(),
+				"/create_comment",
+				map[string]string{},
+				map[string]any{"content": msg, "expense_id": fmt.Sprint(target.ID)},
+			)
+			if err != nil {
+				return classifyAPIError(err, flags)
+			}
+			if status < 200 || status >= 300 {
+				return fmt.Errorf("create-comment failed: status %d", status)
+			}
+			if envErr := splitwiseMutationError(data); envErr != nil {
+				return envErr
+			}
+
+			result["sent"] = true
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, result)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "sent reminder to %s on expense %d\n", friendName, target.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&customMessage, "message", "", "Custom reminder message")
+	cmd.Flags().IntVar(&overrideExpenseID, "expense-id", 0, "Override the target expense id")
+	cmd.Flags().BoolVar(&send, "send", false, "Post the reminder comment")
+	return cmd
+}
+
+func selectNudgeExpense(expenses []Expense, friendID, youID int) (Expense, bool) {
+	var bestYouPaid Expense
+	var bestYouPaidDate time.Time
+	bestYouPaidOK := false
+	bestYouPaidParsed := false
+
+	var bestFallback Expense
+	var bestFallbackDate time.Time
+	bestFallbackOK := false
+	bestFallbackParsed := false
+
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		friendOwes := false
+		youPaid := false
+		for _, u := range e.Users {
+			if u.UserID == friendID && parseAmount(u.OwedShare) > 0 {
+				friendOwes = true
+			}
+			if u.UserID == youID && parseAmount(u.PaidShare) > 0 {
+				youPaid = true
+			}
+		}
+		if !friendOwes {
+			continue
+		}
+
+		t, parsed := parseSplitwiseDate(e.Date)
+		if youPaid {
+			if !bestYouPaidOK || isMoreRecentCandidate(parsed, t, bestYouPaidParsed, bestYouPaidDate) {
+				bestYouPaid = e
+				bestYouPaidDate = t
+				bestYouPaidOK = true
+				bestYouPaidParsed = parsed
+			}
+			continue
+		}
+		if !bestFallbackOK || isMoreRecentCandidate(parsed, t, bestFallbackParsed, bestFallbackDate) {
+			bestFallback = e
+			bestFallbackDate = t
+			bestFallbackOK = true
+			bestFallbackParsed = parsed
+		}
+	}
+
+	if bestYouPaidOK {
+		return bestYouPaid, true
+	}
+	if bestFallbackOK {
+		return bestFallback, true
+	}
+	return Expense{}, false
+}
+
+func isMoreRecentCandidate(parsed bool, t time.Time, bestParsed bool, best time.Time) bool {
+	if parsed {
+		if !bestParsed {
+			return true
+		}
+		return t.After(best)
+	}
+	return !bestParsed
+}
+
+func buildNudgeMessage(friendName string, friendID int, e Expense, custom string) string {
+	if custom != "" {
+		return custom
+	}
+	desc := strings.TrimSpace(e.Description)
+	if desc == "" {
+		desc = fmt.Sprintf("expense %d", e.ID)
+	}
+	// Quote the friend's own owed_share on this expense — the amount the reminder
+	// is actually about — not the expense total, which would overstate what they
+	// owe on a split. Fall back to the expense cost only if no share is recorded.
+	amount := strings.TrimSpace(e.Cost)
+	for _, u := range e.Users {
+		if u.UserID == friendID {
+			if s := strings.TrimSpace(u.OwedShare); s != "" {
+				amount = s
+			}
+			break
+		}
+	}
+	if amount == "" {
+		amount = "0"
+	}
+	amountStr := strings.TrimSpace(amount + " " + strings.TrimSpace(e.CurrencyCode))
+	// Reachability caveat: Friend does not expose registration/email status in
+	// this CLI, so v1 does not pre-gate recipient deliverability.
+	return fmt.Sprintf("Hey %s, friendly reminder about your share of %q (%s) whenever you get a chance - thanks!", friendName, desc, amountStr)
+}
+
+func findExpenseByID(expenses []Expense, id int) (Expense, bool) {
+	for _, e := range expenses {
+		if e.ID == id {
+			return e, true
+		}
+	}
+	return Expense{}, false
+}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge.go
@@ -14,8 +14,14 @@ func newFairnessNudgeCmd(flags *rootFlags) *cobra.Command {
 	var send bool
 
 	cmd := &cobra.Command{
-		Use:   "nudge <friend>",
-		Args:  cobra.ExactArgs(1),
+		Use: "nudge <friend>",
+		// MinimumNArgs(1), not ExactArgs(1): the MCP command-mirror whitespace-splits
+		// a quoted multi-word friend name (args:"Tahoe Trip") into several positionals
+		// (["Tahoe","Trip"]). ExactArgs(1) rejected those before resolution could run,
+		// and even when it didn't, only the first token reached resolveFairnessFriend
+		// and substring-matched the wrong friend. Accept the extra positionals and
+		// rejoin them below.
+		Args:  cobra.MinimumNArgs(1),
 		Short: "Send a friendly payment reminder to a friend who owes you",
 		// CLI-only write action: keep nudge off the MCP surface so an agent can't
 		// auto-post reminders, and so it is never grouped under the read-only
@@ -43,9 +49,14 @@ func newFairnessNudgeCmd(flags *rootFlags) *cobra.Command {
 			}
 			youID := loadCurrentUserID(db)
 
-			friendID, friendName, ok := resolveFairnessFriend(args[0], friends)
+			// Rejoin multi-word names split into separate positionals by the MCP
+			// command-mirror. Inline join (not joinNameArgs) keeps this branch
+			// self-contained; once the multiword settle/resolve PR lands joinNameArgs
+			// in this package, this can be refactored to call it.
+			friendQuery := strings.TrimSpace(strings.Join(args, " "))
+			friendID, friendName, ok := resolveFairnessFriend(friendQuery, friends)
 			if !ok {
-				return usageErr(fmt.Errorf("no friend matches %q; run sync first", args[0]))
+				return usageErr(fmt.Errorf("no friend matches %q; run sync first", friendQuery))
 			}
 
 			target, ok := selectNudgeExpense(expenses, friendID, youID)

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
@@ -85,6 +85,25 @@ func TestFindExpenseByID(t *testing.T) {
 	}
 }
 
+// TestNudgeAcceptsMultiWordPositional guards the multi-word friend-name path:
+// the MCP command-mirror whitespace-splits a quoted friend name into several
+// positionals (["Tahoe","Trip"]). cobra.ExactArgs(1) rejected that before RunE
+// could rejoin them; the validator must now accept 2+ positionals so the inline
+// join can resolve the full name.
+func TestNudgeAcceptsMultiWordPositional(t *testing.T) {
+	cmd := newFairnessNudgeCmd(&rootFlags{})
+	if cmd.Args == nil {
+		t.Fatal("nudge command has no Args validator")
+	}
+	if err := cmd.Args(cmd, []string{"Tahoe", "Trip"}); err != nil {
+		t.Errorf("nudge rejected a split multi-word name (2 positionals): %v", err)
+	}
+	// Zero positionals must still be rejected (MinimumNArgs(1)).
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("nudge accepted zero positionals, want a missing-argument error")
+	}
+}
+
 func TestNudgeExpenseProblem(t *testing.T) {
 	friendID := 2
 	owes := []ExpenseUser{{UserID: friendID, OwedShare: "10"}, {UserID: 1, PaidShare: "10"}}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
@@ -84,3 +84,32 @@ func TestFindExpenseByID(t *testing.T) {
 		t.Fatalf("findExpenseByID(99) returned ok=true, want false")
 	}
 }
+
+func TestNudgeExpenseProblem(t *testing.T) {
+	friendID := 2
+	owes := []ExpenseUser{{UserID: friendID, OwedShare: "10"}, {UserID: 1, PaidShare: "10"}}
+	deleted := "2026-01-01"
+
+	// valid target → no problem
+	if got := nudgeExpenseProblem(Expense{Users: owes}, friendID); got != "" {
+		t.Fatalf("valid target problem=%q, want empty", got)
+	}
+	// deleted → flagged
+	if got := nudgeExpenseProblem(Expense{DeletedAt: &deleted, Users: owes}, friendID); !strings.Contains(got, "deleted") {
+		t.Fatalf("deleted problem=%q, want 'deleted'", got)
+	}
+	// payment/settlement → flagged
+	if got := nudgeExpenseProblem(Expense{Payment: true, Users: owes}, friendID); !strings.Contains(got, "payment") {
+		t.Fatalf("payment problem=%q, want 'payment'", got)
+	}
+	// friend not a member → flagged (prevents a wrong-amount reminder)
+	notMember := []ExpenseUser{{UserID: 999, OwedShare: "10"}, {UserID: 1, PaidShare: "10"}}
+	if got := nudgeExpenseProblem(Expense{Users: notMember}, friendID); !strings.Contains(got, "owed share") {
+		t.Fatalf("non-member problem=%q, want 'owed share'", got)
+	}
+	// friend on it but owes zero → flagged
+	owesZero := []ExpenseUser{{UserID: friendID, OwedShare: "0"}, {UserID: 1, PaidShare: "10"}}
+	if got := nudgeExpenseProblem(Expense{Users: owesZero}, friendID); got == "" {
+		t.Fatalf("zero-owed problem empty, want flagged")
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_nudge_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectNudgeExpense(t *testing.T) {
+	friendID := 2
+	youID := 1
+	deleted := "2026-01-01"
+
+	expenses := []Expense{
+		{ID: 10, Description: "Deleted", Cost: "10.00", CurrencyCode: "USD", Date: "2026-05-01", DeletedAt: &deleted, Users: []ExpenseUser{{UserID: friendID, OwedShare: "10.00"}, {UserID: youID, PaidShare: "10.00"}}},
+		{ID: 11, Description: "Payment", Cost: "11.00", CurrencyCode: "USD", Date: "2026-05-02", Payment: true, Users: []ExpenseUser{{UserID: friendID, OwedShare: "11.00"}, {UserID: youID, PaidShare: "11.00"}}},
+		{ID: 12, Description: "Not member", Cost: "12.00", CurrencyCode: "USD", Date: "2026-05-03", Users: []ExpenseUser{{UserID: 999, OwedShare: "12.00"}, {UserID: youID, PaidShare: "12.00"}}},
+		{ID: 13, Description: "Friend owes zero", Cost: "13.00", CurrencyCode: "USD", Date: "2026-05-04", Users: []ExpenseUser{{UserID: friendID, OwedShare: "0"}, {UserID: youID, PaidShare: "13.00"}}},
+		{ID: 14, Description: "You paid older", Cost: "14.00", CurrencyCode: "USD", Date: "2026-05-05", Users: []ExpenseUser{{UserID: friendID, OwedShare: "14.00"}, {UserID: youID, PaidShare: "14.00"}}},
+		{ID: 15, Description: "You paid newest", Cost: "15.00", CurrencyCode: "USD", Date: "2026-05-20", Users: []ExpenseUser{{UserID: friendID, OwedShare: "15.00"}, {UserID: youID, PaidShare: "15.00"}}},
+		{ID: 16, Description: "Friend owes fallback", Cost: "16.00", CurrencyCode: "USD", Date: "2026-05-25", Users: []ExpenseUser{{UserID: friendID, OwedShare: "16.00"}, {UserID: youID, PaidShare: "0"}}},
+	}
+
+	got, ok := selectNudgeExpense(expenses, friendID, youID)
+	if !ok {
+		t.Fatalf("selectNudgeExpense returned ok=false")
+	}
+	if got.ID != 15 {
+		t.Fatalf("selected expense id=%d, want 15", got.ID)
+	}
+
+	fallbackOnly := []Expense{
+		{ID: 21, Description: "Fallback older", Cost: "21.00", CurrencyCode: "USD", Date: "2026-04-01", Users: []ExpenseUser{{UserID: friendID, OwedShare: "21.00"}, {UserID: youID, PaidShare: "0"}}},
+		{ID: 22, Description: "Fallback newest", Cost: "22.00", CurrencyCode: "USD", Date: "2026-05-01", Users: []ExpenseUser{{UserID: friendID, OwedShare: "22.00"}, {UserID: youID, PaidShare: "0"}}},
+	}
+	got, ok = selectNudgeExpense(fallbackOnly, friendID, youID)
+	if !ok {
+		t.Fatalf("fallback selectNudgeExpense returned ok=false")
+	}
+	if got.ID != 22 {
+		t.Fatalf("fallback selected expense id=%d, want 22", got.ID)
+	}
+
+	none := []Expense{
+		{ID: 31, Description: "No debt", Cost: "31.00", CurrencyCode: "USD", Date: "2026-05-01", Users: []ExpenseUser{{UserID: friendID, OwedShare: "0"}, {UserID: youID, PaidShare: "31.00"}}},
+		{ID: 32, Description: "Payment", Cost: "32.00", CurrencyCode: "USD", Date: "2026-05-02", Payment: true, Users: []ExpenseUser{{UserID: friendID, OwedShare: "32.00"}, {UserID: youID, PaidShare: "32.00"}}},
+	}
+	_, ok = selectNudgeExpense(none, friendID, youID)
+	if ok {
+		t.Fatalf("expected no candidate, got ok=true")
+	}
+}
+
+func TestBuildNudgeMessage(t *testing.T) {
+	friendID := 2
+	e := Expense{Description: "Dinner", Cost: "42.50", CurrencyCode: "USD", Users: []ExpenseUser{{UserID: friendID, OwedShare: "10.63"}, {UserID: 1, PaidShare: "42.50"}}}
+	custom := "Ping when you can, thanks"
+	if got := buildNudgeMessage("Alex", friendID, e, custom); got != custom {
+		t.Fatalf("custom message = %q, want %q", got, custom)
+	}
+
+	got := buildNudgeMessage("Alex", friendID, e, "")
+	// The default reminder quotes the friend's SHARE (10.63), not the expense
+	// total (42.50) — sending the total would overstate what they owe on a split.
+	for _, part := range []string{"Alex", "Dinner", "10.63", "USD", "your share"} {
+		if !strings.Contains(got, part) {
+			t.Fatalf("default message %q missing %q", got, part)
+		}
+	}
+	if strings.Contains(got, "42.50") {
+		t.Fatalf("default message %q must quote the friend's share, not the expense total", got)
+	}
+}
+
+func TestFindExpenseByID(t *testing.T) {
+	expenses := []Expense{
+		{ID: 10, Description: "A"},
+		{ID: 20, Description: "B"},
+	}
+	got, ok := findExpenseByID(expenses, 20)
+	if !ok || got.ID != 20 {
+		t.Fatalf("findExpenseByID(20) = (%+v, %v), want id 20, true", got, ok)
+	}
+	if _, ok := findExpenseByID(expenses, 99); ok {
+		t.Fatalf("findExpenseByID(99) returned ok=true, want false")
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
@@ -379,6 +379,31 @@ func assertAbsentPerson(t *testing.T, people []fairnessPerson, id int) {
 	}
 }
 
+func TestRoleForContributionCarrierWhenPaidButOwesNothing(t *testing.T) {
+	r110 := 1.10
+	r200 := 2.00
+	r050 := 0.50
+	cases := []struct {
+		name       string
+		hasHistory bool
+		paid, owed float64
+		ratio      *float64
+		want       string
+	}{
+		{"paid but owes nothing -> carrier", true, 50, 0, nil, "carrier"},
+		{"no history -> new even if paid>0 owed==0", false, 50, 0, nil, "new"},
+		{"owes nothing and paid nothing -> rider", true, 0, 0, nil, "rider"},
+		{"normal rider (low ratio)", true, 5, 50, &r050, "rider"},
+		{"even ratio", true, 55, 50, &r110, "even"},
+		{"carrier via high ratio", true, 100, 50, &r200, "carrier"},
+	}
+	for _, c := range cases {
+		if got := roleForContribution(c.hasHistory, c.paid, c.owed, c.ratio); got != c.want {
+			t.Errorf("%s: roleForContribution(%v,%v,%v,ratio)=%q want %q", c.name, c.hasHistory, c.paid, c.owed, got, c.want)
+		}
+	}
+}
+
 func ptrFloat(v float64) *float64 { return &v }
 
 func mustDate(t *testing.T, s string) time.Time {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
@@ -248,6 +248,14 @@ func TestComputeFairnessSinceKeepsOutstandingDebtor(t *testing.T) {
 	if res.NewMembers != 0 {
 		t.Fatalf("NewMembers=%d (an outstanding debtor was wrongly counted as new)", res.NewMembers)
 	}
+	// Debt age uses FULL history, not the --since window, so an old silent debt
+	// is still classified write_off — --since must not suppress the tier.
+	if o.DebtAgeDays == nil || *o.DebtAgeDays < 365 {
+		t.Fatalf("Olivia debt age=%v (should reflect the 2024 expense, not be windowed away)", o.DebtAgeDays)
+	}
+	if o.RiskTier != "write_off" {
+		t.Fatalf("Olivia tier=%q, expected write_off (--since must not downgrade an old debt)", o.RiskTier)
+	}
 }
 
 func TestClampUnit(t *testing.T) {

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
@@ -226,6 +226,30 @@ func TestComputeFairnessGroupScope(t *testing.T) {
 	}
 }
 
+func TestComputeFairnessSinceKeepsOutstandingDebtor(t *testing.T) {
+	youID := 1
+	// Olivia's only shared expense is in 2024 (before --since), but she still
+	// owes you $40 via Friend.Balance. She must NOT be dropped or counted as new.
+	friends := []Friend{{ID: 50, FirstName: "Olivia", LastName: "Old", Balance: []Balance{{CurrencyCode: "USD", Amount: "40.00"}}}}
+	expenses := []Expense{
+		{ID: 1, CurrencyCode: "USD", Date: "2024-03-01", Users: []ExpenseUser{{UserID: 50, PaidShare: "0", OwedShare: "40"}, {UserID: youID, PaidShare: "40", OwedShare: "0"}}},
+	}
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	opts := fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1,
+		since: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), hasSince: true}
+	res := computeFairness(youID, friends, nil, expenses, now, opts)
+	o := findFairnessPerson(t, res.People, 50) // fails (person not found) without the fix
+	if !o.HasHistory {
+		t.Fatalf("Olivia HasHistory=false despite an open balance")
+	}
+	if o.OutstandingTotal != 40 {
+		t.Fatalf("Olivia outstanding=%.2f", o.OutstandingTotal)
+	}
+	if res.NewMembers != 0 {
+		t.Fatalf("NewMembers=%d (an outstanding debtor was wrongly counted as new)", res.NewMembers)
+	}
+}
+
 func TestClampUnit(t *testing.T) {
 	cases := []struct {
 		in   float64
@@ -283,6 +307,47 @@ func TestClassifyRoleBoundaries(t *testing.T) {
 				t.Fatalf("role=%q want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHumanizeDays(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{in: -3, want: "0d"},
+		{in: 0, want: "0d"},
+		{in: 5, want: "5d"},
+		{in: 6, want: "6d"},
+		{in: 7, want: "1w"},
+		{in: 19, want: "2w 5d"},
+		{in: 29, want: "4w 1d"},
+		{in: 30, want: "1mo"},
+		{in: 48, want: "1mo 18d"},
+		{in: 334, want: "11mo 4d"},
+		{in: 365, want: "1y"},
+		{in: 366, want: "1y 1d"},
+		{in: 900, want: "2y 5mo 20d"},
+		{in: 1558, want: "4y 3mo 8d"},
+	}
+	for _, tc := range cases {
+		if got := humanizeDays(tc.in); got != tc.want {
+			t.Fatalf("humanizeDays(%d)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAgeCell(t *testing.T) {
+	if got := ageCell(nil); got != "-" {
+		t.Fatalf("ageCell(nil)=%q want %q", got, "-")
+	}
+	z := 0
+	if got := ageCell(&z); got != "0d" {
+		t.Fatalf("ageCell(0)=%q want 0d", got)
+	}
+	n := 1558
+	if got := ageCell(&n); got != "4y 3mo 8d" {
+		t.Fatalf("ageCell(1558)=%q want 4y 3mo 8d", got)
 	}
 }
 

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestComputeFairnessAnchors(t *testing.T) {
+	youID := 1
+	carol := Friend{ID: 4, FirstName: "Carol", LastName: "EDCO", Balance: []Balance{{CurrencyCode: "USD", Amount: "100.00"}}}
+	bob := Friend{ID: 3, FirstName: "Bob", LastName: "Brown", Balance: []Balance{{CurrencyCode: "USD", Amount: "0.00"}}}
+	dave := Friend{ID: 5, FirstName: "Dave", LastName: "New", Balance: []Balance{{CurrencyCode: "USD", Amount: "0.00"}}}
+	erin := Friend{ID: 6, FirstName: "Erin", LastName: "Carrier", Balance: []Balance{{CurrencyCode: "USD", Amount: "10.00"}}}
+	frank := Friend{ID: 7, FirstName: "Frank", LastName: "FX", Balance: []Balance{{CurrencyCode: "USD", Amount: "30.00"}, {CurrencyCode: "EUR", Amount: "20.00"}}}
+	nudger := Friend{ID: 8, FirstName: "Nadia", LastName: "Nudge", Balance: []Balance{{CurrencyCode: "USD", Amount: "40.00"}}}
+	chaser := Friend{ID: 9, FirstName: "Chase", LastName: "Risk", Balance: []Balance{{CurrencyCode: "USD", Amount: "60.00"}}}
+
+	friends := []Friend{carol, bob, dave, erin, frank, nudger, chaser}
+	groups := []Group{
+		{ID: 42, Name: "Trip", Members: []GroupMember{{ID: youID, FirstName: "You"}, {ID: carol.ID, FirstName: "Carol"}}, SimplifiedDebts: []SimplifiedDebt{{From: carol.ID, To: youID, Amount: "100.00", CurrencyCode: "USD"}}},
+	}
+
+	expenses := []Expense{
+		// A. Carol write-off shape (open, old, no payment)
+		{ID: 1, Description: "E1", CurrencyCode: "USD", Date: "2025-01-10", Payment: false, Users: []ExpenseUser{{UserID: carol.ID, PaidShare: "0", OwedShare: "50"}, {UserID: youID, PaidShare: "100", OwedShare: "50"}}},
+		{ID: 2, Description: "E2", CurrencyCode: "USD", Date: "2025-03-10", Payment: false, Users: []ExpenseUser{{UserID: carol.ID, PaidShare: "0", OwedShare: "50"}, {UserID: youID, PaidShare: "100", OwedShare: "50"}}},
+		// B. Bob closed episode
+		{ID: 3, Description: "X1", CurrencyCode: "USD", Date: "2025-12-01", Payment: false, Users: []ExpenseUser{{UserID: bob.ID, PaidShare: "0", OwedShare: "20"}, {UserID: youID, PaidShare: "40", OwedShare: "20"}}},
+		{ID: 4, Description: "X2", CurrencyCode: "USD", Date: "2025-12-20", Payment: true, Users: []ExpenseUser{{UserID: bob.ID, PaidShare: "20", OwedShare: "0"}}},
+		// D. Erin carrier
+		{ID: 5, Description: "C1", CurrencyCode: "USD", Date: "2025-06-01", Payment: false, Users: []ExpenseUser{{UserID: erin.ID, PaidShare: "80", OwedShare: "20"}}},
+		{ID: 6, Description: "C2", CurrencyCode: "USD", Date: "2025-06-15", Payment: false, Users: []ExpenseUser{{UserID: erin.ID, PaidShare: "60", OwedShare: "20"}}},
+		// E. Frank has history for collectability lens
+		{ID: 13, Description: "F1", CurrencyCode: "USD", Date: "2025-09-01", Payment: false, Users: []ExpenseUser{{UserID: frank.ID, PaidShare: "0", OwedShare: "30"}, {UserID: youID, PaidShare: "30", OwedShare: "0"}}},
+		// F. nudge (~45)
+		{ID: 7, Description: "N1", CurrencyCode: "USD", Date: "2025-08-01", Payment: false, Users: []ExpenseUser{{UserID: nudger.ID, PaidShare: "0", OwedShare: "40"}, {UserID: youID, PaidShare: "40", OwedShare: "0"}}},
+		{ID: 8, Description: "N2", CurrencyCode: "USD", Date: "2025-08-15", Payment: true, Users: []ExpenseUser{{UserID: nudger.ID, PaidShare: "40", OwedShare: "0"}}},
+		{ID: 9, Description: "N3", CurrencyCode: "USD", Date: "2025-08-20", Payment: false, Users: []ExpenseUser{{UserID: nudger.ID, PaidShare: "0", OwedShare: "40"}, {UserID: youID, PaidShare: "40", OwedShare: "0"}}},
+		// F. chase (~70)
+		{ID: 10, Description: "R1", CurrencyCode: "USD", Date: "2025-02-01", Payment: false, Users: []ExpenseUser{{UserID: chaser.ID, PaidShare: "0", OwedShare: "60"}, {UserID: youID, PaidShare: "60", OwedShare: "0"}}},
+		{ID: 11, Description: "R2", CurrencyCode: "USD", Date: "2025-05-31", Payment: true, Users: []ExpenseUser{{UserID: chaser.ID, PaidShare: "60", OwedShare: "0"}}},
+		{ID: 12, Description: "R3", CurrencyCode: "USD", Date: "2025-06-01", Payment: false, Users: []ExpenseUser{{UserID: chaser.ID, PaidShare: "0", OwedShare: "60"}, {UserID: youID, PaidShare: "60", OwedShare: "0"}}},
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		opts fairnessOpts
+		fn   func(t *testing.T, res fairnessResult)
+	}{
+		{
+			name: "A write-off risk exact score",
+			now:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				carol := findFairnessPerson(t, res.People, 4)
+				if !carol.HasHistory {
+					t.Fatalf("Carol HasHistory=false")
+				}
+				if carol.Paid != 0 || carol.Owed != 100 {
+					t.Fatalf("Carol paid/owed got %.2f/%.2f", carol.Paid, carol.Owed)
+				}
+				if carol.CarryRatio == nil || *carol.CarryRatio != 0 {
+					t.Fatalf("Carol carry ratio got %v", carol.CarryRatio)
+				}
+				if carol.Role != "rider" {
+					t.Fatalf("Carol role=%q", carol.Role)
+				}
+				if carol.OutstandingTotal != 100 {
+					t.Fatalf("Carol outstanding=%.2f", carol.OutstandingTotal)
+				}
+				if carol.DebtAgeDays == nil || *carol.DebtAgeDays < 365 {
+					t.Fatalf("Carol debt age=%v", carol.DebtAgeDays)
+				}
+				if carol.LastSettledDays != nil {
+					t.Fatalf("Carol last settled expected nil, got %v", *carol.LastSettledDays)
+				}
+				if carol.AvgLatencyDays != nil {
+					t.Fatalf("Carol avg latency expected nil, got %v", *carol.AvgLatencyDays)
+				}
+				if carol.RiskScore == nil || *carol.RiskScore != 90 {
+					t.Fatalf("Carol risk score got %v", carol.RiskScore)
+				}
+				if carol.RiskTier != "write_off" {
+					t.Fatalf("Carol tier=%q", carol.RiskTier)
+				}
+				if res.WriteOffTotal != 100 {
+					t.Fatalf("WriteOffTotal=%.2f", res.WriteOffTotal)
+				}
+			},
+		},
+		{
+			name: "B settled excluded from risk",
+			now:  time.Date(2025, 12, 25, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				assertAbsentPerson(t, res.People, 3)
+			},
+		},
+		{
+			name: "B collectability includes settled",
+			now:  time.Date(2025, 12, 25, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "collectability", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				bob := findFairnessPerson(t, res.People, 3)
+				if !bob.HasHistory {
+					t.Fatalf("Bob HasHistory=false")
+				}
+				if bob.AvgLatencyDays == nil || *bob.AvgLatencyDays != 19 {
+					t.Fatalf("Bob avg latency=%v", bob.AvgLatencyDays)
+				}
+				if bob.LastSettledDays == nil || *bob.LastSettledDays != 5 {
+					t.Fatalf("Bob last settled=%v", bob.LastSettledDays)
+				}
+				if bob.DebtAgeDays != nil {
+					t.Fatalf("Bob debt age expected nil, got %v", *bob.DebtAgeDays)
+				}
+				if bob.OutstandingTotal != 0 {
+					t.Fatalf("Bob outstanding=%.2f", bob.OutstandingTotal)
+				}
+			},
+		},
+		{
+			name: "C new member counting",
+			now:  time.Date(2025, 12, 25, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				if res.NewMembers != 1 {
+					t.Fatalf("NewMembers=%d", res.NewMembers)
+				}
+				assertAbsentPerson(t, res.People, 5)
+			},
+		},
+		{
+			name: "D carrier leads contribution",
+			now:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "contribution", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				erin := findFairnessPerson(t, res.People, 6)
+				if erin.Paid != 140 || erin.Owed != 40 || erin.Net != 100 {
+					t.Fatalf("Erin paid/owed/net %.2f/%.2f/%.2f", erin.Paid, erin.Owed, erin.Net)
+				}
+				if erin.CarryRatio == nil || *erin.CarryRatio != 3.5 {
+					t.Fatalf("Erin ratio=%v", erin.CarryRatio)
+				}
+				if erin.Role != "carrier" {
+					t.Fatalf("Erin role=%q", erin.Role)
+				}
+				if len(res.People) < 2 {
+					t.Fatalf("need at least 2 people")
+				}
+				if res.People[0].UserID != 6 {
+					t.Fatalf("expected Erin first, got user_id=%d", res.People[0].UserID)
+				}
+			},
+		},
+		{
+			name: "E multi currency all",
+			now:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "collectability", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				frank := findFairnessPerson(t, res.People, 7)
+				if frank.OutstandingByCurrency["USD"] != 30 || frank.OutstandingByCurrency["EUR"] != 20 || frank.OutstandingTotal != 50 {
+					t.Fatalf("Frank outstanding map=%v total=%.2f", frank.OutstandingByCurrency, frank.OutstandingTotal)
+				}
+			},
+		},
+		{
+			name: "E multi currency USD filter",
+			now:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "collectability", writeOffDays: 365, ghostDays: 180, minEpisodes: 1, currency: "USD"},
+			fn: func(t *testing.T, res fairnessResult) {
+				frank := findFairnessPerson(t, res.People, 7)
+				if len(frank.OutstandingByCurrency) != 1 || frank.OutstandingByCurrency["USD"] != 30 || frank.OutstandingTotal != 30 {
+					t.Fatalf("Frank USD-filter map=%v total=%.2f", frank.OutstandingByCurrency, frank.OutstandingTotal)
+				}
+			},
+		},
+		{
+			name: "F nudge vs chase",
+			now:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			opts: fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1},
+			fn: func(t *testing.T, res fairnessResult) {
+				n := findFairnessPerson(t, res.People, 8)
+				c := findFairnessPerson(t, res.People, 9)
+				if n.RiskTier != "nudge" {
+					t.Fatalf("nudger tier=%q score=%v", n.RiskTier, n.RiskScore)
+				}
+				if c.RiskTier != "chase" {
+					t.Fatalf("chaser tier=%q score=%v", c.RiskTier, c.RiskScore)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := computeFairness(youID, friends, groups, expenses, tt.now, tt.opts)
+			tt.fn(t, res)
+		})
+	}
+}
+
+func TestComputeFairnessGroupScope(t *testing.T) {
+	youID := 1
+	friends := []Friend{{ID: 4, FirstName: "Carol", LastName: "EDCO"}}
+	groups := []Group{{
+		ID:   42,
+		Name: "Trip",
+		Members: []GroupMember{
+			{ID: youID, FirstName: "You"},
+			{ID: 4, FirstName: "Carol"},
+		},
+		SimplifiedDebts: []SimplifiedDebt{{From: 4, To: youID, Amount: "100.00", CurrencyCode: "USD"}},
+	}}
+	expenses := []Expense{{ID: 1, GroupID: 42, CurrencyCode: "USD", Date: "2025-01-10", Users: []ExpenseUser{{UserID: 4, PaidShare: "0", OwedShare: "50"}}}}
+	res := computeFairness(youID, friends, groups, expenses, time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC), fairnessOpts{by: "risk", writeOffDays: 365, ghostDays: 180, minEpisodes: 1, groupID: 42, groupScoped: true})
+	if !res.GroupCaveat {
+		t.Fatalf("GroupCaveat=false")
+	}
+	if res.Scope != "group:Trip" {
+		t.Fatalf("scope=%q", res.Scope)
+	}
+	if len(res.People) != 1 || res.People[0].UserID != 4 {
+		t.Fatalf("unexpected people: %+v", res.People)
+	}
+}
+
+func TestClampUnit(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want float64
+	}{
+		{in: -1, want: 0},
+		{in: 0.5, want: 0.5},
+		{in: 2, want: 1},
+	}
+	for _, tc := range cases {
+		got := clampUnit(tc.in)
+		if got != tc.want {
+			t.Fatalf("clampUnit(%.2f)=%.2f want %.2f", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEpisodeMetricsTwoCycles(t *testing.T) {
+	now := time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC)
+	entries := []subjectEvent{
+		{date: mustDate(t, "2025-01-01"), payment: false},
+		{date: mustDate(t, "2025-01-11"), payment: true},
+		{date: mustDate(t, "2025-02-01"), payment: false},
+		{date: mustDate(t, "2025-02-21"), payment: true},
+	}
+	m := episodeMetrics(now, entries, 2)
+	if m.avgLatencyDays == nil || *m.avgLatencyDays != 15 {
+		t.Fatalf("avg latency=%v", m.avgLatencyDays)
+	}
+	if m.debtAgeDays != nil {
+		t.Fatalf("debt age expected nil, got %v", *m.debtAgeDays)
+	}
+	if m.lastSettledDays == nil || *m.lastSettledDays <= 0 {
+		t.Fatalf("last settled=%v", m.lastSettledDays)
+	}
+}
+
+func TestClassifyRoleBoundaries(t *testing.T) {
+	cases := []struct {
+		name       string
+		hasHistory bool
+		ratio      *float64
+		want       string
+	}{
+		{name: "new", hasHistory: false, ratio: ptrFloat(1), want: "new"},
+		{name: "rider lower", hasHistory: true, ratio: ptrFloat(0.89), want: "rider"},
+		{name: "even low boundary", hasHistory: true, ratio: ptrFloat(0.90), want: "even"},
+		{name: "even high boundary", hasHistory: true, ratio: ptrFloat(1.10), want: "even"},
+		{name: "carrier", hasHistory: true, ratio: ptrFloat(1.11), want: "carrier"},
+		{name: "nil ratio rider", hasHistory: true, ratio: nil, want: "rider"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyRole(tc.hasHistory, tc.ratio); got != tc.want {
+				t.Fatalf("role=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func findFairnessPerson(t *testing.T, people []fairnessPerson, id int) fairnessPerson {
+	t.Helper()
+	for _, p := range people {
+		if p.UserID == id {
+			return p
+		}
+	}
+	t.Fatalf("person %d not found", id)
+	return fairnessPerson{}
+}
+
+func assertAbsentPerson(t *testing.T, people []fairnessPerson, id int) {
+	t.Helper()
+	for _, p := range people {
+		if p.UserID == id {
+			t.Fatalf("person %d unexpectedly present", id)
+		}
+	}
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+
+func mustDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, ok := parseSplitwiseDate(s)
+	if !ok {
+		t.Fatalf("bad date %q", s)
+	}
+	return d
+}

--- a/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_fairness_test.go
@@ -359,6 +359,99 @@ func TestAgeCell(t *testing.T) {
 	}
 }
 
+func TestProjectSettle(t *testing.T) {
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+
+	lat := 30.0
+	age := 10
+	daysOut, date := projectSettle(&age, &lat, now)
+	if daysOut == nil || *daysOut != 20 {
+		t.Fatalf("daysOut=%v want 20", daysOut)
+	}
+	if date == nil || *date != "2026-01-30" {
+		t.Fatalf("date=%v want 2026-01-30", date)
+	}
+
+	age = 40
+	daysOut, date = projectSettle(&age, &lat, now)
+	if daysOut == nil || *daysOut != -10 {
+		t.Fatalf("daysOut=%v want -10", daysOut)
+	}
+	if date == nil || *date != "2025-12-31" {
+		t.Fatalf("date=%v want 2025-12-31", date)
+	}
+
+	daysOut, date = projectSettle(nil, &lat, now)
+	if daysOut != nil || date != nil {
+		t.Fatalf("nil debt age expected nil,nil got %v,%v", daysOut, date)
+	}
+
+	daysOut, date = projectSettle(&age, nil, now)
+	if daysOut != nil || date != nil {
+		t.Fatalf("nil avg latency expected nil,nil got %v,%v", daysOut, date)
+	}
+
+	rounded := 29.6
+	age = 10
+	daysOut, date = projectSettle(&age, &rounded, now)
+	if daysOut == nil || *daysOut != 20 {
+		t.Fatalf("rounded daysOut=%v want 20", daysOut)
+	}
+	if date == nil || *date != "2026-01-30" {
+		t.Fatalf("rounded date=%v want 2026-01-30", date)
+	}
+}
+
+func TestComputeFairnessCollectabilityProjectedSettle(t *testing.T) {
+	youID := 1
+	alex := Friend{ID: 2, FirstName: "Alex", LastName: "Late", Balance: []Balance{{CurrencyCode: "USD", Amount: "30.00"}}}
+	blair := Friend{ID: 3, FirstName: "Blair", LastName: "New", Balance: []Balance{{CurrencyCode: "USD", Amount: "20.00"}}}
+	// Casey is fully settled (owes 0) but has a closed episode (latency) PLUS a
+	// dangling open episode (debtAge) — so projectSettle would otherwise fire.
+	// The outstanding>0 gate must suppress it: a $0 balance never gets a
+	// projected settle date (this was caught in live dogfood, where the only
+	// people with projections were settled debtors showing "overdue by 2459d").
+	casey := Friend{ID: 6, FirstName: "Casey", LastName: "Settled"}
+	friends := []Friend{alex, blair, casey}
+
+	expenses := []Expense{
+		{ID: 1, Description: "A1", CurrencyCode: "USD", Date: "2025-10-01", Payment: false, Users: []ExpenseUser{{UserID: alex.ID, PaidShare: "0", OwedShare: "30"}, {UserID: youID, PaidShare: "30", OwedShare: "0"}}},
+		{ID: 2, Description: "A2", CurrencyCode: "USD", Date: "2025-10-21", Payment: true, Users: []ExpenseUser{{UserID: alex.ID, PaidShare: "30", OwedShare: "0"}}},
+		{ID: 3, Description: "A3", CurrencyCode: "USD", Date: "2025-12-20", Payment: false, Users: []ExpenseUser{{UserID: alex.ID, PaidShare: "0", OwedShare: "30"}, {UserID: youID, PaidShare: "30", OwedShare: "0"}}},
+		{ID: 4, Description: "B1", CurrencyCode: "USD", Date: "2025-12-25", Payment: false, Users: []ExpenseUser{{UserID: blair.ID, PaidShare: "0", OwedShare: "20"}, {UserID: youID, PaidShare: "20", OwedShare: "0"}}},
+		{ID: 5, Description: "C1", CurrencyCode: "USD", Date: "2025-09-01", Payment: false, Users: []ExpenseUser{{UserID: casey.ID, PaidShare: "0", OwedShare: "15"}, {UserID: youID, PaidShare: "15", OwedShare: "0"}}},
+		{ID: 6, Description: "C2", CurrencyCode: "USD", Date: "2025-09-20", Payment: true, Users: []ExpenseUser{{UserID: casey.ID, PaidShare: "15", OwedShare: "0"}}},
+		{ID: 7, Description: "C3", CurrencyCode: "USD", Date: "2025-12-01", Payment: false, Users: []ExpenseUser{{UserID: casey.ID, PaidShare: "0", OwedShare: "15"}, {UserID: youID, PaidShare: "15", OwedShare: "0"}}},
+	}
+
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	res := computeFairness(youID, friends, nil, expenses, now, fairnessOpts{by: "collectability", writeOffDays: 365, ghostDays: 180, minEpisodes: 1})
+
+	alexPerson := findFairnessPerson(t, res.People, 2)
+	if alexPerson.ProjectedDaysOut == nil {
+		t.Fatalf("Alex projected_days_out=nil")
+	}
+	if *alexPerson.ProjectedDaysOut >= 0 {
+		t.Fatalf("Alex projected_days_out=%d want negative (overdue)", *alexPerson.ProjectedDaysOut)
+	}
+	if alexPerson.ProjectedSettleDate == nil {
+		t.Fatalf("Alex projected_settle_date=nil")
+	}
+
+	blairPerson := findFairnessPerson(t, res.People, 3)
+	if blairPerson.ProjectedDaysOut != nil || blairPerson.ProjectedSettleDate != nil {
+		t.Fatalf("Blair projection expected nil,nil got %v,%v", blairPerson.ProjectedDaysOut, blairPerson.ProjectedSettleDate)
+	}
+
+	caseyPerson := findFairnessPerson(t, res.People, 6)
+	if caseyPerson.OutstandingTotal != 0 {
+		t.Fatalf("Casey outstanding=%.2f want 0 (test fixture expects a settled debtor)", caseyPerson.OutstandingTotal)
+	}
+	if caseyPerson.ProjectedDaysOut != nil || caseyPerson.ProjectedSettleDate != nil {
+		t.Fatalf("Casey (settled, owes 0) projection expected nil,nil got %v,%v", caseyPerson.ProjectedDaysOut, caseyPerson.ProjectedSettleDate)
+	}
+}
+
 func findFairnessPerson(t *testing.T, people []fairnessPerson, id int) fairnessPerson {
 	t.Helper()
 	for _, p := range people {

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -1,0 +1,257 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type forecastEntry struct {
+	Description    string  `json:"description"`
+	Group          string  `json:"group"`
+	LastDate       string  `json:"last_date"`
+	ExpectedDate   string  `json:"expected_date"`
+	ExpectedAmount float64 `json:"expected_amount"`
+	CadenceDays    int     `json:"cadence_days"`
+	Occurrences    int     `json:"occurrences"`
+	Overdue        bool    `json:"overdue"`
+}
+
+func looksLikeSettlement(desc string) bool {
+	d := strings.ToLower(strings.TrimSpace(desc))
+	switch d {
+	case "settle all balances", "settle up", "payment":
+		return true
+	}
+	return strings.HasPrefix(d, "paid via ")
+}
+
+// computeForecast projects upcoming obligations. groupNames maps group_id -> display name
+// (with 0 -> "Non-group"). now is the reference time. windowDays is the forecast window.
+// limit caps the returned slice (apply after sorting). Returns entries sorted by
+// expected_date ascending.
+func computeForecast(expenses []Expense, groupNames map[int]string, now time.Time, windowDays, limit int) []forecastEntry {
+	type cluster struct {
+		dates      []time.Time
+		costs      []float64
+		labels     map[string]int
+		groupCount map[int]int
+	}
+
+	clusters := make(map[string]*cluster)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) || looksLikeSettlement(e.Description) {
+			continue
+		}
+		key := normalizeRecurringKey(e.Description)
+		if key == "" {
+			continue
+		}
+		if clusters[key] == nil {
+			clusters[key] = &cluster{
+				dates:      make([]time.Time, 0),
+				costs:      make([]float64, 0),
+				labels:     make(map[string]int),
+				groupCount: make(map[int]int),
+			}
+		}
+		c := clusters[key]
+		if t, ok := parseFlexibleDate(e.Date); ok {
+			c.dates = append(c.dates, t)
+			c.costs = append(c.costs, parseAmount(e.Cost))
+		}
+		label := strings.TrimSpace(e.Description)
+		if label == "" {
+			label = key
+		}
+		c.labels[label]++
+		c.groupCount[e.GroupID]++
+	}
+
+	result := make([]forecastEntry, 0)
+	windowEnd := now.AddDate(0, 0, windowDays)
+	for key, c := range clusters {
+		if len(c.dates) < 3 {
+			continue
+		}
+		sort.Slice(c.dates, func(i, j int) bool { return c.dates[i].Before(c.dates[j]) })
+
+		gaps := make([]float64, 0, len(c.dates)-1)
+		totalGap := 0.0
+		for i := 1; i < len(c.dates); i++ {
+			gap := c.dates[i].Sub(c.dates[i-1]).Hours() / 24
+			gaps = append(gaps, gap)
+			totalGap += gap
+		}
+		if len(gaps) == 0 {
+			continue
+		}
+		cadence := int(math.Round(totalGap / float64(len(gaps))))
+		if cadence < 2 || cadence > 400 {
+			continue
+		}
+		if len(gaps) >= 2 {
+			minGap := gaps[0]
+			maxGap := gaps[0]
+			for _, gap := range gaps[1:] {
+				if gap < minGap {
+					minGap = gap
+				}
+				if gap > maxGap {
+					maxGap = gap
+				}
+			}
+			if minGap <= 0 {
+				continue
+			}
+			if maxGap > 3.0*minGap {
+				continue
+			}
+		}
+
+		lastDate := c.dates[len(c.dates)-1]
+		expectedDate := lastDate.AddDate(0, 0, cadence)
+		overdue := expectedDate.Before(now)
+		if !overdue {
+			if expectedDate.After(windowEnd) || expectedDate.Before(now) {
+				continue
+			}
+		}
+
+		totalCost := 0.0
+		for _, cost := range c.costs {
+			totalCost += cost
+		}
+		expectedAmount := 0.0
+		if len(c.costs) > 0 {
+			expectedAmount = round2(totalCost / float64(len(c.costs)))
+		}
+
+		groupID := 0
+		bestCount := -1
+		for id, count := range c.groupCount {
+			if count > bestCount || (count == bestCount && id < groupID) {
+				groupID = id
+				bestCount = count
+			}
+		}
+		groupName := ""
+		if groupID == 0 {
+			groupName = groupNames[0]
+		} else if name, ok := groupNames[groupID]; ok && strings.TrimSpace(name) != "" {
+			groupName = strings.TrimSpace(name)
+		} else {
+			groupName = fmt.Sprintf("Group %d", groupID)
+		}
+
+		result = append(result, forecastEntry{
+			Description:    mostCommonString(c.labels, key),
+			Group:          groupName,
+			LastDate:       lastDate.Format("2006-01-02"),
+			ExpectedDate:   expectedDate.Format("2006-01-02"),
+			ExpectedAmount: expectedAmount,
+			CadenceDays:    cadence,
+			Occurrences:    len(c.dates),
+			Overdue:        overdue,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ExpectedDate == result[j].ExpectedDate {
+			return result[i].Description < result[j].Description
+		}
+		return result[i].ExpectedDate < result[j].ExpectedDate
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result
+}
+
+// pp:data-source local
+func newForecastCmd(flags *rootFlags) *cobra.Command {
+	days := 35
+	limit := 50
+
+	cmd := &cobra.Command{
+		Use:         "forecast",
+		Short:       "Project upcoming shared obligations from recurring spending patterns",
+		Example:     "  splitwise-pp-cli forecast --agent\n  splitwise-pp-cli forecast --days 60 --limit 20 --json",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would forecast upcoming obligations")
+				return nil
+			}
+			if days < 1 {
+				return usageErr(fmt.Errorf("--days must be >= 1"))
+			}
+			if limit < 1 {
+				return usageErr(fmt.Errorf("--limit must be >= 1"))
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-expenses")
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
+
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			groups, err := loadGroups(db)
+			if err != nil {
+				return err
+			}
+
+			now := time.Now().UTC()
+			groupNames := make(map[int]string)
+			groupNames[0] = "Non-group"
+			for _, g := range groups {
+				groupNames[g.ID] = strings.TrimSpace(g.Name)
+			}
+
+			entries := computeForecast(expenses, groupNames, now, days, limit)
+			if entries == nil {
+				entries = make([]forecastEntry, 0)
+			}
+			view := struct {
+				AsOf       string          `json:"as_of"`
+				WindowDays int             `json:"window_days"`
+				Upcoming   []forecastEntry `json:"upcoming"`
+			}{
+				AsOf:       now.Format("2006-01-02"),
+				WindowDays: days,
+				Upcoming:   entries,
+			}
+
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, view)
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "As of %s, forecast window %d days:\n", view.AsOf, days)
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintln(tw, "DESCRIPTION\tGROUP\tEXPECTED\tAMOUNT\tCADENCE\tLAST\tOCCURRENCES\tOVERDUE")
+			for _, row := range view.Upcoming {
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%.2f\t%d\t%s\t%d\t%t\n", row.Description, row.Group, row.ExpectedDate, row.ExpectedAmount, row.CadenceDays, row.LastDate, row.Occurrences, row.Overdue)
+			}
+			return tw.Flush()
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 35, "Forecast window in days")
+	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum upcoming entries to return")
+	return cmd
+}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -64,13 +64,13 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		if t, ok := parseFlexibleDate(e.Date); ok {
 			c.dates = append(c.dates, t)
 			c.costs = append(c.costs, parseAmount(e.Cost))
+			label := strings.TrimSpace(e.Description)
+			if label == "" {
+				label = key
+			}
+			c.labels[label]++
+			c.groupCount[e.GroupID]++
 		}
-		label := strings.TrimSpace(e.Description)
-		if label == "" {
-			label = key
-		}
-		c.labels[label]++
-		c.groupCount[e.GroupID]++
 	}
 
 	result := make([]forecastEntry, 0)
@@ -118,7 +118,7 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		expectedDate := lastDate.AddDate(0, 0, cadence)
 		overdue := expectedDate.Before(now)
 		if !overdue {
-			if expectedDate.After(windowEnd) || expectedDate.Before(now) {
+			if expectedDate.After(windowEnd) {
 				continue
 			}
 		}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -74,7 +74,8 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 	}
 
 	result := make([]forecastEntry, 0)
-	windowEnd := now.AddDate(0, 0, windowDays)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	windowEnd := today.AddDate(0, 0, windowDays)
 	for key, c := range clusters {
 		if len(c.dates) < 3 {
 			continue
@@ -95,28 +96,27 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		if cadence < 2 || cadence > 400 {
 			continue
 		}
-		if len(gaps) >= 2 {
-			minGap := gaps[0]
-			maxGap := gaps[0]
-			for _, gap := range gaps[1:] {
-				if gap < minGap {
-					minGap = gap
-				}
-				if gap > maxGap {
-					maxGap = gap
-				}
+		// Invariant: len(c.dates) >= 3 implies len(gaps) >= 2.
+		minGap := gaps[0]
+		maxGap := gaps[0]
+		for _, gap := range gaps[1:] {
+			if gap < minGap {
+				minGap = gap
 			}
-			if minGap <= 0 {
-				continue
+			if gap > maxGap {
+				maxGap = gap
 			}
-			if maxGap > 3.0*minGap {
-				continue
-			}
+		}
+		if minGap <= 0 {
+			continue
+		}
+		if maxGap > 3.0*minGap {
+			continue
 		}
 
 		lastDate := c.dates[len(c.dates)-1]
 		expectedDate := lastDate.AddDate(0, 0, cadence)
-		overdue := expectedDate.Before(now)
+		overdue := expectedDate.Before(today)
 		if !overdue {
 			if expectedDate.After(windowEnd) {
 				continue

--- a/library/payments/splitwise/internal/cli/splitwise_forecast.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast.go
@@ -117,10 +117,17 @@ func computeForecast(expenses []Expense, groupNames map[int]string, now time.Tim
 		lastDate := c.dates[len(c.dates)-1]
 		expectedDate := lastDate.AddDate(0, 0, cadence)
 		overdue := expectedDate.Before(today)
-		if !overdue {
-			if expectedDate.After(windowEnd) {
+		if overdue {
+			// Staleness cap: once a recurring series has missed several
+			// consecutive cycles it has clearly stopped (e.g. a charge shared
+			// with a since-departed roommate), so stop surfacing it as
+			// "overdue" forever.
+			const maxMissedCycles = 3
+			if today.After(expectedDate.AddDate(0, 0, maxMissedCycles*cadence)) {
 				continue
 			}
+		} else if expectedDate.After(windowEnd) {
+			continue
 		}
 
 		totalCost := 0.0

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -79,7 +79,7 @@ func TestComputeForecastIrregularExcluded(t *testing.T) {
 }
 
 func TestComputeForecastOverdueIncluded(t *testing.T) {
-	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
 	expenses := []Expense{
 		{Description: "Utilities", GroupID: 0, Cost: "90", Date: "2026-01-01"},
 		{Description: "Utilities", GroupID: 0, Cost: "100", Date: "2026-01-31"},
@@ -96,6 +96,23 @@ func TestComputeForecastOverdueIncluded(t *testing.T) {
 	}
 	if got[0].ExpectedDate != "2026-04-01" {
 		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-04-01")
+	}
+}
+
+func TestComputeForecastVeryStaleExcluded(t *testing.T) {
+	// A recurring series silent for years has clearly stopped and must not
+	// keep appearing as "overdue".
+	now := time.Date(2029, 1, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Utilities", GroupID: 0, Cost: "90", Date: "2026-01-01"},
+		{Description: "Utilities", GroupID: 0, Cost: "100", Date: "2026-01-31"},
+		{Description: "Utilities", GroupID: 0, Cost: "110", Date: "2026-03-02"},
+	}
+	groups := map[int]string{0: "Non-group"}
+
+	got := computeForecast(expenses, groups, now, 20, 50)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0 (series silent for years should be dropped)", len(got))
 	}
 }
 

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -99,6 +99,50 @@ func TestComputeForecastOverdueIncluded(t *testing.T) {
 	}
 }
 
+func TestComputeForecastDueTodayAtMiddayNotOverdue(t *testing.T) {
+	now := time.Date(2026, 6, 1, 14, 30, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-06-01")
+	}
+	if got[0].Overdue {
+		t.Fatalf("Overdue = true, want false")
+	}
+}
+
+func TestComputeForecastYesterdayAtMiddayOverdue(t *testing.T) {
+	now := time.Date(2026, 6, 2, 14, 30, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-06-01")
+	}
+	if !got[0].Overdue {
+		t.Fatalf("Overdue = false, want true")
+	}
+}
+
 func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	groups := map[int]string{0: "Non-group", 1: "Trip"}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -133,3 +133,32 @@ func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
 		t.Fatalf("ExpectedAmount = %.2f, want 50.00", got[0].ExpectedAmount)
 	}
 }
+
+func TestComputeForecastUndatedExpensesDoNotAffectAttribution(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Dinner", GroupID: 10, Cost: "10.00", Date: "2026-03-01"},
+		{Description: "Dinner", GroupID: 10, Cost: "20.00", Date: "2026-04-01"},
+		{Description: "Dinner", GroupID: 10, Cost: "30.00", Date: "2026-05-01"},
+		{Description: "Bogus label", GroupID: 999, Cost: "999.00", Date: "not-a-date"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Home", 999: "ShouldNotWin"}
+
+	got := computeForecast(expenses, groups, now, 40, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row.Description != "Dinner" {
+		t.Fatalf("Description = %q, want %q", row.Description, "Dinner")
+	}
+	if row.Group != "Home" {
+		t.Fatalf("Group = %q, want %q", row.Group, "Home")
+	}
+	if row.Occurrences != 3 {
+		t.Fatalf("Occurrences = %d, want 3", row.Occurrences)
+	}
+	if row.ExpectedAmount != 20.00 {
+		t.Fatalf("ExpectedAmount = %.2f, want 20.00", row.ExpectedAmount)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_forecast_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLooksLikeSettlement(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want bool
+	}{
+		{name: "settle all balances", desc: "Settle all balances", want: true},
+		{name: "settle up", desc: " settle up ", want: true},
+		{name: "payment", desc: "payment", want: true},
+		{name: "paid via", desc: "paid via Venmo", want: true},
+		{name: "non-settlement", desc: "Dinner", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeSettlement(tc.desc); got != tc.want {
+				t.Fatalf("looksLikeSettlement(%q) = %v, want %v", tc.desc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeForecastMonthlyInsideWindow(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Rent", GroupID: 10, Cost: "100.00", Date: "2026-02-01"},
+		{Description: "Rent", GroupID: 10, Cost: "110.00", Date: "2026-03-03"},
+		{Description: "Rent", GroupID: 10, Cost: "120.00", Date: "2026-04-02"},
+		{Description: "Rent", GroupID: 10, Cost: "130.00", Date: "2026-05-02"},
+	}
+	groups := map[int]string{0: "Non-group", 10: "Roommates"}
+
+	got := computeForecast(expenses, groups, now, 35, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	row := got[0]
+	if row.Description != "Rent" {
+		t.Fatalf("Description = %q, want %q", row.Description, "Rent")
+	}
+	if row.Group != "Roommates" {
+		t.Fatalf("Group = %q, want %q", row.Group, "Roommates")
+	}
+	if row.ExpectedDate != "2026-06-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", row.ExpectedDate, "2026-06-01")
+	}
+	if row.Overdue {
+		t.Fatalf("Overdue = true, want false")
+	}
+	if row.CadenceDays != 30 {
+		t.Fatalf("CadenceDays = %d, want 30", row.CadenceDays)
+	}
+	if row.ExpectedAmount != 115.00 {
+		t.Fatalf("ExpectedAmount = %.2f, want 115.00", row.ExpectedAmount)
+	}
+}
+
+func TestComputeForecastIrregularExcluded(t *testing.T) {
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-01"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-03"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-01-05"},
+		{Description: "Gym", GroupID: 0, Cost: "40", Date: "2026-02-14"},
+	}
+	groups := map[int]string{0: "Non-group"}
+
+	got := computeForecast(expenses, groups, now, 90, 50)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestComputeForecastOverdueIncluded(t *testing.T) {
+	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	expenses := []Expense{
+		{Description: "Utilities", GroupID: 0, Cost: "90", Date: "2026-01-01"},
+		{Description: "Utilities", GroupID: 0, Cost: "100", Date: "2026-01-31"},
+		{Description: "Utilities", GroupID: 0, Cost: "110", Date: "2026-03-02"},
+	}
+	groups := map[int]string{0: "Non-group"}
+
+	got := computeForecast(expenses, groups, now, 20, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if !got[0].Overdue {
+		t.Fatalf("Overdue = false, want true")
+	}
+	if got[0].ExpectedDate != "2026-04-01" {
+		t.Fatalf("ExpectedDate = %q, want %q", got[0].ExpectedDate, "2026-04-01")
+	}
+}
+
+func TestComputeForecastFiltersPaymentsAndSettlements(t *testing.T) {
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	groups := map[int]string{0: "Non-group", 1: "Trip"}
+
+	onlyFiltered := []Expense{
+		{Description: "Settle all balances", GroupID: 1, Cost: "10", Date: "2026-01-01"},
+		{Description: "paid via Venmo", GroupID: 1, Cost: "10", Date: "2026-02-01"},
+		{Description: "Payment", GroupID: 1, Cost: "10", Date: "2026-03-01", Payment: true},
+	}
+	got := computeForecast(onlyFiltered, groups, now, 60, 50)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+
+	mixed := []Expense{
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-02-01"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-03-03"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-04-02"},
+		{Description: "Internet", GroupID: 1, Cost: "50", Date: "2026-05-02"},
+		{Description: "Settle all balances", GroupID: 1, Cost: "999", Date: "2026-05-10"},
+		{Description: "paid via Venmo", GroupID: 1, Cost: "888", Date: "2026-05-12"},
+		{Description: "Internet", GroupID: 1, Cost: "777", Date: "2026-05-14", Payment: true},
+	}
+	got = computeForecast(mixed, groups, now, 40, 50)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Description != "Internet" {
+		t.Fatalf("Description = %q, want Internet", got[0].Description)
+	}
+	if got[0].ExpectedAmount != 50 {
+		t.Fatalf("ExpectedAmount = %.2f, want 50.00", got[0].ExpectedAmount)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -219,6 +219,13 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			youID := loadCurrentUserID(db)
+			if youID == 0 {
+				// Without a synced current user the Spend per-user owed-share loop
+				// never matches, so Spend totals are silently 0.00. Warn on stderr in
+				// every output mode (mirrors balances --by-group) so the zero reads as
+				// an unknown-identity artifact, not a real total.
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "note: current user not synced; run sync to populate get-current-user")
+			}
 
 			res := computeNormalize(friends, expenses, youID, mergedRates, baseCode)
 			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -112,8 +112,11 @@ func makeNormalizeMetric(byCurrency map[string]float64, rates map[string]float64
 		metric.Rows = append(metric.Rows, normalizeRow{
 			CurrencyCode: cc,
 			Original:     original,
-			Rate:         round2(rate),
-			Converted:    converted,
+			// Keep the full-precision rate actually used in the conversion so a
+			// reader can reproduce original*rate≈converted; rounding it for display
+			// disagreed with the conversion math (Greptile #970).
+			Rate:      rate,
+			Converted: converted,
 		})
 		metric.TotalBase = round2(metric.TotalBase + converted)
 	}
@@ -203,7 +206,9 @@ func newNormalizeCmd(flags *rootFlags) *cobra.Command {
 			defer db.Close()
 
 			hintIfUnsynced(cmd, db, "get-friends")
+			hintIfUnsynced(cmd, db, "get-expenses")
 			hintIfStale(cmd, db, "get-friends", flags.maxAge)
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
 
 			friends, err := loadFriends(db)
 			if err != nil {

--- a/library/payments/splitwise/internal/cli/splitwise_normalize.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type normalizeUnconverted struct {
+	CurrencyCode string  `json:"currency_code"`
+	Original     float64 `json:"original"`
+}
+
+type normalizeRow struct {
+	CurrencyCode string  `json:"currency_code"`
+	Original     float64 `json:"original"`
+	Rate         float64 `json:"rate"`
+	Converted    float64 `json:"converted"`
+}
+
+type normalizeMetric struct {
+	Rows        []normalizeRow         `json:"rows"`
+	TotalBase   float64                `json:"total_base"`
+	Unconverted []normalizeUnconverted `json:"unconverted"`
+}
+
+type normalizeResult struct {
+	Base  string          `json:"base"`
+	Net   normalizeMetric `json:"net"`
+	Spend normalizeMetric `json:"spend"`
+}
+
+func parseNormalizeRates(raw []string) (map[string]float64, error) {
+	rates := make(map[string]float64)
+	for _, item := range raw {
+		parts := strings.SplitN(strings.TrimSpace(item), "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --rate %q: expected CUR=FACTOR", item)
+		}
+		cc := strings.ToUpper(strings.TrimSpace(parts[0]))
+		if cc == "" {
+			return nil, fmt.Errorf("invalid --rate %q: currency code is required", item)
+		}
+		factor, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --rate %q: factor must be numeric", item)
+		}
+		if factor <= 0 {
+			return nil, fmt.Errorf("invalid --rate %q: factor must be > 0", item)
+		}
+		rates[cc] = factor
+	}
+	return rates, nil
+}
+
+func loadNormalizeRatesFile(path string) (map[string]float64, error) {
+	if strings.TrimSpace(path) == "" {
+		return map[string]float64{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --rates-file: %w", err)
+	}
+	var raw map[string]float64
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse --rates-file JSON object: %w", err)
+	}
+	rates := make(map[string]float64, len(raw))
+	for k, v := range raw {
+		cc := strings.ToUpper(strings.TrimSpace(k))
+		if cc == "" {
+			return nil, fmt.Errorf("--rates-file contains empty currency code")
+		}
+		if v <= 0 {
+			return nil, fmt.Errorf("--rates-file contains non-positive factor for %s", cc)
+		}
+		rates[cc] = v
+	}
+	return rates, nil
+}
+
+func makeNormalizeMetric(byCurrency map[string]float64, rates map[string]float64, base string) normalizeMetric {
+	metric := normalizeMetric{
+		Rows:        make([]normalizeRow, 0),
+		Unconverted: make([]normalizeUnconverted, 0),
+	}
+	currencies := make([]string, 0, len(byCurrency))
+	for cc := range byCurrency {
+		currencies = append(currencies, cc)
+	}
+	sort.Strings(currencies)
+
+	for _, cc := range currencies {
+		original := round2(byCurrency[cc])
+		rate := 0.0
+		if cc == base {
+			rate = 1.0
+		} else {
+			rate = rates[cc]
+		}
+		if rate <= 0 {
+			metric.Unconverted = append(metric.Unconverted, normalizeUnconverted{CurrencyCode: cc, Original: original})
+			continue
+		}
+		converted := round2(original * rate)
+		metric.Rows = append(metric.Rows, normalizeRow{
+			CurrencyCode: cc,
+			Original:     original,
+			Rate:         round2(rate),
+			Converted:    converted,
+		})
+		metric.TotalBase = round2(metric.TotalBase + converted)
+	}
+
+	return metric
+}
+
+func computeNormalize(friends []Friend, expenses []Expense, youID int, rates map[string]float64, base string) normalizeResult {
+	netByCurrency := make(map[string]float64)
+	for _, f := range friends {
+		for _, b := range f.Balance {
+			cc := strings.ToUpper(strings.TrimSpace(b.CurrencyCode))
+			if cc == "" {
+				continue
+			}
+			netByCurrency[cc] += parseAmount(b.Amount)
+		}
+	}
+
+	spendByCurrency := make(map[string]float64)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+		if cc == "" {
+			continue
+		}
+		for _, u := range e.Users {
+			if u.UserID == youID {
+				spendByCurrency[cc] += parseAmount(u.OwedShare)
+				break
+			}
+		}
+	}
+
+	return normalizeResult{
+		Base:  base,
+		Net:   makeNormalizeMetric(netByCurrency, rates, base),
+		Spend: makeNormalizeMetric(spendByCurrency, rates, base),
+	}
+}
+
+// pp:data-source local
+func newNormalizeCmd(flags *rootFlags) *cobra.Command {
+	base := "USD"
+	rateFlags := make([]string, 0)
+	ratesFile := ""
+
+	cmd := &cobra.Command{
+		Use:         "normalize",
+		Short:       "Normalize multi-currency net and spend into one base currency using user-supplied FX rates",
+		Example:     "  splitwise-pp-cli normalize --base USD --rate EUR=1.08 --rate GBP=1.27 --agent",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would normalize multi-currency balances and spend")
+				return nil
+			}
+
+			baseCode := strings.ToUpper(strings.TrimSpace(base))
+			if baseCode == "" {
+				return usageErr(fmt.Errorf("--base must not be empty"))
+			}
+
+			mergedRates, err := loadNormalizeRatesFile(ratesFile)
+			if err != nil {
+				return usageErr(err)
+			}
+			inlineRates, err := parseNormalizeRates(rateFlags)
+			if err != nil {
+				return usageErr(err)
+			}
+			for cc, rate := range inlineRates {
+				mergedRates[cc] = rate
+			}
+			mergedRates[baseCode] = 1.0
+
+			// Historical/automatic FX lookup is intentionally out of scope; normalize is deterministic and offline-only.
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-friends")
+			hintIfStale(cmd, db, "get-friends", flags.maxAge)
+
+			friends, err := loadFriends(db)
+			if err != nil {
+				return err
+			}
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			res := computeNormalize(friends, expenses, youID, mergedRates, baseCode)
+			if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+				return flags.printJSON(cmd, res)
+			}
+
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintln(out, "Net position")
+			tw := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintf(tw, "CURRENCY\tORIGINAL\tRATE\tIN %s\n", res.Base)
+			for _, row := range res.Net.Rows {
+				_, _ = fmt.Fprintf(tw, "%s\t%.2f\t%.4f\t%.2f\n", row.CurrencyCode, row.Original, row.Rate, row.Converted)
+			}
+			if err := tw.Flush(); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "Total ≈ %.2f %s\n", res.Net.TotalBase, res.Base)
+
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintln(out, "Spend")
+			tw2 := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintf(tw2, "CURRENCY\tORIGINAL\tRATE\tIN %s\n", res.Base)
+			for _, row := range res.Spend.Rows {
+				_, _ = fmt.Fprintf(tw2, "%s\t%.2f\t%.4f\t%.2f\n", row.CurrencyCode, row.Original, row.Rate, row.Converted)
+			}
+			if err := tw2.Flush(); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(out, "Total ≈ %.2f %s\n", res.Spend.TotalBase, res.Base)
+
+			if len(res.Net.Unconverted) > 0 || len(res.Spend.Unconverted) > 0 {
+				_, _ = fmt.Fprintln(out)
+				_, _ = fmt.Fprintln(out, "Unconverted currencies (add --rate CUR=FACTOR):")
+				for _, row := range res.Net.Unconverted {
+					_, _ = fmt.Fprintf(out, "net: %s %.2f\n", row.CurrencyCode, row.Original)
+				}
+				for _, row := range res.Spend.Unconverted {
+					_, _ = fmt.Fprintf(out, "spend: %s %.2f\n", row.CurrencyCode, row.Original)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&base, "base", "USD", "Base currency code used for normalization")
+	cmd.Flags().StringArrayVar(&rateFlags, "rate", nil, "FX rate CUR=FACTOR where 1 CUR equals FACTOR in base currency (repeatable)")
+	cmd.Flags().StringVar(&ratesFile, "rates-file", "", "JSON file with currency-rate object, e.g. {\"EUR\":1.08}; merged before --rate overrides")
+	cmd.Long = "Normalize your multi-currency Splitwise net position and spend into one base currency using only user-supplied rates from --rate and/or --rates-file. Historical or automatic FX lookup is intentionally out of scope."
+
+	return cmd
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -248,3 +248,21 @@ func TestLoadNormalizeRatesFile(t *testing.T) {
 		t.Fatalf("missing file: expected error, got nil")
 	}
 }
+
+func TestComputeNormalize_RatePrecision(t *testing.T) {
+	// The Rate field must carry the FULL-precision rate used in the conversion,
+	// not a rounded display value, so a reader can reproduce original*rate≈converted.
+	friends := []Friend{{Balance: []Balance{{CurrencyCode: "EUR", Amount: "10.00"}}}}
+	got := computeNormalize(friends, nil, 1, map[string]float64{"EUR": 1.3333}, "USD")
+	if len(got.Net.Rows) != 1 {
+		t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+	}
+	row := got.Net.Rows[0]
+	if row.Rate != 1.3333 {
+		t.Fatalf("Rate = %v, want 1.3333 (full precision, not rounded)", row.Rate)
+	}
+	// converted = round2(10 * 1.3333) = round2(13.333) = 13.33
+	if row.Converted != 13.33 {
+		t.Fatalf("Converted = %v, want 13.33", row.Converted)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestComputeNormalize(t *testing.T) {
+	tests := []struct {
+		name      string
+		friends   []Friend
+		expenses  []Expense
+		youID     int
+		rates     map[string]float64
+		base      string
+		assertion func(t *testing.T, got normalizeResult)
+	}{
+		{
+			name: "multi-currency net converts and totals",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "USD", Amount: "10"}, {CurrencyCode: "EUR", Amount: "5"}}},
+				{Balance: []Balance{{CurrencyCode: "GBP", Amount: "2"}}},
+			},
+			rates: map[string]float64{"EUR": 1.08, "GBP": 1.27},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 17.94 {
+					t.Fatalf("Net.TotalBase = %.2f, want 17.94", got.Net.TotalBase)
+				}
+				if len(got.Net.Rows) != 3 {
+					t.Fatalf("len(Net.Rows) = %d, want 3", len(got.Net.Rows))
+				}
+			},
+		},
+		{
+			name: "missing rate is unconverted and excluded from total",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "USD", Amount: "10"}, {CurrencyCode: "JPY", Amount: "1200"}}},
+			},
+			rates: map[string]float64{},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 10 {
+					t.Fatalf("Net.TotalBase = %.2f, want 10.00", got.Net.TotalBase)
+				}
+				if len(got.Net.Unconverted) != 1 {
+					t.Fatalf("len(Net.Unconverted) = %d, want 1", len(got.Net.Unconverted))
+				}
+				if got.Net.Unconverted[0].CurrencyCode != "JPY" || got.Net.Unconverted[0].Original != 1200 {
+					t.Fatalf("unexpected unconverted row: %+v", got.Net.Unconverted[0])
+				}
+			},
+		},
+		{
+			name: "base currency passes through at rate one",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "usd", Amount: "3.33"}}},
+			},
+			rates: map[string]float64{"EUR": 1.08},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Net.Rows) != 1 {
+					t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+				}
+				row := got.Net.Rows[0]
+				if row.CurrencyCode != "USD" || row.Rate != 1 || row.Converted != 3.33 {
+					t.Fatalf("unexpected row: %+v", row)
+				}
+			},
+		},
+		{
+			name: "spend counts only non-payment non-deleted owed_share for you",
+			expenses: []Expense{
+				{
+					CurrencyCode: "USD",
+					Users:        []ExpenseUser{{UserID: 9, OwedShare: "10.00"}, {UserID: 1, OwedShare: "10.00"}},
+				},
+				{
+					CurrencyCode: "USD",
+					Payment:      true,
+					Users:        []ExpenseUser{{UserID: 1, OwedShare: "50.00"}},
+				},
+				{
+					CurrencyCode: "EUR",
+					DeletedAt: func() *string {
+						s := "2026-01-01"
+						return &s
+					}(),
+					Users: []ExpenseUser{{UserID: 1, OwedShare: "20.00"}},
+				},
+			},
+			youID: 1,
+			rates: map[string]float64{},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Spend.Rows) != 1 {
+					t.Fatalf("len(Spend.Rows) = %d, want 1", len(got.Spend.Rows))
+				}
+				if got.Spend.Rows[0].Original != 10 {
+					t.Fatalf("Spend USD original = %.2f, want 10.00", got.Spend.Rows[0].Original)
+				}
+			},
+		},
+		{
+			name:     "empty inputs return zero totals",
+			friends:  []Friend{},
+			expenses: []Expense{},
+			rates:    map[string]float64{},
+			base:     "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if got.Net.TotalBase != 0 || got.Spend.TotalBase != 0 {
+					t.Fatalf("totals not zero: net=%.2f spend=%.2f", got.Net.TotalBase, got.Spend.TotalBase)
+				}
+				if got.Net.Rows == nil || got.Spend.Rows == nil {
+					t.Fatalf("rows should be non-nil")
+				}
+			},
+		},
+		{
+			name: "rounding to two decimals",
+			friends: []Friend{
+				{Balance: []Balance{{CurrencyCode: "EUR", Amount: "1.006"}}},
+			},
+			rates: map[string]float64{"EUR": 1.3333},
+			base:  "USD",
+			assertion: func(t *testing.T, got normalizeResult) {
+				t.Helper()
+				if len(got.Net.Rows) != 1 {
+					t.Fatalf("len(Net.Rows) = %d, want 1", len(got.Net.Rows))
+				}
+				row := got.Net.Rows[0]
+				if row.Original != 1.01 {
+					t.Fatalf("Original = %.2f, want 1.01", row.Original)
+				}
+				if math.Abs(row.Converted-1.35) > 1e-9 {
+					t.Fatalf("Converted = %.2f, want 1.35", row.Converted)
+				}
+				if got.Net.TotalBase != 1.35 {
+					t.Fatalf("Net.TotalBase = %.2f, want 1.35", got.Net.TotalBase)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeNormalize(tt.friends, tt.expenses, tt.youID, tt.rates, tt.base)
+			tt.assertion(t, got)
+		})
+	}
+}
+
+func TestParseNormalizeRates(t *testing.T) {
+	tests := []struct {
+		name    string
+		rateArg []string
+		want    map[string]float64
+		wantErr bool
+	}{
+		{
+			name:    "valid map",
+			rateArg: []string{"EUR=1.08", "gbp=1.27", "USD=1"},
+			want:    map[string]float64{"EUR": 1.08, "GBP": 1.27, "USD": 1},
+		},
+		{name: "missing equals", rateArg: []string{"EUR"}, wantErr: true},
+		{name: "empty currency", rateArg: []string{"=1.2"}, wantErr: true},
+		{name: "non-positive", rateArg: []string{"JPY=0"}, wantErr: true},
+		{name: "bad factor", rateArg: []string{"CAD=abc"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNormalizeRates(tt.rateArg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("rates = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNormalizeRatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// empty path → empty map, no error
+	if got, err := loadNormalizeRatesFile(""); err != nil || len(got) != 0 {
+		t.Fatalf("empty path = (%v, %v), want (empty map, nil)", got, err)
+	}
+
+	// valid JSON object, currency codes upper-cased
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, []byte(`{"eur":1.08,"GBP":1.27}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadNormalizeRatesFile(good)
+	if err != nil {
+		t.Fatalf("valid file: unexpected error %v", err)
+	}
+	if !reflect.DeepEqual(got, map[string]float64{"EUR": 1.08, "GBP": 1.27}) {
+		t.Fatalf("valid file rates = %#v", got)
+	}
+
+	// non-positive factor → error
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte(`{"EUR":0}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(bad); err == nil {
+		t.Fatalf("non-positive factor: expected error, got nil")
+	}
+
+	// empty currency code → error
+	emptyCode := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(emptyCode, []byte(`{"  ":1.1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(emptyCode); err == nil {
+		t.Fatalf("empty currency code: expected error, got nil")
+	}
+
+	// malformed JSON → error
+	malformed := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformed, []byte(`not json`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadNormalizeRatesFile(malformed); err == nil {
+		t.Fatalf("malformed JSON: expected error, got nil")
+	}
+
+	// missing file → error
+	if _, err := loadNormalizeRatesFile(filepath.Join(dir, "nope.json")); err == nil {
+		t.Fatalf("missing file: expected error, got nil")
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_normalize_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
 )
 
 func TestComputeNormalize(t *testing.T) {
@@ -264,5 +268,45 @@ func TestComputeNormalize_RatePrecision(t *testing.T) {
 	// converted = round2(10 * 1.3333) = round2(13.333) = 13.33
 	if row.Converted != 13.33 {
 		t.Fatalf("Converted = %v, want 13.33", row.Converted)
+	}
+}
+
+// TestNormalizeUnsyncedUserNote guards that normalize emits the
+// "current user not synced" stderr note when get-current-user is unsynced
+// (youID == 0), so a silently-zero Spend total is explained rather than
+// mistaken for real data. Mirrors balances --by-group.
+func TestNormalizeUnsyncedUserNote(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// An expense is present, but get-current-user is NOT synced -> youID == 0.
+	if err := s.Upsert("get-expenses", "1", []byte(`{"id":1,"currency_code":"USD","cost":"10.00","users":[{"user_id":42,"owed_share":"10.00"}]}`)); err != nil {
+		t.Fatalf("seed expense: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	flags := &rootFlags{agent: true} // structured output path
+	cmd := newNormalizeCmd(flags)
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	// --base is required to bypass the "no flags → help" guard (NFlag()==0 check).
+	cmd.SetArgs([]string{"--base=USD"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "current user not synced") {
+		t.Errorf("expected unsynced-current-user note on stderr, got: %q", errBuf.String())
 	}
 }

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -145,6 +145,11 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 			switch format {
 			case "csv":
 				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportCSV(res))
+				if res.Truncated {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"note: CSV truncated to %d of %d expense row(s); use --limit 0 for all rows\n",
+						len(res.Expenses), res.ExpenseCount)
+				}
 				return nil
 			case "md":
 				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportMarkdown(res))

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -19,7 +19,6 @@ type reportOpts struct {
 	Until      string
 	Currency   string
 	Limit      int
-	Scope      string
 }
 
 type reportPerson struct {
@@ -129,13 +128,10 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 			}
 			youID := loadCurrentUserID(db)
 
-			scope := "all"
 			if strings.TrimSpace(groupRef) != "" {
-				_, groupName, ok := resolveReportGroup(groupRef, groups)
-				if !ok {
+				if _, _, ok := resolveReportGroup(groupRef, groups); !ok {
 					return usageErr(fmt.Errorf("no group matches %q; run sync first", groupRef))
 				}
-				scope = "group:" + groupName
 			}
 
 			res := computeReport(expenses, groups, youID, reportOpts{
@@ -144,7 +140,6 @@ func newReportCmd(flags *rootFlags) *cobra.Command {
 				Until:      until,
 				Currency:   currency,
 				Limit:      limit,
-				Scope:      scope,
 			})
 
 			switch format {
@@ -201,23 +196,28 @@ func resolveReportGroup(input string, groups []Group) (int, string, bool) {
 
 func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpts) reportResult {
 	res := reportResult{
-		Scope:      strings.TrimSpace(opts.Scope),
+		Scope:      "all",
 		People:     make([]reportPerson, 0),
 		Categories: make([]reportCategory, 0),
 		Expenses:   make([]reportExpenseRow, 0),
-	}
-	if res.Scope == "" {
-		res.Scope = "all"
 	}
 
 	var groupID int
 	groupFilter := false
 	if strings.TrimSpace(opts.GroupInput) != "" {
 		id, name, ok := resolveReportGroup(opts.GroupInput, groups)
+		groupFilter = true
 		if ok {
-			groupFilter = true
 			groupID = id
 			res.Scope = "group:" + name
+		} else {
+			// GroupInput was given but matches no group. Filter to nothing rather
+			// than silently falling through to an unfiltered report — no expense has
+			// a negative group id, so this yields an empty, correctly-scoped report
+			// even if this pure function is called without the command's
+			// pre-validation. (Greptile #971)
+			groupID = -1
+			res.Scope = "group:" + strings.TrimSpace(opts.GroupInput) + " (no match)"
 		}
 	}
 
@@ -253,7 +253,11 @@ func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpt
 			}
 		}
 		if hasUntil {
-			if !ok || t.After(untilT.Add(24*time.Hour-time.Nanosecond)) {
+			// --until is inclusive of the whole named day: extend the bound to just
+			// before the next midnight so a same-day timestamp with a time component
+			// (e.g. "2025-12-31T18:00") still matches.
+			endOfUntil := untilT.Add(24*time.Hour - time.Nanosecond)
+			if !ok || t.After(endOfUntil) {
 				continue
 			}
 		}

--- a/library/payments/splitwise/internal/cli/splitwise_report.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report.go
@@ -1,0 +1,566 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type reportOpts struct {
+	GroupInput string
+	Since      string
+	Until      string
+	Currency   string
+	Limit      int
+	Scope      string
+}
+
+type reportPerson struct {
+	UserID int     `json:"user_id"`
+	Name   string  `json:"name"`
+	Paid   float64 `json:"paid"`
+	Owed   float64 `json:"owed"`
+	Net    float64 `json:"net"`
+}
+
+type reportCategory struct {
+	Name  string  `json:"name"`
+	Total float64 `json:"total"`
+	Count int     `json:"count"`
+}
+
+type reportExpenseRow struct {
+	ID           int     `json:"id"`
+	Date         string  `json:"date"`
+	Description  string  `json:"description"`
+	Cost         float64 `json:"cost"`
+	CurrencyCode string  `json:"currency_code"`
+	Payer        string  `json:"payer"`
+}
+
+type reportResult struct {
+	Scope                 string             `json:"scope"`
+	Currency              string             `json:"currency"`
+	PeriodStart           string             `json:"period_start"`
+	PeriodEnd             string             `json:"period_end"`
+	ExpenseCount          int                `json:"expense_count"`
+	ExcludedOtherCurrency int                `json:"excluded_other_currency"`
+	TotalCost             float64            `json:"total_cost"`
+	YourPaid              float64            `json:"your_paid"`
+	YourOwed              float64            `json:"your_owed"`
+	YourNet               float64            `json:"your_net"`
+	People                []reportPerson     `json:"people"`
+	Categories            []reportCategory   `json:"categories"`
+	Expenses              []reportExpenseRow `json:"expenses"`
+	Truncated             bool               `json:"truncated"`
+}
+
+func newReportCmd(flags *rootFlags) *cobra.Command {
+	var groupRef string
+	var since string
+	var until string
+	var currency string
+	var format string
+	limit := 100
+
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Export an offline trip/period spend report (md/csv/json; PDF out of scope in v1)",
+		Example: "  splitwise-pp-cli report --group \"Tahoe Trip\" --format md\n" +
+			"  splitwise-pp-cli report --since 2025-01-01 --until 2025-12-31 --format csv > 2025.csv",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+				return cmd.Help()
+			}
+			if dryRunOK(flags) {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "would compute report")
+				return nil
+			}
+
+			format = strings.ToLower(strings.TrimSpace(format))
+			if format != "" && format != "md" && format != "csv" && format != "json" {
+				return usageErr(fmt.Errorf("invalid --format value %q: must be md, csv, or json", format))
+			}
+
+			if strings.TrimSpace(since) != "" {
+				if _, err := time.Parse("2006-01-02", strings.TrimSpace(since)); err != nil {
+					return usageErr(fmt.Errorf("invalid --since %q: %w", since, err))
+				}
+			}
+			if strings.TrimSpace(until) != "" {
+				if _, err := time.Parse("2006-01-02", strings.TrimSpace(until)); err != nil {
+					return usageErr(fmt.Errorf("invalid --until %q: %w", until, err))
+				}
+			}
+			if strings.TrimSpace(since) != "" && strings.TrimSpace(until) != "" {
+				sv, _ := time.Parse("2006-01-02", strings.TrimSpace(since))
+				uv, _ := time.Parse("2006-01-02", strings.TrimSpace(until))
+				if uv.Before(sv) {
+					return usageErr(fmt.Errorf("--until must be on/after --since"))
+				}
+			}
+
+			db, err := openSplitwiseStore(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			hintIfUnsynced(cmd, db, "get-expenses")
+			hintIfUnsynced(cmd, db, "get-groups")
+			hintIfStale(cmd, db, "get-expenses", flags.maxAge)
+			hintIfStale(cmd, db, "get-groups", flags.maxAge)
+
+			expenses, err := loadExpenses(db)
+			if err != nil {
+				return err
+			}
+			groups, err := loadGroups(db)
+			if err != nil {
+				return err
+			}
+			youID := loadCurrentUserID(db)
+
+			scope := "all"
+			if strings.TrimSpace(groupRef) != "" {
+				_, groupName, ok := resolveReportGroup(groupRef, groups)
+				if !ok {
+					return usageErr(fmt.Errorf("no group matches %q; run sync first", groupRef))
+				}
+				scope = "group:" + groupName
+			}
+
+			res := computeReport(expenses, groups, youID, reportOpts{
+				GroupInput: groupRef,
+				Since:      since,
+				Until:      until,
+				Currency:   currency,
+				Limit:      limit,
+				Scope:      scope,
+			})
+
+			switch format {
+			case "csv":
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportCSV(res))
+				return nil
+			case "md":
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), renderReportMarkdown(res))
+				return nil
+			case "json":
+				return flags.printJSON(cmd, res)
+			default:
+				if flags.asJSON || flags.agent || !isTerminal(cmd.OutOrStdout()) {
+					return flags.printJSON(cmd, res)
+				}
+				return printReportSummary(cmd, res)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&groupRef, "group", "", "Group name or id")
+	cmd.Flags().StringVar(&since, "since", "", "Include expenses on/after YYYY-MM-DD")
+	cmd.Flags().StringVar(&until, "until", "", "Include expenses on/before YYYY-MM-DD")
+	cmd.Flags().StringVar(&currency, "currency", "", "Single currency code (default picks most common and excludes others)")
+	cmd.Flags().StringVar(&format, "format", "", "Output format: md|csv|json (PDF is out of scope in v1)")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Max expense rows in output (<=0 means all)")
+	return cmd
+}
+
+// resolveReportGroup maps a --group reference (numeric id or exact, case-insensitive
+// name) to its group id and display name. Self-contained so `report` does not depend on
+// any other novel command's resolver; prefers an exact match and never substring-guesses.
+func resolveReportGroup(input string, groups []Group) (int, string, bool) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return 0, "", false
+	}
+	if isAllDigits(trimmed) {
+		id, _ := strconv.Atoi(trimmed)
+		for _, g := range groups {
+			if g.ID == id {
+				return g.ID, strings.TrimSpace(g.Name), true
+			}
+		}
+		return 0, "", false
+	}
+	for _, g := range groups {
+		if strings.EqualFold(strings.TrimSpace(g.Name), trimmed) {
+			return g.ID, strings.TrimSpace(g.Name), true
+		}
+	}
+	return 0, "", false
+}
+
+func computeReport(expenses []Expense, groups []Group, youID int, opts reportOpts) reportResult {
+	res := reportResult{
+		Scope:      strings.TrimSpace(opts.Scope),
+		People:     make([]reportPerson, 0),
+		Categories: make([]reportCategory, 0),
+		Expenses:   make([]reportExpenseRow, 0),
+	}
+	if res.Scope == "" {
+		res.Scope = "all"
+	}
+
+	var groupID int
+	groupFilter := false
+	if strings.TrimSpace(opts.GroupInput) != "" {
+		id, name, ok := resolveReportGroup(opts.GroupInput, groups)
+		if ok {
+			groupFilter = true
+			groupID = id
+			res.Scope = "group:" + name
+		}
+	}
+
+	var sinceT time.Time
+	hasSince := false
+	if strings.TrimSpace(opts.Since) != "" {
+		if t, err := time.Parse("2006-01-02", strings.TrimSpace(opts.Since)); err == nil {
+			sinceT = t
+			hasSince = true
+		}
+	}
+	var untilT time.Time
+	hasUntil := false
+	if strings.TrimSpace(opts.Until) != "" {
+		if t, err := time.Parse("2006-01-02", strings.TrimSpace(opts.Until)); err == nil {
+			untilT = t
+			hasUntil = true
+		}
+	}
+
+	filtered := make([]Expense, 0)
+	for _, e := range expenses {
+		if e.Payment || expenseDeleted(e.DeletedAt) {
+			continue
+		}
+		if groupFilter && e.GroupID != groupID {
+			continue
+		}
+		t, ok := parseSplitwiseDate(e.Date)
+		if hasSince {
+			if !ok || t.Before(sinceT) {
+				continue
+			}
+		}
+		if hasUntil {
+			if !ok || t.After(untilT.Add(24*time.Hour-time.Nanosecond)) {
+				continue
+			}
+		}
+		filtered = append(filtered, e)
+	}
+
+	currency := strings.ToUpper(strings.TrimSpace(opts.Currency))
+	if currency == "" {
+		freq := make(map[string]int)
+		for _, e := range filtered {
+			cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+			if cc == "" {
+				continue
+			}
+			freq[cc]++
+		}
+		maxCount := 0
+		for cc, n := range freq {
+			if n > maxCount || (n == maxCount && (currency == "" || cc < currency)) {
+				currency = cc
+				maxCount = n
+			}
+		}
+	}
+	res.Currency = currency
+
+	kept := make([]Expense, 0, len(filtered))
+	for _, e := range filtered {
+		cc := strings.ToUpper(strings.TrimSpace(e.CurrencyCode))
+		if currency != "" && cc != currency {
+			res.ExcludedOtherCurrency++
+			continue
+		}
+		kept = append(kept, e)
+	}
+
+	type personAgg struct {
+		name string
+		paid float64
+		owed float64
+	}
+	type catAgg struct {
+		total float64
+		count int
+	}
+	people := make(map[int]*personAgg)
+	cats := make(map[string]*catAgg)
+
+	var minDate *time.Time
+	var maxDate *time.Time
+
+	for _, e := range kept {
+		cost := round2(parseAmount(e.Cost))
+		res.TotalCost = round2(res.TotalCost + cost)
+		res.ExpenseCount++
+
+		if t, ok := parseSplitwiseDate(e.Date); ok {
+			td := t.UTC()
+			if minDate == nil || td.Before(*minDate) {
+				cpy := td
+				minDate = &cpy
+			}
+			if maxDate == nil || td.After(*maxDate) {
+				cpy := td
+				maxDate = &cpy
+			}
+		}
+
+		catName := strings.TrimSpace(e.Category.Name)
+		if catName == "" {
+			catName = "Uncategorized"
+		}
+		if _, ok := cats[catName]; !ok {
+			cats[catName] = &catAgg{}
+		}
+		cats[catName].total = round2(cats[catName].total + cost)
+		cats[catName].count++
+
+		payerName := ""
+		paidPositive := 0
+		maxPaid := 0.0
+		for _, u := range e.Users {
+			paid := round2(parseAmount(u.PaidShare))
+			owed := round2(parseAmount(u.OwedShare))
+			name := strings.TrimSpace(strings.TrimSpace(u.User.FirstName) + " " + strings.TrimSpace(u.User.LastName))
+			if name == "" {
+				name = fmt.Sprintf("user %d", u.UserID)
+			}
+			if _, ok := people[u.UserID]; !ok {
+				people[u.UserID] = &personAgg{name: name}
+			}
+			if people[u.UserID].name == "" {
+				people[u.UserID].name = name
+			}
+			people[u.UserID].paid = round2(people[u.UserID].paid + paid)
+			people[u.UserID].owed = round2(people[u.UserID].owed + owed)
+
+			if u.UserID == youID {
+				res.YourPaid = round2(res.YourPaid + paid)
+				res.YourOwed = round2(res.YourOwed + owed)
+			}
+
+			if paid > 0 {
+				paidPositive++
+			}
+			if paid > maxPaid {
+				maxPaid = paid
+				payerName = name
+			}
+		}
+		if paidPositive >= 2 {
+			payerName = "multiple"
+		}
+		if payerName == "" {
+			// No participant has a positive paid_share — distinct from a genuine
+			// 2+-payer split, so don't mislabel it "multiple".
+			payerName = "-"
+		}
+
+		ds := strings.TrimSpace(e.Date)
+		if t, ok := parseSplitwiseDate(e.Date); ok {
+			ds = t.UTC().Format("2006-01-02")
+		}
+		res.Expenses = append(res.Expenses, reportExpenseRow{
+			ID:           e.ID,
+			Date:         ds,
+			Description:  strings.TrimSpace(e.Description),
+			Cost:         cost,
+			CurrencyCode: strings.ToUpper(strings.TrimSpace(e.CurrencyCode)),
+			Payer:        payerName,
+		})
+	}
+	res.YourNet = round2(res.YourPaid - res.YourOwed)
+
+	if minDate != nil {
+		res.PeriodStart = minDate.Format("2006-01-02")
+	}
+	if maxDate != nil {
+		res.PeriodEnd = maxDate.Format("2006-01-02")
+	}
+
+	for id, a := range people {
+		name := strings.TrimSpace(a.name)
+		if name == "" {
+			name = fmt.Sprintf("user %d", id)
+		}
+		res.People = append(res.People, reportPerson{
+			UserID: id,
+			Name:   name,
+			Paid:   round2(a.paid),
+			Owed:   round2(a.owed),
+			Net:    round2(a.paid - a.owed),
+		})
+	}
+	sort.Slice(res.People, func(i, j int) bool {
+		if res.People[i].Net != res.People[j].Net {
+			return res.People[i].Net > res.People[j].Net
+		}
+		if res.People[i].Name != res.People[j].Name {
+			return res.People[i].Name < res.People[j].Name
+		}
+		return res.People[i].UserID < res.People[j].UserID
+	})
+
+	for name, a := range cats {
+		res.Categories = append(res.Categories, reportCategory{Name: name, Total: round2(a.total), Count: a.count})
+	}
+	sort.Slice(res.Categories, func(i, j int) bool {
+		if res.Categories[i].Total != res.Categories[j].Total {
+			return res.Categories[i].Total > res.Categories[j].Total
+		}
+		return res.Categories[i].Name < res.Categories[j].Name
+	})
+
+	sort.Slice(res.Expenses, func(i, j int) bool {
+		if res.Expenses[i].Date != res.Expenses[j].Date {
+			return res.Expenses[i].Date < res.Expenses[j].Date
+		}
+		return res.Expenses[i].ID < res.Expenses[j].ID
+	})
+
+	if opts.Limit > 0 && len(res.Expenses) > opts.Limit {
+		res.Expenses = res.Expenses[:opts.Limit]
+		res.Truncated = true
+	}
+
+	return res
+}
+
+func renderReportMarkdown(r reportResult) string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "# Report — %s\n\n", r.Scope)
+	_, _ = fmt.Fprintf(&b, "Period: %s to %s  | Currency: %s  | Expenses: %d  | Total: %.2f  | Your net: %.2f\n\n", valueOrDash(r.PeriodStart), valueOrDash(r.PeriodEnd), valueOrDash(r.Currency), r.ExpenseCount, r.TotalCost, r.YourNet)
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(&b, "Excluded %d expense(s) in other currencies.\n\n", r.ExcludedOtherCurrency)
+	}
+
+	b.WriteString("## By person\n\n")
+	b.WriteString("| Name | Paid | Owed | Net |\n")
+	b.WriteString("| --- | ---: | ---: | ---: |\n")
+	for _, p := range r.People {
+		_, _ = fmt.Fprintf(&b, "| %s | %.2f | %.2f | %.2f |\n", mdCell(p.Name), p.Paid, p.Owed, p.Net)
+	}
+	b.WriteString("\n## By category\n\n")
+	b.WriteString("| Category | Total | Count |\n")
+	b.WriteString("| --- | ---: | ---: |\n")
+	for _, c := range r.Categories {
+		_, _ = fmt.Fprintf(&b, "| %s | %.2f | %d |\n", mdCell(c.Name), c.Total, c.Count)
+	}
+	b.WriteString("\n## Expenses\n\n")
+	b.WriteString("| ID | Date | Description | Cost | Currency | Payer |\n")
+	b.WriteString("| ---: | --- | --- | ---: | --- | --- |\n")
+	for _, e := range r.Expenses {
+		_, _ = fmt.Fprintf(&b, "| %d | %s | %s | %.2f | %s | %s |\n", e.ID, e.Date, mdCell(e.Description), e.Cost, e.CurrencyCode, mdCell(e.Payer))
+	}
+	if r.Truncated {
+		_, _ = fmt.Fprintf(&b, "\nShowing first %d expense row(s) of %d.\n", len(r.Expenses), r.ExpenseCount)
+	}
+	return b.String()
+}
+
+// mdCell escapes a user-controlled value for a Markdown table cell: a literal
+// pipe would inject an extra column and a newline would split the row. Splitwise
+// descriptions frequently contain '|', so this keeps the rendered table well-formed.
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
+func renderReportCSV(r reportResult) string {
+	var b bytes.Buffer
+	w := csv.NewWriter(&b)
+	_ = w.Write([]string{"id", "date", "description", "cost", "currency", "payer"})
+	for _, e := range r.Expenses {
+		_ = w.Write([]string{
+			strconv.Itoa(e.ID),
+			e.Date,
+			e.Description,
+			fmt.Sprintf("%.2f", e.Cost),
+			e.CurrencyCode,
+			e.Payer,
+		})
+	}
+	w.Flush()
+	return b.String()
+}
+
+func printReportSummary(cmd *cobra.Command, r reportResult) error {
+	out := cmd.OutOrStdout()
+	tw := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tVALUE")
+	_, _ = fmt.Fprintf(tw, "scope\t%s\n", r.Scope)
+	_, _ = fmt.Fprintf(tw, "period\t%s to %s\n", valueOrDash(r.PeriodStart), valueOrDash(r.PeriodEnd))
+	_, _ = fmt.Fprintf(tw, "currency\t%s\n", valueOrDash(r.Currency))
+	_, _ = fmt.Fprintf(tw, "expense_count\t%d\n", r.ExpenseCount)
+	_, _ = fmt.Fprintf(tw, "total\t%.2f\n", r.TotalCost)
+	_, _ = fmt.Fprintf(tw, "your_net\t%.2f\n", r.YourNet)
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(tw, "excluded_other_currency\t%d\n", r.ExcludedOtherCurrency)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out)
+	twPeople := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(twPeople, "PERSON\tPAID\tOWED\tNET")
+	for i, p := range r.People {
+		if i >= 8 {
+			break
+		}
+		_, _ = fmt.Fprintf(twPeople, "%s\t%.2f\t%.2f\t%.2f\n", p.Name, p.Paid, p.Owed, p.Net)
+	}
+	if err := twPeople.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(out)
+	twCat := tabwriter.NewWriter(out, 2, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(twCat, "CATEGORY\tTOTAL\tCOUNT")
+	for i, c := range r.Categories {
+		if i >= 8 {
+			break
+		}
+		_, _ = fmt.Fprintf(twCat, "%s\t%.2f\t%d\n", c.Name, c.Total, c.Count)
+	}
+	if err := twCat.Flush(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "\n%d expenses — use --format md for the full report\n", r.ExpenseCount)
+	if r.Truncated {
+		_, _ = fmt.Fprintf(out, "rows capped at %d; use --limit 0 for all rows\n", len(r.Expenses))
+	}
+	if r.ExcludedOtherCurrency > 0 {
+		_, _ = fmt.Fprintf(out, "note: excluded %d expense(s) in other currencies\n", r.ExcludedOtherCurrency)
+	}
+	return nil
+}
+
+func valueOrDash(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+func TestComputeReport_TableDriven(t *testing.T) {
+	expenses := []Expense{
+		{
+			ID:           101,
+			GroupID:      10,
+			Description:  "Lunch",
+			Cost:         "40.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-10T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Food"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "40.00", OwedShare: "20.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "0", OwedShare: "20.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           102,
+			GroupID:      10,
+			Description:  "Cab",
+			Cost:         "20.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-11T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Transport"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "10.00", OwedShare: "10.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "10.00", OwedShare: "10.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           103,
+			GroupID:      10,
+			Description:  "Museum",
+			Cost:         "30.00",
+			CurrencyCode: "EUR",
+			Date:         "2025-01-12T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Entertainment"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "0", OwedShare: "15.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 2, PaidShare: "30.00", OwedShare: "15.00", User: NestedUser{ID: 2, FirstName: "Alex", LastName: "Kim"}},
+			},
+		},
+		{
+			ID:           104,
+			GroupID:      11,
+			Description:  "Hotel",
+			Cost:         "80.00",
+			CurrencyCode: "USD",
+			Date:         "2025-02-01T12:00:00Z",
+			Payment:      false,
+			Category:     Category{Name: "Lodging"},
+			Users: []ExpenseUser{
+				{UserID: 1, PaidShare: "80.00", OwedShare: "40.00", User: NestedUser{ID: 1, FirstName: "You", LastName: "Person"}},
+				{UserID: 3, PaidShare: "0", OwedShare: "40.00", User: NestedUser{ID: 3, FirstName: ""}},
+			},
+		},
+		{
+			ID:           105,
+			GroupID:      10,
+			Description:  "Settlement",
+			Cost:         "10.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-15T12:00:00Z",
+			Payment:      true,
+			Category:     Category{Name: ""},
+		},
+		{
+			ID:           106,
+			GroupID:      10,
+			Description:  "Deleted Meal",
+			Cost:         "10.00",
+			CurrencyCode: "USD",
+			Date:         "2025-01-16T12:00:00Z",
+			Payment:      false,
+			DeletedAt:    ptr("2025-01-17T00:00:00Z"),
+			Category:     Category{Name: "Food"},
+		},
+	}
+
+	groups := []Group{{ID: 10, Name: "Tahoe Trip"}, {ID: 11, Name: "Ski Weekend"}}
+
+	tests := []struct {
+		name   string
+		opts   reportOpts
+		assert func(t *testing.T, got reportResult)
+	}{
+		{
+			name: "group date payment deleted and currency default",
+			opts: reportOpts{GroupInput: "Tahoe Trip", Since: "2025-01-10", Until: "2025-01-31", Limit: 100},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Scope != "group:Tahoe Trip" {
+					t.Fatalf("Scope=%q", got.Scope)
+				}
+				if got.Currency != "USD" {
+					t.Fatalf("Currency=%q, want USD", got.Currency)
+				}
+				if got.ExcludedOtherCurrency != 1 {
+					t.Fatalf("ExcludedOtherCurrency=%d, want 1", got.ExcludedOtherCurrency)
+				}
+				if got.ExpenseCount != 2 {
+					t.Fatalf("ExpenseCount=%d, want 2", got.ExpenseCount)
+				}
+				if got.TotalCost != 60 {
+					t.Fatalf("TotalCost=%.2f, want 60", got.TotalCost)
+				}
+				if got.YourPaid != 50 || got.YourOwed != 30 || got.YourNet != 20 {
+					t.Fatalf("your totals paid=%.2f owed=%.2f net=%.2f", got.YourPaid, got.YourOwed, got.YourNet)
+				}
+				if got.PeriodStart != "2025-01-10" || got.PeriodEnd != "2025-01-11" {
+					t.Fatalf("period=%s..%s", got.PeriodStart, got.PeriodEnd)
+				}
+				if len(got.People) != 2 {
+					t.Fatalf("len(People)=%d, want 2", len(got.People))
+				}
+				if got.People[0].Name != "You Person" || got.People[0].Net != 20 {
+					t.Fatalf("people[0]=%+v", got.People[0])
+				}
+				if got.People[1].Name != "Alex Kim" || got.People[1].Net != -20 {
+					t.Fatalf("people[1]=%+v", got.People[1])
+				}
+				if len(got.Categories) != 2 {
+					t.Fatalf("len(Categories)=%d, want 2", len(got.Categories))
+				}
+				if got.Categories[0].Name != "Food" || got.Categories[0].Total != 40 || got.Categories[0].Count != 1 {
+					t.Fatalf("categories[0]=%+v", got.Categories[0])
+				}
+				if got.Categories[1].Name != "Transport" || got.Categories[1].Total != 20 || got.Categories[1].Count != 1 {
+					t.Fatalf("categories[1]=%+v", got.Categories[1])
+				}
+				if len(got.Expenses) != 2 {
+					t.Fatalf("len(Expenses)=%d, want 2", len(got.Expenses))
+				}
+				if got.Expenses[0].ID != 101 || got.Expenses[0].Payer != "You Person" {
+					t.Fatalf("expense[0]=%+v", got.Expenses[0])
+				}
+				if got.Expenses[1].ID != 102 || got.Expenses[1].Payer != "multiple" {
+					t.Fatalf("expense[1]=%+v", got.Expenses[1])
+				}
+			},
+		},
+		{
+			name: "explicit currency and limit with fallback user name",
+			opts: reportOpts{Currency: "USD", Limit: 1},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Scope != "all" {
+					t.Fatalf("Scope=%q, want all", got.Scope)
+				}
+				if got.Currency != "USD" {
+					t.Fatalf("Currency=%q, want USD", got.Currency)
+				}
+				if got.ExcludedOtherCurrency != 1 {
+					t.Fatalf("ExcludedOtherCurrency=%d, want 1", got.ExcludedOtherCurrency)
+				}
+				if got.ExpenseCount != 3 {
+					t.Fatalf("ExpenseCount=%d, want 3", got.ExpenseCount)
+				}
+				if got.Truncated != true || len(got.Expenses) != 1 {
+					t.Fatalf("Truncated=%v len(Expenses)=%d", got.Truncated, len(got.Expenses))
+				}
+				if got.People[0].Name != "You Person" || got.People[2].Name != "user 3" {
+					t.Fatalf("people ordering/fallback: %+v", got.People)
+				}
+				if got.PeriodStart != "2025-01-10" || got.PeriodEnd != "2025-02-01" {
+					t.Fatalf("period=%s..%s", got.PeriodStart, got.PeriodEnd)
+				}
+			},
+		},
+		{
+			name: "limit zero means all",
+			opts: reportOpts{Limit: 0},
+			assert: func(t *testing.T, got reportResult) {
+				if got.Truncated {
+					t.Fatalf("Truncated=true, want false")
+				}
+				if len(got.Expenses) != got.ExpenseCount {
+					t.Fatalf("len(Expenses)=%d ExpenseCount=%d", len(got.Expenses), got.ExpenseCount)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeReport(expenses, groups, 1, tc.opts)
+			tc.assert(t, got)
+		})
+	}
+}
+
+func TestRenderReportMarkdown(t *testing.T) {
+	r := reportResult{
+		Scope:                 "group:Tahoe Trip",
+		Currency:              "USD",
+		PeriodStart:           "2025-01-10",
+		PeriodEnd:             "2025-01-11",
+		ExpenseCount:          2,
+		ExcludedOtherCurrency: 1,
+		TotalCost:             60,
+		YourNet:               20,
+		People:                []reportPerson{{Name: "You Person", Paid: 50, Owed: 30, Net: 20}},
+		Categories:            []reportCategory{{Name: "Food", Total: 40, Count: 1}},
+		Expenses:              []reportExpenseRow{{ID: 101, Date: "2025-01-10", Description: "Lunch", Cost: 40, CurrencyCode: "USD", Payer: "You Person"}},
+	}
+
+	md := renderReportMarkdown(r)
+	mustContain := []string{
+		"# Report — group:Tahoe Trip",
+		"## By person",
+		"## By category",
+		"## Expenses",
+		"| You Person | 50.00 | 30.00 | 20.00 |",
+		"| Food | 40.00 | 1 |",
+		"Excluded 1 expense(s) in other currencies.",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q\n%s", want, md)
+		}
+	}
+}
+
+func TestRenderReportCSV_EscapingAndRows(t *testing.T) {
+	r := reportResult{Expenses: []reportExpenseRow{
+		{ID: 101, Date: "2025-01-10", Description: "Simple", Cost: 40, CurrencyCode: "USD", Payer: "You Person"},
+		{ID: 102, Date: "2025-01-11", Description: "Taxi, \"airport\"", Cost: 20, CurrencyCode: "USD", Payer: "multiple"},
+	}}
+
+	out := renderReportCSV(r)
+	rows, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+	if err != nil {
+		t.Fatalf("csv parse: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows=%d, want 3", len(rows))
+	}
+	head := strings.Join(rows[0], ",")
+	if head != "id,date,description,cost,currency,payer" {
+		t.Fatalf("header=%q", head)
+	}
+	if rows[2][2] != "Taxi, \"airport\"" {
+		t.Fatalf("escaped description mismatch: %q", rows[2][2])
+	}
+}
+
+func TestRenderReportMarkdown_EscapesPipes(t *testing.T) {
+	r := reportResult{
+		Scope:    "all",
+		Currency: "USD",
+		People:   []reportPerson{{Name: "A | B", Paid: 1, Owed: 0, Net: 1}},
+		Expenses: []reportExpenseRow{
+			{ID: 1, Date: "2025-01-10", Description: "Dinner | drinks\nlate", Cost: 50, CurrencyCode: "USD", Payer: "You"},
+		},
+	}
+	md := renderReportMarkdown(r)
+	if !strings.Contains(md, `Dinner \| drinks late`) {
+		t.Fatalf("description pipe/newline not escaped:\n%s", md)
+	}
+	if strings.Contains(md, "Dinner | drinks") {
+		t.Fatalf("raw unescaped pipe leaked into markdown:\n%s", md)
+	}
+	if !strings.Contains(md, `A \| B`) {
+		t.Fatalf("person-name pipe not escaped:\n%s", md)
+	}
+	// The expense data row must remain a single 6-cell row (7 structural pipes),
+	// regardless of pipes inside the (now-escaped) description.
+	for _, line := range strings.Split(md, "\n") {
+		if strings.HasPrefix(line, "| 1 | 2025-01-10 |") {
+			if structural := strings.Count(line, "|") - strings.Count(line, `\|`); structural != 7 {
+				t.Fatalf("expense row has %d structural pipes, want 7: %q", structural, line)
+			}
+		}
+	}
+}
+
+func TestComputeReport_CurrencyTieBreak(t *testing.T) {
+	// 1 USD + 1 EUR is a tie; the default currency picks the alphabetically-first
+	// code (EUR) deterministically, and the USD expense is excluded (not mixed).
+	expenses := []Expense{
+		{ID: 1, Description: "u", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", Users: []ExpenseUser{{UserID: 1, PaidShare: "10", OwedShare: "10"}}},
+		{ID: 2, Description: "e", Cost: "20", CurrencyCode: "EUR", Date: "2025-01-02", Users: []ExpenseUser{{UserID: 1, PaidShare: "20", OwedShare: "20"}}},
+	}
+	got := computeReport(expenses, nil, 1, reportOpts{Limit: 0})
+	if got.Currency != "EUR" {
+		t.Fatalf("tie-break currency=%q want EUR", got.Currency)
+	}
+	if got.ExpenseCount != 1 || got.ExcludedOtherCurrency != 1 {
+		t.Fatalf("expense_count=%d excluded=%d want 1/1", got.ExpenseCount, got.ExcludedOtherCurrency)
+	}
+}
+
+func TestComputeReport_NoPayer(t *testing.T) {
+	// No participant has a positive paid_share -> payer "-", distinct from a
+	// genuine 2+-payer "multiple".
+	expenses := []Expense{
+		{ID: 1, Description: "x", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", Users: []ExpenseUser{
+			{UserID: 1, PaidShare: "0", OwedShare: "5", User: NestedUser{ID: 1, FirstName: "A"}},
+			{UserID: 2, PaidShare: "0", OwedShare: "5", User: NestedUser{ID: 2, FirstName: "B"}},
+		}},
+	}
+	got := computeReport(expenses, nil, 1, reportOpts{Limit: 0})
+	if len(got.Expenses) != 1 || got.Expenses[0].Payer != "-" {
+		t.Fatalf("payer=%q want '-'", got.Expenses[0].Payer)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -1,9 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
 )
 
 func TestComputeReport_TableDriven(t *testing.T) {
@@ -330,3 +336,61 @@ func TestComputeReport_UnresolvableGroupYieldsEmpty(t *testing.T) {
 }
 
 func ptr(s string) *string { return &s }
+
+// TestReportCSVTruncationWarnsOnStderr verifies that when --limit truncates
+// the expense list, the CSV output path emits a note on stderr (matching
+// json/md/summary) while stdout remains valid, parseable CSV.
+func TestReportCSVTruncationWarnsOnStderr(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := defaultDBPath("splitwise-pp-cli")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Seed 3 same-currency expenses so --limit 1 truncates (2 dropped).
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+		body := fmt.Sprintf(
+			`{"id":%d,"currency_code":"USD","cost":"10.00","date":"2025-01-0%d","description":"expense%d","users":[{"user_id":42,"owed_share":"10.00","paid_share":"10.00","user":{"id":42,"first_name":"You","last_name":"Person"}}]}`,
+			i, i, i,
+		)
+		if err := s.Upsert("get-expenses", id, []byte(body)); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	cmd := newReportCmd(&rootFlags{})
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--format", "csv", "--limit", "1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr: %s)", err, errBuf.String())
+	}
+
+	// Assertion that will FAIL before the fix: stderr must contain "truncated".
+	if !strings.Contains(errBuf.String(), "truncated") {
+		t.Errorf("expected CSV truncation note on stderr, got: %q", errBuf.String())
+	}
+	// stdout must still be valid CSV with the expected header.
+	if !strings.Contains(out.String(), "id,date,description") {
+		t.Errorf("expected CSV header on stdout, got: %q", out.String())
+	}
+	// Confirm stdout is parseable CSV.
+	rows, parseErr := csv.NewReader(strings.NewReader(out.String())).ReadAll()
+	if parseErr != nil {
+		t.Errorf("stdout is not valid CSV: %v\nraw: %q", parseErr, out.String())
+	}
+	// header + 1 data row (limit=1)
+	if len(rows) != 2 {
+		t.Errorf("expected 2 CSV rows (header+1 data), got %d", len(rows))
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_report_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_report_test.go
@@ -313,4 +313,20 @@ func TestComputeReport_NoPayer(t *testing.T) {
 	}
 }
 
+func TestComputeReport_UnresolvableGroupYieldsEmpty(t *testing.T) {
+	// A --group that matches no group must NOT silently fall through to an
+	// unfiltered report; the pure function filters to nothing and scopes the label.
+	expenses := []Expense{
+		{ID: 1, Description: "x", Cost: "10", CurrencyCode: "USD", Date: "2025-01-01", GroupID: 7, Users: []ExpenseUser{{UserID: 1, PaidShare: "10", OwedShare: "10"}}},
+	}
+	groups := []Group{{ID: 7, Name: "Real Group"}}
+	got := computeReport(expenses, groups, 1, reportOpts{GroupInput: "Nonexistent Group", Limit: 0})
+	if got.ExpenseCount != 0 || len(got.Expenses) != 0 {
+		t.Fatalf("expense_count=%d len=%d, want 0/0 (unresolvable group must filter to nothing)", got.ExpenseCount, len(got.Expenses))
+	}
+	if !strings.Contains(got.Scope, "no match") {
+		t.Fatalf("scope=%q, want it to flag the unmatched group", got.Scope)
+	}
+}
+
 func ptr(s string) *string { return &s }

--- a/library/payments/splitwise/internal/cli/splitwise_settle.go
+++ b/library/payments/splitwise/internal/cli/splitwise_settle.go
@@ -46,7 +46,7 @@ func newSettleUpCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer db.Close()
 
-			input := strings.TrimSpace(args[0])
+			input := joinNameArgs(args)
 			if input == "" {
 				return usageErr(errors.New("group name/id or friend name is required"))
 			}
@@ -69,7 +69,7 @@ func newSettleUpCmd(flags *rootFlags) *cobra.Command {
 			groupMatch, hasGroupMatch, groupAmbErr := resolveSettleGroup(input, groups)
 			if isAllDigits(input) || hasGroupMatch {
 				if !hasGroupMatch {
-					return usageErr(fmt.Errorf("no group or friend matches %q; run sync first", args[0]))
+					return usageErr(fmt.Errorf("no group or friend matches %q; run sync first", input))
 				}
 				targetType = "group"
 				targetName = strings.TrimSpace(groupMatch.Name)
@@ -118,7 +118,7 @@ func newSettleUpCmd(flags *rootFlags) *cobra.Command {
 					case friendAmbErr != nil:
 						return usageErr(friendAmbErr)
 					default:
-						return usageErr(fmt.Errorf("no group or friend matches %q; run sync first", args[0]))
+						return usageErr(fmt.Errorf("no group or friend matches %q; run sync first", input))
 					}
 				}
 				targetType = "friend"
@@ -264,6 +264,16 @@ func newSettleUpCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().BoolVar(&record, "record", false, "Create payment expenses from the computed plan")
 	return cmd
+}
+
+// joinNameArgs derives a single group/friend name from positional args by joining
+// them with spaces, so a multi-word name survives whitespace-splitting (e.g. the
+// MCP command-mirror tokenizes `args:"EDCO 2021"` into ["EDCO","2021"]). Joining
+// reassembles "EDCO 2021" so the exact-match path resolves it to the one group,
+// instead of the bare prefix "EDCO" substring-matching several. Shared by the
+// name-positional commands (settle-up, resolve).
+func joinNameArgs(args []string) string {
+	return strings.TrimSpace(strings.Join(args, " "))
 }
 
 // matchGroupsByName returns groups matching input with exact-match preference:

--- a/library/payments/splitwise/internal/cli/splitwise_settle_input_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_settle_input_test.go
@@ -18,6 +18,8 @@ func TestNameCommandsAcceptMultiWordPositionals(t *testing.T) {
 	cmds := map[string]*cobra.Command{
 		"settle-up": newSettleUpCmd(flags),
 		"resolve":   newResolveCmd(flags),
+		"split":     newSplitCmd(flags),
+		"ledger":    newLedgerCmd(flags),
 	}
 	for name, cmd := range cmds {
 		if cmd.Args == nil {
@@ -58,5 +60,21 @@ func TestSettleResolvesMultiWordGroupName(t *testing.T) {
 	}
 	if !ok || g.ID != 1 {
 		t.Fatalf("expected unique EDCO 2021 (id 1), got ok=%v id=%d", ok, g.ID)
+	}
+}
+
+// TestLedgerResolvesMultiWordGroupName is the parallel regression for the ledger
+// and split commands, which resolve group names via resolveLedgerGroup /
+// resolveSettleGroup. The exact group name "EDCO 2021" arriving as split args must
+// resolve to the one EDCO 2021 group, not error as the ambiguous prefix "EDCO".
+func TestLedgerResolvesMultiWordGroupName(t *testing.T) {
+	groups := []Group{{ID: 1, Name: "EDCO 2021"}, {ID: 2, Name: "EDCO 2022"}}
+	input := joinNameArgs([]string{"EDCO", "2021"})
+	id, name, _, err := resolveLedgerGroup(input, groups)
+	if err != nil {
+		t.Fatalf("unexpected ambiguity error: %v", err)
+	}
+	if id != 1 || name != "EDCO 2021" {
+		t.Fatalf("expected unique EDCO 2021 (id 1), got id=%d name=%q", id, name)
 	}
 }

--- a/library/payments/splitwise/internal/cli/splitwise_settle_input_test.go
+++ b/library/payments/splitwise/internal/cli/splitwise_settle_input_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestNameCommandsAcceptMultiWordPositionals guards the actual failure path: a
+// multi-word name arrives as multiple positionals (the MCP command-mirror splits
+// `args:"EDCO 2021"` into ["EDCO","2021"]). A command whose Args validator caps at
+// one positional (cobra.ExactArgs(1)) rejects this BEFORE RunE runs, making the
+// joinNameArgs rejoin unreachable. These name-positional commands must accept
+// 2+ positionals so the rejoin can do its job.
+func TestNameCommandsAcceptMultiWordPositionals(t *testing.T) {
+	flags := &rootFlags{}
+	cmds := map[string]*cobra.Command{
+		"settle-up": newSettleUpCmd(flags),
+		"resolve":   newResolveCmd(flags),
+	}
+	for name, cmd := range cmds {
+		if cmd.Args == nil {
+			continue // ArbitraryArgs already accepts multiple positionals
+		}
+		if err := cmd.Args(cmd, []string{"EDCO", "2021"}); err != nil {
+			t.Errorf("%s rejected a split multi-word name (2 positionals): %v", name, err)
+		}
+	}
+}
+
+// TestJoinNameArgs: a multi-word positional (a group/friend name) that
+// arrives as multiple args — e.g. when the MCP command-mirror whitespace-splits
+// `args:"EDCO 2021"` into ["EDCO","2021"] — must be rejoined into the full name,
+// not truncated to the first token.
+func TestJoinNameArgs(t *testing.T) {
+	if got := joinNameArgs([]string{"EDCO", "2021"}); got != "EDCO 2021" {
+		t.Fatalf("joinNameArgs([EDCO 2021]) = %q, want \"EDCO 2021\"", got)
+	}
+	if got := joinNameArgs([]string{"  Tahoe Trip  "}); got != "Tahoe Trip" {
+		t.Fatalf("joinNameArgs trims, got %q", got)
+	}
+	if got := joinNameArgs([]string{"28194161"}); got != "28194161" {
+		t.Fatalf("joinNameArgs single numeric, got %q", got)
+	}
+}
+
+// TestSettleResolvesMultiWordGroupName is the regression for the dogfood finding:
+// the exact group name "EDCO 2021" arriving as split args must resolve to the one
+// EDCO 2021 group, NOT error as the ambiguous prefix "EDCO" (which substring-matches
+// both EDCO 2021 and EDCO 2022).
+func TestSettleResolvesMultiWordGroupName(t *testing.T) {
+	groups := []Group{{ID: 1, Name: "EDCO 2021"}, {ID: 2, Name: "EDCO 2022"}}
+	input := joinNameArgs([]string{"EDCO", "2021"})
+	g, ok, err := resolveSettleGroup(input, groups)
+	if err != nil {
+		t.Fatalf("unexpected ambiguity error: %v", err)
+	}
+	if !ok || g.ID != 1 {
+		t.Fatalf("expected unique EDCO 2021 (id 1), got ok=%v id=%d", ok, g.ID)
+	}
+}

--- a/library/payments/splitwise/internal/cli/splitwise_spend.go
+++ b/library/payments/splitwise/internal/cli/splitwise_spend.go
@@ -168,7 +168,9 @@ func newLedgerCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			groupID, groupName, memberNames, err := resolveLedgerGroup(args[0], groups)
+			// Rejoin a multi-word group name the MCP command-mirror split into
+			// several positionals (see joinNameArgs in splitwise_settle.go).
+			groupID, groupName, memberNames, err := resolveLedgerGroup(joinNameArgs(args), groups)
 			if err != nil {
 				return usageErr(err)
 			}

--- a/library/payments/splitwise/internal/cli/splitwise_split.go
+++ b/library/payments/splitwise/internal/cli/splitwise_split.go
@@ -55,12 +55,15 @@ func newSplitCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			group, ok, ambErr := resolveSettleGroup(args[0], groups)
+			// Rejoin a multi-word group name the MCP command-mirror split into
+			// several positionals (see joinNameArgs in splitwise_settle.go).
+			groupName := joinNameArgs(args)
+			group, ok, ambErr := resolveSettleGroup(groupName, groups)
 			if ambErr != nil {
 				return usageErr(ambErr)
 			}
 			if !ok {
-				return usageErr(fmt.Errorf("no group matches %q; run sync first", args[0]))
+				return usageErr(fmt.Errorf("no group matches %q; run sync first", groupName))
 			}
 
 			payer := paidBy

--- a/library/payments/splitwise/internal/mcp/discoverability_test.go
+++ b/library/payments/splitwise/internal/mcp/discoverability_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEntryPointToolsAreDiscoverableByAppName pins the app name into the
+// descriptions of the three app-level entry-point tools (context/search/sql).
+// A deferred-tool-loading host (e.g. Claude Cowork) searches the tool surface by
+// keyword; without the app name on at least the "call this first" tool, a search
+// for "splitwise" matches nothing and the host wrongly concludes no connector is
+// installed. Leading these descriptions with the app name gives that search a hit.
+func TestEntryPointToolsAreDiscoverableByAppName(t *testing.T) {
+	for name, desc := range map[string]string{
+		"context": contextToolDesc,
+		"search":  searchToolDesc,
+		"sql":     sqlToolDesc,
+	} {
+		if !strings.Contains(desc, "Splitwise") {
+			t.Errorf("%s tool description must mention the app name \"Splitwise\" so a deferred-tool search by app name surfaces it; got: %q", name, desc)
+		}
+	}
+}

--- a/library/payments/splitwise/internal/mcp/format_param_test.go
+++ b/library/payments/splitwise/internal/mcp/format_param_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package mcp
+
+import "testing"
+
+func TestFormatMCPParamValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"large integer id (was 1.925035e+06)", float64(1925035), "1925035"},
+		{"another big id", float64(4346907350), "4346907350"},
+		{"decimal amount", float64(28.48), "28.48"},
+		{"zero", float64(0), "0"},
+		{"string passthrough", "2024-01-01", "2024-01-01"},
+		{"int", 42, "42"},
+	}
+	for _, c := range cases {
+		if got := formatMCPParamValue(c.in); got != c.want {
+			t.Errorf("%s: formatMCPParamValue(%v) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}

--- a/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
+++ b/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
@@ -1,7 +1,10 @@
 // Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
 package mcp
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMCPIntArg(t *testing.T) {
 	args := map[string]any{"offset": float64(7), "limit": float64(0)}
@@ -20,5 +23,37 @@ func TestBindingHasName(t *testing.T) {
 	}
 	if bindingHasName(bindings, "offset") {
 		t.Fatalf("expected bindingHasName(offset)=false")
+	}
+}
+
+// TestClientCursorNames guards the wiring that stops a client-side pagination
+// cursor from leaking into the upstream query string. A cursor name is consumed
+// by the client pager (and so must be marked known, NOT forwarded) only when the
+// tool has no native binding of that name. For an endpoint that pages
+// server-side, the native binding owns the arg, so it is excluded here and still
+// reaches the API.
+func TestClientCursorNames(t *testing.T) {
+	// No native offset/limit (e.g. get_comments as a list tool): both are
+	// client cursors and must be consumed.
+	noNative := clientCursorNames([]mcpParamBinding{{PublicName: "expense_id", WireName: "expense_id", Location: "query"}})
+	if got := strings.Join(noNative, ","); got != "offset,limit" {
+		t.Fatalf("clientCursorNames(no native) = %q, want \"offset,limit\"", got)
+	}
+
+	// Native offset AND limit (e.g. get_expenses): neither is a client cursor;
+	// both must reach the upstream API, so the consumed set is empty.
+	bothNative := clientCursorNames([]mcpParamBinding{
+		{PublicName: "offset", WireName: "offset", Location: "query"},
+		{PublicName: "limit", WireName: "limit", Location: "query"},
+	})
+	if len(bothNative) != 0 {
+		t.Fatalf("clientCursorNames(both native) = %v, want empty", bothNative)
+	}
+
+	// Mixed (e.g. get_notifications declares limit but not offset): only the
+	// undeclared cursor (offset) is consumed.
+	mixed := clientCursorNames([]mcpParamBinding{{PublicName: "limit", WireName: "limit", Location: "query"}})
+	if got := strings.Join(mixed, ","); got != "offset" {
+		t.Fatalf("clientCursorNames(limit native) = %q, want \"offset\"", got)
 	}
 }

--- a/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
+++ b/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package mcp
+
+import "testing"
+
+func TestMCPIntArg(t *testing.T) {
+	args := map[string]any{"offset": float64(7), "limit": float64(0)}
+	if got := mcpIntArg(args, "offset"); got != 7 {
+		t.Fatalf("offset = %d, want 7", got)
+	}
+	if got := mcpIntArg(args, "missing"); got != 0 {
+		t.Fatalf("missing = %d, want 0", got)
+	}
+}
+
+func TestBindingHasName(t *testing.T) {
+	bindings := []mcpParamBinding{{PublicName: "limit", WireName: "limit", Location: "query"}}
+	if !bindingHasName(bindings, "limit") {
+		t.Fatalf("expected bindingHasName(limit)=true")
+	}
+	if bindingHasName(bindings, "offset") {
+		t.Fatalf("expected bindingHasName(offset)=false")
+	}
+}

--- a/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
+++ b/library/payments/splitwise/internal/mcp/pagination_wiring_test.go
@@ -1,10 +1,7 @@
 // Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
 package mcp
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestMCPIntArg(t *testing.T) {
 	args := map[string]any{"offset": float64(7), "limit": float64(0)}
@@ -26,34 +23,30 @@ func TestBindingHasName(t *testing.T) {
 	}
 }
 
-// TestClientCursorNames guards the wiring that stops a client-side pagination
-// cursor from leaking into the upstream query string. A cursor name is consumed
-// by the client pager (and so must be marked known, NOT forwarded) only when the
-// tool has no native binding of that name. For an endpoint that pages
-// server-side, the native binding owns the arg, so it is excluded here and still
-// reaches the API.
-func TestClientCursorNames(t *testing.T) {
-	// No native offset/limit (e.g. get_comments as a list tool): both are
-	// client cursors and must be consumed.
-	noNative := clientCursorNames([]mcpParamBinding{{PublicName: "expense_id", WireName: "expense_id", Location: "query"}})
-	if got := strings.Join(noNative, ","); got != "offset,limit" {
-		t.Fatalf("clientCursorNames(no native) = %q, want \"offset,limit\"", got)
+// TestPaginatesNatively guards the gate that decides whether a GET tool's
+// response is left untouched (the API already paged it) or re-wrapped by the
+// client byte-budget pager. A tool pages natively when it declares an offset or
+// limit query binding; for those the pager is disabled so the native response
+// schema and full-collection total are preserved. Tools with no such binding are
+// client-paged, so offset/limit are consumed locally and not forwarded upstream.
+func TestPaginatesNatively(t *testing.T) {
+	// No native offset/limit (e.g. get_comments as a list tool): client-paged.
+	if paginatesNatively([]mcpParamBinding{{PublicName: "expense_id", WireName: "expense_id", Location: "query"}}) {
+		t.Fatalf("expense_id-only tool must not be treated as natively paged")
 	}
-
-	// Native offset AND limit (e.g. get_expenses): neither is a client cursor;
-	// both must reach the upstream API, so the consumed set is empty.
-	bothNative := clientCursorNames([]mcpParamBinding{
+	// No bindings at all (e.g. get_groups): client-paged.
+	if paginatesNatively(nil) {
+		t.Fatalf("binding-less list tool must not be treated as natively paged")
+	}
+	// Native offset AND limit (e.g. get_expenses): natively paged.
+	if !paginatesNatively([]mcpParamBinding{
 		{PublicName: "offset", WireName: "offset", Location: "query"},
 		{PublicName: "limit", WireName: "limit", Location: "query"},
-	})
-	if len(bothNative) != 0 {
-		t.Fatalf("clientCursorNames(both native) = %v, want empty", bothNative)
+	}) {
+		t.Fatalf("offset+limit tool must be treated as natively paged")
 	}
-
-	// Mixed (e.g. get_notifications declares limit but not offset): only the
-	// undeclared cursor (offset) is consumed.
-	mixed := clientCursorNames([]mcpParamBinding{{PublicName: "limit", WireName: "limit", Location: "query"}})
-	if got := strings.Join(mixed, ","); got != "offset" {
-		t.Fatalf("clientCursorNames(limit native) = %q, want \"offset\"", got)
+	// limit-only (e.g. get_notifications): natively paged.
+	if !paginatesNatively([]mcpParamBinding{{PublicName: "limit", WireName: "limit", Location: "query"}}) {
+		t.Fatalf("limit-only tool must be treated as natively paged")
 	}
 }

--- a/library/payments/splitwise/internal/mcp/sql_description_test.go
+++ b/library/payments/splitwise/internal/mcp/sql_description_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Vinny Pasceri and contributors. Licensed under Apache-2.0. See LICENSE.
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSQLToolParamDescribesRealSchema pins the sql tool's query-parameter
+// description to the store's ACTUAL schema. The store keeps every synced record
+// in one `resources` table keyed by `resource_type` with the raw record in a
+// JSON `data` column — there are no per-resource tables. The prior description
+// ("Tables match resource names.") sent agent hosts down a dead end: they tried
+// `FROM groups` / `FROM get_groups` and got "no such table". The description
+// must instead point at `resources`, `resource_type`, and `json_extract`.
+func TestSQLToolParamDescribesRealSchema(t *testing.T) {
+	desc := sqlQueryParamDesc
+
+	for _, must := range []string{"resources", "resource_type", "json_extract"} {
+		if !strings.Contains(desc, must) {
+			t.Errorf("sql query param description must mention %q so hosts query the real schema; got: %q", must, desc)
+		}
+	}
+
+	if strings.Contains(desc, "Tables match resource names") {
+		t.Errorf("sql query param description still contains the misleading 'Tables match resource names' claim: %q", desc)
+	}
+}

--- a/library/payments/splitwise/internal/mcp/tools.go
+++ b/library/payments/splitwise/internal/mcp/tools.go
@@ -67,6 +67,22 @@ func paginatesNatively(bindings []mcpParamBinding) bool {
 	return bindingHasName(bindings, "offset") || bindingHasName(bindings, "limit")
 }
 
+// sqlQueryParamDesc documents the real local schema for the sql tool: a single
+// `resources` table keyed by resource_type with the raw record in a JSON `data`
+// column (there are no per-resource tables). Agents that assume table-per-resource
+// hit "no such table"; this points them at resource_type + json_extract instead.
+const sqlQueryParamDesc = "SQL query (SELECT or WITH...SELECT). All synced records live in ONE table: resources(resource_type, id, data, synced_at, updated_at), where data is the raw JSON record. Filter by resource_type (e.g. 'get-groups', 'get-friends', 'get-expenses') and read fields with json_extract(data,'$.field'); expand nested arrays with json_each. Example: SELECT json_extract(data,'$.name') FROM resources WHERE resource_type='get-groups'."
+
+// contextToolDesc / searchToolDesc / sqlToolDesc front-load the "Splitwise" app
+// name so a deferred-tool host (e.g. Claude Cowork) that searches the tool surface
+// by app name surfaces these entry-point tools instead of concluding no connector
+// is installed.
+const (
+	contextToolDesc = "Splitwise: API domain context — resource taxonomy, auth requirements, query tips, and unique capabilities. Call this first when working with Splitwise."
+	searchToolDesc  = "Splitwise: full-text search across all synced Splitwise data. Faster than paginating list endpoints. Requires sync first."
+	sqlToolDesc     = "Splitwise: read-only SQL against the local Splitwise database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first."
+)
+
 // RegisterTools registers all API operations as MCP tools.
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
@@ -367,7 +383,7 @@ func RegisterTools(s *server.MCPServer) {
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
 		mcplib.NewTool("search",
-			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithDescription(searchToolDesc),
 			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
 			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
 			mcplib.WithReadOnlyHintAnnotation(true),
@@ -378,8 +394,8 @@ func RegisterTools(s *server.MCPServer) {
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(
 		mcplib.NewTool("sql",
-			mcplib.WithDescription("Run read-only SQL against local database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first."),
-			mcplib.WithString("query", mcplib.Required(), mcplib.Description("SQL query (SELECT or WITH...SELECT). Tables match resource names.")),
+			mcplib.WithDescription(sqlToolDesc),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description(sqlQueryParamDesc)),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 		),
@@ -390,7 +406,7 @@ func RegisterTools(s *server.MCPServer) {
 	// Call this first to understand the API taxonomy, query patterns, and capabilities.
 	s.AddTool(
 		mcplib.NewTool("context",
-			mcplib.WithDescription("Get API domain context: resource taxonomy, auth requirements, query tips, and unique capabilities. Call this first."),
+			mcplib.WithDescription(contextToolDesc),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 		),

--- a/library/payments/splitwise/internal/mcp/tools.go
+++ b/library/payments/splitwise/internal/mcp/tools.go
@@ -55,6 +55,22 @@ func bindingHasName(bindings []mcpParamBinding, name string) bool {
 	return false
 }
 
+// clientCursorNames returns the pagination cursor args (offset/limit) that the
+// client-side byte-budget pager consumes for a GET tool — i.e. the cursor names
+// the tool does NOT declare as a native query binding. These must both be read
+// for PaginateBody and be marked as consumed so the generic args-forwarding loop
+// does not also append them to the upstream query string (a leaked client cursor
+// makes the API return a partial slice, which then yields a wrong page total).
+func clientCursorNames(bindings []mcpParamBinding) []string {
+	var names []string
+	for _, name := range []string{"offset", "limit"} {
+		if !bindingHasName(bindings, name) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
 // RegisterTools registers all API operations as MCP tools.
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
@@ -462,6 +478,18 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				params[binding.WireName] = fmt.Sprintf("%v", v)
 			}
 		}
+		// Mark the client-side pagination cursor (offset/limit) as consumed so
+		// the generic args-forwarding loop below does not append it to the
+		// upstream query string. For endpoints that page server-side (e.g.
+		// get_expenses, get_comments) the native binding owns the arg, so
+		// clientCursorNames excludes it and it still reaches the API. Without
+		// this guard a client-cursor offset leaks upstream, the API returns a
+		// partial slice, and PaginateBody then reports a wrong total/next_offset.
+		if method == "GET" {
+			for _, name := range clientCursorNames(bindings) {
+				knownArgs[name] = true
+			}
+		}
 		for _, p := range positionalParams {
 			placeholder := "{" + p + "}"
 			if !strings.Contains(pathTemplate, placeholder) {
@@ -600,11 +628,13 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		// get_expenses) are not double-skipped.
 		if method == "GET" {
 			clientOffset, clientLimit := 0, 0
-			if !bindingHasName(bindings, "offset") {
-				clientOffset = mcpIntArg(args, "offset")
-			}
-			if !bindingHasName(bindings, "limit") {
-				clientLimit = mcpIntArg(args, "limit")
+			for _, name := range clientCursorNames(bindings) {
+				switch name {
+				case "offset":
+					clientOffset = mcpIntArg(args, "offset")
+				case "limit":
+					clientLimit = mcpIntArg(args, "limit")
+				}
 			}
 			if out, ok := cli.PaginateBody(data, clientOffset, clientLimit, mcpListMaxBytes(), ""); ok {
 				return mcplib.NewToolResultText(string(out)), nil

--- a/library/payments/splitwise/internal/mcp/tools.go
+++ b/library/payments/splitwise/internal/mcp/tools.go
@@ -55,20 +55,16 @@ func bindingHasName(bindings []mcpParamBinding, name string) bool {
 	return false
 }
 
-// clientCursorNames returns the pagination cursor args (offset/limit) that the
-// client-side byte-budget pager consumes for a GET tool — i.e. the cursor names
-// the tool does NOT declare as a native query binding. These must both be read
-// for PaginateBody and be marked as consumed so the generic args-forwarding loop
-// does not also append them to the upstream query string (a leaked client cursor
-// makes the API return a partial slice, which then yields a wrong page total).
-func clientCursorNames(bindings []mcpParamBinding) []string {
-	var names []string
-	for _, name := range []string{"offset", "limit"} {
-		if !bindingHasName(bindings, name) {
-			names = append(names, name)
-		}
-	}
-	return names
+// paginatesNatively reports whether a GET tool already pages server-side, i.e.
+// it declares a native offset or limit query binding (e.g. get_expenses,
+// get_notifications). For those tools the byte-budget client pager is disabled
+// entirely: their response is already paginated by the API, so re-wrapping it in
+// the {total,...,items} envelope would change the schema and report a `total`
+// covering only the server's returned page. For tools that do NOT page natively,
+// offset/limit are purely client-side cursors owned by the pager — consumed
+// locally and never forwarded upstream.
+func paginatesNatively(bindings []mcpParamBinding) bool {
+	return bindingHasName(bindings, "offset") || bindingHasName(bindings, "limit")
 }
 
 // RegisterTools registers all API operations as MCP tools.
@@ -480,15 +476,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		}
 		// Mark the client-side pagination cursor (offset/limit) as consumed so
 		// the generic args-forwarding loop below does not append it to the
-		// upstream query string. For endpoints that page server-side (e.g.
-		// get_expenses, get_comments) the native binding owns the arg, so
-		// clientCursorNames excludes it and it still reaches the API. Without
-		// this guard a client-cursor offset leaks upstream, the API returns a
-		// partial slice, and PaginateBody then reports a wrong total/next_offset.
-		if method == "GET" {
-			for _, name := range clientCursorNames(bindings) {
-				knownArgs[name] = true
-			}
+		// upstream query string. This applies only to GET tools that do NOT page
+		// natively — for those, the client pager (below) owns offset/limit, so
+		// neither must reach the API (a leaked client-cursor offset makes the API
+		// return a partial slice, which PaginateBody then mis-totals). Tools that
+		// page natively keep offset/limit as real query bindings, so they are
+		// left in knownArgs via the bindings loop and forwarded normally.
+		if method == "GET" && !paginatesNatively(bindings) {
+			knownArgs["offset"] = true
+			knownArgs["limit"] = true
 		}
 		for _, p := range positionalParams {
 			placeholder := "{" + p + "}"
@@ -621,21 +617,18 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		}
 
-		// For GET list responses, byte-budget-paginate by default so a large
-		// collection never blows the host token budget. The client cursor
-		// (offset/limit) is only consumed for tools WITHOUT a native query
-		// binding of that name, so endpoints that page server-side (e.g.
-		// get_expenses) are not double-skipped.
-		if method == "GET" {
-			clientOffset, clientLimit := 0, 0
-			for _, name := range clientCursorNames(bindings) {
-				switch name {
-				case "offset":
-					clientOffset = mcpIntArg(args, "offset")
-				case "limit":
-					clientLimit = mcpIntArg(args, "limit")
-				}
-			}
+		// For GET list responses on tools WITHOUT native server-side paging,
+		// byte-budget-paginate by default so a large collection never blows the
+		// host token budget. Endpoints that already page server-side
+		// (get_expenses, get_notifications declare native offset/limit query
+		// bindings) are left untouched: re-wrapping their already-paginated
+		// response in the {total,...,items} envelope would both change their
+		// schema and report a `total` that reflects only the server's returned
+		// page rather than the full collection. paginatesNatively gates the
+		// whole pager off for those tools.
+		if method == "GET" && !paginatesNatively(bindings) {
+			clientOffset := mcpIntArg(args, "offset")
+			clientLimit := mcpIntArg(args, "limit")
 			if out, ok := cli.PaginateBody(data, clientOffset, clientLimit, mcpListMaxBytes(), ""); ok {
 				return mcplib.NewToolResultText(string(out)), nil
 			}

--- a/library/payments/splitwise/internal/mcp/tools.go
+++ b/library/payments/splitwise/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,37 @@ import (
 	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/mcp/cobratree"
 	"github.com/mvanhorn/printing-press-library/library/payments/splitwise/internal/store"
 )
+
+// mcpListMaxBytes is the per-page byte budget for paginated GET list responses.
+// Overridable via PP_MCP_MAX_BYTES for tuning.
+func mcpListMaxBytes() int {
+	if v := os.Getenv("PP_MCP_MAX_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 24000
+}
+
+// mcpIntArg reads an integer-valued MCP argument (JSON numbers arrive as float64);
+// returns 0 when absent or not a number.
+func mcpIntArg(args map[string]any, key string) int {
+	if f, ok := args[key].(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+// bindingHasName reports whether the tool already declares a query/path binding of
+// this name, so the client-side pager must not also consume it.
+func bindingHasName(bindings []mcpParamBinding, name string) bool {
+	for _, b := range bindings {
+		if b.PublicName == name {
+			return true
+		}
+	}
+	return false
+}
 
 // RegisterTools registers all API operations as MCP tools.
 func RegisterTools(s *server.MCPServer) {
@@ -121,6 +153,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("get-categories_list",
+			mcplib.WithNumber("offset", mcplib.Description("Pagination cursor: index of the first item to return (use the next_offset from a prior page). Default 0.")),
+			mcplib.WithNumber("limit", mcplib.Description("Max items to return in this page (the byte budget may return fewer). Default: as many as fit.")),
 			mcplib.WithDescription("Returns a list of all categories Splitwise allows for expenses. There are parent categories that represent groups of categories with subcategories for more specific categorization. When creating expenses, you must use a subcategory, not a parent category. If you intend for an expense to be represented by the parent category and nothing more specific, please use the 'Other' subcategory. (public)"),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -130,6 +164,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("get-comments_list",
+			mcplib.WithNumber("offset", mcplib.Description("Pagination cursor: index of the first item to return (use the next_offset from a prior page). Default 0.")),
+			mcplib.WithNumber("limit", mcplib.Description("Max items to return in this page (the byte budget may return fewer). Default: as many as fit.")),
 			mcplib.WithDescription("Get expense comments. Required: expense_id. Returns the GetCommentsListResponse."),
 			mcplib.WithNumber("expense_id", mcplib.Required(), mcplib.Description("Expense id")),
 			mcplib.WithReadOnlyHintAnnotation(true),
@@ -140,6 +176,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("get-currencies_list",
+			mcplib.WithNumber("offset", mcplib.Description("Pagination cursor: index of the first item to return (use the next_offset from a prior page). Default 0.")),
+			mcplib.WithNumber("limit", mcplib.Description("Max items to return in this page (the byte budget may return fewer). Default: as many as fit.")),
 			mcplib.WithDescription("Returns a list of all currencies allowed by the system. These are mostly ISO 4217 codes, but we do sometimes use pending codes or unofficial, colloquial codes (like BTC instead of XBT for Bitcoin). (public)"),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -195,6 +233,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("get-friends_list",
+			mcplib.WithNumber("offset", mcplib.Description("Pagination cursor: index of the first item to return (use the next_offset from a prior page). Default 0.")),
+			mcplib.WithNumber("limit", mcplib.Description("Max items to return in this page (the byte budget may return fewer). Default: as many as fit.")),
 			mcplib.WithDescription("**Note**: `group` objects only include group balances with that friend. Returns the GetFriendsListResponse."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -214,6 +254,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("get-groups_list",
+			mcplib.WithNumber("offset", mcplib.Description("Pagination cursor: index of the first item to return (use the next_offset from a prior page). Default 0.")),
+			mcplib.WithNumber("limit", mcplib.Description("Max items to return in this page (the byte budget may return fewer). Default: as many as fit.")),
 			mcplib.WithDescription("**Note**: Expenses that are not associated with a group are listed in a group with ID 0. Returns the GetGroupsListResponse."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -551,19 +593,21 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 		}
 
-		// For GET responses, wrap bare arrays with count metadata
+		// For GET list responses, byte-budget-paginate by default so a large
+		// collection never blows the host token budget. The client cursor
+		// (offset/limit) is only consumed for tools WITHOUT a native query
+		// binding of that name, so endpoints that page server-side (e.g.
+		// get_expenses) are not double-skipped.
 		if method == "GET" {
-			trimmed := strings.TrimSpace(string(data))
-			if len(trimmed) > 0 && trimmed[0] == '[' {
-				var items []json.RawMessage
-				if json.Unmarshal(data, &items) == nil {
-					wrapped := map[string]any{
-						"count": len(items),
-						"items": items,
-					}
-					out, _ := json.Marshal(wrapped)
-					return mcplib.NewToolResultText(string(out)), nil
-				}
+			clientOffset, clientLimit := 0, 0
+			if !bindingHasName(bindings, "offset") {
+				clientOffset = mcpIntArg(args, "offset")
+			}
+			if !bindingHasName(bindings, "limit") {
+				clientLimit = mcpIntArg(args, "limit")
+			}
+			if out, ok := cli.PaginateBody(data, clientOffset, clientLimit, mcpListMaxBytes(), ""); ok {
+				return mcplib.NewToolResultText(string(out)), nil
 			}
 		}
 		if binaryResponse {

--- a/library/payments/splitwise/internal/mcp/tools.go
+++ b/library/payments/splitwise/internal/mcp/tools.go
@@ -424,6 +424,19 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+// formatMCPParamValue stringifies an MCP argument for a path or query parameter.
+// JSON numbers arrive as float64, and fmt's %v renders a large integer-valued
+// float in scientific notation (e.g. id 1925035 -> "1.925035e+06"), which
+// corrupts numeric path params like /get_friend/{id} and numeric query filters.
+// FormatFloat with 'f' and precision -1 emits the minimal decimal form
+// ("1925035", "28.48") with no exponent; non-numeric values fall back to %v.
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -472,7 +485,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			case "body_json":
@@ -487,7 +500,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 					bodyJSONOverride = json.RawMessage(s)
 				}
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		// Mark the client-side pagination cursor (offset/limit) as consumed so
@@ -509,7 +522,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -521,7 +534,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Per maintainer request to land a single splitwise PR, this consolidates **9 previously-separate amend PRs** (#959, #960, #970, #971, #961, #972, #980, #981, #982) into one branch built fresh off `main`. Each feature already passed CI on its own PR; nothing here is new code beyond merging them and migrating every patch manifest to the new per-file `.printing-press-patches/` layout (#994). The superseded PRs are closed with a pointer here.

## Features folded in

| Feature | Surface | Supersedes |
|---|---|---|
| Data-quality **audit** (duplicate clusters + per-category cost outliers) | `audit` | #959 |
| Upcoming-obligations **forecast** (projects recurring spend) | `forecast` | #960 |
| Multi-currency **normalize** (net/spend into one base currency via user FX rates) | `normalize` | #970 |
| Trip/period **report** export (md/csv/json) | `report` | #971 |
| **Fairness** analysis (contribution / collectability / risk) | `fairness` | #961 |
| Fairness **projected-settle + nudge** | `fairness nudge` | #972 |
| MCP list **byte-pagination** | MCP list tools | #980 |
| MCP **tool-surface quality** (app-name discovery, sql/schema descriptions, version banner, scientific-notation params) | MCP tools | #981 |
| Multi-word **positional names** fix | `resolve` + name args | #982 |

Full per-feature design/rationale lives in each superseded PR's description.

## Patches

16 new per-file manifests under `library/payments/splitwise/.printing-press-patches/` (the #994 layout — one file per amend, no singular-file collisions). The old singular `.printing-press-patches.json` is not reintroduced.

## Changes

`git diff --stat origin/main`: **45 files, +5415 / −43**. New command files: `splitwise_audit.go`, `splitwise_forecast.go`, `splitwise_normalize.go`, `splitwise_report.go`, `splitwise_fairness.go`, `splitwise_fairness_nudge.go`, `internal/mcp/pagination.go` (+ tests). Modified: `root.go` (registers all new commands), `splitwise_balances.go` (age rendering via new `ageCell` helper), `internal/mcp/tools.go`, `cmd/splitwise-pp-mcp/main.go`, `README.md`, `SKILL.md`.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (all new feature + MCP tests) |

Commit history is preserved per-feature (28 commits, no squash) so each amend stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
