### PR TITLE
ci: bump Go to 1.26.4 for stdlib security fixes (GO-2026-5037, GO-2026-5039)

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # Public library is a monorepo with per-CLI go.mod under library/<cat>/<slug>/.
           # Point setup-go at this matrix entry's go.sum so its module cache is keyed
           # correctly. Without this, setup-go warns "Dependencies file is not found".
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache-dependency-path: library/${{ matrix.target }}/go.sum
       - name: Build CLI binary
         env:

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # Audit walks every CLI; no single go.sum to key the module cache on,
           # and the cache hit-rate would be near zero anyway (every CLI's go.sum
           # differs). Disable caching to silence the "Dependencies file is not

--- a/.github/workflows/generate-registry.yml
+++ b/.github/workflows/generate-registry.yml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.ADMIN_PUSH_PAT }}
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
       - name: Run generator
         run: go run ./tools/generate-registry/main.go
       - name: Commit if changed

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/setup-go@v6
         if: steps.modules.outputs.count != '0'
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # This workflow may scan several unrelated standalone modules. There
           # is no single dependency file that produces a useful setup-go cache.
           cache: false

--- a/.github/workflows/verify-library-conventions.yml
+++ b/.github/workflows/verify-library-conventions.yml
@@ -243,7 +243,7 @@ jobs:
       # binary that will run after merge.
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Validate registry source descriptions
         # Reject PRs whose .printing-press.json + .goreleaser.yaml sources would


### PR DESCRIPTION
## Summary

`govulncheck` fails on every PR that puts a CLI into the changed-module scan scope, reporting two reachable Go **standard-library** vulnerabilities:

| Advisory | Package | Fixed in |
|---|---|---|
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | crypto/x509 | go1.26.4 |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | net/textproto | go1.26.4 |

These are not introduced by any individual CLI change — they affect every Go build produced with the currently-pinned `go1.26.3`.

## Why bump setup-go (not go.mod)

The Go jobs build and scan with the version pinned in `actions/setup-go`, not the per-CLI `go.mod` directive — `govulncheck.yml` runs under `GOTOOLCHAIN=local`, so a `go.mod` bump would just fail to load (`go.mod requires go >= 1.26.4; running go 1.26.3`). Bumping the pinned setup-go version rebuilds against the patched standard library and clears the gate repo-wide.

## Change

Every `go-version: '1.26.3'` pin → `'1.26.4'` across the Go workflows:

- `build-mcpb.yml` (×2)
- `bundle-audit.yml`
- `generate-registry.yml`
- `govulncheck.yml`
- `verify-library-conventions.yml`

`generate-skills.yml` is intentionally left at its existing `1.23` pin — it does not build CLI code through the vulnerable stdlib paths.

## Validation

| Check | Result |
|---|---|
| `grep -rn 1.26.3 .github/workflows/` | no matches remain |
| `verify-supply-chain/scan.py --base-ref origin/main` | no findings |
| Diff | 5 files, +6/-6 (version strings only) |