### PR TITLE
fix(ci): run govulncheck with Go 1.26.4

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/setup-go@v6
         if: steps.modules.outputs.count != '0'
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # This workflow may scan several unrelated standalone modules. There
           # is no single dependency file that produces a useful setup-go cache.
           cache: false


### PR DESCRIPTION
Reachable GO-2026-5039 and GO-2026-5037 findings on go1.26.3 affect any library CLI that uses net/http (RSS fetch, probes, etc.). setup-go pins GOTOOLCHAIN=local, so per-CLI go.mod bumps cannot upgrade the CI toolchain. Install Go 1.26.4 in the govulncheck workflow instead.

## Summary

- 

## Published CLI Metadata

Use this section for Printing Press library publishes. Delete it only when the
PR does not add or modify `library/<category>/<slug>/`.

**API:** `<slug>` | **Category:** `<category>` | **Press version:** `<version>`
**Spec:** `<spec_url or spec.yaml>`  
**Required env:** `<none or env vars>`

## What Changed

- 

## CLI Shape

```bash
$ <cli-name> --help
<paste high-signal help output>
```

## What This CLI Does

<Use the first 2-3 README paragraphs or a concise equivalent.>

## Manuscripts

- [Research Brief](./library/<category>/<slug>/.manuscripts/<run-id>/research/)
- [Shipcheck Results](./library/<category>/<slug>/.manuscripts/<run-id>/proofs/)

## Validation

- [ ] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/<category>/<slug>/`
- [ ] `go build ./...` from the touched CLI root
- [ ] `go vet ./...` from the touched CLI root
- [ ] `go test ./...` from the touched CLI root
- [ ] `govulncheck ./...` from the touched CLI root
- [ ] `go run ./tools/generate-skills/main.go` when `library/**/SKILL.md` changed
- [ ] `git diff --check`

## Gaps / Follow-Up

- 
