### PR TITLE
fix(auth): set-token writes the api_key field AuthHeader reads (9 CLIs)

### DIFF
--- a/library/developer-tools/scrape-creators/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/developer-tools/scrape-creators/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260501-171858",
   "base_printing_press_version": "3.2.1",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/developer-tools/scrape-creators/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/developer-tools/scrape-creators/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260501-171858",
+  "base_printing_press_version": "3.2.1",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/developer-tools/scrape-creators/internal/cli/auth.go
+++ b/library/developer-tools/scrape-creators/internal/cli/auth.go
@@ -67,15 +67,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/developer-tools/scrape-creators/internal/config/config.go
+++ b/library/developer-tools/scrape-creators/internal/config/config.go
@@ -118,6 +118,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.ScrapeCreatorsApiKeyAuth = ""
 	return c.save()
 }
 

--- a/library/developer-tools/scrape-creators/internal/config/config.go
+++ b/library/developer-tools/scrape-creators/internal/config/config.go
@@ -99,6 +99,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.ScrapeCreatorsApiKeyAuth = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/food-and-dining/recipe-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/food-and-dining/recipe-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260426-002121",
   "base_printing_press_version": "3.6.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/food-and-dining/recipe-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/food-and-dining/recipe-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260426-002121",
+  "base_printing_press_version": "3.6.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/food-and-dining/recipe-goat/internal/cli/auth.go
+++ b/library/food-and-dining/recipe-goat/internal/cli/auth.go
@@ -67,15 +67,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/food-and-dining/recipe-goat/internal/config/config.go
+++ b/library/food-and-dining/recipe-goat/internal/config/config.go
@@ -118,6 +118,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.UsdaFdcApiKey = ""
 	return c.save()
 }
 

--- a/library/food-and-dining/recipe-goat/internal/config/config.go
+++ b/library/food-and-dining/recipe-goat/internal/config/config.go
@@ -99,6 +99,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.UsdaFdcApiKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-06-03",
   "base_run_id": "2026-05-02T04:49:52.124135Z",
   "base_printing_press_version": "3.4.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": ["internal/cli/auth.go", "internal/config/config.go"],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_printing_press_version": "3.4.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/ahrefs/.printing-press-patches/set-token-writes-api-key-field.json
@@ -2,12 +2,10 @@
   "schema_version": 2,
   "id": "set-token-writes-api-key-field",
   "applied_at": "2026-06-03",
+  "base_run_id": "2026-05-02T04:49:52.124135Z",
   "base_printing_press_version": "3.4.0",
   "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
-  "files": [
-    "internal/cli/auth.go",
-    "internal/config/config.go"
-  ],
+  "files": ["internal/cli/auth.go", "internal/config/config.go"],
   "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
 }

--- a/library/marketing/ahrefs/internal/cli/auth.go
+++ b/library/marketing/ahrefs/internal/cli/auth.go
@@ -67,15 +67,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/marketing/ahrefs/internal/config/config.go
+++ b/library/marketing/ahrefs/internal/config/config.go
@@ -122,6 +122,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.AhrefsApiKey = ""
 	return c.save()
 }
 

--- a/library/marketing/ahrefs/internal/config/config.go
+++ b/library/marketing/ahrefs/internal/config/config.go
@@ -103,6 +103,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.AhrefsApiKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,8 +4,8 @@
   "applied_at": "2026-06-03",
   "base_run_id": "2026-05-02T18:02:09.219489Z",
   "base_printing_press_version": "3.5.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": ["internal/cli/auth.go", "internal/config/config.go"],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
@@ -2,12 +2,10 @@
   "schema_version": 2,
   "id": "set-token-writes-api-key-field",
   "applied_at": "2026-06-03",
+  "base_run_id": "2026-05-02T18:02:09.219489Z",
   "base_printing_press_version": "3.5.0",
   "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
-  "files": [
-    "internal/cli/auth.go",
-    "internal/config/config.go"
-  ],
+  "files": ["internal/cli/auth.go", "internal/config/config.go"],
   "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
 }

--- a/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/marketing/klaviyo/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_printing_press_version": "3.5.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/marketing/klaviyo/internal/cli/auth.go
+++ b/library/marketing/klaviyo/internal/cli/auth.go
@@ -67,15 +67,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/marketing/klaviyo/internal/config/config.go
+++ b/library/marketing/klaviyo/internal/config/config.go
@@ -123,6 +123,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.KlaviyoApiKey = ""
 	return c.save()
 }
 

--- a/library/marketing/klaviyo/internal/config/config.go
+++ b/library/marketing/klaviyo/internal/config/config.go
@@ -104,6 +104,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.KlaviyoApiKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260504-004256",
   "base_printing_press_version": "3.8.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/media-and-entertainment/movie-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/media-and-entertainment/movie-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260504-004256",
+  "base_printing_press_version": "3.8.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/media-and-entertainment/movie-goat/internal/cli/auth.go
+++ b/library/media-and-entertainment/movie-goat/internal/cli/auth.go
@@ -82,15 +82,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/media-and-entertainment/movie-goat/internal/config/config.go
+++ b/library/media-and-entertainment/movie-goat/internal/config/config.go
@@ -118,6 +118,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.TmdbApiKey = ""
 	return c.save()
 }
 

--- a/library/media-and-entertainment/movie-goat/internal/config/config.go
+++ b/library/media-and-entertainment/movie-goat/internal/config/config.go
@@ -99,6 +99,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.TmdbApiKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/payments/kalshi/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/payments/kalshi/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260504-204550",
   "base_printing_press_version": "3.9.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/payments/kalshi/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/payments/kalshi/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260504-204550",
+  "base_printing_press_version": "3.9.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/payments/kalshi/internal/cli/auth.go
+++ b/library/payments/kalshi/internal/cli/auth.go
@@ -85,15 +85,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/payments/kalshi/internal/config/config.go
+++ b/library/payments/kalshi/internal/config/config.go
@@ -180,6 +180,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.APIKey = ""
 	return c.save()
 }
 

--- a/library/payments/kalshi/internal/config/config.go
+++ b/library/payments/kalshi/internal/config/config.go
@@ -161,6 +161,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.APIKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/productivity/opensnow/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/productivity/opensnow/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260508-183509",
   "base_printing_press_version": "4.0.3",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/productivity/opensnow/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/productivity/opensnow/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260508-183509",
+  "base_printing_press_version": "4.0.3",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/productivity/opensnow/internal/cli/auth.go
+++ b/library/productivity/opensnow/internal/cli/auth.go
@@ -85,15 +85,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/productivity/opensnow/internal/config/config.go
+++ b/library/productivity/opensnow/internal/config/config.go
@@ -100,6 +100,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.OpensnowApiKey = ""
 	return c.save()
 }
 

--- a/library/productivity/opensnow/internal/config/config.go
+++ b/library/productivity/opensnow/internal/config/config.go
@@ -81,6 +81,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.OpensnowApiKey = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/travel/flight-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/travel/flight-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260411-000903",
   "base_printing_press_version": "3.6.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/travel/flight-goat/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/travel/flight-goat/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260411-000903",
+  "base_printing_press_version": "3.6.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/travel/flight-goat/internal/cli/auth.go
+++ b/library/travel/flight-goat/internal/cli/auth.go
@@ -67,15 +67,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/travel/flight-goat/internal/config/config.go
+++ b/library/travel/flight-goat/internal/config/config.go
@@ -118,6 +118,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.FlightGoatApiKeyAuth = ""
 	return c.save()
 }
 

--- a/library/travel/flight-goat/internal/config/config.go
+++ b/library/travel/flight-goat/internal/config/config.go
@@ -99,6 +99,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.FlightGoatApiKeyAuth = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""

--- a/library/travel/seats-aero/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/travel/seats-aero/.printing-press-patches/set-token-writes-api-key-field.json
@@ -4,11 +4,11 @@
   "applied_at": "2026-06-03",
   "base_run_id": "20260506-seats-aero",
   "base_printing_press_version": "3.10.0",
-  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field; auth logout clears that api_key field as well.",
   "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
   "files": [
     "internal/cli/auth.go",
     "internal/config/config.go"
   ],
-  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+  "validated_outcome": "go test ./...; auth set-token writes the api_key field (access_token left empty); auth logout clears the api_key field; auth status reports Authenticated from the config file before logout."
 }

--- a/library/travel/seats-aero/.printing-press-patches/set-token-writes-api-key-field.json
+++ b/library/travel/seats-aero/.printing-press-patches/set-token-writes-api-key-field.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "set-token-writes-api-key-field",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260506-seats-aero",
+  "base_printing_press_version": "3.10.0",
+  "summary": "auth set-token now persists the token to the api_key field that AuthHeader() reads (via a new Config.SaveCredential), instead of the unread access_token field.",
+  "reason": "For api_key auth, AuthHeader() builds the header from the env-var-derived api_key field and has no AccessToken fallback; set-token wrote the token to access_token via SaveTokens, so the saved value never reached the header and auth status/doctor reported 'not configured'. This output predates the generator's api_key SaveCredential branch.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/config/config.go"
+  ],
+  "validated_outcome": "go build ./...; auth set-token writes the api_key field (access_token left empty); auth status reports Authenticated from the config file."
+}

--- a/library/travel/seats-aero/internal/cli/auth.go
+++ b/library/travel/seats-aero/internal/cli/auth.go
@@ -85,15 +85,18 @@ func newAuthSetTokenCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			// Clear any legacy auth_header so AuthHeader() falls through to
-			// "Bearer " + AccessToken with the new token. Without this, a
-			// pre-existing auth_header value (common after regenerate) shadows
-			// the newly-saved access_token and set-token silently has no effect.
-			// Silent clear (no log line): a masked-tail variant could leak
-			// token bytes through scripted dogfood that captures stderr.
+			// the newly-saved credential. Without this, a pre-existing
+			// auth_header value (common after regenerate) shadows the saved
+			// token and set-token silently has no effect. Silent clear (no
+			// log line): a masked-tail variant could leak token bytes through
+			// scripted dogfood that captures stderr.
 			cfg.AuthHeaderVal = ""
 
-			// Save the token directly via the config's save mechanism
-			if err := cfg.SaveTokens("", "", args[0], "", cfg.TokenExpiry); err != nil {
+			// api_key auth: AuthHeader() reads the env-var-derived field, not
+			// AccessToken. Writing the token to AccessToken via SaveTokens
+			// would persist the bytes but leave doctor reporting "not
+			// configured" — the slot the header builder consults stays empty.
+			if err := cfg.SaveCredential(args[0]); err != nil {
 				return configErr(fmt.Errorf("saving token: %w", err))
 			}
 

--- a/library/travel/seats-aero/internal/config/config.go
+++ b/library/travel/seats-aero/internal/config/config.go
@@ -122,6 +122,7 @@ func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.SeatsAeroPartnerPartnerAuthorization = ""
 	return c.save()
 }
 

--- a/library/travel/seats-aero/internal/config/config.go
+++ b/library/travel/seats-aero/internal/config/config.go
@@ -103,6 +103,21 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	return c.save()
 }
 
+// SaveCredential persists a single API credential to the field that
+// AuthHeader() consults for api_key auth. Writing to AccessToken (the
+// bearer slot) would silently no-op since AuthHeader() reads the env-var-
+// derived field, not AccessToken, when Auth.Type == "api_key".
+//
+// The clears precede the assignment so a canonical env-var whose placeholder
+// collides with a builtin tag (e.g. an env var named XXX_ACCESS_TOKEN
+// resolving to the AccessToken field) ends up holding the new token.
+func (c *Config) SaveCredential(token string) error {
+	c.AuthHeaderVal = ""
+	c.AccessToken = ""
+	c.SeatsAeroPartnerPartnerAuthorization = token
+	return c.save()
+}
+
 func (c *Config) ClearTokens() error {
 	c.AccessToken = ""
 	c.RefreshToken = ""


### PR DESCRIPTION
## What

`auth set-token <token>` was a silent no-op for api_key-auth CLIs. It called `cfg.SaveTokens("", "", token, "", …)`, which persists the token to the **`access_token`** field. But `AuthHeader()` for these CLIs builds the header from the **env-var-derived api_key field** and has **no `access_token` fallback** — so the saved token never reached the request header. `auth set-token` reported success while `auth status` / `doctor` reported "not configured."

### Fix

Add `Config.SaveCredential(token)` — clears `auth_header` and `access_token`, then writes the api_key field `AuthHeader()` actually reads — and route `set-token` through it. This is exactly what the current generator emits (template guard `auth_type == "api_key" && CanonicalEnvVar`); the published output predates that branch, so the change is byte-identical to a regen.

## Scope: which CLIs (and which were *not* touched)

The bug fires only when `AuthHeader()` has no `access_token` fallback. I derived the set from each CLI's `auth_type` (`.printing-press.json`) cross-checked against the actual `AuthHeader()` body, **not** from the `toml:"api_key"` tag alone — `bearer_token` CLIs also carry an api_key-tagged env field but *do* fall back to `access_token`, so their `set-token` already works and they are correctly left alone (verified: `render` set-token → `auth status: Authenticated`).

**9 fixed** (api_key auth, no access_token fallback):
`marketing/ahrefs`, `developer-tools/scrape-creators`, `food-and-dining/recipe-goat`, `media-and-entertainment/movie-goat`, `payments/kalshi`, `productivity/opensnow`, `travel/flight-goat`, `travel/seats-aero`, `marketing/klaviyo`.

`posthog` was excluded despite `auth_type == "api_key"` because its `AuthHeader()` *does* have a reachable `access_token` branch (dual personal-key/oauth) — set-token already works there.

## Verification (per CLI)

- `go build ./...` clean; `gofmt` clean.
- `auth set-token tk_TEST --config /tmp/x.toml` → token lands in the api_key field, `access_token` left empty.
- `auth status --config /tmp/x.toml` → **Authenticated** (was "no credentials configured").
- Independent second-opinion review (codex) confirmed each `SaveCredential` writes the same field `AuthHeader()` reads and no CLI was wrongly included/excluded.

## Patch records

Each CLI gets a `.printing-press-patches/set-token-writes-api-key-field.json` (schema v2, directory form per current `AGENTS.md`). Where a legacy single-file `.printing-press-patches.json` still exists, it's left untouched — the post-merge `normalize-patches` workflow folds it into the directory.