### PR TITLE
fix(granola): transcript auth in headless environments

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/setup-go@v6
         if: steps.modules.outputs.count != '0'
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           # This workflow may scan several unrelated standalone modules. There
           # is no single dependency file that produces a useful setup-go cache.
           cache: false

--- a/library/productivity/granola/.printing-press-patches.json
+++ b/library/productivity/granola/.printing-press-patches.json
@@ -86,6 +86,37 @@
       ],
       "summary": "Auto-refresh the local store as the first action of every command. PersistentPreRunE invokes runAutoRefresh after agent-mode expansion; the dispatcher detects which auth surfaces are present (encrypted desktop cache and/or GRANOLA_API_KEY) and runs the corresponding sync routine for each. Both fire when both are configured. Refresh is best-effort: failures print a one-line stderr warning and the user's command proceeds. Opt-outs: --no-refresh flag, GRANOLA_NO_AUTO_REFRESH env, and per-profile no-refresh value (precedence: flag > env). Skip list: sync, sync-api, auth, doctor, help, version, completion, agent-context, profile, feedback, which. Provenance line suppressed under --json / --compact / --quiet / --agent / non-TTY stderr. agent-context exposes the auto_refresh contract for introspecting agents. SKILL.md and README.md document the contract; the stale 'Run sync first' advisory in the troubleshooting section is replaced with auto-refresh-aware guidance.",
       "reason": "User-visible problem: `granola-pp-cli meetings list` returned stale data because the CLI's SQLite store had not been synced. The old contract required agents and humans to remember `sync` before every read. Agents are the dominant caller and the worst kind of caller to depend on for ceremonial pre-steps. Auto-refresh closes the gap by treating freshness as a CLI-level invariant. Plan: docs/plans/2026-05-14-001-feat-cli-auto-refresh-every-invocation-plan.md."
+    },
+    {
+      "id": "granola-current-client-identity",
+      "applied_at": "2026-06-03",
+      "files": [
+        "internal/granola/internalapi.go",
+        "internal/granola/workos.go",
+        "internal/granola/workos_test.go"
+      ],
+      "summary": "Granola's internal API and token refresh only work when the CLI impersonates a CURRENT Granola desktop build: it must send the desktop's current client-version / platform / User-Agent headers, and it must refresh through Granola's own refresh endpoint rather than the legacy direct-WorkOS authenticate flow. The client version is a moving target - a reprint must re-discover the value a live desktop sends, not trust any generated or previously-pinned default.",
+      "reason": "Spec/generator defaults (a fixed client version and the documented WorkOS flow) are silently rejected by current Granola sessions - WorkOS returns invalid_client - which breaks live transcript access from headless/agent runs. A reprint that regenerates those defaults reintroduces the breakage.",
+      "validated_outcome": "With current desktop headers + native refresh, `transcript get` against a document that previously returned no segments returned a full live transcript."
+    },
+    {
+      "id": "keychain-access-must-be-bounded",
+      "applied_at": "2026-06-03",
+      "files": [
+        "internal/granola/safestorage/safestorage_darwin.go"
+      ],
+      "summary": "Every macOS Keychain access the CLI makes (to read Granola's Safe Storage key) must be time-bounded. In headless/agent environments there is no human to approve the Keychain GUI prompt, so an unbounded call hangs indefinitely; the bounded call must instead fail with an actionable 'approve the prompt or use a token override' error.",
+      "reason": "A fresh print that reads the encrypted store without a timeout reintroduces an indefinite hang on any machine without an interactive desktop session. This is the headless-safety half of the encrypted-storage handling already flagged for the generator template under deferred_to_upstream."
+    },
+    {
+      "id": "d6-read-only-applies-to-all-desktop-token-sources",
+      "applied_at": "2026-06-03",
+      "files": [
+        "internal/granola/workos.go",
+        "internal/granola/workos_test.go"
+      ],
+      "summary": "Two coupled invariants for the desktop token store. (1) When the encrypted store is unreadable SPECIFICALLY because the Keychain is blocked (not for other errors), fall back to the plaintext token so headless runs don't report a false 'no token / transcript unavailable'. (2) Treat that fallback token as desktop-owned and never refresh/rotate it. This extends the D6 read-only rule from the existing workos-encrypted-supabase-and-d6 patch to the plaintext-fallback source - a reprint must apply D6 to EVERY desktop-owned token source, not just the encrypted one.",
+      "reason": "Without the fallback, Keychain-blocked headless runs look unauthenticated even when a usable token exists. But the fallback must stay read-only: Granola refresh tokens are single-use, so rotating one the desktop still holds signs the user out of the desktop next time it refreshes."
     }
   ],
   "deferred_to_upstream": [

--- a/library/productivity/granola/.printing-press.json
+++ b/library/productivity/granola/.printing-press.json
@@ -9,6 +9,12 @@
     "handle": "dstevens",
     "name": "Damien Stevens"
   },
+  "contributors": [
+    {
+      "handle": "jeffreydebolt",
+      "name": "Jeff DeBolt"
+    }
+  ],
   "owner": "dstevens",
   "printer": "dstevens",
   "printer_name": "Damien Stevens",

--- a/library/productivity/granola/internal/granola/internalapi.go
+++ b/library/productivity/granola/internal/granola/internalapi.go
@@ -25,7 +25,9 @@ const InternalBaseURL = "https://api.granola.ai"
 // granolaUserAgent identifies the CLI to the internal API. Granola returns
 // "Unsupported client" without a recognizable User-Agent; the form
 // "Granola/<ver> (<os>; <client-name>)" passes the gate as of 2026-05.
-const granolaUserAgent = "Granola/6.0.0 (macOS; granola-pp-cli)"
+const granolaClientVersion = "7.299.0"
+const granolaPlatform = "darwin"
+const granolaUserAgent = "Granola/7.299.0 (macOS; granola-pp-cli)"
 
 // InternalClient is the typed wrapper for Granola's internal API. It is
 // auto-discovering: NewInternalClient reads the token from the Granola
@@ -91,6 +93,8 @@ func (c *InternalClient) postAttempt(path string, body any, isRetry bool) ([]byt
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Accept-Encoding", "gzip, deflate")
 	req.Header.Set("User-Agent", granolaUserAgent)
+	req.Header.Set("X-Client-Version", granolaClientVersion)
+	req.Header.Set("X-Granola-Platform", granolaPlatform)
 
 	// Pace requests via the AdaptiveLimiter. Granola's internal API has no
 	// published rate limit; the limiter starts at defaultInternalAPIRateLimit

--- a/library/productivity/granola/internal/granola/safestorage/safestorage_darwin.go
+++ b/library/productivity/granola/internal/granola/safestorage/safestorage_darwin.go
@@ -132,10 +132,10 @@ func fetchKeychainEntry() (string, error) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
-	if ctx.Err() == context.DeadlineExceeded {
-		return "", fmt.Errorf("%w: Keychain access timed out after 15s; approve the Granola Safe Storage prompt or use a token override for headless/agent runs", ErrKeyUnavailable)
-	}
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("%w: Keychain access timed out after 15s; approve the Granola Safe Storage prompt or use a token override for headless/agent runs", ErrKeyUnavailable)
+		}
 		msg := strings.TrimSpace(stderr.String())
 		if strings.Contains(msg, "could not be found") || strings.Contains(msg, "errSecItemNotFound") {
 			return "", fmt.Errorf("%w: Keychain entry %q / %q not found (sign in to Granola desktop first)", ErrKeyUnavailable, keychainSvc, keychainAcct)

--- a/library/productivity/granola/internal/granola/safestorage/safestorage_darwin.go
+++ b/library/productivity/granola/internal/granola/safestorage/safestorage_darwin.go
@@ -6,6 +6,7 @@ package safestorage
 
 import (
 	"bytes"
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/pbkdf2"
@@ -17,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Layer-1 constants match Electron's safeStorage v10 envelope (Chromium OSCrypt).
@@ -121,13 +123,18 @@ func loadDEK() ([]byte, error) {
 // the plan); the alternative is a CGO Security.framework call where the
 // ACL grant attaches to granola-pp-cli specifically.
 func fetchKeychainEntry() (string, error) {
-	cmd := exec.Command("/usr/bin/security", "find-generic-password",
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password",
 		"-s", keychainSvc,
 		"-a", keychainAcct,
 		"-w")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("%w: Keychain access timed out after 15s; approve the Granola Safe Storage prompt or use a token override for headless/agent runs", ErrKeyUnavailable)
+	}
 	if err != nil {
 		msg := strings.TrimSpace(stderr.String())
 		if strings.Contains(msg, "could not be found") || strings.Contains(msg, "errSecItemNotFound") {

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -20,9 +20,9 @@ import (
 
 // WorkOSClientID is the Granola desktop client's WorkOS application client
 // id. It is hardcoded across the community ecosystem (getprobo, granola.py,
-// granola-mcp) because Granola does not document a per-user OAuth app for
-// the internal API; this value is the only client_id WorkOS will accept on
-// the refresh-token endpoint for Granola's tokens.
+// granola-mcp) and kept here for reference / ecosystem compatibility.
+// The active refresh flow now uses GranolaRefreshEndpoint directly and no
+// longer sends this client_id in the request body.
 const WorkOSClientID = "client_01HJK46TGGY2DFQ2NX9P9XYJZN"
 
 // GranolaRefreshEndpoint is Granola desktop's refresh endpoint. Modern
@@ -261,6 +261,8 @@ func loadFromSupabaseJSON() (workosTokens, TokenSource, error) {
 			if _, statErr := os.Stat(plainPath); statErr == nil {
 				if tok, src, plainErr := loadFromSupabasePlain(plainPath); plainErr == nil {
 					return tok, src, nil
+				} else {
+					return workosTokens{}, TokenSourceUnknown, fmt.Errorf("supabase.json.enc: Keychain unavailable; supabase.json fallback also failed: %w", plainErr)
 				}
 			}
 		}
@@ -418,12 +420,6 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	req.Header.Set("User-Agent", granolaUserAgent)
 	req.Header.Set("X-Client-Version", granolaClientVersion)
 	req.Header.Set("X-Granola-Platform", granolaPlatform)
-	tokenMu.Lock()
-	access := cachedAccess
-	tokenMu.Unlock()
-	if access != "" {
-		req.Header.Set("Authorization", "Bearer "+access)
-	}
 	workosLimiter.Wait()
 	resp, err := refreshClient.Do(req)
 	if err != nil {

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -154,6 +154,12 @@ const (
 	// D6: refresh refused on this source to avoid signing the user out
 	// of Granola desktop.
 	TokenSourceEncryptedSupabase
+	// TokenSourcePlaintextSupabaseDesktopFallback: supabase.json.enc was
+	// present but unavailable because Keychain access failed, so the token
+	// was read from plaintext supabase.json. Treat this as desktop-owned
+	// for D6 because the plaintext and encrypted files may share the same
+	// single-use refresh token.
+	TokenSourcePlaintextSupabaseDesktopFallback
 	// TokenSourceStoredAccounts: stored-accounts.json fallback. Refresh
 	// allowed - this surface is rarely populated on modern installs and
 	// is not the canonical token store the desktop tracks.
@@ -259,8 +265,8 @@ func loadFromSupabaseJSON() (workosTokens, TokenSource, error) {
 		if errors.Is(encErr, safestorage.ErrKeyUnavailable) {
 			plainPath := supabaseJSONPath()
 			if _, statErr := os.Stat(plainPath); statErr == nil {
-				if tok, src, plainErr := loadFromSupabasePlain(plainPath); plainErr == nil {
-					return tok, src, nil
+				if tok, _, plainErr := loadFromSupabasePlain(plainPath); plainErr == nil {
+					return tok, TokenSourcePlaintextSupabaseDesktopFallback, nil
 				} else {
 					return workosTokens{}, TokenSourceUnknown, fmt.Errorf("supabase.json.enc: Keychain unavailable; supabase.json fallback also failed: %w", plainErr)
 				}
@@ -390,9 +396,10 @@ var workosLimiter = cliutil.NewAdaptiveLimiter(2.0)
 // write back to Granola's files).
 //
 // PATCH(encrypted-cache): refuses to refresh when the in-memory token
-// came from supabase.json.enc (D6). Refreshing would mint a new
-// refresh_token and invalidate the one Granola desktop still has on
-// disk, signing the user out next time the desktop tries to refresh.
+// came from supabase.json.enc, or from plaintext supabase.json as a fallback
+// because the encrypted store was Keychain-blocked (D6). Refreshing would
+// mint a new refresh_token and invalidate the one Granola desktop still has
+// on disk, signing the user out next time the desktop tries to refresh.
 // The env override path (GRANOLA_WORKOS_TOKEN) is opt-in: power users
 // who set it accept the desktop-sign-out trade-off. The plaintext
 // supabase.json and stored-accounts.json paths still allow refresh
@@ -403,7 +410,7 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	// the network call. Single-CLI-invocation processes don't see this race
 	// in practice; long-running agents that call sync concurrently would.
 	tokenMu.Lock()
-	if cachedSource == TokenSourceEncryptedSupabase {
+	if cachedSource == TokenSourceEncryptedSupabase || cachedSource == TokenSourcePlaintextSupabaseDesktopFallback {
 		tokenMu.Unlock()
 		return RefreshAccessTokenResponse{}, ErrRefreshRefused
 	}

--- a/library/productivity/granola/internal/granola/workos.go
+++ b/library/productivity/granola/internal/granola/workos.go
@@ -25,10 +25,11 @@ import (
 // the refresh-token endpoint for Granola's tokens.
 const WorkOSClientID = "client_01HJK46TGGY2DFQ2NX9P9XYJZN"
 
-// WorkOSAuthEndpoint is the refresh endpoint. POST a JSON body of
-// {client_id, grant_type:"refresh_token", refresh_token} and you receive
-// a new access_token plus a NEW refresh_token (single-use rotation).
-const WorkOSAuthEndpoint = "https://api.workos.com/user_management/authenticate"
+// GranolaRefreshEndpoint is Granola desktop's refresh endpoint. Modern
+// Granola tokens are refreshed through Granola's API rather than by calling
+// WorkOS directly; the older WorkOS client_id flow can return invalid_client
+// for current desktop sessions.
+const GranolaRefreshEndpoint = "https://api.granola.ai/v1/refresh-access-token"
 
 // granolaSupportDir is the macOS support directory for Granola.
 func granolaSupportDir() string {
@@ -245,10 +246,25 @@ func loadTokensRaw() (workosTokens, TokenSource, error) {
 // Returns the parsed token plus a TokenSource flag so the caller knows
 // whether D6's refresh-refusal applies.
 func loadFromSupabaseJSON() (workosTokens, TokenSource, error) {
-	// Prefer the .enc sibling when present, fall back to plaintext.
+	// Prefer the .enc sibling when present, but do not let a blocked
+	// Keychain prompt make headless/agent runs report "no token" when a
+	// legacy/plaintext supabase.json fallback is also available. Other
+	// encrypted-store errors still surface instead of silently falling back.
 	encPath := supabaseJSONPath() + ".enc"
 	if _, err := os.Stat(encPath); err == nil {
-		return loadFromSupabaseEnc(encPath)
+		tok, src, encErr := loadFromSupabaseEnc(encPath)
+		if encErr == nil {
+			return tok, src, nil
+		}
+		if errors.Is(encErr, safestorage.ErrKeyUnavailable) {
+			plainPath := supabaseJSONPath()
+			if _, statErr := os.Stat(plainPath); statErr == nil {
+				if tok, src, plainErr := loadFromSupabasePlain(plainPath); plainErr == nil {
+					return tok, src, nil
+				}
+			}
+		}
+		return workosTokens{}, TokenSourceUnknown, encErr
 	}
 	return loadFromSupabasePlain(supabaseJSONPath())
 }
@@ -351,22 +367,22 @@ func loadFromStoredAccountsJSON() (workosTokens, error) {
 	return best, nil
 }
 
-// RefreshAccessTokenResponse is the parsed body from a WorkOS refresh call.
+// RefreshAccessTokenResponse is the parsed body from a Granola refresh call.
 type RefreshAccessTokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
-	// WorkOS returns the new expiry as expires_in (seconds) when present.
+	// Granola returns the new expiry as expires_in (seconds) when present.
 	ExpiresIn int `json:"expires_in"`
 }
 
-// workosLimiter paces WorkOS refresh-token calls. The endpoint is hit at most
+// workosLimiter paces Granola refresh-token calls. The endpoint is hit at most
 // once per CLI invocation under normal conditions; the limiter is here for the
 // pathological case where a caller burst-refreshes (and so the typed 429
 // contract below is exercised by the AdaptiveLimiter as well).
 var workosLimiter = cliutil.NewAdaptiveLimiter(2.0)
 
 // RefreshAccessToken exchanges the current refresh token for a new
-// access/refresh pair. WorkOS rotates refresh tokens single-use per
+// access/refresh pair. Granola/WorkOS rotates refresh tokens single-use per
 // getprobo's findings; the caller MUST persist the new refresh token if
 // it intends to refresh again (we cache it in-process only - we do not
 // write back to Granola's files).
@@ -391,20 +407,27 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 	}
 	tokenMu.Unlock()
 	body, _ := json.Marshal(map[string]string{
-		"client_id":     WorkOSClientID,
-		"grant_type":    "refresh_token",
 		"refresh_token": refreshToken,
 	})
-	req, err := http.NewRequest("POST", WorkOSAuthEndpoint, bytes.NewReader(body))
+	req, err := http.NewRequest("POST", GranolaRefreshEndpoint, bytes.NewReader(body))
 	if err != nil {
 		return RefreshAccessTokenResponse{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", granolaUserAgent)
+	req.Header.Set("X-Client-Version", granolaClientVersion)
+	req.Header.Set("X-Granola-Platform", granolaPlatform)
+	tokenMu.Lock()
+	access := cachedAccess
+	tokenMu.Unlock()
+	if access != "" {
+		req.Header.Set("Authorization", "Bearer "+access)
+	}
 	workosLimiter.Wait()
 	resp, err := refreshClient.Do(req)
 	if err != nil {
-		return RefreshAccessTokenResponse{}, fmt.Errorf("workos refresh: %w", err)
+		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: %w", err)
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
@@ -414,21 +437,21 @@ func RefreshAccessToken(refreshToken string) (RefreshAccessTokenResponse, error)
 		workosLimiter.OnRateLimit()
 		wait := cliutil.RetryAfter(resp)
 		return RefreshAccessTokenResponse{}, &cliutil.RateLimitError{
-			URL:        WorkOSAuthEndpoint,
+			URL:        GranolaRefreshEndpoint,
 			RetryAfter: wait,
 			Body:       string(respBody),
 		}
 	}
 	workosLimiter.OnSuccess()
 	if resp.StatusCode != http.StatusOK {
-		return RefreshAccessTokenResponse{}, fmt.Errorf("workos refresh: status %d: %s", resp.StatusCode, string(respBody))
+		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: status %d: %s", resp.StatusCode, string(respBody))
 	}
 	var parsed RefreshAccessTokenResponse
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
-		return RefreshAccessTokenResponse{}, fmt.Errorf("workos refresh: parse response: %w", err)
+		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: parse response: %w", err)
 	}
 	if parsed.AccessToken == "" {
-		return RefreshAccessTokenResponse{}, fmt.Errorf("workos refresh: empty access_token in response")
+		return RefreshAccessTokenResponse{}, fmt.Errorf("granola refresh: empty access_token in response")
 	}
 	// Cache the new pair in-process.
 	tokenMu.Lock()

--- a/library/productivity/granola/internal/granola/workos_test.go
+++ b/library/productivity/granola/internal/granola/workos_test.go
@@ -113,6 +113,28 @@ func TestRefreshAccessToken_RefusesEncryptedSource(t *testing.T) {
 	}
 }
 
+func TestRefreshAccessToken_RefusesPlaintextDesktopFallbackSource(t *testing.T) {
+	ResetTokenCache()
+	defer ResetTokenCache()
+
+	// Simulate a plaintext supabase.json fallback after supabase.json.enc was
+	// present but Keychain-unavailable. The refresh token is still desktop-owned
+	// and may be the same single-use token Granola desktop has encrypted on disk.
+	tokenMu.Lock()
+	cachedAccess = "old-access"
+	cachedRefresh = "old-refresh"
+	cachedSource = TokenSourcePlaintextSupabaseDesktopFallback
+	tokenMu.Unlock()
+
+	_, err := RefreshAccessToken("old-refresh")
+	if err == nil {
+		t.Fatal("expected ErrRefreshRefused, got nil")
+	}
+	if err != ErrRefreshRefused {
+		t.Errorf("expected ErrRefreshRefused, got %v", err)
+	}
+}
+
 func TestRefreshAccessToken_AllowsEnvOverrideSource(t *testing.T) {
 	ResetTokenCache()
 	defer ResetTokenCache()

--- a/library/productivity/granola/internal/granola/workos_test.go
+++ b/library/productivity/granola/internal/granola/workos_test.go
@@ -41,14 +41,14 @@ func TestRefreshAccessToken_RotatesRefresh(t *testing.T) {
 	if resp.RefreshToken != "new-refresh" {
 		t.Errorf("expected new-refresh, got %q", resp.RefreshToken)
 	}
-	if gotBody["grant_type"] != "refresh_token" {
-		t.Errorf("expected grant_type=refresh_token, got %q", gotBody["grant_type"])
-	}
 	if gotBody["refresh_token"] != "old-refresh" {
 		t.Errorf("expected refresh_token=old-refresh, got %q", gotBody["refresh_token"])
 	}
-	if gotBody["client_id"] != WorkOSClientID {
-		t.Errorf("expected client_id=%q, got %q", WorkOSClientID, gotBody["client_id"])
+	if _, ok := gotBody["client_id"]; ok {
+		t.Errorf("did not expect legacy WorkOS client_id in Granola refresh body")
+	}
+	if _, ok := gotBody["grant_type"]; ok {
+		t.Errorf("did not expect legacy WorkOS grant_type in Granola refresh body")
 	}
 
 	// Verify cache holds the new pair.


### PR DESCRIPTION
## Summary

Fixes Granola transcript/live API access for headless or agent environments where the desktop encrypted store can block on macOS Keychain and the local cache may incorrectly make transcripts look unavailable.

This came up using `granola-pp-cli` from an OpenClaw agent session: the CLI could find the meeting records, but local cache reported no transcript data. The transcripts did exist via Granola's live API, but the live path was blocked by a combination of Keychain access and stale refresh/client behavior.

## What changed

- Add current Granola desktop headers to internal API calls:
  - `X-Client-Version: 7.299.0`
  - `X-Granola-Platform: darwin`
  - updated `User-Agent`
- Refresh expired tokens through Granola's current refresh endpoint:
  - `POST https://api.granola.ai/v1/refresh-access-token`
  - instead of the legacy direct WorkOS client-id flow, which returned `invalid_client` in this environment
- If `supabase.json.enc` decrypt fails because Keychain is unavailable, fall back to plaintext `supabase.json` when present
  - other encrypted-store errors still surface rather than silently falling back
- Add a 15s timeout around the macOS `/usr/bin/security find-generic-password` call so headless runs fail clearly instead of hanging indefinitely
- Update refresh tests for the Granola refresh request shape

## Why

In headless/agent workflows, the current behavior can create false negatives or indefinite hangs:

1. Local cache says `transcript_available = 0` / no segments.
2. Live transcript fetch tries to decrypt Granola safe storage.
3. macOS Keychain prompt can block indefinitely without a human at the desktop.
4. Existing refresh fallback can fail with `invalid_client` against current Granola sessions.

The live transcript endpoint works once the current refresh path and headers are used.

## Verification

From `library/productivity/granola`:

```sh
GRANOLA_SUPPORT_DIR=$(mktemp -d) go test ./internal/granola ./internal/granola/safestorage ./internal/cli
```

Passed.

Live smoke test against a document that previously failed from the CLI:

```sh
go run ./cmd/granola-pp-cli --no-refresh --data-source live transcript get 5d26f463-928a-4940-9f59-c7770b9709e8 --format json --json
```

Result:

- `source: live`
- `segments: 1083`
- first segment text: `Hey.`

