### PR TITLE
docs(icloud): rebrand display name and descriptions to Apple iCloud

### DIFF
--- a/library/media-and-entertainment/icloud/.printing-press-patches/apple-branding-help-text.json
+++ b/library/media-and-entertainment/icloud/.printing-press-patches/apple-branding-help-text.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 2,
+  "id": "apple-branding-help-text",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260517-000000",
+  "base_printing_press_version": "4.8.0",
+  "summary": "Add \"Apple\" to the root command's --help short/long descriptions.",
+  "reason": "The display name and catalog/skill descriptions were rebranded to \"Apple iCloud\" for support and discovery; the --help text is the user-facing support surface and should match.",
+  "files": ["internal/cli/root.go"]
+}

--- a/library/media-and-entertainment/icloud/.printing-press.json
+++ b/library/media-and-entertainment/icloud/.printing-press.json
@@ -6,7 +6,7 @@
   "generated_at": "2026-05-17T00:00:00Z",
   "printing_press_version": "4.8.0",
   "api_name": "icloud",
-  "display_name": "iCloud",
+  "display_name": "Apple iCloud",
   "cli_name": "icloud-pp-cli",
   "creator": {
     "handle": "matysanchez",
@@ -16,10 +16,14 @@
     {
       "handle": "mvanhorn",
       "name": "Matt Van Horn"
+    },
+    {
+      "handle": "tmchow",
+      "name": "Trevin Chow"
     }
   ],
   "category": "media-and-entertainment",
-  "description": "Query iCloud data stored locally on macOS — Photos library storage analysis, with Contacts and more coming. All reads hit local SQLite databases directly; no network calls or iCloud API token required.",
+  "description": "Query Apple iCloud data stored locally on macOS — Photos library storage analysis, with Contacts and more coming. All reads hit local SQLite databases directly; no network calls or iCloud API token required.",
   "auth_type": "none",
   "spec_format": "local",
   "spec_source": "local-sqlite",

--- a/library/media-and-entertainment/icloud/README.md
+++ b/library/media-and-entertainment/icloud/README.md
@@ -8,7 +8,7 @@ directly — no Photos.app launch, no API token, no network calls.
 ---
 
 Created by [@matysanchez](https://github.com/matysanchez) (Matias Sanchez Moises).
-Contributors: [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
+Contributors: [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn), [@tmchow](https://github.com/tmchow) (Trevin Chow).
 
 ## Install
 

--- a/library/media-and-entertainment/icloud/README.md
+++ b/library/media-and-entertainment/icloud/README.md
@@ -1,6 +1,6 @@
 # icloud-pp-cli
 
-Query your iCloud data from the command line. Reads your Mac's local databases
+Query your Apple iCloud data from the command line. Reads your Mac's local databases
 directly — no Photos.app launch, no API token, no network calls.
 
 **[icloudcli.com](https://icloudcli.com)** · macOS · Apache-2.0

--- a/library/media-and-entertainment/icloud/SKILL.md
+++ b/library/media-and-entertainment/icloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icloud-pp-cli
-description: "Query your iCloud data from the command line — Photos library storage analysis, iMessage history search and export, largest-file finder, and delete via AppleScript. macOS only. No network calls or iCloud API token required."
+description: "Query your Apple iCloud data from the command line — Photos library storage analysis, iMessage history search and export, largest-file finder, and delete via AppleScript. macOS only. No network calls or iCloud API token required."
 author: "Matias Sanchez Moises"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install"
@@ -16,7 +16,7 @@ metadata:
         module: github.com/matysanchez/icloudcli/cmd/icloud-pp-cli
 ---
 
-# iCloud — CLI Skill
+# Apple iCloud — CLI Skill
 
 ## Prerequisites: Install the CLI
 

--- a/library/media-and-entertainment/icloud/internal/cli/root.go
+++ b/library/media-and-entertainment/icloud/internal/cli/root.go
@@ -24,8 +24,8 @@ func Execute() error {
 
 	root := &cobra.Command{
 		Use:   "icloud-pp-cli",
-		Short: "Query your iCloud data from the command line",
-		Long: `icloud-pp-cli gives AI agents and power users direct access to iCloud data
+		Short: "Query your Apple iCloud data from the command line",
+		Long: `icloud-pp-cli gives AI agents and power users direct access to Apple iCloud data
 stored locally on macOS — Photos library storage analysis today, with Contacts
 and more coming.
 


### PR DESCRIPTION
## Summary

The iCloud CLI now surfaces "Apple" in its catalog display name, descriptions, and `--help` output, so it's easier to find and recognize. The `icloud-pp-cli` binary and `pp-icloud` skill names are unchanged — only human-facing copy and metadata move.

## What changes on the next regen

- The registry `api` label becomes **Apple iCloud** — `apiDisplayName` in `tools/generate-registry` treats the bare `iCloud` as superseded by the brand-qualified name (the same rule behind "Microsoft Clarity" / "Apple Developer Documentation"), and there's no display-name collision.
- `search_terms` pick up "Apple iCloud" and the new description, so catalog/skill search for "Apple" hits this CLI.
- The rendered registry `description` field is **curated-wins**, so it intentionally keeps its current text; discovery is carried by the display name and search terms. `registry.json` and the `cli-skills/` mirror are deliberately absent from this diff — both regenerate post-merge.

## Also here

- `--help` short/long text rebranded, recorded under `.printing-press-patches/apple-branding-help-text.json`.
- `@tmchow` added to `contributors[]`.

Verified locally: `go build`, `go vet`, `go test`, and `verify_skill.py` pass; `generate-registry -validate icloud` passes (no display-name collision); `--help` renders the new text. The two reachable findings from a local `govulncheck` are stdlib CVEs fixed in go1.25.6/1.25.8 and unrelated to this change — CI builds with go1.26.3, where they're not reported.
