### PR TITLE
fix(suno): generate describe body bug + adaptive-gate UX (retry, agent error, doctor probe)

### DIFF
--- a/library/media-and-entertainment/suno/.printing-press-patches/captcha-required-structured-agent-error.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/captcha-required-structured-agent-error.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "captcha-required-structured-agent-error",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "On the adaptive gate, JSON/agent mode emits a structured envelope with error_type \"captcha_required\"; a regen must keep agents able to branch on a field, not prose.",
+  "reason": "The friendly captcha guidance was prose-only on stderr, so an --agent/JSON consumer could not distinguish the retriable captcha gate from other failures. The envelope (error_type, retriable, hint, code) rides the existing writeAPIErrorEnvelope pattern; human mode is unchanged. Exit code stays 2 (usage) in both modes.",
+  "files": ["internal/cli/suno_generate_run.go"],
+  "validated_outcome": "generate describe --no-captcha --agent (gate tripped) emits parseable JSON {error_type:captcha_required,retriable:true,code:2} on stdout; human mode keeps stdout clean with prose on stderr."
+}

--- a/library/media-and-entertainment/suno/.printing-press-patches/doctor-probe-gate-honest-reachability.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/doctor-probe-gate-honest-reachability.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "doctor-probe-gate-honest-reachability",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "doctor --probe-gate issues a real inspiration-mode generation to report the live gate as open/tripped; a regen must keep an honest generate-path probe that the billing-layer check cannot provide.",
+  "reason": "The default doctor reachability check (GET /api/billing/info/) stays green while generation is gated, a false green. Only a real generate exercises the adaptive gate. The probe is opt-in because it spends credits and creates a clip when the gate is open (best-effort trashed); it is free when the gate is tripped. Logic lives in the hand-authored internal/cli/suno_doctor_gate.go so a regen of generated doctor.go only needs the small flag+call hook re-applied.",
+  "files": ["internal/cli/suno_doctor_gate.go", "internal/cli/doctor.go"],
+  "validated_outcome": "doctor --probe-gate --agent reports generate_gate \"tripped\" (free) when the gate is active, distinct from the billing-layer \"reachable\"."
+}

--- a/library/media-and-entertainment/suno/.printing-press-patches/inspiration-title-tags-must-be-json-strings.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/inspiration-title-tags-must-be-json-strings.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "inspiration-title-tags-must-be-json-strings",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "title and tags in the generate body must serialize as JSON strings, never null; a regen must keep them non-nil.",
+  "reason": "The Suno API rejects a null title with 422 [{loc:[body,params,title],msg:Input should be a valid string}] before the captcha gate is evaluated, which broke every inspiration-mode (describe) request that did not pass an explicit --title. The browser sends \"\" for both fields in inspiration mode. strPtr(\"\") returning nil for these two fields is the trap.",
+  "files": ["internal/cli/suno_generate_types.go"],
+  "validated_outcome": "After the fix, `generate describe --prompt X --no-captcha` reaches the captcha gate (friendly hCaptcha error) instead of a params.title body-validation 422."
+}

--- a/library/media-and-entertainment/suno/.printing-press-patches/wait-for-gate-opt-in-retry.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/wait-for-gate-opt-in-retry.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "wait-for-gate-opt-in-retry",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "Generation commands carry an opt-in --wait-for-gate/--gate-timeout that backs off and retries only on the adaptive captcha gate; a regen must keep it opt-in and gate-scoped.",
+  "reason": "Suno's generation gate is volume-triggered and reopens after a cooldown (minutes to hours). A single-shot CLI forces manual reruns. Retry is opt-in (off by default) so scripted callers stay single-shot and an unattended loop never sustains the gate. Retry fires only on isCaptchaRequired errors — never on 401, budget cap, or other failures.",
+  "files": ["internal/cli/generate.go", "internal/cli/suno_generate_run.go"],
+  "validated_outcome": "retryOnGate unit tests cover disabled-single-attempt, succeed-on-second, timeout, non-captcha-no-retry, and context-cancellation with an injected clock."
+}

--- a/library/media-and-entertainment/suno/.printing-press-patches/wait-for-gate-refresh-jwt-per-retry.json
+++ b/library/media-and-entertainment/suno/.printing-press-patches/wait-for-gate-refresh-jwt-per-retry.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "id": "wait-for-gate-refresh-jwt-per-retry",
+  "applied_at": "2026-06-03",
+  "base_run_id": "20260528-222057",
+  "base_printing_press_version": "4.14.0",
+  "summary": "The --wait-for-gate retry loop must re-mint the Clerk JWT before each attempt; a regen must keep per-retry EnsureFreshJWT or long waits die with a 401.",
+  "reason": "The Clerk __session JWT is short-lived (minutes). A --wait-for-gate wait can run for many minutes/hours, so the JWT expires mid-wait. The retry only fires on the captcha gate (not 401), so without re-minting, a long wait surfaces a 401 instead of riding out the cooldown — defeating the feature's primary purpose. The client reads c.Config.AuthHeader() live, and EnsureFreshJWT no-ops when fresh and re-mints from the long-lived __client cookie when expired, so calling it before each attempt is cheap and correct. Caught by live dogfooding (a real --wait-for-gate run died with 401 after ~30m).",
+  "files": ["internal/cli/suno_generate_run.go"],
+  "validated_outcome": "A --wait-for-gate run that spans past the JWT lifetime keeps retrying and eventually generates, instead of failing with 401 Unauthorized."
+}

--- a/library/media-and-entertainment/suno/SKILL.md
+++ b/library/media-and-entertainment/suno/SKILL.md
@@ -122,7 +122,9 @@ These capabilities aren't available in any other tool for this API.
 **generate** — Music, lyrics, and video generation jobs
 
 - `suno-pp-cli generate create` — Generate a custom song from lyrics (captcha-gated). `--variation high|normal|subtle`, `--project <id>`.
-- `suno-pp-cli generate describe` — Description-driven (inspiration) generation. `--variation`, `--instrumental`.
+- `suno-pp-cli generate describe` — Description-driven (inspiration) generation. `--variation`, `--instrumental`. No `--title` is needed; the model writes its own.
+
+All captcha-gated generate commands accept `--wait-for-gate` (with `--gate-timeout`, default 30m): when Suno's adaptive gate is tripped (HTTP 422 `token_validation_failed`), the command backs off and retries until the gate reopens or the timeout elapses. Off by default. In `--agent`/JSON mode a gate failure is emitted as a structured envelope on stdout with `error_type: "captcha_required"` and `retriable: true`, so agents branch on a field rather than parsing prose.
 - `suno-pp-cli generate extend <clip_id>` — Extend a clip from a timestamp
 - `suno-pp-cli generate cover <clip_id>` — Cover / restyle a clip
 - `suno-pp-cli generate remaster <clip_id>` — Remaster a clip
@@ -238,7 +240,7 @@ Triggers WAV conversion, polls until ready, and saves the lossless file (Pro/Pre
 
 Suno uses Clerk session auth (auth.suno.com). Run `suno-pp-cli auth login --chrome` to capture your logged-in session cookie from Chrome; the CLI mints and refreshes the short-lived JWT for you. No password or API key is stored. Music generation is attempted optimistically with no token. Suno gates generation adaptively (an hCaptcha anti-bot challenge that usually fires only after sustained use), so many generations succeed outright; if Suno challenges a request, the CLI tells you to retry with `--token` carrying an hCaptcha token (e.g. solved via 2Captcha). All read, library, and metadata commands never need a captcha.
 
-Run `suno-pp-cli doctor` to verify setup.
+Run `suno-pp-cli doctor` to verify setup. Add `--probe-gate` to check the live generation gate specifically: the default health check only proves the billing API is reachable, which stays green even while generation is gated. `doctor --probe-gate` reports `tripped` (the adaptive hCaptcha gate is active) or `open`. WARNING: it issues a real generation — free when the gate is tripped, but it creates a clip and spends credits when the gate is open (the probe clip is best-effort trashed).
 
 ## Agent Mode
 

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -66,6 +66,7 @@ func looksLikeDoctorInterstitial(body []byte) string {
 
 func newDoctorCmd(flags *rootFlags) *cobra.Command {
 	var failOn string
+	var probeGate bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Check CLI health",
@@ -221,6 +222,22 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 							report["credentials"] = fmt.Sprintf("error: %s", authErr)
 						}
 					}
+
+					// Step 3 (opt-in): honest generate-gate reachability. The
+					// billing-layer reachability check above cannot see Suno's
+					// adaptive generation gate, so a plain "reachable" is a false
+					// green for generation. This probe issues a real minimal
+					// generation only when --probe-gate is passed, and is skipped
+					// under dry-run / verify (it is a mutating POST).
+					if probeGate && !flags.dryRun && !cliutil.IsVerifyEnv() {
+						if authHeader == "" {
+							report["generate_gate"] = "skipped (no auth configured)"
+						} else if reachErr != nil && !errors.As(reachErr, &reachAPIErr) {
+							report["generate_gate"] = "skipped (API unreachable)"
+						} else {
+							report["generate_gate"] = runGateProbe(cmd.Context(), c)
+						}
+					}
 				}
 			} else if cfg != nil && cfg.BaseURL == "" {
 				report["api"] = "not configured (set base_url in config file)"
@@ -318,6 +335,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&failOn, "fail-on", "", "Exit non-zero when a health level is reached: stale, error. Default is never.")
+	cmd.Flags().BoolVar(&probeGate, "probe-gate", false, "Probe the live generation gate and report open/tripped. WARNING: issues a real generation — free when the gate is tripped, but creates a clip and spends credits when the gate is open (the probe clip is best-effort trashed).")
 	return cmd
 }
 

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -314,6 +314,21 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				}
 				fmt.Fprintf(w, "  %s %s: %s\n", indicator, ck.label, s)
 			}
+			// Generate-gate verdict (only present with --probe-gate). Rendered
+			// with its own indicator: tripped/skipped are WARN (transient or
+			// not-run), auth-failure/unreachable are FAIL, open is OK. Without
+			// this block the verdict would be invisible in human mode.
+			if gv, ok := report["generate_gate"]; ok {
+				s := fmt.Sprintf("%v", gv)
+				indicator := green("OK")
+				switch {
+				case strings.HasPrefix(s, "auth-failure"), strings.HasPrefix(s, "unreachable"):
+					indicator = red("FAIL")
+				case strings.HasPrefix(s, "tripped"), strings.HasPrefix(s, "skipped"), strings.HasPrefix(s, "reachable"):
+					indicator = yellow("WARN")
+				}
+				fmt.Fprintf(w, "  %s %s: %s\n", indicator, "Generate Gate", s)
+			}
 			// Print info keys without status indicator
 			for _, key := range []string{"config_path", "base_url", "auth_source", "version"} {
 				if v, ok := report[key]; ok {

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -367,7 +367,7 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 	for _, v := range report {
 		s, ok := v.(string)
 		if ok {
-			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") {
+			if strings.Contains(s, "error") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing") || strings.HasPrefix(s, "auth-failure") {
 				worstError = true
 			}
 		}

--- a/library/media-and-entertainment/suno/internal/cli/doctor.go
+++ b/library/media-and-entertainment/suno/internal/cli/doctor.go
@@ -322,9 +322,13 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				s := fmt.Sprintf("%v", gv)
 				indicator := green("OK")
 				switch {
-				case strings.HasPrefix(s, "auth-failure"), strings.HasPrefix(s, "unreachable"):
+				case strings.HasPrefix(s, "auth-failure"), strings.HasPrefix(s, "unreachable"), strings.HasPrefix(s, "reachable"):
+					// "reachable" is gateReachableOther: gate not tripped but the
+					// probe hit an unexpected error. FAIL (not WARN) so the human
+					// indicator matches --fail-on=error, which trips on the
+					// "error" in the verdict string.
 					indicator = red("FAIL")
-				case strings.HasPrefix(s, "tripped"), strings.HasPrefix(s, "skipped"), strings.HasPrefix(s, "reachable"):
+				case strings.HasPrefix(s, "tripped"), strings.HasPrefix(s, "skipped"):
 					indicator = yellow("WARN")
 				}
 				fmt.Fprintf(w, "  %s %s: %s\n", indicator, "Generate Gate", s)

--- a/library/media-and-entertainment/suno/internal/cli/generate.go
+++ b/library/media-and-entertainment/suno/internal/cli/generate.go
@@ -26,8 +26,8 @@ func newGenerateCmd(flags *rootFlags) *cobra.Command {
 	// and a retry loop never sustains the gate unattended. Registered as
 	// persistent flags so create/describe/extend/cover/remaster inherit them;
 	// runGenerationFlow reads them via cmd.Flags().
-	cmd.PersistentFlags().Bool("wait-for-gate", false, "On a captcha gate (422 token_validation_failed), back off and retry until the gate reopens or --gate-timeout elapses")
-	cmd.PersistentFlags().Duration("gate-timeout", 30*time.Minute, "Maximum time to keep retrying when --wait-for-gate is set")
+	cmd.PersistentFlags().Bool(flagWaitForGate, false, "On a captcha gate (422 token_validation_failed), back off and retry until the gate reopens or --gate-timeout elapses")
+	cmd.PersistentFlags().Duration(flagGateTimeout, 30*time.Minute, "Maximum time to keep retrying when --wait-for-gate is set")
 
 	// Hand-authored, captcha-aware generation/transform commands.
 	cmd.AddCommand(newSunoGenerateCreateCmd(flags))

--- a/library/media-and-entertainment/suno/internal/cli/generate.go
+++ b/library/media-and-entertainment/suno/internal/cli/generate.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +17,17 @@ func newGenerateCmd(flags *rootFlags) *cobra.Command {
 		Short: "Create tracks: music, lyrics, and video generation jobs",
 		RunE:  parentNoSubcommandRunE(flags),
 	}
+
+	// Adaptive-gate retry (opt-in). Suno's generation gate is volume-triggered:
+	// when tripped it returns 422 token_validation_failed for all clients and
+	// reopens after a cooldown (minutes to hours). With --wait-for-gate the
+	// captcha-gated commands back off and retry until the gate reopens or
+	// --gate-timeout elapses. Off by default so scripted callers stay single-shot
+	// and a retry loop never sustains the gate unattended. Registered as
+	// persistent flags so create/describe/extend/cover/remaster inherit them;
+	// runGenerationFlow reads them via cmd.Flags().
+	cmd.PersistentFlags().Bool("wait-for-gate", false, "On a captcha gate (422 token_validation_failed), back off and retry until the gate reopens or --gate-timeout elapses")
+	cmd.PersistentFlags().Duration("gate-timeout", 30*time.Minute, "Maximum time to keep retrying when --wait-for-gate is set")
 
 	// Hand-authored, captcha-aware generation/transform commands.
 	cmd.AddCommand(newSunoGenerateCreateCmd(flags))

--- a/library/media-and-entertainment/suno/internal/cli/skill_suno.md
+++ b/library/media-and-entertainment/suno/internal/cli/skill_suno.md
@@ -122,7 +122,9 @@ These capabilities aren't available in any other tool for this API.
 **generate** — Music, lyrics, and video generation jobs
 
 - `suno-pp-cli generate create` — Generate a custom song from lyrics (captcha-gated). `--variation high|normal|subtle`, `--project <id>`.
-- `suno-pp-cli generate describe` — Description-driven (inspiration) generation. `--variation`, `--instrumental`.
+- `suno-pp-cli generate describe` — Description-driven (inspiration) generation. `--variation`, `--instrumental`. No `--title` is needed; the model writes its own.
+
+All captcha-gated generate commands accept `--wait-for-gate` (with `--gate-timeout`, default 30m): when Suno's adaptive gate is tripped (HTTP 422 `token_validation_failed`), the command backs off and retries until the gate reopens or the timeout elapses. Off by default. In `--agent`/JSON mode a gate failure is emitted as a structured envelope on stdout with `error_type: "captcha_required"` and `retriable: true`, so agents branch on a field rather than parsing prose.
 - `suno-pp-cli generate extend <clip_id>` — Extend a clip from a timestamp
 - `suno-pp-cli generate cover <clip_id>` — Cover / restyle a clip
 - `suno-pp-cli generate remaster <clip_id>` — Remaster a clip
@@ -238,7 +240,7 @@ Triggers WAV conversion, polls until ready, and saves the lossless file (Pro/Pre
 
 Suno uses Clerk session auth (auth.suno.com). Run `suno-pp-cli auth login --chrome` to capture your logged-in session cookie from Chrome; the CLI mints and refreshes the short-lived JWT for you. No password or API key is stored. Music generation is attempted optimistically with no token. Suno gates generation adaptively (an hCaptcha anti-bot challenge that usually fires only after sustained use), so many generations succeed outright; if Suno challenges a request, the CLI tells you to retry with `--token` carrying an hCaptcha token (e.g. solved via 2Captcha). All read, library, and metadata commands never need a captcha.
 
-Run `suno-pp-cli doctor` to verify setup.
+Run `suno-pp-cli doctor` to verify setup. Add `--probe-gate` to check the live generation gate specifically: the default health check only proves the billing API is reachable, which stays green even while generation is gated. `doctor --probe-gate` reports `tripped` (the adaptive hCaptcha gate is active) or `open`. WARNING: it issues a real generation — free when the gate is tripped, but it creates a clip and spends credits when the gate is open (the probe clip is best-effort trashed).
 
 ## Agent Mode
 

--- a/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/client"
 )
@@ -62,6 +63,16 @@ func classifyGateProbe(err error) string {
 // it created — trashing does not refund the spent credits, it only avoids
 // littering the library.
 func runGateProbe(ctx context.Context, c *client.Client) string {
+	// Respect a configured budget cap: the probe spends credits when the gate
+	// is open, so honor the same cap that submitGeneration enforces rather than
+	// silently breaching it from a diagnostic command.
+	if bs, berr := openExistingStore(ctx); berr == nil && bs != nil {
+		capCredits, period, exceeded, cerr := budgetCapExceeded(ctx, bs)
+		_ = bs.Close()
+		if cerr == nil && exceeded {
+			return fmt.Sprintf("skipped (%s budget cap of %d credits reached; raise it with 'budget set %s <N>' or clear it before probing)", period, capCredits, period)
+		}
+	}
 	mv, _ := resolveModel("", sunoGenerateModels, sunoGenerateModelOrder)
 	body := buildGenerateBody(generateInput{
 		createMode: "inspiration",
@@ -110,5 +121,10 @@ func trashProbeClips(ctx context.Context, c *client.Client, ids []string) {
 	if len(ids) == 0 {
 		return
 	}
-	_, _, _ = c.Post(ctx, "/api/feed/trash", map[string]any{"ids": ids})
+	// Detached short context so cleanup still fires if the probe's request
+	// context was cancelled (Ctrl-C / doctor timeout) right after the create —
+	// otherwise the billable clip would litter the library.
+	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	_, _, _ = c.Post(cctx, "/api/feed/trash", map[string]any{"ids": ids})
 }

--- a/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate.go
@@ -1,0 +1,114 @@
+// Copyright 2026 horknfbr. Licensed under Apache-2.0. See LICENSE.
+//
+// pp:data-source live
+//
+// Hand-authored gate-aware reachability probe for `doctor --probe-gate`. Suno's
+// generation gate is adaptive: it returns 422 token_validation_failed for all
+// clients when tripped and reopens after a cooldown. The standard doctor
+// reachability check (GET /api/billing/info/) cannot see the gate — it is open
+// at the billing layer while generation is blocked, which is a false green.
+// This probe issues a real minimal inspiration-mode generation so the verdict
+// reflects what `generate` actually experiences. It is opt-in because it spends
+// credits and creates a clip when the gate is open (best-effort trashed).
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/client"
+)
+
+// gate-probe verdict classes.
+const (
+	gateOpen           = "open"
+	gateTripped        = "tripped"
+	gateAuthFailure    = "auth-failure"
+	gateReachableOther = "reachable-other"
+	gateUnreachable    = "unreachable"
+)
+
+// classifyGateProbe maps a generate-probe error to a verdict class. Pure and
+// table-testable; the network call and side effects live in runGateProbe.
+//   - nil error            -> gate open (a clip was created)
+//   - captcha gate         -> tripped (free, no clip)
+//   - HTTP 401             -> auth failure
+//   - other HTTP error     -> reachable but unexpected (gate not tripped)
+//   - transport error      -> unreachable
+func classifyGateProbe(err error) string {
+	switch {
+	case err == nil:
+		return gateOpen
+	case isCaptchaRequired(err):
+		return gateTripped
+	default:
+		var apiErr *client.APIError
+		if As(err, &apiErr) {
+			if apiErr.StatusCode == 401 {
+				return gateAuthFailure
+			}
+			return gateReachableOther
+		}
+		return gateUnreachable
+	}
+}
+
+// runGateProbe issues a minimal inspiration-mode generation through c (which
+// carries the Device-Id + Browser-Token transport) and returns a human verdict
+// string for the doctor report. On an open gate it best-effort trashes the clip
+// it created — trashing does not refund the spent credits, it only avoids
+// littering the library.
+func runGateProbe(ctx context.Context, c *client.Client) string {
+	mv, _ := resolveModel("", sunoGenerateModels, sunoGenerateModelOrder)
+	body := buildGenerateBody(generateInput{
+		createMode: "inspiration",
+		mv:         mv,
+		prompt:     "doctor gate probe",
+	})
+	data, _, err := c.Post(ctx, sunoGeneratePath, body)
+	switch classifyGateProbe(err) {
+	case gateOpen:
+		ids := probeClipIDs(data)
+		trashProbeClips(ctx, c, ids)
+		if len(ids) > 0 {
+			return fmt.Sprintf("open — generation reachable; probe created and trashed clip(s) %s (this spent generation credits)", strings.Join(ids, ", "))
+		}
+		return "open — generation reachable (a probe generation was submitted; this spent generation credits)"
+	case gateTripped:
+		return "tripped — the adaptive hCaptcha gate is active right now; no clip created and no credits spent. Wait for the cooldown or pass --token."
+	case gateAuthFailure:
+		return "auth-failure (HTTP 401) at the generate endpoint — credentials were rejected"
+	case gateReachableOther:
+		return fmt.Sprintf("reachable — gate not tripped, but the probe returned an unexpected error: %v", err)
+	default:
+		return fmt.Sprintf("unreachable: %v", err)
+	}
+}
+
+// probeClipIDs extracts clip IDs from a generate response body (best-effort).
+func probeClipIDs(data []byte) []string {
+	var resp sunoGenerateResponse
+	if json.Unmarshal(data, &resp) != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(resp.Clips))
+	for _, raw := range resp.Clips {
+		var cs clipStatus
+		if json.Unmarshal(raw, &cs) == nil && cs.ID != "" {
+			ids = append(ids, cs.ID)
+		}
+	}
+	return ids
+}
+
+// trashProbeClips moves probe-created clips to trash (POST /api/feed/trash).
+// Best-effort: a failure is ignored since the probe verdict is already known.
+func trashProbeClips(ctx context.Context, c *client.Client, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	_, _, _ = c.Post(ctx, "/api/feed/trash", map[string]any{"ids": ids})
+}

--- a/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
@@ -41,3 +41,29 @@ func TestProbeClipIDs(t *testing.T) {
 		t.Errorf("probeClipIDs(garbage) = %v, want nil", got)
 	}
 }
+
+// TestDoctorExitForFailOn_GateAuthFailure locks the P1 fix: a generate_gate
+// auth-failure verdict must trip --fail-on=error (CI must not stay green while
+// generation is blocked by rejected credentials).
+func TestDoctorExitForFailOn_GateAuthFailure(t *testing.T) {
+	report := map[string]any{
+		"generate_gate": "auth-failure (HTTP 401) at the generate endpoint — credentials were rejected",
+	}
+	if err := doctorExitForFailOn("error", report); err == nil {
+		t.Errorf("--fail-on=error must trigger on a generate_gate auth-failure verdict")
+	}
+
+	// A tripped gate is transient, not an error — it must NOT trip --fail-on=error.
+	tripped := map[string]any{
+		"generate_gate": "tripped — the adaptive hCaptcha gate is active right now; no clip created and no credits spent.",
+	}
+	if err := doctorExitForFailOn("error", tripped); err != nil {
+		t.Errorf("--fail-on=error must NOT trigger on a transient tripped-gate verdict, got %v", err)
+	}
+
+	// An open gate is healthy — must not trip.
+	open := map[string]any{"generate_gate": "open — generation reachable"}
+	if err := doctorExitForFailOn("error", open); err != nil {
+		t.Errorf("--fail-on=error must NOT trigger on an open gate, got %v", err)
+	}
+}

--- a/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 horknfbr. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/client"
+)
+
+func TestClassifyGateProbe(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"open", nil, gateOpen},
+		{"tripped", errors.New(`HTTP 422: {"error_type":"token_validation_failed"}`), gateTripped},
+		{"tripped-verify-phrase", errors.New("we couldn't verify your request"), gateTripped},
+		{"auth", &client.APIError{StatusCode: 401, Body: "Unauthorized"}, gateAuthFailure},
+		{"other-http", &client.APIError{StatusCode: 500, Body: "boom"}, gateReachableOther},
+		{"transport", errors.New("dial tcp: connection refused"), gateUnreachable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyGateProbe(tc.err); got != tc.want {
+				t.Errorf("classifyGateProbe(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeClipIDs(t *testing.T) {
+	data := []byte(`{"status":"ok","clips":[{"id":"abc"},{"id":"def"},{"id":""}]}`)
+	ids := probeClipIDs(data)
+	if len(ids) != 2 || ids[0] != "abc" || ids[1] != "def" {
+		t.Errorf("probeClipIDs = %v, want [abc def]", ids)
+	}
+	if got := probeClipIDs([]byte("not json")); got != nil {
+		t.Errorf("probeClipIDs(garbage) = %v, want nil", got)
+	}
+}

--- a/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_doctor_gate_test.go
@@ -66,4 +66,13 @@ func TestDoctorExitForFailOn_GateAuthFailure(t *testing.T) {
 	if err := doctorExitForFailOn("error", open); err != nil {
 		t.Errorf("--fail-on=error must NOT trigger on an open gate, got %v", err)
 	}
+
+	// gateReachableOther (unexpected error past the gate) must trip
+	// --fail-on=error, consistent with its FAIL human indicator.
+	reachableOther := map[string]any{
+		"generate_gate": "reachable — gate not tripped, but the probe returned an unexpected error: HTTP 500",
+	}
+	if err := doctorExitForFailOn("error", reachableOther); err == nil {
+		t.Errorf("--fail-on=error must trigger on a gateReachableOther (unexpected error) verdict")
+	}
 }

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
@@ -26,6 +26,16 @@ import (
 
 const sunoGeneratePath = "/api/generate/v2-web/"
 
+// Gate-retry flag names. Shared between registration (generate.go, as inherited
+// persistent flags) and the string-keyed reads in runGenerationFlow, so a
+// rename cannot silently desync the two (the reads are by name, not by a bound
+// variable, because runGenerationFlow is a shared tail that does not own the
+// flag vars).
+const (
+	flagWaitForGate = "wait-for-gate"
+	flagGateTimeout = "gate-timeout"
+)
+
 // captchaRequiredError returns the actionable usage error (exit 2) shown when
 // Suno's adaptive hCaptcha challenge actually fires for a generation. The CLI
 // attempts generation optimistically (no token); this only surfaces when the
@@ -315,8 +325,8 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 	// Adaptive-gate retry is opt-in via --wait-for-gate (inherited persistent
 	// flag on the generate parent). When off, this is a single submit attempt —
 	// identical to the prior behavior.
-	waitForGate, _ := cmd.Flags().GetBool("wait-for-gate")
-	gateTimeout, _ := cmd.Flags().GetDuration("gate-timeout")
+	waitForGate, _ := cmd.Flags().GetBool(flagWaitForGate)
+	gateTimeout, _ := cmd.Flags().GetDuration(flagGateTimeout)
 	cfg := gateRetryConfig{
 		enabled:        waitForGate,
 		timeout:        gateTimeout,
@@ -325,7 +335,10 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 		now:            time.Now,
 		sleep:          sleepCtx,
 	}
-	if waitForGate && humanFriendly {
+	// Show retry progress on any non-JSON run (not just --human-friendly): a
+	// --wait-for-gate wait can last many minutes, and a silent process reads as
+	// a hang. Agent/JSON mode stays clean (progress would corrupt stdout JSON).
+	if waitForGate && !flags.asJSON {
 		cfg.onWait = func(attempt int, wait time.Duration) {
 			fmt.Fprintf(cmd.ErrOrStderr(), "gate challenged; waiting %s before retry %d (until --gate-timeout %s)...\n", wait.Round(time.Second), attempt, gateTimeout)
 		}

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
@@ -45,8 +45,9 @@ func captchaRequiredError() error {
 	return usageErr(fmt.Errorf(
 		"Suno required an hCaptcha token for this generation.\n" +
 			"      Suno gates generation adaptively — many requests succeed with no token,\n" +
-			"      but this one was challenged (typically after sustained use). Retry with:\n" +
+			"      but this one was challenged (typically after sustained use). Options:\n" +
 			"        --token <hcaptcha-token>   (e.g. solved via 2Captcha)\n" +
+			"        --wait-for-gate            (backs off and retries until the gate reopens; --gate-timeout sets the ceiling)\n" +
 			"      This CLI will not launch a browser or solver on your behalf."))
 }
 
@@ -339,8 +340,10 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 	// --wait-for-gate wait can last many minutes, and a silent process reads as
 	// a hang. Agent/JSON mode stays clean (progress would corrupt stdout JSON).
 	if waitForGate && !flags.asJSON {
+		deadline := time.Now().Add(gateTimeout)
 		cfg.onWait = func(attempt int, wait time.Duration) {
-			fmt.Fprintf(cmd.ErrOrStderr(), "gate challenged; waiting %s before retry %d (until --gate-timeout %s)...\n", wait.Round(time.Second), attempt, gateTimeout)
+			remaining := time.Until(deadline).Round(time.Second)
+			fmt.Fprintf(cmd.ErrOrStderr(), "gate challenged; waiting %s before retry %d (%s remaining of --gate-timeout)...\n", wait.Round(time.Second), attempt, remaining)
 		}
 	}
 	resp, err := retryOnGate(ctx, cfg, func() (*sunoGenerateResponse, error) {

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
@@ -54,6 +54,67 @@ func isCaptchaRequired(err error) bool {
 		strings.Contains(msg, "verify your request")
 }
 
+// gateRetryConfig parameterizes retryOnGate. now/sleep are injectable so the
+// backoff logic is unit-testable without real time. enabled mirrors
+// --wait-for-gate; timeout mirrors --gate-timeout.
+type gateRetryConfig struct {
+	enabled        bool
+	timeout        time.Duration
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	now            func() time.Time
+	sleep          func(context.Context, time.Duration) error
+	onWait         func(attempt int, wait time.Duration)
+}
+
+// retryOnGate calls submit once; if the result is an adaptive-gate challenge
+// (isCaptchaRequired) AND retry is enabled, it backs off with capped
+// exponential delay and retries until submit succeeds, returns a non-gate
+// error, or the timeout deadline passes. On timeout it returns the last gate
+// error so the caller maps it to captchaRequiredError. Non-gate errors and
+// successes return immediately — retry never fires on a 401, budget cap, etc.
+func retryOnGate(ctx context.Context, cfg gateRetryConfig, submit func() (*sunoGenerateResponse, error)) (*sunoGenerateResponse, error) {
+	resp, err := submit()
+	if err == nil || !cfg.enabled || !isCaptchaRequired(err) {
+		return resp, err
+	}
+	deadline := cfg.now().Add(cfg.timeout)
+	backoff := cfg.initialBackoff
+	for attempt := 1; cfg.now().Before(deadline); attempt++ {
+		wait := backoff
+		if rem := deadline.Sub(cfg.now()); rem < wait {
+			wait = rem
+		}
+		if wait <= 0 {
+			break
+		}
+		if cfg.onWait != nil {
+			cfg.onWait(attempt, wait)
+		}
+		if serr := cfg.sleep(ctx, wait); serr != nil {
+			return nil, serr
+		}
+		resp, err = submit()
+		if err == nil || !isCaptchaRequired(err) {
+			return resp, err
+		}
+		if backoff *= 2; backoff > cfg.maxBackoff {
+			backoff = cfg.maxBackoff
+		}
+	}
+	return resp, err
+}
+
+// sleepCtx sleeps for d or returns early if the context is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
 // resolveModel maps a CLI model value to its wire key using the supplied
 // table. Returns a usage error listing valid values on an unknown key.
 func resolveModel(value string, table map[string]string, order []string) (string, error) {
@@ -222,7 +283,29 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 	if err != nil {
 		return err
 	}
-	resp, err := submitGeneration(cmd.Context(), c, flags.configPath, body)
+	ctx := cmd.Context()
+
+	// Adaptive-gate retry is opt-in via --wait-for-gate (inherited persistent
+	// flag on the generate parent). When off, this is a single submit attempt —
+	// identical to the prior behavior.
+	waitForGate, _ := cmd.Flags().GetBool("wait-for-gate")
+	gateTimeout, _ := cmd.Flags().GetDuration("gate-timeout")
+	cfg := gateRetryConfig{
+		enabled:        waitForGate,
+		timeout:        gateTimeout,
+		initialBackoff: 30 * time.Second,
+		maxBackoff:     5 * time.Minute,
+		now:            time.Now,
+		sleep:          sleepCtx,
+	}
+	if waitForGate && humanFriendly {
+		cfg.onWait = func(attempt int, wait time.Duration) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "gate challenged; waiting %s before retry %d (until --gate-timeout %s)...\n", wait.Round(time.Second), attempt, gateTimeout)
+		}
+	}
+	resp, err := retryOnGate(ctx, cfg, func() (*sunoGenerateResponse, error) {
+		return submitGeneration(ctx, c, flags.configPath, body)
+	})
 	if err != nil {
 		if isCaptchaRequired(err) {
 			return captchaRequiredError()

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
@@ -40,6 +40,33 @@ func captchaRequiredError() error {
 			"      This CLI will not launch a browser or solver on your behalf."))
 }
 
+// captchaGateEnvelope is the structured payload emitted to stdout in
+// JSON/agent mode when the adaptive hCaptcha gate fires. Agents branch on
+// error_type "captcha_required" (and retriable) rather than parsing the prose
+// message. Kept as its own function so the shape is unit-testable.
+func captchaGateEnvelope() map[string]any {
+	return map[string]any{
+		"error_type": "captcha_required",
+		"error":      "Suno required an hCaptcha token for this generation",
+		"retriable":  true,
+		"hint":       "retry with --token <hcaptcha-token>, or pass --wait-for-gate to wait out the adaptive cooldown",
+		"code":       2,
+	}
+}
+
+// captchaGateError surfaces the adaptive hCaptcha gate. In JSON/agent mode it
+// writes the captchaGateEnvelope to stdout so consumers can branch on a stable
+// error_type; in human mode it returns only the prose usage error. The exit
+// code is 2 (usage) in both modes, matching captchaRequiredError. Mirrors the
+// writeAPIErrorEnvelope pattern: stdout carries machine output, the returned
+// error drives the exit code (and cobra's stderr prose for humans).
+func captchaGateError(cmd *cobra.Command, flags *rootFlags) error {
+	if flags != nil && flags.asJSON {
+		_ = json.NewEncoder(cmd.OutOrStdout()).Encode(captchaGateEnvelope())
+	}
+	return captchaRequiredError()
+}
+
 // isCaptchaRequired reports whether a generate error is Suno's adaptive
 // hCaptcha challenge (HTTP 422 token_validation_failed / "we couldn't verify
 // your request"). Because the client keeps the Clerk JWT fresh before every
@@ -308,7 +335,7 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 	})
 	if err != nil {
 		if isCaptchaRequired(err) {
-			return captchaRequiredError()
+			return captchaGateError(cmd, flags)
 		}
 		return classifyAPIError(err, flags)
 	}

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/auth"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/client"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/cliutil"
 	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/internal/config"
@@ -347,6 +348,16 @@ func runGenerationFlow(cmd *cobra.Command, flags *rootFlags, body sunoGenerateBo
 		}
 	}
 	resp, err := retryOnGate(ctx, cfg, func() (*sunoGenerateResponse, error) {
+		// Re-mint the short-lived Clerk JWT before each attempt. A
+		// --wait-for-gate wait can outlive the session JWT (minutes), and the
+		// client reads c.Config.AuthHeader() live, so without this a long wait
+		// dies with a 401 instead of riding out the cooldown. EnsureFreshJWT
+		// no-ops when the JWT is still fresh and re-mints from the long-lived
+		// __client cookie when it has expired. Best-effort: a refresh failure
+		// falls through to the stored token and surfaces as the real error.
+		if !flags.dryRun && !cliutil.IsVerifyEnv() && c.Config != nil {
+			_ = auth.EnsureFreshJWT(ctx, c.Config)
+		}
 		return submitGeneration(ctx, c, flags.configPath, body)
 	})
 	if err != nil {

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 horknfbr. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// captchaErr is an error whose message trips isCaptchaRequired.
+var captchaErr = errors.New(`HTTP 422: {"error_type": "token_validation_failed"}`)
+
+// fakeClock drives retryOnGate without real sleeping: sleep advances now().
+type fakeClock struct{ t time.Time }
+
+func (f *fakeClock) now() time.Time { return f.t }
+func (f *fakeClock) sleep(_ context.Context, d time.Duration) error {
+	f.t = f.t.Add(d)
+	return nil
+}
+
+func baseGateCfg(fc *fakeClock, enabled bool) gateRetryConfig {
+	return gateRetryConfig{
+		enabled:        enabled,
+		timeout:        30 * time.Minute,
+		initialBackoff: 30 * time.Second,
+		maxBackoff:     5 * time.Minute,
+		now:            fc.now,
+		sleep:          fc.sleep,
+	}
+}
+
+func TestRetryOnGate_DisabledSingleAttempt(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(0, 0)}
+	calls := 0
+	submit := func() (*sunoGenerateResponse, error) {
+		calls++
+		return nil, captchaErr
+	}
+	_, err := retryOnGate(context.Background(), baseGateCfg(fc, false), submit)
+	if calls != 1 {
+		t.Errorf("submit called %d times, want 1 (retry disabled)", calls)
+	}
+	if !isCaptchaRequired(err) {
+		t.Errorf("want captcha error returned, got %v", err)
+	}
+}
+
+func TestRetryOnGate_EnabledSucceedsOnSecond(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(0, 0)}
+	calls := 0
+	submit := func() (*sunoGenerateResponse, error) {
+		calls++
+		if calls >= 2 {
+			return &sunoGenerateResponse{Status: "ok"}, nil
+		}
+		return nil, captchaErr
+	}
+	resp, err := retryOnGate(context.Background(), baseGateCfg(fc, true), submit)
+	if err != nil {
+		t.Fatalf("want success after retry, got err %v", err)
+	}
+	if resp == nil || resp.Status != "ok" {
+		t.Errorf("resp = %v, want status ok", resp)
+	}
+	if calls != 2 {
+		t.Errorf("submit called %d times, want 2", calls)
+	}
+}
+
+func TestRetryOnGate_TimesOutOnPersistentGate(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(0, 0)}
+	calls := 0
+	submit := func() (*sunoGenerateResponse, error) {
+		calls++
+		return nil, captchaErr
+	}
+	_, err := retryOnGate(context.Background(), baseGateCfg(fc, true), submit)
+	if !isCaptchaRequired(err) {
+		t.Errorf("want last captcha error after timeout, got %v", err)
+	}
+	if calls < 2 {
+		t.Errorf("want multiple attempts before timeout, got %d", calls)
+	}
+	if calls > 100 {
+		t.Errorf("attempts unbounded (%d) — backoff/deadline not enforced", calls)
+	}
+	// The fake clock must have advanced at least one full timeout window.
+	if fc.t.Before(time.Unix(0, 0).Add(30 * time.Minute)) {
+		t.Errorf("clock advanced to %v, expected past the 30m deadline", fc.t)
+	}
+}
+
+func TestRetryOnGate_NonCaptchaErrorNotRetried(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(0, 0)}
+	calls := 0
+	other := errors.New("HTTP 401: Unauthorized")
+	submit := func() (*sunoGenerateResponse, error) {
+		calls++
+		return nil, other
+	}
+	_, err := retryOnGate(context.Background(), baseGateCfg(fc, true), submit)
+	if calls != 1 {
+		t.Errorf("submit called %d times, want 1 (non-captcha error must not retry)", calls)
+	}
+	if !errors.Is(err, other) {
+		t.Errorf("want the original 401 error surfaced, got %v", err)
+	}
+}
+
+func TestRetryOnGate_ContextCancellationStops(t *testing.T) {
+	fc := &fakeClock{t: time.Unix(0, 0)}
+	calls := 0
+	submit := func() (*sunoGenerateResponse, error) {
+		calls++
+		return nil, captchaErr
+	}
+	cfg := baseGateCfg(fc, true)
+	cfg.sleep = func(_ context.Context, _ time.Duration) error {
+		return context.Canceled
+	}
+	_, err := retryOnGate(context.Background(), cfg, submit)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("submit called %d times, want 1 (cancelled during first backoff)", calls)
+	}
+}

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_run_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_run_test.go
@@ -3,10 +3,14 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 // captchaErr is an error whose message trips isCaptchaRequired.
@@ -127,5 +131,57 @@ func TestRetryOnGate_ContextCancellationStops(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("submit called %d times, want 1 (cancelled during first backoff)", calls)
+	}
+}
+
+// TestIsCaptchaRequired_DistinguishesBodyValidation confirms the gate detector
+// fires on token_validation_failed but NOT on a params.title body-validation
+// 422 (the U1 bug shape), so the two never get conflated.
+func TestIsCaptchaRequired_DistinguishesBodyValidation(t *testing.T) {
+	if !isCaptchaRequired(captchaErr) {
+		t.Errorf("token_validation_failed should be detected as captcha gate")
+	}
+	bodyValidation := errors.New(`HTTP 422: [{"loc":["body","params","title"],"msg":"Input should be a valid string"}]`)
+	if isCaptchaRequired(bodyValidation) {
+		t.Errorf("a params.title body-validation 422 must NOT be treated as the captcha gate")
+	}
+	if isCaptchaRequired(errors.New("HTTP 401: Unauthorized")) {
+		t.Errorf("a 401 must NOT be treated as the captcha gate")
+	}
+}
+
+// TestCaptchaGateError_AgentModeEmitsStructuredEnvelope verifies the JSON path
+// writes error_type captcha_required to stdout, the human path does not, and
+// the exit code is 2 in both modes.
+func TestCaptchaGateError_AgentModeEmitsStructuredEnvelope(t *testing.T) {
+	// Agent/JSON mode: structured envelope on stdout.
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	err := captchaGateError(cmd, &rootFlags{asJSON: true})
+	if ExitCode(err) != 2 {
+		t.Errorf("exit code = %d, want 2 (usage)", ExitCode(err))
+	}
+	var env map[string]any
+	if jerr := json.Unmarshal(out.Bytes(), &env); jerr != nil {
+		t.Fatalf("agent-mode stdout is not JSON: %v (%q)", jerr, out.String())
+	}
+	if env["error_type"] != "captcha_required" {
+		t.Errorf("error_type = %v, want captcha_required", env["error_type"])
+	}
+	if env["retriable"] != true {
+		t.Errorf("retriable = %v, want true", env["retriable"])
+	}
+
+	// Human mode: no JSON envelope on stdout, still exit code 2.
+	var hout bytes.Buffer
+	hcmd := &cobra.Command{}
+	hcmd.SetOut(&hout)
+	herr := captchaGateError(hcmd, &rootFlags{asJSON: false})
+	if ExitCode(herr) != 2 {
+		t.Errorf("human-mode exit code = %d, want 2", ExitCode(herr))
+	}
+	if hout.Len() != 0 {
+		t.Errorf("human mode must not write a JSON envelope to stdout, got %q", hout.String())
 	}
 }

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types.go
@@ -68,7 +68,11 @@ type sunoGenerateMetadata struct {
 
 // sunoGenerateBody is the full POST /api/generate/v2-web/ request body. Every
 // field is always serialized; *string / *float64 fields emit JSON null when
-// nil, which the upstream API requires as explicit placeholders.
+// nil, which the upstream API requires as explicit placeholders for the
+// optional reference fields (cover_clip_id, persona_id, continue_*). Title and
+// Tags are the exception: the API requires them to be JSON strings (a null
+// title is rejected before the captcha gate), so they are always non-nil — see
+// alwaysStrPtr.
 type sunoGenerateBody struct {
 	Token                  *string              `json:"token"`
 	GenerationType         string               `json:"generation_type"`
@@ -90,11 +94,24 @@ type sunoGenerateBody struct {
 	TransactionUUID        string               `json:"transaction_uuid"`
 }
 
-// strPtr returns a pointer to s, or nil when s is empty.
+// strPtr returns a pointer to s, or nil when s is empty. Used for the optional
+// reference fields (cover_clip_id, persona_id, continue_clip_id) that the
+// upstream API genuinely wants as JSON null when absent.
 func strPtr(s string) *string {
 	if s == "" {
 		return nil
 	}
+	return &s
+}
+
+// alwaysStrPtr returns a pointer to s even when s is empty, so the field
+// serializes as a JSON string ("") rather than null. title and tags must use
+// this: the upstream API rejects a null title with
+// 422 [{"loc":["body","params","title"],"msg":"Input should be a valid string"}]
+// before the captcha gate is ever evaluated, which broke every inspiration-mode
+// (describe) request that did not pass an explicit --title. The browser sends ""
+// for both fields in inspiration mode.
+func alwaysStrPtr(s string) *string {
 	return &s
 }
 
@@ -163,8 +180,8 @@ func buildGenerateBody(in generateInput) sunoGenerateBody {
 	return sunoGenerateBody{
 		Token:            strPtr(in.token),
 		GenerationType:   "TEXT",
-		Title:            strPtr(in.title),
-		Tags:             strPtr(in.tags),
+		Title:            alwaysStrPtr(in.title),
+		Tags:             alwaysStrPtr(in.tags),
 		NegativeTags:     "",
 		Mv:               in.mv,
 		Prompt:           in.prompt,

--- a/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
+++ b/library/media-and-entertainment/suno/internal/cli/suno_generate_types_test.go
@@ -2,7 +2,11 @@
 
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestBuildGenerateBody_Custom(t *testing.T) {
 	body := buildGenerateBody(generateInput{
@@ -41,6 +45,75 @@ func TestBuildGenerateBody_Custom(t *testing.T) {
 	}
 	if body.Metadata.ControlSliders != nil {
 		t.Errorf("control_sliders should be nil when no sliders set")
+	}
+}
+
+// TestBuildGenerateBody_InspirationTitleNotNull locks the fix for the
+// inspiration-mode (describe) body bug: an empty title/tags must serialize as
+// JSON "" not null, because the upstream API rejects a null title with
+// 422 params.title before the captcha gate is evaluated.
+func TestBuildGenerateBody_InspirationTitleNotNull(t *testing.T) {
+	body := buildGenerateBody(generateInput{
+		createMode: "inspiration",
+		mv:         "chirp-fenix",
+		prompt:     "a fun upbeat song about a donkey",
+		// no title, no tags — the common describe case
+	})
+	if body.Title == nil {
+		t.Fatalf("title pointer must be non-nil (empty string), got nil -> serializes as null")
+	}
+	if *body.Title != "" {
+		t.Errorf("title = %q, want empty string", *body.Title)
+	}
+	if body.Tags == nil {
+		t.Fatalf("tags pointer must be non-nil (empty string), got nil -> serializes as null")
+	}
+	if *body.Tags != "" {
+		t.Errorf("tags = %q, want empty string", *body.Tags)
+	}
+
+	// Wire-shape assertion: the marshaled JSON must carry "title":"" and
+	// "tags":"", never null.
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(raw)
+	if !strings.Contains(js, `"title":""`) {
+		t.Errorf("serialized body must contain \"title\":\"\", got: %s", js)
+	}
+	if !strings.Contains(js, `"tags":""`) {
+		t.Errorf("serialized body must contain \"tags\":\"\", got: %s", js)
+	}
+	if strings.Contains(js, `"title":null`) || strings.Contains(js, `"tags":null`) {
+		t.Errorf("serialized body must not contain null title/tags, got: %s", js)
+	}
+	if !strings.Contains(js, `"create_mode":"inspiration"`) {
+		t.Errorf("serialized body must carry create_mode inspiration, got: %s", js)
+	}
+}
+
+// TestBuildGenerateBody_TitlePreservedAndReferencesNull confirms a real title
+// round-trips and that the optional reference fields still serialize as null
+// (the fix is scoped to title/tags only).
+func TestBuildGenerateBody_TitlePreservedAndReferencesNull(t *testing.T) {
+	body := buildGenerateBody(generateInput{
+		createMode: "custom",
+		mv:         "chirp-fenix",
+		title:      "Night Drive",
+		tags:       "synthwave",
+		prompt:     "neon lights",
+	})
+	if body.Title == nil || *body.Title != "Night Drive" {
+		t.Errorf("title = %v, want Night Drive", body.Title)
+	}
+	raw, _ := json.Marshal(body)
+	js := string(raw)
+	if !strings.Contains(js, `"cover_clip_id":null`) {
+		t.Errorf("cover_clip_id should remain null when absent, got: %s", js)
+	}
+	if !strings.Contains(js, `"persona_id":null`) {
+		t.Errorf("persona_id should remain null when absent, got: %s", js)
 	}
 }
 


### PR DESCRIPTION
## suno: fix `generate describe` body bug + adaptive-gate UX

Bug fixes and UX hardening for the published `suno` CLI's generation path. All changes are scoped to `library/media-and-entertainment/suno/`; cataloged under `.printing-press-patches/`.

### The bug

`generate describe` (and any inspiration-mode generation without an explicit `--title`) sent `"title": null` in the request body. The Suno API rejects a null title with `422 [{"loc":["body","params","title"],"msg":"Input should be a valid string"}]` **before the captcha gate is evaluated**, so the most common "describe a song" use case failed outright. Root cause: `strPtr("")` returns `nil` and `Title` is a `*string` with no `omitempty`. The browser sends `"title": ""` in inspiration mode.

### What changed

- **Title/tags as JSON strings, not null** (`suno_generate_types.go`). `title` and `tags` now always serialize as strings (empty when unset), matching the browser. Other optional reference fields (`cover_clip_id`, `persona_id`, `continue_*`) still serialize as `null`. This is the actual fix for the broken `describe` path.
- **Opt-in `--wait-for-gate` retry** (`generate.go`, `suno_generate_run.go`). Suno's generation gate is adaptive and volume-triggered: when tripped it returns `422 token_validation_failed` for all clients and reopens after a cooldown. `--wait-for-gate` (with `--gate-timeout`, default 30m) backs off with capped exponential delay and retries until the gate reopens or the timeout elapses. Off by default; retries only on the captcha gate, never on 401/budget/other errors.
- **Structured `captcha_required` error for `--agent` mode** (`suno_generate_run.go`). JSON/agent consumers get `{"error_type":"captcha_required","retriable":true,"hint":...}` on stdout instead of prose, so they can branch on a field. Human mode is unchanged.
- **`doctor --probe-gate`** (`doctor.go`, `suno_doctor_gate.go`). The default health check only proves the billing API is reachable, which stays green while generation is gated. `--probe-gate` issues a real minimal generation and reports `tripped` (free, no clip) or `open`. Opt-in and documented: it spends credits and creates a (best-effort-trashed) clip when the gate is open; respects the configured budget cap.

### Validation

| Check | Result |
|---|---|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./...` | PASS (new tests for the body fix, retry helper, captcha envelope, gate classifier) |
| `verify_skill.py` | PASS |
| Live: `generate describe --no-captcha` | reaches the gate (was `422 params.title`) |
| Live: `--agent` gate failure | emits parseable `error_type: captcha_required` on stdout |
| Live: `doctor --probe-gate` | reports `tripped` (free) when the gate is active |

### Post-deploy monitoring

CLI change, no server component. Validate by running `suno-pp-cli generate describe --prompt "..." --no-captcha` (should reach the gate or generate, never a `params.title` 422) and `suno-pp-cli doctor --probe-gate` (should report a gate verdict line). No dashboards or rollback automation required; revert the branch if the generate body regresses.

### Known residuals

- `govulncheck ./...` reports two Go 1.26.3 stdlib advisories (GO-2026-5039, GO-2026-5037) in `internal/cliutil/probe.go` and `internal/store/store.go` — both pre-existing on `main` and in files untouched by this PR (toolchain-version issue, not introduced here). Left out of scope per the library's "no per-PR dependency-freshness campaign" convention.
