### PR TITLE
fix(granola): align attribution-derived surfaces to creator handle DamienStevens

### DIFF
--- a/library/productivity/granola/.goreleaser.yaml
+++ b/library/productivity/granola/.goreleaser.yaml
@@ -42,7 +42,7 @@ checksum:
 brews:
   - name: granola-pp-cli
     repository:
-      owner: dstevens
+      owner: DamienStevens
       name: homebrew-tap
     homepage: "https://github.com/mvanhorn/printing-press-library"
     description: "Every Granola feature — plus offline SQLite cross-meeting search, attendee timelines, and a MEMO pipeline runner..."

--- a/library/productivity/granola/.manuscripts/20260511-211333/research.json
+++ b/library/productivity/granola/.manuscripts/20260511-211333/research.json
@@ -4,7 +4,7 @@
   "alternatives": [
     {
       "name": "granola.py",
-      "url": "https://github.com/dstevens/cc-skills",
+      "url": "https://github.com/DamienStevens/cc-skills",
       "language": "Python",
       "install_method": "",
       "stars": 0,

--- a/library/productivity/granola/.printing-press.json
+++ b/library/productivity/granola/.printing-press.json
@@ -6,7 +6,7 @@
   "display_name": "Granola",
   "cli_name": "granola-pp-cli",
   "creator": {
-    "handle": "dstevens",
+    "handle": "DamienStevens",
     "name": "Damien Stevens"
   },
   "contributors": [
@@ -15,7 +15,7 @@
       "name": "Jeff DeBolt"
     }
   ],
-  "owner": "dstevens",
+  "owner": "DamienStevens",
   "printer": "dstevens",
   "printer_name": "Damien Stevens",
   "spec_format": "openapi3",

--- a/library/productivity/granola/LICENSE
+++ b/library/productivity/granola/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 dstevens
+   Copyright 2026 Damien Stevens and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/library/productivity/granola/NOTICE
+++ b/library/productivity/granola/NOTICE
@@ -1,7 +1,7 @@
 granola-pp-cli
 Copyright 2026 Damien Stevens and contributors
 
-Created by Damien Stevens (@dstevens).
+Created by Damien Stevens (@DamienStevens).
 Contributors:
   - Jeff DeBolt (@jeffreydebolt)
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -4,7 +4,7 @@
 
 granola-pp-cli reads Granola’s local cache directly and adds the queries Granola.ai’s web app and existing community CLIs cannot answer. Cache-first, then internal API, then public API — transparent fallthrough. memo run, memo queue, attendee timeline, recipes coverage, calendar overlay, and talktime are local-data joins no per-meeting tool produces. Works offline; agent-native JSON by default.
 
-Created by [@dstevens](https://github.com/dstevens) (Damien Stevens).
+Created by [@DamienStevens](https://github.com/DamienStevens) (Damien Stevens).
 Contributors: [@jeffreydebolt](https://github.com/jeffreydebolt) (Jeff DeBolt).
 
 ## Install
@@ -342,7 +342,7 @@ Environment variables:
 
 This CLI was built by studying these projects and resources:
 
-- [**granola.py**](https://github.com/dstevens/cc-skills) — Python
+- [**granola.py**](https://github.com/DamienStevens/cc-skills) — Python
 - [**GranolaMCP (pedramamini)**](https://github.com/pedramamini/GranolaMCP) — Python
 - [**granola-mcp (chrisguillory)**](https://github.com/chrisguillory/granola-mcp) — Python
 - [**reverse-engineering-granola-api (getprobo)**](https://github.com/getprobo/reverse-engineering-granola-api) — Python


### PR DESCRIPTION
## Summary

- Companion to #1033 (the dedicated printer-only attribution PR). The granola entry was printed with Press v4.4.0, which derived the owner handle from my macOS username (`dstevens`) instead of my GitHub handle (`DamienStevens`). **`github.com/dstevens` is an unrelated real GitHub user**, so the README byline and NOTICE currently credit and link to someone else's account.
- Per the verify-attribution guard, `printer` moves in #1033; this PR aligns the derived surfaces. Display name ("Damien Stevens") and creator identity unchanged — same human, corrected handle.

## What Changed

8 lines across 6 files, all in `library/productivity/granola/`:

| File | Change |
|---|---|
| `.printing-press.json` | `creator.handle` + legacy `owner` dual-write → `DamienStevens` (`printer` untouched — see #1033) |
| `README.md` | Byline link → my actual profile; `granola.py` alternatives link → `DamienStevens/cc-skills` (the real repo — `dstevens/cc-skills` 404s) |
| `NOTICE` | `Created by Damien Stevens (@DamienStevens).` |
| `LICENSE` (appendix) | v4.4.0-era slug holder → canonical `Copyright 2026 Damien Stevens and contributors` (matches the `.go` headers already migrated by the #900 sweep) |
| `.goreleaser.yaml` | brew tap `owner:` → creator handle, per the generator template |
| `.manuscripts/.../research.json` | same cc-skills URL correction |

Manifest/README/NOTICE move together, so attribution stays converged across all three surfaces. `registry.json` and the catalog README cell are intentionally untouched — they regenerate post-merge from the manifest. `contributors[]` (@jeffreydebolt, #1022) unchanged. The two `/Users/dstevens/...` runstate paths in report JSONs are machine paths, not attribution, and are left as-is.

If you'd rather regenerate these surfaces via `tools/sweep-canonical -attribution-only` after #1033 lands, happy to close this one — note the sweep does not cover the LICENSE appendix, `owner` dual-write, goreleaser tap owner, or the cc-skills links, so some of these lines need this PR (or a follow-up) either way.

## Validation

- [x] `python3 .github/scripts/verify-attribution/verify_attribution.py --base upstream/main` — passes (no printer/printer_name change)
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/` — all checks passed
- [x] Both edited JSON files parse cleanly
- [x] `grep -rn dstevens library/productivity/granola/` after #1033 + this → only the two runstate machine paths remain
- No Go source touched (metadata/docs only), so build/vet/test/govulncheck are N/A

## AI / Automation Disclosure

Prepared with Claude Code, reviewed by me (@DamienStevens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)