### PR TITLE
fix(granola): correct printer handle dstevens -> DamienStevens

### DIFF
--- a/library/productivity/granola/.printing-press.json
+++ b/library/productivity/granola/.printing-press.json
@@ -16,7 +16,7 @@
     }
   ],
   "owner": "dstevens",
-  "printer": "dstevens",
+  "printer": "DamienStevens",
   "printer_name": "Damien Stevens",
   "spec_format": "openapi3",
   "spec_checksum": "sha256:36161dcacb09ce0d24cf874157ebfad5ac53f2c90170a5b61460e97097da96a7",


### PR DESCRIPTION
## Summary

- Dedicated attribution-only correction: the granola entry's `printer` is `dstevens` — my macOS username, baked in by a Press v4.4.0 print-time derivation — not my GitHub handle. **`github.com/dstevens` is an unrelated real GitHub user.** My handle is `DamienStevens`; the display name (`printer_name: "Damien Stevens"`) is already correct and unchanged.

## Primary evidence

- This PR is opened by [@DamienStevens](https://github.com/DamienStevens) — the same account the corrected handle points to.
- `printer_name` ("Damien Stevens") matches my profile display name; [@dstevens](https://github.com/dstevens) is a different person with no connection to this CLI.
- The granola README's `granola.py` alternatives entry references the creator's prior work at `cc-skills` — that repo lives at [DamienStevens/cc-skills](https://github.com/DamienStevens/cc-skills) (`dstevens/cc-skills` 404s).
- #1022 / #1024 history credits this CLI's creator as "Damien Stevens" by name throughout.

## What Changed

One line: `library/productivity/granola/.printing-press.json` `printer` → `DamienStevens`.

Per the verify-attribution guard, the derived surfaces (creator block, legacy `owner` dual-write, README byline, NOTICE, LICENSE holder, goreleaser tap owner) are split into companion PR #1031, or can be regenerated via `tools/sweep-canonical -attribution-only` (whose `resolveCreator` derives the handle from `printer`) — whichever you prefer.

## Validation

- [x] `python3 .github/scripts/verify-attribution/verify_attribution.py --base upstream/main` — passes (attribution-only, no surface changes)
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/productivity/granola/` — all checks passed
- No Go source touched; build/vet/test/govulncheck N/A

## AI / Automation Disclosure

Prepared with Claude Code, reviewed by me (@DamienStevens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)