### PR TITLE
feat(npm): support explicit binary install directory

### DIFF
--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -66,7 +66,7 @@ def read_utf8(path: Path) -> str:
 
 
 COMMON_FLAGS = {
-    "help", "version", "json", "csv", "plain", "quiet", "agent",
+    "help", "version", "json", "csv", "plain", "quiet", "agent", "bin-dir",
     "select", "compact", "dry-run", "no-cache", "yes", "no-input",
     "no-color", "human-friendly", "config", "base-url", "rate-limit",
     "timeout", "data-source", "stdin", "limit", "format", "output",

--- a/library/ai/elevenlabs/README.md
+++ b/library/ai/elevenlabs/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-elevenlabs -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-elevenlabs --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install elevenlabs --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-elevenlabs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-elevenlabs. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/ai/elevenlabs/SKILL.md
+++ b/library/ai/elevenlabs/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `elevenlabs-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install elevenlabs --cli-only
+   npx -y @mvanhorn/printing-press-library install elevenlabs --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `elevenlabs-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/elevenlabs/cmd/elevenlabs-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/ai/midjourney/README.md
+++ b/library/ai/midjourney/README.md
@@ -35,30 +35,69 @@ Created by [@dave-agent-cerebro](https://github.com/dave-agent-cerebro) (Dave Fa
 
 ## Install
 
-From the Printing Press public library, once this CLI is published:
+The recommended path installs both the `midjourney-pp-cli` binary and the `pp-midjourney` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install midjourney
 ```
 
-CLI only:
+For CLI only (no skill):
 
 ```bash
 npx -y @mvanhorn/printing-press-library install midjourney --cli-only
 ```
 
-Go fallback:
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install midjourney --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install midjourney --agent claude-code
+npx -y @mvanhorn/printing-press-library install midjourney --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/ai/midjourney/cmd/midjourney-pp-cli@latest
 ```
 
-Local development build:
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/midjourney-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
 
 ```bash
-go build -o ./midjourney-pp-cli ./cmd/midjourney-pp-cli
-./midjourney-pp-cli --help
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-midjourney --force
 ```
+
+Inside a Hermes chat session:
+
+```text
+/skills install mvanhorn/printing-press-library/cli-skills/pp-midjourney --force
+```
+
+## Install for OpenClaw
+
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
+
+```bash
+npx -y @mvanhorn/printing-press-library install midjourney --agent openclaw --bin-dir ~/.local/bin
+```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/ai/midjourney/SKILL.md
+++ b/library/ai/midjourney/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `midjourney-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install midjourney --cli-only
+   npx -y @mvanhorn/printing-press-library install midjourney --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `midjourney-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/midjourney/cmd/midjourney-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Unofficial browser-session CLI for Midjourney's web app API.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/ai/ollama-cloud/README.md
+++ b/library/ai/ollama-cloud/README.md
@@ -4,9 +4,11 @@
 
 Ollama Cloud's catalog spans 20+ open-weights models (Qwen3, GPT-OSS, DeepSeek-V3, Kimi-K2, GLM, Llama, Gemma) and growing. No built-in picker exists. This CLI is the only one that combines live catalog metadata with prompt-feature extraction and emits a why/alternatives envelope you can pipe into other agents.
 
+Created by [@rvdlaar](https://github.com/rvdlaar) (Rick van de Laar).
+
 ## Install
 
-The recommended path installs both the `ollama-cloud-pp-cli` binary and the `pp-ollama-cloud` agent skill in one shot:
+The recommended path installs both the `ollama-cloud-pp-cli` binary and the `pp-ollama-cloud` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install ollama-cloud
@@ -18,10 +20,28 @@ For CLI only (no skill):
 npx -y @mvanhorn/printing-press-library install ollama-cloud --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install ollama-cloud --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install ollama-cloud --agent claude-code
+npx -y @mvanhorn/printing-press-library install ollama-cloud --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/ai/ollama-cloud/cmd/ollama-cloud-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -38,17 +58,56 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ollama-cloud
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ollama-cloud --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ollama-cloud --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ollama-cloud skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ollama-cloud. The skill defines how its required CLI can be installed.
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/ollama-cloud-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `OLLAMA_CLOUD_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "ollama-cloud": {
+      "command": "ollama-cloud-pp-mcp",
+      "env": {
+        "OLLAMA_CLOUD_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
 ```
+
+</details>
 
 ## Authentication
 
@@ -60,18 +119,14 @@ Bearer auth via OLLAMA_CLOUD_API_KEY (intentionally distinct from any local-Olla
 # Confirms auth, catalog reachable
 ollama-cloud-pp-cli doctor
 
-
 # Live catalog of hosted models
 ollama-cloud-pp-cli tags --json
-
 
 # Inspect drift between live catalog and curated metadata overlay
 ollama-cloud-pp-cli advise --validate-catalog --json
 
-
 # Pick a model for a specific prompt; pass any file path (or - for stdin)
 ollama-cloud-pp-cli advise --prompt-file ./prompt.txt --task-hint coding --json
-
 
 # Probe free-tier quota before launching long sessions
 ollama-cloud-pp-cli budget --json
@@ -174,7 +229,6 @@ Manage tags
 
 - **`ollama-cloud-pp-cli tags tags`** - Returns the live catalog of hosted Ollama Cloud models.
 
-
 ## Output Formats
 
 ```bash
@@ -209,69 +263,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-ollama-cloud -g
-```
-
-Then invoke `/pp-ollama-cloud <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add ollama-cloud ollama-cloud-pp-mcp -e OLLAMA_CLOUD_API_KEY=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/ollama-cloud-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `OLLAMA_CLOUD_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "ollama-cloud": {
-      "command": "ollama-cloud-pp-mcp",
-      "env": {
-        "OLLAMA_CLOUD_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/ai/ollama-cloud/SKILL.md
+++ b/library/ai/ollama-cloud/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `ollama-cloud-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ollama-cloud --cli-only
+   npx -y @mvanhorn/printing-press-library install ollama-cloud --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ollama-cloud-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/ollama-cloud/cmd/ollama-cloud-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Ollama Cloud's catalog spans 20+ open-weights models (Qwen3, GPT-OSS, DeepSeek-V3, Kimi-K2, GLM, Llama, Gemma) and growing. No built-in picker exists. This CLI is the only one that combines live catalog metadata with prompt-feature extraction and emits a why/alternatives envelope you can pipe into other agents.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/ai/openrouter/README.md
+++ b/library/ai/openrouter/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-openrouter -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-openrouter --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install openrouter --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-openrouter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-openrouter. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/ai/openrouter/SKILL.md
+++ b/library/ai/openrouter/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `openrouter-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install openrouter --cli-only
+   npx -y @mvanhorn/printing-press-library install openrouter --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `openrouter-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/openrouter/cmd/openrouter-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/ai/surgegraph/README.md
+++ b/library/ai/surgegraph/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-surgegraph -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-surgegraph --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install surgegraph --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-surgegraph skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-surgegraph. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/ai/surgegraph/SKILL.md
+++ b/library/ai/surgegraph/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `surgegraph-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install surgegraph --cli-only
+   npx -y @mvanhorn/printing-press-library install surgegraph --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `surgegraph-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/surgegraph/cmd/surgegraph-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/ai/wavespeed/README.md
+++ b/library/ai/wavespeed/README.md
@@ -55,7 +55,6 @@ This installs the CLI only — no skill.
 Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/wavespeed-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 <!-- pp-hermes-install-anchor -->
-
 ## Install for Hermes
 
 From the Hermes CLI:
@@ -66,17 +65,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wavespeed --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-wavespeed --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install wavespeed --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-wavespeed skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wavespeed. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/ai/wavespeed/SKILL.md
+++ b/library/ai/wavespeed/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `wavespeed-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install wavespeed --cli-only
+   npx -y @mvanhorn/printing-press-library install wavespeed --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `wavespeed-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,16 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/ai/wavespeed/cmd/wavespeed-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Docs-derived OpenAPI spec for WaveSpeed AI's REST API. WaveSpeed is a
-unified AI generation platform for image, video, audio, 3D, and LLM models.
-
-The dynamic model-run endpoint is not represented as a generated OpenAPI
-path because WaveSpeed model IDs are slash-delimited API paths such as
-`wavespeed-ai/hunyuan-video/t2v`; ordinary OpenAPI path-parameter clients
-correctly percent-encode slashes. The printed CLI adds a hand-authored
-`run` command that submits to the literal model path.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/cloud/azure-functions-admin/README.md
+++ b/library/cloud/azure-functions-admin/README.md
@@ -4,7 +4,7 @@
 
 Azure Functions runs your code on demand without you managing servers. This CLI is a read-only inspector for the Function Apps in your Azure subscription: it lists your apps and functions, reads their settings and keys, and pulls invocation history from Application Insights into a local database. That local history unlocks answers a stateless `az` command can't give — like how often your functions cold-start, whether you should move off the Consumption plan, and where plaintext secrets are hiding in your app settings. It does not deploy code (use `func` or `az functionapp` for that); it tells you what your functions are doing and how to improve them.
 
-Printed by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
+Created by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
 
 ## Install
 
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-azure-functi
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-azure-functions-admin --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install azure-functions-admin --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-azure-functions-admin skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-azure-functions-admin. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -207,7 +209,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Cold-start check before a plan decision
 
 ```bash
@@ -290,7 +291,6 @@ List deployment slots for a Function App
 List Azure subscriptions reachable by the current credential
 
 - **`azure-functions-admin-pp-cli subscriptions`** - List accessible subscriptions
-
 
 ## Output Formats
 

--- a/library/cloud/azure-functions-admin/SKILL.md
+++ b/library/cloud/azure-functions-admin/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `azure-functions-admin-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install azure-functions-admin --cli-only
+   npx -y @mvanhorn/printing-press-library install azure-functions-admin --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `azure-functions-admin-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/azure-functions-admin/cmd/azure-functions-admin-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Azure Functions runs your code on demand without you managing servers. This CLI is a read-only inspector for the Function Apps in your Azure subscription: it lists your apps and functions, reads their settings and keys, and pulls invocation history from Application Insights into a local database. That local history unlocks answers a stateless `az` command can't give — like how often your functions cold-start, whether you should move off the Consumption plan, and where plaintext secrets are hiding in your app settings. It does not deploy code (use `func` or `az functionapp` for that); it tells you what your functions are doing and how to improve them.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/cloud/cf-domain/README.md
+++ b/library/cloud/cf-domain/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-cf-domain --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-cf-domain --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install cf-domain --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-cf-domain skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-cf-domain. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/cloud/cf-domain/SKILL.md
+++ b/library/cloud/cf-domain/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `cf-domain-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install cf-domain --cli-only
+   npx -y @mvanhorn/printing-press-library install cf-domain --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `cf-domain-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/cf-domain/cmd/cf-domain-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/cloud/cloud-run-admin/README.md
+++ b/library/cloud/cloud-run-admin/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-cloud-run-ad
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-cloud-run-admin --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install cloud-run-admin --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-cloud-run-admin skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-cloud-run-admin. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/cloud/cloud-run-admin/SKILL.md
+++ b/library/cloud/cloud-run-admin/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `cloud-run-admin-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install cloud-run-admin --cli-only
+   npx -y @mvanhorn/printing-press-library install cloud-run-admin --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `cloud-run-admin-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/cloud-run-admin/cmd/cloud-run-admin-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/cloud/digitalocean/README.md
+++ b/library/cloud/digitalocean/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-digitalocean
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-digitalocean --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install digitalocean --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-digitalocean skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-digitalocean. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/cloud/digitalocean/SKILL.md
+++ b/library/cloud/digitalocean/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `digitalocean-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install digitalocean --cli-only
+   npx -y @mvanhorn/printing-press-library install digitalocean --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `digitalocean-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/digitalocean/cmd/digitalocean-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/cloud/here-now/README.md
+++ b/library/cloud/here-now/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-here-now --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-here-now --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install here-now --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-here-now skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-here-now. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -192,7 +194,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Publish a folder and keep it permanently
 
@@ -333,7 +334,6 @@ Manage publishes
 Authenticated support requests.
 
 - **`here-now-pp-cli support`** - Send an authenticated support request
-
 
 ## Output Formats
 

--- a/library/cloud/here-now/SKILL.md
+++ b/library/cloud/here-now/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `here-now-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install here-now --cli-only
+   npx -y @mvanhorn/printing-press-library install here-now --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `here-now-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/here-now/cmd/here-now-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-here.now lets agents publish static Sites to live URLs and keep private files in cloud Drives. This CLI is the missing layer on top: `publish dir ./site` orchestrates the whole inline-upload-finalize dance for you, `drives sync` pushes only what changed, and a local claim-token vault keeps your free-tier anonymous sites from silently expiring. Built free-plan-first — anonymous publishing needs no account, and paid-only analytics fails soft with a clear message instead of a raw error.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/cloud/render/README.md
+++ b/library/cloud/render/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-render --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-render --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install render --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-render skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-render. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/cloud/render/SKILL.md
+++ b/library/cloud/render/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `render-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install render --cli-only
+   npx -y @mvanhorn/printing-press-library install render --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `render-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/cloud/render/cmd/render-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/amazon-ads/README.md
+++ b/library/commerce/amazon-ads/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-ads -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-ads --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install amazon-ads --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-amazon-ads skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-ads. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -479,7 +481,6 @@ Manage history
 
 Manage hsa
 
-
 ### insights
 
 Manage insights
@@ -852,7 +853,6 @@ Note:
 
 The recommended bids are derrived from the last 7 days of winning auction bids for the related targeting clause.
 
-
 Receive bid recommendations using the following:
 Contextual targeting clause|Description|
 |-----------|----|
@@ -860,18 +860,15 @@ Contextual targeting clause|Description|
 |asinCategorySameAs=12345|Receive a bid recommendation for this target category
 |similarProduct|Receive a bid recommendation for targets that are similar to the advertised asins.
 
-
 Audience targeting clause|Description|
 |-----------|----|
 |views(asinCategorySameAs=12345 lookback=30)|Receive a bid recommendation for a target audience that has viewed products in the given category
 |views(similarProduct lookback=30)|Receive a bid recommendation for a target audience that has viewed similar products to the advertised asins
 |views(exactProduct lookback=30)|Receive a bid recommendation for a target audience that has viewed the advertised asins
 
-
 #### Notes:
 - Bid recommendations for purchases and audiences are **not currently supported**. This note will be removed when these operations are available.
 - Refinements are currently not supported and if included will not impact the bid recommendation for the target.
-
 
 #### Advertised ASIN Notes:
 - For asinSameAs targets the advertised asins will not impact the bid recommendation
@@ -1155,11 +1152,9 @@ Manage sponsored display sd
 ["advertiser_campaign_view"]
 - **`amazon-ads-pp-cli sponsored-display-sd get-request-results`** - When a user adds domains to their Brand Safety Deny List, the request is processed asynchronously, and a requestId is provided to the user. This requestId can be used to view the request results for up to 90 days from when the request was submitted. The results provide the status of each domain in the given request. Request results may contain multiple pages. This endpoint will only be available once the request has completed processing. To see the status of the request you can call GET /sd/brandSafety/{requestId}/status. Note that this endpoint only lists the results of POST requests to /sd/brandSafety/deny - it does not reflect the results of DELETE requests.
 
-
 **Requires one of these permissions**:
 ["advertiser_campaign_edit","advertiser_campaign_view"]
 - **`amazon-ads-pp-cli sponsored-display-sd get-request-status`** - When a user modifies their Brand Safety Deny List, the request is processed asynchronously, and a requestId is provided to the user. This requestId can be used to check the status of the request for up to 90 days from when the request was submitted
-
 
 **Requires one of these permissions**:
 ["advertiser_campaign_edit","advertiser_campaign_view"]
@@ -1171,7 +1166,6 @@ Manage sponsored display sd
 
 The recommended bids are derrived from the last 7 days of winning auction bids for the related targeting clause.
 
-
 Receive bid recommendations using the following:
 Product targeting clause|Description|
 |-----------|----|
@@ -1179,17 +1173,14 @@ Product targeting clause|Description|
 |asinCategorySameAs=12345|Receive a bid recommendation for this target category
 |similarProduct|Receive a bid recommendation for targets that are similar to the advertised asins.
 
-
 Audience targeting clause|Description|
 |-----------|----|
 |views(asinCategorySameAs=12345 lookback=30)|Receive a bid recommendation for a target audience that has viewed products in the given category
 |views(similarProduct lookback=30)|Receive a bid recommendation for a target audience that has viewed similar products to the advertised asins
 |views(exactProduct lookback=30)|Receive a bid recommendation for a target audience that has viewed the advertised asins
 
-
 #### Refinement Notes:
 - Refinements are currently not supported and if included will not impact the bid recommendation for the target
-
 
 #### Advertised ASIN Notes:
 - For asinSameAs targets the advertised asins will not impact the bid recommendation
@@ -1211,11 +1202,9 @@ The currently available tactic identifiers are:
 - **`amazon-ads-pp-cli sponsored-display-sd list-associated-budget-rules-for-sdcampaigns`** - Gets a list of budget rules associated to a campaign specified by identifier.
 - **`amazon-ads-pp-cli sponsored-display-sd list-domains`** - Gets an array of websites/apps that are on the advertiser's Brand Safety Deny List. It can take up to 15 minutes from the time a domain is added/deleted to the time it is reflected in the deny list.
 
-
 **Requires one of these permissions**:
 ["advertiser_campaign_edit","advertiser_campaign_view"]
 - **`amazon-ads-pp-cli sponsored-display-sd list-request-status`** - List status of all Brand Safety List requests. The list will contain requests that were submitted in the past 90 days.
-
 
 **Requires one of these permissions**:
 ["advertiser_campaign_edit","advertiser_campaign_view"]
@@ -1391,7 +1380,6 @@ Manage sponsored products sp
 Manage targeting expression
 
 - **`amazon-ads-pp-cli targeting-expression`** - Localizes (maps) targeting expressions from a source marketplace to one or more target marketplaces. V3: Providing locales in your request's source details or target details, will now return in &lt;sourceField&gt; and &lt;targetField&gt; respectively the translations of your targeting expressions.
-
 
 ## Output Formats
 

--- a/library/commerce/amazon-ads/SKILL.md
+++ b/library/commerce/amazon-ads/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `amazon-ads-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install amazon-ads --cli-only
+   npx -y @mvanhorn/printing-press-library install amazon-ads --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `amazon-ads-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-ads/cmd/amazon-ads-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Amazon Ads CLI for reports, profitability analytics, keyword optimization, profile-aware OAuth setup, and guarded campaign automation.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/commerce/amazon-orders/README.md
+++ b/library/commerce/amazon-orders/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-order
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-orders --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install amazon-orders --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-amazon-orders skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-orders. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/amazon-orders/SKILL.md
+++ b/library/commerce/amazon-orders/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `amazon-orders-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install amazon-orders --cli-only
+   npx -y @mvanhorn/printing-press-library install amazon-orders --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `amazon-orders-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-orders/cmd/amazon-orders-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/amazon-seller/README.md
+++ b/library/commerce/amazon-seller/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-selle
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-amazon-seller --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install amazon-seller --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-amazon-seller skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-amazon-seller. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/amazon-seller/SKILL.md
+++ b/library/commerce/amazon-seller/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `amazon-seller-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install amazon-seller --cli-only
+   npx -y @mvanhorn/printing-press-library install amazon-seller --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `amazon-seller-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/amazon-seller/cmd/amazon-seller-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/commerce/blacklane/README.md
+++ b/library/commerce/blacklane/README.md
@@ -4,6 +4,8 @@
 
 Quote Blacklane's fixed all-inclusive chauffeur fares (airport transfers and by-the-hour) by address, compare vehicle classes, and keep a searchable local log of every quote. Addresses resolve via OpenStreetMap — no API key, no login, no booking.
 
+Created by [@omarshahine](https://github.com/omarshahine) (Omar Shahine).
+
 ## Install
 
 The recommended path installs both the `blacklane-pp-cli` binary and the `pp-blacklane` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -31,9 +33,15 @@ npx -y @mvanhorn/printing-press-library install blacklane --agent claude-code
 npx -y @mvanhorn/printing-press-library install blacklane --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/blacklane/cmd/blacklane-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-blacklane --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-blacklane --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install blacklane --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-blacklane skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-blacklane. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -186,7 +196,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Quote and keep only class + price
 
 ```bash
@@ -220,7 +229,6 @@ Vehicle-class service catalog (models, capacity, features)
 Raw pricing quotes (prefer the top-level 'quote' command)
 
 - **`blacklane-pp-cli prices`** - Request prices for a journey (raw body; see 'quote' for a friendly interface)
-
 
 ## Output Formats
 

--- a/library/commerce/blacklane/SKILL.md
+++ b/library/commerce/blacklane/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `blacklane-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install blacklane --cli-only
+   npx -y @mvanhorn/printing-press-library install blacklane --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `blacklane-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/blacklane/cmd/blacklane-pp-cli@latest
+```
 
-Quote Blacklane's fixed all-inclusive chauffeur fares (airport transfers and by-the-hour) by address, compare vehicle classes, and keep a searchable local log of every quote. Addresses resolve via OpenStreetMap — no API key, no login, no booking.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/craigslist/README.md
+++ b/library/commerce/craigslist/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-craigslist --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install craigslist --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-craigslist skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-craigslist. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/craigslist/SKILL.md
+++ b/library/commerce/craigslist/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `craigslist-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install craigslist --cli-only
+   npx -y @mvanhorn/printing-press-library install craigslist --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `craigslist-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/craigslist/cmd/craigslist-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/doordash/README.md
+++ b/library/commerce/doordash/README.md
@@ -1,7 +1,6 @@
 # Doordash CLI
 > Private-beta staging note: this generated Go tree is unofficial/experimental reference material. The active working runtime is the sibling `../active-wrapper/` Node/CycleTLS package. Do not commit credentials or session material. Live cart/order mutations require explicit bricenice17 approval and the CLI safety gates.
 
-
 Discovered API spec for doordash
 
 Learn more at [Doordash](https://www.doordash.com).
@@ -9,52 +8,94 @@ Created by [@bricenice17](https://github.com/bricenice17) (bricenice17).
 
 ## Install
 
-This directory is the generated Printing Press Go skeleton/reference tree. It is not the runtime users should install for DoorDash browser-facing calls.
-
-The public-install path for the working DoorDash PP is the repository root Node package, which exposes the same Node/CycleTLS runtime used by Hermes:
+The recommended path installs both the `doordash-pp-cli` binary and the `pp-doordash` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-# After bricenice17 approves the visibility flip:
-npm install -g github:bricenice17/doordash-pp-cli-clean
-doordash-pp-cli --help
-doordash-pp-cli doctor --json
+npx -y @mvanhorn/printing-press-library install doordash
 ```
 
-Until the repo is public, verify from the private checkout root:
+For CLI only (no skill):
 
 ```bash
-npm ci
-npm run build
-node dist/cli.js --help
-node dist/cli.js doctor --json
+npx -y @mvanhorn/printing-press-library install doordash --cli-only
 ```
 
-Do not use `npx -y @mvanhorn/printing-press install doordash`, public release downloads, or generated Go binaries as the working DoorDash install story unless the Go runtime is later ported to the Node/CycleTLS behavior and reverified.
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
+```bash
+npx -y @mvanhorn/printing-press-library install doordash --skill-only
+```
 
-### Without Node
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
-There is no approved no-Node runtime path. The Go skeleton can be built locally for credential-free PP/spec tests, but it is not the working DoorDash runtime.
+```bash
+npx -y @mvanhorn/printing-press-library install doordash --agent claude-code
+npx -y @mvanhorn/printing-press-library install doordash --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/commerce/doordash/cmd/doordash-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
-No standalone pre-built binary is approved. The public-ready install path is the root Node package from the GitHub repo after visibility approval.
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/doordash-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
-Hermes should use the Node/CycleTLS runtime exposed by the root package or the installed wrappers. For private Hermes testing, verify:
+From the Hermes CLI:
 
 ```bash
-/home/hermes/go/bin/doordash-pp-mcp
-/home/hermes/go/bin/doordash-pp-cli doctor --json
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-doordash --force
 ```
 
-If this generated skeleton is built for credential-free checks, do not present it as the runtime replacement.
+Inside a Hermes chat session:
+
+```text
+/skills install mvanhorn/printing-press-library/cli-skills/pp-doordash --force
+```
 
 ## Install for OpenClaw
 
-For OpenClaw/Paperclip work, point agents at the GitHub/root Node install path once public, or the private checkout before release. Tell them the active runtime is the root package / `active-wrapper/`, not this generated Go tree.
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
+
+```bash
+npx -y @mvanhorn/printing-press-library install doordash --agent openclaw --bin-dir ~/.local/bin
+```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
+
+## Use with Claude Desktop
+
+Do not install this DoorDash MCP/CLI from `mvanhorn/printing-press-library` releases as the working runtime. After public approval, install the root GitHub Node package and register `doordash-pp-mcp`.
+
+For private local testing, build from this checkout and register the Node/CycleTLS MCP wrapper.
+
+<details>
+<summary>Manual JSON config (private local testing only)</summary>
+
+If private MCP use is needed before bricenice17 approves public release and the release gate passes, install/register only from this private local checkout or an explicitly approved private build.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "doordash": {
+      "command": "doordash-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -175,7 +216,6 @@ The generated Go skeleton preserves the curated low-level GraphQL operation spec
 - **`doordash-pp-cli graphql create-update-cart-item-v2`** - POST /graphql/updateCartItemV2
 - **`doordash-pp-cli graphql create-validate-consumer-address-with-address-link-id`** - POST /graphql/validateConsumerAddressWithAddressLinkId
 
-
 ## Output Formats
 
 ```bash
@@ -206,57 +246,6 @@ This CLI is designed for AI agent consumption:
 - **Runtime-truth first** - the active wrapper may not expose every generated skeleton flag (`--agent`, `--select`, `which`, `agent-context`); inspect `--help` before use.
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-doordash -g
-```
-
-Then invoke `/pp-doordash <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-If MCP use is needed before bricenice17 approves public release and the release gate passes, install/register only from the private local checkout or an explicitly approved private build.
-
-Then register it:
-
-```bash
-claude mcp add doordash doordash-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-Do not install this DoorDash MCP/CLI from `mvanhorn/printing-press-library` releases as the working runtime. After public approval, install the root GitHub Node package and register `doordash-pp-mcp`.
-
-For private local testing, build from this checkout and register the Node/CycleTLS MCP wrapper.
-
-<details>
-<summary>Manual JSON config (private local testing only)</summary>
-
-If private MCP use is needed before bricenice17 approves public release and the release gate passes, install/register only from this private local checkout or an explicitly approved private build.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "doordash": {
-      "command": "doordash-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/commerce/doordash/SKILL.md
+++ b/library/commerce/doordash/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `doordash-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install doordash --cli-only
+   npx -y @mvanhorn/printing-press-library install doordash --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `doordash-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,11 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/doordash/cmd/doordash-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Private repo note: this generated skill describes the Go skeleton binary for PP verification/public-library packaging. In the private DoorDash repo, `docs/SKILL.md` describes the active Node/CycleTLS runtime used by Herman today. Keep the two surfaces separate until the Go runtime fully replaces the wrapper.
-
-DoorDash GraphQL operation spec curated from sniffed traffic and ashah360/doordash-mcp query files. This skeleton is intentionally low-level; later phases add safe domain commands and session transport.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/commerce/ebay/README.md
+++ b/library/commerce/ebay/README.md
@@ -75,17 +75,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ebay --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ebay --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ebay skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ebay. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/ebay/SKILL.md
+++ b/library/commerce/ebay/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `ebay-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ebay --cli-only
+   npx -y @mvanhorn/printing-press-library install ebay --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ebay-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/ebay/cmd/ebay-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/commerce/facebook-marketplace/README.md
+++ b/library/commerce/facebook-marketplace/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-facebook-mar
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-facebook-marketplace --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install facebook-marketplace --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-facebook-marketplace skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-facebook-marketplace. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/facebook-marketplace/SKILL.md
+++ b/library/commerce/facebook-marketplace/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `facebook-marketplace-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install facebook-marketplace --cli-only
+   npx -y @mvanhorn/printing-press-library install facebook-marketplace --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `facebook-marketplace-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/facebook-marketplace/cmd/facebook-marketplace-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/fedex/README.md
+++ b/library/commerce/fedex/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-fedex --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install fedex --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-fedex skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-fedex. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/fedex/SKILL.md
+++ b/library/commerce/fedex/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `fedex-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install fedex --cli-only
+   npx -y @mvanhorn/printing-press-library install fedex --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `fedex-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/fedex/cmd/fedex-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/gumroad/README.md
+++ b/library/commerce/gumroad/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-gumroad --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-gumroad --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install gumroad --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-gumroad skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-gumroad. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/gumroad/SKILL.md
+++ b/library/commerce/gumroad/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `gumroad-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install gumroad --cli-only
+   npx -y @mvanhorn/printing-press-library install gumroad --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `gumroad-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/gumroad/cmd/gumroad-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/harris-teeter/README.md
+++ b/library/commerce/harris-teeter/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-harris-teete
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-harris-teeter --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install harris-teeter --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-harris-teeter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-harris-teeter. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/harris-teeter/SKILL.md
+++ b/library/commerce/harris-teeter/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `harris-teeter-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install harris-teeter --cli-only
+   npx -y @mvanhorn/printing-press-library install harris-teeter --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `harris-teeter-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/harris-teeter/cmd/harris-teeter-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/commerce/instacart/README.md
+++ b/library/commerce/instacart/README.md
@@ -275,7 +275,6 @@ available for offline reads.
   the ranked list, then pass `--item-id` to `add` for precision.
 
 Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
-Contributors: [@omarshahine](https://github.com/omarshahine) (Omar Shahine).
 
 ## Install
 
@@ -330,15 +329,17 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-instacart --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install instacart --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-instacart skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-instacart. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 

--- a/library/commerce/instacart/SKILL.md
+++ b/library/commerce/instacart/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `instacart-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install instacart --cli-only
+   npx -y @mvanhorn/printing-press-library install instacart --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `instacart-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/instacart/cmd/instacart-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/loopnet/README.md
+++ b/library/commerce/loopnet/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-loopnet --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-loopnet --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install loopnet --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-loopnet skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-loopnet. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/loopnet/SKILL.md
+++ b/library/commerce/loopnet/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `loopnet-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install loopnet --cli-only
+   npx -y @mvanhorn/printing-press-library install loopnet --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `loopnet-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/loopnet/cmd/loopnet-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/offerup/README.md
+++ b/library/commerce/offerup/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-offerup --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-offerup --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install offerup --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-offerup skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-offerup. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -189,7 +191,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Narrow a verbose search for an agent
 
 ```bash
@@ -234,7 +235,6 @@ Search and view OfferUp listings (public, no login)
 
 - **`offerup-pp-cli listings get`** - Get the full detail for one listing
 - **`offerup-pp-cli listings search`** - Search live OfferUp listings by keyword and location
-
 
 ## Output Formats
 

--- a/library/commerce/offerup/SKILL.md
+++ b/library/commerce/offerup/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `offerup-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install offerup --cli-only
+   npx -y @mvanhorn/printing-press-library install offerup --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `offerup-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/offerup/cmd/offerup-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-OfferUp's web scrapers all dump a one-shot listing array and forget it. This CLI persists every listing in a local SQLite store, then layers on price intelligence no marketplace tool offers: price-check tells you the going rate in your area, deals flags listings below the local median, new-since and price-drops track saved searches over time, and seller-scan profiles a seller's whole inventory. Built for agents too — every command speaks --json, --select, and an MCP surface.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/printify/README.md
+++ b/library/commerce/printify/README.md
@@ -38,7 +38,7 @@ npx -y @mvanhorn/printing-press-library install printify --agent claude-code --a
 If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
-go install github.com/mvanhorn/printing-press-library/library/other/printify/cmd/printify-pp-cli@latest
+go install github.com/mvanhorn/printing-press-library/library/commerce/printify/cmd/printify-pp-cli@latest
 ```
 
 This installs the CLI only — no skill.
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-printify --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-printify --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install printify --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-printify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-printify. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -196,7 +198,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Find a shop with narrow output
 
 ```bash
@@ -266,7 +267,6 @@ Browse the Printify catalog including blueprints, print providers, product varia
 
 Manage Printify shops and shop connections. Retrieve shop information and disconnect shops from your account.
 
-
 ### shops-json
 
 Manage shops json
@@ -285,7 +285,6 @@ Upload and manage images and assets. Upload images from URLs or base64-encoded c
 Manage uploads json
 
 - **`printify-pp-cli uploads-json`** - Retrieve a list of uploaded images
-
 
 ## Output Formats
 

--- a/library/commerce/printify/SKILL.md
+++ b/library/commerce/printify/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `printify-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install printify --cli-only
+   npx -y @mvanhorn/printing-press-library install printify --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `printify-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/printify/cmd/printify-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-This CLI covers Printify's official product, upload, catalog, order, shop, and webhook API surface, then adds workflow commands for product creation confidence. Agents can compile personalized manifests, upload images, validate placement, compare drift, and inspect fulfillment risk without parsing raw nested API payloads.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/restaurant365-odata/README.md
+++ b/library/commerce/restaurant365-odata/README.md
@@ -6,7 +6,7 @@ Restaurant365 is a restaurant back-office platform for accounting, operations, p
 
 This CLI focuses on the engineering work around that feed: discovering available views, checking schemas, taking redacted samples, planning daily refreshes, building bounded backfills, tracking rowVersion-based incremental loads, and checking deleted-record tombstones.
 
-Printed by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
+Created by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
 
 ## Install
 
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-restaurant36
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-restaurant365-odata --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install restaurant365-odata --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-restaurant365-odata skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-restaurant365-odata. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -335,7 +337,6 @@ Manage transaction
 Manage transaction detail
 
 - **`restaurant365-odata-pp-cli transaction-detail`** - Returns TransactionDetail reporting rows from Restaurant365 OData.
-
 
 ## Output Formats
 

--- a/library/commerce/restaurant365-odata/SKILL.md
+++ b/library/commerce/restaurant365-odata/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `restaurant365-odata-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install restaurant365-odata --cli-only
+   npx -y @mvanhorn/printing-press-library install restaurant365-odata --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `restaurant365-odata-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,11 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/restaurant365-odata/cmd/restaurant365-odata-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Restaurant365 is a restaurant back-office platform used for accounting, operations, payroll, inventory, sales, and restaurant-level financial reporting. Its OData connector exposes reporting views that engineers load into warehouses and BI tools.
-
-This CLI is read-only. Use it for schema discovery, safe sampling, bounded export, local sync, incremental-load planning, and delete-tombstone checks. It is especially useful when an engineer needs to validate a Restaurant365 tenant without printing private row values.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/commerce/shopify/README.md
+++ b/library/commerce/shopify/README.md
@@ -5,7 +5,6 @@ Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk o
 Learn more at [Shopify](https://shopify.dev/docs/api/admin-graphql).
 
 Created by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
-Contributors: [@benjaminn8](https://github.com/benjaminn8) (Benjamin Huang).
 
 ## Install
 
@@ -59,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-shopify --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install shopify --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-shopify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-shopify. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -197,7 +198,6 @@ Shopify products with product status, catalog metadata, and a compact variant in
 
 - **`shopify-pp-cli products get`** - Get one Shopify product by GraphQL ID.
 - **`shopify-pp-cli products list`** - List products from the Shopify Admin GraphQL API.
-
 
 ## Output Formats
 

--- a/library/commerce/shopify/SKILL.md
+++ b/library/commerce/shopify/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `shopify-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install shopify --cli-only
+   npx -y @mvanhorn/printing-press-library install shopify --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `shopify-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/shopify/cmd/shopify-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk operations via the Shopify Admin GraphQL API.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/commerce/slickdeals/README.md
+++ b/library/commerce/slickdeals/README.md
@@ -73,17 +73,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-slickdeals -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-slickdeals --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install slickdeals --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-slickdeals skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-slickdeals. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/slickdeals/SKILL.md
+++ b/library/commerce/slickdeals/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `slickdeals-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install slickdeals --cli-only
+   npx -y @mvanhorn/printing-press-library install slickdeals --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `slickdeals-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/slickdeals/cmd/slickdeals-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/commerce/squarespace/README.md
+++ b/library/commerce/squarespace/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-squarespace 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-squarespace --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install squarespace --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-squarespace skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-squarespace. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/commerce/squarespace/SKILL.md
+++ b/library/commerce/squarespace/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `squarespace-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install squarespace --cli-only
+   npx -y @mvanhorn/printing-press-library install squarespace --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `squarespace-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/squarespace/cmd/squarespace-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Account Dashboard Auth
 

--- a/library/commerce/tiktok-shop/README.md
+++ b/library/commerce/tiktok-shop/README.md
@@ -5,7 +5,6 @@ Safe v1 CLI and MCP server for confirmed TikTok Shop Seller APIs.
 This package intentionally exposes a conservative surface based only on official TikTok Shop Partner Center docs: auth readiness, token exchange and refresh, shop discovery, read-only orders, products, inventory search, fulfillment packages, and warehouses. Inventory update is documented as confirmed but remains deferred until idempotency, retry, and operator-confirmation safety are designed.
 
 Created by [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
-Contributors: [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
@@ -59,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-tiktok-shop --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install tiktok-shop --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-tiktok-shop skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tiktok-shop. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Configure
 

--- a/library/commerce/tiktok-shop/SKILL.md
+++ b/library/commerce/tiktok-shop/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `tiktok-shop-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install tiktok-shop --cli-only
+   npx -y @mvanhorn/printing-press-library install tiktok-shop --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `tiktok-shop-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/tiktok-shop/cmd/tiktok-shop-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Official Source Boundaries
 

--- a/library/commerce/ucp/README.md
+++ b/library/commerce/ucp/README.md
@@ -69,17 +69,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ucp --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ucp --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ucp --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ucp skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ucp. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -208,7 +210,6 @@ Run `ucp-pp-cli --help` for the full command reference and flag list.
 Operations on checkout
 
 - **`ucp-pp-cli checkout`** - POST /checkout
-
 
 ## Output Formats
 

--- a/library/commerce/ucp/SKILL.md
+++ b/library/commerce/ucp/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `ucp-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ucp --cli-only
+   npx -y @mvanhorn/printing-press-library install ucp --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ucp-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/ucp/cmd/ucp-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-UCP-pp-cli is the terminal-grade tool the official Python and JS SDKs don't ship. It speaks both REST and MCP transports so it works against real merchants like checkout.coffeecircle.com (Shopify-hosted, MCP-only) and the bundled mock. Local SQLite holds carts, checkout sessions, and a merchant directory, enabling cross-merchant search, capability diffs, and price-drift watch loops nothing else offers today.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Real-Merchant Compatibility
 

--- a/library/commerce/yahoo-finance/README.md
+++ b/library/commerce/yahoo-finance/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-financ
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-yahoo-finance --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install yahoo-finance --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-yahoo-finance skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-yahoo-finance. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -211,7 +213,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Daily market briefing across your watchlist
 
 ```bash
@@ -318,7 +319,6 @@ Predefined and custom stock screeners
 Trending symbols by region
 
 - **`yahoo-finance-pp-cli trending <region>`** - Top trending symbols in a region right now
-
 
 ## Output Formats
 

--- a/library/commerce/yahoo-finance/SKILL.md
+++ b/library/commerce/yahoo-finance/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `yahoo-finance-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install yahoo-finance --cli-only
+   npx -y @mvanhorn/printing-press-library install yahoo-finance --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `yahoo-finance-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/commerce/yahoo-finance/cmd/yahoo-finance-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-yahoo-finance-pp-cli matches yfinance and yahoo-finance2 for raw endpoint coverage, then adds the things only a local store + agent-shaped CLI can do: cost-basis-aware portfolio performance, dividend income with yield-on-cost, a SQL-backed fundamentals screener, options moneyness + DTE filtering, and an `auth login --chrome` cookie escape hatch when Yahoo blocks your IP.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/agent-capture/SKILL.md
+++ b/library/developer-tools/agent-capture/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `agent-capture-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install agent-capture --cli-only
+   npx -y @mvanhorn/printing-press-library install agent-capture --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `agent-capture-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/agent-capture/cmd/agent-capture-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/airframe/README.md
+++ b/library/developer-tools/airframe/README.md
@@ -224,17 +224,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-airframe --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-airframe --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install airframe --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-airframe skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-airframe. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Sync flags reference
 

--- a/library/developer-tools/airframe/SKILL.md
+++ b/library/developer-tools/airframe/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `airframe-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install airframe --cli-only
+   npx -y @mvanhorn/printing-press-library install airframe --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `airframe-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/airframe/cmd/airframe-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## The two-tier model (read this first, every invocation)
 

--- a/library/developer-tools/apify/README.md
+++ b/library/developer-tools/apify/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-apify --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-apify --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install apify --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-apify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-apify. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/apify/SKILL.md
+++ b/library/developer-tools/apify/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `apify-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install apify --cli-only
+   npx -y @mvanhorn/printing-press-library install apify --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `apify-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/apify/cmd/apify-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/apple-docs/README.md
+++ b/library/developer-tools/apple-docs/README.md
@@ -4,7 +4,7 @@
 
 apple-docs-pp-cli mirrors developer.apple.com's DocC JSON into a local SQLite store you can grep across every framework, diff between releases, and project down to just the fields an agent needs. Ships with offline FTS, a cross-platform 'port-to' walker, a deprecation-cliff report, and an MCP server you can plug into Claude Desktop.
 
-Printed by [@jcastillo725](https://github.com/jcastillo725) (Joseph Alvin Castillo).
+Created by [@jcastillo725](https://github.com/jcastillo725) (Joseph Alvin Castillo).
 
 ## Install
 
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-apple-docs -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-apple-docs --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install apple-docs --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-apple-docs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-apple-docs. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -197,7 +199,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Find a symbol's iOS introduction version
 
 ```bash
@@ -261,7 +262,6 @@ Fetch the full structured index of a framework (every symbol, in tree form)
 List every Apple framework and technology (Swift, SwiftUI, UIKit, etc.)
 
 - **`apple-docs-pp-cli technologies`** - Fetch the master technologies index — every Apple framework, grouped by topic.
-
 
 ## Output Formats
 

--- a/library/developer-tools/apple-docs/SKILL.md
+++ b/library/developer-tools/apple-docs/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `apple-docs-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install apple-docs --cli-only
+   npx -y @mvanhorn/printing-press-library install apple-docs --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `apple-docs-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/apple-docs/cmd/apple-docs-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-apple-docs-pp-cli mirrors developer.apple.com's DocC JSON into a local SQLite store you can grep across every framework, diff between releases, and project down to just the fields an agent needs. Ships with offline FTS, a cross-platform 'port-to' walker, a deprecation-cliff report, and an MCP server you can plug into Claude Desktop.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/company-goat/README.md
+++ b/library/developer-tools/company-goat/README.md
@@ -103,17 +103,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-company-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install company-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-company-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-company-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/company-goat/SKILL.md
+++ b/library/developer-tools/company-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `company-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install company-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install company-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `company-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/company-goat/cmd/company-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/docker-hub/README.md
+++ b/library/developer-tools/docker-hub/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-docker-hub --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install docker-hub --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-docker-hub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-docker-hub. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/docker-hub/SKILL.md
+++ b/library/developer-tools/docker-hub/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `docker-hub-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install docker-hub --cli-only
+   npx -y @mvanhorn/printing-press-library install docker-hub --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `docker-hub-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/docker-hub/cmd/docker-hub-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/domain-goat/README.md
+++ b/library/developer-tools/domain-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-domain-goat 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-domain-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install domain-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-domain-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-domain-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/domain-goat/SKILL.md
+++ b/library/developer-tools/domain-goat/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `domain-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install domain-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install domain-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `domain-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/domain-goat/cmd/domain-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/firecrawl/README.md
+++ b/library/developer-tools/firecrawl/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-firecrawl --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install firecrawl --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-firecrawl skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-firecrawl. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/firecrawl/SKILL.md
+++ b/library/developer-tools/firecrawl/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `firecrawl-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install firecrawl --cli-only
+   npx -y @mvanhorn/printing-press-library install firecrawl --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `firecrawl-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/firecrawl/cmd/firecrawl-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/developer-tools/godaddy/README.md
+++ b/library/developer-tools/godaddy/README.md
@@ -2,7 +2,7 @@
 
 Combined CLI for multiple API services
 
-Printed by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
+Created by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
 
 ## Install
 
@@ -31,9 +31,15 @@ npx -y @mvanhorn/printing-press-library install godaddy --agent claude-code
 npx -y @mvanhorn/printing-press-library install godaddy --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/godaddy/cmd/godaddy-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -50,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-godaddy --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-godaddy --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install godaddy --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-godaddy skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-godaddy. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -184,7 +192,6 @@ Manage agreements
 
 Manage customers
 
-
 ### auctions-aftermarket
 
 Manage aftermarket
@@ -242,7 +249,6 @@ Manage domains
 
 Manage customers
 
-
 ### orders
 
 Manage orders
@@ -275,7 +281,6 @@ Manage subscriptions
 - **`godaddy-pp-cli subscriptions list`** - Retrieve a list of Subscriptions for the specified Shopper
 - **`godaddy-pp-cli subscriptions product-groups`** - Retrieve a list of ProductGroups for the specified Shopper
 - **`godaddy-pp-cli subscriptions update`** - Only Subscription properties that can be changed without immediate financial impact can be modified via PATCH, whereas some properties can be changed by purchasing a renewal<br/><strong>This endpoint only supports JWT authentication</strong>
-
 
 ## Output Formats
 

--- a/library/developer-tools/godaddy/SKILL.md
+++ b/library/developer-tools/godaddy/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `godaddy-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install godaddy --cli-only
+   npx -y @mvanhorn/printing-press-library install godaddy --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `godaddy-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/developer-tools/godaddy/cmd/godaddy-pp-cli@latest
+```
 
-Combined CLI for multiple API services
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/developer-tools/namecheap/README.md
+++ b/library/developer-tools/namecheap/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-namecheap --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-namecheap --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install namecheap --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-namecheap skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-namecheap. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/namecheap/SKILL.md
+++ b/library/developer-tools/namecheap/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `namecheap-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install namecheap --cli-only
+   npx -y @mvanhorn/printing-press-library install namecheap --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `namecheap-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/namecheap/cmd/namecheap-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/nse-india/README.md
+++ b/library/developer-tools/nse-india/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nse-india --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-nse-india --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install nse-india --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-nse-india skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nse-india. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/nse-india/SKILL.md
+++ b/library/developer-tools/nse-india/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `nse-india-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install nse-india --cli-only
+   npx -y @mvanhorn/printing-press-library install nse-india --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `nse-india-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/nse-india/cmd/nse-india-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/nvd/README.md
+++ b/library/developer-tools/nvd/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-nvd --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install nvd --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-nvd skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nvd. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/nvd/SKILL.md
+++ b/library/developer-tools/nvd/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `nvd-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install nvd --cli-only
+   npx -y @mvanhorn/printing-press-library install nvd --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `nvd-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/nvd/cmd/nvd-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/openfda/README.md
+++ b/library/developer-tools/openfda/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-openfda --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-openfda --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install openfda --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-openfda skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-openfda. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/openfda/SKILL.md
+++ b/library/developer-tools/openfda/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `openfda-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install openfda --cli-only
+   npx -y @mvanhorn/printing-press-library install openfda --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `openfda-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/openfda/cmd/openfda-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/openipa/README.md
+++ b/library/developer-tools/openipa/README.md
@@ -113,17 +113,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-openipa --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-openipa --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install openipa --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-openipa skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-openipa. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/openipa/SKILL.md
+++ b/library/developer-tools/openipa/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `openipa-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install openipa --cli-only
+   npx -y @mvanhorn/printing-press-library install openipa --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `openipa-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/openipa/cmd/openipa-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Perché openipa?
 

--- a/library/developer-tools/pdok-location/README.md
+++ b/library/developer-tools/pdok-location/README.md
@@ -73,17 +73,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pdok-locatio
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pdok-location --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pdok-location --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pdok-location skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pdok-location. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/pdok-location/SKILL.md
+++ b/library/developer-tools/pdok-location/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `pdok-location-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pdok-location --cli-only
+   npx -y @mvanhorn/printing-press-library install pdok-location --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pdok-location-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/pdok-location/cmd/pdok-location-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/posthog/README.md
+++ b/library/developer-tools/posthog/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-posthog --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-posthog --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install posthog --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-posthog skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-posthog. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/posthog/SKILL.md
+++ b/library/developer-tools/posthog/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `posthog-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install posthog --cli-only
+   npx -y @mvanhorn/printing-press-library install posthog --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `posthog-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/posthog/cmd/posthog-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/postman-explore/README.md
+++ b/library/developer-tools/postman-explore/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-postman-expl
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-postman-explore --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install postman-explore --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-postman-explore skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-postman-explore. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/postman-explore/SKILL.md
+++ b/library/developer-tools/postman-explore/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `postman-explore-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install postman-explore --cli-only
+   npx -y @mvanhorn/printing-press-library install postman-explore --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `postman-explore-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/postman-explore/cmd/postman-explore-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/pypi/README.md
+++ b/library/developer-tools/pypi/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pypi --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pypi --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pypi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pypi. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/pypi/SKILL.md
+++ b/library/developer-tools/pypi/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `pypi-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pypi --cli-only
+   npx -y @mvanhorn/printing-press-library install pypi --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pypi-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/pypi/cmd/pypi-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/developer-tools/scrape-creators/README.md
+++ b/library/developer-tools/scrape-creators/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creat
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-scrape-creators --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install scrape-creators --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-scrape-creators skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-scrape-creators. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/scrape-creators/SKILL.md
+++ b/library/developer-tools/scrape-creators/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `scrape-creators-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install scrape-creators --cli-only
+   npx -y @mvanhorn/printing-press-library install scrape-creators --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `scrape-creators-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/scrape-creators/cmd/scrape-creators-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/sec-edgar/README.md
+++ b/library/developer-tools/sec-edgar/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sec-edgar --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-sec-edgar --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install sec-edgar --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-sec-edgar skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sec-edgar. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/sec-edgar/SKILL.md
+++ b/library/developer-tools/sec-edgar/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `sec-edgar-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install sec-edgar --cli-only
+   npx -y @mvanhorn/printing-press-library install sec-edgar --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `sec-edgar-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/sec-edgar/cmd/sec-edgar-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/supabase/README.md
+++ b/library/developer-tools/supabase/README.md
@@ -61,17 +61,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-supabase --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-supabase --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install supabase --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-supabase skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-supabase. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/supabase/SKILL.md
+++ b/library/developer-tools/supabase/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `supabase-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install supabase --cli-only
+   npx -y @mvanhorn/printing-press-library install supabase --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `supabase-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/supabase/cmd/supabase-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/trigger-dev/README.md
+++ b/library/developer-tools/trigger-dev/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-trigger-dev --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install trigger-dev --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-trigger-dev skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trigger-dev. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/trigger-dev/SKILL.md
+++ b/library/developer-tools/trigger-dev/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `trigger-dev-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install trigger-dev --cli-only
+   npx -y @mvanhorn/printing-press-library install trigger-dev --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `trigger-dev-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/trigger-dev/cmd/trigger-dev-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/developer-tools/uspto-tsdr/README.md
+++ b/library/developer-tools/uspto-tsdr/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-uspto-tsdr -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-uspto-tsdr --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install uspto-tsdr --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-uspto-tsdr skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-uspto-tsdr. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/developer-tools/uspto-tsdr/SKILL.md
+++ b/library/developer-tools/uspto-tsdr/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `uspto-tsdr-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install uspto-tsdr --cli-only
+   npx -y @mvanhorn/printing-press-library install uspto-tsdr --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `uspto-tsdr-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/developer-tools/uspto-tsdr/cmd/uspto-tsdr-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/devices/adminbyrequest/README.md
+++ b/library/devices/adminbyrequest/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-adminbyreque
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-adminbyrequest --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install adminbyrequest --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-adminbyrequest skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-adminbyrequest. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/devices/adminbyrequest/SKILL.md
+++ b/library/devices/adminbyrequest/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `adminbyrequest-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install adminbyrequest --cli-only
+   npx -y @mvanhorn/printing-press-library install adminbyrequest --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `adminbyrequest-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/devices/adminbyrequest/cmd/adminbyrequest-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/devices/dreo/README.md
+++ b/library/devices/dreo/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dreo --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-dreo --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install dreo --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-dreo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dreo. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/devices/dreo/SKILL.md
+++ b/library/devices/dreo/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `dreo-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install dreo --cli-only
+   npx -y @mvanhorn/printing-press-library install dreo --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `dreo-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/devices/dreo/cmd/dreo-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/devices/hayward-omnilogic/README.md
+++ b/library/devices/hayward-omnilogic/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hayward-omni
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-hayward-omnilogic --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install hayward-omnilogic --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-hayward-omnilogic skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hayward-omnilogic. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/devices/hayward-omnilogic/SKILL.md
+++ b/library/devices/hayward-omnilogic/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `hayward-omnilogic-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install hayward-omnilogic --cli-only
+   npx -y @mvanhorn/printing-press-library install hayward-omnilogic --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `hayward-omnilogic-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/devices/hayward-omnilogic/cmd/hayward-omnilogic-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Pool sensor capabilities — configure once per site
 

--- a/library/devices/tesla/README.md
+++ b/library/devices/tesla/README.md
@@ -7,38 +7,43 @@ The Tesla owner-API as JSON-first commands, with a local SQLite that remembers e
 Learn more at [Tesla](https://owner-api.teslamotors.com).
 
 Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
-Contributors: [@ameshalexk](https://github.com/ameshalexk) (Amesh Alex Kuruvilla).
 
 ## Install
 
 The recommended path installs both the `tesla-pp-cli` binary and the `pp-tesla` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install tesla
+npx -y @mvanhorn/printing-press-library install tesla
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tesla --cli-only
+npx -y @mvanhorn/printing-press-library install tesla --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install tesla --skill-only
+npx -y @mvanhorn/printing-press-library install tesla --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install tesla --agent claude-code
-npx -y @mvanhorn/printing-press install tesla --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install tesla --agent claude-code
+npx -y @mvanhorn/printing-press-library install tesla --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/tesla/cmd/tesla-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -55,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tesla --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-tesla --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install tesla --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-tesla skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tesla. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -226,22 +233,17 @@ The same Fleet creds and the same enrolled key now work on both machines. The ca
 # Confirm auth and list your vehicle_id / VINs / energy sites. Run 'tesla auth login' first if needed (see Auth section above).
 tesla products --json
 
-
 # Confirm auth works and list your vehicle_id / VINs / energy site IDs.
 tesla products --json
-
 
 # Classify each vehicle: REST-OK (legacy) or signed-command-required (newer).
 tesla reachability --json
 
-
 # Capture a vehicle_data snapshot for every car; populates the local store for analytics.
 tesla snap --all --json
 
-
 # Single yes/no "can I leave?" with the blocker list.
 tesla ready 5YJ3E1EA6XXXXXXXX --json
-
 
 # Last 30 days of charging cost, home vs Supercharger split.
 tesla cost ledger --since 30d --json
@@ -443,7 +445,6 @@ Per-vehicle data, climate, locks, remote start, and Hermes telemetry token
 - **`tesla-pp-cli vehicles get-release-notes`** - Release notes for the current/queued software update
 - **`tesla-pp-cli vehicles get-service-data`** - Open service appointments and recent service history for this vehicle
 - **`tesla-pp-cli vehicles get-vehicle-data`** - Full vehicle state snapshot: charge, climate, drive, GUI, vehicle config, and software
-
 
 ## Output Formats
 

--- a/library/devices/tesla/SKILL.md
+++ b/library/devices/tesla/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `tesla-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install tesla --cli-only
+   npx -y @mvanhorn/printing-press-library install tesla --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `tesla-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/devices/tesla/cmd/tesla-pp-cli@latest
+```
 
-The Tesla owner-API as JSON-first commands, with a local SQLite that remembers every vehicle state. Get a single `ready` yes/no for departure, a tariff-aware charging cost ledger that replaces TeslaMate's Docker stack, and a supercharger queue watcher you can subscribe to from an agent. For 2018+ Models S/X and pre-2021 Models 3/Y, commands route end-to-end on plain REST; newer vehicles get a clear shim message via `tesla reachability`.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/devices/vestaboard/README.md
+++ b/library/devices/vestaboard/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-vestaboard -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-vestaboard --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install vestaboard --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-vestaboard skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-vestaboard. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -154,7 +156,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Read the board as text
 
 ```bash
@@ -212,7 +213,6 @@ Transition animation settings for the board (Flagship and Note devices).
 Vestaboard Markup Language (VBML) text formatting service.
 
 - **`vestaboard-pp-cli vbml`** - Convert a text string into a 2D array of Vestaboard character codes.
-
 
 ## Output Formats
 

--- a/library/devices/vestaboard/SKILL.md
+++ b/library/devices/vestaboard/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `vestaboard-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install vestaboard --cli-only
+   npx -y @mvanhorn/printing-press-library install vestaboard --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `vestaboard-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/devices/vestaboard/cmd/vestaboard-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Wraps the Vestaboard Cloud Read/Write API (read the current message, send text or character-code messages, control transitions) plus the VBML text formatter on its own host. The novel 'message preview' renders the live board as readable text, and 'characters' prints the code table so you can build character-array payloads by hand.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/devices/whoop/README.md
+++ b/library/devices/whoop/README.md
@@ -54,17 +54,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-whoop --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-whoop --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install whoop --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-whoop skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-whoop. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/devices/whoop/SKILL.md
+++ b/library/devices/whoop/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `whoop-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install whoop --cli-only
+   npx -y @mvanhorn/printing-press-library install whoop --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `whoop-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/devices/whoop/cmd/whoop-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/education/ankiweb/README.md
+++ b/library/education/ankiweb/README.md
@@ -6,7 +6,7 @@ Every existing Anki CLI wraps the desktop AnkiConnect add-on; none touches ankiw
 
 Learn more at [AnkiWeb](https://ankiweb.net).
 
-Printed by [@paulbockewitz](https://github.com/paulbockewitz) (Paul Bockewitz).
+Created by [@paulb](https://github.com/paulb) (Paul Bockewitz).
 
 ## Install
 
@@ -35,9 +35,15 @@ npx -y @mvanhorn/printing-press-library install ankiweb --agent claude-code
 npx -y @mvanhorn/printing-press-library install ankiweb --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/education/ankiweb/cmd/ankiweb-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ankiweb --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ankiweb --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ankiweb --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ankiweb skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ankiweb. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -196,7 +204,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Find the best audio-rich Spanish deck
 
 ```bash
@@ -248,7 +255,6 @@ Browse, search, and download public shared decks (no login required)
 - **`ankiweb-pp-cli shared download`** - Download a shared deck .apkg. NOTE: requires a signed ?t= token minted client-side (op=sdd); without it the endpoint returns 400/503.
 - **`ankiweb-pp-cli shared info`** - Full detail + reviews for one shared deck (protobuf response)
 - **`ankiweb-pp-cli shared search`** - Search the shared-deck catalog by keyword (protobuf response)
-
 
 ## Output Formats
 

--- a/library/education/ankiweb/SKILL.md
+++ b/library/education/ankiweb/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `ankiweb-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ankiweb --cli-only
+   npx -y @mvanhorn/printing-press-library install ankiweb --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ankiweb-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/education/ankiweb/cmd/ankiweb-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Every existing Anki CLI wraps the desktop AnkiConnect add-on; none touches ankiweb.net. AnkiWeb CLI talks directly to the website's service layer, decodes its protobuf responses, and keeps a local SQLite catalog so you can rank decks by approval rate, filter by audio coverage, compare candidates side by side, watch for new decks since your last sync, and add notes straight to your cloud collection.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/education/lawhub/README.md
+++ b/library/education/lawhub/README.md
@@ -87,17 +87,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-lawhub --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-lawhub --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install lawhub --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-lawhub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-lawhub. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/education/lawhub/SKILL.md
+++ b/library/education/lawhub/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `lawhub-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install lawhub --cli-only
+   npx -y @mvanhorn/printing-press-library install lawhub --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `lawhub-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/education/lawhub/cmd/lawhub-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Prerequisites
 

--- a/library/food-and-dining/allrecipes/README.md
+++ b/library/food-and-dining/allrecipes/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-allrecipes --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install allrecipes --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-allrecipes skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-allrecipes. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/allrecipes/SKILL.md
+++ b/library/food-and-dining/allrecipes/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `allrecipes-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install allrecipes --cli-only
+   npx -y @mvanhorn/printing-press-library install allrecipes --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `allrecipes-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/allrecipes/cmd/allrecipes-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/anylist/README.md
+++ b/library/food-and-dining/anylist/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-anylist --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-anylist --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install anylist --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-anylist skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-anylist. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/anylist/SKILL.md
+++ b/library/food-and-dining/anylist/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `anylist-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install anylist --cli-only
+   npx -y @mvanhorn/printing-press-library install anylist --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `anylist-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/anylist/cmd/anylist-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/coffee-goat/README.md
+++ b/library/food-and-dining/coffee-goat/README.md
@@ -64,17 +64,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-coffee-goat 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-coffee-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install coffee-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-coffee-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-coffee-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/coffee-goat/SKILL.md
+++ b/library/food-and-dining/coffee-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `coffee-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install coffee-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install coffee-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `coffee-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/coffee-goat/cmd/coffee-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/dominos/README.md
+++ b/library/food-and-dining/dominos/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-dominos --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install dominos --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-dominos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dominos. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/dominos/SKILL.md
+++ b/library/food-and-dining/dominos/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `dominos-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install dominos --cli-only
+   npx -y @mvanhorn/printing-press-library install dominos --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `dominos-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/dominos/cmd/dominos-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/food52/README.md
+++ b/library/food-and-dining/food52/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-food52 --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install food52 --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-food52 skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-food52. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/food-and-dining/food52/SKILL.md
+++ b/library/food-and-dining/food52/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `food52-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install food52 --cli-only
+   npx -y @mvanhorn/printing-press-library install food52 --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `food52-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/food52/cmd/food52-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/jimmy-johns/README.md
+++ b/library/food-and-dining/jimmy-johns/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-jimmy-johns 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-jimmy-johns --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install jimmy-johns --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-jimmy-johns skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-jimmy-johns. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/jimmy-johns/SKILL.md
+++ b/library/food-and-dining/jimmy-johns/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `jimmy-johns-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install jimmy-johns --cli-only
+   npx -y @mvanhorn/printing-press-library install jimmy-johns --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `jimmy-johns-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/jimmy-johns/cmd/jimmy-johns-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/ordertogo/README.md
+++ b/library/food-and-dining/ordertogo/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ordertogo --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ordertogo --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ordertogo --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ordertogo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ordertogo. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/ordertogo/SKILL.md
+++ b/library/food-and-dining/ordertogo/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `ordertogo-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ordertogo --cli-only
+   npx -y @mvanhorn/printing-press-library install ordertogo --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ordertogo-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/ordertogo/cmd/ordertogo-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/pagliacci/README.md
+++ b/library/food-and-dining/pagliacci/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pagliacci --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pagliacci --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pagliacci skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pagliacci. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/pagliacci/SKILL.md
+++ b/library/food-and-dining/pagliacci/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `pagliacci-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pagliacci --cli-only
+   npx -y @mvanhorn/printing-press-library install pagliacci --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pagliacci-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/pagliacci/cmd/pagliacci-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/rappi/README.md
+++ b/library/food-and-dining/rappi/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-rappi --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-rappi --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install rappi --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-rappi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-rappi. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/rappi/SKILL.md
+++ b/library/food-and-dining/rappi/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `rappi-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install rappi --cli-only
+   npx -y @mvanhorn/printing-press-library install rappi --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `rappi-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/rappi/cmd/rappi-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/recipe-goat/README.md
+++ b/library/food-and-dining/recipe-goat/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-recipe-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install recipe-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-recipe-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-recipe-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/recipe-goat/SKILL.md
+++ b/library/food-and-dining/recipe-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `recipe-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install recipe-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install recipe-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `recipe-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/recipe-goat/cmd/recipe-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/food-and-dining/table-reservation-goat/README.md
+++ b/library/food-and-dining/table-reservation-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-table-reserv
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-table-reservation-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install table-reservation-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-table-reservation-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-table-reservation-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/food-and-dining/table-reservation-goat/SKILL.md
+++ b/library/food-and-dining/table-reservation-goat/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `table-reservation-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install table-reservation-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install table-reservation-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `table-reservation-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/table-reservation-goat/cmd/table-reservation-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/food-and-dining/wolt/README.md
+++ b/library/food-and-dining/wolt/README.md
@@ -35,9 +35,15 @@ npx -y @mvanhorn/printing-press-library install wolt --agent claude-code
 npx -y @mvanhorn/printing-press-library install wolt --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/food-and-dining/wolt/cmd/wolt-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wolt --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-wolt --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install wolt --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-wolt skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wolt. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -156,7 +164,6 @@ Manage venues
 - **`wolt-pp-cli venues <slug>`** - Documented community endpoint. As of the last sniff, returns HTTP 200 with
 empty body via CloudFront cache. The CLI surfaces this honestly and includes
 --debug to capture the failing request for upstream investigation.
-
 
 ## Output Formats
 

--- a/library/food-and-dining/wolt/SKILL.md
+++ b/library/food-and-dining/wolt/SKILL.md
@@ -20,12 +20,12 @@ metadata:
 
 This skill drives the `wolt-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install wolt --cli-only
+   npx -y @mvanhorn/printing-press-library install wolt --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `wolt-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -33,13 +33,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/food-and-dining/wolt/cmd/wolt-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Browse-only Wolt consumer CLI. Lists cities, finds venues near a lat/lon,
-searches venues and items, and pulls per-venue delivery/ETA snapshots.
-
-Built on Wolt's unauthenticated consumer endpoints discovered via reverse
-engineering (OzTamir gist + live browser-sniff). No login, no cart, no orders.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/marketing/ahrefs/README.md
+++ b/library/marketing/ahrefs/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ahrefs --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ahrefs --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ahrefs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ahrefs. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/ahrefs/SKILL.md
+++ b/library/marketing/ahrefs/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `ahrefs-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ahrefs --cli-only
+   npx -y @mvanhorn/printing-press-library install ahrefs --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ahrefs-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/ahrefs/cmd/ahrefs-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/marketing/beehiiv/README.md
+++ b/library/marketing/beehiiv/README.md
@@ -54,17 +54,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-beehiiv --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-beehiiv --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install beehiiv --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-beehiiv skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-beehiiv. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/beehiiv/SKILL.md
+++ b/library/marketing/beehiiv/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `beehiiv-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install beehiiv --cli-only
+   npx -y @mvanhorn/printing-press-library install beehiiv --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `beehiiv-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/beehiiv/cmd/beehiiv-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/marketing/bento/README.md
+++ b/library/marketing/bento/README.md
@@ -11,31 +11,37 @@ Created by [@bossriceshark](https://github.com/bossriceshark) (bossriceshark).
 The recommended path installs both the `bento-pp-cli` binary and the `pp-bento` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install bento
+npx -y @mvanhorn/printing-press-library install bento
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install bento --cli-only
+npx -y @mvanhorn/printing-press-library install bento --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install bento --skill-only
+npx -y @mvanhorn/printing-press-library install bento --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install bento --agent claude-code
-npx -y @mvanhorn/printing-press install bento --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install bento --agent claude-code
+npx -y @mvanhorn/printing-press-library install bento --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/bento/cmd/bento-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-bento --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-bento --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install bento --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-bento skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-bento. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -331,7 +339,6 @@ Run `bento-pp-cli <command> --help` for full flag and argument details on any co
 | `bento feedback "<note>"` | Capture friction locally at `~/.bento-pp-cli/feedback.jsonl` (opt-in upstream POST via `--send`) |
 | `bento version` | Print version |
 | `bento completion <shell>` | Generate shell completion scripts |
-
 
 ## Output Formats
 

--- a/library/marketing/bento/SKILL.md
+++ b/library/marketing/bento/SKILL.md
@@ -18,16 +18,20 @@ metadata:
 
 This skill drives the `bento-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install bento --cli-only
+   npx -y @mvanhorn/printing-press-library install bento --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `bento-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/bento/cmd/bento-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/botsee/README.md
+++ b/library/marketing/botsee/README.md
@@ -11,31 +11,37 @@ Created by [@grahac](https://github.com/grahac) (grahac).
 The recommended path installs both the `botsee-pp-cli` binary and the `pp-botsee` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install botsee
+npx -y @mvanhorn/printing-press-library install botsee
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install botsee --cli-only
+npx -y @mvanhorn/printing-press-library install botsee --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install botsee --skill-only
+npx -y @mvanhorn/printing-press-library install botsee --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install botsee --agent claude-code
-npx -y @mvanhorn/printing-press install botsee --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install botsee --agent claude-code
+npx -y @mvanhorn/printing-press-library install botsee --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/botsee/cmd/botsee-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-botsee --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-botsee --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install botsee --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-botsee skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-botsee. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -111,18 +119,14 @@ BotSee uses Bearer tokens prefixed `bts_live_`. Set `BOTSEE_API_KEY` in your env
 # Verify auth, reachability, and remaining rate-limit budget
 botsee-pp-cli doctor
 
-
 # Flagship — bootstrap a new site, run analysis, print results. Idempotent: a second run on the same domain reuses the existing site and just runs a fresh analysis.
 botsee-pp-cli ai-visibility-audit example.com --types 2 --personas 2 --questions 5 --watch
-
 
 # Inspect the customer-types / personas / questions tree for the site (with copy-paste edit commands)
 botsee-pp-cli site-config --site $SITE_UUID --agent
 
-
 # Generate next-step recommendations from the analysis (cached locally)
 botsee-pp-cli recommendations $ANALYSIS_UUID --agent
-
 
 # Cross-site cited-source rollup — useful once you've audited multiple domains
 botsee-pp-cli sites-summary --agent
@@ -273,7 +277,6 @@ Manage webhooks
 - **`botsee-pp-cli webhooks delete`** - Deletes a webhook. Returns 204 No Content on success.
 - **`botsee-pp-cli webhooks list`** - Lists all registered webhooks for the organization.
 - **`botsee-pp-cli webhooks list-events`** - Returns the catalog of event types this API can emit, with JSON Schemas per event. Use this to self-discover available events programmatically without parsing the full OpenAPI doc.
-
 
 ## Output Formats
 

--- a/library/marketing/botsee/SKILL.md
+++ b/library/marketing/botsee/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `botsee-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install botsee --cli-only
+   npx -y @mvanhorn/printing-press-library install botsee --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `botsee-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/marketing/botsee/cmd/botsee-pp-cli@latest
+```
 
-BotSee is the API-first GEO platform; this CLI is the API-first front door. The flagship `ai-visibility-audit <url>` mirrors the proven Python create-site+analyze flow as a single idempotent Go command. The other 64 commands cover the entire BotSee surface (CRUD on sites/customer-types/personas/questions, the full analysis lifecycle, recommendations, blog content, billing, signup including USDC/x402, webhooks, api-key rotation, usage) plus framework commands (sync/search/sql/doctor) over a local SQLite cache.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/clarity/README.md
+++ b/library/marketing/clarity/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-clarity --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-clarity --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install clarity --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-clarity skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-clarity. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/clarity/SKILL.md
+++ b/library/marketing/clarity/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `clarity-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install clarity --cli-only
+   npx -y @mvanhorn/printing-press-library install clarity --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `clarity-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/clarity/cmd/clarity-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/customer-io/README.md
+++ b/library/marketing/customer-io/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-customer-io 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-customer-io --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install customer-io --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-customer-io skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-customer-io. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/customer-io/SKILL.md
+++ b/library/marketing/customer-io/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `customer-io-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install customer-io --cli-only
+   npx -y @mvanhorn/printing-press-library install customer-io --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `customer-io-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/customer-io/cmd/customer-io-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/dub/README.md
+++ b/library/marketing/dub/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-dub --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install dub --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-dub skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dub. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/dub/SKILL.md
+++ b/library/marketing/dub/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `dub-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install dub --cli-only
+   npx -y @mvanhorn/printing-press-library install dub --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `dub-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/dub/cmd/dub-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/emailoctopus/README.md
+++ b/library/marketing/emailoctopus/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-emailoctopus
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-emailoctopus --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install emailoctopus --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-emailoctopus skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-emailoctopus. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/emailoctopus/SKILL.md
+++ b/library/marketing/emailoctopus/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `emailoctopus-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install emailoctopus --cli-only
+   npx -y @mvanhorn/printing-press-library install emailoctopus --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `emailoctopus-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/emailoctopus/cmd/emailoctopus-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/erank/README.md
+++ b/library/marketing/erank/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-erank --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-erank --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install erank --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-erank skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-erank. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -197,7 +199,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Compact top listings for an agent
 
 ```bash
@@ -315,7 +316,6 @@ Operations on daily
 Operations on last-refresh
 
 - **`erank-pp-cli refresh-data`** - GET /api/refresh-data/listings/last-refresh
-
 
 ## Output Formats
 

--- a/library/marketing/erank/SKILL.md
+++ b/library/marketing/erank/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `erank-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install erank --cli-only
+   npx -y @mvanhorn/printing-press-library install erank --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `erank-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/erank/cmd/erank-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Use eRank from a terminal to capture keyword stats, top listings, tags, related searches, and keyword lists in agent-ready formats. The CLI adds opportunity scoring, drift detection, and listing-gap analysis on top of the captured Keyword Tool workflow.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/everbee/README.md
+++ b/library/marketing/everbee/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-everbee --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-everbee --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install everbee --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-everbee skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-everbee. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -208,7 +210,6 @@ Insight commands read local research snapshots first. If matching data is missin
 
 ## Recipes
 
-
 ### Narrow product analytics for agents
 
 ```bash
@@ -276,7 +277,6 @@ Operations on default_product_analytics
 Operations on shops
 
 - **`everbee-pp-cli shops`** - GET /shops
-
 
 ## Output Formats
 

--- a/library/marketing/everbee/SKILL.md
+++ b/library/marketing/everbee/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `everbee-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install everbee --cli-only
+   npx -y @mvanhorn/printing-press-library install everbee --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `everbee-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/everbee/cmd/everbee-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-EverBee is strongest inside an interactive browser. This CLI turns captured product analytics, shop analyzer, and keyword research workflows into repeatable commands with JSON, local snapshots, search, SQL, and cross-workflow opportunity scoring.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/google-ads/README.md
+++ b/library/marketing/google-ads/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-google-ads -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-google-ads --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install google-ads --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-google-ads skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-google-ads. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/google-ads/SKILL.md
+++ b/library/marketing/google-ads/SKILL.md
@@ -21,12 +21,12 @@ metadata:
 
 This skill drives the `google-ads-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install google-ads --cli-only
+   npx -y @mvanhorn/printing-press-library install google-ads --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `google-ads-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -34,7 +34,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/google-ads/cmd/google-ads-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/marketing/google-search-console/README.md
+++ b/library/marketing/google-search-console/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-google-searc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-google-search-console --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install google-search-console --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-google-search-console skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-google-search-console. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/google-search-console/SKILL.md
+++ b/library/marketing/google-search-console/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `google-search-console-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install google-search-console --cli-only
+   npx -y @mvanhorn/printing-press-library install google-search-console --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `google-search-console-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/google-search-console/cmd/google-search-console-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/kit/README.md
+++ b/library/marketing/kit/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-kit --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-kit --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install kit --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-kit skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-kit. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/kit/SKILL.md
+++ b/library/marketing/kit/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `kit-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install kit --cli-only
+   npx -y @mvanhorn/printing-press-library install kit --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `kit-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/kit/cmd/kit-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Agentic Kit Workflows
 

--- a/library/marketing/klaviyo/README.md
+++ b/library/marketing/klaviyo/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-klaviyo --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install klaviyo --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-klaviyo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-klaviyo. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/klaviyo/SKILL.md
+++ b/library/marketing/klaviyo/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `klaviyo-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install klaviyo --cli-only
+   npx -y @mvanhorn/printing-press-library install klaviyo --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `klaviyo-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/klaviyo/cmd/klaviyo-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/mailchimp/README.md
+++ b/library/marketing/mailchimp/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-mailchimp --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-mailchimp --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install mailchimp --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-mailchimp skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-mailchimp. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/mailchimp/SKILL.md
+++ b/library/marketing/mailchimp/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `mailchimp-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install mailchimp --cli-only
+   npx -y @mvanhorn/printing-press-library install mailchimp --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `mailchimp-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/mailchimp/cmd/mailchimp-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/meta-ads/README.md
+++ b/library/marketing/meta-ads/README.md
@@ -6,7 +6,7 @@ Read-only insights CLI for Meta Marketing API focused on creative-fatigue detect
 
 Learn more at [Meta Ads](https://developers.facebook.com/docs/marketing-api).
 
-Printed by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
+Created by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
 
 ## Install
 
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-meta-ads --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-meta-ads --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install meta-ads --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-meta-ads skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-meta-ads. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -203,7 +205,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Triage creative fatigue across a campaign
 
 ```bash
@@ -310,7 +311,6 @@ Manage me
 
 - **`meta-ads-pp-cli me`** - Returns every ad account the access token has been granted access to.
 Use this on first run to discover which accounts you can query.
-
 
 ## Output Formats
 

--- a/library/marketing/meta-ads/SKILL.md
+++ b/library/marketing/meta-ads/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `meta-ads-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install meta-ads --cli-only
+   npx -y @mvanhorn/printing-press-library install meta-ads --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `meta-ads-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/meta-ads/cmd/meta-ads-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Read-only insights CLI for Meta Marketing API focused on creative-fatigue detection, audience overlap analysis, and attribution forensics. Daily insights land in a local SQLite store so commands like `fatigue`, `decay`, `learning`, and `reconcile` can join across history. Single META_ACCESS_TOKEN env var with `ads_read` scope.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/producthunt/README.md
+++ b/library/marketing/producthunt/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-producthunt --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install producthunt --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-producthunt skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-producthunt. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/producthunt/SKILL.md
+++ b/library/marketing/producthunt/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `producthunt-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install producthunt --cli-only
+   npx -y @mvanhorn/printing-press-library install producthunt --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `producthunt-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/producthunt/cmd/producthunt-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/semrush/README.md
+++ b/library/marketing/semrush/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-semrush --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-semrush --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install semrush --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-semrush skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-semrush. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -233,7 +235,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Monday baseline + Friday diff
 
@@ -427,7 +428,6 @@ URL-level analytics: overview, organic/paid keywords
 - **`semrush-pp-cli url overview-all`** - URL Overview (all databases). 10 units/line.
 - **`semrush-pp-cli url overview-history`** - URL Overview (history). 10 units/line. Monthly historical rankings for a URL.
 - **`semrush-pp-cli url paid-keywords`** - URL Paid Search Keywords. 30 units/line. Keywords this URL has been advertised against.
-
 
 ## Output Formats
 

--- a/library/marketing/semrush/SKILL.md
+++ b/library/marketing/semrush/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `semrush-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install semrush --cli-only
+   npx -y @mvanhorn/printing-press-library install semrush --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `semrush-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/semrush/cmd/semrush-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Wraps the Semrush v3 Analytics + Projects APIs with a real local store so weekly drift, keyword gap, backlink gap, and Site Audit triage become one-shot queries instead of multi-tab CSV diffs. Every API unit you spend is logged to a queryable budget ledger, and offline FTS5 search over everything you've ever synced means follow-up questions cost zero credits.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/stackadapt/README.md
+++ b/library/marketing/stackadapt/README.md
@@ -4,7 +4,7 @@
 
 StackAdapt is a programmatic advertising platform. This read-only CLI queries your advertisers, campaigns, ads, audiences, and delivery reporting straight from the StackAdapt GraphQL API and answers questions the dashboard shows one screen at a time and the warehouse connectors only dump raw rows for: which campaigns are under-pacing, whose CTR has drifted, where budget is being wasted. It does not change anything in StackAdapt (read-only); it tells you what your campaigns are doing.
 
-Printed by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
+Created by [@sdhilip200](https://github.com/sdhilip200) (Dhilip Subramanian).
 
 ## Install
 
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-stackadapt -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-stackadapt --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install stackadapt --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-stackadapt skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-stackadapt. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -211,7 +213,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Find under-pacing campaigns
 
 ```bash
@@ -255,7 +256,6 @@ Run `stackadapt-pp-cli --help` for the full command reference and flag list.
 Raw GraphQL query passthrough (advanced; prefer the typed commands)
 
 - **`stackadapt-pp-cli graphql`** - Execute a raw GraphQL query against the StackAdapt API
-
 
 ## Output Formats
 

--- a/library/marketing/stackadapt/SKILL.md
+++ b/library/marketing/stackadapt/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `stackadapt-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install stackadapt --cli-only
+   npx -y @mvanhorn/printing-press-library install stackadapt --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `stackadapt-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/stackadapt/cmd/stackadapt-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-StackAdapt is a programmatic advertising platform. This read-only CLI queries your advertisers, campaigns, ads, audiences, and delivery reporting straight from the StackAdapt GraphQL API and answers questions the dashboard shows one screen at a time and the warehouse connectors only dump raw rows for: which campaigns are under-pacing, whose CTR has drifted, where budget is being wasted. It does not change anything in StackAdapt (read-only); it tells you what your campaigns are doing.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/trendhunter/README.md
+++ b/library/marketing/trendhunter/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-trendhunter 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-trendhunter --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install trendhunter --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-trendhunter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trendhunter. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/trendhunter/SKILL.md
+++ b/library/marketing/trendhunter/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `trendhunter-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install trendhunter --cli-only
+   npx -y @mvanhorn/printing-press-library install trendhunter --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `trendhunter-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/trendhunter/cmd/trendhunter-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/marketing/trustpilot/README.md
+++ b/library/marketing/trustpilot/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-trustpilot -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-trustpilot --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install trustpilot --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-trustpilot skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-trustpilot. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/marketing/trustpilot/SKILL.md
+++ b/library/marketing/trustpilot/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `trustpilot-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install trustpilot --cli-only
+   npx -y @mvanhorn/printing-press-library install trustpilot --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `trustpilot-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/marketing/trustpilot/cmd/trustpilot-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/archive-is/README.md
+++ b/library/media-and-entertainment/archive-is/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-archive-is --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install archive-is --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-archive-is skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-archive-is. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Quick Start
 

--- a/library/media-and-entertainment/archive-is/SKILL.md
+++ b/library/media-and-entertainment/archive-is/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `archive-is-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install archive-is --cli-only
+   npx -y @mvanhorn/printing-press-library install archive-is --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `archive-is-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/archive-is/cmd/archive-is-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/art-goat/README.md
+++ b/library/media-and-entertainment/art-goat/README.md
@@ -30,22 +30,40 @@ Pull all of them with `art-goat-pp-cli sources sync`, or scope to one with `--so
 
 ## Install
 
-The recommended path installs both the `art-goat-pp-cli` binary and the `pp-art-goat` agent skill in one shot:
+The recommended path installs both the `art-goat-pp-cli` binary and the `pp-art-goat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install art-goat
+npx -y @mvanhorn/printing-press-library install art-goat
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install art-goat --cli-only
+npx -y @mvanhorn/printing-press-library install art-goat --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install art-goat --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install art-goat --agent claude-code
+npx -y @mvanhorn/printing-press-library install art-goat --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/art-goat/cmd/art-goat-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -62,17 +80,56 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-art-goat --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-art-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install art-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-art-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-art-goat. The skill defines how its required CLI can be installed.
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/art-goat-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `ART_GOAT_API_KEY` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "art-goat": {
+      "command": "art-goat-pp-mcp",
+      "env": {
+        "ART_GOAT_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
 ```
+
+</details>
 
 ## Authentication
 
@@ -84,18 +141,14 @@ Anonymous out of the box. AIC, Met, Cleveland, and NPM Taiwan need no key. NASA 
 # Populate the local corpus across all configured sources (AIC, APOD, Met, Cleveland, Harvard, Smithsonian, NPM Taiwan). Anonymous; no setup wall.
 art-goat-pp-cli sources sync
 
-
 # Today's curated piece — opinionated against your practice, with a one-line 'why this today'.
 art-goat-pp-cli today
-
 
 # Sit with a random piece. Image opens in your browser; reflection captured in terminal.
 art-goat-pp-cli sit
 
-
 # See breadth, variety, region coverage, mood drift. Streak available at the bottom if you want to know.
 art-goat-pp-cli journal stats
-
 
 # Step laterally from one piece to another across the corpus.
 art-goat-pp-cli similar aic:24645 --json --select source,title,creator
@@ -215,7 +268,6 @@ Manage planetary
 
 - **`art-goat-pp-cli planetary apod-get`** - Fetch the Astronomy Picture of the Day for a given date or date range. Anonymous via DEMO_KEY.
 
-
 ## Output Formats
 
 ```bash
@@ -248,69 +300,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-art-goat -g
-```
-
-Then invoke `/pp-art-goat <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add art-goat art-goat-pp-mcp -e ART_GOAT_API_KEY=<your-key>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/art-goat-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `ART_GOAT_API_KEY` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "art-goat": {
-      "command": "art-goat-pp-mcp",
-      "env": {
-        "ART_GOAT_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/media-and-entertainment/art-goat/SKILL.md
+++ b/library/media-and-entertainment/art-goat/SKILL.md
@@ -18,20 +18,20 @@ metadata:
 
 This skill drives the `art-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install art-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install art-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `art-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/art-goat/cmd/art-goat-pp-cli@latest
+```
 
-art-goat is an OmniMuseum aggregator. Eight open-access museum and astronomy sources — Art Institute of Chicago, NASA APOD, Metropolitan Museum of Art, Cleveland Museum of Art, Rijksmuseum, Smithsonian Open Access, Te Papa Tongarewa, and the National Palace Museum Taiwan — collapse into one local SQLite corpus that drives a daily contemplative practice. Sit with one piece for a fixed period, capture your reflection, and let an opinionated `today` pick rotate against your recent practice. The contemplative spine (`sit`, `today`, `path`, `journal`) is the soul; the federated cross-source commands (`browse`, `similar`, `compare`, `artist --arc`, `presence`, `random`) ride alongside it.
-
-The point of the eight-source aggregation is not catalog completeness in any one museum — it's that one daily practice ranges across a federated corpus. `today` rotates source/region/medium against your recent sits; `path --theme` walks a theme through the federation; `artist --arc` reads a creator across museums as a stylistic narrative. Most invocations should not need to choose a specific source.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/bandsintown/README.md
+++ b/library/media-and-entertainment/bandsintown/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-bandsintown 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-bandsintown --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install bandsintown --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-bandsintown skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-bandsintown. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/bandsintown/SKILL.md
+++ b/library/media-and-entertainment/bandsintown/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `bandsintown-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install bandsintown --cli-only
+   npx -y @mvanhorn/printing-press-library install bandsintown --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `bandsintown-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/bandsintown/cmd/bandsintown-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/blu-ray/README.md
+++ b/library/media-and-entertainment/blu-ray/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-blu-ray --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-blu-ray --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install blu-ray --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-blu-ray skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-blu-ray. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/blu-ray/SKILL.md
+++ b/library/media-and-entertainment/blu-ray/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `blu-ray-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install blu-ray --cli-only
+   npx -y @mvanhorn/printing-press-library install blu-ray --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `blu-ray-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/blu-ray/cmd/blu-ray-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/dice-fm/README.md
+++ b/library/media-and-entertainment/dice-fm/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-dice-fm --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-dice-fm --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install dice-fm --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-dice-fm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-dice-fm. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -265,7 +267,6 @@ Run `dice-fm-pp-cli <command> --help` for the full flag list on any command.
 | `tail` | Stream live changes by polling the API at intervals |
 | `doctor` | Check auth, config, and connectivity |
 | `import` | Import data from a JSONL file via API create/upsert calls |
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/dice-fm/SKILL.md
+++ b/library/media-and-entertainment/dice-fm/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `dice-fm-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install dice-fm --cli-only
+   npx -y @mvanhorn/printing-press-library install dice-fm --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `dice-fm-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/dice-fm/cmd/dice-fm-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The DICE Partners GraphQL API gives promoters access to their ticket, fan, and order data — but only one event at a time, only through a web dashboard or raw API calls. This CLI syncs all your data locally and unlocks cross-event analytics: who are your repeat buyers, what's your real net revenue, which events have anomalous refund rates, who's valid at the door tonight.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/digg/README.md
+++ b/library/media-and-entertainment/digg/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-digg --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-digg --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install digg --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-digg skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-digg. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/digg/SKILL.md
+++ b/library/media-and-entertainment/digg/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `digg-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install digg --cli-only
+   npx -y @mvanhorn/printing-press-library install digg --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `digg-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/digg/cmd/digg-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/drudgereport/README.md
+++ b/library/media-and-entertainment/drudgereport/README.md
@@ -11,31 +11,37 @@ Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 The recommended path installs both the `drudgereport-pp-cli` binary and the `pp-drudgereport` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install drudgereport
+npx -y @mvanhorn/printing-press-library install drudgereport
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install drudgereport --cli-only
+npx -y @mvanhorn/printing-press-library install drudgereport --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install drudgereport --skill-only
+npx -y @mvanhorn/printing-press-library install drudgereport --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install drudgereport --agent claude-code
-npx -y @mvanhorn/printing-press install drudgereport --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install drudgereport --agent claude-code
+npx -y @mvanhorn/printing-press-library install drudgereport --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/drudgereport/cmd/drudgereport-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-drudgereport
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-drudgereport --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install drudgereport --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-drudgereport skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-drudgereport. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -103,22 +111,17 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # the one command an agent should reach for first when asked 'what's on Drudge?'
 drudgereport splash --json
 
-
 # every red headline right now, ordered by slot
 drudgereport breaking --json
-
 
 # ranked headlines in agent-shaped form
 drudgereport headlines --limit 10 --json --select title,slot,is_red,url
 
-
 # snapshot the current page into local SQLite so tail/tenure/on-date have history to draw on
 drudgereport sync
 
-
 # what got promoted, demoted, or went red in the last 6 hours
 drudgereport tail --since 6h --json
-
 
 # longest-tenured splashes the CLI has observed
 drudgereport tenure --history --json
@@ -222,7 +225,6 @@ Unofficial community RSS feed mirror of Drudge Report (feedpress.me). Used as a 
 Drudge Report's curated home page. Most users should run `sync` then `splash`/`headlines`/`breaking`; the raw fetch is exposed for debugging.
 
 - **`drudgereport-pp-cli page`** - Fetch the raw drudgereport.com HTML page. The CLI's parser turns this into ranked headlines with slot, is_red, image_url, and outbound_domain fields. Most users do not need to call this directly.
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/drudgereport/SKILL.md
+++ b/library/media-and-entertainment/drudgereport/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `drudgereport-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install drudgereport --cli-only
+   npx -y @mvanhorn/printing-press-library install drudgereport --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `drudgereport-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/drudgereport/cmd/drudgereport-pp-cli@latest
+```
 
-Read Drudge's lead, breaking-red items, and ranked headlines in one bounded JSON call. Keep a local SQLite snapshot history so you can answer 'what's changed since I checked,' 'how long has that been the splash,' and 'what was Drudge leading with on Tuesday' — none of which the live site supports.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/espn/README.md
+++ b/library/media-and-entertainment/espn/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-espn --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install espn --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-espn skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-espn. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/media-and-entertainment/espn/SKILL.md
+++ b/library/media-and-entertainment/espn/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `espn-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install espn --cli-only
+   npx -y @mvanhorn/printing-press-library install espn --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `espn-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/espn/cmd/espn-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/eventbrite/README.md
+++ b/library/media-and-entertainment/eventbrite/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-eventbrite -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-eventbrite --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install eventbrite --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-eventbrite skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-eventbrite. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -208,7 +210,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Find your slowest-selling live events
 
 ```bash
@@ -266,7 +267,6 @@ Run `eventbrite-pp-cli --help` for the full command reference and flag list.
 ### balance
 
 Manage balance
-
 
 ### categories
 
@@ -437,7 +437,6 @@ Information from expansions fields are not normally returned when requesting inf
 | `checkout_settings   `    | `checkout_settings`   | Event checkout and payment settings.                                                                                                                                                                                                                     |
 | `listing_properties`      | `listing_properties`  | Display/listing details about the event                                                                                                                                                                                                                  |
 | `has_digital_content`     | `has_digital_content` | Whether or not an event [Has Digital Content](#has_digital_content_object)                                                                                                                                                                                                   |
-
 
 ### events
 
@@ -733,7 +732,6 @@ Use these fields to specify information about an Organization.
 | `image_id` | `string` | (Optional) ID of the image for an Organization.                                                                                                          |
 | `vertical` | `string` | Type of business vertical within which this Organization operates. Currently, the only values are `default` and `music`. If not specified, the value is `default`. |
 
-
 ### pricing
 
 <a name="Pricing_object"></a>
@@ -865,7 +863,6 @@ For more information regarding deprecated APIs, refer to our [changelog](https:/
 > Warning: Access to this API will be no longer usable on June 1st, 2020.
 
 For more information regarding deprecated APIs, refer to our [changelog](https://www.eventbrite.com/platform/docs/changelog).
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/eventbrite/SKILL.md
+++ b/library/media-and-entertainment/eventbrite/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `eventbrite-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install eventbrite --cli-only
+   npx -y @mvanhorn/printing-press-library install eventbrite --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `eventbrite-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/eventbrite/cmd/eventbrite-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Existing Eventbrite tools wrap a handful of event CRUD calls one event at a time. This CLI mirrors the full v3 organizer API and syncs your events, orders, attendees, ticket classes, and discounts into a local SQLite store, then layers cross-event analytics on top: sales-velocity ranks your live events by sell rate, repeat-attendees surfaces returning fans across your whole history, and org-rollup gives agencies a single pane across every client organization.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/goodreads/README.md
+++ b/library/media-and-entertainment/goodreads/README.md
@@ -14,11 +14,11 @@ or raw Kindle highlight text.
 
 Learn more at [Goodreads](https://www.goodreads.com).
 
-Printed by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
+Created by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
 
 ## Install
 
-The recommended path installs both the `goodreads-pp-cli` binary and the `pp-goodreads` agent skill for the supported harnesses (Claude Code, Codex, OpenClaw, and Hermes) in one shot:
+The recommended path installs both the `goodreads-pp-cli` binary and the `pp-goodreads` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
 npx -y @mvanhorn/printing-press-library install goodreads
@@ -43,9 +43,15 @@ npx -y @mvanhorn/printing-press-library install goodreads --agent claude-code
 npx -y @mvanhorn/printing-press-library install goodreads --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/goodreads/cmd/goodreads-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -62,17 +68,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-goodreads --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-goodreads --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install goodreads --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-goodreads skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-goodreads. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -344,7 +352,6 @@ Inspect Goodreads most-followed people discovery
 Plan custom Goodreads shelf creation
 
 - **`goodreads-pp-cli user-shelves`** - Create a custom user shelf.
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/goodreads/SKILL.md
+++ b/library/media-and-entertainment/goodreads/SKILL.md
@@ -18,25 +18,20 @@ metadata:
 
 This skill drives the `goodreads-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install goodreads --cli-only
+   npx -y @mvanhorn/printing-press-library install goodreads --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `goodreads-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/goodreads/cmd/goodreads-pp-cli@latest
+```
 
-This is an evidence-backed starting map for a future Goodreads CLI. Goodreads has no current
-public developer API, so these routes are reverse-engineered from the logged-in web app.
-
-Evidence was captured on 2026-05-22 with browser-harness-js. Raw artifacts live under
-goodreads/proofs/ and are mode 0600 because they contain account-visible metadata.
-
-This spec intentionally does not include cookies, CSRF tokens, request headers, response bodies,
-or raw Kindle highlight text.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## HTTP Transport
 

--- a/library/media-and-entertainment/google-photos/README.md
+++ b/library/media-and-entertainment/google-photos/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-google-photo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-google-photos --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install google-photos --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-google-photos skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-google-photos. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/google-photos/SKILL.md
+++ b/library/media-and-entertainment/google-photos/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `google-photos-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install google-photos --cli-only
+   npx -y @mvanhorn/printing-press-library install google-photos --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `google-photos-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/google-photos/cmd/google-photos-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/media-and-entertainment/hackernews/README.md
+++ b/library/media-and-entertainment/hackernews/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-hackernews --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install hackernews --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-hackernews skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hackernews. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/hackernews/SKILL.md
+++ b/library/media-and-entertainment/hackernews/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `hackernews-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install hackernews --cli-only
+   npx -y @mvanhorn/printing-press-library install hackernews --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `hackernews-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/hackernews/cmd/hackernews-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/icloud/README.md
+++ b/library/media-and-entertainment/icloud/README.md
@@ -8,7 +8,6 @@ directly — no Photos.app launch, no API token, no network calls.
 ---
 
 Created by [@matysanchez](https://github.com/matysanchez) (Matias Sanchez Moises).
-Contributors: [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn), [@tmchow](https://github.com/tmchow) (Trevin Chow).
 
 ## Install
 
@@ -62,17 +61,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-icloud --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-icloud --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install icloud --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-icloud skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-icloud. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Quick start
 

--- a/library/media-and-entertainment/icloud/SKILL.md
+++ b/library/media-and-entertainment/icloud/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `icloud-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install icloud --cli-only
+   npx -y @mvanhorn/printing-press-library install icloud --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `icloud-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/icloud/cmd/icloud-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Pre-flight Check
 

--- a/library/media-and-entertainment/marginalrevolution/README.md
+++ b/library/media-and-entertainment/marginalrevolution/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-marginalrevo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-marginalrevolution --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install marginalrevolution --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-marginalrevolution skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-marginalrevolution. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/marginalrevolution/SKILL.md
+++ b/library/media-and-entertainment/marginalrevolution/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `marginalrevolution-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install marginalrevolution --cli-only
+   npx -y @mvanhorn/printing-press-library install marginalrevolution --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `marginalrevolution-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/marginalrevolution/cmd/marginalrevolution-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/mobalytics-lol/README.md
+++ b/library/media-and-entertainment/mobalytics-lol/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-mobalytics-l
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-mobalytics-lol --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install mobalytics-lol --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-mobalytics-lol skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-mobalytics-lol. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -113,18 +115,14 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # Hydrate the local store with the latest patch's champions, items, runes, tier snapshots, builds, and matchups
 mobalytics-lol-pp-cli sync --full
 
-
 # Look up the recommended Aatrox top build for Emerald+ — the single most common ritual
 mobalytics-lol-pp-cli champion build aatrox
-
 
 # Diamond+ mid-lane tier list with WR/PR/BR
 mobalytics-lol-pp-cli tier-list --role mid
 
-
 # Pool-vs-pool matchup matrix coaches do in their head
 mobalytics-lol-pp-cli counter-pool --our darius,aatrox,garen --their fiora,sett,renekton
-
 
 # What moved up or down since two patches ago
 mobalytics-lol-pp-cli meta-shift --since-patch 14.10 --agent --select winner,loser,delta
@@ -218,14 +216,12 @@ Run `mobalytics-lol-pp-cli --help` for the full command reference and flag list.
 
 Manage cdn
 
-
 ### versions-json
 
 Manage versions json
 
 - **`mobalytics-lol-pp-cli versions-json`** - Returns the full list of LoL patch versions known to Data Dragon, newest
 first. The first element is the current patch.
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/mobalytics-lol/SKILL.md
+++ b/library/media-and-entertainment/mobalytics-lol/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `mobalytics-lol-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install mobalytics-lol --cli-only
+   npx -y @mvanhorn/printing-press-library install mobalytics-lol --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `mobalytics-lol-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/mobalytics-lol/cmd/mobalytics-lol-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-mobalytics-lol-pp-cli pulls champion data, builds, runes, counters, and tier ratings from Mobalytics and Riot Data Dragon, hydrates them into a local SQLite store, then exposes cross-champion SQL queries no aggregator page surfaces: counter-pool matrices, patch meta-shift deltas, head-to-head compares, region-split tier views, and ARAM batch item-set exports for the LoL client. Free, offline-after-sync, agent-native (--json + --select + --agent), and the only LoL data source agentically accessible without a headless browser.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/movie-goat/README.md
+++ b/library/media-and-entertainment/movie-goat/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-movie-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install movie-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-movie-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-movie-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/movie-goat/SKILL.md
+++ b/library/media-and-entertainment/movie-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `movie-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install movie-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install movie-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `movie-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/movie-goat/cmd/movie-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/nasa-images/README.md
+++ b/library/media-and-entertainment/nasa-images/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nasa-images 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-nasa-images --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install nasa-images --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-nasa-images skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nasa-images. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/nasa-images/SKILL.md
+++ b/library/media-and-entertainment/nasa-images/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `nasa-images-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install nasa-images --cli-only
+   npx -y @mvanhorn/printing-press-library install nasa-images --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `nasa-images-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/nasa-images/cmd/nasa-images-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/podcast-goat/README.md
+++ b/library/media-and-entertainment/podcast-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-podcast-goat
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-podcast-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install podcast-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-podcast-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-podcast-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/podcast-goat/SKILL.md
+++ b/library/media-and-entertainment/podcast-goat/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `podcast-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install podcast-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install podcast-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `podcast-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/podcast-goat/cmd/podcast-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/podscan/README.md
+++ b/library/media-and-entertainment/podscan/README.md
@@ -59,17 +59,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-podscan --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-podscan --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install podscan --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-podscan skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-podscan. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/podscan/SKILL.md
+++ b/library/media-and-entertainment/podscan/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `podscan-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install podscan --cli-only
+   npx -y @mvanhorn/printing-press-library install podscan --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `podscan-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/podscan/cmd/podscan-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/media-and-entertainment/pokeapi/README.md
+++ b/library/media-and-entertainment/pokeapi/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pokeapi --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pokeapi --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pokeapi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pokeapi. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/media-and-entertainment/pokeapi/SKILL.md
+++ b/library/media-and-entertainment/pokeapi/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `pokeapi-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pokeapi --cli-only
+   npx -y @mvanhorn/printing-press-library install pokeapi --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pokeapi-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/pokeapi/cmd/pokeapi-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/setlist-fm/README.md
+++ b/library/media-and-entertainment/setlist-fm/README.md
@@ -5,7 +5,6 @@
 Setlist.fm rate-limits to 2 requests per second and 1,440 per day, which makes any real analytics workflow impossible against the live API. This CLI syncs an artist's full setlist history to a local SQLite store once, then runs every transcendence query — predict, overdue, tour shape, song gap, covers, attended stats — instantly and offline. Six SDK wrappers exist across five languages; none of them store anything. This one does.
 
 Created by [@davemorin](https://github.com/davemorin) (Dave Morin).
-Contributors: [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
@@ -59,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-setlist-fm -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-setlist-fm --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install setlist-fm --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-setlist-fm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-setlist-fm. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/setlist-fm/SKILL.md
+++ b/library/media-and-entertainment/setlist-fm/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `setlist-fm-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install setlist-fm --cli-only
+   npx -y @mvanhorn/printing-press-library install setlist-fm --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `setlist-fm-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/setlist-fm/cmd/setlist-fm-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/skool/README.md
+++ b/library/media-and-entertainment/skool/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-skool --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-skool --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install skool --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-skool skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-skool. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/skool/SKILL.md
+++ b/library/media-and-entertainment/skool/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `skool-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install skool --cli-only
+   npx -y @mvanhorn/printing-press-library install skool --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `skool-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/skool/cmd/skool-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/spotify/README.md
+++ b/library/media-and-entertainment/spotify/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-spotify --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-spotify --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install spotify --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-spotify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-spotify. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/spotify/SKILL.md
+++ b/library/media-and-entertainment/spotify/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `spotify-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install spotify --cli-only
+   npx -y @mvanhorn/printing-press-library install spotify --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `spotify-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/spotify/cmd/spotify-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/steam-web/README.md
+++ b/library/media-and-entertainment/steam-web/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-steam-web --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install steam-web --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-steam-web skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-steam-web. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/steam-web/SKILL.md
+++ b/library/media-and-entertainment/steam-web/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `steam-web-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install steam-web --cli-only
+   npx -y @mvanhorn/printing-press-library install steam-web --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `steam-web-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/steam-web/cmd/steam-web-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/substack/README.md
+++ b/library/media-and-entertainment/substack/README.md
@@ -4,6 +4,8 @@
 
 Substack has no public API and the closed-source tools that work around it (WriteStack, StackSweller) stop at Notes scheduling and a heatmap. This CLI covers the read endpoints the community has reverse-engineered across the 8 wrappers we studied, plus rich authoring (30+ flags on `drafts create`/`update`, Markdown→ProseMirror conversion), a multi-publication portfolio layer (`portfolio sync` → `portfolio`, `posts best`, `grep`, `schedule board`, `subs churn`, `subs cross-sell`), and local-SQLite analytics. Every command is MCP-callable so an agent can drive the full publish → engage → measure → swap loop.
 
+Created by [@chirantan](https://github.com/chirantan) (Chirantan Rajhans).
+
 ## Install
 
 The recommended path installs both the `substack-pp-cli` binary and the `pp-substack` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -56,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-substack --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-substack --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install substack --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-substack skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-substack. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -310,7 +314,6 @@ Custom-domain publications are supported: `auth login --chrome` captures the Cre
 
 ## Recipes
 
-
 ### Daily growth-loop morning ritual
 
 ```bash
@@ -550,7 +553,6 @@ Post tags
 
 - **`substack-pp-cli tags create`** - Create a new tag
 - **`substack-pp-cli tags list`** - List all tags for the publication
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/substack/SKILL.md
+++ b/library/media-and-entertainment/substack/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `substack-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install substack --cli-only
+   npx -y @mvanhorn/printing-press-library install substack --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `substack-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/cmd/substack-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Substack has no public API and the closed-source tools that work around it (WriteStack, StackSweller) stop at Notes scheduling and a heatmap. This CLI covers the read endpoints the community has reverse-engineered across the 8 wrappers we studied, plus rich authoring (30+ flags on `drafts create`/`update`, Markdown→ProseMirror conversion), a multi-publication portfolio layer (`portfolio sync` → `portfolio`, `posts best`, `grep`, `schedule board`, `subs churn`, `subs cross-sell`), and local-SQLite analytics. Every command is MCP-callable so an agent can drive the full publish → engage → measure → swap loop.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/suno/README.md
+++ b/library/media-and-entertainment/suno/README.md
@@ -4,7 +4,7 @@
 
 Suno has no official API and every reverse-engineered client is abandoned and wrong in ways that matter today — broken pagination, broken cover, stale pre-2026 auth, no local persistence. This CLI is built from the current contract: it walks the real opaque feed cursor, sends the now-required cover title, tolerates the drifted billing schema, authenticates against the current auth.suno.com Clerk flow via your logged-in browser, and persists your whole library to local SQLite for offline grep, SQL, lineage, and analytics. Generate, extend, cover, remaster, stems, lyrics, download — all with --json, --select, --dry-run, and typed exit codes.
 
-Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn). Superset rebuild contributed by [@horknfbr](https://github.com/horknfbr) (Scott Macdonald).
+Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-suno --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-suno --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install suno --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-suno skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-suno. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -181,7 +183,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Generate a custom song and wait for it
 
@@ -330,7 +331,6 @@ Parity with the 2026-05-15 build — these coexist with the novel commands (`gre
 - **`suno-pp-cli tail <resource> --interval 10s`** - Poll the API and stream changes as NDJSON
 - **`suno-pp-cli tree <clip-id>`** - Render a clip's local lineage tree (legacy view; see also `lineage`)
 - **`suno-pp-cli custom-model`** - List pending custom-model training jobs
-
 
 ## Output Formats
 

--- a/library/media-and-entertainment/suno/SKILL.md
+++ b/library/media-and-entertainment/suno/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `suno-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install suno --cli-only
+   npx -y @mvanhorn/printing-press-library install suno --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `suno-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/suno/cmd/suno-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Suno has no official API and every reverse-engineered client is abandoned and wrong in ways that matter today — broken pagination, broken cover, stale pre-2026 auth, no local persistence. This CLI is built from the current contract: it walks the real opaque feed cursor, sends the now-required cover title, tolerates the drifted billing schema, authenticates against the current auth.suno.com Clerk flow via your logged-in browser, and persists your whole library to local SQLite for offline grep, SQL, lineage, and analytics. Generate, extend, cover, remaster, stems, lyrics, download — all with --json, --select, --dry-run, and typed exit codes.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/tella/README.md
+++ b/library/media-and-entertainment/tella/README.md
@@ -5,7 +5,6 @@
 Tella ships an API and an official MCP server; this CLI gives you both surfaces in one binary, plus a local-first store that makes cross-video transcript search, view-milestone rollups, and webhook replay actually fast. Every endpoint is a Cobra command, every command emits structured JSON, and every mutation supports --dry-run.
 
 Created by [@gregce](https://github.com/gregce) (Greg Ceccarelli).
-Contributors: [@cathrynlavery](https://github.com/cathrynlavery) (Cathryn Lavery).
 
 ## Install
 
@@ -59,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tella --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-tella --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install tella --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-tella skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tella. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/tella/SKILL.md
+++ b/library/media-and-entertainment/tella/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `tella-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install tella --cli-only
+   npx -y @mvanhorn/printing-press-library install tella --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `tella-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/tella/cmd/tella-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/ticketmaster/README.md
+++ b/library/media-and-entertainment/ticketmaster/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ticketmaster
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ticketmaster --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ticketmaster --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ticketmaster skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ticketmaster. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/ticketmaster/SKILL.md
+++ b/library/media-and-entertainment/ticketmaster/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `ticketmaster-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ticketmaster --cli-only
+   npx -y @mvanhorn/printing-press-library install ticketmaster --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ticketmaster-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/ticketmaster/cmd/ticketmaster-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/media-and-entertainment/wikipedia/README.md
+++ b/library/media-and-entertainment/wikipedia/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-wikipedia --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install wikipedia --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-wikipedia skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wikipedia. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/wikipedia/SKILL.md
+++ b/library/media-and-entertainment/wikipedia/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `wikipedia-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install wikipedia --cli-only
+   npx -y @mvanhorn/printing-press-library install wikipedia --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `wikipedia-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/wikipedia/cmd/wikipedia-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/media-and-entertainment/youtube/README.md
+++ b/library/media-and-entertainment/youtube/README.md
@@ -62,17 +62,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-youtube --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-youtube --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install youtube --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-youtube skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-youtube. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/media-and-entertainment/youtube/SKILL.md
+++ b/library/media-and-entertainment/youtube/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `youtube-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install youtube --cli-only
+   npx -y @mvanhorn/printing-press-library install youtube --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `youtube-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/media-and-entertainment/youtube/cmd/youtube-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/monitoring/adguard-home/README.md
+++ b/library/monitoring/adguard-home/README.md
@@ -20,26 +20,26 @@ Created by [@e-jung](https://github.com/e-jung) (Eric Jung).
 The recommended path installs both the `adguard-home-pp-cli` binary and the `pp-adguard-home` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install adguard-home
+npx -y @mvanhorn/printing-press-library install adguard-home
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install adguard-home --cli-only
+npx -y @mvanhorn/printing-press-library install adguard-home --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install adguard-home --skill-only
+npx -y @mvanhorn/printing-press-library install adguard-home --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install adguard-home --agent claude-code
-npx -y @mvanhorn/printing-press install adguard-home --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install adguard-home --agent claude-code
+npx -y @mvanhorn/printing-press-library install adguard-home --agent claude-code --agent codex
 ```
 
 ### Without Node (Go fallback)
@@ -67,17 +67,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-adguard-home
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-adguard-home --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install adguard-home --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-adguard-home skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-adguard-home. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -404,7 +406,6 @@ Manage update
 Manage version json
 
 - **`adguard-home-pp-cli version-json`** - Gets information about the latest available version of AdGuard
-
 
 ## Output Formats
 

--- a/library/monitoring/adguard-home/SKILL.md
+++ b/library/monitoring/adguard-home/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `adguard-home-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install adguard-home --cli-only
+   npx -y @mvanhorn/printing-press-library install adguard-home --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `adguard-home-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/monitoring/adguard-home/cmd/adguard-home-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-AdGuard Home REST-ish API.  Our admin web interface is built on top of this REST-ish API.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/monitoring/sentry/README.md
+++ b/library/monitoring/sentry/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-sentry --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install sentry --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-sentry skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sentry. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/monitoring/sentry/SKILL.md
+++ b/library/monitoring/sentry/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `sentry-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install sentry --cli-only
+   npx -y @mvanhorn/printing-press-library install sentry --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `sentry-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/monitoring/sentry/cmd/sentry-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/american-reindustrialization/README.md
+++ b/library/other/american-reindustrialization/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-american-rei
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-american-reindustrialization --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install american-reindustrialization --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-american-reindustrialization skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-american-reindustrialization. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/american-reindustrialization/SKILL.md
+++ b/library/other/american-reindustrialization/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `american-reindustrialization-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install american-reindustrialization --cli-only
+   npx -y @mvanhorn/printing-press-library install american-reindustrialization --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `american-reindustrialization-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/american-reindustrialization/cmd/american-reindustrialization-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/apartments/README.md
+++ b/library/other/apartments/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-apartments -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-apartments --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install apartments --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-apartments skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-apartments. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/apartments/SKILL.md
+++ b/library/other/apartments/SKILL.md
@@ -14,12 +14,12 @@ metadata: '{"openclaw":{"requires":{"bins":["apartments-pp-cli"]},"install":[{"i
 
 This skill drives the `apartments-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install apartments --cli-only
+   npx -y @mvanhorn/printing-press-library install apartments --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `apartments-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -27,7 +27,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/apartments/cmd/apartments-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/ars-sicilia/README.md
+++ b/library/other/ars-sicilia/README.md
@@ -6,7 +6,7 @@ Sostituisce le 12 maschere JSP del portale ufficiale con una CLI agent-native. S
 
 Learn more at [ARS Sicilia](https://dati.ars.sicilia.it).
 
-Printed by [@aborruso](https://github.com/aborruso) (aborruso).
+Created by [@aborruso](https://github.com/aborruso) (aborruso).
 
 ## Install
 
@@ -35,9 +35,15 @@ npx -y @mvanhorn/printing-press-library install ars-sicilia --agent claude-code
 npx -y @mvanhorn/printing-press-library install ars-sicilia --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/ars-sicilia/cmd/ars-sicilia-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ars-sicilia 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ars-sicilia --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ars-sicilia --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ars-sicilia skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ars-sicilia. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -198,7 +206,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Sync iniziale completo XVIII legislatura
 
@@ -378,7 +385,6 @@ Risoluzioni parlamentari (archivio 238).
 
 - **`ars-sicilia-pp-cli risoluzioni cerca`** - Cerca risoluzioni.
 - **`ars-sicilia-pp-cli risoluzioni get`** - Scarica una singola risoluzione.
-
 
 ## Output Formats
 

--- a/library/other/ars-sicilia/SKILL.md
+++ b/library/other/ars-sicilia/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `ars-sicilia-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ars-sicilia --cli-only
+   npx -y @mvanhorn/printing-press-library install ars-sicilia --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ars-sicilia-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/ars-sicilia/cmd/ars-sicilia-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Sostituisce le 12 maschere JSP del portale ufficiale con una CLI agent-native. Sync in SQLite locale per query SQL, ricerca full-text cross-archivio, e novel commands come `ddl iter` (timeline completa di un disegno di legge) e `deputato profilo` (tutta l'attività di un parlamentare in un'unica chiamata).
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/arxiv/README.md
+++ b/library/other/arxiv/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-arxiv --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-arxiv --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install arxiv --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-arxiv skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-arxiv. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/arxiv/SKILL.md
+++ b/library/other/arxiv/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `arxiv-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install arxiv --cli-only
+   npx -y @mvanhorn/printing-press-library install arxiv --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `arxiv-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/arxiv/cmd/arxiv-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/other/defillama/README.md
+++ b/library/other/defillama/README.md
@@ -94,17 +94,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-defillama --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-defillama --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install defillama --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-defillama skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-defillama. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -494,7 +496,6 @@ Data from our yields/APY dashboard
 - **`defillama-pp-cli yields list-perps`** - Funding rates and Open Interest of perps across exchanges, including both Decentralized and Centralized
 - **`defillama-pp-cli yields list-poolsborrow`** - Borrow costs APY of assets from lending markets
 - **`defillama-pp-cli yields list-poolsold`** - Same as /pools but it also includes a new parameter `pool_old` which usually contains pool address (but not guaranteed)
-
 
 ## Output Formats
 

--- a/library/other/defillama/SKILL.md
+++ b/library/other/defillama/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `defillama-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install defillama --cli-only
+   npx -y @mvanhorn/printing-press-library install defillama --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `defillama-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/defillama/cmd/defillama-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Using AI?
 

--- a/library/other/edgar/README.md
+++ b/library/other/edgar/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-edgar --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-edgar --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install edgar --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-edgar skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-edgar. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/edgar/SKILL.md
+++ b/library/other/edgar/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `edgar-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install edgar --cli-only
+   npx -y @mvanhorn/printing-press-library install edgar --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `edgar-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/edgar/cmd/edgar-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/elezioni-sicilia/README.md
+++ b/library/other/elezioni-sicilia/README.md
@@ -10,18 +10,30 @@ Created by [@aborruso](https://github.com/aborruso) (aborruso).
 
 ## Install
 
-The recommended path installs both the `elezioni-sicilia-pp-cli` binary and the `pp-elezioni-sicilia` agent skill in one shot:
+The recommended path installs both the `elezioni-sicilia-pp-cli` binary and the `pp-elezioni-sicilia` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install elezioni-sicilia
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install elezioni-sicilia --cli-only
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia --agent claude-code
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia --agent claude-code --agent codex
+```
 
 ### Without Node (Go fallback)
 
@@ -48,17 +60,54 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-elezioni-sic
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-elezioni-sicilia --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install elezioni-sicilia --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-elezioni-sicilia skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-elezioni-sicilia. The skill defines how its required CLI can be installed.
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/elezioni-sicilia-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/elezioni-sicilia/cmd/elezioni-sicilia-pp-mcp@latest
 ```
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "elezioni-sicilia": {
+      "command": "elezioni-sicilia-pp-mcp"
+    }
+  }
+}
+```
+
+</details>
 
 ## Quick Start
 
@@ -66,18 +115,14 @@ Install the pp-elezioni-sicilia skill from https://github.com/mvanhorn/printing-
 # Tabella affluenza regionale aggiornata
 elezioni-sicilia-pp-cli affluenza --json
 
-
 # Comuni alle elezioni in provincia di Palermo
 elezioni-sicilia-pp-cli comuni --provincia PA --json
-
 
 # Voti per candidato sindaco ad Agrigento
 elezioni-sicilia-pp-cli candidati Agrigento --json
 
-
 # Confronto affluenza dal 2009 al 2026
 elezioni-sicilia-pp-cli storico Agrigento --json
-
 
 # Elezioni regionali (ARS) — Presidente 2022 con liste collegate
 elezioni-sicilia-pp-cli regionali presidente --anno 2022 --json
@@ -178,7 +223,6 @@ elezioni-sicilia-pp-cli regionali affluenza --anno 2017
 elezioni-sicilia-pp-cli regionali candidati --provincia CT --anno 2022 --json
 ```
 
-
 ## Output Formats
 
 ```bash
@@ -211,69 +255,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-elezioni-sicilia -g
-```
-
-Then invoke `/pp-elezioni-sicilia <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/other/elezioni-sicilia/cmd/elezioni-sicilia-pp-mcp@latest
-```
-
-Then register it:
-
-```bash
-claude mcp add elezioni-sicilia elezioni-sicilia-pp-mcp
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/elezioni-sicilia-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-```bash
-go install github.com/mvanhorn/printing-press-library/library/other/elezioni-sicilia/cmd/elezioni-sicilia-pp-mcp@latest
-```
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "elezioni-sicilia": {
-      "command": "elezioni-sicilia-pp-mcp"
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/other/elezioni-sicilia/SKILL.md
+++ b/library/other/elezioni-sicilia/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `elezioni-sicilia-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install elezioni-sicilia --cli-only
+   npx -y @mvanhorn/printing-press-library install elezioni-sicilia --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `elezioni-sicilia-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/elezioni-sicilia/cmd/elezioni-sicilia-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Il sito ufficiale della Regione Siciliana pubblica i risultati delle elezioni comunali solo in HTML e PDF. Questa CLI estrae affluenza, voti, candidati e risultati in JSON strutturato, con archivio dal 2009 e confronto storico tra anni.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/gisis/README.md
+++ b/library/other/gisis/README.md
@@ -6,7 +6,7 @@ GISIS is the IMO's canonical ship registry, gated by a login + Cloudflare Turnst
 
 Learn more at [GISIS](https://gisis.imo.org).
 
-Printed by [@6myfzqx6bv-ctrl](https://github.com/6myfzqx6bv-ctrl).
+Created by [@6myfzqx6bv-ctrl](https://github.com/6myfzqx6bv-ctrl) (ivory_elephant).
 
 ## Install
 
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-gisis --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-gisis --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install gisis --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-gisis skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-gisis. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -201,7 +203,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Look up an IMO with structured output
 
 ```bash
@@ -253,7 +254,6 @@ Run `gisis-pp-cli --help` for the full command reference and flag list.
 Ship particulars — authoritative IMO vessel registry data (name, flag, type, gross tonnage, ownership, classification society).
 
 - **`gisis-pp-cli ship <IMONumber>`** - Get ship particulars by IMO number from the IMO Ship and Company Particulars module.
-
 
 ## Output Formats
 

--- a/library/other/gisis/SKILL.md
+++ b/library/other/gisis/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `gisis-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install gisis --cli-only
+   npx -y @mvanhorn/printing-press-library install gisis --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `gisis-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/gisis/cmd/gisis-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-GISIS is the IMO's canonical ship registry, gated by a login + Cloudflare Turnstile and only readable from a server-rendered web app. This CLI scrapes it politely (1 req/2-3s), caches every result to local SQLite, exposes 'ship get' as an MCP tool, and adds maritime-DD-specific commands like 'ship history' for flag-hop detection and 'owner fleet' for counterparty exposure that the GISIS web app itself can't answer.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/gravitus/README.md
+++ b/library/other/gravitus/README.md
@@ -13,31 +13,37 @@ Created by [@azaaron](https://github.com/azaaron) (mvanhorn).
 The recommended path installs both the `gravitus-pp-cli` binary and the `pp-gravitus` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install gravitus
+npx -y @mvanhorn/printing-press-library install gravitus
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gravitus --cli-only
+npx -y @mvanhorn/printing-press-library install gravitus --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install gravitus --skill-only
+npx -y @mvanhorn/printing-press-library install gravitus --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install gravitus --agent claude-code
-npx -y @mvanhorn/printing-press install gravitus --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install gravitus --agent claude-code
+npx -y @mvanhorn/printing-press-library install gravitus --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/gravitus/cmd/gravitus-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-gravitus --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-gravitus --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install gravitus --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-gravitus skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-gravitus. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -115,18 +123,14 @@ Gravitus uses Django session auth. Run `gravitus-pp-cli auth login-password` wit
 # authenticate — handles the CSRF dance automatically
 gravitus-pp-cli auth login
 
-
 # pull all workouts into dev.db as LiftingSession records
 gravitus-pp-cli gravitus-sync --dashboard-db ./prisma/dev.db
-
 
 # only fetch new workouts since last sync
 gravitus-pp-cli gravitus-sync --incremental --dashboard-db ./prisma/dev.db
 
-
 # view all personal records as structured JSON
 gravitus-pp-cli exercises prs --agent
-
 
 # find lifts with no progress in 6 weeks
 gravitus-pp-cli exercises plateau --weeks 6
@@ -205,7 +209,6 @@ User profile and paginated workout history
 Workout sessions with exercises, sets, reps, weight, and PRs
 
 - **`gravitus-pp-cli workouts <workout_id>`** - Fetch full workout detail — exercises, sets, reps, weight, personal records
-
 
 ## Output Formats
 

--- a/library/other/gravitus/SKILL.md
+++ b/library/other/gravitus/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `gravitus-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install gravitus --cli-only
+   npx -y @mvanhorn/printing-press-library install gravitus --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `gravitus-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/gravitus/cmd/gravitus-pp-cli@latest
+```
 
-Gravitus has no API and no data export. gravitus-pp-cli handles the session auth, paginates your full workout history, and writes LiftingSession records directly into your dashboard's SQLite database — incremental, reliable, and scriptable.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/greatclips/README.md
+++ b/library/other/greatclips/README.md
@@ -92,17 +92,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-greatclips -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-greatclips --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install greatclips --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-greatclips skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-greatclips. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/greatclips/SKILL.md
+++ b/library/other/greatclips/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `greatclips-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install greatclips --cli-only
+   npx -y @mvanhorn/printing-press-library install greatclips --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `greatclips-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/greatclips/cmd/greatclips-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/numista/README.md
+++ b/library/other/numista/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-numista --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-numista --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install numista --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-numista skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-numista. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/numista/SKILL.md
+++ b/library/other/numista/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `numista-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install numista --cli-only
+   npx -y @mvanhorn/printing-press-library install numista --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `numista-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/numista/cmd/numista-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/open-meteo/README.md
+++ b/library/other/open-meteo/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-open-meteo --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install open-meteo --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-open-meteo skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-open-meteo. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/open-meteo/SKILL.md
+++ b/library/other/open-meteo/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `open-meteo-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install open-meteo --cli-only
+   npx -y @mvanhorn/printing-press-library install open-meteo --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `open-meteo-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/open-meteo/cmd/open-meteo-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/openalex/README.md
+++ b/library/other/openalex/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-openalex --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-openalex --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install openalex --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-openalex skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-openalex. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/openalex/SKILL.md
+++ b/library/other/openalex/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `openalex-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install openalex --cli-only
+   npx -y @mvanhorn/printing-press-library install openalex --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `openalex-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/openalex/cmd/openalex-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/other/pcgs/README.md
+++ b/library/other/pcgs/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pcgs --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pcgs --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pcgs --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pcgs skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pcgs. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/pcgs/SKILL.md
+++ b/library/other/pcgs/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `pcgs-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pcgs --cli-only
+   npx -y @mvanhorn/printing-press-library install pcgs --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pcgs-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/pcgs/cmd/pcgs-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/pvgis/README.md
+++ b/library/other/pvgis/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pvgis --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pvgis --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pvgis --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pvgis skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pvgis. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/pvgis/SKILL.md
+++ b/library/other/pvgis/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `pvgis-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pvgis --cli-only
+   npx -y @mvanhorn/printing-press-library install pvgis --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pvgis-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/pvgis/cmd/pvgis-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/redfin/README.md
+++ b/library/other/redfin/README.md
@@ -7,7 +7,6 @@ Search homes for sale via Redfin's internal Stingray endpoints from the terminal
 Learn more at [Redfin](https://www.redfin.com).
 
 Created by [@rderwin](https://github.com/rderwin) (rderwin).
-Contributors: [@jwmoss](https://github.com/jwmoss) (Jonathan Moss).
 
 ## Install
 
@@ -61,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-redfin --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-redfin --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install redfin --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-redfin skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-redfin. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/redfin/SKILL.md
+++ b/library/other/redfin/SKILL.md
@@ -14,12 +14,12 @@ metadata: '{"openclaw":{"requires":{"bins":["redfin-pp-cli"]},"install":[{"id":"
 
 This skill drives the `redfin-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install redfin --cli-only
+   npx -y @mvanhorn/printing-press-library install redfin --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `redfin-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -27,7 +27,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/redfin/cmd/redfin-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/ufo-goat/README.md
+++ b/library/other/ufo-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-ufo-goat --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-ufo-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install ufo-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-ufo-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-ufo-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/ufo-goat/SKILL.md
+++ b/library/other/ufo-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `ufo-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install ufo-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install ufo-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `ufo-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/ufo-goat/cmd/ufo-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/usgs-earthquakes/README.md
+++ b/library/other/usgs-earthquakes/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-usgs-earthqu
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-usgs-earthquakes --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install usgs-earthquakes --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-usgs-earthquakes skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-usgs-earthquakes. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/other/usgs-earthquakes/SKILL.md
+++ b/library/other/usgs-earthquakes/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `usgs-earthquakes-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install usgs-earthquakes --cli-only
+   npx -y @mvanhorn/printing-press-library install usgs-earthquakes --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `usgs-earthquakes-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/usgs-earthquakes/cmd/usgs-earthquakes-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/other/weather-goat/README.md
+++ b/library/other/weather-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-weather-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install weather-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-weather-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-weather-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/other/weather-goat/SKILL.md
+++ b/library/other/weather-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `weather-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install weather-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install weather-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `weather-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/other/weather-goat/cmd/weather-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/coingecko/README.md
+++ b/library/payments/coingecko/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-coingecko --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install coingecko --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-coingecko skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-coingecko. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Quick Start
 

--- a/library/payments/coingecko/SKILL.md
+++ b/library/payments/coingecko/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `coingecko-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install coingecko --cli-only
+   npx -y @mvanhorn/printing-press-library install coingecko --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `coingecko-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/coingecko/cmd/coingecko-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/payments/exchangerate-api/README.md
+++ b/library/payments/exchangerate-api/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-exchangerate
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-exchangerate-api --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install exchangerate-api --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-exchangerate-api skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-exchangerate-api. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/exchangerate-api/SKILL.md
+++ b/library/payments/exchangerate-api/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `exchangerate-api-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install exchangerate-api --cli-only
+   npx -y @mvanhorn/printing-press-library install exchangerate-api --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `exchangerate-api-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/exchangerate-api/cmd/exchangerate-api-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/kalshi/README.md
+++ b/library/payments/kalshi/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-kalshi --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install kalshi --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-kalshi skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-kalshi. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/kalshi/SKILL.md
+++ b/library/payments/kalshi/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `kalshi-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install kalshi --cli-only
+   npx -y @mvanhorn/printing-press-library install kalshi --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `kalshi-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/kalshi/cmd/kalshi-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/lemonsqueezy/README.md
+++ b/library/payments/lemonsqueezy/README.md
@@ -4,6 +4,8 @@
 
 Lemon Squeezy's official SDKs are libraries, not CLIs, and the dashboard is a click-walk per store. This CLI mirrors all 19 LS resources to local SQLite with offline FTS5 and cross-entity SQL, then layers transcendence commands — `revenue-snapshot`, `mrr-trend`, `churn-watch`, `dunning-alert`, `license-rollup`, `refund-cascade`, `campaign-watch`, `webhook-audit` — that combine entities no single endpoint returns. Built for indie SaaS founders and license-key sellers who live in the LS state machine.
 
+Created by [@jcastillo725](https://github.com/jcastillo725) (Joseph Alvin Castillo).
+
 ## Install
 
 The recommended path installs both the `lemonsqueezy-pp-cli` binary and the `pp-lemonsqueezy` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -56,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-lemonsqueezy
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-lemonsqueezy --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install lemonsqueezy --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-lemonsqueezy skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-lemonsqueezy. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -195,7 +199,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Monday-morning revenue + churn sweep
 
@@ -397,7 +400,6 @@ Manage webhooks
 - **`lemonsqueezy-pp-cli webhooks get`** - Lemon Squeezy Retrieve a webhook
 - **`lemonsqueezy-pp-cli webhooks list`** - Lemon Squeezy List all webhooks
 - **`lemonsqueezy-pp-cli webhooks update`** - Lemon Squeezy Update a webhook
-
 
 ## Output Formats
 

--- a/library/payments/lemonsqueezy/SKILL.md
+++ b/library/payments/lemonsqueezy/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `lemonsqueezy-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install lemonsqueezy --cli-only
+   npx -y @mvanhorn/printing-press-library install lemonsqueezy --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `lemonsqueezy-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/lemonsqueezy/cmd/lemonsqueezy-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Lemon Squeezy's official SDKs are libraries, not CLIs, and the dashboard is a click-walk per store. This CLI mirrors all 19 LS resources to local SQLite with offline FTS5 and cross-entity SQL, then layers transcendence commands — `revenue-snapshot`, `mrr-trend`, `churn-watch`, `dunning-alert`, `license-rollup`, `refund-cascade`, `campaign-watch`, `webhook-audit` — that combine entities no single endpoint returns. Built for indie SaaS founders and license-key sellers who live in the LS state machine.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/lunch-money/README.md
+++ b/library/payments/lunch-money/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-lunch-money 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-lunch-money --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install lunch-money --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-lunch-money skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-lunch-money. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/lunch-money/SKILL.md
+++ b/library/payments/lunch-money/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `lunch-money-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install lunch-money --cli-only
+   npx -y @mvanhorn/printing-press-library install lunch-money --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `lunch-money-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/lunch-money/cmd/lunch-money-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/mercury/README.md
+++ b/library/payments/mercury/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-mercury --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install mercury --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-mercury skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-mercury. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/mercury/SKILL.md
+++ b/library/payments/mercury/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `mercury-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install mercury --cli-only
+   npx -y @mvanhorn/printing-press-library install mercury --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `mercury-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/mercury/cmd/mercury-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/payments/monarch-money/README.md
+++ b/library/payments/monarch-money/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-monarch-mone
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-monarch-money --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install monarch-money --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-monarch-money skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-monarch-money. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/payments/monarch-money/SKILL.md
+++ b/library/payments/monarch-money/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `monarch-money-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install monarch-money --cli-only
+   npx -y @mvanhorn/printing-press-library install monarch-money --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `monarch-money-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/monarch-money/cmd/monarch-money-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/pop/README.md
+++ b/library/payments/pop/README.md
@@ -78,17 +78,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pop --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pop --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pop --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pop skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pop. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/pop/SKILL.md
+++ b/library/payments/pop/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `pop-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pop --cli-only
+   npx -y @mvanhorn/printing-press-library install pop --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pop-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/pop/cmd/pop-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/payments/revenuecat/README.md
+++ b/library/payments/revenuecat/README.md
@@ -4,6 +4,8 @@
 
 Drive the full RevenueCat Developer API v2 from the shell or an agent: customers, subscriptions, entitlements, products, offerings, purchases, invoices, and charts. On top of the typed endpoint surface it adds a local SQLite mirror and novel commands — revenue-snapshot with run-over-run diffs, mrr-trend with movement decomposition, churn-watch with dollar exposure, dunning-alert, entitlement-rollup, refund-cascade, and trial-funnel — that join synced data in ways no single API call returns.
 
+Created by [@jcastillo725](https://github.com/jcastillo725) (Joseph Alvin Castillo).
+
 ## Install
 
 The recommended path installs both the `revenuecat-pp-cli` binary and the `pp-revenuecat` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -56,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-revenuecat -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-revenuecat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install revenuecat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-revenuecat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-revenuecat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -195,7 +199,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Morning standup revenue line
 
@@ -427,7 +430,6 @@ Manage virtual currencies
 - **`revenuecat-pp-cli virtual-currencies get-virtual-currency`** - This endpoint requires the following permission(s): <code>project_configuration:virtual_currencies:read</code>. This endpoint belongs to the <strong>Project Configuration</strong> domain, which has a default rate limit of <strong>60 requests per minute</strong>.
 - **`revenuecat-pp-cli virtual-currencies list`** - This endpoint requires the following permission(s): <code>project_configuration:virtual_currencies:read</code>. This endpoint belongs to the <strong>Project Configuration</strong> domain, which has a default rate limit of <strong>60 requests per minute</strong>.
 - **`revenuecat-pp-cli virtual-currencies update-virtual-currency`** - This endpoint requires the following permission(s): <code>project_configuration:virtual_currencies:read_write</code>. This endpoint belongs to the <strong>Project Configuration</strong> domain, which has a default rate limit of <strong>60 requests per minute</strong>.
-
 
 ## Output Formats
 

--- a/library/payments/revenuecat/SKILL.md
+++ b/library/payments/revenuecat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `revenuecat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install revenuecat --cli-only
+   npx -y @mvanhorn/printing-press-library install revenuecat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `revenuecat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/revenuecat/cmd/revenuecat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Drive the full RevenueCat Developer API v2 from the shell or an agent: customers, subscriptions, entitlements, products, offerings, purchases, invoices, and charts. On top of the typed endpoint surface it adds a local SQLite mirror and novel commands — revenue-snapshot with run-over-run diffs, mrr-trend with movement decomposition, churn-watch with dollar exposure, dunning-alert, entitlement-rollup, refund-cascade, and trial-funnel — that join synced data in ways no single API call returns.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/robinhood/README.md
+++ b/library/payments/robinhood/README.md
@@ -12,11 +12,9 @@ To get started, head to your [crypto account settings](https://robinhood.com/acc
 
 The Robinhood Crypto Trading API is available to customers in the United States only. Use of the Robinhood Crypto Trading API is subject to the [Robinhood Crypto Customer Agreement](https://cdn.robinhood.com/assets/robinhood/legal/Robinhood%20Crypto%20Customer%20Agreement.pdf) as well as all other terms and disclosures made available on [Robinhood Crypto's about page](https://robinhood.com/us/en/about/crypto).
 
-
 # Authentication
 
 To get started with the Robinhood Crypto Trading API, you need to create a key, signature, and headers. Authenticated requests must include all three `x-api-key`, `x-signature`, and `x-timestamp` HTTP headers.
-
 
 ## Creating an API key
 
@@ -24,9 +22,7 @@ Head to your [crypto account settings](https://robinhood.com/account/crypto) on 
 
 Your API key will be used as the `x-api-key` header you will need to pass during authentication when calling our API endpoints. Additionally, you will need the public key generated in the [Creating a key pair](#section/Authentication/Creating-a-key-pair) section to create your API credentials.
 
-
 ## Creating a key pair
-
 
 #### Below are example scripts on how to generate the public and private key pair. You'll need the public key for creating an API credential and the private key for authenticating requests. Remember to never share your private key with anyone. Robinhood will never ask you to share it with us.
 
@@ -59,11 +55,9 @@ print("Public Key (Base64):")
 print(public_key_base64)
 ```
 
-
 ## Headers and Signature
 
 <SecurityDefinitions />
-
 
 # Making your first API call
 
@@ -209,7 +203,6 @@ class CryptoAPITrading:
         path = "/api/v1/crypto/trading/orders/"
         return self.make_api_request("GET", path)
 
-
 def main():
     api_trading_client = CryptoAPITrading()
     print(api_trading_client.get_account())
@@ -225,7 +218,6 @@ def main():
           {"asset_quantity": "0.0001"}
     )
     """
-
 
 if __name__ == "__main__":
     main()
@@ -244,7 +236,6 @@ from nacl.signing import SigningKey
 
 API_KEY = "ADD YOUR API KEY HERE"
 BASE64_PRIVATE_KEY = "ADD YOUR PRIVATE KEY HERE"
-
 
 class CryptoAPITradingV2:
     def __init__(self):
@@ -410,7 +401,6 @@ class CryptoAPITradingV2:
         path = f"/api/v2/crypto/trading/orders/{query_params}"
         return self.make_api_request("GET", path)
 
-
 def main():
     api_trading_client = CryptoAPITradingV2()
     print(api_trading_client.get_trading_pairs())
@@ -439,7 +429,6 @@ def main():
     )
     """
 
-
 if __name__ == "__main__":
     main()
 ```
@@ -453,12 +442,9 @@ python robinhood_api_trading.py
 python robinhood_api_trading_v2.py
 ```
 
-
 # Pagination
 
-
  Endpoints that return a list of results allow you to paginate to have more control over how many and which results to display.
-
 
 ### Pagination Parameters
 
@@ -467,9 +453,7 @@ python robinhood_api_trading_v2.py
 | cursor | The cursor is a unique identifier for each page in a list of results. The cursor is used to paginate through the pages of results. |
 | limit | The limit is the number of items to return in a single page. Some of our endpoints support this query parameter. You can view support by checking the query parameters in the documentation of each endpoint.  |
 
-
 ### Pagination Response
-
 
 | Field | Description |
 |-|-|
@@ -477,20 +461,15 @@ python robinhood_api_trading_v2.py
 | previous | The API request endpoint that includes the previous cursor query parameter to use for pagination. |
 | results | The list of response items for the current cursor.
 
-
 # Rate Limiting
-
 
 ### Rate Limits
 * Requests per minute per user account: 100
 * Requests per minute per user account in bursts: 300
 
-
 Rate limiting is applied using a token bucket implementation. The burst size or `capacity` is the number of tokens you can use to call an endpoint. This capacity is initialized at the maximum capacity and will be refilled using a `refill amount` at a timed interval called `refill interval` until the max capacity is once again reached.
 
-
 ### Rate Limiting Terms
-
 
 | Term | Description |
 |-|-|
@@ -501,9 +480,7 @@ Rate limiting is applied using a token bucket implementation. The burst size or 
 
  The actual values of the configuration will fluctuate depending on the availability of our service and our current expected volume at the time of service. Rate limits are applied per endpoint and may differ among each endpoint depending on their expected use case.
 
-
  #### Example rate limiting configuration:
-
 
 | Term | Value |
 |-|-|
@@ -511,7 +488,6 @@ Rate limiting is applied using a token bucket implementation. The burst size or 
 | Remaining amount | 2 |
 | Refill amount | 1 |
 | Refill interval | 1 second |
-
 
 | Action | Time (in seconds) | Remaining amount | Description |
 |-|-|-|-|
@@ -523,9 +499,7 @@ Rate limiting is applied using a token bucket implementation. The burst size or 
 | No refill | 3 | 5 | No refill since max capacity has been reached and no endpoints were called. |
 | Endpoint call 3 | 3.5 | 4 | One token consumed for calling endpoint 3.
 
-
 # Error Responses
-
 
 ### Error response format
 
@@ -537,15 +511,12 @@ Rate limiting is applied using a token bucket implementation. The burst size or 
 | client_error | 4XX, excluding 400 |
 | server_error | 5XX |
 
-
 #### Errors
 The `errors` field will contain a list of error details, each item will contain a nested `attr` and `detail` field.
 | Field | Description |
 |-|-|
 | attr | Error types of `validation_error` will specify the field name or `non_field_errors` if the error cannot be attributed to a field. Will be `null` for error types of either `client_error` and `server_error`. |
 | detail | Will contain a human readable string describing the error. |
-
-
 
 ### Example Error Response
 Here's a sample error response where the `client_order_id` field in the payload was a value that was not expected when calling the ***Add Crypto Order*** endpoint. The `detail` field for each error in the `errors` list will help understand why the `validation_error` was thrown. The `attr` field will indicate which field name in the request body or query parameter the error was thrown for if applicable.
@@ -561,7 +532,6 @@ Here's a sample error response where the `client_order_id` field in the payload 
 }
 ```
 
-
 ### Common Error Status Codes
  | Status Code | Error |
 |-|-|
@@ -576,7 +546,7 @@ Here's a sample error response where the `client_order_id` field in the payload 
 | 500 | Internal server error |
 | 503 | Service unavailable |
 
-Printed by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
+Created by [@zaydiscold](https://github.com/zaydiscold) (zaydiscold).
 
 ## Install
 
@@ -605,9 +575,15 @@ npx -y @mvanhorn/printing-press-library install robinhood --agent claude-code
 npx -y @mvanhorn/printing-press-library install robinhood --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/payments/robinhood/cmd/robinhood-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -624,17 +600,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-robinhood --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-robinhood --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install robinhood --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-robinhood skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-robinhood. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -812,7 +790,6 @@ Inspect Robinhood brokerage/account route maps and the typed brokerage surface. 
 - **`robinhood-pp-cli brokerage dividends`** - Dividends (paid + pending). Maps `GET /dividends/`.
 - **`robinhood-pp-cli brokerage history`** - Account transaction history. Maps `GET /history/transactions/` (minerva).
 - **`robinhood-pp-cli brokerage watchlist`** - Default watchlist; `items`/`add`/`remove` subcommands. Maps `GET /discovery/lists/default/`.
-
 
 ## Output Formats
 

--- a/library/payments/robinhood/SKILL.md
+++ b/library/payments/robinhood/SKILL.md
@@ -18,16 +18,20 @@ metadata:
 
 This skill drives the `robinhood-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install robinhood --cli-only
+   npx -y @mvanhorn/printing-press-library install robinhood --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `robinhood-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/payments/robinhood/cmd/robinhood-pp-cli@latest
+```
+
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Agent Rules
 

--- a/library/payments/splitwise/README.md
+++ b/library/payments/splitwise/README.md
@@ -4,6 +4,8 @@
 
 splitwise-pp-cli wraps the full Splitwise API — expenses, groups, friends, comments, settle-ups — and keeps a local copy of your whole ledger. That local store powers a net `balances` view, `debts --aged` (who never pays you back), `spend` rollups by category or month, offline `search`, a group `ledger` with running balances, and a `settle-up` plan that minimizes transfers. Fuzzy name resolution means you never paste a numeric ID.
 
+Created by [@vinnyp](https://github.com/vinnyp) (Vinny Pasceri).
+
 ## Install
 
 The recommended path installs both the `splitwise-pp-cli` binary and the `pp-splitwise` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -56,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-splitwise --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-splitwise --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install splitwise --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-splitwise skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-splitwise. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -623,7 +627,6 @@ shares for the expense will be overwritten with the provided values.
 Manage update user
 
 - **`splitwise-pp-cli update-user <id>`** - Update a user
-
 
 ## Output Formats
 

--- a/library/payments/splitwise/SKILL.md
+++ b/library/payments/splitwise/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `splitwise-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install splitwise --cli-only
+   npx -y @mvanhorn/printing-press-library install splitwise --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `splitwise-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/splitwise/cmd/splitwise-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-splitwise-pp-cli wraps the full Splitwise API — expenses, groups, friends, comments, settle-ups — and keeps a local copy of your whole ledger. That local store powers a net `balances` view, `debts --aged` (who never pays you back), `spend` rollups by category or month, offline `search`, a group `ledger` with running balances, and a `settle-up` plan that minimizes transfers. Fuzzy name resolution means you never paste a numeric ID.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/payments/stripe/README.md
+++ b/library/payments/stripe/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-stripe --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-stripe --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install stripe --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-stripe skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-stripe. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/payments/stripe/SKILL.md
+++ b/library/payments/stripe/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `stripe-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install stripe --cli-only
+   npx -y @mvanhorn/printing-press-library install stripe --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `stripe-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/payments/stripe/cmd/stripe-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/breezedoc/README.md
+++ b/library/productivity/breezedoc/README.md
@@ -15,7 +15,6 @@ If you're building a custom integration to BreezeDoc which requires users to aut
 
 Using the `authorization_code` grant type to authenticate users using OAuth 2.0 to retrieve an access token is fairly conventional, more information on that process can be found here: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
 
-
 * Authorization URL: https://breezedoc.com/oauth/authorize
 * Access Token URL: https://breezedoc.com/oauth/token
 
@@ -78,17 +77,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-breezedoc --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-breezedoc --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install breezedoc --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-breezedoc skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-breezedoc. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -205,14 +206,12 @@ Manage recipients
 
 Manage teams
 
-
 ### templates
 
 Manage templates
 
 - **`breezedoc-pp-cli templates get`** - Get a specific template
 - **`breezedoc-pp-cli templates list`** - Get list of templates
-
 
 ## Output Formats
 

--- a/library/productivity/breezedoc/SKILL.md
+++ b/library/productivity/breezedoc/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `breezedoc-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install breezedoc --cli-only
+   npx -y @mvanhorn/printing-press-library install breezedoc --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `breezedoc-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,29 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/breezedoc/cmd/breezedoc-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-# Introduction
-BreezeDoc's REST API provides a handful of endpoints which can be used to get information about your account and bookings.  It uses conventional OAuth 2.0 protocol for authentication.
-
-# Authentication
-### Personal Access Token
-Create a personal access token at https://breezedoc.com/integrations/api.  Once created, it can be used to authenticate requests by passing it in the `Authorization` header.
-```
-Authorization: Bearer {TOKEN}
-```
-
-### OAuth 2.0 Client
-If you're building a custom integration to BreezeDoc which requires users to authenticate in order to get access tokens to make API requests on their behalf, you'll need to create an OAuth 2.0 client. This is easy to do from the \"OAuth Apps\" settings page found here https://breezedoc.com/integrations/api
-
-Using the `authorization_code` grant type to authenticate users using OAuth 2.0 to retrieve an access token is fairly conventional, more information on that process can be found here: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
-
-
-* Authorization URL: https://breezedoc.com/oauth/authorize
-* Access Token URL: https://breezedoc.com/oauth/token
-
-# Rate Limiting
-The API currently has a rate limit of 60 requests per minute. If you exceed this limit, you will receive a 429 error.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/productivity/cal-com/README.md
+++ b/library/productivity/cal-com/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-cal-com --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install cal-com --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-cal-com skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-cal-com. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/cal-com/SKILL.md
+++ b/library/productivity/cal-com/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `cal-com-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install cal-com --cli-only
+   npx -y @mvanhorn/printing-press-library install cal-com --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `cal-com-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/cal-com/cmd/cal-com-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/chrome-history/SKILL.md
+++ b/library/productivity/chrome-history/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pp-chrome-history
 description: "Query your local Chrome browsing history — search, topic clusters (Chrome's own Journeys), time/productivity reports, session timelines, downloads, and a behavioral profile — all read-only and on-device. Trigger phrases: `what have I been browsing`, `search my chrome history`, `what was that page I saw`, `my browsing journeys / topics`, `what did I download in chrome`, `what sites do I visit most`, `my browsing time report`, `my browsing profile`, `what was I researching last week`, `use chrome-history`, `run chrome-history-pp-cli`."
+license: "Apache-2.0"
 ---
 
 # pp-chrome-history
@@ -9,18 +10,20 @@ description: "Query your local Chrome browsing history — search, topic cluster
 
 This skill drives the `chrome-history-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install chrome-history --cli-only
+   npx -y @mvanhorn/printing-press-library install chrome-history --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `chrome-history-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/chrome-history/cmd/chrome-history-pp-cli@latest
+```
 
-`chrome-history-pp-cli` reads your local Chrome history SQLite database, snapshots it to `~/.cache/chrome-history/`, builds an offline full-text index, and answers questions about your browsing. **Read-only, zero network — nothing leaves the machine.** Every command supports `--json` and `--select`, and the same surface is exposed as MCP tools (all read-only) via `chrome-history-pp-cli mcp`.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to use
 

--- a/library/productivity/clockify/README.md
+++ b/library/productivity/clockify/README.md
@@ -11,31 +11,37 @@ Created by [@melanson633](https://github.com/melanson633) (melanson633).
 The recommended path installs both the `clockify-pp-cli` binary and the `pp-clockify` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install clockify
+npx -y @mvanhorn/printing-press-library install clockify
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install clockify --cli-only
+npx -y @mvanhorn/printing-press-library install clockify --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install clockify --skill-only
+npx -y @mvanhorn/printing-press-library install clockify --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install clockify --agent claude-code
-npx -y @mvanhorn/printing-press install clockify --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install clockify --agent claude-code
+npx -y @mvanhorn/printing-press-library install clockify --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/clockify/cmd/clockify-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-clockify --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-clockify --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install clockify --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-clockify skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-clockify. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -111,18 +119,14 @@ Authenticate with a personal API key from the Clockify web app (Profile Settings
 # Confirm the API key works and Clockify is reachable before anything else.
 clockify-pp-cli doctor
 
-
 # Pull workspaces, projects, clients, tags, and time entries into the local store — every offline command reads from here.
 clockify-pp-cli sync
-
 
 # Reconstruct this week's grid from the synced entries — the headline view.
 clockify-pp-cli timesheet week
 
-
 # Find the days you are short before you submit the timesheet.
 clockify-pp-cli timesheet gaps
-
 
 # See where your tracked time actually went.
 clockify-pp-cli recap
@@ -211,7 +215,6 @@ Run `clockify-pp-cli --help` for the full command reference and flag list.
 ### addons
 
 Manage addons
-
 
 ### approval-requests
 
@@ -443,7 +446,6 @@ Manage workspaces
 - **`clockify-pp-cli workspaces create`** - Add a workspace
 - **`clockify-pp-cli workspaces get-of-user`** - Get all my workspaces
 - **`clockify-pp-cli workspaces get-of-user-workspaceid`** - Get workspace info
-
 
 ## Output Formats
 

--- a/library/productivity/clockify/SKILL.md
+++ b/library/productivity/clockify/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `clockify-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install clockify --cli-only
+   npx -y @mvanhorn/printing-press-library install clockify --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `clockify-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/clockify/cmd/clockify-pp-cli@latest
+```
 
-Other Clockify CLIs are timers with a thin reporting bolt-on, and none of them remember anything. This one keeps a local SQLite mirror of every time entry, project, client, and tag, so reports, timesheet reconstruction, gap detection, and billable audits run offline and instantly. It also covers the half of Clockify no terminal tool touches — invoices, expenses, time-off, approvals, and scheduling.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/etherpad/README.md
+++ b/library/productivity/etherpad/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-etherpad --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-etherpad --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install etherpad --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-etherpad skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-etherpad. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/etherpad/SKILL.md
+++ b/library/productivity/etherpad/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `etherpad-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install etherpad --cli-only
+   npx -y @mvanhorn/printing-press-library install etherpad --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `etherpad-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/etherpad/cmd/etherpad-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/productivity/fathom/README.md
+++ b/library/productivity/fathom/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-fathom --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-fathom --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install fathom --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-fathom skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-fathom. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/fathom/SKILL.md
+++ b/library/productivity/fathom/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `fathom-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install fathom --cli-only
+   npx -y @mvanhorn/printing-press-library install fathom --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `fathom-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/fathom/cmd/fathom-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/figma/README.md
+++ b/library/productivity/figma/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-figma --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-figma --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install figma --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-figma skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-figma. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/figma/SKILL.md
+++ b/library/productivity/figma/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `figma-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install figma --cli-only
+   npx -y @mvanhorn/printing-press-library install figma --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `figma-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/figma/cmd/figma-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/fireflies/README.md
+++ b/library/productivity/fireflies/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-fireflies --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-fireflies --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install fireflies --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-fireflies skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-fireflies. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/fireflies/SKILL.md
+++ b/library/productivity/fireflies/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `fireflies-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install fireflies --cli-only
+   npx -y @mvanhorn/printing-press-library install fireflies --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `fireflies-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/fireflies/cmd/fireflies-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/freshservice/README.md
+++ b/library/productivity/freshservice/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-freshservice
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-freshservice --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install freshservice --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-freshservice skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-freshservice. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/freshservice/SKILL.md
+++ b/library/productivity/freshservice/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `freshservice-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install freshservice --cli-only
+   npx -y @mvanhorn/printing-press-library install freshservice --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `freshservice-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/freshservice/cmd/freshservice-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/granola/README.md
+++ b/library/productivity/granola/README.md
@@ -5,7 +5,6 @@
 granola-pp-cli reads Granola’s local cache directly and adds the queries Granola.ai’s web app and existing community CLIs cannot answer. Cache-first, then internal API, then public API — transparent fallthrough. memo run, memo queue, attendee timeline, recipes coverage, calendar overlay, and talktime are local-data joins no per-meeting tool produces. Works offline; agent-native JSON by default.
 
 Created by [@dstevens](https://github.com/dstevens) (Damien Stevens).
-Contributors: [@jeffreydebolt](https://github.com/jeffreydebolt) (Jeff DeBolt).
 
 ## Install
 
@@ -59,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-granola --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-granola --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install granola --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-granola skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-granola. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/granola/SKILL.md
+++ b/library/productivity/granola/SKILL.md
@@ -23,12 +23,12 @@ metadata:
 
 This skill drives the `granola-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install granola --cli-only
+   npx -y @mvanhorn/printing-press-library install granola --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `granola-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -36,7 +36,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/granola/cmd/granola-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/marianatek/README.md
+++ b/library/productivity/marianatek/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-marianatek -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-marianatek --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install marianatek --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-marianatek skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-marianatek. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/marianatek/SKILL.md
+++ b/library/productivity/marianatek/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `marianatek-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install marianatek --cli-only
+   npx -y @mvanhorn/printing-press-library install marianatek --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `marianatek-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/marianatek/cmd/marianatek-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/myfitnesspal/README.md
+++ b/library/productivity/myfitnesspal/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-myfitnesspal
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-myfitnesspal --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install myfitnesspal --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-myfitnesspal skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-myfitnesspal. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/myfitnesspal/SKILL.md
+++ b/library/productivity/myfitnesspal/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `myfitnesspal-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install myfitnesspal --cli-only
+   npx -y @mvanhorn/printing-press-library install myfitnesspal --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `myfitnesspal-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/myfitnesspal/cmd/myfitnesspal-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/notion/README.md
+++ b/library/productivity/notion/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-notion --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-notion --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install notion --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-notion skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-notion. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/notion/SKILL.md
+++ b/library/productivity/notion/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `notion-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install notion --cli-only
+   npx -y @mvanhorn/printing-press-library install notion --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `notion-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/notion/cmd/notion-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/nylas/README.md
+++ b/library/productivity/nylas/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nylas --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-nylas --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install nylas --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-nylas skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-nylas. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/nylas/SKILL.md
+++ b/library/productivity/nylas/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `nylas-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install nylas --cli-only
+   npx -y @mvanhorn/printing-press-library install nylas --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `nylas-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/nylas/cmd/nylas-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/obsidian/README.md
+++ b/library/productivity/obsidian/README.md
@@ -62,17 +62,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-obsidian --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-obsidian --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install obsidian --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-obsidian skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-obsidian. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/obsidian/SKILL.md
+++ b/library/productivity/obsidian/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `obsidian-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install obsidian --cli-only
+   npx -y @mvanhorn/printing-press-library install obsidian --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `obsidian-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/obsidian/cmd/obsidian-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/productivity/opensnow/README.md
+++ b/library/productivity/opensnow/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-opensnow --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-opensnow --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install opensnow --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-opensnow skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-opensnow. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/opensnow/SKILL.md
+++ b/library/productivity/opensnow/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `opensnow-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install opensnow --cli-only
+   npx -y @mvanhorn/printing-press-library install opensnow --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `opensnow-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/opensnow/cmd/opensnow-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/outlook-calendar/README.md
+++ b/library/productivity/outlook-calendar/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-outlook-cale
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-outlook-calendar --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install outlook-calendar --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-outlook-calendar skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-outlook-calendar. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/outlook-calendar/SKILL.md
+++ b/library/productivity/outlook-calendar/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `outlook-calendar-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install outlook-calendar --cli-only
+   npx -y @mvanhorn/printing-press-library install outlook-calendar --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `outlook-calendar-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/outlook-calendar/cmd/outlook-calendar-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/outlook-email/README.md
+++ b/library/productivity/outlook-email/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-outlook-emai
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-outlook-email --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install outlook-email --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-outlook-email skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-outlook-email. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/outlook-email/SKILL.md
+++ b/library/productivity/outlook-email/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `outlook-email-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install outlook-email --cli-only
+   npx -y @mvanhorn/printing-press-library install outlook-email --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `outlook-email-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/outlook-email/cmd/outlook-email-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/resend/README.md
+++ b/library/productivity/resend/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-resend --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-resend --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install resend --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-resend skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-resend. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/resend/SKILL.md
+++ b/library/productivity/resend/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `resend-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install resend --cli-only
+   npx -y @mvanhorn/printing-press-library install resend --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `resend-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/resend/cmd/resend-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/roam/README.md
+++ b/library/productivity/roam/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-roam --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-roam --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install roam --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-roam skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-roam. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/roam/SKILL.md
+++ b/library/productivity/roam/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `roam-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install roam --cli-only
+   npx -y @mvanhorn/printing-press-library install roam --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `roam-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/roam/cmd/roam-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/safari-history/SKILL.md
+++ b/library/productivity/safari-history/SKILL.md
@@ -9,18 +9,20 @@ description: Query local Safari browsing history with zero network access: searc
 
 This skill drives the `safari-history-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install safari-history --cli-only
+   npx -y @mvanhorn/printing-press-library install safari-history --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `safari-history-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/safari-history/cmd/safari-history-pp-cli@latest
+```
 
-`safari-history-pp-cli` reads Safari's local `History.db`, snapshots it to `~/.cache/safari-history/`, builds an offline full-text index, and answers questions about your browsing. **Read-only, zero network — nothing leaves the machine.** Requires macOS Full Disk Access to read `~/Library/Safari/History.db`. Every command supports `--json` and `--select`, and the same surface is exposed as MCP tools (all read-only) via `safari-history-pp-cli mcp`.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to use
 

--- a/library/productivity/sendgrid/README.md
+++ b/library/productivity/sendgrid/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sendgrid --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-sendgrid --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install sendgrid --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-sendgrid skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sendgrid. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/sendgrid/SKILL.md
+++ b/library/productivity/sendgrid/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `sendgrid-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install sendgrid --cli-only
+   npx -y @mvanhorn/printing-press-library install sendgrid --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `sendgrid-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/sendgrid/cmd/sendgrid-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/slack/README.md
+++ b/library/productivity/slack/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-slack --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-slack --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install slack --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-slack skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-slack. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Quick Start
 

--- a/library/productivity/slack/SKILL.md
+++ b/library/productivity/slack/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `slack-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install slack --cli-only
+   npx -y @mvanhorn/printing-press-library install slack --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `slack-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/slack/cmd/slack-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/strava/README.md
+++ b/library/productivity/strava/README.md
@@ -11,31 +11,37 @@ Created by [@azaaron](https://github.com/azaaron) (azaaron).
 The recommended path installs both the `strava-pp-cli` binary and the `pp-strava` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install strava
+npx -y @mvanhorn/printing-press-library install strava
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install strava --cli-only
+npx -y @mvanhorn/printing-press-library install strava --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install strava --skill-only
+npx -y @mvanhorn/printing-press-library install strava --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install strava --agent claude-code
-npx -y @mvanhorn/printing-press install strava --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install strava --agent claude-code
+npx -y @mvanhorn/printing-press-library install strava --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/strava/cmd/strava-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-strava --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-strava --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install strava --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-strava skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-strava. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -111,22 +119,17 @@ Strava uses OAuth2. Run `strava-pp-cli auth login` to open the browser authoriza
 # Verify credentials and API connectivity (run auth login first if not authenticated)
 strava-pp-cli doctor
 
-
 # Verify credentials and check API connectivity
 strava-pp-cli doctor
-
 
 # Mirror your Strava data to a local SQLite database
 strava-pp-cli sync
 
-
 # See your CTL/ATL/TSB training load timeline
 strava-pp-cli training load --weeks 12
 
-
 # Compute your power curve from synced stream data
 strava-pp-cli athlete power-curve --since 2025-01-01
-
 
 # Track your progression on a specific segment over time
 strava-pp-cli segments progress 229781
@@ -229,7 +232,6 @@ Manage athlete
 
 Manage athletes
 
-
 ### clubs
 
 Manage clubs
@@ -269,7 +271,6 @@ Manage uploads
 
 - **`strava-pp-cli uploads create`** - Uploads a new data file to create an activity from. Requires activity:write scope.
 - **`strava-pp-cli uploads get-by-id`** - Returns an upload for a given identifier. Requires activity:write scope.
-
 
 ## Output Formats
 

--- a/library/productivity/strava/SKILL.md
+++ b/library/productivity/strava/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `strava-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install strava --cli-only
+   npx -y @mvanhorn/printing-press-library install strava --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `strava-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/strava/cmd/strava-pp-cli@latest
+```
 
-This CLI mirrors your entire Strava history to a local SQLite database (via `strava-pp-cli sync`), then unlocks the analytics your training actually requires: CTL/ATL training load, power curve, zone time distribution, aerobic decoupling, and segment effort progression. Everything works offline, composes with jq, and speaks JSON natively for AI coaching agents.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/superhuman/README.md
+++ b/library/productivity/superhuman/README.md
@@ -8,22 +8,40 @@ Created by [@mvanhorn](https://github.com/mvanhorn) (Matt Van Horn).
 
 ## Install
 
-The recommended path installs both the `superhuman-pp-cli` binary and the `pp-superhuman` agent skill in one shot:
+The recommended path installs both the `superhuman-pp-cli` binary and the `pp-superhuman` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install superhuman
+npx -y @mvanhorn/printing-press-library install superhuman
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install superhuman --cli-only
+npx -y @mvanhorn/printing-press-library install superhuman --cli-only
 ```
 
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
-### Without Node
+```bash
+npx -y @mvanhorn/printing-press-library install superhuman --skill-only
+```
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install superhuman --agent claude-code
+npx -y @mvanhorn/printing-press-library install superhuman --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/superhuman/cmd/superhuman-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -40,17 +58,56 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-superhuman -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-superhuman --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install superhuman --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-superhuman skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-superhuman. The skill defines how its required CLI can be installed.
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/superhuman-current).
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `SUPERHUMAN_JWT` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+
+Install the MCP binary from this CLI's published public-library entry or pre-built release.
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "superhuman": {
+      "command": "superhuman-pp-mcp",
+      "env": {
+        "SUPERHUMAN_JWT": "<your-key>"
+      }
+    }
+  }
+}
 ```
+
+</details>
 
 ## Authentication
 
@@ -70,22 +127,17 @@ superhuman-pp-cli doctor
 # One-time: capture durable tokens from Chrome's on-disk session
 superhuman-pp-cli auth login --disk
 
-
 # Confirm auth and connectivity are green
 superhuman-pp-cli doctor
-
 
 # Populate the local SQLite store; read commands refresh recent Gmail history automatically
 superhuman-pp-cli bootstrap --per-folder 100
 
-
 # List recent threads as structured JSON
 superhuman-pp-cli threads list --type inbox --limit 20 --json
 
-
 # Send with an undo window
 superhuman-pp-cli send --to teammate@example.com --subject "Update" --body-file body.txt --undo 30s
-
 
 # Look up Superhuman's live enrichment for a contact
 superhuman-pp-cli lookup teammate@example.com --json --select name,location,twitterHandle
@@ -276,7 +328,6 @@ Existing commands and flags continue to work. The overhaul adds automatic bootst
 
 Older pre-backend builds stored snippets at `~/.superhuman-pp-cli/snippets.json`. The first `snippets list` after upgrading prints a one-time migration hint if that local file exists and is non-empty. The CLI never auto-uploads, modifies, or deletes that file; recreate any snippets you still need with `snippets create --name <n> --body <b>`.
 
-
 ## Output Formats
 
 ```bash
@@ -311,69 +362,6 @@ This CLI is designed for AI agent consumption:
 - **Agent-safe by default** - no colors or formatting unless `--human-friendly` is set
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
-
-## Use with Claude Code
-
-Install the focused skill — it auto-installs the CLI on first invocation:
-
-```bash
-npx skills add mvanhorn/printing-press-library/cli-skills/pp-superhuman -g
-```
-
-Then invoke `/pp-superhuman <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
-
-<details>
-<summary>Use as an MCP server in Claude Code (advanced)</summary>
-
-If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Then register it:
-
-```bash
-claude mcp add superhuman superhuman-pp-mcp -e SUPERHUMAN_JWT=<your-token>
-```
-
-</details>
-
-## Use with Claude Desktop
-
-This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
-
-To install:
-
-1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/superhuman-current).
-2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
-3. Fill in `SUPERHUMAN_JWT` when Claude Desktop prompts you.
-
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
-
-<details>
-<summary>Manual JSON config (advanced)</summary>
-
-If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
-
-
-Install the MCP binary from this CLI's published public-library entry or pre-built release.
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "superhuman": {
-      "command": "superhuman-pp-mcp",
-      "env": {
-        "SUPERHUMAN_JWT": "<your-key>"
-      }
-    }
-  }
-}
-```
-
-</details>
 
 ## Health Check
 

--- a/library/productivity/superhuman/SKILL.md
+++ b/library/productivity/superhuman/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `superhuman-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install superhuman --cli-only
+   npx -y @mvanhorn/printing-press-library install superhuman --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `superhuman-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/productivity/superhuman/cmd/superhuman-pp-cli@latest
+```
 
-Read, draft, send, and snooze Superhuman email from your terminal or Claude Code. Pair a JWT lifted from your logged-in Chrome session with a local SQLite store for offline thread search, draft management, and Ask AI semantic queries.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/techmeme/README.md
+++ b/library/productivity/techmeme/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-techmeme --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-techmeme --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install techmeme --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-techmeme skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-techmeme. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/techmeme/SKILL.md
+++ b/library/productivity/techmeme/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `techmeme-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install techmeme --cli-only
+   npx -y @mvanhorn/printing-press-library install techmeme --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `techmeme-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/techmeme/cmd/techmeme-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/tidycal/README.md
+++ b/library/productivity/tidycal/README.md
@@ -15,7 +15,6 @@ If you're building a custom integration to TidyCal which requires users to authe
 
 Using the `authorization_code` grant type to authenticate users using OAuth 2.0 to retrieve an access token is fairly conventional, more information on that process can be found here: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
 
-
 * Authorization URL: https://tidycal.com/oauth/authorize
 * Access Token URL: https://tidycal.com/oauth/token
 
@@ -75,17 +74,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tidycal --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-tidycal --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install tidycal --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-tidycal skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tidycal. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -240,7 +241,6 @@ Manage teams
 
 - **`tidycal-pp-cli teams get`** - Get details of a specific team.
 - **`tidycal-pp-cli teams list`** - Get a list of teams the authenticated user has access to.
-
 
 ## Output Formats
 

--- a/library/productivity/tidycal/SKILL.md
+++ b/library/productivity/tidycal/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `tidycal-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install tidycal --cli-only
+   npx -y @mvanhorn/printing-press-library install tidycal --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `tidycal-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,26 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/tidycal/cmd/tidycal-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-# Introduction
-TidyCal's REST API provides a handful of endpoints which can be used to get information about your account and bookings.  It uses conventional OAuth 2.0 protocol for authentication.
-
-# Authentication
-### Personal Access Token
-Create a personal access token at https://tidycal.com/integrations/oauth.  Once created, it can be used to authenticate requests by passing it in the `Authorization` header.
-```
-Authorization: Bearer {TOKEN}
-```
-
-### OAuth 2.0 Client
-If you're building a custom integration to TidyCal which requires users to authenticate in order to get access tokens to make API requests on their behalf, you'll need to create an OAuth 2.0 client. This is easy to do from the \"OAuth Apps\" settings page found here https://tidycal.com/integrations/oauth
-
-Using the `authorization_code` grant type to authenticate users using OAuth 2.0 to retrieve an access token is fairly conventional, more information on that process can be found here: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
-
-
-* Authorization URL: https://tidycal.com/oauth/authorize
-* Access Token URL: https://tidycal.com/oauth/token
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Unique Capabilities
 

--- a/library/productivity/zoho-expense/README.md
+++ b/library/productivity/zoho-expense/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-zoho-expense
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-zoho-expense --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install zoho-expense --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-zoho-expense skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-zoho-expense. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -127,22 +129,17 @@ Zoho Expense uses OAuth 2.0 with a self-client authorization-code flow. Create a
 # Exchange the 10-min code for a refresh token
 zoho-expense-pp-cli auth login --client-id $ZOHO_EXPENSE_CLIENT_ID --client-secret $ZOHO_EXPENSE_CLIENT_SECRET
 
-
 # Set the active organization (first one in the list)
 zoho-expense-pp-cli org use $(zoho-expense-pp-cli organizations list --json | jq -r '.[0].organization_id')
-
 
 # Sync categories, reporting tags, projects, customers, expenses into the local store
 zoho-expense-pp-cli sync
 
-
 # Upload one receipt with hash-dedup and auto-tag
 zoho-expense-pp-cli receipt upload ~/Downloads/uber-receipt.pdf --auto-tag
 
-
 # Batch ingest a folder for AI consumption
 zoho-expense-pp-cli invoice ingest ~/Downloads/october-invoices --auto-tag --agent
-
 
 # Bundle the month into a report and submit
 zoho-expense-pp-cli close --month 2026-10 --auto-submit
@@ -345,7 +342,6 @@ Manage users in the organization
 - **`zoho-expense-pp-cli users list`** - List users
 - **`zoho-expense-pp-cli users me`** - Get the authenticated user's profile
 - **`zoho-expense-pp-cli users update`** - Update a user
-
 
 ## Output Formats
 

--- a/library/productivity/zoho-expense/SKILL.md
+++ b/library/productivity/zoho-expense/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `zoho-expense-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install zoho-expense --cli-only
+   npx -y @mvanhorn/printing-press-library install zoho-expense --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `zoho-expense-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/zoho-expense/cmd/zoho-expense-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Zoho ships autoscan; this CLI ships everything that comes after — receipt dedup, learned merchant→category mapping, India GST splitting, and monthly report bundling. Built for AI agents that ingest invoices from an inbox on a cadence and need an idempotent, structured-output upload path. India-region by default; works against any Zoho datacenter by overriding the base URL.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/productivity/zoom/README.md
+++ b/library/productivity/zoom/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-zoom --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-zoom --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install zoom --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-zoom skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-zoom. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/productivity/zoom/SKILL.md
+++ b/library/productivity/zoom/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `zoom-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install zoom --cli-only
+   npx -y @mvanhorn/printing-press-library install zoom --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `zoom-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/productivity/zoom/cmd/zoom-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/project-management/clickup/README.md
+++ b/library/project-management/clickup/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-clickup --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-clickup --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install clickup --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-clickup skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-clickup. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/project-management/clickup/SKILL.md
+++ b/library/project-management/clickup/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `clickup-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install clickup --cli-only
+   npx -y @mvanhorn/printing-press-library install clickup --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `clickup-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/project-management/clickup/cmd/clickup-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/project-management/jira/README.md
+++ b/library/project-management/jira/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-jira --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-jira --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install jira --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-jira skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-jira. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/project-management/jira/SKILL.md
+++ b/library/project-management/jira/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `jira-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install jira --cli-only
+   npx -y @mvanhorn/printing-press-library install jira --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `jira-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/project-management/jira/cmd/jira-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/project-management/linear/README.md
+++ b/library/project-management/linear/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-linear --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-linear --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install linear --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-linear skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-linear. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/project-management/linear/SKILL.md
+++ b/library/project-management/linear/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `linear-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install linear --cli-only
+   npx -y @mvanhorn/printing-press-library install linear --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `linear-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/project-management/plane/README.md
+++ b/library/project-management/plane/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-plane --forc
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-plane --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install plane --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-plane skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-plane. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -293,7 +295,6 @@ Plane's issue API never returns module membership, so a plain `sync` leaves `mod
 - **`plane-pp-cli module sync`** - Walk modules → module-issues, populate a junction table, and patch each issue's `module_ids` (also runs automatically inside `sync`).
 - **`plane-pp-cli module of <issue>`** - Show which modules an issue belongs to (from the local cache).
 - **`plane-pp-cli module create-issue <module> <project> <slug> --name "..."`** - Create a work item and add it to a module in one step.
-
 
 ## Output Formats
 

--- a/library/project-management/plane/SKILL.md
+++ b/library/project-management/plane/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `plane-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install plane --cli-only
+   npx -y @mvanhorn/printing-press-library install plane --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `plane-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,11 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/project-management/plane/cmd/plane-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The Plane REST API
-
-Visit our quick start guide and full API documentation at [developers.plane.so](https://developers.plane.so/api-reference/introduction).
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Command Reference
 

--- a/library/sales-and-crm/conduyt-crm/README.md
+++ b/library/sales-and-crm/conduyt-crm/README.md
@@ -127,17 +127,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-conduyt-crm 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-conduyt-crm --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install conduyt-crm --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-conduyt-crm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-conduyt-crm. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/sales-and-crm/conduyt-crm/SKILL.md
+++ b/library/sales-and-crm/conduyt-crm/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `conduyt-crm-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install conduyt-crm --cli-only
+   npx -y @mvanhorn/printing-press-library install conduyt-crm --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `conduyt-crm-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/conduyt-crm/cmd/conduyt-crm-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Authentication
 

--- a/library/sales-and-crm/contact-goat/README.md
+++ b/library/sales-and-crm/contact-goat/README.md
@@ -57,17 +57,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-contact-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install contact-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-contact-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-contact-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/sales-and-crm/contact-goat/SKILL.md
+++ b/library/sales-and-crm/contact-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `contact-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install contact-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install contact-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `contact-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/contact-goat/cmd/contact-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/eu-tenders/README.md
+++ b/library/sales-and-crm/eu-tenders/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-eu-tenders -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-eu-tenders --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install eu-tenders --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-eu-tenders skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-eu-tenders. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/sales-and-crm/eu-tenders/SKILL.md
+++ b/library/sales-and-crm/eu-tenders/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `eu-tenders-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install eu-tenders --cli-only
+   npx -y @mvanhorn/printing-press-library install eu-tenders --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `eu-tenders-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/eu-tenders/cmd/eu-tenders-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/gohighlevel/README.md
+++ b/library/sales-and-crm/gohighlevel/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-gohighlevel 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-gohighlevel --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install gohighlevel --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-gohighlevel skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-gohighlevel. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/sales-and-crm/gohighlevel/SKILL.md
+++ b/library/sales-and-crm/gohighlevel/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `gohighlevel-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install gohighlevel --cli-only
+   npx -y @mvanhorn/printing-press-library install gohighlevel --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `gohighlevel-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/gohighlevel/cmd/gohighlevel-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/gorgias/README.md
+++ b/library/sales-and-crm/gorgias/README.md
@@ -11,17 +11,73 @@ The MCP server runs in code-orchestration mode: ~15 tools (a `gorgias_search` + 
 
 Learn more at [Gorgias](https://www.gorgias.com).
 
+Created by [@chrisyoungcooks](https://github.com/chrisyoungcooks) (Chris Young).
+
 ## Install
+
+The recommended path installs both the `gorgias-pp-cli` binary and the `pp-gorgias` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+
+```bash
+npx -y @mvanhorn/printing-press-library install gorgias
+```
+
+For CLI only (no skill):
 
 ```bash
 npx -y @mvanhorn/printing-press-library install gorgias --cli-only
 ```
 
-If the installer is unavailable, install from the Printing Press Library module:
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install gorgias --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install gorgias --agent claude-code
+npx -y @mvanhorn/printing-press-library install gorgias --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/gorgias/cmd/gorgias-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/gorgias-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-gorgias --force
+```
+
+Inside a Hermes chat session:
+
+```text
+/skills install mvanhorn/printing-press-library/cli-skills/pp-gorgias --force
+```
+
+## Install for OpenClaw
+
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
+
+```bash
+npx -y @mvanhorn/printing-press-library install gorgias --agent openclaw --bin-dir ~/.local/bin
+```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Authentication
 

--- a/library/sales-and-crm/gorgias/SKILL.md
+++ b/library/sales-and-crm/gorgias/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `gorgias-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install gorgias --cli-only
+   npx -y @mvanhorn/printing-press-library install gorgias --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `gorgias-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/gorgias/cmd/gorgias-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-A token-efficient CLI for the Gorgias customer support API with a sibling MCP server. Covers 108 endpoints across tickets, customers, messages, macros, tags, teams, integrations, events, rules, satisfaction surveys, voice calls, custom fields, and views. Built for AI agents first: JSON output, structured doctor checks, local SQLite mirror, and code-orchestration MCP — 15 tools (~9K tokens measured for `tools/list`) cover the full 108-endpoint surface via the `gorgias_search` + `gorgias_execute` gateway.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/intercom/README.md
+++ b/library/sales-and-crm/intercom/README.md
@@ -35,9 +35,15 @@ npx -y @mvanhorn/printing-press-library install intercom --agent claude-code
 npx -y @mvanhorn/printing-press-library install intercom --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/intercom/cmd/intercom-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-intercom --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-intercom --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install intercom --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-intercom skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-intercom. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -166,7 +174,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Tag every conversation mentioning an outage
 
@@ -975,7 +982,6 @@ Everything about your Visitors
 **Option 1.** You can update a visitor by passing in the `user_id` of the visitor in the Request body.
 
 **Option 2.** You can update a visitor by passing in the `id` of the visitor in the Request body.
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/intercom/SKILL.md
+++ b/library/sales-and-crm/intercom/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `intercom-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install intercom --cli-only
+   npx -y @mvanhorn/printing-press-library install intercom --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `intercom-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/intercom/cmd/intercom-pp-cli@latest
+```
 
-This CLI exposes the full Intercom REST API as a single Go binary. Every endpoint is a subcommand. A `sync` command mirrors conversations, contacts, companies, tickets, and articles into a local SQLite database so offline `search` and four headline transcendence commands — `incident-tag`, `articles pull/push`, `contact 360`, and `conversations sla` — answer the questions the API alone can't. Region-aware (`--region us|eu|au`) and built for agents (JSON-first, typed exit codes, MCP-mirrored).
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/jobber/README.md
+++ b/library/sales-and-crm/jobber/README.md
@@ -11,31 +11,37 @@ Created by [@melanson633](https://github.com/melanson633) (melanson633).
 The recommended path installs both the `jobber-pp-cli` binary and the `pp-jobber` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install jobber
+npx -y @mvanhorn/printing-press-library install jobber
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jobber --cli-only
+npx -y @mvanhorn/printing-press-library install jobber --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install jobber --skill-only
+npx -y @mvanhorn/printing-press-library install jobber --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install jobber --agent claude-code
-npx -y @mvanhorn/printing-press install jobber --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install jobber --agent claude-code
+npx -y @mvanhorn/printing-press-library install jobber --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/jobber/cmd/jobber-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-jobber --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-jobber --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install jobber --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-jobber skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-jobber. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -117,18 +125,14 @@ Jobber uses OAuth2 authorization code flow with mandatory refresh-token rotation
 # verify OAuth token, GraphQL version, and throttle budget before a long pull
 jobber-pp-cli doctor
 
-
 # one-time full pull of every read-only surface into local SQLite
 jobber-pp-cli sync --full
-
 
 # your first analytical question — aged AR by client, offline
 jobber-pp-cli ar aging --as-of 2026-05-15 --json
 
-
 # per-invoice ledger filtered to invoices whose payments don't equal total
 jobber-pp-cli invoices trace --mismatched --json
-
 
 # FTS5 across every text field in the synced store
 jobber-pp-cli search "smith" --json
@@ -213,7 +217,6 @@ Quotes (Jobber `quotes` Relay connection)
 Visits (Jobber `visits` Relay connection)
 
 - **`jobber-pp-cli visits`** - List visits with optional filters
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/jobber/SKILL.md
+++ b/library/sales-and-crm/jobber/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `jobber-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install jobber --cli-only
+   npx -y @mvanhorn/printing-press-library install jobber --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `jobber-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/jobber/cmd/jobber-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The `jobber-pp-cli` binary syncs the whole Jobber GraphQL surface into a local SQLite database, then lets you slice it with `ar aging`, `invoices trace`, `snapshot diff`, FTS `search`, and ad-hoc `sql`. Existing Jobber MCPs are RPC proxies — you can't run them on a plane, you can't compose them with SQL, and they don't store data locally. This tool does. It also ships read-only by construction (no mutation commands are emitted), which makes it safe to hand to an advisor or auditor on a live client tenant.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/servicetitan-pricebook/README.md
+++ b/library/sales-and-crm/servicetitan-pricebook/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-servicetitan
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-servicetitan-pricebook --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-servicetitan-pricebook skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-servicetitan-pricebook. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/sales-and-crm/servicetitan-pricebook/SKILL.md
+++ b/library/sales-and-crm/servicetitan-pricebook/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `servicetitan-pricebook-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --cli-only
+   npx -y @mvanhorn/printing-press-library install servicetitan-pricebook --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `servicetitan-pricebook-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/servicetitan-pricebook/cmd/servicetitan-pricebook-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/smartlead/README.md
+++ b/library/sales-and-crm/smartlead/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-smartlead --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-smartlead --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install smartlead --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-smartlead skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-smartlead. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/sales-and-crm/smartlead/SKILL.md
+++ b/library/sales-and-crm/smartlead/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `smartlead-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install smartlead --cli-only
+   npx -y @mvanhorn/printing-press-library install smartlead --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `smartlead-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/smartlead/cmd/smartlead-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/sales-and-crm/tenderned/README.md
+++ b/library/sales-and-crm/tenderned/README.md
@@ -35,9 +35,15 @@ npx -y @mvanhorn/printing-press-library install tenderned --agent claude-code
 npx -y @mvanhorn/printing-press-library install tenderned --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned/cmd/tenderned-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -54,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-tenderned --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-tenderned --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install tenderned --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-tenderned skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-tenderned. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -146,7 +154,6 @@ Search, list and fetch tender notices (aankondigingen) from TenderNed — mirror
 
 - **`tenderned-pp-cli notices get`** - Fetch full structured metadata for one publication
 - **`tenderned-pp-cli notices list`** - Search and list tender publications with rich filters (CPV, dates, buyer, procedure, scope)
-
 
 ## Output Formats
 

--- a/library/sales-and-crm/tenderned/SKILL.md
+++ b/library/sales-and-crm/tenderned/SKILL.md
@@ -20,22 +20,20 @@ metadata:
 
 This skill drives the `tenderned-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install tenderned --cli-only
+   npx -y @mvanhorn/printing-press-library install tenderned --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `tenderned-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned/cmd/tenderned-pp-cli@latest
+```
 
-Every Dutch public tender, with the sub-threshold long tail that EU TED never sees, in a local-first CLI you can pipe.
-
-TenderNed is the Dutch national public procurement platform run by PIANOo / Ministerie van EZK. Every Dutch contracting authority must publish above- and below-threshold tender notices here. Above-threshold notices are forwarded to EU TED; the sub-threshold long tail (€40k–€220k) is TenderNed-only.
-
-This CLI covers the unauthenticated TNS publication webservice (search/list/filter publications, document download, contracting-authority directory, RSS feed) and the Basic-auth eForms XML endpoint. Data is CC-0 public domain.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/social-and-messaging/bird/README.md
+++ b/library/social-and-messaging/bird/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-bird --force
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-bird --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install bird --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-bird skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-bird. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/social-and-messaging/bird/SKILL.md
+++ b/library/social-and-messaging/bird/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `bird-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install bird --cli-only
+   npx -y @mvanhorn/printing-press-library install bird --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `bird-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/bird/cmd/bird-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/multimail/README.md
+++ b/library/social-and-messaging/multimail/README.md
@@ -4,6 +4,8 @@
 
 The only CLI that makes MultiMail's trust ladder a first-class operator surface. Sync mailboxes, emails, and audit events to local SQLite, then query oversight velocity, allowlist coverage, and inbox health across your entire fleet — insights no single API call provides.
 
+Created by [@H179922](https://github.com/H179922) (H179922).
+
 ## Install
 
 The recommended path installs both the `multimail-pp-cli` binary and the `pp-multimail` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
@@ -56,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-multimail --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-multimail --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install multimail --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-multimail skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-multimail. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -214,7 +218,6 @@ These capabilities aren't available in any other tool for this API.
   ```
 
 ## Recipes
-
 
 ### Approve all pending emails for a mailbox
 
@@ -459,7 +462,6 @@ Manage well known
 - **`multimail-pp-cli well-known list`** - Returns the ECDSA P-256 public key used to sign X-MultiMail-Identity headers.
 - **`multimail-pp-cli well-known list-wellknown`** - Returns OAuth authorization server metadata with an agent_auth extension block describing the auth.md agent registration flow.
 - **`multimail-pp-cli well-known list-wellknown-2`** - Returns metadata about MultiMail as an OAuth-protected resource, including supported scopes and authorization servers. Part of the auth.md agent registration protocol.
-
 
 ## Output Formats
 

--- a/library/social-and-messaging/multimail/SKILL.md
+++ b/library/social-and-messaging/multimail/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `multimail-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install multimail --cli-only
+   npx -y @mvanhorn/printing-press-library install multimail --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `multimail-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/multimail/cmd/multimail-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-The only CLI that makes MultiMail's trust ladder a first-class operator surface. Sync mailboxes, emails, and audit events to local SQLite, then query oversight velocity, allowlist coverage, and inbox health across your entire fleet — insights no single API call provides.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/pushover/README.md
+++ b/library/social-and-messaging/pushover/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pushover --f
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pushover --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pushover --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pushover skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pushover. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/social-and-messaging/pushover/SKILL.md
+++ b/library/social-and-messaging/pushover/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `pushover-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pushover --cli-only
+   npx -y @mvanhorn/printing-press-library install pushover --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pushover-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/pushover/cmd/pushover-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/twilio/README.md
+++ b/library/social-and-messaging/twilio/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-twilio --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-twilio --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install twilio --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-twilio skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-twilio. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/social-and-messaging/twilio/SKILL.md
+++ b/library/social-and-messaging/twilio/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `twilio-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install twilio --cli-only
+   npx -y @mvanhorn/printing-press-library install twilio --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `twilio-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/twilio/cmd/twilio-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/x-twitter/README.md
+++ b/library/social-and-messaging/x-twitter/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-x-twitter --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-x-twitter --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install x-twitter --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-x-twitter skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-x-twitter. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/social-and-messaging/x-twitter/SKILL.md
+++ b/library/social-and-messaging/x-twitter/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `x-twitter-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install x-twitter --cli-only
+   npx -y @mvanhorn/printing-press-library install x-twitter --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `x-twitter-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/cmd/x-twitter-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## HTTP Transport
 

--- a/library/travel/airbnb/README.md
+++ b/library/travel/airbnb/README.md
@@ -62,17 +62,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --for
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-airbnb --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install airbnb --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-airbnb skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-airbnb. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/airbnb/SKILL.md
+++ b/library/travel/airbnb/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `airbnb-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install airbnb --cli-only
+   npx -y @mvanhorn/printing-press-library install airbnb --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `airbnb-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/airbnb/cmd/airbnb-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/alaska-airlines/README.md
+++ b/library/travel/alaska-airlines/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-alaska-airli
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-alaska-airlines --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install alaska-airlines --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-alaska-airlines skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-alaska-airlines. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/alaska-airlines/SKILL.md
+++ b/library/travel/alaska-airlines/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `alaska-airlines-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install alaska-airlines --cli-only
+   npx -y @mvanhorn/printing-press-library install alaska-airlines --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `alaska-airlines-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/alaska-airlines/cmd/alaska-airlines-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/alltrails/README.md
+++ b/library/travel/alltrails/README.md
@@ -33,9 +33,15 @@ npx -y @mvanhorn/printing-press-library install alltrails --agent claude-code
 npx -y @mvanhorn/printing-press-library install alltrails --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/alltrails/cmd/alltrails-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-alltrails --
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-alltrails --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install alltrails --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-alltrails skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-alltrails. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -147,7 +155,6 @@ Manage alltrails
 - **`alltrails-pp-cli alltrails get-v3-5`** - User activity list
 - **`alltrails-pp-cli alltrails list`** - Trail search by text, location, and filters
 - **`alltrails-pp-cli alltrails list-v3`** - Current account profile
-
 
 ## Output Formats
 

--- a/library/travel/alltrails/SKILL.md
+++ b/library/travel/alltrails/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `alltrails-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install alltrails --cli-only
+   npx -y @mvanhorn/printing-press-library install alltrails --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `alltrails-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/alltrails/cmd/alltrails-pp-cli@latest
+```
 
-Evidence-labeled, live-capable route map for AllTrails browser/mobile surfaces. Not an official API contract.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## HTTP Transport
 

--- a/library/travel/booking-com/README.md
+++ b/library/travel/booking-com/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-booking-com 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-booking-com --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install booking-com --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-booking-com skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-booking-com. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/booking-com/SKILL.md
+++ b/library/travel/booking-com/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `booking-com-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install booking-com --cli-only
+   npx -y @mvanhorn/printing-press-library install booking-com --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `booking-com-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/booking-com/cmd/booking-com-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/delta-trip/README.md
+++ b/library/travel/delta-trip/README.md
@@ -11,31 +11,37 @@ Created by [@paulbockewitz](https://github.com/paulbockewitz) (Paul Bockewitz).
 The recommended path installs both the `delta-trip-pp-cli` binary and the `pp-delta-trip` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install delta-trip
+npx -y @mvanhorn/printing-press-library install delta-trip
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install delta-trip --cli-only
+npx -y @mvanhorn/printing-press-library install delta-trip --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install delta-trip --skill-only
+npx -y @mvanhorn/printing-press-library install delta-trip --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install delta-trip --agent claude-code
-npx -y @mvanhorn/printing-press install delta-trip --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install delta-trip --agent claude-code
+npx -y @mvanhorn/printing-press-library install delta-trip --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/delta-trip/cmd/delta-trip-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-delta-trip -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-delta-trip --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install delta-trip --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-delta-trip skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-delta-trip. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -146,7 +154,6 @@ Seat assignment and upgrade eligibility per passenger per flight
 Delta trip lookup and management by confirmation number
 
 - **`delta-trip-pp-cli trips`** - Look up a trip by confirmation number, first name, and last name
-
 
 ## Output Formats
 

--- a/library/travel/delta-trip/SKILL.md
+++ b/library/travel/delta-trip/SKILL.md
@@ -18,18 +18,20 @@ metadata:
 
 This skill drives the `delta-trip-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install delta-trip --cli-only
+   npx -y @mvanhorn/printing-press-library install delta-trip --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `delta-trip-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/delta-trip/cmd/delta-trip-pp-cli@latest
+```
 
-Look up and manage Delta Air Lines trips by confirmation number — view all flights, seats, baggage, upgrade options, and flight details without logging in.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/travel/flight-goat/README.md
+++ b/library/travel/flight-goat/README.md
@@ -99,17 +99,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat 
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-flight-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install flight-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-flight-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-flight-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/flight-goat/SKILL.md
+++ b/library/travel/flight-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `flight-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install flight-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install flight-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `flight-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/flight-goat/cmd/flight-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## Categories
 AeroAPI is divided into several categories to make things easier to

--- a/library/travel/hotel-goat/README.md
+++ b/library/travel/hotel-goat/README.md
@@ -93,17 +93,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hotel-goat -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-hotel-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install hotel-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-hotel-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hotel-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -179,7 +181,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Cheapest 4-star+ stay in Paris under EUR 300 for a specific weekend
 
 ```bash
@@ -226,13 +227,11 @@ Hotel search results from Google Hotels for a location + date range
 - **`hotel-goat-pp-cli hotels`** - Search hotels by location and date range. Returns ~30-40 properties per query
 with full OTA price breakdown and booking deep-links.
 
-
 ### properties
 
 Property detail records cached from Google's property detail pages
 
 - **`hotel-goat-pp-cli properties`** - Full property detail by Google's property_token
-
 
 ## Output Formats
 

--- a/library/travel/hotel-goat/SKILL.md
+++ b/library/travel/hotel-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `hotel-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install hotel-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install hotel-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `hotel-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,28 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/hotel-goat/cmd/hotel-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-hotel-goat fans out across **two cash-price sources** by default:
-- **Google Hotels** — scraped from the server-rendered page
-- **Trivago** — called via the public Trivago MCP server (no key); aggregates OTA rates from Booking.com, Expedia, Agoda, Hotels.com, Priceline, etc.
-
-Control which sources run with `--source google|trivago|both` on the `hotels` command. Default is `both`. Matched hotels (lat/lng within 250m and name token-overlap ≥ 0.5, with both sides carrying ≥2 informative tokens after stopword stripping) get a unified `prices[]` array with one entry per source; Trivago-only properties are appended as standalone rows with `property_token` prefixed `trivago:`.
-
-Trivago is geolocated server-side and returns EUR regardless of client hints. When the headline currency differs from Trivago's, each Trivago price is converted via the Frankfurter ECB FX endpoint (free, no key, 24h cache) so cross-source comparisons are apples-to-apples. Source label semantics:
-
-- `trivago/<OTA> [EUR 802 -> USD]` — FX conversion ran. The numeric `price` field is in the target currency; the original EUR amount is in the label.
-- `trivago/<OTA> [EUR]` — FX lookup failed. The numeric `price` is native EUR and the headline `price_per_night` is NOT overridden.
-- `trivago/<OTA>` (no suffix) — currencies already matched.
-
-v1 ships:
-- `hotels <loc> <ci> <co>` — multi-source search with brand / hotel-class / price / rating / amenity / `--source` filters
-- `dates <loc> --from --to --nights N` — sweep a date window for the cheapest pair per stay
-- `near "<address>" --radius Nmi` — geo-radius around any address (auto-geocoded via OSM Nominatim)
-- `hotel show/reviews <token>` — single-property detail + reviews
-- `wishlist add/list/remove <token>` — local SQLite save
-
-Brand-loyalty expansion, full month-window scans, price drift, multi-room family logic, and per-OTA breakdown are deferred to v0.2.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/hotel-tonight/README.md
+++ b/library/travel/hotel-tonight/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hotel-tonigh
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-hotel-tonight --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install hotel-tonight --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-hotel-tonight skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hotel-tonight. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/hotel-tonight/SKILL.md
+++ b/library/travel/hotel-tonight/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `hotel-tonight-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install hotel-tonight --cli-only
+   npx -y @mvanhorn/printing-press-library install hotel-tonight --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `hotel-tonight-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/hotel-tonight/cmd/hotel-tonight-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/infotbm/README.md
+++ b/library/travel/infotbm/README.md
@@ -4,7 +4,7 @@
 
 Syncs the full TBM GTFS dataset locally so schedule lookups, stop searches, and frequency analysis work without an internet connection. Overlays live real-time data from the SIRI-Lite API for arrival predictions, vehicle tracking, and disruption alerts. Computes journeys, detects ghost services, and diffs timetable changes — capabilities no existing Bordeaux transit tool provides.
 
-Printed by [@pawlclawbot](https://github.com/pawlclawbot).
+Created by [@pawlclawbot](https://github.com/pawlclawbot) (pawlclawbot).
 
 ## Install
 
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-infotbm --fo
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-infotbm --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install infotbm --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-infotbm skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-infotbm. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -197,7 +199,6 @@ These capabilities aren't available in any other tool for this API.
 
 ## Recipes
 
-
 ### Morning commute check
 
 ```bash
@@ -246,56 +247,38 @@ Run `infotbm-pp-cli --help` for the full command reference and flag list.
 
 ### agencies
 
-
-
 - **`infotbm-pp-cli agencies`** - Transit agencies in the Bordeaux network
 
 ### alerts
-
-
 
 - **`infotbm-pp-cli alerts`** - Active service disruption alerts
 
 ### fares
 
-
-
 - **`infotbm-pp-cli fares`** - Fare structure including pricing and transfer rules
 
 ### feed-info
-
-
 
 - **`infotbm-pp-cli feed-info`** - GTFS feed metadata including validity dates and timestamps
 
 ### kml
 
-
-
 - **`infotbm-pp-cli kml`** - KML geographic data export with route geometry and stop locations
 
 ### realtime
-
-
 
 - **`infotbm-pp-cli realtime stop`** - Real-time departure information at a specific stop
 - **`infotbm-pp-cli realtime vehicles`** - Real-time vehicle positions across the network
 
 ### routes
 
-
-
 - **`infotbm-pp-cli routes`** - All transit routes/lines in the TBM network
 
 ### server-info
 
-
-
 - **`infotbm-pp-cli server-info`** - API version and build information
 
 ### siri
-
-
 
 - **`infotbm-pp-cli siri check-status`** - SIRI service health check
 - **`infotbm-pp-cli siri estimated-timetable`** - Estimated real-time timetable for a line
@@ -306,10 +289,7 @@ Run `infotbm-pp-cli --help` for the full command reference and flag list.
 
 ### stops
 
-
-
 - **`infotbm-pp-cli stops`** - All transit stops in the TBM network
-
 
 ## Output Formats
 

--- a/library/travel/infotbm/SKILL.md
+++ b/library/travel/infotbm/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `infotbm-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install infotbm --cli-only
+   npx -y @mvanhorn/printing-press-library install infotbm --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `infotbm-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,9 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/infotbm/cmd/infotbm-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Syncs the full TBM GTFS dataset locally so schedule lookups, stop searches, and frequency analysis work without an internet connection. Overlays live real-time data from the SIRI-Lite API for arrival predictions, vehicle tracking, and disruption alerts. Computes journeys, detects ghost services, and diffs timetable changes — capabilities no existing Bordeaux transit tool provides.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/nynj-world-cup-concierge/README.md
+++ b/library/travel/nynj-world-cup-concierge/README.md
@@ -4,11 +4,73 @@ Read-only Printing Press CLI for the public NYNJ World Cup Concierge and Host Co
 
 The CLI extracts normalized JSON candidates from public NYNJ World Cup 26 sources, including Explore NYNJ cards, Fan Experiences, and Watch Parties/Public Viewing guidance. It is designed for trip-planning agents that need official, source-linked activity candidates with stable IDs.
 
+Created by [@amit](https://github.com/amit) (Amit).
+
 ## Install
+
+The recommended path installs both the `nynj-world-cup-concierge-pp-cli` binary and the `pp-nynj-world-cup-concierge` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
+
+```bash
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge
+```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --cli-only
+```
+
+For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
+
+```bash
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --skill-only
+```
+
+To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
+
+```bash
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --agent claude-code
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --agent claude-code --agent codex
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/travel/nynj-world-cup-concierge/cmd/nynj-world-cup-concierge-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/nynj-world-cup-concierge-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
+<!-- pp-hermes-install-anchor -->
+## Install for Hermes
+
+From the Hermes CLI:
+
+```bash
+hermes skills install mvanhorn/printing-press-library/cli-skills/pp-nynj-world-cup-concierge --force
+```
+
+Inside a Hermes chat session:
+
+```text
+/skills install mvanhorn/printing-press-library/cli-skills/pp-nynj-world-cup-concierge --force
+```
+
+## Install for OpenClaw
+
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
+
+```bash
+npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --agent openclaw --bin-dir ~/.local/bin
+```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Commands
 

--- a/library/travel/nynj-world-cup-concierge/SKILL.md
+++ b/library/travel/nynj-world-cup-concierge/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `nynj-world-cup-concierge-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --cli-only
+   npx -y @mvanhorn/printing-press-library install nynj-world-cup-concierge --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `nynj-world-cup-concierge-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/nynj-world-cup-concierge/cmd/nynj-world-cup-concierge-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When To Use This CLI
 

--- a/library/travel/pointhound/README.md
+++ b/library/travel/pointhound/README.md
@@ -60,17 +60,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-pointhound -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-pointhound --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install pointhound --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-pointhound skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-pointhound. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/pointhound/SKILL.md
+++ b/library/travel/pointhound/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `pointhound-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install pointhound --cli-only
+   npx -y @mvanhorn/printing-press-library install pointhound --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `pointhound-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,7 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/pointhound/cmd/pointhound-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/seats-aero/README.md
+++ b/library/travel/seats-aero/README.md
@@ -56,17 +56,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero -
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-seats-aero --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install seats-aero --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-seats-aero skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-seats-aero. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/seats-aero/SKILL.md
+++ b/library/travel/seats-aero/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `seats-aero-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install seats-aero --cli-only
+   npx -y @mvanhorn/printing-press-library install seats-aero --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `seats-aero-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/seats-aero/cmd/seats-aero-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/travel/sncf-connect/README.md
+++ b/library/travel/sncf-connect/README.md
@@ -19,31 +19,37 @@ Created by [@jmbernabotto](https://github.com/jmbernabotto) (jmbernabotto).
 The recommended path installs both the `sncf-connect-pp-cli` binary and the `pp-sncf-connect` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install sncf-connect
+npx -y @mvanhorn/printing-press-library install sncf-connect
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sncf-connect --cli-only
+npx -y @mvanhorn/printing-press-library install sncf-connect --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install sncf-connect --skill-only
+npx -y @mvanhorn/printing-press-library install sncf-connect --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install sncf-connect --agent claude-code
-npx -y @mvanhorn/printing-press install sncf-connect --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install sncf-connect --agent claude-code
+npx -y @mvanhorn/printing-press-library install sncf-connect --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/sncf-connect/cmd/sncf-connect-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -60,17 +66,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-sncf-connect
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-sncf-connect --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install sncf-connect --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-sncf-connect skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-sncf-connect. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -243,7 +251,6 @@ Manage terminus schedules
 Manage vehicle journeys
 
 - **`sncf-connect-pp-cli vehicle-journeys`** - Get
-
 
 ## Output Formats
 

--- a/library/travel/sncf-connect/SKILL.md
+++ b/library/travel/sncf-connect/SKILL.md
@@ -18,26 +18,20 @@ metadata:
 
 This skill drives the `sncf-connect-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install sncf-connect --cli-only
+   npx -y @mvanhorn/printing-press-library install sncf-connect --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `sncf-connect-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/sncf-connect/cmd/sncf-connect-pp-cli@latest
+```
 
-navitia.io is the open API for building cool stuff with mobility data. It provides the following services
-
-    * journeys computation
-    * line schedules
-    * next departures
-    * exploration of public transport data / search places
-    * and sexy things such as isochrones
-
-    navitia is a HATEOAS API that returns JSON formated results
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When Not to Use This CLI
 

--- a/library/travel/visit-detroit-blog/README.md
+++ b/library/travel/visit-detroit-blog/README.md
@@ -11,31 +11,37 @@ Created by [@stanrails](https://github.com/stanrails) (stanrails).
 The recommended path installs both the `visit-detroit-blog-pp-cli` binary and the `pp-visit-detroit-blog` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install visit-detroit-blog
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install visit-detroit-blog --cli-only
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install visit-detroit-blog --skill-only
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install visit-detroit-blog --agent claude-code
-npx -y @mvanhorn/printing-press install visit-detroit-blog --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog --agent claude-code
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog --agent claude-code --agent codex
 ```
 
-### Without Node
+### Without Node (Go fallback)
 
-The generated install path is category-agnostic until this CLI is published. If `npx` is not available before publish, install Node or use the category-specific Go fallback from the public-library entry after publish.
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/travel/visit-detroit-blog/cmd/visit-detroit-blog-pp-cli@latest
+```
+
+This installs the CLI only — no skill.
 
 ### Pre-built binary
 
@@ -52,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-visit-detroi
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-visit-detroit-blog --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install visit-detroit-blog --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-visit-detroit-blog skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-visit-detroit-blog. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 
@@ -103,18 +111,14 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 # Pull the full Inside the D blog into the local store. Run once; re-run to refresh.
 visit-detroit-blog-pp-cli sync
 
-
 # Ranked full-text search across every article body, offline.
 visit-detroit-blog-pp-cli search "ethiopian food"
-
 
 # The cross-axis filter the website's single-facet search can't do.
 visit-detroit-blog-pp-cli blogs list --category Dining --region Corktown
 
-
 # Read the full article body in your terminal — no browser.
 visit-detroit-blog-pp-cli blogs get donuts
-
 
 # Find related reads by shared category and neighborhood.
 visit-detroit-blog-pp-cli blogs related donuts --limit 5
@@ -180,7 +184,6 @@ Run `visit-detroit-blog-pp-cli sync` once to populate the local store, then:
 - **`visit-detroit-blog-pp-cli regions`** - list neighborhoods/regions with article counts
 - **`visit-detroit-blog-pp-cli recent`** - newest articles by post date
 - **`visit-detroit-blog-pp-cli sync`** - pull all articles into the local store
-
 
 ## Output Formats
 

--- a/library/travel/visit-detroit-blog/SKILL.md
+++ b/library/travel/visit-detroit-blog/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 
 This skill drives the `visit-detroit-blog-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press install visit-detroit-blog --cli-only
+   npx -y @mvanhorn/printing-press-library install visit-detroit-blog --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `visit-detroit-blog-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -31,9 +31,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/visit-detroit-blog/cmd/visit-detroit-blog-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
-
-Inside the D CLI mirrors Visit Detroit's editorial blog into a local SQLite store, so you can full-text search every article body offline and then slice it by category, neighborhood, and date in a single query (blogs list) — something the site's single-facet instant-search can't do. blogs related surfaces articles that share the most topics and neighborhoods; blogs coverage maps where the blog is dense or thin; blogs reading-list exports a neutral, sponsored-free reading list for a team.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/library/travel/wanderlust-goat/README.md
+++ b/library/travel/wanderlust-goat/README.md
@@ -58,17 +58,19 @@ hermes skills install mvanhorn/printing-press-library/cli-skills/pp-wanderlust-g
 
 Inside a Hermes chat session:
 
-```bash
+```text
 /skills install mvanhorn/printing-press-library/cli-skills/pp-wanderlust-goat --force
 ```
 
 ## Install for OpenClaw
 
-Tell your OpenClaw agent (copy this):
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
+```bash
+npx -y @mvanhorn/printing-press-library install wanderlust-goat --agent openclaw --bin-dir ~/.local/bin
 ```
-Install the pp-wanderlust-goat skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-wanderlust-goat. The skill defines how its required CLI can be installed.
-```
+
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/library/travel/wanderlust-goat/SKILL.md
+++ b/library/travel/wanderlust-goat/SKILL.md
@@ -22,12 +22,12 @@ metadata:
 
 This skill drives the `wanderlust-goat-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install wanderlust-goat --cli-only
+   npx -y @mvanhorn/printing-press-library install wanderlust-goat --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `wanderlust-goat-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -35,7 +35,7 @@ If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go in
 go install github.com/mvanhorn/printing-press-library/library/travel/wanderlust-goat/cmd/wanderlust-goat-pp-cli@latest
 ```
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 ## When to Use This CLI
 

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.16
+
+- Add `install --bin-dir <dir>` and thread it through `update` / `reinstall` so Go binaries can be installed into a runtime-visible user bin directory such as `~/.local/bin`.
+- Document OpenClaw installs as `--agent openclaw --bin-dir ~/.local/bin`, keeping skill placement and binary placement explicit.
+
 ## 0.1.15
 
 - Add a version-lifecycle guard for npm releases: `preversion` now checks that `package-lock.json` is in sync before the bump, and `version` refreshes/checks the lockfile after `package.json` changes so future release commits cannot accidentally leave the lockfile version stale.

--- a/npm/README.md
+++ b/npm/README.md
@@ -112,6 +112,12 @@ npx -y @mvanhorn/printing-press-library install espn --skill-only
 # Constrain skill installation to a specific agent (repeatable)
 npx -y @mvanhorn/printing-press-library install espn --agent claude-code
 
+# Install the Go binary into a runtime-visible user bin directory
+npx -y @mvanhorn/printing-press-library install espn --bin-dir ~/.local/bin
+
+# OpenClaw: target OpenClaw skills and put the binary somewhere gateway PATHs commonly include
+npx -y @mvanhorn/printing-press-library install espn --agent openclaw --bin-dir ~/.local/bin
+
 # Machine-readable output
 npx -y @mvanhorn/printing-press-library install espn --json
 npx -y @mvanhorn/printing-press-library search sports --json
@@ -137,7 +143,19 @@ More bundles will be added over time. To suggest one, open an issue at the [prin
 - Go 1.26.3 or newer (for `go install`)
 - The Go install directory on your `PATH` so installed CLIs are runnable by name — `$(go env GOPATH)/bin` (usually `$HOME/go/bin`) on macOS/Linux, or `%USERPROFILE%\go\bin` on Windows. Go does not add this to `PATH` for you. If it's missing, `install` still installs the focused skill, then prints the exact, copy-pasteable line to add for your platform and shell (zsh/bash/fish, PowerShell, cmd, or Git Bash).
 
-Agent and gateway environments often run with a frozen or sanitized `PATH`. Updating `.zshrc`, `.bashrc`, or the Windows user environment may not affect an already-running agent process until you restart that session or gateway. If your harness already includes a user bin directory such as `~/.local/bin`, a symlink from the Go-installed binary into that directory is also a reasonable bridge:
+Use `--bin-dir <dir>` when you want `go install` to write somewhere specific. The installer creates the directory first, sets `GOBIN=<dir>` for the install, and reports the resulting binary path:
+
+```bash
+npx -y @mvanhorn/printing-press-library install espn --bin-dir ~/.local/bin
+```
+
+Agent and gateway environments often run with a frozen or sanitized `PATH`. Updating `.zshrc`, `.bashrc`, or the Windows user environment may not affect an already-running agent process until you restart that session or gateway. For OpenClaw and similar gateway deployments, prefer installing directly into a user bin directory already exposed to the gateway:
+
+```bash
+npx -y @mvanhorn/printing-press-library install <slug> --agent openclaw --bin-dir ~/.local/bin
+```
+
+If you installed before `--bin-dir` or cannot reinstall yet, a symlink from the Go-installed binary into that directory is also a reasonable bridge:
 
 ```bash
 ln -sf "$(go env GOPATH)/bin/<tool>" "$HOME/.local/bin/<tool>"

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mvanhorn/printing-press-library",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mvanhorn/printing-press-library",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Installer and catalog CLI for Printing Press-generated CLIs.",
   "type": "module",
   "license": "MIT",

--- a/npm/src/cli.ts
+++ b/npm/src/cli.ts
@@ -81,6 +81,7 @@ Install options:
   --cli-only             Install only the Go binary (skip the focused skill)
   --skill-only           Install only the focused skill (skip the Go binary)
   --agent <agent>        Constrain skill install to a specific agent (repeatable)
+  --bin-dir <dir>        Install the Go binary into this directory via GOBIN
   --json                 Emit machine-readable output
 
 Top-level options:

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -1,5 +1,6 @@
 import { BUNDLES, isBundle } from "../bundles.js";
-import { realpath } from "node:fs/promises";
+import { mkdir, realpath } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
 import { detectGo, goInstall, goInstallDir, type GoDetection, type GoInstallDir } from "../go.js";
 import { pathFixInstructions } from "../pathfix.js";
 import { commandOnPath, type RunResult } from "../process.js";
@@ -20,6 +21,7 @@ interface InstallOptions {
   registryUrl: string;
   cliOnly: boolean;
   skillOnly: boolean;
+  binDir?: string;
 }
 
 interface InstallDeps {
@@ -30,6 +32,7 @@ interface InstallDeps {
   goInstallDir: () => Promise<GoInstallDir>;
   commandOnPath: (binary: string) => Promise<string | null>;
   realpath: (path: string) => Promise<string | null>;
+  mkdir: (path: string) => Promise<void>;
   installSkill: (skillName: string, agents: string[]) => Promise<RunResult>;
   stdout: (message: string) => void;
   stderr: (message: string) => void;
@@ -82,6 +85,9 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
         return null;
       }
     },
+    mkdir: async (path) => {
+      await mkdir(path, { recursive: true });
+    },
     installSkill: (skillName, agents) => installSkill(skillName, { agents }),
     stdout: (message) => console.log(message),
     stderr: (message) => console.error(message),
@@ -95,7 +101,9 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     const parsed = parseInstallArgs(args);
     if ("error" in parsed) {
       deps.stderr(parsed.error);
-      deps.stderr("Usage: printing-press-library install <name|bundle>... [--agent <agent>...] [--json]");
+      deps.stderr(
+        "Usage: printing-press-library install <name|bundle>... [--agent <agent>...] [--bin-dir <dir>] [--json]",
+      );
       return 1;
     }
 
@@ -156,7 +164,19 @@ async function installOne(
       `github.com/mvanhorn/printing-press-library/${entry.path}`;
     const modulePath = `${moduleRoot}/cmd/${binary}`;
 
-    const install = await deps.goInstall(modulePath, "latest");
+    if (options.binDir) {
+      try {
+        await deps.mkdir(options.binDir);
+      } catch (error) {
+        deps.stderr(
+          `Failed to create --bin-dir ${options.binDir}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return { ok: false, name: entry.name, error: "bin dir create failed" };
+      }
+    }
+
+    const installEnv = options.binDir ? { ...process.env, GOBIN: options.binDir } : undefined;
+    const install = await deps.goInstall(modulePath, "latest", installEnv);
     if (install.code !== 0) {
       deps.stderr(`go install failed for ${modulePath}`);
       if (install.stderr.trim()) {
@@ -165,7 +185,7 @@ async function installOne(
       return { ok: false, name: entry.name, error: "go install failed" };
     }
 
-    const installed = await resolveInstalledPath(binary, deps);
+    const installed = await resolveInstalledPath(binary, deps, options.binDir);
     const installedPath = installed?.binaryPath ?? null;
     const pathBinaryPath = await deps.commandOnPath(binary);
 
@@ -312,6 +332,12 @@ function parseInstallArgs(args: string[]):
       options.cliOnly = true;
     } else if (arg === "--skill-only") {
       options.skillOnly = true;
+    } else if (arg === "--bin-dir") {
+      const value = args[++i];
+      if (!value) {
+        return { error: "Missing value for --bin-dir" };
+      }
+      options.binDir = normalizeBinDir(value, process.env.HOME ?? process.env.USERPROFILE);
     } else if (arg === "--agent" || arg === "-a") {
       const agent = args[++i];
       if (!agent) {
@@ -333,6 +359,10 @@ function parseInstallArgs(args: string[]):
 
   if (options.cliOnly && options.skillOnly) {
     return { error: "--cli-only and --skill-only are mutually exclusive" };
+  }
+
+  if (options.skillOnly && options.binDir) {
+    return { error: "--bin-dir cannot be used with --skill-only" };
   }
 
   if (names.length === 0) {
@@ -362,7 +392,15 @@ interface InstalledPath {
 async function resolveInstalledPath(
   binary: string,
   deps: InstallDeps,
+  binDirOverride?: string,
 ): Promise<InstalledPath | null> {
+  if (binDirOverride) {
+    const sep = deps.platform === "win32" ? "\\" : "/";
+    const suffix = deps.platform === "win32" ? ".exe" : "";
+    const clean = stripTrailingSeparators(binDirOverride);
+    return { binDir: clean, binaryPath: `${clean}${sep}${binary}${suffix}` };
+  }
+
   const info = await deps.goInstallDir();
   if (!info.binDir) {
     return null;
@@ -370,6 +408,29 @@ async function resolveInstalledPath(
   const sep = deps.platform === "win32" ? "\\" : "/";
   const suffix = deps.platform === "win32" ? ".exe" : "";
   return { binDir: info.binDir, binaryPath: `${info.binDir}${sep}${binary}${suffix}` };
+}
+
+function normalizeBinDir(input: string, home?: string): string {
+  const expanded = expandHome(input, home);
+  const cleaned = stripTrailingSeparators(expanded);
+  return isAbsolute(cleaned) ? cleaned : resolve(cleaned);
+}
+
+function expandHome(input: string, home?: string): string {
+  if (!home) {
+    return input;
+  }
+  if (input === "~") {
+    return home;
+  }
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return `${home}${input.slice(1)}`;
+  }
+  return input;
+}
+
+function stripTrailingSeparators(path: string): string {
+  return path.replace(/[\\/]+$/, "");
 }
 
 function memoize<T>(fn: () => Promise<T>): () => Promise<T> {

--- a/npm/src/commands/install.ts
+++ b/npm/src/commands/install.ts
@@ -41,6 +41,8 @@ interface InstallDeps {
   shell?: string;
   /** Home directory, used to prefer the portable `$HOME/go/bin` form in PATH instructions. */
   home?: string;
+  /** Environment inherited by subprocesses; injectable for targeted install tests. */
+  env: NodeJS.ProcessEnv;
 }
 
 interface InstallSummary {
@@ -94,11 +96,12 @@ export function createInstallCommand(overrides: Partial<InstallDeps> = {}) {
     platform: process.platform,
     shell: process.env.SHELL,
     home: process.env.HOME ?? process.env.USERPROFILE,
+    env: process.env,
     ...overrides,
   };
 
   return async function installCommandWithDeps(args: string[]): Promise<number> {
-    const parsed = parseInstallArgs(args);
+    const parsed = parseInstallArgs(args, deps.home);
     if ("error" in parsed) {
       deps.stderr(parsed.error);
       deps.stderr(
@@ -175,7 +178,7 @@ async function installOne(
       }
     }
 
-    const installEnv = options.binDir ? { ...process.env, GOBIN: options.binDir } : undefined;
+    const installEnv = options.binDir ? { ...deps.env, GOBIN: options.binDir } : undefined;
     const install = await deps.goInstall(modulePath, "latest", installEnv);
     if (install.code !== 0) {
       deps.stderr(`go install failed for ${modulePath}`);
@@ -312,7 +315,10 @@ function reportResults(outcomes: InstallOutcome[], options: InstallOptions, deps
 
 export const installCommand = createInstallCommand();
 
-function parseInstallArgs(args: string[]):
+function parseInstallArgs(
+  args: string[],
+  home?: string,
+):
   | { names: string[]; options: InstallOptions }
   | { error: string } {
   const options: InstallOptions = {
@@ -337,7 +343,7 @@ function parseInstallArgs(args: string[]):
       if (!value) {
         return { error: "Missing value for --bin-dir" };
       }
-      options.binDir = normalizeBinDir(value, process.env.HOME ?? process.env.USERPROFILE);
+      options.binDir = normalizeBinDir(value, home);
     } else if (arg === "--agent" || arg === "-a") {
       const agent = args[++i];
       if (!agent) {

--- a/npm/src/commands/update.ts
+++ b/npm/src/commands/update.ts
@@ -126,9 +126,9 @@ function parseUpdateArgs(args: string[]):
       }
       registryUrl = value;
       installArgs.push("--registry-url", value);
-    } else if (arg === "--json" || arg === "--agent" || arg === "-a") {
+    } else if (arg === "--json" || arg === "--agent" || arg === "-a" || arg === "--bin-dir") {
       installArgs.push(arg);
-      if (arg === "--agent" || arg === "-a") {
+      if (arg === "--agent" || arg === "-a" || arg === "--bin-dir") {
         const value = args[++i];
         if (!value) {
           return { error: `Missing value for ${arg}` };

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -210,8 +210,8 @@ test("update command refreshes detected installed CLIs", async () => {
     },
   });
 
-  assert.equal(await command(["--agent", "claude-code"]), 0);
-  assert.deepEqual(installs, [["espn", "--agent", "claude-code"]]);
+  assert.equal(await command(["--agent", "claude-code", "--bin-dir", "/Users/example/.local/bin"]), 0);
+  assert.deepEqual(installs, [["espn", "--agent", "claude-code", "--bin-dir", "/Users/example/.local/bin"]]);
 });
 
 test("reinstall dispatches to the update handler rather than the unknown-command path", async () => {

--- a/npm/tests/commands.test.ts
+++ b/npm/tests/commands.test.ts
@@ -210,6 +210,21 @@ test("update command refreshes detected installed CLIs", async () => {
     },
   });
 
+  assert.equal(await command(["--agent", "claude-code"]), 0);
+  assert.deepEqual(installs, [["espn", "--agent", "claude-code"]]);
+});
+
+test("update command forwards --bin-dir to detected installed CLIs", async () => {
+  const installs: string[][] = [];
+  const command = createUpdateCommand({
+    fetchRegistry: async () => registry,
+    commandOnPath: async (binary) => (binary === "espn-pp-cli" ? "/bin/espn-pp-cli" : null),
+    createInstall: () => async (args) => {
+      installs.push(args);
+      return 0;
+    },
+  });
+
   assert.equal(await command(["--agent", "claude-code", "--bin-dir", "/Users/example/.local/bin"]), 0);
   assert.deepEqual(installs, [["espn", "--agent", "claude-code", "--bin-dir", "/Users/example/.local/bin"]]);
 });

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -426,11 +426,14 @@ test("install command with --bin-dir sets GOBIN and reports the chosen binary pa
     installSkill: async () => ok(),
     stdout: (message) => stdout.push(message),
     stderr: () => {},
+    home: "/Users/example",
+    env: { KEEP_ME: "yes", GOBIN: "/old/go/bin" },
   });
 
-  assert.equal(await command(["espn", "--bin-dir", "/Users/example/.local/bin"]), 0);
+  assert.equal(await command(["espn", "--bin-dir", "~/.local/bin"]), 0);
   assert.deepEqual(mkdirCalls, ["/Users/example/.local/bin"]);
   assert.equal(goCalls.length, 1);
+  assert.equal(goCalls[0]!.env?.KEEP_ME, "yes");
   assert.equal(goCalls[0]!.env?.GOBIN, "/Users/example/.local/bin");
   assert.match(stdout.join("\n"), /binary: \/Users\/example\/\.local\/bin\/espn-pp-cli/);
 });

--- a/npm/tests/install.test.ts
+++ b/npm/tests/install.test.ts
@@ -404,6 +404,48 @@ test("install command with --skill-only skips go install and PATH check", async 
   assert.doesNotMatch(stdout.join("\n"), /binary:/);
 });
 
+test("install command with --bin-dir sets GOBIN and reports the chosen binary path", async () => {
+  const goCalls: Array<{ modulePath: string; env?: NodeJS.ProcessEnv }> = [];
+  const mkdirCalls: string[] = [];
+  const stdout: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    resolveModulePath: async () => null,
+    detectGo: async () => ({ installed: true }),
+    goInstall: async (modulePath, _ref, env) => {
+      goCalls.push({ modulePath, env });
+      return ok();
+    },
+    goInstallDir: async () => {
+      throw new Error("goInstallDir should not be called when --bin-dir is explicit");
+    },
+    mkdir: async (path) => {
+      mkdirCalls.push(path);
+    },
+    commandOnPath: async () => "/Users/example/.local/bin/espn-pp-cli",
+    installSkill: async () => ok(),
+    stdout: (message) => stdout.push(message),
+    stderr: () => {},
+  });
+
+  assert.equal(await command(["espn", "--bin-dir", "/Users/example/.local/bin"]), 0);
+  assert.deepEqual(mkdirCalls, ["/Users/example/.local/bin"]);
+  assert.equal(goCalls.length, 1);
+  assert.equal(goCalls[0]!.env?.GOBIN, "/Users/example/.local/bin");
+  assert.match(stdout.join("\n"), /binary: \/Users\/example\/\.local\/bin\/espn-pp-cli/);
+});
+
+test("install command rejects --bin-dir with --skill-only", async () => {
+  const stderr: string[] = [];
+  const command = createInstallCommand({
+    fetchRegistry: async () => registry,
+    stderr: (message) => stderr.push(message),
+  });
+
+  assert.equal(await command(["espn", "--skill-only", "--bin-dir", "/tmp/bin"]), 1);
+  assert.match(stderr.join("\n"), /--bin-dir cannot be used with --skill-only/);
+});
+
 test("install command rejects --cli-only and --skill-only together", async () => {
   const stderr: string[] = [];
   const command = createInstallCommand({

--- a/skills/printing-press-library/SKILL.md
+++ b/skills/printing-press-library/SKILL.md
@@ -58,13 +58,14 @@ The library is an open-source catalog of focused CLIs and matching agent skills 
    - Install the narrowest useful tool. Do not install a family of adjacent tools just because the search returned them.
 
 4. Install through the library installer when the selected tool is useful.
-   - The primitive is `npx -y @mvanhorn/printing-press-library install <slug>`.
+   - The default primitive is `npx -y @mvanhorn/printing-press-library install <slug>`.
+   - In OpenClaw, use `npx -y @mvanhorn/printing-press-library install <slug> --agent openclaw --bin-dir ~/.local/bin` so the focused skill is materialized under OpenClaw's managed skills root and the Go binary lands in a runtime-visible user bin directory.
    - The install command installs both the CLI and the matching focused agent skill.
    - `install <slug>` is idempotent: re-running it on an already-installed tool refreshes the Go binary and overwrites/re-adds the focused skill in place.
    - Behind the scenes, the installer uses `go install <module>@latest` for the CLI and the Vercel Agent Skills-compatible `skills` CLI to install the focused `pp-*` skill globally from this repo.
    - If the Go binary installs successfully but is not on the current process `PATH`, treat that as a warning, not a failed skill install. The installer should still install the focused skill and print platform-specific PATH instructions.
    - In agent/gateway environments, shell startup files may not affect the already-running process. Restart the session/gateway after PATH changes, or use a PATH-visible user bin directory such as `~/.local/bin` when that is already exposed by the harness.
-   - In OpenClaw, this same install command installs the focused skill for OpenClaw; do not replace it with a separate repo-path skill install unless the user explicitly asks for skill-only installation.
+   - For OpenClaw gateway/service deployments, verify the gateway process PATH can resolve `<slug>-pp-cli`; an interactive shell `which` is not enough.
    - Pass `--cli-only` or `--skill-only` only when the user explicitly wants just one side.
 
 5. Make the newly installed skill visible to the running agent.
@@ -112,6 +113,12 @@ The Printing Press Library CLI is the canonical interface for installing catalog
 npx -y @mvanhorn/printing-press-library install <slug>
 ```
 
+For OpenClaw, pass the OpenClaw agent target explicitly and put the binary in a user bin directory the OpenClaw runtime can see:
+
+```bash
+npx -y @mvanhorn/printing-press-library install <slug> --agent openclaw --bin-dir ~/.local/bin
+```
+
 That command installs both halves of a catalog entry:
 
 - the Go CLI binary
@@ -127,7 +134,13 @@ So the catalog installer is still the right top-level command: it installs the C
 
 The install operation is idempotent and works as a reinstall for one tool. Re-running `install <slug>` uses `go install <module>@latest` for the binary and re-adds the focused skill non-interactively, overwriting the existing install in place. No uninstall-first step is needed.
 
-If install warns that the binary directory is not on `PATH`, the binary and focused skill can still be installed successfully. Follow the printed platform-specific PATH instructions, then restart the running agent session or gateway if it inherits a fixed environment. On Unix-like systems where the harness already exposes `~/.local/bin`, a symlink can be a practical bridge:
+If install warns that the binary directory is not on `PATH`, the binary and focused skill can still be installed successfully. Prefer reinstalling with an explicit runtime-visible bin directory when an agent or gateway will run the CLI:
+
+```bash
+npx -y @mvanhorn/printing-press-library install <slug> --bin-dir ~/.local/bin
+```
+
+Otherwise follow the printed platform-specific PATH instructions, then restart the running agent session or gateway if it inherits a fixed environment. On Unix-like systems where the harness already exposes `~/.local/bin`, a symlink can be a practical bridge:
 
 ```bash
 ln -sf "$(go env GOPATH)/bin/<tool>" "$HOME/.local/bin/<tool>"

--- a/tools/sweep-canonical/main.go
+++ b/tools/sweep-canonical/main.go
@@ -750,12 +750,12 @@ func buildPrerequisitesSection(ctx patchSkillCtx) string {
 
 This skill drives the `+"`%s`"+` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    `+"```bash"+`
-   npx -y @mvanhorn/printing-press-library install %s --cli-only
+   npx -y @mvanhorn/printing-press-library install %s --cli-only --bin-dir ~/.local/bin
    `+"```"+`
 2. Verify: `+"`%s --version`"+`
-3. Ensure `+"`$GOPATH/bin`"+` (or `+"`$HOME/go/bin`"+`) is on `+"`$PATH`"+`.
+3. Ensure `+"`~/.local/bin`"+` is on `+"`$PATH`"+` for the agent/runtime that will invoke this skill.
 
 If the `+"`npx`"+` install fails (no Node, offline, etc.), fall back to a direct Go install (requires %s):
 
@@ -763,7 +763,7 @@ If the `+"`npx`"+` install fails (no Node, offline, etc.), fall back to a direct
 go install %s@latest
 `+"```"+`
 
-If `+"`--version`"+` reports "command not found" after install, the install step did not put the binary on `+"`$PATH`"+`. Do not proceed with skill commands until verification succeeds.
+If `+"`--version`"+` reports "command not found" after install, the runtime cannot see the binary directory on `+"`$PATH`"+`. Do not proceed with skill commands until verification succeeds.
 
 `, ctx.CLIName, ctx.APIName, ctx.CLIName, minimumGoVersion, module)
 }
@@ -1126,18 +1126,19 @@ func buildReadmeInstallSections(ctx patchReadmeCtx) string {
 	return fmt.Sprintf("## Install for Hermes\n\n"+
 		"From the Hermes CLI:\n\n"+
 		"```bash\n"+
-		"hermes skills install mvanhorn/printing-press-library/cli-skills/pp-%s\n"+
+		"hermes skills install mvanhorn/printing-press-library/cli-skills/pp-%s --force\n"+
 		"```\n\n"+
 		"Inside a Hermes chat session:\n\n"+
 		"```text\n"+
-		"/skills install mvanhorn/printing-press-library/cli-skills/pp-%s\n"+
+		"/skills install mvanhorn/printing-press-library/cli-skills/pp-%s --force\n"+
 		"```\n\n"+
 		"## Install for OpenClaw\n\n"+
-		"Tell your OpenClaw agent (copy this):\n\n"+
-		"```\n"+
-		"Install the pp-%s skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-%s. The skill defines how its required CLI can be installed.\n"+
-		"```\n\n",
-		ctx.APIName, ctx.APIName, ctx.APIName, ctx.APIName,
+		"Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:\n\n"+
+		"```bash\n"+
+		"npx -y @mvanhorn/printing-press-library install %s --agent openclaw --bin-dir ~/.local/bin\n"+
+		"```\n\n"+
+		"Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.\n\n",
+		ctx.APIName, ctx.APIName, ctx.APIName,
 	)
 }
 

--- a/tools/sweep-canonical/main_test.go
+++ b/tools/sweep-canonical/main_test.go
@@ -251,7 +251,7 @@ stuff.
 	if strings.Contains(got, "STALE INSTALL CONTENT") {
 		t.Errorf("stale Prerequisites content not removed:\n%s", got)
 	}
-	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --cli-only") {
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --cli-only --bin-dir ~/.local/bin") {
 		t.Errorf("canonical npx install line not present:\n%s", got)
 	}
 	if strings.Count(got, "## Prerequisites: Install the CLI") != 1 {
@@ -500,6 +500,9 @@ auth body.
 	}
 	if !strings.Contains(got, "## Install for Hermes") || !strings.Contains(got, "## Install for OpenClaw") {
 		t.Errorf("canonical Hermes/OpenClaw blocks missing:\n%s", got)
+	}
+	if !strings.Contains(got, "npx -y @mvanhorn/printing-press-library install x --agent openclaw --bin-dir ~/.local/bin") {
+		t.Errorf("canonical OpenClaw install command missing:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `install --bin-dir <dir>` and thread it through `update` / `reinstall` via `GOBIN`
- document OpenClaw installs as `--agent openclaw --bin-dir ~/.local/bin`
- update the discovery skill, sweep-canonical, verifier allowlist, npm version/changelog, and retrofit existing `library/**/README.md` / `SKILL.md` install guidance

Closes #631

## Tests
- `npm test`
- `npm pack --dry-run`
- `GO111MODULE=off go test .` in `tools/sweep-canonical`
- `python3 .github/scripts/verify-skill/verify_skill.py --dir library/project-management/linear`
- `git diff --check`

## Related
- Companion generator PR: https://github.com/mvanhorn/cli-printing-press/pull/2615