### PR TITLE
ci(verify-skill): allow home in COMMON_FLAGS for paths-and-state SKILLs

### DIFF
--- a/.github/scripts/verify-skill/verify_skill.py
+++ b/.github/scripts/verify-skill/verify_skill.py
@@ -68,7 +68,7 @@ def read_utf8(path: Path) -> str:
 COMMON_FLAGS = {
     "help", "version", "json", "csv", "plain", "quiet", "agent", "bin-dir",
     "select", "compact", "dry-run", "no-cache", "yes", "no-input",
-    "no-color", "human-friendly", "config", "base-url", "rate-limit",
+    "no-color", "human-friendly", "config", "home", "base-url", "rate-limit",
     "timeout", "data-source", "stdin", "limit", "format", "output",
     "no-prompt", "days",
 }

--- a/.github/scripts/verify-skill/verify_skill_test.py
+++ b/.github/scripts/verify-skill/verify_skill_test.py
@@ -1,4 +1,5 @@
-"""Tests for verify_skill.py's skill-guard-literals check.
+"""Tests for verify_skill.py's skill-guard-literals check and the
+COMMON_FLAGS allowlist honored by the flag-names/flag-commands checks.
 
 Run from this directory:
 
@@ -93,6 +94,41 @@ class SkillGuardLiteralsRunChecksTest(unittest.TestCase):
             report = verify_skill.run_checks(cli_dir, only={"skill-guard-literals"})
         self.assertEqual(report.checks_run, ["skill-guard-literals"])
         self.assertFalse(report.has_real_failures())
+
+
+class CommonFlagsAllowlistTest(unittest.TestCase):
+    """COMMON_FLAGS entries are root flags every printed CLI registers in
+    root.go, so they never appear as declarations in internal/cli/*.go.
+    Both flag checks must skip them — and must keep firing for flags
+    outside the allowlist, so the allowlist can't silently swallow real
+    undeclared-flag findings."""
+
+    def _check_flags(self, skill_text: str) -> verify_skill.Report:
+        with tempfile.TemporaryDirectory() as d:
+            cli_dir = Path(d)
+            (cli_dir / "internal" / "cli").mkdir(parents=True)
+            skill = cli_dir / "SKILL.md"
+            skill.write_text(skill_text, encoding="utf-8")
+            report = verify_skill.Report(cli_dir=str(cli_dir), skill_path=str(skill))
+            verify_skill.check_flag_names(cli_dir, skill, "thing-pp-cli", report)
+            verify_skill.check_flag_commands(cli_dir, skill, "thing-pp-cli", report)
+            return report
+
+    def test_home_recipe_produces_no_findings(self):
+        # --home is the paths-and-state relocation root flag documented in
+        # every generated SKILL.md (cli-printing-press#2633); without the
+        # allowlist entry this recipe fails both flag checks on regen.
+        report = self._check_flags(
+            "# Thing\n\n```bash\nthing-pp-cli doctor --home /srv/thing --json\n```\n"
+        )
+        self.assertEqual(report.findings, [])
+
+    def test_undeclared_flag_still_fails_both_checks(self):
+        report = self._check_flags(
+            "# Thing\n\n```bash\nthing-pp-cli doctor --not-a-real-flag x\n```\n"
+        )
+        self.assertTrue(any(f.check == "flag-names" for f in report.findings))
+        self.assertTrue(any(f.check == "flag-commands" for f in report.findings))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `home` to `COMMON_FLAGS` in `.github/scripts/verify-skill/verify_skill.py` so SKILL.md flag validation accepts the root `--home` flag that mvanhorn/cli-printing-press#2633 emits on every generated CLI.

## What Changed

- One-line allowlist addition next to `config` (the other root path flag). `python3 -m unittest verify_skill_test` passes (7 tests).
- This is §3 of #1048 — the merge-ordering-sensitive piece that must land **before or with** the first library regen that picks up cli-printing-press#2633. The sweep-canonical retrofits (§2/§4 of #1048) remain tracked there.

## AI disclosure

Change implemented and verified by Claude Code on behalf of @bobeglz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)