### PR TITLE
fix(x-twitter): render native article elements

### DIFF
--- a/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/phase5-acceptance.json
+++ b/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/phase5-acceptance.json
@@ -8,6 +8,7 @@
   "tests_passed": 351,
   "tests_skipped": 449,
   "auth_context": {
-    "type": "bearer_token"
+    "type": "bearer_token",
+    "api_key_available": true
   }
 }

--- a/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/publish-live-gate.json
+++ b/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/publish-live-gate.json
@@ -1,0 +1,7584 @@
+{
+  "dir": "/Users/cathrynlavery/printing-press/library/x-twitter",
+  "binary": "/Users/cathrynlavery/printing-press/library/x-twitter/x-twitter-pp-cli-dogfood",
+  "level": "full",
+  "verdict": "PASS",
+  "matrix_size": 351,
+  "passed": 351,
+  "failed": 0,
+  "skipped": 449,
+  "commands": [
+    "account-activity create-subscription",
+    "account-activity delete-subscription",
+    "account-activity get-subscription-count",
+    "account-activity get-subscriptions",
+    "account-activity validate-subscription",
+    "activity create-subscription",
+    "activity delete-subscription",
+    "activity delete-subscriptions-by-ids",
+    "activity get-subscriptions",
+    "activity update-subscription",
+    "analytics",
+    "api",
+    "articles create-draft",
+    "articles delete",
+    "articles list",
+    "articles publish",
+    "articles set-cover",
+    "articles unpublish",
+    "articles update-content",
+    "articles update-cover-media",
+    "articles update-title",
+    "articles upload-media",
+    "articles-publish-md",
+    "chat add-group-members",
+    "chat create-conversation",
+    "chat get-conversation",
+    "chat get-conversation-events",
+    "chat get-conversations",
+    "chat initialize-conversation-keys",
+    "chat initialize-group",
+    "chat mark-conversation-read",
+    "chat media-download",
+    "chat media-upload-append",
+    "chat media-upload-finalize",
+    "chat media-upload-initialize",
+    "chat send-message",
+    "chat send-typing-indicator",
+    "communities get-by-id",
+    "communities search",
+    "compliance create-jobs",
+    "compliance get-jobs",
+    "compliance get-jobs-by-id",
+    "connections delete-all",
+    "connections delete-by-endpoint",
+    "connections delete-by-uuids",
+    "connections get-history",
+    "dm-conversations create-direct-messages-by-participant-id",
+    "dm-conversations create-direct-messages-conversation",
+    "dm-conversations dm-events get-direct-messages-events-by-conversation-id",
+    "dm-conversations get-direct-messages-events-by-participant-id",
+    "dm-conversations media-download",
+    "dm-conversations messages create-direct-by-conversation-id",
+    "dm-events delete-direct-messages-events",
+    "dm-events get-direct-messages-events",
+    "dm-events get-direct-messages-events-by-id",
+    "doctor",
+    "evaluate-note",
+    "feedback list",
+    "import",
+    "insights get-historical",
+    "insights get-insights28-hr",
+    "jobs get",
+    "jobs list",
+    "jobs prune",
+    "lists create",
+    "lists delete",
+    "lists followers get-lists",
+    "lists get-by-id",
+    "lists members add-lists",
+    "lists members get-lists",
+    "lists members remove-lists-by-user-id",
+    "lists tweets get-lists-posts",
+    "lists update",
+    "media append-upload",
+    "media create-metadata",
+    "media create-subtitles",
+    "media delete-subtitles",
+    "media finalize-upload",
+    "media get-analytics",
+    "media get-by-key",
+    "media get-by-keys",
+    "media get-upload-status",
+    "media initialize-upload",
+    "media upload",
+    "news get",
+    "news search",
+    "notes create-community",
+    "notes delete-community",
+    "notes search-community-written",
+    "notes search-eligible-posts",
+    "openapi-json",
+    "profile delete",
+    "profile list",
+    "profile save",
+    "profile show",
+    "profile use",
+    "search",
+    "spaces buyers get-spaces",
+    "spaces get-by-creator-ids",
+    "spaces get-by-id",
+    "spaces get-by-ids",
+    "spaces search",
+    "spaces tweets get-spaces-posts",
+    "sync",
+    "tail",
+    "thread compose",
+    "thread show",
+    "trends",
+    "tweets create-posts",
+    "tweets create-webhooks-stream-link",
+    "tweets delete-posts",
+    "tweets delete-webhooks-stream-link",
+    "tweets get-posts-analytics",
+    "tweets get-posts-by-id",
+    "tweets get-posts-by-ids",
+    "tweets get-posts-counts-all",
+    "tweets get-posts-counts-recent",
+    "tweets get-rule-counts",
+    "tweets get-rules",
+    "tweets get-webhooks-stream-links",
+    "tweets hidden hide-posts-reply",
+    "tweets liking-users get-posts",
+    "tweets quote-tweets get-posts-quoted-posts",
+    "tweets retweeted-by get-posts-reposted-by",
+    "tweets retweets get-posts-reposts",
+    "tweets search-posts-all",
+    "tweets search-posts-recent",
+    "tweets update-rules",
+    "usage",
+    "users affiliates get-users",
+    "users blocking get-users",
+    "users bookmarks create-users",
+    "users bookmarks delete-users",
+    "users bookmarks find",
+    "users bookmarks get-users",
+    "users bookmarks get-users-by-folder-id",
+    "users bookmarks get-users-folders",
+    "users dm block-users",
+    "users dm unblock-users",
+    "users followed-lists follow-list",
+    "users followed-lists get-users",
+    "users followed-lists unfollow-list",
+    "users followers get-users",
+    "users following follow-user",
+    "users following get-users",
+    "users following unfollow-user",
+    "users get-by-id",
+    "users get-by-ids",
+    "users get-by-username",
+    "users get-by-usernames",
+    "users get-me",
+    "users get-public-keys",
+    "users get-reposts-of-me",
+    "users get-trends-personalized-trends",
+    "users liked-tweets get-users-liked-posts",
+    "users likes post",
+    "users likes unlike-post",
+    "users list-memberships get-users",
+    "users mentions get-users",
+    "users muting get-users",
+    "users muting mute-user",
+    "users muting unmute-user",
+    "users owned-lists get-users",
+    "users pinned-lists get-users",
+    "users pinned-lists pin-list",
+    "users pinned-lists unpin-list",
+    "users public-keys add-user",
+    "users public-keys get-users",
+    "users retweets repost-post",
+    "users retweets unrepost-post",
+    "users search",
+    "users timelines get-users",
+    "users tweets get-users-posts",
+    "webhooks create",
+    "webhooks create-replay-job",
+    "webhooks delete",
+    "webhooks get",
+    "webhooks validate",
+    "which",
+    "workflow archive",
+    "workflow status"
+  ],
+  "tests": [
+    {
+      "command": "account-activity create-subscription",
+      "kind": "help",
+      "args": [
+        "account-activity",
+        "create-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates an Account Activity subscription for the user and the given webhook.\n\nUsage:\n  x-twitter-pp-cli account-activity create-subscription \u003cwebhook_id\u003e [flags]\n\nAliases:\n  create-subscription, create\n\nExamples:\n  x-twitter-pp-cli account-activity create-subscription 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for create-subscription\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "account-activity create-subscription",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity create-subscription",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity create-subscription",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "account-activity create-subscription",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity delete-subscription",
+      "kind": "help",
+      "args": [
+        "account-activity",
+        "delete-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes an Account Activity subscription for the given webhook and user ID.\n\nUsage:\n  x-twitter-pp-cli account-activity delete-subscription \u003cwebhook_id\u003e \u003cuser_id\u003e [flags]\n\nAliases:\n  delete-subscription, delete\n\nExamples:\n  x-twitter-pp-cli account-activity delete-subscription 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-subscription\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "account-activity delete-subscription",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [account-activity delete-subscription] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "account-activity delete-subscription",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [account-activity delete-subscription] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "account-activity delete-subscription",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "account-activity delete-subscription",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [account-activity delete-subscription] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "account-activity get-subscription-count",
+      "kind": "help",
+      "args": [
+        "account-activity",
+        "get-subscription-count",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a count of currently active Account Activity subscriptions.\n\nUsage:\n  x-twitter-pp-cli account-activity get-subscription-count [flags]\n\nAliases:\n  get-subscription-count, list\n\nExamples:\n  x-twitter-pp-cli account-activity get-subscription-count\n\nFlags:\n  -h, --help   help for get-subscription-count\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "account-activity get-subscription-count",
+      "kind": "happy_path",
+      "args": [
+        "account-activity",
+        "get-subscription-count"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": {\n      \"account_name\": \"Knox\",\n      \"provisioned_count\": \"3\",\n      \"subscriptions_count_all\": \"0\",\n      \"subscriptions_count_direct_messages\": \"0\"\n    }\n  }\n}\nwarning: 1/1 account-activity items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "account-activity get-subscription-count",
+      "kind": "json_fidelity",
+      "args": [
+        "account-activity",
+        "get-subscription-count",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": {\n      \"account_name\": \"Knox\",\n      \"provisioned_count\": \"3\",\n      \"subscriptions_count_all\": \"0\",\n      \"subscriptions_count_direct_messages\": \"0\"\n    }\n  }\n}\nwarning: 1/1 account-activity items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "account-activity get-subscription-count",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "account-activity get-subscriptions",
+      "kind": "help",
+      "args": [
+        "account-activity",
+        "get-subscriptions",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of all active subscriptions for a given webhook.\n\nUsage:\n  x-twitter-pp-cli account-activity get-subscriptions \u003cwebhook_id\u003e [flags]\n\nAliases:\n  get-subscriptions, get\n\nExamples:\n  x-twitter-pp-cli account-activity get-subscriptions 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for get-subscriptions\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "account-activity get-subscriptions",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity get-subscriptions",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity get-subscriptions",
+      "kind": "error_path",
+      "args": [
+        "account-activity",
+        "get-subscriptions",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/account_activity/webhooks/__printing_press_invalid__/subscriptions/all/list returned HTTP 400: {\"errors\":[{\"parameters\":{\"webhook_id\":[\"__printing_press_invalid__\"]},\"message\":\"The `webhook_id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/account_activity/webhooks/__printing_press_invalid__/subscriptions/all/list returned HTTP 400: {\"errors\":[{\"parameters\":{\"webhook_id\":[\"__printing_press_invalid__\"]},\"message\":\"The `webhook_id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "account-activity validate-subscription",
+      "kind": "help",
+      "args": [
+        "account-activity",
+        "validate-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Checks a user’s Account Activity subscription for a given webhook.\n\nUsage:\n  x-twitter-pp-cli account-activity validate-subscription \u003cwebhook_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli account-activity validate-subscription 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for validate-subscription\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "account-activity validate-subscription",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity validate-subscription",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "account-activity validate-subscription",
+      "kind": "error_path",
+      "args": [
+        "account-activity",
+        "validate-subscription",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/account_activity/webhooks/__printing_press_invalid__/subscriptions/all returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/account_activity/webhooks/__printing_press_invalid__/subscriptions/all returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "activity create-subscription",
+      "kind": "help",
+      "args": [
+        "activity",
+        "create-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a subscription for an X activity event\n\nUsage:\n  x-twitter-pp-cli activity create-subscription [flags]\n\nAliases:\n  create-subscription, create\n\nExamples:\n  x-twitter-pp-cli activity create-subscription --event-type profile.update.bio\n\nFlags:\n      --event-type string         Event type\n      --filter-direction string   Optional direction filter for directional events.\n      --filter-keyword string     A keyword to filter on.\n      --filter-user-id string     Unique identifier of this User.\n  -h, --help                      help for create-subscription\n      --stdin                     Read request body as JSON from stdin\n      --tag string                Tag\n      --webhook-id string         The unique identifier of this webhook config.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "activity create-subscription",
+      "kind": "happy_path",
+      "args": [
+        "activity",
+        "create-subscription",
+        "--event-type",
+        "profile.update.bio",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/activity/subscriptions\",\n  \"resource\": \"activity\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/activity/subscriptions\n  Body:\n{\n    \"event_type\": \"profile.update.bio\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "activity create-subscription",
+      "kind": "json_fidelity",
+      "args": [
+        "activity",
+        "create-subscription",
+        "--event-type",
+        "profile.update.bio",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/activity/subscriptions\",\n  \"resource\": \"activity\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/activity/subscriptions\n  Body:\n{\n    \"event_type\": \"profile.update.bio\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "activity create-subscription",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "activity create-subscription",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "activity delete-subscription",
+      "kind": "help",
+      "args": [
+        "activity",
+        "delete-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a subscription for an X activity event\n\nUsage:\n  x-twitter-pp-cli activity delete-subscription \u003csubscription_id\u003e [flags]\n\nAliases:\n  delete-subscription, delete\n\nExamples:\n  x-twitter-pp-cli activity delete-subscription 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-subscription\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "activity delete-subscription",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "activity delete-subscription",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "activity delete-subscription",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "activity delete-subscription",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "activity delete-subscriptions-by-ids",
+      "kind": "help",
+      "args": [
+        "activity",
+        "delete-subscriptions-by-ids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes multiple subscriptions for X activity events by their IDs\n\nUsage:\n  x-twitter-pp-cli activity delete-subscriptions-by-ids [flags]\n\nExamples:\n  x-twitter-pp-cli activity delete-subscriptions-by-ids --ids example-value\n\nFlags:\n  -h, --help         help for delete-subscriptions-by-ids\n      --ids string   Comma-separated list of subscription IDs to delete.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "activity delete-subscriptions-by-ids",
+      "kind": "happy_path",
+      "args": [
+        "activity",
+        "delete-subscriptions-by-ids",
+        "--ids",
+        "example-value",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/activity/subscriptions\",\n  \"resource\": \"activity\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/activity/subscriptions\n  ?ids=example-value\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "activity delete-subscriptions-by-ids",
+      "kind": "json_fidelity",
+      "args": [
+        "activity",
+        "delete-subscriptions-by-ids",
+        "--ids",
+        "example-value",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/activity/subscriptions\",\n  \"resource\": \"activity\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/activity/subscriptions\n  ?ids=example-value\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "activity delete-subscriptions-by-ids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "activity delete-subscriptions-by-ids",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "activity get-subscriptions",
+      "kind": "help",
+      "args": [
+        "activity",
+        "get-subscriptions",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Get a list of active subscriptions for XAA\n\nUsage:\n  x-twitter-pp-cli activity get-subscriptions [flags]\n\nAliases:\n  get-subscriptions, list\n\nExamples:\n  x-twitter-pp-cli activity get-subscriptions\n\nFlags:\n      --all                       Fetch all pages\n  -h, --help                      help for get-subscriptions\n      --max-results int           The maximum number of results to return per page. (default 1000)\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "activity get-subscriptions",
+      "kind": "happy_path",
+      "args": [
+        "activity",
+        "get-subscriptions"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [],\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\n"
+    },
+    {
+      "command": "activity get-subscriptions",
+      "kind": "json_fidelity",
+      "args": [
+        "activity",
+        "get-subscriptions",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [],\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\n"
+    },
+    {
+      "command": "activity get-subscriptions",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "activity update-subscription",
+      "kind": "help",
+      "args": [
+        "activity",
+        "update-subscription",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Updates a subscription for an X activity event\n\nUsage:\n  x-twitter-pp-cli activity update-subscription \u003csubscription_id\u003e [flags]\n\nAliases:\n  update-subscription, update\n\nExamples:\n  x-twitter-pp-cli activity update-subscription 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                help for update-subscription\n      --stdin               Read request body as JSON from stdin\n      --tag string          Tag\n      --webhook-id string   The unique identifier of this webhook config.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "activity update-subscription",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "activity update-subscription",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "activity update-subscription",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "activity update-subscription",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"subscription_id\""
+    },
+    {
+      "command": "analytics",
+      "kind": "help",
+      "args": [
+        "analytics",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Analyze locally synced data with count, group-by, and summary operations.\nData must be synced first with the sync command.\n\nUsage:\n  x-twitter-pp-cli analytics [flags]\n\nExamples:\n  # Count records by type\n  x-twitter-pp-cli analytics --type messages\n\n  # Group by a field\n  x-twitter-pp-cli analytics --type messages --group-by author_id\n\n  # Top 10 most frequent values\n  x-twitter-pp-cli analytics --type messages --group-by channel_id --limit 10 --json\n\nFlags:\n      --db string         Database path\n      --group-by string   Field to group by\n  -h, --help              help for analytics\n      --limit int         Max groups to show (default 25)\n      --type string       Resource type to analyze\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "analytics",
+      "kind": "happy_path",
+      "args": [
+        "analytics",
+        "--type",
+        "messages"
+      ],
+      "status": "pass",
+      "output_sample": "messages: 0 records\nhint: local store has not been synced yet. Run 'x-twitter-pp-cli sync' before trusting local results.\n"
+    },
+    {
+      "command": "analytics",
+      "kind": "json_fidelity",
+      "args": [
+        "analytics",
+        "--type",
+        "messages",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"count\": 0,\n  \"resource_type\": \"messages\"\n}\nhint: local store has not been synced yet. Run 'x-twitter-pp-cli sync' before trusting local results.\n"
+    },
+    {
+      "command": "analytics",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "api",
+      "kind": "help",
+      "args": [
+        "api",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Browse and call any API endpoint using the raw interface names.\n\nThe friendly top-level commands cover the most common operations.\nThis command provides access to ALL endpoints for power users and\nagents that need full API coverage.\n\nRun 'api' with no arguments to list all interfaces.\nRun 'api \u003cinterface\u003e' to see that interface's methods.\n\nUsage:\n  x-twitter-pp-cli api [interface] [flags]\n\nExamples:\n  # List all available interfaces\n  x-twitter-pp-cli api\n\n  # Show methods for a specific interface\n  x-twitter-pp-cli api \u003cinterface-name\u003e\n\nFlags:\n  -h, --help   help for api\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "api",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [api] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "api",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [api] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "api",
+      "kind": "error_path",
+      "args": [
+        "api",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: interface \"__printing_press_invalid__\" not found. Run 'x-twitter-pp-cli api' to list all interfaces\ninterface \"__printing_press_invalid__\" not found. Run 'x-twitter-pp-cli api' to list all interfaces\n"
+    },
+    {
+      "command": "articles create-draft",
+      "kind": "help",
+      "args": [
+        "articles",
+        "create-draft",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/g1l5N8BxGewYuCy5USe_bQ/ArticleEntityDraftCreate\n\nUsage:\n  x-twitter-pp-cli articles create-draft [flags]\n\nExamples:\n  x-twitter-pp-cli articles create-draft --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for create-draft\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles create-draft",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "create-draft",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/g1l5N8BxGewYuCy5USe_bQ/ArticleEntityDraftCreate\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/g1l5N8BxGewYuCy5USe_bQ/ArticleEntityDraftCreate\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles create-draft",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "create-draft",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/g1l5N8BxGewYuCy5USe_bQ/ArticleEntityDraftCreate\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/g1l5N8BxGewYuCy5USe_bQ/ArticleEntityDraftCreate\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles create-draft",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles create-draft",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles delete",
+      "kind": "help",
+      "args": [
+        "articles",
+        "delete",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete\n\nUsage:\n  x-twitter-pp-cli articles delete [flags]\n\nExamples:\n  x-twitter-pp-cli articles delete --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n  -h, --help               help for delete\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles delete",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "delete",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles delete",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "delete",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/e4lWqB6m2TA8Fn_j9L9xEA/ArticleEntityDelete\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles delete",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles delete",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles list",
+      "kind": "help",
+      "args": [
+        "articles",
+        "list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "GET /i/api/graphql/N1zzFzRPspT-sP9Q42n_bg/ArticleEntitiesSlice\n\nUsage:\n  x-twitter-pp-cli articles list [flags]\n\nExamples:\n  x-twitter-pp-cli articles list\n\nFlags:\n      --features string    \n  -h, --help               help for list\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles list",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"cookie\""
+    },
+    {
+      "command": "articles list",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"cookie\""
+    },
+    {
+      "command": "articles list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"cookie\""
+    },
+    {
+      "command": "articles publish",
+      "kind": "help",
+      "args": [
+        "articles",
+        "publish",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/m4SHicYMoWO_qkLvjhDk7Q/ArticleEntityPublish\n\nUsage:\n  x-twitter-pp-cli articles publish [flags]\n\nExamples:\n  x-twitter-pp-cli articles publish --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for publish\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles publish",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "publish",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/m4SHicYMoWO_qkLvjhDk7Q/ArticleEntityPublish\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/m4SHicYMoWO_qkLvjhDk7Q/ArticleEntityPublish\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles publish",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "publish",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/m4SHicYMoWO_qkLvjhDk7Q/ArticleEntityPublish\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/m4SHicYMoWO_qkLvjhDk7Q/ArticleEntityPublish\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles publish",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles publish",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles set-cover",
+      "kind": "help",
+      "args": [
+        "articles",
+        "set-cover",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Upload an image and set it as an X Article cover\n\nUsage:\n  x-twitter-pp-cli articles set-cover \u003carticle-id\u003e \u003cimage-file\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli articles set-cover 1750000000000000000 ./cover.jpg\n\nFlags:\n  -h, --help   help for set-cover\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles set-cover",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [articles set-cover] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "articles set-cover",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [articles set-cover] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "articles set-cover",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "articles set-cover",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [articles set-cover] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "articles unpublish",
+      "kind": "help",
+      "args": [
+        "articles",
+        "unpublish",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/WbeMAOZdMHilHrqhgpjObw/ArticleEntityUnpublish\n\nUsage:\n  x-twitter-pp-cli articles unpublish [flags]\n\nExamples:\n  x-twitter-pp-cli articles unpublish --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for unpublish\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles unpublish",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "unpublish",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/WbeMAOZdMHilHrqhgpjObw/ArticleEntityUnpublish\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/WbeMAOZdMHilHrqhgpjObw/ArticleEntityUnpublish\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles unpublish",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "unpublish",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/WbeMAOZdMHilHrqhgpjObw/ArticleEntityUnpublish\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/WbeMAOZdMHilHrqhgpjObw/ArticleEntityUnpublish\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles unpublish",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles unpublish",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles update-content",
+      "kind": "help",
+      "args": [
+        "articles",
+        "update-content",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent\n\nUsage:\n  x-twitter-pp-cli articles update-content [flags]\n\nExamples:\n  x-twitter-pp-cli articles update-content --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for update-content\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles update-content",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "update-content",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-content",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "update-content",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/M7N2FrPrlOmu-YrVIBxFnQ/ArticleEntityUpdateContent\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-content",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles update-content",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles update-cover-media",
+      "kind": "help",
+      "args": [
+        "articles",
+        "update-cover-media",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia\n\nUsage:\n  x-twitter-pp-cli articles update-cover-media [flags]\n\nExamples:\n  x-twitter-pp-cli articles update-cover-media --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for update-cover-media\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles update-cover-media",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "update-cover-media",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-cover-media",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "update-cover-media",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/Es8InPh7mEkK9PxclxFAVQ/ArticleEntityUpdateCoverMedia\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-cover-media",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles update-cover-media",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles update-title",
+      "kind": "help",
+      "args": [
+        "articles",
+        "update-title",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle\n\nUsage:\n  x-twitter-pp-cli articles update-title [flags]\n\nExamples:\n  x-twitter-pp-cli articles update-title --data example-value --query-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --data string        \n      --features string    \n  -h, --help               help for update-title\n      --query-id string    \n      --stdin              Read request body as JSON from stdin\n      --variables string\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles update-title",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "update-title",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-title",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "update-title",
+        "--data",
+        "example-value",
+        "--query-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://x.com/i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://x.com/i/api/graphql/x75E2ABzm8_mGTg1bz8hcA/ArticleEntityUpdateTitle\n  Body:\n{\n    \"queryId\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles update-title",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles update-title",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles upload-media",
+      "kind": "help",
+      "args": [
+        "articles",
+        "upload-media",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "POST /i/media/upload.json\n\nUsage:\n  x-twitter-pp-cli articles upload-media [flags]\n\nExamples:\n  x-twitter-pp-cli articles upload-media\n\nFlags:\n      --command string          \n  -h, --help                    help for upload-media\n      --media-category string   \n      --media-id string         \n      --media-type string       \n      --original-md5 string     \n      --stdin                   Read request body as JSON from stdin\n      --total-bytes int\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles upload-media",
+      "kind": "happy_path",
+      "args": [
+        "articles",
+        "upload-media",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://upload.x.com/i/media/upload.json\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://upload.x.com/i/media/upload.json\n  Body:\n{}\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles upload-media",
+      "kind": "json_fidelity",
+      "args": [
+        "articles",
+        "upload-media",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"https://upload.x.com/i/media/upload.json\",\n  \"resource\": \"articles\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://upload.x.com/i/media/upload.json\n  Body:\n{}\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "articles upload-media",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "articles upload-media",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "articles-publish-md",
+      "kind": "help",
+      "args": [
+        "articles-publish-md",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Parses frontmatter (title, cover, tags) and body, converts the body to the Draft.js content_state JSON X's Articles editor accepts. Previews the payload by default (no API call); pass --draft to save a draft (not published) or --post to create and publish the article publicly.\n\nUsage:\n  x-twitter-pp-cli articles-publish-md \u003cmarkdown-file\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli articles-publish-md draft.md\n\nFlags:\n      --draft   Create the article as a draft without publishing\n  -h, --help    help for articles-publish-md\n      --post    Create and publish the article publicly (default: preview only)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "articles-publish-md",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [articles-publish-md] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "articles-publish-md",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [articles-publish-md] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "articles-publish-md",
+      "kind": "error_path",
+      "args": [
+        "articles-publish-md",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: read __printing_press_invalid__: open __printing_press_invalid__: no such file or directory\nread __printing_press_invalid__: open __printing_press_invalid__: no such file or directory\n"
+    },
+    {
+      "command": "chat add-group-members",
+      "kind": "help",
+      "args": [
+        "chat",
+        "add-group-members",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Adds one or more members to an existing encrypted Chat group conversation, rotating the conversation key.\n\nUsage:\n  x-twitter-pp-cli chat add-group-members \u003cid\u003e [flags]\n\nAliases:\n  add-group-members, create\n\nExamples:\n  x-twitter-pp-cli chat add-group-members 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --action-signatures string               Cryptographic signatures for the add-members action.\n      --conversation-key-version string        Version of the new rotated conversation key.\n      --conversation-participant-keys string   Encrypted conversation keys for each new participant after key rotation.\n      --encrypted-avatar-url string            Re-encrypted group avatar URL with new conversation key.\n      --encrypted-title string                 Re-encrypted group title with new conversation key.\n  -h, --help                                   help for add-group-members\n      --stdin                                  Read request body as JSON from stdin\n      --user-ids string                        List of user IDs to add to the group conversation.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat add-group-members",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat add-group-members",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat add-group-members",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat add-group-members",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat create-conversation",
+      "kind": "help",
+      "args": [
+        "chat",
+        "create-conversation",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a new encrypted Chat group conversation on behalf of the authenticated user.\n\nUsage:\n  x-twitter-pp-cli chat create-conversation [flags]\n\nExamples:\n  x-twitter-pp-cli chat create-conversation --conversation-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --action-signatures string               Cryptographic signatures for the create action.\n      --base64-encoded-key-rotation string     Base64-encoded key rotation payload.\n      --conversation-id string                 Client-generated conversation ID.\n      --conversation-key-version string        Version of the conversation encryption key.\n      --conversation-participant-keys string   Encrypted conversation keys for each participant.\n      --group-admins string                    User IDs of group admins. Defaults to the creator if omitted.\n      --group-avatar-url string                URL of the avatar image for the group conversation.\n      --group-description string               Description for the group conversation.\n      --group-members string                   User IDs of group members to include in the conversation.\n      --group-name string                      Display name for the group conversation.\n  -h, --help                                   help for create-conversation\n      --stdin                                  Read request body as JSON from stdin\n      --ttl-msec string                        Message time-to-live in milliseconds. Messages expire after this duration.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat create-conversation",
+      "kind": "happy_path",
+      "args": [
+        "chat",
+        "create-conversation",
+        "--conversation-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/conversations/group\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/conversations/group\n  Body:\n{\n    \"conversation_id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat create-conversation",
+      "kind": "json_fidelity",
+      "args": [
+        "chat",
+        "create-conversation",
+        "--conversation-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/conversations/group\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/conversations/group\n  Body:\n{\n    \"conversation_id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat create-conversation",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "chat create-conversation",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "chat get-conversation",
+      "kind": "help",
+      "args": [
+        "chat",
+        "get-conversation",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns metadata for a Chat conversation including type, muted status, and group details. Use chat_conversation.\n\nUsage:\n  x-twitter-pp-cli chat get-conversation \u003cid\u003e [flags]\n\nAliases:\n  get-conversation, get\n\nExamples:\n  x-twitter-pp-cli chat get-conversation 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --chat-conversation-fields string   A comma separated list of ChatConversation fields to display.\n      --expansions string                 A comma separated list of fields to expand.\n  -h, --help                              help for get-conversation\n      --user-fields string                A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat get-conversation",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat get-conversation",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat get-conversation",
+      "kind": "error_path",
+      "args": [
+        "chat",
+        "get-conversation",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/chat/conversations/__printing_press_invalid__ returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/chat/conversations/__printing_press_invalid__ returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "chat get-conversation-events",
+      "kind": "help",
+      "args": [
+        "chat",
+        "get-conversation-events",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves messages and key change events for a specific Chat conversation with pagination support.\n\nUsage:\n  x-twitter-pp-cli chat get-conversation-events \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat get-conversation-events 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                                Fetch all pages\n      --chat-message-event-fields string   A comma separated list of ChatMessageEvent fields to display.\n  -h, --help                               help for get-conversation-events\n      --max-results int                    Maximum number of message events to return. (default 10)\n      --pagination-token string            Token for pagination to retrieve the next page of results.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat get-conversation-events",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat get-conversation-events",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat get-conversation-events",
+      "kind": "error_path",
+      "args": [
+        "chat",
+        "get-conversation-events",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/chat/conversations/__printing_press_invalid__/events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/chat/conversations/__printing_press_invalid__/events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "chat get-conversations",
+      "kind": "help",
+      "args": [
+        "chat",
+        "get-conversations",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Chat conversations for the authenticated user's inbox.\n\nUsage:\n  x-twitter-pp-cli chat get-conversations [flags]\n\nAliases:\n  get-conversations, list\n\nExamples:\n  x-twitter-pp-cli chat get-conversations\n\nFlags:\n      --all                               Fetch all pages\n      --chat-conversation-fields string   A comma separated list of ChatConversation fields to display.\n      --expansions string                 A comma separated list of fields to expand.\n  -h, --help                              help for get-conversations\n      --max-results int                   Maximum number of conversations to return. (default 10)\n      --pagination-token string           Token for pagination to retrieve the next page of results.\n      --user-fields string                A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat get-conversations",
+      "kind": "happy_path",
+      "args": [
+        "chat",
+        "get-conversations"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/chat/conversations returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/chat/conversations returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "chat get-conversations",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "chat get-conversations",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "chat initialize-conversation-keys",
+      "kind": "help",
+      "args": [
+        "chat",
+        "initialize-conversation-keys",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Initializes encryption keys for a Chat conversation.\n\nUsage:\n  x-twitter-pp-cli chat initialize-conversation-keys \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat initialize-conversation-keys 550e8400-e29b-41d4-a716-446655440000 --conversation-key-version your-token-here\n\nFlags:\n      --action-signatures string               Cryptographic signatures for the key initialization action.\n      --base64-encoded-key-rotation string     Base64-encoded key rotation payload for ratchet tree key management.\n      --conversation-key-version string        Version of the conversation encryption key (typically a timestamp in milliseconds).\n      --conversation-participant-keys string   The conversation key encrypted for each participant using their public key.\n  -h, --help                                   help for initialize-conversation-keys\n      --stdin                                  Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat initialize-conversation-keys",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat initialize-conversation-keys",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat initialize-conversation-keys",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat initialize-conversation-keys",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat initialize-group",
+      "kind": "help",
+      "args": [
+        "chat",
+        "initialize-group",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Initializes a new XChat group conversation and returns a unique conversation ID.\n\nUsage:\n  x-twitter-pp-cli chat initialize-group [flags]\n\nExamples:\n  x-twitter-pp-cli chat initialize-group\n\nFlags:\n  -h, --help    help for initialize-group\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat initialize-group",
+      "kind": "happy_path",
+      "args": [
+        "chat",
+        "initialize-group",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/conversations/group/initialize\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/conversations/group/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat initialize-group",
+      "kind": "json_fidelity",
+      "args": [
+        "chat",
+        "initialize-group",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/conversations/group/initialize\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/conversations/group/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat initialize-group",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "chat initialize-group",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "chat mark-conversation-read",
+      "kind": "help",
+      "args": [
+        "chat",
+        "mark-conversation-read",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Marks a specific Chat conversation as read on behalf of the authenticated user.\n\nUsage:\n  x-twitter-pp-cli chat mark-conversation-read \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat mark-conversation-read 550e8400-e29b-41d4-a716-446655440000 --seen-until-sequence-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                            help for mark-conversation-read\n      --seen-until-sequence-id string   The sequence ID of the last message to mark as read up to.\n      --stdin                           Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat mark-conversation-read",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat mark-conversation-read",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat mark-conversation-read",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat mark-conversation-read",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-download",
+      "kind": "help",
+      "args": [
+        "chat",
+        "media-download",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Downloads encrypted media bytes from an XChat conversation. The response body contains raw binary bytes.\n\nUsage:\n  x-twitter-pp-cli chat media-download \u003cid\u003e \u003cmedia_hash_key\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat media-download 550e8400-e29b-41d4-a716-446655440000 your-token-here\n\nFlags:\n  -h, --help   help for media-download\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat media-download",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [chat media-download] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "chat media-download",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [chat media-download] has fewer segments than placeholders (2)"
+    },
+    {
+      "command": "chat media-download",
+      "kind": "error_path",
+      "args": [
+        "chat",
+        "media-download",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 2,
+      "output_sample": "Error: media_hash_key is required\nUsage: x-twitter-pp-cli chat media-download \u003cmedia_hash_key\u003e\nmedia_hash_key is required\nUsage: x-twitter-pp-cli chat media-download \u003cmedia_hash_key\u003e\n"
+    },
+    {
+      "command": "chat media-upload-append",
+      "kind": "help",
+      "args": [
+        "chat",
+        "media-upload-append",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Appends media data to an XChat upload session.\n\nUsage:\n  x-twitter-pp-cli chat media-upload-append \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat media-upload-append 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --body-json string   Provide the full request body as a JSON object string (this endpoint accepts a polymorphic schema: oneOf/anyOf)\n  -h, --help               help for media-upload-append\n      --stdin              Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat media-upload-append",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-append",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-append",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat media-upload-append",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-finalize",
+      "kind": "help",
+      "args": [
+        "chat",
+        "media-upload-finalize",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Finalizes an XChat media upload session.\n\nUsage:\n  x-twitter-pp-cli chat media-upload-finalize \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat media-upload-finalize 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --conversation-id string   XChat conversation identifier for the upload.\n  -h, --help                     help for media-upload-finalize\n      --media-hash-key string    Media hash key returned from initialize.\n      --message-id string        Optional message identifier associated with the upload.\n      --num-parts string         Total number of uploaded parts as a numeric string.\n      --stdin                    Read request body as JSON from stdin\n      --ttl-msec string          Optional TTL for the media in milliseconds.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat media-upload-finalize",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-finalize",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-finalize",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat media-upload-finalize",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat media-upload-initialize",
+      "kind": "help",
+      "args": [
+        "chat",
+        "media-upload-initialize",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Initializes an XChat media upload session.\n\nUsage:\n  x-twitter-pp-cli chat media-upload-initialize [flags]\n\nExamples:\n  x-twitter-pp-cli chat media-upload-initialize\n\nFlags:\n      --conversation-id string   XChat conversation identifier for the upload.\n  -h, --help                     help for media-upload-initialize\n      --stdin                    Read request body as JSON from stdin\n      --total-bytes int          Total size of the media upload in bytes.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat media-upload-initialize",
+      "kind": "happy_path",
+      "args": [
+        "chat",
+        "media-upload-initialize",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/media/upload/initialize\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/media/upload/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat media-upload-initialize",
+      "kind": "json_fidelity",
+      "args": [
+        "chat",
+        "media-upload-initialize",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/chat/media/upload/initialize\",\n  \"resource\": \"chat\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/chat/media/upload/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "chat media-upload-initialize",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "chat media-upload-initialize",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "chat send-message",
+      "kind": "help",
+      "args": [
+        "chat",
+        "send-message",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Sends an encrypted message to a specific Chat conversation.\n\nUsage:\n  x-twitter-pp-cli chat send-message \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat send-message 550e8400-e29b-41d4-a716-446655440000 --encoded-message-create-event example-value\n\nFlags:\n      --conversation-token string                Optional conversation token.\n      --encoded-message-create-event string      Base64-encoded Thrift MessageCreateEvent containing encrypted message contents.\n      --encoded-message-event-signature string   Base64-encoded Thrift MessageEventSignature for message verification.\n  -h, --help                                     help for send-message\n      --message-id string                        Unique identifier for this message.\n      --stdin                                    Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat send-message",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat send-message",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat send-message",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat send-message",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat send-typing-indicator",
+      "kind": "help",
+      "args": [
+        "chat",
+        "send-typing-indicator",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Sends a typing indicator to a specific Chat conversation on behalf of the authenticated user.\n\nUsage:\n  x-twitter-pp-cli chat send-typing-indicator \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli chat send-typing-indicator 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for send-typing-indicator\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "chat send-typing-indicator",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat send-typing-indicator",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "chat send-typing-indicator",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "chat send-typing-indicator",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "communities get-by-id",
+      "kind": "help",
+      "args": [
+        "communities",
+        "get-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific Community by its ID.\n\nUsage:\n  x-twitter-pp-cli communities get-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-by-id, get\n\nExamples:\n  x-twitter-pp-cli communities get-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --community-fields string   A comma separated list of Community fields to display.\n  -h, --help                      help for get-by-id\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "communities get-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "communities get-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "communities get-by-id",
+      "kind": "error_path",
+      "args": [
+        "communities",
+        "get-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/communities/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/communities/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "communities search",
+      "kind": "help",
+      "args": [
+        "communities",
+        "search",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Communities matching the specified search query.\n\nUsage:\n  x-twitter-pp-cli communities search [flags]\n\nAliases:\n  search, list\n\nExamples:\n  x-twitter-pp-cli communities search --query example-value\n\nFlags:\n      --all                       Fetch all pages\n      --community-fields string   A comma separated list of Community fields to display.\n  -h, --help                      help for search\n      --max-results int           The maximum number of search results to be returned by a request. (default 10)\n      --next-token string         This parameter is used to get the next 'page' of results.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --query string              Query to search communities.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "communities search",
+      "kind": "happy_path",
+      "args": [
+        "communities",
+        "search",
+        "--query",
+        "example-value"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/communities/search returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/communities/search returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "communities search",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "communities search",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "compliance create-jobs",
+      "kind": "help",
+      "args": [
+        "compliance",
+        "create-jobs",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a new Compliance Job for the specified job type.\n\nUsage:\n  x-twitter-pp-cli compliance create-jobs [flags]\n\nAliases:\n  create-jobs, create\n\nExamples:\n  x-twitter-pp-cli compliance create-jobs --type tweets\n\nFlags:\n  -h, --help          help for create-jobs\n      --name string   User-provided name for a compliance job.\n      --resumable     If true, this endpoint will return a pre-signed URL with resumable uploads enabled.\n      --stdin         Read request body as JSON from stdin\n      --type string   Type of compliance job to list.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "compliance create-jobs",
+      "kind": "happy_path",
+      "args": [
+        "compliance",
+        "create-jobs",
+        "--type",
+        "tweets",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/compliance/jobs\",\n  \"resource\": \"compliance\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/compliance/jobs\n  Body:\n{\n    \"type\": \"tweets\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "compliance create-jobs",
+      "kind": "json_fidelity",
+      "args": [
+        "compliance",
+        "create-jobs",
+        "--type",
+        "tweets",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/compliance/jobs\",\n  \"resource\": \"compliance\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/compliance/jobs\n  Body:\n{\n    \"type\": \"tweets\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "compliance create-jobs",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "compliance create-jobs",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "compliance get-jobs",
+      "kind": "help",
+      "args": [
+        "compliance",
+        "get-jobs",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Compliance Jobs filtered by job type and optional status.\n\nUsage:\n  x-twitter-pp-cli compliance get-jobs [flags]\n\nAliases:\n  get-jobs, list\n\nExamples:\n  x-twitter-pp-cli compliance get-jobs --type tweets\n\nFlags:\n      --compliance-job-fields string   A comma separated list of ComplianceJob fields to display.\n  -h, --help                           help for get-jobs\n      --status string                  Status of Compliance Job to list. (one of: created, in_progress, failed, complete)\n      --type string                    Type of Compliance Job to list. (one of: tweets, users)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "compliance get-jobs",
+      "kind": "happy_path",
+      "args": [
+        "compliance",
+        "get-jobs",
+        "--type",
+        "tweets"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 compliance items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "compliance get-jobs",
+      "kind": "json_fidelity",
+      "args": [
+        "compliance",
+        "get-jobs",
+        "--type",
+        "tweets",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 compliance items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "compliance get-jobs",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "compliance get-jobs-by-id",
+      "kind": "help",
+      "args": [
+        "compliance",
+        "get-jobs-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific Compliance Job by its ID.\n\nUsage:\n  x-twitter-pp-cli compliance get-jobs-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-jobs-by-id, get\n\nExamples:\n  x-twitter-pp-cli compliance get-jobs-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --compliance-job-fields string   A comma separated list of ComplianceJob fields to display.\n  -h, --help                           help for get-jobs-by-id\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "compliance get-jobs-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "compliance get-jobs-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "compliance get-jobs-by-id",
+      "kind": "error_path",
+      "args": [
+        "compliance",
+        "get-jobs-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/compliance/jobs/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/compliance/jobs/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "connections delete-all",
+      "kind": "help",
+      "args": [
+        "connections",
+        "delete-all",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Terminates all active streaming connections for the authenticated application.\n\nUsage:\n  x-twitter-pp-cli connections delete-all [flags]\n\nAliases:\n  delete-all, delete\n\nExamples:\n  x-twitter-pp-cli connections delete-all\n\nFlags:\n  -h, --help   help for delete-all\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "connections delete-all",
+      "kind": "happy_path",
+      "args": [
+        "connections",
+        "delete-all",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections/all\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections/all\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-all",
+      "kind": "json_fidelity",
+      "args": [
+        "connections",
+        "delete-all",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections/all\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections/all\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-all",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "connections delete-all",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "connections delete-by-endpoint",
+      "kind": "help",
+      "args": [
+        "connections",
+        "delete-by-endpoint",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Terminates all streaming connections for a specific endpoint ID for the authenticated application.\n\nUsage:\n  x-twitter-pp-cli connections delete-by-endpoint [flags]\n\nExamples:\n  x-twitter-pp-cli connections delete-by-endpoint --endpoint-id filtered_stream\n\nFlags:\n      --endpoint-id string   The endpoint ID to terminate connections for. (one of: filtered_stream, sample_stream, sample10_stream, firehose_stream, tweets_compliance_stream, users_compliance_stream, tweet_label_stream, firehose_stream_lang_en, firehose_stream_lang_ja, firehose_stream_lang_ko, firehose_stream_lang_pt, likes_firehose_stream, likes_sample10_stream, likes_compliance_stream) (default \"filtered_stream\")\n  -h, --help                 help for delete-by-endpoint\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "connections delete-by-endpoint",
+      "kind": "happy_path",
+      "args": [
+        "connections",
+        "delete-by-endpoint",
+        "--endpoint-id",
+        "filtered_stream",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections/filtered_stream\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections/filtered_stream\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-by-endpoint",
+      "kind": "json_fidelity",
+      "args": [
+        "connections",
+        "delete-by-endpoint",
+        "--endpoint-id",
+        "filtered_stream",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections/filtered_stream\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections/filtered_stream\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-by-endpoint",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "connections delete-by-endpoint",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "connections delete-by-uuids",
+      "kind": "help",
+      "args": [
+        "connections",
+        "delete-by-uuids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Terminates multiple streaming connections by their UUIDs for the authenticated application.\n\nUsage:\n  x-twitter-pp-cli connections delete-by-uuids [flags]\n\nExamples:\n  x-twitter-pp-cli connections delete-by-uuids\n\nFlags:\n  -h, --help           help for delete-by-uuids\n      --stdin          Read request body as JSON from stdin\n      --uuids string   Array of connection UUIDs to terminate\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "connections delete-by-uuids",
+      "kind": "happy_path",
+      "args": [
+        "connections",
+        "delete-by-uuids",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-by-uuids",
+      "kind": "json_fidelity",
+      "args": [
+        "connections",
+        "delete-by-uuids",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/connections\",\n  \"resource\": \"connections\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/connections\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "connections delete-by-uuids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "connections delete-by-uuids",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "connections get-history",
+      "kind": "help",
+      "args": [
+        "connections",
+        "get-history",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns active and historical streaming connections with disconnect reasons for the authenticated application.\n\nUsage:\n  x-twitter-pp-cli connections get-history [flags]\n\nAliases:\n  get-history, list\n\nExamples:\n  x-twitter-pp-cli connections get-history\n\nFlags:\n      --all                        Fetch all pages\n      --connection-fields string   A comma separated list of Connection fields to display.\n      --endpoints string           Filter by streaming endpoint. Specify one or more endpoint names to filter results.\n  -h, --help                       help for get-history\n      --max-results int            The maximum number of results to return per page. (default 10)\n      --pagination-token string    Token for paginating through results. Use the value from 'next_token' in the previous response.\n      --status string              Filter by connection status. (one of: active, inactive, all) (default \"active\")\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "connections get-history",
+      "kind": "happy_path",
+      "args": [
+        "connections",
+        "get-history"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 connections items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "connections get-history",
+      "kind": "json_fidelity",
+      "args": [
+        "connections",
+        "get-history",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 connections items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "connections get-history",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-by-participant-id",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "create-direct-messages-by-participant-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Sends a new direct message to a specific participant by their ID.\n\nUsage:\n  x-twitter-pp-cli dm-conversations create-direct-messages-by-participant-id \u003cparticipant_id\u003e [flags]\n\nAliases:\n  create-direct-messages-by-participant-id, create\n\nExamples:\n  x-twitter-pp-cli dm-conversations create-direct-messages-by-participant-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --body-json string   Provide the full request body as a JSON object string (this endpoint accepts a polymorphic schema: oneOf/anyOf)\n  -h, --help               help for create-direct-messages-by-participant-id\n      --stdin              Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-by-participant-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"participant_id\""
+    },
+    {
+      "command": "dm-conversations create-direct-messages-by-participant-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"participant_id\""
+    },
+    {
+      "command": "dm-conversations create-direct-messages-by-participant-id",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-by-participant-id",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"participant_id\""
+    },
+    {
+      "command": "dm-conversations create-direct-messages-conversation",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "create-direct-messages-conversation",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Initiates a new direct message conversation with specified participants.\n\nUsage:\n  x-twitter-pp-cli dm-conversations create-direct-messages-conversation [flags]\n\nExamples:\n  x-twitter-pp-cli dm-conversations create-direct-messages-conversation --conversation-type Group\n\nFlags:\n      --conversation-type string   The conversation type that is being created.\n  -h, --help                       help for create-direct-messages-conversation\n      --message string             Message\n      --participant-ids string     Participants for the DM Conversation.\n      --stdin                      Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-conversation",
+      "kind": "happy_path",
+      "args": [
+        "dm-conversations",
+        "create-direct-messages-conversation",
+        "--conversation-type",
+        "Group",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/dm_conversations\",\n  \"resource\": \"dm-conversations\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/dm_conversations\n  Body:\n{\n    \"conversation_type\": \"Group\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-conversation",
+      "kind": "json_fidelity",
+      "args": [
+        "dm-conversations",
+        "create-direct-messages-conversation",
+        "--conversation-type",
+        "Group",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/dm_conversations\",\n  \"resource\": \"dm-conversations\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/dm_conversations\n  Body:\n{\n    \"conversation_type\": \"Group\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-conversation",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "dm-conversations create-direct-messages-conversation",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "dm-conversations dm-events get-direct-messages-events-by-conversation-id",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "dm-events",
+        "get-direct-messages-events-by-conversation-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves direct message events for a specific conversation.\n\nUsage:\n  x-twitter-pp-cli dm-conversations dm-events get-direct-messages-events-by-conversation-id \u003cid\u003e [flags]\n\nAliases:\n  get-direct-messages-events-by-conversation-id, get\n\nExamples:\n  x-twitter-pp-cli dm-conversations dm-events get-direct-messages-events-by-conversation-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --dm-event-fields string    A comma separated list of DmEvent fields to display.\n      --event-types string        The set of event_types to include in the results. (default \"[\\\"MessageCreate\\\",\\\"ParticipantsLeave\\\",\\\"ParticipantsJoin\\\"]\")\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-direct-messages-events-by-conversation-id\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations dm-events get-direct-messages-events-by-conversation-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "dm-conversations dm-events get-direct-messages-events-by-conversation-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "dm-conversations dm-events get-direct-messages-events-by-conversation-id",
+      "kind": "error_path",
+      "args": [
+        "dm-conversations",
+        "dm-events",
+        "get-direct-messages-events-by-conversation-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/dm_conversations/__printing_press_invalid__/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/dm_conversations/__printing_press_invalid__/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "dm-conversations get-direct-messages-events-by-participant-id",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "get-direct-messages-events-by-participant-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves direct message events for a specific conversation.\n\nUsage:\n  x-twitter-pp-cli dm-conversations get-direct-messages-events-by-participant-id \u003cparticipant_id\u003e [flags]\n\nAliases:\n  get-direct-messages-events-by-participant-id, get\n\nExamples:\n  x-twitter-pp-cli dm-conversations get-direct-messages-events-by-participant-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --dm-event-fields string    A comma separated list of DmEvent fields to display.\n      --event-types string        The set of event_types to include in the results. (default \"[\\\"MessageCreate\\\",\\\"ParticipantsLeave\\\",\\\"ParticipantsJoin\\\"]\")\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-direct-messages-events-by-participant-id\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations get-direct-messages-events-by-participant-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"participant_id\""
+    },
+    {
+      "command": "dm-conversations get-direct-messages-events-by-participant-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"participant_id\""
+    },
+    {
+      "command": "dm-conversations get-direct-messages-events-by-participant-id",
+      "kind": "error_path",
+      "args": [
+        "dm-conversations",
+        "get-direct-messages-events-by-participant-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/dm_conversations/with/__printing_press_invalid__/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/dm_conversations/with/__printing_press_invalid__/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "dm-conversations media-download",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "media-download",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Downloads media attached to a legacy Direct Message.\n\nUsage:\n  x-twitter-pp-cli dm-conversations media-download \u003cdm_id\u003e \u003cmedia_id\u003e \u003cresource_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli dm-conversations media-download 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for media-download\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations media-download",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [dm-conversations media-download] has fewer segments than placeholders (3)"
+    },
+    {
+      "command": "dm-conversations media-download",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [dm-conversations media-download] has fewer segments than placeholders (3)"
+    },
+    {
+      "command": "dm-conversations media-download",
+      "kind": "error_path",
+      "args": [
+        "dm-conversations",
+        "media-download",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 2,
+      "output_sample": "Error: media_id is required\nUsage: x-twitter-pp-cli dm-conversations media-download \u003cmedia_id\u003e\nmedia_id is required\nUsage: x-twitter-pp-cli dm-conversations media-download \u003cmedia_id\u003e\n"
+    },
+    {
+      "command": "dm-conversations messages create-direct-by-conversation-id",
+      "kind": "help",
+      "args": [
+        "dm-conversations",
+        "messages",
+        "create-direct-by-conversation-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Sends a new direct message to a specific conversation by its ID.\n\nUsage:\n  x-twitter-pp-cli dm-conversations messages create-direct-by-conversation-id \u003cdm_conversation_id\u003e [flags]\n\nAliases:\n  create-direct-by-conversation-id, create\n\nExamples:\n  x-twitter-pp-cli dm-conversations messages create-direct-by-conversation-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --body-json string   Provide the full request body as a JSON object string (this endpoint accepts a polymorphic schema: oneOf/anyOf)\n  -h, --help               help for create-direct-by-conversation-id\n      --stdin              Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-conversations messages create-direct-by-conversation-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"dm_conversation_id\""
+    },
+    {
+      "command": "dm-conversations messages create-direct-by-conversation-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"dm_conversation_id\""
+    },
+    {
+      "command": "dm-conversations messages create-direct-by-conversation-id",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "dm-conversations messages create-direct-by-conversation-id",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"dm_conversation_id\""
+    },
+    {
+      "command": "dm-events delete-direct-messages-events",
+      "kind": "help",
+      "args": [
+        "dm-events",
+        "delete-direct-messages-events",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a specific direct message event by its ID, if owned by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli dm-events delete-direct-messages-events \u003cevent_id\u003e [flags]\n\nAliases:\n  delete-direct-messages-events, delete\n\nExamples:\n  x-twitter-pp-cli dm-events delete-direct-messages-events 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-direct-messages-events\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-events delete-direct-messages-events",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"event_id\""
+    },
+    {
+      "command": "dm-events delete-direct-messages-events",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"event_id\""
+    },
+    {
+      "command": "dm-events delete-direct-messages-events",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "dm-events delete-direct-messages-events",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"event_id\""
+    },
+    {
+      "command": "dm-events get-direct-messages-events",
+      "kind": "help",
+      "args": [
+        "dm-events",
+        "get-direct-messages-events",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of recent direct message events across all conversations.\n\nUsage:\n  x-twitter-pp-cli dm-events get-direct-messages-events [flags]\n\nAliases:\n  get-direct-messages-events, list\n\nExamples:\n  x-twitter-pp-cli dm-events get-direct-messages-events\n\nFlags:\n      --all                       Fetch all pages\n      --dm-event-fields string    A comma separated list of DmEvent fields to display.\n      --event-types string        The set of event_types to include in the results. (default \"[\\\"MessageCreate\\\",\\\"ParticipantsLeave\\\",\\\"ParticipantsJoin\\\"]\")\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-direct-messages-events\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-events get-direct-messages-events",
+      "kind": "happy_path",
+      "args": [
+        "dm-events",
+        "get-direct-messages-events"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/dm_events returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "dm-events get-direct-messages-events",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "dm-events get-direct-messages-events",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "dm-events get-direct-messages-events-by-id",
+      "kind": "help",
+      "args": [
+        "dm-events",
+        "get-direct-messages-events-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific direct message event by its ID.\n\nUsage:\n  x-twitter-pp-cli dm-events get-direct-messages-events-by-id \u003cevent_id\u003e [flags]\n\nAliases:\n  get-direct-messages-events-by-id, get\n\nExamples:\n  x-twitter-pp-cli dm-events get-direct-messages-events-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --dm-event-fields string   A comma separated list of DmEvent fields to display.\n      --expansions string        A comma separated list of fields to expand.\n  -h, --help                     help for get-direct-messages-events-by-id\n      --media-fields string      A comma separated list of Media fields to display.\n      --tweet-fields string      A comma separated list of Tweet fields to display.\n      --user-fields string       A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "dm-events get-direct-messages-events-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"event_id\""
+    },
+    {
+      "command": "dm-events get-direct-messages-events-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"event_id\""
+    },
+    {
+      "command": "dm-events get-direct-messages-events-by-id",
+      "kind": "error_path",
+      "args": [
+        "dm-events",
+        "get-direct-messages-events-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/dm_events/__printing_press_invalid__ returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/dm_events/__printing_press_invalid__ returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "doctor",
+      "kind": "help",
+      "args": [
+        "doctor",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Check CLI health\n\nUsage:\n  x-twitter-pp-cli doctor [flags]\n\nExamples:\n  x-twitter-pp-cli doctor\n  x-twitter-pp-cli doctor --json\n  x-twitter-pp-cli doctor --fail-on warn\n\nFlags:\n      --fail-on string   Exit non-zero when a health level is reached: stale, error. Default is never.\n  -h, --help             help for doctor\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "doctor",
+      "kind": "happy_path",
+      "args": [
+        "doctor"
+      ],
+      "status": "pass",
+      "output_sample": "  OK Config: ok\n  OK Auth: configured\n  OK Env Vars: OK X_OAUTH2_USER_TOKEN optional\n  OK Verify Mode: normal operation\n  OK API: reachable (HTTP 403 at /)\n  WARN Credentials: scope-limited (HTTP 403) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.\n  config_path: /var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.config/x-twitter-pp-cli/config.toml\n  base_url: https://api.x.com\n  auth_source: env:X_BEARER_TOKEN\n  version: 1.0.0\n  INFO Cache: unknown\n    db_path: /var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.local/share/x-twitter-pp-cli/data.db\n    schema_version: 3\n    db_bytes: 970752\n    stale_after: 6h0m0s\n    hint: sync_state is empty; run 'x-twitter-pp-cli sync' to hydrate.\n"
+    },
+    {
+      "command": "doctor",
+      "kind": "json_fidelity",
+      "args": [
+        "doctor",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"agentcookie\": \"not detected (optional)\",\n  \"api\": \"reachable (HTTP 403 at /)\",\n  \"auth\": \"configured\",\n  \"auth_source\": \"env:X_BEARER_TOKEN\",\n  \"base_url\": \"https://api.x.com\",\n  \"cache\": {\n    \"db_bytes\": 970752,\n    \"db_path\": \"/var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.local/share/x-twitter-pp-cli/data.db\",\n    \"hint\": \"sync_state is empty; run 'x-twitter-pp-cli sync' to hydrate.\",\n    \"resources\": null,\n    \"schema_version\": 3,\n    \"stale_after\": \"6h0m0s\",\n    \"status\": \"unknown\"\n  },\n  \"config\": \"ok\",\n  \"config_path\": \"/var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.config/x-twitter-pp-cli/config.toml\",\n  \"credentials\": \"scope-limited (HTTP 403) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.\",\n  \"env_vars\": \"OK X_OAUTH2_USER_TOKEN optional\",\n  \"verify_mode\": \"normal operation\",\n  \"version\": \"1.0.0\"\n}\n"
+    },
+    {
+      "command": "doctor",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "evaluate-note",
+      "kind": "help",
+      "args": [
+        "evaluate-note",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Endpoint to evaluate a community note.\n\nUsage:\n  x-twitter-pp-cli evaluate-note [flags]\n\nExamples:\n  x-twitter-pp-cli evaluate-note --note-text example-value\n\nFlags:\n  -h, --help               help for evaluate-note\n      --note-text string   Text for the community note.\n      --post-id string     Unique identifier of this Tweet.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "evaluate-note",
+      "kind": "happy_path",
+      "args": [
+        "evaluate-note",
+        "--note-text",
+        "example-value",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"dry_run\": true\n  }\n}\nPOST https://api.x.com/2/evaluate_note\n  Body:\n{\n    \"note_text\": \"example-value\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "evaluate-note",
+      "kind": "json_fidelity",
+      "args": [
+        "evaluate-note",
+        "--note-text",
+        "example-value",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"dry_run\": true\n  }\n}\nPOST https://api.x.com/2/evaluate_note\n  Body:\n{\n    \"note_text\": \"example-value\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "evaluate-note",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "evaluate-note",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "feedback list",
+      "kind": "help",
+      "args": [
+        "feedback",
+        "list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "List recent feedback entries\n\nUsage:\n  x-twitter-pp-cli feedback list [flags]\n\nExamples:\n  x-twitter-pp-cli feedback list\n  x-twitter-pp-cli feedback list --limit 5\n  x-twitter-pp-cli feedback list --json\n\nFlags:\n  -h, --help        help for list\n      --limit int   Maximum number of recent entries to return (default 20)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "feedback list",
+      "kind": "happy_path",
+      "args": [
+        "feedback",
+        "list"
+      ],
+      "status": "pass"
+    },
+    {
+      "command": "feedback list",
+      "kind": "json_fidelity",
+      "args": [
+        "feedback",
+        "list",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "[]\n"
+    },
+    {
+      "command": "feedback list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "import",
+      "kind": "help",
+      "args": [
+        "import",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Import data from a JSONL file by issuing POST requests for each record.\nEach line must be a valid JSON object. Failed records are logged to stderr\nbut do not stop the import.\n\nUsage:\n  x-twitter-pp-cli import \u003cresource\u003e [flags]\n\nExamples:\n  # Import from a JSONL file\n  x-twitter-pp-cli import \u003cresource\u003e --input data.jsonl\n\n  # Dry-run to preview without sending\n  x-twitter-pp-cli import \u003cresource\u003e --input data.jsonl --dry-run\n\n  # Import from stdin\n  cat data.jsonl | x-twitter-pp-cli import \u003cresource\u003e --input -\n\nFlags:\n      --batch-size int   Records per batch (future: batch API support) (default 1)\n      --dry-run          Preview import without sending requests\n  -h, --help             help for import\n  -i, --input string     Input JSONL file path (use - for stdin)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "import",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [import] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "import",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [import] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "import",
+      "kind": "error_path",
+      "args": [
+        "import",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 2,
+      "output_sample": "Error: required flag(s) \"input\" not set\nrequired flag(s) \"input\" not set\n"
+    },
+    {
+      "command": "insights get-historical",
+      "kind": "help",
+      "args": [
+        "insights",
+        "get-historical",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves historical engagement metrics for specified Posts within a defined time range.\n\nUsage:\n  x-twitter-pp-cli insights get-historical [flags]\n\nAliases:\n  get-historical, list\n\nExamples:\n  x-twitter-pp-cli insights get-historical --tweet-ids example-value --end-time 2026-01-15T09:00:00Z --start-time 2026-01-15T09:00:00Z --granularity Daily --requested-metrics example-value\n\nFlags:\n      --end-time string            YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the end of the time range.\n      --engagement-fields string   A comma separated list of Engagement fields to display.\n      --granularity string         granularity of metrics response. (one of: Daily, Hourly, Weekly, Total)\n  -h, --help                       help for get-historical\n      --requested-metrics string   request metrics for historical request.\n      --start-time string          YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the start of the time range.\n      --tweet-ids string           List of PostIds for historical metrics.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "insights get-historical",
+      "kind": "happy_path",
+      "args": [
+        "insights",
+        "get-historical",
+        "--tweet-ids",
+        "example-value",
+        "--end-time",
+        "2026-01-15T09:00:00Z",
+        "--start-time",
+        "2026-01-15T09:00:00Z",
+        "--granularity",
+        "Daily",
+        "--requested-metrics",
+        "example-value"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/insights/historical returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/insights/historical returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "insights get-historical",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "insights get-historical",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "insights get-insights28-hr",
+      "kind": "help",
+      "args": [
+        "insights",
+        "get-insights28-hr",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves engagement metrics for specified Posts over the last 28 hours.\n\nUsage:\n  x-twitter-pp-cli insights get-insights28-hr [flags]\n\nExamples:\n  x-twitter-pp-cli insights get-insights28-hr --tweet-ids example-value --granularity Daily --requested-metrics example-value\n\nFlags:\n      --engagement-fields string   A comma separated list of Engagement fields to display.\n      --granularity string         granularity of metrics response. (one of: Daily, Hourly, Weekly, Total)\n  -h, --help                       help for get-insights28-hr\n      --requested-metrics string   request metrics for historical request.\n      --tweet-ids string           List of PostIds for 28hr metrics.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "insights get-insights28-hr",
+      "kind": "happy_path",
+      "args": [
+        "insights",
+        "get-insights28-hr",
+        "--tweet-ids",
+        "example-value",
+        "--granularity",
+        "Daily",
+        "--requested-metrics",
+        "example-value"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/insights/28hr returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/insights/28hr returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "insights get-insights28-hr",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "insights get-insights28-hr",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "jobs get",
+      "kind": "help",
+      "args": [
+        "jobs",
+        "get",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Show the latest state row for a job\n\nUsage:\n  x-twitter-pp-cli jobs get \u003cjob-id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli jobs get 1750000000000000000 --json\n\nFlags:\n  -h, --help   help for get\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "jobs get",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no id parseable from companion at depth 0"
+    },
+    {
+      "command": "jobs get",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no id parseable from companion at depth 0"
+    },
+    {
+      "command": "jobs get",
+      "kind": "error_path",
+      "args": [
+        "jobs",
+        "get",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: job \"__printing_press_invalid__\" not found in local ledger\njob \"__printing_press_invalid__\" not found in local ledger\n"
+    },
+    {
+      "command": "jobs list",
+      "kind": "help",
+      "args": [
+        "jobs",
+        "list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "List recent async jobs\n\nUsage:\n  x-twitter-pp-cli jobs list [flags]\n\nExamples:\n  x-twitter-pp-cli jobs list\n  x-twitter-pp-cli jobs list --all --json\n\nFlags:\n      --all         Show every state transition rather than the latest row per job\n  -h, --help        help for list\n      --limit int   Maximum rows to list (0 for unlimited) (default 50)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "jobs list",
+      "kind": "happy_path",
+      "args": [
+        "jobs",
+        "list"
+      ],
+      "status": "pass",
+      "output_sample": "JOB_ID  RESOURCE  STATUS  SUBMITTED  UPDATED\n"
+    },
+    {
+      "command": "jobs list",
+      "kind": "json_fidelity",
+      "args": [
+        "jobs",
+        "list",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "[]\n"
+    },
+    {
+      "command": "jobs list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "jobs prune",
+      "kind": "help",
+      "args": [
+        "jobs",
+        "prune",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Remove job rows older than --older-than\n\nUsage:\n  x-twitter-pp-cli jobs prune [flags]\n\nExamples:\n  x-twitter-pp-cli jobs prune --older-than 168h\n\nFlags:\n  -h, --help                  help for prune\n      --older-than duration   Prune rows whose latest update is older than this duration (default 168h0m0s)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "jobs prune",
+      "kind": "happy_path",
+      "args": [
+        "jobs",
+        "prune",
+        "--older-than",
+        "168h"
+      ],
+      "status": "pass",
+      "output_sample": "pruned 0, kept 0\n"
+    },
+    {
+      "command": "jobs prune",
+      "kind": "json_fidelity",
+      "args": [
+        "jobs",
+        "prune",
+        "--older-than",
+        "168h",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"kept\": 0,\n  \"pruned\": 0\n}\n"
+    },
+    {
+      "command": "jobs prune",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "lists create",
+      "kind": "help",
+      "args": [
+        "lists",
+        "create",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a new List for the authenticated user.\n\nUsage:\n  x-twitter-pp-cli lists create [flags]\n\nExamples:\n  x-twitter-pp-cli lists create --name example-resource\n\nFlags:\n      --description string   Description\n  -h, --help                 help for create\n      --name string          Name\n      --private              Private\n      --stdin                Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists create",
+      "kind": "happy_path",
+      "args": [
+        "lists",
+        "create",
+        "--name",
+        "example-resource",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/lists\",\n  \"resource\": \"lists\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/lists\n  Body:\n{\n    \"name\": \"\u003credacted\u003e\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "lists create",
+      "kind": "json_fidelity",
+      "args": [
+        "lists",
+        "create",
+        "--name",
+        "example-resource",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/lists\",\n  \"resource\": \"lists\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/lists\n  Body:\n{\n    \"name\": \"\u003credacted\u003e\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "lists create",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "lists create",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "lists delete",
+      "kind": "help",
+      "args": [
+        "lists",
+        "delete",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a specific List owned by the authenticated user by its ID.\n\nUsage:\n  x-twitter-pp-cli lists delete \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli lists delete 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists delete",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists delete",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists delete",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "lists delete",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists followers get-lists",
+      "kind": "help",
+      "args": [
+        "lists",
+        "followers",
+        "get-lists",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who follow a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli lists followers get-lists \u003cid\u003e [flags]\n\nAliases:\n  get-lists, get\n\nExamples:\n  x-twitter-pp-cli lists followers get-lists 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-lists\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists followers get-lists",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists followers get-lists",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists followers get-lists",
+      "kind": "error_path",
+      "args": [
+        "lists",
+        "followers",
+        "get-lists",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/lists/__printing_press_invalid__/followers returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/lists/__printing_press_invalid__/followers returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "lists get-by-id",
+      "kind": "help",
+      "args": [
+        "lists",
+        "get-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli lists get-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-by-id, get\n\nExamples:\n  x-twitter-pp-cli lists get-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string    A comma separated list of fields to expand.\n  -h, --help                 help for get-by-id\n      --list-fields string   A comma separated list of List fields to display.\n      --user-fields string   A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists get-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists get-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists get-by-id",
+      "kind": "error_path",
+      "args": [
+        "lists",
+        "get-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/lists/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/lists/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "lists members add-lists",
+      "kind": "help",
+      "args": [
+        "lists",
+        "members",
+        "add-lists",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Adds a User to a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli lists members add-lists \u003cid\u003e [flags]\n\nAliases:\n  add-lists, create\n\nExamples:\n  x-twitter-pp-cli lists members add-lists 550e8400-e29b-41d4-a716-446655440000 --user-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help             help for add-lists\n      --stdin            Read request body as JSON from stdin\n      --user-id string   Unique identifier of this User.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists members add-lists",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members add-lists",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members add-lists",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "lists members add-lists",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members get-lists",
+      "kind": "help",
+      "args": [
+        "lists",
+        "members",
+        "get-lists",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who are members of a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli lists members get-lists \u003cid\u003e [flags]\n\nAliases:\n  get-lists, get\n\nExamples:\n  x-twitter-pp-cli lists members get-lists 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-lists\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists members get-lists",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members get-lists",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members get-lists",
+      "kind": "error_path",
+      "args": [
+        "lists",
+        "members",
+        "get-lists",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/lists/__printing_press_invalid__/members returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/lists/__printing_press_invalid__/members returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "lists members remove-lists-by-user-id",
+      "kind": "help",
+      "args": [
+        "lists",
+        "members",
+        "remove-lists-by-user-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Removes a User from a specific List by its ID and the User’s ID.\n\nUsage:\n  x-twitter-pp-cli lists members remove-lists-by-user-id \u003cid\u003e \u003cuser_id\u003e [flags]\n\nAliases:\n  remove-lists-by-user-id, delete\n\nExamples:\n  x-twitter-pp-cli lists members remove-lists-by-user-id 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for remove-lists-by-user-id\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists members remove-lists-by-user-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members remove-lists-by-user-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists members remove-lists-by-user-id",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "lists members remove-lists-by-user-id",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists tweets get-lists-posts",
+      "kind": "help",
+      "args": [
+        "lists",
+        "tweets",
+        "get-lists-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts associated with a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli lists tweets get-lists-posts \u003cid\u003e [flags]\n\nAliases:\n  get-lists-posts, get\n\nExamples:\n  x-twitter-pp-cli lists tweets get-lists-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-lists-posts\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists tweets get-lists-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists tweets get-lists-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists tweets get-lists-posts",
+      "kind": "error_path",
+      "args": [
+        "lists",
+        "tweets",
+        "get-lists-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/lists/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/lists/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "lists update",
+      "kind": "help",
+      "args": [
+        "lists",
+        "update",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Updates the details of a specific List owned by the authenticated user by its ID.\n\nUsage:\n  x-twitter-pp-cli lists update \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli lists update 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --description string   Description\n  -h, --help                 help for update\n      --name string          Name\n      --private              Private\n      --stdin                Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "lists update",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists update",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "lists update",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "lists update",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media append-upload",
+      "kind": "help",
+      "args": [
+        "media",
+        "append-upload",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Appends data to a Media upload request.\n\nUsage:\n  x-twitter-pp-cli media append-upload \u003cid\u003e [flags]\n\nAliases:\n  append-upload, create\n\nExamples:\n  x-twitter-pp-cli media append-upload 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --body-json string   Provide the full request body as a JSON object string (this endpoint accepts a polymorphic schema: oneOf/anyOf)\n  -h, --help               help for append-upload\n      --stdin              Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media append-upload",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media append-upload",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media append-upload",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "media append-upload",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media create-metadata",
+      "kind": "help",
+      "args": [
+        "media",
+        "create-metadata",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates metadata for a Media file.\n\nUsage:\n  x-twitter-pp-cli media create-metadata [flags]\n\nExamples:\n  x-twitter-pp-cli media create-metadata --id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                                                    help for create-metadata\n      --id string                                               The unique identifier of this Media.\n      --metadata-allow-download-status-allow-download           Allow download\n      --metadata-alt-text-text string                           Description of media ( \u003c= 1000 characters )\n      --metadata-audience-policy-creator-subscriptions string   Creator subscriptions\n      --metadata-audience-policy-x-subscriptions string         X subscriptions\n      --metadata-content-expiration-timestamp-sec float         Expiration time for content as a Unix timestamp in seconds\n      --metadata-domain-restrictions-whitelist string           List of whitelisted domains\n      --metadata-found-media-origin-id string                   Unique Identifier of media within provider ( \u003c= 24 characters ))\n      --metadata-found-media-origin-provider string             The media provider (e.g., 'giphy') that sourced the media ( \u003c= 8 Characters )\n      --metadata-geo-restrictions string                        Geo restrictions\n      --metadata-management-info-managed string                 Indicates if the media is managed by Media Studio\n      --metadata-sensitive-media-warning-adult-content          Indicates if the content contains adult material\n      --metadata-sensitive-media-warning-graphic-violence       Indicates if the content depicts graphic violence\n      --metadata-sensitive-media-warning-other                  Indicates if the content has other sensitive characteristics\n      --metadata-shared-info-shared string                      Indicates if the media is shared in direct messages\n      --metadata-sticker-info-stickers string                   Stickers list must not be empty and should not exceed 25\n      --metadata-upload-source-upload-source string             Records the source (e.g., app, device) from which the media was uploaded\n      --stdin                                                   Read request body as JSON from stdin (use this for deeply nested fields not exposed as flags)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fi…[truncated]"
+    },
+    {
+      "command": "media create-metadata",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "create-metadata",
+        "--id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/metadata\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/metadata\n  Body:\n{\n    \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media create-metadata",
+      "kind": "json_fidelity",
+      "args": [
+        "media",
+        "create-metadata",
+        "--id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/metadata\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/metadata\n  Body:\n{\n    \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media create-metadata",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media create-metadata",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "media create-subtitles",
+      "kind": "help",
+      "args": [
+        "media",
+        "create-subtitles",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates subtitles for a specific Media file.\n\nUsage:\n  x-twitter-pp-cli media create-subtitles [flags]\n\nExamples:\n  x-twitter-pp-cli media create-subtitles\n\nFlags:\n  -h, --help                             help for create-subtitles\n      --id string                        The unique identifier of this Media.\n      --media-category string            The media category of uploaded media to which subtitles should be added/deleted\n      --stdin                            Read request body as JSON from stdin\n      --subtitles-display-name string    Language name in a human readable form\n      --subtitles-id string              The unique identifier of this Media.\n      --subtitles-language-code string   The language code should be a BCP47 code (e.g. 'EN', 'SP')\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media create-subtitles",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "create-subtitles",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/subtitles\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/subtitles\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media create-subtitles",
+      "kind": "json_fidelity",
+      "args": [
+        "media",
+        "create-subtitles",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/subtitles\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/subtitles\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media create-subtitles",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media create-subtitles",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "media delete-subtitles",
+      "kind": "help",
+      "args": [
+        "media",
+        "delete-subtitles",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes subtitles for a specific Media file.\n\nUsage:\n  x-twitter-pp-cli media delete-subtitles [flags]\n\nAliases:\n  delete-subtitles, delete\n\nExamples:\n  x-twitter-pp-cli media delete-subtitles\n\nFlags:\n  -h, --help                    help for delete-subtitles\n      --id string               The unique identifier of this Media.\n      --language-code string    The language code should be a BCP47 code (e.g. 'EN', 'SP')\n      --media-category string   The media category of uploaded media to which subtitles should be added/deleted\n      --stdin                   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media delete-subtitles",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "delete-subtitles",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/subtitles\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/media/subtitles\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media delete-subtitles",
+      "kind": "json_fidelity",
+      "args": [
+        "media",
+        "delete-subtitles",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"delete\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/subtitles\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nDELETE https://api.x.com/2/media/subtitles\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media delete-subtitles",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media delete-subtitles",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "media finalize-upload",
+      "kind": "help",
+      "args": [
+        "media",
+        "finalize-upload",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Finalizes a Media upload request.\n\nUsage:\n  x-twitter-pp-cli media finalize-upload \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli media finalize-upload 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for finalize-upload\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media finalize-upload",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media finalize-upload",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media finalize-upload",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "media finalize-upload",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "media get-analytics",
+      "kind": "help",
+      "args": [
+        "media",
+        "get-analytics",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves analytics data for media.\n\nUsage:\n  x-twitter-pp-cli media get-analytics [flags]\n\nAliases:\n  get-analytics, list\n\nExamples:\n  x-twitter-pp-cli media get-analytics --media-keys your-token-here --end-time 2026-01-15T09:00:00Z --start-time 2026-01-15T09:00:00Z --granularity hourly\n\nFlags:\n      --end-time string                 YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the end of the time range.\n      --granularity string              The granularity for the search counts results. (one of: hourly, daily, total) (default \"daily\")\n  -h, --help                            help for get-analytics\n      --media-analytics-fields string   A comma separated list of MediaAnalytics fields to display.\n      --media-keys string               A comma separated list of Media Keys. Up to 100 are allowed in a single request.\n      --start-time string               YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the start of the time range.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media get-analytics",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "get-analytics",
+        "--media-keys",
+        "your-token-here",
+        "--end-time",
+        "2026-01-15T09:00:00Z",
+        "--start-time",
+        "2026-01-15T09:00:00Z",
+        "--granularity",
+        "hourly"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/media/analytics returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/media/analytics returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "media get-analytics",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "media get-analytics",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media get-by-key",
+      "kind": "help",
+      "args": [
+        "media",
+        "get-by-key",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific Media file by its media key.\n\nUsage:\n  x-twitter-pp-cli media get-by-key \u003cmedia_key\u003e [flags]\n\nAliases:\n  get-by-key, get\n\nExamples:\n  x-twitter-pp-cli media get-by-key your-token-here\n\nFlags:\n  -h, --help                  help for get-by-key\n      --media-fields string   A comma separated list of Media fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media get-by-key",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"media_key\" at depth 0"
+    },
+    {
+      "command": "media get-by-key",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"media_key\" at depth 0"
+    },
+    {
+      "command": "media get-by-key",
+      "kind": "error_path",
+      "args": [
+        "media",
+        "get-by-key",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 3,
+      "output_sample": "Error: GET /2/media/__printing_press_invalid__ returned HTTP 404: \nhint: resource not found. Run the 'list' command to see available items\nGET /2/media/__printing_press_invalid__ returned HTTP 404: \nhint: resource not found. Run the 'list' command to see available items\n"
+    },
+    {
+      "command": "media get-by-keys",
+      "kind": "help",
+      "args": [
+        "media",
+        "get-by-keys",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of Media files by their media keys.\n\nUsage:\n  x-twitter-pp-cli media get-by-keys [flags]\n\nExamples:\n  x-twitter-pp-cli media get-by-keys --media-keys your-token-here\n\nFlags:\n  -h, --help                  help for get-by-keys\n      --media-fields string   A comma separated list of Media fields to display.\n      --media-keys string     A comma separated list of Media Keys. Up to 100 are allowed in a single request.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media get-by-keys",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "media get-by-keys",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "media get-by-keys",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "media get-upload-status",
+      "kind": "help",
+      "args": [
+        "media",
+        "get-upload-status",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the status of a Media upload by its ID.\n\nUsage:\n  x-twitter-pp-cli media get-upload-status [flags]\n\nExamples:\n  x-twitter-pp-cli media get-upload-status --media-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --command string    The command for the media upload request. (one of: STATUS)\n  -h, --help              help for get-upload-status\n      --media-id string   Media id for the requested media upload status.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media get-upload-status",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "get-upload-status",
+        "--media-id",
+        "550e8400-e29b-41d4-a716-446655440000"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/media/upload returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/media/upload returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "media get-upload-status",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "media get-upload-status",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media initialize-upload",
+      "kind": "help",
+      "args": [
+        "media",
+        "initialize-upload",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Initializes a media upload.\n\nUsage:\n  x-twitter-pp-cli media initialize-upload [flags]\n\nExamples:\n  x-twitter-pp-cli media initialize-upload\n\nFlags:\n      --additional-owners string   Additional owners\n  -h, --help                       help for initialize-upload\n      --media-category string      A string enum value which identifies a media use-case.\n      --media-type string          The type of media.\n      --shared                     Whether this media is shared or not.\n      --stdin                      Read request body as JSON from stdin\n      --total-bytes int            The total size of the media upload in bytes.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media initialize-upload",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "initialize-upload",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/upload/initialize\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/upload/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media initialize-upload",
+      "kind": "json_fidelity",
+      "args": [
+        "media",
+        "initialize-upload",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/upload/initialize\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/upload/initialize\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media initialize-upload",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media initialize-upload",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "media upload",
+      "kind": "help",
+      "args": [
+        "media",
+        "upload",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Uploads a media file for use in posts or other content.\n\nUsage:\n  x-twitter-pp-cli media upload [flags]\n\nExamples:\n  x-twitter-pp-cli media upload --media example-value\n\nFlags:\n      --additional-owners string   Additional owners\n  -h, --help                       help for upload\n      --media string               Media\n      --media-category string      A string enum value which identifies a media use-case.\n      --media-type string          The type of image or subtitle.\n      --shared                     Whether this media is shared or not.\n      --stdin                      Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "media upload",
+      "kind": "happy_path",
+      "args": [
+        "media",
+        "upload",
+        "--media",
+        "example-value",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/upload\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/upload\n  Body:\n{\n    \"media\": \"example-value\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media upload",
+      "kind": "json_fidelity",
+      "args": [
+        "media",
+        "upload",
+        "--media",
+        "example-value",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/media/upload\",\n  \"resource\": \"media\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/media/upload\n  Body:\n{\n    \"media\": \"example-value\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "media upload",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "media upload",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "news get",
+      "kind": "help",
+      "args": [
+        "news",
+        "get",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves news story by its ID.\n\nUsage:\n  x-twitter-pp-cli news get \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli news get 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                 help for get\n      --news-fields string   A comma separated list of News fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "news get",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "news get",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "news get",
+      "kind": "error_path",
+      "args": [
+        "news",
+        "get",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/news/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/news/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[0-9]{1,19}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "news search",
+      "kind": "help",
+      "args": [
+        "news",
+        "search",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of News stories matching the specified search query.\n\nUsage:\n  x-twitter-pp-cli news search [flags]\n\nAliases:\n  search, list\n\nExamples:\n  x-twitter-pp-cli news search --query example-value\n\nFlags:\n      --all                  Fetch all pages\n  -h, --help                 help for search\n      --max-age-hours int    The maximum age of the News story to search for. (default 168)\n      --max-results int      The number of results to return. (default 10)\n      --news-fields string   A comma separated list of News fields to display.\n      --query string         The search query.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "news search",
+      "kind": "happy_path",
+      "args": [
+        "news",
+        "search",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":{\"data\":[{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Relationships\",\"Dating\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A simple post reframed dating as a marketplace where your value shows in who chooses you—no rigid leagues required.\",\"id\":\"2062214435650044125\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Critter's post explained attraction through supply and demand: if someone pairs with you, that's your market price. Replies mixed agreement with market analogies, like couples as matched trades, and pushback noting differences between casual hookups and lasting relationships, plus how dating apps distort vibes. Data from SSRS and Pew shows apps frustrate many, while studies confirm people often match on similar education, income, and looks, with women leaning toward higher-status partners.\",\"updated_at\":\"2026-06-03T16:56:03.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Cryptocurrency\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"Skeptics promised the NPC NFT collection would crash to zero. Instead, its floor price hit 0.047 ETH after a 17.5% pump.\",\"id\":\"2061421117273682183\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Launched in May 2026 by NPCChain on Ethereum, the 10,000-piece Non Playable Character collection draws from internet NPC memes and has seen 59.5 ETH in 24-hour volume, with over 261 ETH traded total. About 2,040 unique wallets hold 20.4% of supply, as traders boast gains from mint prices of 0.001-0.003 ETH and joke about 'generational wealth.' The buzz contrasts with OpenSea's struggles, including a delayed SEA token launch and bearish Polymarket bets on its future valuation.\",\"updated_at\":\"2026-06-01T12:18:49.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Technology\",\"AI\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A middle schooler puzzles over graphing a circle equation, and Koji steps in with hints and test points, celebrating the 'You got it!' moment. The demo drew cheers and sharp critiques from teachers alike.\",\"id\":\"2061267724287062073\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Brilliant.org introduced Koji on May 29, 2026, an AI tutor for math and coding courses that uses Socratic questions, screen drawings, and real-time guidance to promote deeper thinking. Built on millions of user interactions and expert input, it's available to premium subscribers for about $12 monthly, with free previews and a summer trial for 1,000 learners. While parents and edtech fans praise its accessible tutoring, math educators like Alex Smith and Wendy argue the demos encourage guesswork over core concepts, such as understanding a circle's standard form.\",\"updated_at\":\"2026-06-01T02:09:20.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Business \u0026 Finance\",\"Stocks\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A designer shared a photo of worn-out Apple Lightning cables, captioning it with the company's massive valuation. It struck a chord, drawing thousands of likes and mixed reactions from users.\",\"id\":\"2061566560477839596\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Ramin Nasibov posted the image Monday, questioning why cables fray so easily despite Apple's near $4.5 trillion market cap. Lightning connectors, used since the iPhone 5 in 2012, often split near the plugs from bending, leading to forum tips like heat-shrink fixes or third-party options. Apple switched iPhones to USB-C with the 2023 iPhone 15, partly due to EU charger rules, while replies split between claims of planned obsolescence and defenses of careful handling.\",\"updated_at\":\"2026-06-01T21:59:19.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Religion\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"On an ordinary Thurs…[truncated]"
+    },
+    {
+      "command": "news search",
+      "kind": "json_fidelity",
+      "args": [
+        "news",
+        "search",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":{\"data\":[{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Relationships\",\"Dating\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A simple post reframed dating as a marketplace where your value shows in who chooses you—no rigid leagues required.\",\"id\":\"2062214435650044125\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Critter's post explained attraction through supply and demand: if someone pairs with you, that's your market price. Replies mixed agreement with market analogies, like couples as matched trades, and pushback noting differences between casual hookups and lasting relationships, plus how dating apps distort vibes. Data from SSRS and Pew shows apps frustrate many, while studies confirm people often match on similar education, income, and looks, with women leaning toward higher-status partners.\",\"updated_at\":\"2026-06-03T16:56:03.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Cryptocurrency\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"Skeptics promised the NPC NFT collection would crash to zero. Instead, its floor price hit 0.047 ETH after a 17.5% pump.\",\"id\":\"2061421117273682183\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Launched in May 2026 by NPCChain on Ethereum, the 10,000-piece Non Playable Character collection draws from internet NPC memes and has seen 59.5 ETH in 24-hour volume, with over 261 ETH traded total. About 2,040 unique wallets hold 20.4% of supply, as traders boast gains from mint prices of 0.001-0.003 ETH and joke about 'generational wealth.' The buzz contrasts with OpenSea's struggles, including a delayed SEA token launch and bearish Polymarket bets on its future valuation.\",\"updated_at\":\"2026-06-01T12:18:49.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Technology\",\"AI\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A middle schooler puzzles over graphing a circle equation, and Koji steps in with hints and test points, celebrating the 'You got it!' moment. The demo drew cheers and sharp critiques from teachers alike.\",\"id\":\"2061267724287062073\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Brilliant.org introduced Koji on May 29, 2026, an AI tutor for math and coding courses that uses Socratic questions, screen drawings, and real-time guidance to promote deeper thinking. Built on millions of user interactions and expert input, it's available to premium subscribers for about $12 monthly, with free previews and a summer trial for 1,000 learners. While parents and edtech fans praise its accessible tutoring, math educators like Alex Smith and Wendy argue the demos encourage guesswork over core concepts, such as understanding a circle's standard form.\",\"updated_at\":\"2026-06-01T02:09:20.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Business \u0026 Finance\",\"Stocks\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A designer shared a photo of worn-out Apple Lightning cables, captioning it with the company's massive valuation. It struck a chord, drawing thousands of likes and mixed reactions from users.\",\"id\":\"2061566560477839596\",\"name\":\"\u003credacted\u003e\",\"summary\":\"Ramin Nasibov posted the image Monday, questioning why cables fray so easily despite Apple's near $4.5 trillion market cap. Lightning connectors, used since the iPhone 5 in 2012, often split near the plugs from bending, leading to forum tips like heat-shrink fixes or third-party options. Apple switched iPhones to USB-C with the 2023 iPhone 15, partly due to EU charger rules, while replies split between claims of planned obsolescence and defenses of careful handling.\",\"updated_at\":\"2026-06-01T21:59:19.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Religion\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"On an ordinary Thurs…[truncated]"
+    },
+    {
+      "command": "news search",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "notes create-community",
+      "kind": "help",
+      "args": [
+        "notes",
+        "create-community",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a community note endpoint for LLM use case.\n\nUsage:\n  x-twitter-pp-cli notes create-community [flags]\n\nAliases:\n  create-community, create\n\nExamples:\n  x-twitter-pp-cli notes create-community --post-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                              help for create-community\n      --info-classification string        Community Note classification type.\n      --info-is-media-note                Whether the note is a media note.\n      --info-misleading-tags string       Misleading tags\n      --info-text string                  The text summary in the Community Note.\n      --info-trustworthy-sources string   Whether the note provided trustworthy links.\n      --post-id string                    Unique identifier of this Tweet.\n      --stdin                             Read request body as JSON from stdin\n      --test-mode string                  If true, the note being submitted is only for testing the capability of the bot, and won't be publicly visible.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "notes create-community",
+      "kind": "happy_path",
+      "args": [
+        "notes",
+        "create-community",
+        "--post-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/notes\",\n  \"resource\": \"notes\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/notes\n  Body:\n{\n    \"post_id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "notes create-community",
+      "kind": "json_fidelity",
+      "args": [
+        "notes",
+        "create-community",
+        "--post-id",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/notes\",\n  \"resource\": \"notes\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/notes\n  Body:\n{\n    \"post_id\": \"550e8400-e29b-41d4-a716-446655440000\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "notes create-community",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "notes create-community",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "notes delete-community",
+      "kind": "help",
+      "args": [
+        "notes",
+        "delete-community",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a community note.\n\nUsage:\n  x-twitter-pp-cli notes delete-community \u003cid\u003e [flags]\n\nAliases:\n  delete-community, delete\n\nExamples:\n  x-twitter-pp-cli notes delete-community 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-community\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "notes delete-community",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "notes delete-community",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "notes delete-community",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "notes delete-community",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "notes search-community-written",
+      "kind": "help",
+      "args": [
+        "notes",
+        "search-community-written",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns all the community notes written by the user.\n\nUsage:\n  x-twitter-pp-cli notes search-community-written [flags]\n\nAliases:\n  search-community-written, list\n\nExamples:\n  x-twitter-pp-cli notes search-community-written --test-mode true\n\nFlags:\n      --all                       Fetch all pages\n  -h, --help                      help for search-community-written\n      --max-results int           Max results to return. (default 10)\n      --note-fields string        A comma separated list of Note fields to display.\n      --pagination-token string   Pagination token to get next set of posts eligible for notes.\n      --test-mode string          If true, return the notes the caller wrote for the test. If false, return the notes the caller wrote on the product.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "notes search-community-written",
+      "kind": "happy_path",
+      "args": [
+        "notes",
+        "search-community-written",
+        "--test-mode",
+        "true"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/notes/search/notes_written returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/notes/search/notes_written returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "notes search-community-written",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "notes search-community-written",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "notes search-eligible-posts",
+      "kind": "help",
+      "args": [
+        "notes",
+        "search-eligible-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns all the posts that are eligible for community notes.\n\nUsage:\n  x-twitter-pp-cli notes search-eligible-posts [flags]\n\nExamples:\n  x-twitter-pp-cli notes search-eligible-posts --test-mode true\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for search-eligible-posts\n      --max-results int           Max results to return. (default 10)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   Pagination token to get next set of posts eligible for notes.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --post-selection string     The selection of posts to return. Valid values are 'feed_size: [small|large|xl|xxl], feed_lang: [en|es|...|all]'.\n      --test-mode string          If true, return a list of posts that are for the test.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "notes search-eligible-posts",
+      "kind": "happy_path",
+      "args": [
+        "notes",
+        "search-eligible-posts",
+        "--test-mode",
+        "true"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/notes/search/posts_eligible_for_notes returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/notes/search/posts_eligible_for_notes returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "notes search-eligible-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "notes search-eligible-posts",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "openapi-json",
+      "kind": "help",
+      "args": [
+        "openapi-json",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the full OpenAPI Specification in JSON format. (See https://github.\n\nUsage:\n  x-twitter-pp-cli openapi-json [flags]\n\nExamples:\n  x-twitter-pp-cli openapi-json\n\nFlags:\n  -h, --help   help for openapi-json\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "openapi-json",
+      "kind": "happy_path",
+      "args": [
+        "openapi-json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":{\"components\":{\"parameters\":{\"AnalyticsFieldsParameter\":{\"description\":\"A comma separated list of Analytics fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a Analytics object.\",\"example\":[\"app_install_attempts\",\"app_opens\",\"bookmarks\",\"detail_expands\",\"email_tweet\",\"engagements\",\"follows\",\"hashtag_clicks\",\"id\",\"impressions\",\"likes\",\"media_views\",\"permalink_clicks\",\"quote_tweets\",\"replies\",\"retweets\",\"shares\",\"timestamp\",\"unfollows\",\"unlikes\",\"url_clicks\",\"user_profile_clicks\"],\"items\":{\"enum\":[\"app_install_attempts\",\"app_opens\",\"bookmarks\",\"detail_expands\",\"email_tweet\",\"engagements\",\"follows\",\"hashtag_clicks\",\"id\",\"impressions\",\"likes\",\"media_views\",\"permalink_clicks\",\"quote_tweets\",\"replies\",\"retweets\",\"shares\",\"timestamp\",\"unfollows\",\"unlikes\",\"url_clicks\",\"user_profile_clicks\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatConversationExpansionsParameter\":{\"description\":\"A comma separated list of fields to expand.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"schema\":{\"description\":\"The list of fields you can expand for a [ChatConversation](#ChatConversation) object. If the field has an ID, it can be expanded into a full object.\",\"example\":[\"admin_ids\",\"member_ids\",\"participant_ids\"],\"items\":{\"enum\":[\"admin_ids\",\"member_ids\",\"participant_ids\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatConversationFieldsParameter\":{\"description\":\"A comma separated list of ChatConversation fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ChatConversation object.\",\"example\":[\"admin_ids\",\"created_at\",\"group_avatar_url\",\"group_name\",\"id\",\"is_muted\",\"member_ids\",\"message_ttl_msec\",\"participant_ids\",\"screen_capture_blocking_enabled\",\"screen_capture_detection_enabled\",\"type\",\"updated_at\"],\"items\":{\"enum\":[\"admin_ids\",\"created_at\",\"group_avatar_url\",\"group_name\",\"id\",\"is_muted\",\"member_ids\",\"message_ttl_msec\",\"participant_ids\",\"screen_capture_blocking_enabled\",\"screen_capture_detection_enabled\",\"type\",\"updated_at\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatMessageEventFieldsParameter\":{\"description\":\"A comma separated list of ChatMessageEvent fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ChatMessageEvent object.\",\"example\":[\"conversation_id\",\"conversation_token\",\"created_at_msec\",\"encoded_event\",\"id\",\"is_trusted\",\"message_event_signature\",\"previous_id\",\"sender_id\"],\"items\":{\"enum\":[\"conversation_id\",\"conversation_token\",\"created_at_msec\",\"encoded_event\",\"id\",\"is_trusted\",\"message_event_signature\",\"previous_id\",\"sender_id\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"CommunityFieldsParameter\":{\"description\":\"A comma separated list of Community fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a Community object.\",\"example\":[\"access\",\"created_at\",\"description\",\"id\",\"join_policy\",\"member_count\",\"name\"],\"items\":{\"enum\":[\"access\",\"created_at\",\"description\",\"id\",\"join_policy\",\"member_count\",\"name\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ComplianceJobFieldsParameter\":{\"description\":\"A comma separated list of ComplianceJob fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ComplianceJob object.\",\"example\":[\"created_at\",\"download_expires_at\",\"download_url\",\"id\",\"name\",\"resumable\",\"status\",\"type\",\"upload_expires_at\",\"upload_url\"],\"items\":{\"enum\":[\"created_at\",\"download_expires_at\",\"download_url\",\"id\",\"name\",\"resumable\",\"status\",\"type\",\"upload_expires_at\",\"upload_url\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ConnectionFieldsParameter…[truncated]"
+    },
+    {
+      "command": "openapi-json",
+      "kind": "json_fidelity",
+      "args": [
+        "openapi-json",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":{\"components\":{\"parameters\":{\"AnalyticsFieldsParameter\":{\"description\":\"A comma separated list of Analytics fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a Analytics object.\",\"example\":[\"app_install_attempts\",\"app_opens\",\"bookmarks\",\"detail_expands\",\"email_tweet\",\"engagements\",\"follows\",\"hashtag_clicks\",\"id\",\"impressions\",\"likes\",\"media_views\",\"permalink_clicks\",\"quote_tweets\",\"replies\",\"retweets\",\"shares\",\"timestamp\",\"unfollows\",\"unlikes\",\"url_clicks\",\"user_profile_clicks\"],\"items\":{\"enum\":[\"app_install_attempts\",\"app_opens\",\"bookmarks\",\"detail_expands\",\"email_tweet\",\"engagements\",\"follows\",\"hashtag_clicks\",\"id\",\"impressions\",\"likes\",\"media_views\",\"permalink_clicks\",\"quote_tweets\",\"replies\",\"retweets\",\"shares\",\"timestamp\",\"unfollows\",\"unlikes\",\"url_clicks\",\"user_profile_clicks\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatConversationExpansionsParameter\":{\"description\":\"A comma separated list of fields to expand.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"schema\":{\"description\":\"The list of fields you can expand for a [ChatConversation](#ChatConversation) object. If the field has an ID, it can be expanded into a full object.\",\"example\":[\"admin_ids\",\"member_ids\",\"participant_ids\"],\"items\":{\"enum\":[\"admin_ids\",\"member_ids\",\"participant_ids\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatConversationFieldsParameter\":{\"description\":\"A comma separated list of ChatConversation fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ChatConversation object.\",\"example\":[\"admin_ids\",\"created_at\",\"group_avatar_url\",\"group_name\",\"id\",\"is_muted\",\"member_ids\",\"message_ttl_msec\",\"participant_ids\",\"screen_capture_blocking_enabled\",\"screen_capture_detection_enabled\",\"type\",\"updated_at\"],\"items\":{\"enum\":[\"admin_ids\",\"created_at\",\"group_avatar_url\",\"group_name\",\"id\",\"is_muted\",\"member_ids\",\"message_ttl_msec\",\"participant_ids\",\"screen_capture_blocking_enabled\",\"screen_capture_detection_enabled\",\"type\",\"updated_at\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ChatMessageEventFieldsParameter\":{\"description\":\"A comma separated list of ChatMessageEvent fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ChatMessageEvent object.\",\"example\":[\"conversation_id\",\"conversation_token\",\"created_at_msec\",\"encoded_event\",\"id\",\"is_trusted\",\"message_event_signature\",\"previous_id\",\"sender_id\"],\"items\":{\"enum\":[\"conversation_id\",\"conversation_token\",\"created_at_msec\",\"encoded_event\",\"id\",\"is_trusted\",\"message_event_signature\",\"previous_id\",\"sender_id\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"CommunityFieldsParameter\":{\"description\":\"A comma separated list of Community fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a Community object.\",\"example\":[\"access\",\"created_at\",\"description\",\"id\",\"join_policy\",\"member_count\",\"name\"],\"items\":{\"enum\":[\"access\",\"created_at\",\"description\",\"id\",\"join_policy\",\"member_count\",\"name\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ComplianceJobFieldsParameter\":{\"description\":\"A comma separated list of ComplianceJob fields to display.\",\"explode\":false,\"in\":\"query\",\"name\":\"\u003credacted\u003e\",\"required\":false,\"schema\":{\"description\":\"The fields available for a ComplianceJob object.\",\"example\":[\"created_at\",\"download_expires_at\",\"download_url\",\"id\",\"name\",\"resumable\",\"status\",\"type\",\"upload_expires_at\",\"upload_url\"],\"items\":{\"enum\":[\"created_at\",\"download_expires_at\",\"download_url\",\"id\",\"name\",\"resumable\",\"status\",\"type\",\"upload_expires_at\",\"upload_url\"],\"type\":\"string\"},\"minItems\":1,\"type\":\"array\",\"uniqueItems\":true},\"style\":\"form\"},\"ConnectionFieldsParameter…[truncated]"
+    },
+    {
+      "command": "openapi-json",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "profile delete",
+      "kind": "help",
+      "args": [
+        "profile",
+        "delete",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Remove a profile\n\nUsage:\n  x-twitter-pp-cli profile delete \u003cname\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli profile delete my-defaults --yes\n  x-twitter-pp-cli profile delete old-profile --yes --json\n\nFlags:\n  -h, --help   help for delete\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "profile delete",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile delete",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile delete",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "profile delete",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile list",
+      "kind": "help",
+      "args": [
+        "profile",
+        "list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "List saved profiles\n\nUsage:\n  x-twitter-pp-cli profile list [flags]\n\nExamples:\n  x-twitter-pp-cli profile list\n  x-twitter-pp-cli profile list --json\n\nFlags:\n  -h, --help   help for list\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "profile list",
+      "kind": "happy_path",
+      "args": [
+        "profile",
+        "list"
+      ],
+      "status": "pass",
+      "output_sample": "NAME  FIELDS  DESCRIPTION\n"
+    },
+    {
+      "command": "profile list",
+      "kind": "json_fidelity",
+      "args": [
+        "profile",
+        "list",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "[]\n"
+    },
+    {
+      "command": "profile list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "profile save",
+      "kind": "help",
+      "args": [
+        "profile",
+        "save",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Captures every flag explicitly set on the invocation and stores\nthem under \u003cname\u003e. To update an existing profile, run save again; the\nentry is replaced.\n\nTo avoid creating empty profiles, at least one non-default flag must be\npresent (other than --profile and --config).\n\nUsage:\n  x-twitter-pp-cli profile save \u003cname\u003e [--\u003cflag\u003e \u003cvalue\u003e ...] [flags]\n\nExamples:\n  x-twitter-pp-cli profile save my-defaults --json --compact\n  x-twitter-pp-cli profile save tonight-defaults --region US\n\nFlags:\n      --description string   Short description shown in 'profile list'\n  -h, --help                 help for save\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "profile save",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile save",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile save",
+      "kind": "error_path",
+      "args": [
+        "profile",
+        "save",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: no non-default flags set - pass at least one flag to save into \"__printing_press_invalid__\"\nno non-default flags set - pass at least one flag to save into \"__printing_press_invalid__\"\n"
+    },
+    {
+      "command": "profile show",
+      "kind": "help",
+      "args": [
+        "profile",
+        "show",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Show a profile's values as JSON\n\nUsage:\n  x-twitter-pp-cli profile show \u003cname\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli profile show my-defaults\n  x-twitter-pp-cli profile show tonight-defaults --json\n\nFlags:\n  -h, --help   help for show\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "profile show",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile show",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile show",
+      "kind": "error_path",
+      "args": [
+        "profile",
+        "show",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: profile \"__printing_press_invalid__\" not found\nprofile \"__printing_press_invalid__\" not found\n"
+    },
+    {
+      "command": "profile use",
+      "kind": "help",
+      "args": [
+        "profile",
+        "use",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Print the flag values a profile will apply (does not execute anything)\n\nUsage:\n  x-twitter-pp-cli profile use \u003cname\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli profile use my-defaults\n  x-twitter-pp-cli profile use tonight-defaults --json\n\nFlags:\n  -h, --help   help for use\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "profile use",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile use",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"name\" at depth 0"
+    },
+    {
+      "command": "profile use",
+      "kind": "error_path",
+      "args": [
+        "profile",
+        "use",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: profile \"__printing_press_invalid__\" not found\nprofile \"__printing_press_invalid__\" not found\n"
+    },
+    {
+      "command": "search",
+      "kind": "help",
+      "args": [
+        "search",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Search data using FTS5 full-text search on locally synced data,\nor hit the API's search endpoint when available.\n\nIn auto mode (default): uses the API search endpoint if the API has one,\notherwise searches local data. Falls back to local on network failure.\nIn live mode: uses the API search endpoint only.\nIn local mode: searches locally synced data only.\n\nUsage:\n  x-twitter-pp-cli search \u003cquery\u003e [flags]\n\nExamples:\n  # Search (uses API endpoint if available, local FTS otherwise)\n  x-twitter-pp-cli search \"error timeout\"\n\n  # Force local search only\n  x-twitter-pp-cli search \"payment failed\" --data-source local\n\n  # Search a specific resource type locally\n  x-twitter-pp-cli search \"critical\" --type transactions --data-source local\n\n  # JSON output for piping\n  x-twitter-pp-cli search \"critical\" --json --limit 20\n\nFlags:\n      --db string     Database path (default: ~/.local/share/x-twitter-pp-cli/data.db)\n  -h, --help          help for search\n      --limit int     Maximum results to return (default 50)\n      --type string   Filter by resource type\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "search",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [search] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "search",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [search] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "search",
+      "kind": "error_path",
+      "args": [
+        "search",
+        "__printing_press_invalid__",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":[{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Technology\",\"Software Development\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"Designers have waited for a tool like this: Paper's new Pen Tool lets you draw exact shapes and generate editable SVGs right on a code-native canvas.\",\"id\":\"2062257895899603031\",\"name\":\"\u003credacted\u003e\",\"summary\":\"CEO Stephen Haney announced the update, which brings full vector workflows including point editing, image vectorization, and AI-powered SVG generation from simple prompts like 'a minimalist logo.' Powered by QuiverAI's Arrow 1.1 model, it exports true SVGs with perfect fidelity—no approximations or lost details. Designers praise it as a fast-shipping underdog challenging Figma, with one user ditching the competitor entirely, and the roadmap promises even more features like boolean operations soon.\",\"updated_at\":\"2026-06-03T19:47:04.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Art\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"In a world of endless phone scrolls, one simple act stands out: printing a photo and jotting a cursive note on the back about what made the day special.\",\"id\":\"2062052785974042980\",\"name\":\"\u003credacted\u003e\",\"summary\":\"A Tuesday post by @femiiiszn suggested printing photos and adding quick handwritten notes in cursive, quickly drawing over 22,000 likes and thousands of reposts. People shared plans to grab Polaroid cameras, create scrapbooks with stickers and captions, or restart journaling with personal touches like dramatic confessions or baby moments. The idea connects to slow living, helping folks pause amid digital overload to make lasting, tangible memories that outlive phone screens.\",\"updated_at\":\"2026-06-03T06:08:53.000Z\"},{\"category\":\"News\",\"contexts\":{\"topics\":[\"Technology\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"Imagine your online store suddenly vanishing, showing customers a message that it 'does not exist'—that's the panic thousands of Shopify merchants faced on Wednesday.\",\"id\":\"2062164812445233553\",\"name\":\"\u003credacted\u003e\",\"summary\":\"On June 3, 2026, Shopify's global outage peaked around 9:27 a.m. EDT, blocking access to storefronts, checkouts, admin panels, and point-of-sale systems for about two hours. High-profile sites like Katy Perry's merchandise store went dark, while merchants reported lost sales, API errors, and frustration over an error page that pitched free trials amid the chaos. Shopify acknowledged the issue swiftly, resolved it by 3:32 p.m. UTC, and thanked users, though criticism lingers over the error design and no details on the cause.\",\"updated_at\":\"2026-06-03T21:12:48.000Z\"},{\"category\":\"News\",\"contexts\":{\"topics\":[\"Elections\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time. Grok can make mistakes, verify its outputs.\",\"hook\":\"A primary candidate opened his ballot and saw his name missing—his quick call uncovered a mix-up affecting nearly 9,000 Tooele County voters.\",\"id\":\"2062555651910328547\",\"name\":\"\u003credacted\u003e\",\"summary\":\"In Tooele County, Utah, about 9,000 voters received incorrect ballots for the June 23 primary: Republicans got nonpartisan ones, and nonpartisan voters got Republican ballots due to a print vendor's data error. Officials caught it fast, deactivated the barcodes to block any counting, and arranged for reprints funded by the vendor, with new ballots due early next week and notices sent to affected voters. Clerk Tracy Shaw stressed it's a fixable mistake, not fraud, thanks to safeguards like signature matching—though the incident drew sharp online criticism from figures like Mark Meadows calling for an end to mail-in voting.\",\"updated_at\":\"2026-06-04T20:07:04.000Z\"},{\"category\":\"Other\",\"contexts\":{\"topics\":[\"Art\"]},\"disclaimer\":\"This story is a summary of posts on X and may evolve over time.…[truncated]"
+    },
+    {
+      "command": "spaces buyers get-spaces",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "buyers",
+        "get-spaces",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who purchased tickets to a specific Space by its ID.\n\nUsage:\n  x-twitter-pp-cli spaces buyers get-spaces \u003cid\u003e [flags]\n\nAliases:\n  get-spaces, get\n\nExamples:\n  x-twitter-pp-cli spaces buyers get-spaces 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-spaces\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces buyers get-spaces",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "spaces buyers get-spaces",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "spaces buyers get-spaces",
+      "kind": "error_path",
+      "args": [
+        "spaces",
+        "buyers",
+        "get-spaces",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/spaces/__printing_press_invalid__/buyers returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/spaces/__printing_press_invalid__/buyers returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "spaces get-by-creator-ids",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "get-by-creator-ids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of Spaces created by specified User IDs.\n\nUsage:\n  x-twitter-pp-cli spaces get-by-creator-ids [flags]\n\nAliases:\n  get-by-creator-ids, list\n\nExamples:\n  x-twitter-pp-cli spaces get-by-creator-ids --user-ids example-value\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-creator-ids\n      --space-fields string   A comma separated list of Space fields to display.\n      --topic-fields string   A comma separated list of Topic fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n      --user-ids string       The IDs of Users to search through.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces get-by-creator-ids",
+      "kind": "happy_path",
+      "args": [
+        "spaces",
+        "get-by-creator-ids",
+        "--user-ids",
+        "12"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 spaces items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "spaces get-by-creator-ids",
+      "kind": "json_fidelity",
+      "args": [
+        "spaces",
+        "get-by-creator-ids",
+        "--user-ids",
+        "12",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 spaces items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "spaces get-by-creator-ids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "spaces get-by-id",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "get-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific space by its ID.\n\nUsage:\n  x-twitter-pp-cli spaces get-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-by-id, get\n\nExamples:\n  x-twitter-pp-cli spaces get-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-id\n      --space-fields string   A comma separated list of Space fields to display.\n      --topic-fields string   A comma separated list of Topic fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces get-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "spaces get-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "spaces get-by-id",
+      "kind": "error_path",
+      "args": [
+        "spaces",
+        "get-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/spaces/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[a-zA-Z0-9]{1,13}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/spaces/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[a-zA-Z0-9]{1,13}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "spaces get-by-ids",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "get-by-ids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of multiple Spaces by their IDs.\n\nUsage:\n  x-twitter-pp-cli spaces get-by-ids [flags]\n\nExamples:\n  x-twitter-pp-cli spaces get-by-ids --ids example-value\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-ids\n      --ids string            The list of Space IDs to return.\n      --space-fields string   A comma separated list of Space fields to display.\n      --topic-fields string   A comma separated list of Topic fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces get-by-ids",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "spaces get-by-ids",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "spaces get-by-ids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"live-id\""
+    },
+    {
+      "command": "spaces search",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "search",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Spaces matching the specified search query.\n\nUsage:\n  x-twitter-pp-cli spaces search [flags]\n\nExamples:\n  x-twitter-pp-cli spaces search --query example-value\n\nFlags:\n      --all                   Fetch all pages\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for search\n      --max-results int       The number of results to return. (default 100)\n      --query string          The search query.\n      --space-fields string   A comma separated list of Space fields to display.\n      --state string          The state of Spaces to search for. (one of: live, scheduled, all) (default \"all\")\n      --topic-fields string   A comma separated list of Topic fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces search",
+      "kind": "happy_path",
+      "args": [
+        "spaces",
+        "search",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 spaces items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "spaces search",
+      "kind": "json_fidelity",
+      "args": [
+        "spaces",
+        "search",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 spaces items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "spaces search",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "spaces tweets get-spaces-posts",
+      "kind": "help",
+      "args": [
+        "spaces",
+        "tweets",
+        "get-spaces-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts shared in a specific Space by its ID.\n\nUsage:\n  x-twitter-pp-cli spaces tweets get-spaces-posts \u003cid\u003e [flags]\n\nAliases:\n  get-spaces-posts, get\n\nExamples:\n  x-twitter-pp-cli spaces tweets get-spaces-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                   Fetch all pages\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-spaces-posts\n      --max-results int       The number of Posts to fetch from the provided space. If not provided, the value will default to the maximum of 100. (default 100)\n      --media-fields string   A comma separated list of Media fields to display.\n      --place-fields string   A comma separated list of Place fields to display.\n      --poll-fields string    A comma separated list of Poll fields to display.\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "spaces tweets get-spaces-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "spaces tweets get-spaces-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "spaces tweets get-spaces-posts",
+      "kind": "error_path",
+      "args": [
+        "spaces",
+        "tweets",
+        "get-spaces-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/spaces/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[a-zA-Z0-9]{1,13}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/spaces/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] does not match ^[a-zA-Z0-9]{1,13}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "sync",
+      "kind": "help",
+      "args": [
+        "sync",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Sync data from the API into a local SQLite database. Supports resumable\nincremental sync (only fetches new data since last sync) and full resync.\nOnce synced, use the 'search' command for instant full-text search.\n\nExit codes \u0026 warnings:\n  Resources the API denies access to (HTTP 403, or HTTP 400 with an\n  access-policy body) are reported as warnings rather than failing the\n  run. In --json mode each is emitted as a {\"event\":\"sync_warning\",...}\n  line carrying status, reason, and message fields, and a final\n  {\"event\":\"sync_summary\",...} aggregates the run.\n\n  Exit 0 when at least one resource synced and no resource flagged in\n  the spec as critical (x-critical: true) failed; non-critical failures\n  emit {\"event\":\"sync_warning\",\"reason\":\"exit_policy_default_changed\",\n  ...} so callers can detect that a partial failure was tolerated. Pass\n  --strict to exit non-zero on any per-resource failure. Exit is always\n  non-zero when every selected resource failed, regardless of --strict.\n\nResource scoping:\n  --resources runs the named top-level resources, plus any parent-keyed\n  dependent whose own name is listed OR whose parent table is listed.\n  Naming a parent therefore cascades to its dependents (so \"sync this\n  parent and its children\" works without listing every nested resource\n  by hand). There is no flag today to suppress the cascade for a named\n  parent. To run a dependent without re-syncing its parent, list only\n  the dependent by name; the parent table must already be populated\n  from a prior sync.\n\nUsage:\n  x-twitter-pp-cli sync [flags]\n\nExamples:\n  # Sync all resources\n  x-twitter-pp-cli sync\n\n  # Sync specific resources only\n  x-twitter-pp-cli sync --resources channels,messages\n\n  # Full resync (ignore previous checkpoint)\n  x-twitter-pp-cli sync --full\n\n  # Incremental sync: only records from the last 7 days\n  x-twitter-pp-cli sync --since 7d\n\n  # Parallel sync with 8 workers\n  x-twitter-pp-cli sync --concurrency 8\n\n  # Latest-only: refresh head of each resource, no historical backfill\n  x-twitter-pp-cli sync --latest-only\n\nFlags:\n      --concurrency int              Number of parallel sync workers (default 4)\n      --db string                    Database path (default: ~/.local/share/x-twitter-pp-cli/data.db)\n      --full                         Full resync (ignore previous checkpoint)\n      --global-param stringArray     Extra query param to inject into every sync request including dependent path-scoped calls (repeatable, key=value). Use when an API requires a scope on every call regardless of path nesting.\n  -h, --help                         help for sync\n      --latest-only                  Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).\n      --max-pages int                Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)\n      --param stringArray            Extra query param to inject into flat-list sync requests (repeatable, key=value). Skipped on path-scoped dependent requests so a top-level scope like workspace=\u003cid\u003e does not double up on /parents/\u003cid\u003e/children calls. Use --global-param to inject everywhere. Avoid pagination keys (limit/since/cursor) — overriding them corrupts resume state.\n      --resource-param stringArray   Per-resource extra query param (repeatable, resource:key=value). Wins over --param and --global-param when keys conflict.\n      --resources strings            Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).\n      --since string                 Incremental sync duration (e.g. 7d, 24h, 1w, 30m)\n      --strict                       Exit non-zero on any per-resource failure (default: only critical failures or all-resource failure exit non-zero).\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-ze…[truncated]"
+    },
+    {
+      "command": "sync",
+      "kind": "happy_path",
+      "args": [
+        "sync"
+      ],
+      "status": "pass",
+      "output_sample": "{\"event\":\"sync_start\",\"resource\":\"account-activity\"}\n{\"event\":\"sync_start\",\"resource\":\"activity\"}\n{\"event\":\"sync_start\",\"resource\":\"activity-subscriptions\"}\n{\"event\":\"sync_start\",\"resource\":\"chat\"}\n{\"event\":\"sync_warning\",\"resource\":\"chat\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"compliance\"}\n{\"event\":\"sync_error\",\"resource\":\"account-activity\",\"error\":\"missing id for account_activity\"}\n{\"event\":\"sync_start\",\"resource\":\"connections\"}\n{\"event\":\"sync_complete\",\"resource\":\"activity-subscriptions\",\"total\":0,\"duration_ms\":98}\n{\"event\":\"sync_start\",\"resource\":\"dm-events\"}\n{\"event\":\"sync_error\",\"resource\":\"activity\",\"status\":409,\"method\":\"GET\",\"path\":\"/2/activity/stream\",\"body\":\"{\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\",\"error\":\"GET /2/activity/stream returned HTTP 409: {\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"openapi-json\"}\n{\"event\":\"sync_error\",\"resource\":\"compliance\",\"status\":400,\"method\":\"GET\",\"path\":\"/2/compliance/jobs\",\"body\":\"{\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\",\"error\":\"GET /2/compliance/jobs returned HTTP 400: {\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets\"}\n{\"event\":\"sync_warning\",\"resource\":\"dm-events\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets-search-stream-rules\"}\n{\"event\":\"sync_warning\",\"resource\":\"tweets\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\\"client_id\\\":\\\"32365644\\\",\\\"detail\\\":\\\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\\\",\\\"registration_url\\\":\\\"https://developer.twitter.com/en/docs/projects/overview\\\",\\\"title\\\":\\\"Client Forbidden\\\",\\\"required_enrollment\\\":\\\"Appropriate Level of API Access\\\",\\\"reason\\\":\\\"client-not-enrolled\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/client-forbidden\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets-search-stream-rules-counts\"}\n{\"event\":\"sync_error\",\"resource\":\"connections\",\"error\":\"missing id for connections\"}\n{\"event\":\"sync_start\",\"resource\":\"usage\"}\n{\"event\":\"sync_complete\",\"resource\":\"tweets-search-stream-rules\",\"total\":1,\"duration_ms\":76}\n{\"event\":\"sync_start\",\"resource\":\"users\"}\n{\"event\":\"sync_complete\",\"resource\":\"openapi-json\",\"total\":1,\"duration_ms\":134}\n{\"event\":\"sync_start\",\"resource\":\"users-personalized-trends\"}\n{\"event\"…[truncated]"
+    },
+    {
+      "command": "sync",
+      "kind": "json_fidelity",
+      "args": [
+        "sync",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"event\":\"sync_start\",\"resource\":\"account-activity\"}\n{\"event\":\"sync_start\",\"resource\":\"activity\"}\n{\"event\":\"sync_start\",\"resource\":\"activity-subscriptions\"}\n{\"event\":\"sync_start\",\"resource\":\"chat\"}\n{\"event\":\"sync_warning\",\"resource\":\"activity-subscriptions\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_warning\",\"resource\":\"chat\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"compliance\"}\n{\"event\":\"sync_complete\",\"resource\":\"activity-subscriptions\",\"total\":0,\"duration_ms\":95}\n{\"event\":\"sync_start\",\"resource\":\"connections\"}\n{\"event\":\"sync_error\",\"resource\":\"account-activity\",\"error\":\"missing id for account_activity\"}\n{\"event\":\"sync_start\",\"resource\":\"dm-events\"}\n{\"event\":\"sync_error\",\"resource\":\"activity\",\"status\":409,\"method\":\"GET\",\"path\":\"/2/activity/stream\",\"body\":\"{\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\",\"error\":\"GET /2/activity/stream returned HTTP 409: {\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"openapi-json\"}\n{\"event\":\"sync_warning\",\"resource\":\"openapi-json\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_error\",\"resource\":\"compliance\",\"status\":400,\"method\":\"GET\",\"path\":\"/2/compliance/jobs\",\"body\":\"{\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\",\"error\":\"GET /2/compliance/jobs returned HTTP 400: {\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets\"}\n{\"event\":\"sync_warning\",\"resource\":\"dm-events\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets-search-stream-rules\"}\n{\"event\":\"sync_warning\",\"resource\":\"tweets-search-stream-rules\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_error\",\"resource\":\"connections\",\"error\":\"missing id for connections\"}\n{\"event\":\"sync_start\",\"resource\":\"tweets-search-stream-rules-counts\"}\n{\"event\":\"sync_warning\",\"resource\":\"tweets-search-stream-rules-counts\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_warning\",\"resource\":\"tweets\",\"status\":403,\"reason\":\"forbidden\",\"…[truncated]"
+    },
+    {
+      "command": "sync",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tail",
+      "kind": "help",
+      "args": [
+        "tail",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Tail streams live data changes by polling the API at configurable intervals.\nEvents are emitted as NDJSON to stdout for piping to other tools.\nGracefully shuts down on SIGTERM/SIGINT.\n\nNote: For APIs with WebSocket or SSE support, a future version will use\nnative streaming instead of polling.\n\nUsage:\n  x-twitter-pp-cli tail [resource] [flags]\n\nExamples:\n  # Tail all changes every 10 seconds\n  x-twitter-pp-cli tail --interval 10s\n\n  # Tail a specific resource\n  x-twitter-pp-cli tail messages --interval 5s\n\n  # Pipe to jq for filtering\n  x-twitter-pp-cli tail events --interval 30s | jq 'select(.type == \"error\")'\n\nFlags:\n      --follow              Keep running (set --follow=false for single poll) (default true)\n  -h, --help                help for tail\n      --interval duration   Poll interval (default 10s)\n      --resource string     Resource type to tail\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tail",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [tail] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "tail",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [tail] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "tail",
+      "kind": "error_path",
+      "args": [
+        "tail",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": -1,
+      "output_sample": "Tailing __printing_press_invalid__ every 10s (Ctrl+C to stop)\nwarning: initial fetch failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \nwarning: poll failed: GET /__printing_press_invalid__ returned HTTP 404: \n"
+    },
+    {
+      "command": "thread compose",
+      "kind": "help",
+      "args": [
+        "thread",
+        "compose",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Pack the markdown into ≤280-character tweets, honoring atom boundaries (paragraphs, list items, code fences). Default behavior is dry-run; pass --post to chain-post the thread via the tweets endpoint.\n\nUsage:\n  x-twitter-pp-cli thread compose \u003cmarkdown-file\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli thread compose draft.md\n  x-twitter-pp-cli thread compose draft.md --post\n\nFlags:\n  -h, --help   help for compose\n      --post   Actually post the thread (default: dry-run)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "thread compose",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"markdown-file\" at depth 0"
+    },
+    {
+      "command": "thread compose",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"markdown-file\" at depth 0"
+    },
+    {
+      "command": "thread compose",
+      "kind": "error_path",
+      "args": [
+        "thread",
+        "compose",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 1,
+      "output_sample": "Error: read __printing_press_invalid__: open __printing_press_invalid__: no such file or directory\nread __printing_press_invalid__: open __printing_press_invalid__: no such file or directory\n"
+    },
+    {
+      "command": "thread show",
+      "kind": "help",
+      "args": [
+        "thread",
+        "show",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Reconstruct a conversation thread entirely from the local store. Joins synced posts on\nconversation_id and the replied_to edges in referenced_tweets, ordering them chronologically\nand tagging each with its reply depth — no API call, so it never re-spends read credits.\n\nPopulate the store first with a sync that requests the thread fields, e.g.\n  x-twitter-pp-cli sync --resources tweets --param tweet.fields=conversation_id,referenced_tweets,created_at,author_id\n\nUsage:\n  x-twitter-pp-cli thread show \u003cconversation_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli thread show 1750000000000000000 --agent\n\nFlags:\n      --db string   Path to the local database (defaults to the standard cache location)\n  -h, --help        help for show\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "thread show",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"conversation_id\""
+    },
+    {
+      "command": "thread show",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"conversation_id\""
+    },
+    {
+      "command": "thread show",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no-error-path-probe annotation"
+    },
+    {
+      "command": "trends",
+      "kind": "help",
+      "args": [
+        "trends",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves trending topics for a specific location identified by its WOEID.\n\nUsage:\n  x-twitter-pp-cli trends \u003cwoeid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli trends 42\n\nFlags:\n  -h, --help                  help for trends\n      --max-trends int        The maximum number of results. (default 20)\n      --trend-fields string   A comma separated list of Trend fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "trends",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [trends] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "trends",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [trends] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "trends",
+      "kind": "error_path",
+      "args": [
+        "trends",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/trends/by/woeid/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"woeid\":[\"__printing_press_invalid__\"]},\"message\":\"'__printing_press_invalid__' is not a valid Int\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/trends/by/woeid/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"woeid\":[\"__printing_press_invalid__\"]},\"message\":\"'__printing_press_invalid__' is not a valid Int\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "tweets create-posts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "create-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a new Post for the authenticated user, or edits an existing Post when edit_options are provided.\n\nUsage:\n  x-twitter-pp-cli tweets create-posts [flags]\n\nAliases:\n  create-posts, create\n\nExamples:\n  x-twitter-pp-cli tweets create-posts\n\nFlags:\n      --card-uri string                        Card Uri Parameter. This is mutually exclusive from Quote Tweet Id, Poll, Media, and Direct Message Deep Link.\n      --community-id string                    The unique identifier of this Community.\n      --direct-message-deep-link string        Link to take the conversation from the public timeline to a private Direct Message.\n      --edit-options-previous-post-id string   Unique identifier of this Tweet.\n      --for-super-followers-only               Exclusive Tweet for super followers.\n      --geo-place-id string                    Place id\n  -h, --help                                   help for create-posts\n      --made-with-ai                           Whether this Post contains AI-generated media. When true, the Post will be labeled accordingly.\n      --media-description string               Description for the media. Rendered on the Post card for video and Amplify content.\n      --media-embeddable                       When true, the media's asset URLs do not expire and external syndicated playback is allowed.\n      --media-media-ids string                 A list of Media Ids to be attached to a created Tweet.\n      --media-preview-media-id string          The unique identifier of this Media.\n      --media-tagged-user-ids string           A list of User Ids to be tagged in the media for created Tweet.\n      --media-title string                     Title for the media. Rendered on the Post card for video and Amplify content.\n      --nullcast                               Nullcasted (promoted-only) Posts do not appear in the public timeline and are not served to followers.\n      --paid-partnership                       Whether this Post is a paid partnership. When true, the Post will be labeled as a paid promotion.\n      --poll-duration-minutes int              Duration of the poll in minutes.\n      --poll-options string                    Options\n      --poll-reply-settings string             Settings to indicate who can reply to the Tweet.\n      --quote-tweet-id string                  Unique identifier of this Tweet.\n      --reply-auto-populate-reply-metadata     If set to true, reply metadata will be automatically populated.\n      --reply-exclude-reply-user-ids string    A list of User Ids to be excluded from the reply Tweet.\n      --reply-in-reply-to-tweet-id string      Unique identifier of this Tweet.\n      --reply-settings string                  Settings to indicate who can reply to the Tweet.\n      --share-with-followers                   Share community post with followers too.\n      --stdin                                  Read request body as JSON from stdin (use this for deeply nested fields not exposed as flags)\n      --text string                            The content of the Tweet.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as …[truncated]"
+    },
+    {
+      "command": "tweets create-posts",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "create-posts",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/tweets\",\n  \"resource\": \"tweets\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/tweets\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "tweets create-posts",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "create-posts",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/tweets\",\n  \"resource\": \"tweets\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/tweets\n  Body:\n{}\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "tweets create-posts",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets create-posts",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "tweets create-webhooks-stream-link",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "create-webhooks-stream-link",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a link to deliver FilteredStream events to the given webhook.\n\nUsage:\n  x-twitter-pp-cli tweets create-webhooks-stream-link \u003cwebhook_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli tweets create-webhooks-stream-link 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for create-webhooks-stream-link\n      --media-fields string   A comma separated list of Media fields to display.\n      --place-fields string   A comma separated list of Place fields to display.\n      --poll-fields string    A comma separated list of Poll fields to display.\n      --stdin                 Read request body as JSON from stdin\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets create-webhooks-stream-link",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets create-webhooks-stream-link",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets create-webhooks-stream-link",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "tweets create-webhooks-stream-link",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets delete-posts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "delete-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a specific Post by its ID, if owned by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli tweets delete-posts \u003cid\u003e [flags]\n\nAliases:\n  delete-posts, delete\n\nExamples:\n  x-twitter-pp-cli tweets delete-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-posts\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets delete-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets delete-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets delete-posts",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "tweets delete-posts",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets delete-webhooks-stream-link",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "delete-webhooks-stream-link",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes a link from FilteredStream events to the given webhook.\n\nUsage:\n  x-twitter-pp-cli tweets delete-webhooks-stream-link \u003cwebhook_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli tweets delete-webhooks-stream-link 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-webhooks-stream-link\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets delete-webhooks-stream-link",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets delete-webhooks-stream-link",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets delete-webhooks-stream-link",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "tweets delete-webhooks-stream-link",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "tweets get-posts-analytics",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-posts-analytics",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves analytics data for specified Posts within a defined time range.\n\nUsage:\n  x-twitter-pp-cli tweets get-posts-analytics [flags]\n\nAliases:\n  get-posts-analytics, list\n\nExamples:\n  x-twitter-pp-cli tweets get-posts-analytics --ids example-value --end-time 2026-01-15T09:00:00Z --start-time 2026-01-15T09:00:00Z --granularity hourly\n\nFlags:\n      --analytics-fields string   A comma separated list of Analytics fields to display.\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the end of the time range.\n      --granularity string        The granularity for the search counts results. (one of: hourly, daily, weekly, total) (default \"total\")\n  -h, --help                      help for get-posts-analytics\n      --ids string                A comma separated list of Post IDs. Up to 100 are allowed in a single request.\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The UTC timestamp representing the start of the time range.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-posts-analytics",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-posts-analytics",
+        "--ids",
+        "example-value",
+        "--end-time",
+        "2026-01-15T09:00:00Z",
+        "--start-time",
+        "2026-01-15T09:00:00Z",
+        "--granularity",
+        "hourly"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/tweets/analytics returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/tweets/analytics returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "tweets get-posts-analytics",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "tweets get-posts-analytics",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-posts-by-id",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-posts-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli tweets get-posts-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-posts-by-id, get\n\nExamples:\n  x-twitter-pp-cli tweets get-posts-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-posts-by-id\n      --media-fields string   A comma separated list of Media fields to display.\n      --place-fields string   A comma separated list of Place fields to display.\n      --poll-fields string    A comma separated list of Poll fields to display.\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-posts-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets get-posts-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets get-posts-by-id",
+      "kind": "error_path",
+      "args": [
+        "tweets",
+        "get-posts-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/tweets/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/tweets/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "tweets get-posts-by-ids",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-posts-by-ids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of multiple Posts by their IDs.\n\nUsage:\n  x-twitter-pp-cli tweets get-posts-by-ids [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-posts-by-ids --ids example-value\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-posts-by-ids\n      --ids string            A comma separated list of Post IDs. Up to 100 are allowed in a single request.\n      --media-fields string   A comma separated list of Media fields to display.\n      --place-fields string   A comma separated list of Place fields to display.\n      --poll-fields string    A comma separated list of Poll fields to display.\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-posts-by-ids",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-posts-by-ids",
+        "--ids",
+        "20"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": [\n    {\n      \"edit_history_tweet_ids\": [\n        \"20\"\n      ],\n      \"text\": \"just setting up my twttr\",\n      \"id\": \"20\"\n    }\n  ]\n}\n"
+    },
+    {
+      "command": "tweets get-posts-by-ids",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "get-posts-by-ids",
+        "--ids",
+        "20",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": [\n    {\n      \"edit_history_tweet_ids\": [\n        \"20\"\n      ],\n      \"text\": \"just setting up my twttr\",\n      \"id\": \"20\"\n    }\n  ]\n}\n"
+    },
+    {
+      "command": "tweets get-posts-by-ids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-posts-counts-all",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-posts-counts-all",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the count of Posts matching a search query from the full archive.\n\nUsage:\n  x-twitter-pp-cli tweets get-posts-counts-all [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-posts-counts-all --query example-value\n\nFlags:\n      --end-time string              YYYY-MM-DDTHH:mm:ssZ. The newest, most recent UTC timestamp to which the Posts will be provided.\n      --granularity string           The granularity for the search counts results. (one of: minute, hour, day) (default \"hour\")\n  -h, --help                         help for get-posts-counts-all\n      --next-token string            This parameter is used to get the next 'page' of results.\n      --pagination-token string      This parameter is used to get the next 'page' of results.\n      --query string                 One query/rule/filter for matching Posts. Refer to https://t.co/rulelength to identify the max query length.\n      --search-count-fields string   A comma separated list of SearchCount fields to display.\n      --since-id string              Returns results with a Post ID greater than (that is, more recent than) the specified ID.\n      --start-time string            YYYY-MM-DDTHH:mm:ssZ. The oldest UTC timestamp from which the Posts will be provided.\n      --until-id string              Returns results with a Post ID less than (that is, older than) the specified ID.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-posts-counts-all",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-posts-counts-all",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"end\": \"2026-05-06T01:00:00.000Z\",\n        \"start\": \"2026-05-06T00:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T02:00:00.000Z\",\n        \"start\": \"2026-05-06T01:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T03:00:00.000Z\",\n        \"start\": \"2026-05-06T02:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T04:00:00.000Z\",\n        \"start\": \"2026-05-06T03:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T05:00:00.000Z\",\n        \"start\": \"2026-05-06T04:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T06:00:00.000Z\",\n        \"start\": \"2026-05-06T05:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T07:00:00.000Z\",\n        \"start\": \"2026-05-06T06:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T08:00:00.000Z\",\n        \"start\": \"2026-05-06T07:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T09:00:00.000Z\",\n        \"start\": \"2026-05-06T08:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T10:00:00.000Z\",\n        \"start\": \"2026-05-06T09:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T11:00:00.000Z\",\n        \"start\": \"2026-05-06T10:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T12:00:00.000Z\",\n        \"start\": \"2026-05-06T11:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T13:00:00.000Z\",\n        \"start\": \"2026-05-06T12:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T14:00:00.000Z\",\n        \"start\": \"2026-05-06T13:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T15:00:00.000Z\",\n        \"start\": \"2026-05-06T14:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T16:00:00.000Z\",\n        \"start\": \"2026-05-06T15:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T17:00:00.000Z\",\n        \"start\": \"2026-05-06T16:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T18:00:00.000Z\",\n        \"start\": \"2026-05-06T17:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T19:00:00.000Z\",\n        \"start\": \"2026-05-06T18:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T20:00:00.000Z\",\n        \"start\": \"2026-05-06T19:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T21:00:00.000Z\",\n        \"start\": \"2026-05-06T20:00:00.000Z\",\n        \"tweet_count\": 1\n      },\n      {\n        \"end\": \"2026-05-06T22:00:00.000Z\",\n        \"start\": \"2026-05-06T21:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T23:00:00.000Z\",\n        \"start\": \"2026-05-06T22:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T00:00:00.000Z\",\n        \"start\": \"2026-05-06T23:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T01:00:00.000Z\",\n        \"start\": \"2026-05-07T00:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T02:00:00.000Z\",\n        \"start\": \"2026-05-07T01:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T03:00:00.000Z\",\n        \"start\": \"2026-05-07T02:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T04:00:00.000Z\",\n        \"start\": \"2026-05-07T03:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T05:00:00.000Z\",\n        \"start\": \"2026-05-07T04:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T06:00:00.000Z\",\n        \"start\": \"2026-05-07T05:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T07:00:00.000Z\",\n        \"start\": \"2026-05-07T06:00:00.000Z\",\n        \"tweet_count\": 0\n      …[truncated]"
+    },
+    {
+      "command": "tweets get-posts-counts-all",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "get-posts-counts-all",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"end\": \"2026-05-06T01:00:00.000Z\",\n        \"start\": \"2026-05-06T00:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T02:00:00.000Z\",\n        \"start\": \"2026-05-06T01:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T03:00:00.000Z\",\n        \"start\": \"2026-05-06T02:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T04:00:00.000Z\",\n        \"start\": \"2026-05-06T03:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T05:00:00.000Z\",\n        \"start\": \"2026-05-06T04:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T06:00:00.000Z\",\n        \"start\": \"2026-05-06T05:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T07:00:00.000Z\",\n        \"start\": \"2026-05-06T06:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T08:00:00.000Z\",\n        \"start\": \"2026-05-06T07:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T09:00:00.000Z\",\n        \"start\": \"2026-05-06T08:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T10:00:00.000Z\",\n        \"start\": \"2026-05-06T09:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T11:00:00.000Z\",\n        \"start\": \"2026-05-06T10:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T12:00:00.000Z\",\n        \"start\": \"2026-05-06T11:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T13:00:00.000Z\",\n        \"start\": \"2026-05-06T12:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T14:00:00.000Z\",\n        \"start\": \"2026-05-06T13:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T15:00:00.000Z\",\n        \"start\": \"2026-05-06T14:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T16:00:00.000Z\",\n        \"start\": \"2026-05-06T15:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T17:00:00.000Z\",\n        \"start\": \"2026-05-06T16:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T18:00:00.000Z\",\n        \"start\": \"2026-05-06T17:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T19:00:00.000Z\",\n        \"start\": \"2026-05-06T18:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T20:00:00.000Z\",\n        \"start\": \"2026-05-06T19:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T21:00:00.000Z\",\n        \"start\": \"2026-05-06T20:00:00.000Z\",\n        \"tweet_count\": 1\n      },\n      {\n        \"end\": \"2026-05-06T22:00:00.000Z\",\n        \"start\": \"2026-05-06T21:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-06T23:00:00.000Z\",\n        \"start\": \"2026-05-06T22:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T00:00:00.000Z\",\n        \"start\": \"2026-05-06T23:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T01:00:00.000Z\",\n        \"start\": \"2026-05-07T00:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T02:00:00.000Z\",\n        \"start\": \"2026-05-07T01:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T03:00:00.000Z\",\n        \"start\": \"2026-05-07T02:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T04:00:00.000Z\",\n        \"start\": \"2026-05-07T03:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T05:00:00.000Z\",\n        \"start\": \"2026-05-07T04:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T06:00:00.000Z\",\n        \"start\": \"2026-05-07T05:00:00.000Z\",\n        \"tweet_count\": 0\n      },\n      {\n        \"end\": \"2026-05-07T07:00:00.000Z\",\n        \"start\": \"2026-05-07T06:00:00.000Z\",\n        \"tweet_count\": 0\n      …[truncated]"
+    },
+    {
+      "command": "tweets get-posts-counts-all",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-posts-counts-recent",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-posts-counts-recent",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the count of Posts from the last 7 days matching a search query.\n\nUsage:\n  x-twitter-pp-cli tweets get-posts-counts-recent [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-posts-counts-recent --query example-value\n\nFlags:\n      --end-time string              YYYY-MM-DDTHH:mm:ssZ. The newest, most recent UTC timestamp to which the Posts will be provided.\n      --granularity string           The granularity for the search counts results. (one of: minute, hour, day) (default \"hour\")\n  -h, --help                         help for get-posts-counts-recent\n      --next-token string            This parameter is used to get the next 'page' of results.\n      --pagination-token string      This parameter is used to get the next 'page' of results.\n      --query string                 One query/rule/filter for matching Posts. Refer to https://t.co/rulelength to identify the max query length.\n      --search-count-fields string   A comma separated list of SearchCount fields to display.\n      --since-id string              Returns results with a Post ID greater than (that is, more recent than) the specified ID.\n      --start-time string            YYYY-MM-DDTHH:mm:ssZ. The oldest UTC timestamp (from most recent 7 days) from which the Posts will be provided.\n      --until-id string              Returns results with a Post ID less than (that is, older than) the specified ID.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-posts-counts-recent",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-posts-counts-recent",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"end\": \"2026-05-29T21:00:00.000Z\",\n        \"start\": \"2026-05-29T20:24:11.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-29T22:00:00.000Z\",\n        \"start\": \"2026-05-29T21:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-29T23:00:00.000Z\",\n        \"start\": \"2026-05-29T22:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T00:00:00.000Z\",\n        \"start\": \"2026-05-29T23:00:00.000Z\",\n        \"tweet_count\": 21\n      },\n      {\n        \"end\": \"2026-05-30T01:00:00.000Z\",\n        \"start\": \"2026-05-30T00:00:00.000Z\",\n        \"tweet_count\": 121\n      },\n      {\n        \"end\": \"2026-05-30T02:00:00.000Z\",\n        \"start\": \"2026-05-30T01:00:00.000Z\",\n        \"tweet_count\": 6\n      },\n      {\n        \"end\": \"2026-05-30T03:00:00.000Z\",\n        \"start\": \"2026-05-30T02:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T04:00:00.000Z\",\n        \"start\": \"2026-05-30T03:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T05:00:00.000Z\",\n        \"start\": \"2026-05-30T04:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-30T06:00:00.000Z\",\n        \"start\": \"2026-05-30T05:00:00.000Z\",\n        \"tweet_count\": 17\n      },\n      {\n        \"end\": \"2026-05-30T07:00:00.000Z\",\n        \"start\": \"2026-05-30T06:00:00.000Z\",\n        \"tweet_count\": 5\n      },\n      {\n        \"end\": \"2026-05-30T08:00:00.000Z\",\n        \"start\": \"2026-05-30T07:00:00.000Z\",\n        \"tweet_count\": 9\n      },\n      {\n        \"end\": \"2026-05-30T09:00:00.000Z\",\n        \"start\": \"2026-05-30T08:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T10:00:00.000Z\",\n        \"start\": \"2026-05-30T09:00:00.000Z\",\n        \"tweet_count\": 16\n      },\n      {\n        \"end\": \"2026-05-30T11:00:00.000Z\",\n        \"start\": \"2026-05-30T10:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T12:00:00.000Z\",\n        \"start\": \"2026-05-30T11:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T13:00:00.000Z\",\n        \"start\": \"2026-05-30T12:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T14:00:00.000Z\",\n        \"start\": \"2026-05-30T13:00:00.000Z\",\n        \"tweet_count\": 14\n      },\n      {\n        \"end\": \"2026-05-30T15:00:00.000Z\",\n        \"start\": \"2026-05-30T14:00:00.000Z\",\n        \"tweet_count\": 15\n      },\n      {\n        \"end\": \"2026-05-30T16:00:00.000Z\",\n        \"start\": \"2026-05-30T15:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T17:00:00.000Z\",\n        \"start\": \"2026-05-30T16:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T18:00:00.000Z\",\n        \"start\": \"2026-05-30T17:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-30T19:00:00.000Z\",\n        \"start\": \"2026-05-30T18:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T20:00:00.000Z\",\n        \"start\": \"2026-05-30T19:00:00.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-30T21:00:00.000Z\",\n        \"start\": \"2026-05-30T20:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T22:00:00.000Z\",\n        \"start\": \"2026-05-30T21:00:00.000Z\",\n        \"tweet_count\": 3\n      },\n      {\n        \"end\": \"2026-05-30T23:00:00.000Z\",\n        \"start\": \"2026-05-30T22:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-31T00:00:00.000Z\",\n        \"start\": \"2026-05-30T23:00:00.000Z\",\n        \"tweet_count\": 5\n      },\n      {\n        \"end\": \"2026-05-31T01:00:00.000Z\",\n        \"start\": \"2026-05-31T00:00:00.000Z\",\n        \"tweet_count\": 6\n      },\n      {\n        \"end\": \"2026-05-31T02:00:00.000Z\",\n        \"start\": \"2026-05-31T01:00:00.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-31T03:00:00.000Z\",\n        \"start\": \"2026-05-31T02:00:00.000Z\",\n        \"tweet_…[truncated]"
+    },
+    {
+      "command": "tweets get-posts-counts-recent",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "get-posts-counts-recent",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"end\": \"2026-05-29T21:00:00.000Z\",\n        \"start\": \"2026-05-29T20:24:11.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-29T22:00:00.000Z\",\n        \"start\": \"2026-05-29T21:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-29T23:00:00.000Z\",\n        \"start\": \"2026-05-29T22:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T00:00:00.000Z\",\n        \"start\": \"2026-05-29T23:00:00.000Z\",\n        \"tweet_count\": 21\n      },\n      {\n        \"end\": \"2026-05-30T01:00:00.000Z\",\n        \"start\": \"2026-05-30T00:00:00.000Z\",\n        \"tweet_count\": 121\n      },\n      {\n        \"end\": \"2026-05-30T02:00:00.000Z\",\n        \"start\": \"2026-05-30T01:00:00.000Z\",\n        \"tweet_count\": 6\n      },\n      {\n        \"end\": \"2026-05-30T03:00:00.000Z\",\n        \"start\": \"2026-05-30T02:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T04:00:00.000Z\",\n        \"start\": \"2026-05-30T03:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T05:00:00.000Z\",\n        \"start\": \"2026-05-30T04:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-30T06:00:00.000Z\",\n        \"start\": \"2026-05-30T05:00:00.000Z\",\n        \"tweet_count\": 17\n      },\n      {\n        \"end\": \"2026-05-30T07:00:00.000Z\",\n        \"start\": \"2026-05-30T06:00:00.000Z\",\n        \"tweet_count\": 5\n      },\n      {\n        \"end\": \"2026-05-30T08:00:00.000Z\",\n        \"start\": \"2026-05-30T07:00:00.000Z\",\n        \"tweet_count\": 9\n      },\n      {\n        \"end\": \"2026-05-30T09:00:00.000Z\",\n        \"start\": \"2026-05-30T08:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T10:00:00.000Z\",\n        \"start\": \"2026-05-30T09:00:00.000Z\",\n        \"tweet_count\": 16\n      },\n      {\n        \"end\": \"2026-05-30T11:00:00.000Z\",\n        \"start\": \"2026-05-30T10:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T12:00:00.000Z\",\n        \"start\": \"2026-05-30T11:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T13:00:00.000Z\",\n        \"start\": \"2026-05-30T12:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T14:00:00.000Z\",\n        \"start\": \"2026-05-30T13:00:00.000Z\",\n        \"tweet_count\": 14\n      },\n      {\n        \"end\": \"2026-05-30T15:00:00.000Z\",\n        \"start\": \"2026-05-30T14:00:00.000Z\",\n        \"tweet_count\": 15\n      },\n      {\n        \"end\": \"2026-05-30T16:00:00.000Z\",\n        \"start\": \"2026-05-30T15:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-30T17:00:00.000Z\",\n        \"start\": \"2026-05-30T16:00:00.000Z\",\n        \"tweet_count\": 13\n      },\n      {\n        \"end\": \"2026-05-30T18:00:00.000Z\",\n        \"start\": \"2026-05-30T17:00:00.000Z\",\n        \"tweet_count\": 11\n      },\n      {\n        \"end\": \"2026-05-30T19:00:00.000Z\",\n        \"start\": \"2026-05-30T18:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T20:00:00.000Z\",\n        \"start\": \"2026-05-30T19:00:00.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-30T21:00:00.000Z\",\n        \"start\": \"2026-05-30T20:00:00.000Z\",\n        \"tweet_count\": 12\n      },\n      {\n        \"end\": \"2026-05-30T22:00:00.000Z\",\n        \"start\": \"2026-05-30T21:00:00.000Z\",\n        \"tweet_count\": 3\n      },\n      {\n        \"end\": \"2026-05-30T23:00:00.000Z\",\n        \"start\": \"2026-05-30T22:00:00.000Z\",\n        \"tweet_count\": 8\n      },\n      {\n        \"end\": \"2026-05-31T00:00:00.000Z\",\n        \"start\": \"2026-05-30T23:00:00.000Z\",\n        \"tweet_count\": 5\n      },\n      {\n        \"end\": \"2026-05-31T01:00:00.000Z\",\n        \"start\": \"2026-05-31T00:00:00.000Z\",\n        \"tweet_count\": 6\n      },\n      {\n        \"end\": \"2026-05-31T02:00:00.000Z\",\n        \"start\": \"2026-05-31T01:00:00.000Z\",\n        \"tweet_count\": 7\n      },\n      {\n        \"end\": \"2026-05-31T03:00:00.000Z\",\n        \"start\": \"2026-05-31T02:00:00.000Z\",\n        \"tweet_…[truncated]"
+    },
+    {
+      "command": "tweets get-posts-counts-recent",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-rule-counts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-rule-counts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the count of rules in the active rule set for the filtered stream.\n\nUsage:\n  x-twitter-pp-cli tweets get-rule-counts [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-rule-counts\n\nFlags:\n  -h, --help                        help for get-rule-counts\n      --rules-count-fields string   A comma separated list of RulesCount fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-rule-counts",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-rule-counts"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {}\n}\n"
+    },
+    {
+      "command": "tweets get-rule-counts",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "get-rule-counts",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {}\n}\n"
+    },
+    {
+      "command": "tweets get-rule-counts",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-rules",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-rules",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves the active rule set or a subset of rules for the filtered stream.\n\nUsage:\n  x-twitter-pp-cli tweets get-rules [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-rules\n\nFlags:\n      --all                       Fetch all pages\n  -h, --help                      help for get-rules\n      --ids string                A comma-separated list of Rule IDs.\n      --max-results int           The maximum number of results. (default 1000)\n      --pagination-token string   This value is populated by passing the 'next_token' returned in a request to paginate through results.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-rules",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-rules"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"sent\": \"2026-06-05T20:24:21.930Z\",\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 tweets items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "tweets get-rules",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "get-rules",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"sent\": \"2026-06-05T20:24:21.930Z\",\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 tweets items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "tweets get-rules",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets get-webhooks-stream-links",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "get-webhooks-stream-links",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Get a list of webhook links associated with a filtered stream ruleset.\n\nUsage:\n  x-twitter-pp-cli tweets get-webhooks-stream-links [flags]\n\nExamples:\n  x-twitter-pp-cli tweets get-webhooks-stream-links\n\nFlags:\n  -h, --help   help for get-webhooks-stream-links\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets get-webhooks-stream-links",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "get-webhooks-stream-links"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/tweets/search/webhooks returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/tweets/search/webhooks returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "tweets get-webhooks-stream-links",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "tweets get-webhooks-stream-links",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets hidden hide-posts-reply",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "hidden",
+        "hide-posts-reply",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Hides or unhides a reply to a conversation owned by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli tweets hidden hide-posts-reply \u003ctweet_id\u003e [flags]\n\nAliases:\n  hide-posts-reply, update\n\nExamples:\n  x-twitter-pp-cli tweets hidden hide-posts-reply 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help            help for hide-posts-reply\n      --hidden string   Hidden\n      --stdin           Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets hidden hide-posts-reply",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"tweet_id\""
+    },
+    {
+      "command": "tweets hidden hide-posts-reply",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"tweet_id\""
+    },
+    {
+      "command": "tweets hidden hide-posts-reply",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "tweets hidden hide-posts-reply",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"tweet_id\""
+    },
+    {
+      "command": "tweets liking-users get-posts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "liking-users",
+        "get-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who liked a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli tweets liking-users get-posts \u003cid\u003e [flags]\n\nAliases:\n  get-posts, get\n\nExamples:\n  x-twitter-pp-cli tweets liking-users get-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-posts\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets liking-users get-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets liking-users get-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets liking-users get-posts",
+      "kind": "error_path",
+      "args": [
+        "tweets",
+        "liking-users",
+        "get-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/tweets/__printing_press_invalid__/liking_users returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/tweets/__printing_press_invalid__/liking_users returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "tweets quote-tweets get-posts-quoted-posts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "quote-tweets",
+        "get-posts-quoted-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts that quote a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli tweets quote-tweets get-posts-quoted-posts \u003cid\u003e [flags]\n\nAliases:\n  get-posts-quoted-posts, get\n\nExamples:\n  x-twitter-pp-cli tweets quote-tweets get-posts-quoted-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --exclude string            The set of entities to exclude (e.g. 'replies' or 'retweets').\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-posts-quoted-posts\n      --max-results int           The maximum number of results to be returned. (default 10)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets quote-tweets get-posts-quoted-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets quote-tweets get-posts-quoted-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets quote-tweets get-posts-quoted-posts",
+      "kind": "error_path",
+      "args": [
+        "tweets",
+        "quote-tweets",
+        "get-posts-quoted-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/tweets/__printing_press_invalid__/quote_tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/tweets/__printing_press_invalid__/quote_tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "tweets retweeted-by get-posts-reposted-by",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "retweeted-by",
+        "get-posts-reposted-by",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who reposted a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli tweets retweeted-by get-posts-reposted-by \u003cid\u003e [flags]\n\nAliases:\n  get-posts-reposted-by, get\n\nExamples:\n  x-twitter-pp-cli tweets retweeted-by get-posts-reposted-by 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-posts-reposted-by\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets retweeted-by get-posts-reposted-by",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets retweeted-by get-posts-reposted-by",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets retweeted-by get-posts-reposted-by",
+      "kind": "error_path",
+      "args": [
+        "tweets",
+        "retweeted-by",
+        "get-posts-reposted-by",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/tweets/__printing_press_invalid__/retweeted_by returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/tweets/__printing_press_invalid__/retweeted_by returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "tweets retweets get-posts-reposts",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "retweets",
+        "get-posts-reposts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts that repost a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli tweets retweets get-posts-reposts \u003cid\u003e [flags]\n\nAliases:\n  get-posts-reposts, get\n\nExamples:\n  x-twitter-pp-cli tweets retweets get-posts-reposts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-posts-reposts\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets retweets get-posts-reposts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets retweets get-posts-reposts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "tweets retweets get-posts-reposts",
+      "kind": "error_path",
+      "args": [
+        "tweets",
+        "retweets",
+        "get-posts-reposts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/tweets/__printing_press_invalid__/retweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/tweets/__printing_press_invalid__/retweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "tweets search-posts-all",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "search-posts-all",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves Posts from the full archive matching a search query.\n\nUsage:\n  x-twitter-pp-cli tweets search-posts-all [flags]\n\nExamples:\n  x-twitter-pp-cli tweets search-posts-all --query example-value\n\nFlags:\n      --all                       Fetch all pages\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The newest, most recent UTC timestamp to which the Posts will be provided.\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for search-posts-all\n      --max-results int           The maximum number of search results to be returned by a request. (default 10)\n      --media-fields string       A comma separated list of Media fields to display.\n      --next-token string         This parameter is used to get the next 'page' of results.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --query string              One query/rule/filter for matching Posts. Refer to https://t.co/rulelength to identify the max query length.\n      --since-id string           Returns results with a Post ID greater than (that is, more recent than) the specified ID.\n      --sort-order string         This order in which to return results. (one of: recency, relevancy)\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The oldest UTC timestamp from which the Posts will be provided.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --until-id string           Returns results with a Post ID less than (that is, older than) the specified ID.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets search-posts-all",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "search-posts-all",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"text\": \"@nachkari Also check out the below example.. value creation is real.. unsure of how this shows up in GDP and adoption takes time. \\n\\nhttps://t.co/J53IYtd8VZ\",\n        \"id\": \"2062697523257737290\",\n        \"edit_history_tweet_ids\": [\n          \"2062697523257737290\"\n        ]\n      },\n      {\n        \"text\": \"@hctspur Yes? How can I value a WDC who had a car 2 seconds faster then anyone else and a team-mate ready to unnecessarily hand him wins to secure the champion-ship. I, for example, value HAM 07-13 and MSC 92-00 more than the years they dominated, that's where they showed their true skill\",\n        \"id\": \"2062337574086074822\",\n        \"edit_history_tweet_ids\": [\n          \"2062337574086074822\"\n        ]\n      },\n      {\n        \"text\": \"@Daynlokki @keytrendss @jake_prosser @SleeperNFL He had the most impressive season but look at the stacked roster the Rams have built. Who’s to say the value he brought his team was greater than the (for a bias example) value that Herbert brought the Chargers, carrying the worst Oline, his RB3, and a mid WR room to the playoffs\",\n        \"id\": \"2061568589942133022\",\n        \"edit_history_tweet_ids\": [\n          \"2061568589942133022\"\n        ]\n      },\n      {\n        \"text\": \"Dynasty trading is like stock trading.\\n\\nThe stocks that take a dip can be the best time to buy. \\n\\nTake DK Metcalf for example:\\n\\nValue of 4600 in September of 2025. Would’ve been excellent time to sell. Defensive minded head coach, awful scheme, no other playmakers to draw\",\n        \"id\": \"2060400734382829962\",\n        \"edit_history_tweet_ids\": [\n          \"2060400734382829962\"\n        ]\n      },\n      {\n        \"text\": \"Example value adds:\\n\\n✅ Stadium banner all season\\n✅ Social media shoutouts\\n✅ PA announcements at home games\\n✅ Team photo for business display\\n✅ Season passes\\n✅ Press box access\\n\\nNow sponsors feel like they’re part of the program and not just writing a check.\",\n        \"id\": \"2059719098552975512\",\n        \"edit_history_tweet_ids\": [\n          \"2059719098552975512\"\n        ]\n      },\n      {\n        \"text\": \"RT @FragmentsValue: A Cheap Stock Is Not the Same as a Safe Stock\\n\\nOffice Properties Income Trust is the kind of example value investors sh…\",\n        \"id\": \"2058569085185560702\",\n        \"edit_history_tweet_ids\": [\n          \"2058569085185560702\"\n        ]\n      },\n      {\n        \"text\": \"A Cheap Stock Is Not the Same as a Safe Stock\\n\\nOffice Properties Income Trust is the kind of example value investors should study.\\n\\nThe assets were real. The book value still existed on paper. The stock looked cheap.\\n\\nBut the equity did not control time.\\n\\nDebt, maturities, https://t.co/WHGLW3PMlX\",\n        \"id\": \"2058197760793305131\",\n        \"edit_history_tweet_ids\": [\n          \"2058197760793305131\"\n        ]\n      },\n      {\n        \"text\": \"i j am worthy to live as a righteous example value in Gematria is 4124 https://t.co/VqJgIFfABY\",\n        \"id\": \"2056178130302156808\",\n        \"edit_history_tweet_ids\": [\n          \"2056178130302156808\"\n        ]\n      },\n      {\n        \"text\": \"Show HN: I built a Web-Scraper API that is 6-7x more efficient than current ones https://t.co/N81RKryHbp \\n4\\nRuno is a web-scraping API that returns typed, structured JSON. You define a schema (field name, type, example value), and Runo fetches the page and returns the data. No …\",\n        \"id\": \"2055039617955455227\",\n        \"edit_history_tweet_ids\": [\n          \"2055039617955455227\"\n        ]\n      },\n      {\n        \"text\": \"@WesleyCorbett @Handre I treat value - costs as the firms produced surplus...as pointed out by Marx in Vol 1, Chapter 1, page 1. \\n\\nSorry....not page 1 but the very first sentence after the preface.\\n\\nYou keep conflating price and value. In my example value ONLY equals price because supply equals demand. https://t.co/dTH993t7wQ\",\n        \"id\": \"2054820854010458492\",\n        \"edit_history_tweet_ids\": [\n          \"2054820854010458492\"\n        ]\n      }\n    ],\n    \"me…[truncated]"
+    },
+    {
+      "command": "tweets search-posts-all",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "search-posts-all",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"text\": \"@nachkari Also check out the below example.. value creation is real.. unsure of how this shows up in GDP and adoption takes time. \\n\\nhttps://t.co/J53IYtd8VZ\",\n        \"id\": \"2062697523257737290\",\n        \"edit_history_tweet_ids\": [\n          \"2062697523257737290\"\n        ]\n      },\n      {\n        \"text\": \"@hctspur Yes? How can I value a WDC who had a car 2 seconds faster then anyone else and a team-mate ready to unnecessarily hand him wins to secure the champion-ship. I, for example, value HAM 07-13 and MSC 92-00 more than the years they dominated, that's where they showed their true skill\",\n        \"id\": \"2062337574086074822\",\n        \"edit_history_tweet_ids\": [\n          \"2062337574086074822\"\n        ]\n      },\n      {\n        \"text\": \"@Daynlokki @keytrendss @jake_prosser @SleeperNFL He had the most impressive season but look at the stacked roster the Rams have built. Who’s to say the value he brought his team was greater than the (for a bias example) value that Herbert brought the Chargers, carrying the worst Oline, his RB3, and a mid WR room to the playoffs\",\n        \"id\": \"2061568589942133022\",\n        \"edit_history_tweet_ids\": [\n          \"2061568589942133022\"\n        ]\n      },\n      {\n        \"text\": \"Dynasty trading is like stock trading.\\n\\nThe stocks that take a dip can be the best time to buy. \\n\\nTake DK Metcalf for example:\\n\\nValue of 4600 in September of 2025. Would’ve been excellent time to sell. Defensive minded head coach, awful scheme, no other playmakers to draw\",\n        \"id\": \"2060400734382829962\",\n        \"edit_history_tweet_ids\": [\n          \"2060400734382829962\"\n        ]\n      },\n      {\n        \"text\": \"Example value adds:\\n\\n✅ Stadium banner all season\\n✅ Social media shoutouts\\n✅ PA announcements at home games\\n✅ Team photo for business display\\n✅ Season passes\\n✅ Press box access\\n\\nNow sponsors feel like they’re part of the program and not just writing a check.\",\n        \"id\": \"2059719098552975512\",\n        \"edit_history_tweet_ids\": [\n          \"2059719098552975512\"\n        ]\n      },\n      {\n        \"text\": \"RT @FragmentsValue: A Cheap Stock Is Not the Same as a Safe Stock\\n\\nOffice Properties Income Trust is the kind of example value investors sh…\",\n        \"id\": \"2058569085185560702\",\n        \"edit_history_tweet_ids\": [\n          \"2058569085185560702\"\n        ]\n      },\n      {\n        \"text\": \"A Cheap Stock Is Not the Same as a Safe Stock\\n\\nOffice Properties Income Trust is the kind of example value investors should study.\\n\\nThe assets were real. The book value still existed on paper. The stock looked cheap.\\n\\nBut the equity did not control time.\\n\\nDebt, maturities, https://t.co/WHGLW3PMlX\",\n        \"id\": \"2058197760793305131\",\n        \"edit_history_tweet_ids\": [\n          \"2058197760793305131\"\n        ]\n      },\n      {\n        \"text\": \"i j am worthy to live as a righteous example value in Gematria is 4124 https://t.co/VqJgIFfABY\",\n        \"id\": \"2056178130302156808\",\n        \"edit_history_tweet_ids\": [\n          \"2056178130302156808\"\n        ]\n      },\n      {\n        \"text\": \"Show HN: I built a Web-Scraper API that is 6-7x more efficient than current ones https://t.co/N81RKryHbp \\n4\\nRuno is a web-scraping API that returns typed, structured JSON. You define a schema (field name, type, example value), and Runo fetches the page and returns the data. No …\",\n        \"id\": \"2055039617955455227\",\n        \"edit_history_tweet_ids\": [\n          \"2055039617955455227\"\n        ]\n      },\n      {\n        \"text\": \"@WesleyCorbett @Handre I treat value - costs as the firms produced surplus...as pointed out by Marx in Vol 1, Chapter 1, page 1. \\n\\nSorry....not page 1 but the very first sentence after the preface.\\n\\nYou keep conflating price and value. In my example value ONLY equals price because supply equals demand. https://t.co/dTH993t7wQ\",\n        \"id\": \"2054820854010458492\",\n        \"edit_history_tweet_ids\": [\n          \"2054820854010458492\"\n        ]\n      }\n    ],\n    \"me…[truncated]"
+    },
+    {
+      "command": "tweets search-posts-all",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets search-posts-recent",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "search-posts-recent",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves Posts from the last 7 days matching a search query.\n\nUsage:\n  x-twitter-pp-cli tweets search-posts-recent [flags]\n\nExamples:\n  x-twitter-pp-cli tweets search-posts-recent --query example-value\n\nFlags:\n      --all                       Fetch all pages\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The newest, most recent UTC timestamp to which the Posts will be provided.\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for search-posts-recent\n      --max-results int           The maximum number of search results to be returned by a request. (default 10)\n      --media-fields string       A comma separated list of Media fields to display.\n      --next-token string         This parameter is used to get the next 'page' of results.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --query string              One query/rule/filter for matching Posts. Refer to https://t.co/rulelength to identify the max query length.\n      --since-id string           Returns results with a Post ID greater than (that is, more recent than) the specified ID.\n      --sort-order string         This order in which to return results. (one of: recency, relevancy)\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The oldest UTC timestamp from which the Posts will be provided.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --until-id string           Returns results with a Post ID less than (that is, older than) the specified ID.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets search-posts-recent",
+      "kind": "happy_path",
+      "args": [
+        "tweets",
+        "search-posts-recent",
+        "--query",
+        "example-value"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"id\": \"2062993758883635583\",\n        \"edit_history_tweet_ids\": [\n          \"2062993758883635583\"\n        ],\n        \"text\": \"@SteveHiltonx EXERCISE IS OF SOME VALUE, \\nESPECIALLY FOR VETERANS WITH PTS.\\n\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\nNegative Resistance (Eccentric) Bodybuilding: The Secret to Explosive Muscle GrowthNegative resistance training, also called eccentric training or \\\"negatives,\\\" focuses on the https://t.co/p45HysmTmK\"\n      },\n      {\n        \"id\": \"2062993416510673197\",\n        \"edit_history_tweet_ids\": [\n          \"2062993416510673197\"\n        ],\n        \"text\": \"@stake_jevens @paulg Touché. The summary expanded because there's no fluff left to cut—any rephrasing adds length without adding value. PG's principle wins by example.\"\n      },\n      {\n        \"id\": \"2062993127284367503\",\n        \"edit_history_tweet_ids\": [\n          \"2062993127284367503\"\n        ],\n        \"text\": \"\\uD835\\uDDD7\\uD835\\uDDEE\\uD835\\uDE06 \\uD835\\uDFED\\uD835\\uDFED/\\uD835\\uDFF2\\uD835\\uDFEC \\uD835\\uDDFC\\uD835\\uDDF3 \\uD835\\uDDE6\\uD835\\uDDE4\\uD835\\uDDDF \\uD835\\uDDE6\\uD835\\uDDF2\\uD835\\uDDFF\\uD835\\uDDF6\\uD835\\uDDF2\\uD835\\uDE00 — \\uD835\\uDDEA\\uD835\\uDDFC\\uD835\\uDDFF\\uD835\\uDDF8\\uD835\\uDDF6\\uD835\\uDDFB\\uD835\\uDDF4 \\uD835\\uDE04\\uD835\\uDDF6\\uD835\\uDE01\\uD835\\uDDF5 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF – \\uD835\\uDDDC\\uD835\\uDDE6 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF, \\uD835\\uDDDC\\uD835\\uDDE6 \\uD835\\uDDE1\\uD835\\uDDE2\\uD835\\uDDE7 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF, \\uD835\\uDDEE\\uD835\\uDDFB\\uD835\\uDDF1 \\uD835\\uDDD6\\uD835\\uDDE2\\uD835\\uDDD4\\uD835\\uDDDF\\uD835\\uDDD8\\uD835\\uDDE6\\uD835\\uDDD6\\uD835\\uDDD8\\n\\nIn real-world databases, some values may be missing, unknown, or not yet available.\\n\\nSQL represents these missing values using NULL, and https://t.co/nE9sMt4iUU https://t.co/8b31FcNPIY\"\n      },\n      {\n        \"id\": \"2062992394333925852\",\n        \"article\": {\n          \"title\": \"Engineering Beyond Features: Building Products That Pass Accessibility Audits, Security Reviews, Reg\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"2062992394333925852\"\n        ],\n        \"text\": \"https://t.co/ByP0ugxrwW\"\n      },\n      {\n        \"id\": \"2062992001382093309\",\n        \"edit_history_tweet_ids\": [\n          \"2062992001382093309\"\n        ],\n        \"text\": \"@Thevictoria76 EXERSIZE IS OF SOME VALUE ESPECIALL FOR VERTERENS WITH PTS Negative Resistance (Eccentric) Bodybuilding: The Secret to Explosive Muscle GrowthNegative resistance training, also called eccentric training or \\\"negatives,\\\" focuses on the lowering (lengthening) phase of an exercise. https://t.co/005dm0MSeb\"\n      },\n      {\n        \"id\": \"2062991938287009895\",\n        \"edit_history_tweet_ids\": [\n          \"2062991938287009895\"\n        ],\n        \"text\": \"@stake_jevens @paulg Paul Graham aims to pack his writing with maximum idea density and minimal fluff—so concise that any summary strips away too much value and insight. This post is itself a tight example of the principle. Best \\\"summary\\\": read the original carefully.\"\n      },\n      {\n        \"id\": \"2062991685160927574\",\n        \"article\": {\n          \"title\": \"The Environment is the Coach - Part Deux\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"2062991685160927574\"\n        ],\n        \"text\": \"https://t.co/f1caMfSCc7\"\n      },\n      {\n        \"id\": \"2062991371091530151\",\n        \"article\": {\n          \"title\": \"How Claude AI New Update Runs Jobs Without Coding\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"206299…[truncated]"
+    },
+    {
+      "command": "tweets search-posts-recent",
+      "kind": "json_fidelity",
+      "args": [
+        "tweets",
+        "search-posts-recent",
+        "--query",
+        "example-value",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": [\n      {\n        \"id\": \"2062993758883635583\",\n        \"edit_history_tweet_ids\": [\n          \"2062993758883635583\"\n        ],\n        \"text\": \"@SteveHiltonx EXERCISE IS OF SOME VALUE, \\nESPECIALLY FOR VETERANS WITH PTS.\\n\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\uD83C\\uDDFA\\uD83C\\uDDF8\\nNegative Resistance (Eccentric) Bodybuilding: The Secret to Explosive Muscle GrowthNegative resistance training, also called eccentric training or \\\"negatives,\\\" focuses on the https://t.co/p45HysmTmK\"\n      },\n      {\n        \"id\": \"2062993416510673197\",\n        \"edit_history_tweet_ids\": [\n          \"2062993416510673197\"\n        ],\n        \"text\": \"@stake_jevens @paulg Touché. The summary expanded because there's no fluff left to cut—any rephrasing adds length without adding value. PG's principle wins by example.\"\n      },\n      {\n        \"id\": \"2062993127284367503\",\n        \"edit_history_tweet_ids\": [\n          \"2062993127284367503\"\n        ],\n        \"text\": \"\\uD835\\uDDD7\\uD835\\uDDEE\\uD835\\uDE06 \\uD835\\uDFED\\uD835\\uDFED/\\uD835\\uDFF2\\uD835\\uDFEC \\uD835\\uDDFC\\uD835\\uDDF3 \\uD835\\uDDE6\\uD835\\uDDE4\\uD835\\uDDDF \\uD835\\uDDE6\\uD835\\uDDF2\\uD835\\uDDFF\\uD835\\uDDF6\\uD835\\uDDF2\\uD835\\uDE00 — \\uD835\\uDDEA\\uD835\\uDDFC\\uD835\\uDDFF\\uD835\\uDDF8\\uD835\\uDDF6\\uD835\\uDDFB\\uD835\\uDDF4 \\uD835\\uDE04\\uD835\\uDDF6\\uD835\\uDE01\\uD835\\uDDF5 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF – \\uD835\\uDDDC\\uD835\\uDDE6 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF, \\uD835\\uDDDC\\uD835\\uDDE6 \\uD835\\uDDE1\\uD835\\uDDE2\\uD835\\uDDE7 \\uD835\\uDDE1\\uD835\\uDDE8\\uD835\\uDDDF\\uD835\\uDDDF, \\uD835\\uDDEE\\uD835\\uDDFB\\uD835\\uDDF1 \\uD835\\uDDD6\\uD835\\uDDE2\\uD835\\uDDD4\\uD835\\uDDDF\\uD835\\uDDD8\\uD835\\uDDE6\\uD835\\uDDD6\\uD835\\uDDD8\\n\\nIn real-world databases, some values may be missing, unknown, or not yet available.\\n\\nSQL represents these missing values using NULL, and https://t.co/nE9sMt4iUU https://t.co/8b31FcNPIY\"\n      },\n      {\n        \"id\": \"2062992394333925852\",\n        \"article\": {\n          \"title\": \"Engineering Beyond Features: Building Products That Pass Accessibility Audits, Security Reviews, Reg\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"2062992394333925852\"\n        ],\n        \"text\": \"https://t.co/ByP0ugxrwW\"\n      },\n      {\n        \"id\": \"2062992001382093309\",\n        \"edit_history_tweet_ids\": [\n          \"2062992001382093309\"\n        ],\n        \"text\": \"@Thevictoria76 EXERSIZE IS OF SOME VALUE ESPECIALL FOR VERTERENS WITH PTS Negative Resistance (Eccentric) Bodybuilding: The Secret to Explosive Muscle GrowthNegative resistance training, also called eccentric training or \\\"negatives,\\\" focuses on the lowering (lengthening) phase of an exercise. https://t.co/005dm0MSeb\"\n      },\n      {\n        \"id\": \"2062991938287009895\",\n        \"edit_history_tweet_ids\": [\n          \"2062991938287009895\"\n        ],\n        \"text\": \"@stake_jevens @paulg Paul Graham aims to pack his writing with maximum idea density and minimal fluff—so concise that any summary strips away too much value and insight. This post is itself a tight example of the principle. Best \\\"summary\\\": read the original carefully.\"\n      },\n      {\n        \"id\": \"2062991685160927574\",\n        \"article\": {\n          \"title\": \"The Environment is the Coach - Part Deux\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"2062991685160927574\"\n        ],\n        \"text\": \"https://t.co/f1caMfSCc7\"\n      },\n      {\n        \"id\": \"2062991371091530151\",\n        \"article\": {\n          \"title\": \"How Claude AI New Update Runs Jobs Without Coding\"\n        },\n        \"edit_history_tweet_ids\": [\n          \"206299…[truncated]"
+    },
+    {
+      "command": "tweets search-posts-recent",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "tweets update-rules",
+      "kind": "help",
+      "args": [
+        "tweets",
+        "update-rules",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Adds or deletes rules from the active rule set for the filtered stream.\n\nUsage:\n  x-twitter-pp-cli tweets update-rules [flags]\n\nExamples:\n  x-twitter-pp-cli tweets update-rules\n\nFlags:\n      --body-json string   Provide the full request body as a JSON object string (this endpoint accepts a polymorphic schema: oneOf/anyOf)\n      --delete-all         Delete All can be used to delete all of the rules associated this client app\n      --dry-run            Dry Run can be used with both the add and delete action, with the expected result given\n  -h, --help               help for update-rules\n      --stdin              Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "tweets update-rules",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"pro\""
+    },
+    {
+      "command": "tweets update-rules",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"pro\""
+    },
+    {
+      "command": "tweets update-rules",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"pro\""
+    },
+    {
+      "command": "tweets update-rules",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "blocked-fixture: requires auth tier \"pro\""
+    },
+    {
+      "command": "usage",
+      "kind": "help",
+      "args": [
+        "usage",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves usage statistics for Posts over a specified number of days.\n\nUsage:\n  x-twitter-pp-cli usage [flags]\n\nExamples:\n  x-twitter-pp-cli usage\n\nFlags:\n      --days int              The number of days for which you need usage for. (default 7)\n  -h, --help                  help for usage\n      --usage-fields string   A comma separated list of Usage fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "usage",
+      "kind": "happy_path",
+      "args": [
+        "usage"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": {\n      \"cap_reset_day\": 8,\n      \"project_cap\": \"2000000\",\n      \"project_id\": \"2020615723421163520\",\n      \"project_usage\": \"3599\"\n    }\n  }\n}\nwarning: 1/1 usage items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "usage",
+      "kind": "json_fidelity",
+      "args": [
+        "usage",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"data\": {\n      \"cap_reset_day\": 8,\n      \"project_cap\": \"2000000\",\n      \"project_id\": \"2020615723421163520\",\n      \"project_usage\": \"3599\"\n    }\n  }\n}\nwarning: 1/1 usage items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "usage",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users affiliates get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "affiliates",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who are affiliated with a specific organization User by their ID.\n\nUsage:\n  x-twitter-pp-cli users affiliates get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users affiliates get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users affiliates get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users affiliates get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users affiliates get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "affiliates",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/affiliates returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/affiliates returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users blocking get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "blocking",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users blocked by the specified User ID.\n\nUsage:\n  x-twitter-pp-cli users blocking get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users blocking get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users blocking get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users blocking get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users blocking get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "blocking",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/blocking returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/blocking returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users bookmarks create-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "create-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Adds a post to the authenticated user’s bookmarks.\n\nUsage:\n  x-twitter-pp-cli users bookmarks create-users \u003cid\u003e [flags]\n\nAliases:\n  create-users, create\n\nExamples:\n  x-twitter-pp-cli users bookmarks create-users 550e8400-e29b-41d4-a716-446655440000 --tweet-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help              help for create-users\n      --stdin             Read request body as JSON from stdin\n      --tweet-id string   Unique identifier of this Tweet.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks create-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no id parseable from companion at depth 0"
+    },
+    {
+      "command": "users bookmarks create-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no id parseable from companion at depth 0"
+    },
+    {
+      "command": "users bookmarks create-users",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users bookmarks create-users",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no id parseable from companion at depth 0"
+    },
+    {
+      "command": "users bookmarks delete-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "delete-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Removes a Post from the authenticated user’s Bookmarks by its ID.\n\nUsage:\n  x-twitter-pp-cli users bookmarks delete-users \u003cid\u003e \u003ctweet_id\u003e [flags]\n\nAliases:\n  delete-users, delete\n\nExamples:\n  x-twitter-pp-cli users bookmarks delete-users 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete-users\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks delete-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "users bookmarks delete-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "users bookmarks delete-users",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users bookmarks delete-users",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion failed at depth 0: exit 2"
+    },
+    {
+      "command": "users bookmarks find",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "find",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Search the bookmarks you've synced into the local store. X has no bookmark search and\nits API returns no bookmark timestamp, so bookmarks become a write-only graveyard;\nthis rebuilds the missing retrieval layer from the local store.\n\nMatches the post text (a default bookmark field) and, when present, the author. Results\nare ordered by post date, newest first — note that's when the post was written, not when\nyou bookmarked it, which the X API does not expose.\n\nPopulate the store first:\n  x-twitter-pp-cli users bookmarks get-users \u003cyour-id\u003e   # confirm access\n  x-twitter-pp-cli sync --resources bookmarks\n\nTo enable --from, sync bookmarks with the author field and sync users for handle lookup:\n  x-twitter-pp-cli sync --resources bookmarks --param tweet.fields=author_id,created_at\n  x-twitter-pp-cli sync --resources users\n\nUsage:\n  x-twitter-pp-cli users bookmarks find [query] [flags]\n\nExamples:\n  x-twitter-pp-cli users bookmarks find \"rust async\"\n  x-twitter-pp-cli users bookmarks find --from @karpathy\n  x-twitter-pp-cli users bookmarks find \"llm\" --from elonmusk --limit 20 --agent\n\nFlags:\n      --db string     Path to the local database (defaults to the standard cache location)\n      --from string   Filter by author (@handle resolved via synced users, or a numeric author id)\n  -h, --help          help for find\n      --limit int     Maximum results to return (default 50)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks find",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"query\" at depth 0"
+    },
+    {
+      "command": "users bookmarks find",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"query\" at depth 0"
+    },
+    {
+      "command": "users bookmarks find",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no-error-path-probe annotation"
+    },
+    {
+      "command": "users bookmarks get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts bookmarked by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users bookmarks get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users bookmarks get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/bookmarks returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/bookmarks returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users bookmarks get-users-by-folder-id",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users-by-folder-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves Posts in a specific Bookmark folder by its ID for the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users bookmarks get-users-by-folder-id \u003cid\u003e \u003cfolder_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli users bookmarks get-users-by-folder-id 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for get-users-by-folder-id\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks get-users-by-folder-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users-by-folder-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users-by-folder-id",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users-by-folder-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 2,
+      "output_sample": "Error: folder_id is required\nUsage: x-twitter-pp-cli users bookmarks get-users-by-folder-id \u003cfolder_id\u003e\nfolder_id is required\nUsage: x-twitter-pp-cli users bookmarks get-users-by-folder-id \u003cfolder_id\u003e\n"
+    },
+    {
+      "command": "users bookmarks get-users-folders",
+      "kind": "help",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users-folders",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Bookmark folders created by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users bookmarks get-users-folders \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli users bookmarks get-users-folders 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n  -h, --help                      help for get-users-folders\n      --max-results int           The maximum number of results.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users bookmarks get-users-folders",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users-folders",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users bookmarks get-users-folders",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "bookmarks",
+        "get-users-folders",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/bookmarks/folders returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/bookmarks/folders returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users dm block-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "dm",
+        "block-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Blocks direct messages to or from a specific User by their ID for the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users dm block-users \u003cid\u003e [flags]\n\nAliases:\n  block-users, create\n\nExamples:\n  x-twitter-pp-cli users dm block-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for block-users\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users dm block-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users dm block-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users dm block-users",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users dm block-users",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users dm unblock-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "dm",
+        "unblock-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Unblocks direct messages to or from a specific User by their ID for the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users dm unblock-users \u003cid\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli users dm unblock-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for unblock-users\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users dm unblock-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users dm unblock-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users dm unblock-users",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users dm unblock-users",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists follow-list",
+      "kind": "help",
+      "args": [
+        "users",
+        "followed-lists",
+        "follow-list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to follow a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli users followed-lists follow-list \u003cid\u003e [flags]\n\nAliases:\n  follow-list, create\n\nExamples:\n  x-twitter-pp-cli users followed-lists follow-list 550e8400-e29b-41d4-a716-446655440000 --list-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help             help for follow-list\n      --list-id string   The unique identifier of this List.\n      --stdin            Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users followed-lists follow-list",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists follow-list",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists follow-list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users followed-lists follow-list",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "followed-lists",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Lists followed by a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users followed-lists get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users followed-lists get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --list-fields string        A comma separated list of List fields to display.\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users followed-lists get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "followed-lists",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/followed_lists returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/followed_lists returned HTTP 403: {\"client_id\":\"32365644\",\"detail\":\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\",\"registration_url\":\"https://developer.twitter.com/en/docs/projects/overview\",\"title\":\"Client Forbidden\",\"required_enrollment\":\"Appropriate Level of API Access\",\"reason\":\"client-not-enrolled\",\"type\":\"https://api.twitter.com/2/problems/client-forbidden\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users followed-lists unfollow-list",
+      "kind": "help",
+      "args": [
+        "users",
+        "followed-lists",
+        "unfollow-list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to unfollow a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli users followed-lists unfollow-list \u003cid\u003e \u003clist_id\u003e [flags]\n\nAliases:\n  unfollow-list, delete\n\nExamples:\n  x-twitter-pp-cli users followed-lists unfollow-list 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unfollow-list\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users followed-lists unfollow-list",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists unfollow-list",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users followed-lists unfollow-list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users followed-lists unfollow-list",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users followers get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "followers",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users who follow a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users followers get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users followers get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users followers get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followers get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users followers get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "followers",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/followers returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/followers returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users following follow-user",
+      "kind": "help",
+      "args": [
+        "users",
+        "following",
+        "follow-user",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to follow a specific user by their ID.\n\nUsage:\n  x-twitter-pp-cli users following follow-user \u003cid\u003e [flags]\n\nAliases:\n  follow-user, create\n\nExamples:\n  x-twitter-pp-cli users following follow-user 550e8400-e29b-41d4-a716-446655440000 --target-user-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                    help for follow-user\n      --stdin                   Read request body as JSON from stdin\n      --target-user-id string   Unique identifier of this User.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users following follow-user",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users following follow-user",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users following follow-user",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users following follow-user",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users following get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "following",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users followed by a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users following get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users following get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users following get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users following get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users following get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "following",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/following returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/following returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users following unfollow-user",
+      "kind": "help",
+      "args": [
+        "users",
+        "following",
+        "unfollow-user",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to unfollow a specific user by their ID.\n\nUsage:\n  x-twitter-pp-cli users following unfollow-user \u003csource_user_id\u003e \u003ctarget_user_id\u003e [flags]\n\nAliases:\n  unfollow-user, delete\n\nExamples:\n  x-twitter-pp-cli users following unfollow-user 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unfollow-user\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users following unfollow-user",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users following unfollow-user",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users following unfollow-user",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users following unfollow-user",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users get-by-id",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-by-id",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users get-by-id \u003cid\u003e [flags]\n\nAliases:\n  get-by-id, get\n\nExamples:\n  x-twitter-pp-cli users get-by-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-id\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-by-id",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users get-by-id",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users get-by-id",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "get-by-id",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users get-by-ids",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-by-ids",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of multiple Users by their IDs.\n\nUsage:\n  x-twitter-pp-cli users get-by-ids [flags]\n\nAliases:\n  get-by-ids, list\n\nExamples:\n  x-twitter-pp-cli users get-by-ids --ids example-value\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-ids\n      --ids string            A list of User IDs, comma-separated. You can specify up to 100 IDs.\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-by-ids",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-by-ids",
+        "--ids",
+        "12"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":[{\"id\":\"12\",\"name\":\"\u003credacted\u003e\",\"username\":\"jack\"}]}"
+    },
+    {
+      "command": "users get-by-ids",
+      "kind": "json_fidelity",
+      "args": [
+        "users",
+        "get-by-ids",
+        "--ids",
+        "12",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":[{\"id\":\"12\",\"name\":\"\u003credacted\u003e\",\"username\":\"jack\"}]}"
+    },
+    {
+      "command": "users get-by-ids",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users get-by-username",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-by-username",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of a specific User by their username.\n\nUsage:\n  x-twitter-pp-cli users get-by-username \u003cusername\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli users get-by-username example-resource\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-username\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-by-username",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"username\" at depth 0"
+    },
+    {
+      "command": "users get-by-username",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "non-id positional \"username\" at depth 0"
+    },
+    {
+      "command": "users get-by-username",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "get-by-username",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/by/username/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"username\":[\"__printing_press_invalid__\"]},\"message\":\"The `username` query parameter value [__printing_press_invalid__] does not match ^[A-Za-z0-9_]{1,15}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/by/username/__printing_press_invalid__ returned HTTP 400: {\"errors\":[{\"parameters\":{\"username\":[\"__printing_press_invalid__\"]},\"message\":\"The `username` query parameter value [__printing_press_invalid__] does not match ^[A-Za-z0-9_]{1,15}$\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users get-by-usernames",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-by-usernames",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of multiple Users by their usernames.\n\nUsage:\n  x-twitter-pp-cli users get-by-usernames [flags]\n\nExamples:\n  x-twitter-pp-cli users get-by-usernames --usernames example-resource\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-by-usernames\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n      --usernames string      A list of usernames, comma-separated.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-by-usernames",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-by-usernames",
+        "--usernames",
+        "jack"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":[{\"id\":\"12\",\"name\":\"\u003credacted\u003e\",\"username\":\"jack\"}]}"
+    },
+    {
+      "command": "users get-by-usernames",
+      "kind": "json_fidelity",
+      "args": [
+        "users",
+        "get-by-usernames",
+        "--usernames",
+        "jack",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\"meta\":{\"source\":\"live\"},\"results\":[{\"id\":\"12\",\"name\":\"\u003credacted\u003e\",\"username\":\"jack\"}]}"
+    },
+    {
+      "command": "users get-by-usernames",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users get-me",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-me",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves details of the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users get-me [flags]\n\nExamples:\n  x-twitter-pp-cli users get-me\n\nFlags:\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for get-me\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-me",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-me"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/users/me returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/me returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users get-me",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "users get-me",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users get-public-keys",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-public-keys",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns the public keys and Juicebox configuration for the specified users.\n\nUsage:\n  x-twitter-pp-cli users get-public-keys [flags]\n\nExamples:\n  x-twitter-pp-cli users get-public-keys --ids example-value\n\nFlags:\n  -h, --help                       help for get-public-keys\n      --ids string                 A list of User IDs, comma-separated. You can specify up to 100 IDs.\n      --public-key-fields string   A comma separated list of PublicKey fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-public-keys",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-public-keys",
+        "--ids",
+        "example-value"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/users/public_keys returned HTTP 403: {\"detail\":\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\"title\":\"Unsupported Authentication\",\"status\":403,\"type\":\"https://api.twitter.com/2/problems/unsupported-authentication\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/public_keys returned HTTP 403: {\"detail\":\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\"title\":\"Unsupported Authentication\",\"status\":403,\"type\":\"https://api.twitter.com/2/problems/unsupported-authentication\"}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users get-public-keys",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "users get-public-keys",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users get-reposts-of-me",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-reposts-of-me",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts that repost content from the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users get-reposts-of-me [flags]\n\nExamples:\n  x-twitter-pp-cli users get-reposts-of-me\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-reposts-of-me\n      --max-results int           The maximum number of results. (default 100)\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-reposts-of-me",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-reposts-of-me"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/users/reposts_of_me returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/reposts_of_me returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users get-reposts-of-me",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "users get-reposts-of-me",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users get-trends-personalized-trends",
+      "kind": "help",
+      "args": [
+        "users",
+        "get-trends-personalized-trends",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves personalized trending topics for the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users get-trends-personalized-trends [flags]\n\nExamples:\n  x-twitter-pp-cli users get-trends-personalized-trends\n\nFlags:\n  -h, --help                               help for get-trends-personalized-trends\n      --personalized-trend-fields string   A comma separated list of PersonalizedTrend fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users get-trends-personalized-trends",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "get-trends-personalized-trends"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/users/personalized_trends returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/personalized_trends returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users get-trends-personalized-trends",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "users get-trends-personalized-trends",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users liked-tweets get-users-liked-posts",
+      "kind": "help",
+      "args": [
+        "users",
+        "liked-tweets",
+        "get-users-liked-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts liked by a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users liked-tweets get-users-liked-posts \u003cid\u003e [flags]\n\nAliases:\n  get-users-liked-posts, get\n\nExamples:\n  x-twitter-pp-cli users liked-tweets get-users-liked-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users-liked-posts\n      --max-results int           The maximum number of results.\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users liked-tweets get-users-liked-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users liked-tweets get-users-liked-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users liked-tweets get-users-liked-posts",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "liked-tweets",
+        "get-users-liked-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/liked_tweets returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/liked_tweets returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users likes post",
+      "kind": "help",
+      "args": [
+        "users",
+        "likes",
+        "post",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to Like a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli users likes post \u003cid\u003e [flags]\n\nAliases:\n  post, create\n\nExamples:\n  x-twitter-pp-cli users likes post 550e8400-e29b-41d4-a716-446655440000 --tweet-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help              help for post\n      --stdin             Read request body as JSON from stdin\n      --tweet-id string   Unique identifier of this Tweet.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users likes post",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users likes post",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users likes post",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users likes post",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users likes unlike-post",
+      "kind": "help",
+      "args": [
+        "users",
+        "likes",
+        "unlike-post",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to Unlike a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli users likes unlike-post \u003cid\u003e \u003ctweet_id\u003e [flags]\n\nAliases:\n  unlike-post, delete\n\nExamples:\n  x-twitter-pp-cli users likes unlike-post 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unlike-post\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users likes unlike-post",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users likes unlike-post",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users likes unlike-post",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users likes unlike-post",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users list-memberships get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "list-memberships",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Lists that a specific User is a member of by their ID.\n\nUsage:\n  x-twitter-pp-cli users list-memberships get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users list-memberships get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --list-fields string        A comma separated list of List fields to display.\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users list-memberships get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users list-memberships get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users list-memberships get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "list-memberships",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/list_memberships returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/list_memberships returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users mentions get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "mentions",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Posts that mention a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users mentions get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users mentions get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The latest UTC timestamp to which the Posts will be provided.\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --since-id string           The minimum Post ID to be included in the result set.\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The earliest UTC timestamp from which the Posts will be provided.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --until-id string           The maximum Post ID to be included in the result set.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users mentions get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users mentions get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users mentions get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "mentions",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/mentions returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/mentions returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users muting get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "muting",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users muted by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users muting get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users muting get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users muting get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users muting get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users muting get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "muting",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/muting returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/muting returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users muting mute-user",
+      "kind": "help",
+      "args": [
+        "users",
+        "muting",
+        "mute-user",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to mute a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users muting mute-user \u003cid\u003e [flags]\n\nAliases:\n  mute-user, create\n\nExamples:\n  x-twitter-pp-cli users muting mute-user 550e8400-e29b-41d4-a716-446655440000 --target-user-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                    help for mute-user\n      --stdin                   Read request body as JSON from stdin\n      --target-user-id string   Unique identifier of this User.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users muting mute-user",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users muting mute-user",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users muting mute-user",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users muting mute-user",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users muting unmute-user",
+      "kind": "help",
+      "args": [
+        "users",
+        "muting",
+        "unmute-user",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to unmute a specific user by their ID.\n\nUsage:\n  x-twitter-pp-cli users muting unmute-user \u003csource_user_id\u003e \u003ctarget_user_id\u003e [flags]\n\nAliases:\n  unmute-user, delete\n\nExamples:\n  x-twitter-pp-cli users muting unmute-user 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unmute-user\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users muting unmute-user",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users muting unmute-user",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users muting unmute-user",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users muting unmute-user",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"source_user_id\""
+    },
+    {
+      "command": "users owned-lists get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "owned-lists",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Lists owned by a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users owned-lists get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users owned-lists get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --list-fields string        A comma separated list of List fields to display.\n      --max-results int           The maximum number of results. (default 100)\n      --pagination-token string   This parameter is used to get a specified 'page' of results.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users owned-lists get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users owned-lists get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users owned-lists get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "owned-lists",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/owned_lists returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/owned_lists returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "users pinned-lists get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "pinned-lists",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Lists pinned by the authenticated user.\n\nUsage:\n  x-twitter-pp-cli users pinned-lists get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users pinned-lists get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --expansions string    A comma separated list of fields to expand.\n  -h, --help                 help for get-users\n      --list-fields string   A comma separated list of List fields to display.\n      --user-fields string   A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users pinned-lists get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "pinned-lists",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/pinned_lists returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/pinned_lists returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users pinned-lists pin-list",
+      "kind": "help",
+      "args": [
+        "users",
+        "pinned-lists",
+        "pin-list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to pin a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli users pinned-lists pin-list \u003cid\u003e [flags]\n\nAliases:\n  pin-list, create\n\nExamples:\n  x-twitter-pp-cli users pinned-lists pin-list 550e8400-e29b-41d4-a716-446655440000 --list-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help             help for pin-list\n      --list-id string   The unique identifier of this List.\n      --stdin            Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users pinned-lists pin-list",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists pin-list",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists pin-list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users pinned-lists pin-list",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists unpin-list",
+      "kind": "help",
+      "args": [
+        "users",
+        "pinned-lists",
+        "unpin-list",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to unpin a specific List by its ID.\n\nUsage:\n  x-twitter-pp-cli users pinned-lists unpin-list \u003cid\u003e \u003clist_id\u003e [flags]\n\nAliases:\n  unpin-list, delete\n\nExamples:\n  x-twitter-pp-cli users pinned-lists unpin-list 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unpin-list\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users pinned-lists unpin-list",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists unpin-list",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users pinned-lists unpin-list",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users pinned-lists unpin-list",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys add-user",
+      "kind": "help",
+      "args": [
+        "users",
+        "public-keys",
+        "add-user",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Registers a user's public key for X Chat encryption.\n\nUsage:\n  x-twitter-pp-cli users public-keys add-user \u003cid\u003e [flags]\n\nAliases:\n  add-user, create\n\nExamples:\n  x-twitter-pp-cli users public-keys add-user 550e8400-e29b-41d4-a716-446655440000 --version example-value\n\nFlags:\n      --generate-version                                  When true, the server generates a new version.\n  -h, --help                                              help for add-user\n      --public-key-identity-public-key-signature string   Signature over the identity public key.\n      --public-key-public-key string                      Identity public key (base64 encoded).\n      --public-key-public-key-fingerprint string          Fingerprint of the identity public key.\n      --public-key-registration-method string             Registration method for the public key.\n      --public-key-signing-public-key string              Signing public key (base64 encoded).\n      --public-key-signing-public-key-signature string    Signature over the signing public key.\n      --stdin                                             Read request body as JSON from stdin\n      --version string                                    Public key version.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users public-keys add-user",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys add-user",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys add-user",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users public-keys add-user",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "public-keys",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Returns the public keys and Juicebox configuration for the specified user.\n\nUsage:\n  x-twitter-pp-cli users public-keys get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users public-keys get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help                       help for get-users\n      --public-key-fields string   A comma separated list of PublicKey fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users public-keys get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users public-keys get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "public-keys",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/public_keys returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/public_keys returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users retweets repost-post",
+      "kind": "help",
+      "args": [
+        "users",
+        "retweets",
+        "repost-post",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to repost a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli users retweets repost-post \u003cid\u003e [flags]\n\nAliases:\n  repost-post, create\n\nExamples:\n  x-twitter-pp-cli users retweets repost-post 550e8400-e29b-41d4-a716-446655440000 --tweet-id 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help              help for repost-post\n      --stdin             Read request body as JSON from stdin\n      --tweet-id string   Unique identifier of this Tweet.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users retweets repost-post",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users retweets repost-post",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users retweets repost-post",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users retweets repost-post",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users retweets unrepost-post",
+      "kind": "help",
+      "args": [
+        "users",
+        "retweets",
+        "unrepost-post",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Causes the authenticated user to unrepost a specific Post by its ID.\n\nUsage:\n  x-twitter-pp-cli users retweets unrepost-post \u003cid\u003e \u003csource_tweet_id\u003e [flags]\n\nAliases:\n  unrepost-post, delete\n\nExamples:\n  x-twitter-pp-cli users retweets unrepost-post 550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for unrepost-post\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users retweets unrepost-post",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users retweets unrepost-post",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users retweets unrepost-post",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "users retweets unrepost-post",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "list companion previously failed at depth 0 for \"id\""
+    },
+    {
+      "command": "users search",
+      "kind": "help",
+      "args": [
+        "users",
+        "search",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of Users matching a search query.\n\nUsage:\n  x-twitter-pp-cli users search [flags]\n\nExamples:\n  x-twitter-pp-cli users search --query example-value\n\nFlags:\n      --all                   Fetch all pages\n      --expansions string     A comma separated list of fields to expand.\n  -h, --help                  help for search\n      --max-results int       The maximum number of results. (default 100)\n      --next-token string     This parameter is used to get the next 'page' of results.\n      --query string          TThe the query string by which to query for users.\n      --tweet-fields string   A comma separated list of Tweet fields to display.\n      --user-fields string    A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users search",
+      "kind": "happy_path",
+      "args": [
+        "users",
+        "search",
+        "--query",
+        "example-value"
+      ],
+      "status": "skip",
+      "exit_code": 4,
+      "reason": "unavailable for runner credentials",
+      "output_sample": "Error: GET /2/users/search returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/search returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users search",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "unavailable for runner credentials"
+    },
+    {
+      "command": "users search",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "users timelines get-users",
+      "kind": "help",
+      "args": [
+        "users",
+        "timelines",
+        "get-users",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a reverse chronological list of Posts in the authenticated User’s Timeline.\n\nUsage:\n  x-twitter-pp-cli users timelines get-users \u003cid\u003e [flags]\n\nAliases:\n  get-users, get\n\nExamples:\n  x-twitter-pp-cli users timelines get-users 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The latest UTC timestamp to which the Posts will be provided.\n      --exclude string            The set of entities to exclude (e.g. 'replies' or 'retweets').\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users\n      --max-results int           The maximum number of results.\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --since-id string           The minimum Post ID to be included in the result set.\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The earliest UTC timestamp from which the Posts will be provided.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --until-id string           The maximum Post ID to be included in the result set.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users timelines get-users",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users timelines get-users",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users timelines get-users",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "timelines",
+        "get-users",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 4,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/timelines/reverse_chronological returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\nGET /2/users/__printing_press_invalid__/timelines/reverse_chronological returned HTTP 403: {\n  \"title\": \"Unsupported Authentication\",\n  \"detail\": \"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 2.0 User Context, OAuth 1.0a User Context].\",\n  \"type\": \"https://api.twitter.com/2/problems/unsupported-authentication\",\n  \"status\": 403\n}\nhint: permission denied. Your credentials are valid but lack access to this resource.\n      Check that your API key has the required permissions.\n      Set it with: export X_BEARER_TOKEN=\u003cyour-key\u003e\n      Get a key at: https://console.x.com/\n      Bearer Token (required) is on your app Keys and Tokens page at console.x.com. Optional X_OAUTH2_USER_TOKEN unlocks v2 writes and personal reads. X Articles authoring uses browser cookies captured via auth login --chrome.\n      Run 'x-twitter-pp-cli doctor' to check auth status.\n"
+    },
+    {
+      "command": "users tweets get-users-posts",
+      "kind": "help",
+      "args": [
+        "users",
+        "tweets",
+        "get-users-posts",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Retrieves a list of posts authored by a specific User by their ID.\n\nUsage:\n  x-twitter-pp-cli users tweets get-users-posts \u003cid\u003e [flags]\n\nAliases:\n  get-users-posts, get\n\nExamples:\n  x-twitter-pp-cli users tweets get-users-posts 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n      --all                       Fetch all pages\n      --end-time string           YYYY-MM-DDTHH:mm:ssZ. The latest UTC timestamp to which the Posts will be provided.\n      --exclude string            The set of entities to exclude (e.g. 'replies' or 'retweets').\n      --expansions string         A comma separated list of fields to expand.\n  -h, --help                      help for get-users-posts\n      --max-results int           The maximum number of results.\n      --media-fields string       A comma separated list of Media fields to display.\n      --pagination-token string   This parameter is used to get the next 'page' of results.\n      --place-fields string       A comma separated list of Place fields to display.\n      --poll-fields string        A comma separated list of Poll fields to display.\n      --since-id string           The minimum Post ID to be included in the result set.\n      --start-time string         YYYY-MM-DDTHH:mm:ssZ. The earliest UTC timestamp from which the Posts will be provided.\n      --tweet-fields string       A comma separated list of Tweet fields to display.\n      --until-id string           The maximum Post ID to be included in the result set.\n      --user-fields string        A comma separated list of User fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "users tweets get-users-posts",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users tweets get-users-posts",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"id\""
+    },
+    {
+      "command": "users tweets get-users-posts",
+      "kind": "error_path",
+      "args": [
+        "users",
+        "tweets",
+        "get-users-posts",
+        "__printing_press_invalid__"
+      ],
+      "status": "pass",
+      "exit_code": 5,
+      "output_sample": "Error: GET /2/users/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\nGET /2/users/__printing_press_invalid__/tweets returned HTTP 400: {\"errors\":[{\"parameters\":{\"id\":[\"__printing_press_invalid__\"]},\"message\":\"The `id` query parameter value [__printing_press_invalid__] is not valid\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n"
+    },
+    {
+      "command": "webhooks create",
+      "kind": "help",
+      "args": [
+        "webhooks",
+        "create",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a new webhook configuration.\n\nUsage:\n  x-twitter-pp-cli webhooks create [flags]\n\nExamples:\n  x-twitter-pp-cli webhooks create --url https://example.com/resource\n\nFlags:\n  -h, --help         help for create\n      --stdin        Read request body as JSON from stdin\n      --url string   Url\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "webhooks create",
+      "kind": "happy_path",
+      "args": [
+        "webhooks",
+        "create",
+        "--url",
+        "https://example.com/resource",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/webhooks\",\n  \"resource\": \"webhooks\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/webhooks\n  Body:\n{\n    \"url\": \"https://example.com/resource\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "webhooks create",
+      "kind": "json_fidelity",
+      "args": [
+        "webhooks",
+        "create",
+        "--url",
+        "https://example.com/resource",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/webhooks\",\n  \"resource\": \"webhooks\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/webhooks\n  Body:\n{\n    \"url\": \"https://example.com/resource\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "webhooks create",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "webhooks create",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "webhooks create-replay-job",
+      "kind": "help",
+      "args": [
+        "webhooks",
+        "create-replay-job",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Creates a replay job to retrieve events from up to the past 24 hours for all events delivered or attempted to be\n\nUsage:\n  x-twitter-pp-cli webhooks create-replay-job [flags]\n\nExamples:\n  x-twitter-pp-cli webhooks create-replay-job --from-date 2026-01-15\n\nFlags:\n      --from-date string         The oldest (starting) UTC timestamp (inclusive) from which events will be provided, in yyyymmddhhmm format.\n  -h, --help                     help for create-replay-job\n      --stdin                    Read request body as JSON from stdin\n      --to-date string           The oldest (starting) UTC timestamp (inclusive) from which events will be provided, in yyyymmddhhmm format.\n      --wait                     Block until the submitted job reaches a terminal status\n      --wait-interval duration   Initial poll interval when --wait is set (default 2s)\n      --wait-timeout duration    Maximum duration to wait when --wait is set (0 = no timeout) (default 10m0s)\n      --webhook-id string        The unique identifier of this webhook config.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "webhooks create-replay-job",
+      "kind": "happy_path",
+      "args": [
+        "webhooks",
+        "create-replay-job",
+        "--from-date",
+        "2026-01-15",
+        "--dry-run"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/webhooks/replay\",\n  \"resource\": \"webhooks\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/webhooks/replay\n  Body:\n{\n    \"from_date\": \"2026-01-15\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "webhooks create-replay-job",
+      "kind": "json_fidelity",
+      "args": [
+        "webhooks",
+        "create-replay-job",
+        "--from-date",
+        "2026-01-15",
+        "--dry-run",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"action\": \"post\",\n  \"data\": {\n    \"dry_run\": true\n  },\n  \"dry_run\": true,\n  \"path\": \"/2/webhooks/replay\",\n  \"resource\": \"webhooks\",\n  \"status\": 0,\n  \"success\": false\n}\nPOST https://api.x.com/2/webhooks/replay\n  Body:\n{\n    \"from_date\": \"2026-01-15\"\n  }\n  Authorization: ****GXdA\n\n(dry run - no request sent)\n"
+    },
+    {
+      "command": "webhooks create-replay-job",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "webhooks create-replay-job",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command dry-run only"
+    },
+    {
+      "command": "webhooks delete",
+      "kind": "help",
+      "args": [
+        "webhooks",
+        "delete",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Deletes an existing webhook configuration.\n\nUsage:\n  x-twitter-pp-cli webhooks delete \u003cwebhook_id\u003e [flags]\n\nExamples:\n  x-twitter-pp-cli webhooks delete 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help   help for delete\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "webhooks delete",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "webhooks delete",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "webhooks delete",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "webhooks delete",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "webhooks get",
+      "kind": "help",
+      "args": [
+        "webhooks",
+        "get",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Get a list of webhook configs associated with a client app.\n\nUsage:\n  x-twitter-pp-cli webhooks get [flags]\n\nAliases:\n  get, list\n\nExamples:\n  x-twitter-pp-cli webhooks get\n\nFlags:\n  -h, --help                           help for get\n      --webhook-config-fields string   A comma separated list of WebhookConfig fields to display.\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "webhooks get",
+      "kind": "happy_path",
+      "args": [
+        "webhooks",
+        "get"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 webhooks items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "webhooks get",
+      "kind": "json_fidelity",
+      "args": [
+        "webhooks",
+        "get",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"meta\": {\n    \"source\": \"live\"\n  },\n  \"results\": {\n    \"meta\": {\n      \"result_count\": 0\n    }\n  }\n}\nwarning: 1/1 webhooks items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n"
+    },
+    {
+      "command": "webhooks get",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "webhooks validate",
+      "kind": "help",
+      "args": [
+        "webhooks",
+        "validate",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Triggers a CRC check for a given webhook.\n\nUsage:\n  x-twitter-pp-cli webhooks validate \u003cwebhook_id\u003e [flags]\n\nAliases:\n  validate, update\n\nExamples:\n  x-twitter-pp-cli webhooks validate 550e8400-e29b-41d4-a716-446655440000\n\nFlags:\n  -h, --help    help for validate\n      --stdin   Read request body as JSON from stdin\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "webhooks validate",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "webhooks validate",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "webhooks validate",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "mutating command; error_path would call live API without --dry-run"
+    },
+    {
+      "command": "webhooks validate",
+      "kind": "error_path_real",
+      "args": null,
+      "status": "skip",
+      "reason": "no list companion at depth 0 for \"webhook_id\""
+    },
+    {
+      "command": "which",
+      "kind": "help",
+      "args": [
+        "which",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "which resolves a natural-language capability query (for example, \"search messages\" or \"stale tickets\") to the best matching command from this CLI's curated feature index.\n\nExit codes:\n  0  at least one match found\n  2  no confident match - the query did not score against any indexed capability; fall back to '--help' or 'search' if this CLI has one\n\nUsage:\n  x-twitter-pp-cli which [query] [flags]\n\nExamples:\n  x-twitter-pp-cli which \"stale tickets\"\n  x-twitter-pp-cli which \"bottleneck\"\n  x-twitter-pp-cli which --limit 1 \"send message\"\n  x-twitter-pp-cli which                                # list the full capability index\n\nFlags:\n  -h, --help        help for which\n      --limit int   Maximum number of matches to return (default 3)\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "which",
+      "kind": "happy_path",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [which] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "which",
+      "kind": "json_fidelity",
+      "args": null,
+      "status": "skip",
+      "reason": "command path [which] has fewer segments than placeholders (1)"
+    },
+    {
+      "command": "which",
+      "kind": "error_path",
+      "args": [
+        "which",
+        "__printing_press_invalid__",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"matches\": []\n}\n"
+    },
+    {
+      "command": "workflow archive",
+      "kind": "help",
+      "args": [
+        "workflow",
+        "archive",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Archive fetches all syncable resources from the API and stores them in a\nlocal SQLite database. Supports incremental sync (only new data since last run)\nand full resync. After archiving, use 'search' for instant full-text search.\n\nUsage:\n  x-twitter-pp-cli workflow archive [flags]\n\nExamples:\n  # Archive all resources\n  x-twitter-pp-cli workflow archive\n\n  # Full re-archive (ignore previous sync state)\n  x-twitter-pp-cli workflow archive --full\n\nFlags:\n      --db string   Database path (default: ~/.local/share/x-twitter-pp-cli/data.db)\n      --full        Full re-archive (ignore previous sync state)\n  -h, --help        help for archive\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "workflow archive",
+      "kind": "happy_path",
+      "args": [
+        "workflow",
+        "archive"
+      ],
+      "status": "pass",
+      "output_sample": "{\"event\":\"sync_start\",\"resource\":\"account-activity\"}\n{\"event\":\"sync_error\",\"resource\":\"account-activity\",\"error\":\"missing id for account_activity\"}\n{\"event\":\"sync_start\",\"resource\":\"activity\"}\n{\"event\":\"sync_error\",\"resource\":\"activity\",\"status\":409,\"method\":\"GET\",\"path\":\"/2/activity/stream\",\"body\":\"{\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\",\"error\":\"GET /2/activity/stream returned HTTP 409: {\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"activity-subscriptions\"}\n{\"event\":\"sync_warning\",\"resource\":\"activity-subscriptions\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_complete\",\"resource\":\"activity-subscriptions\",\"total\":0,\"duration_ms\":62}\n{\"event\":\"sync_start\",\"resource\":\"chat\"}\n{\"event\":\"sync_warning\",\"resource\":\"chat\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"compliance\"}\n{\"event\":\"sync_error\",\"resource\":\"compliance\",\"status\":400,\"method\":\"GET\",\"path\":\"/2/compliance/jobs\",\"body\":\"{\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\",\"error\":\"GET /2/compliance/jobs returned HTTP 400: {\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\"}\n{\"event\":\"sync_start\",\"resource\":\"connections\"}\n{\"event\":\"sync_error\",\"resource\":\"connections\",\"error\":\"missing id for connections\"}\n{\"event\":\"sync_start\",\"resource\":\"dm-events\"}\n{\"event\":\"sync_warning\",\"resource\":\"dm-events\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n{\"event\":\"sync_start\",\"resource\":\"openapi-json\"}\n{\"event\":\"sync_warning\",\"resource\":\"openapi-json\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_complete\",\"resource\":\"openapi-json\",\"total\":1,\"duration_ms\":189}\n{\"event\":\"sync_start\",\"resource\":\"tweets\"}\n{\"event\":\"sync_warning\",\"resource\":\"tweets\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\\"client_id\\\":\\\"32365644\\\",\\\"detail\\\":\\\"When authenticating requests to the Twitter API v2 endpoints, you must use keys and tokens from a Twitter developer App that is attached to a Project. You can create a project via the developer portal.\\\",\\\"registration_url\\\":\\\"https://developer.twitter.com/en/docs/projects/overview\\\",\\\"title\\\":\\\"Client Forbidden\\\",\\\"required_enrollment\\\":\\\"Appropriate Level of API Access\\\",\\\"reason\\\":\\\"client-not-enrolled\\\",\\\"type\\\":\\\"https://api.twitter.c…[truncated]"
+    },
+    {
+      "command": "workflow archive",
+      "kind": "json_fidelity",
+      "args": [
+        "workflow",
+        "archive",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"resources_synced\": 16,\n  \"store_path\": \"/var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.local/share/x-twitter-pp-cli/data.db\",\n  \"timestamp\": \"2026-06-05T20:24:29Z\",\n  \"total_items\": 3\n}\n{\"event\":\"sync_start\",\"resource\":\"account-activity\"}\n{\"event\":\"sync_error\",\"resource\":\"account-activity\",\"error\":\"missing id for account_activity\"}\n  account-activity: error: missing id for account_activity\n{\"event\":\"sync_start\",\"resource\":\"activity\"}\n{\"event\":\"sync_error\",\"resource\":\"activity\",\"status\":409,\"method\":\"GET\",\"path\":\"/2/activity/stream\",\"body\":\"{\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\",\"error\":\"GET /2/activity/stream returned HTTP 409: {\\\"title\\\":\\\"ConnectionException\\\",\\\"detail\\\":\\\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\\\",\\\"connection_issue\\\":\\\"SubscriptionConfigurationIssue\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/streaming-connection\\\"}\"}\n  activity: error: fetching activity: GET /2/activity/stream returned HTTP 409: {\"title\":\"ConnectionException\",\"detail\":\"You must define at least one subscription using the POST /2/activity/subscriptions endpoint before connecting to activity stream.\",\"connection_issue\":\"SubscriptionConfigurationIssue\",\"type\":\"https://api.twitter.com/2/problems/streaming-connection\"}\n{\"event\":\"sync_start\",\"resource\":\"activity-subscriptions\"}\n{\"event\":\"sync_warning\",\"resource\":\"activity-subscriptions\",\"reason\":\"resource_not_incremental\",\"message\":\"endpoint does not declare a temporal filter parameter; incremental sync has no effect for this resource\"}\n{\"event\":\"sync_complete\",\"resource\":\"activity-subscriptions\",\"total\":0,\"duration_ms\":66}\n  activity-subscriptions: 0 synced\n{\"event\":\"sync_start\",\"resource\":\"chat\"}\n{\"event\":\"sync_warning\",\"resource\":\"chat\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].\\\",\\n  \\\"type\\\": \\\"https://api.twitter.com/2/problems/unsupported-authentication\\\",\\n  \\\"status\\\": 403\\n}\"}\n  chat: warning: skipped chat: forbidden\n{\"event\":\"sync_start\",\"resource\":\"compliance\"}\n{\"event\":\"sync_error\",\"resource\":\"compliance\",\"status\":400,\"method\":\"GET\",\"path\":\"/2/compliance/jobs\",\"body\":\"{\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\",\"error\":\"GET /2/compliance/jobs returned HTTP 400: {\\\"errors\\\":[{\\\"parameters\\\":{\\\"type\\\":[]},\\\"message\\\":\\\"The `type` query parameter can not be empty\\\"}],\\\"title\\\":\\\"Invalid Request\\\",\\\"detail\\\":\\\"One or more parameters to your request was invalid.\\\",\\\"type\\\":\\\"https://api.twitter.com/2/problems/invalid-request\\\"}\"}\n  compliance: error: fetching compliance: GET /2/compliance/jobs returned HTTP 400: {\"errors\":[{\"parameters\":{\"type\":[]},\"message\":\"The `type` query parameter can not be empty\"}],\"title\":\"Invalid Request\",\"detail\":\"One or more parameters to your request was invalid.\",\"type\":\"https://api.twitter.com/2/problems/invalid-request\"}\n{\"event\":\"sync_start\",\"resource\":\"connections\"}\n{\"event\":\"sync_error\",\"resource\":\"connections\",\"error\":\"missing id for connections\"}\n  connections: error: missing id for connections\n{\"event\":\"sync_start\",\"resource\":\"dm-events\"}\n{\"event\":\"sync_warning\",\"resource\":\"dm-events\",\"status\":403,\"reason\":\"forbidden\",\"message\":\"{\\n  \\\"title\\\": \\\"Unsupported Authentication\\\",\\n  \\\"detail\\\": \\\"Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication typ…[truncated]"
+    },
+    {
+      "command": "workflow archive",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    },
+    {
+      "command": "workflow status",
+      "kind": "help",
+      "args": [
+        "workflow",
+        "status",
+        "--help"
+      ],
+      "status": "pass",
+      "output_sample": "Show local archive status and sync state for all resources\n\nUsage:\n  x-twitter-pp-cli workflow status [flags]\n\nExamples:\n  # Show archive status\n  x-twitter-pp-cli workflow status\n\n  # Show status as JSON\n  x-twitter-pp-cli workflow status --json\n\nFlags:\n      --db string   Database path\n  -h, --help        help for status\n\nGlobal Flags:\n      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)\n      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit\n      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage\n      --config string           Config file path\n      --csv                     Output as CSV (table and array responses)\n      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default \"auto\")\n      --deliver string          Route output to a sink: stdout (default), file:\u003cpath\u003e, webhook:\u003curl\u003e\n      --dry-run                 Show request without sending\n      --human-friendly          Enable colored output and rich formatting\n      --idempotent              Treat already-existing create results as a successful no-op\n      --ignore-missing          Treat missing delete targets as a successful no-op\n      --json                    Output as JSON\n      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)\n      --no-cache                Bypass response cache\n      --no-color                Disable colored output\n      --no-input                Disable all interactive prompts (for CI/agents)\n      --plain                   Output as plain tab-separated text\n      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')\n      --quiet                   Bare output, one value per line\n      --rate-limit float        Max requests per second (0 to disable)\n      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)\n      --timeout duration        Request timeout (default 1m0s)\n      --yes                     Skip confirmation prompts (for agents and scripts)\n"
+    },
+    {
+      "command": "workflow status",
+      "kind": "happy_path",
+      "args": [
+        "workflow",
+        "status"
+      ],
+      "status": "pass",
+      "output_sample": "Archive Status:\n  openapi-json                   1 items\n  tweets                         21 items\n  tweets-search-stream-rules     1 items\n  tweets-search-stream-rules-counts 1 items\n  users                          1 items\n  news                           10 items\n\n  Total: 35 items\n  Store: /var/folders/_5/2zb6vq_j54vctjyh6fq3cnh40000gn/T/printing-press-subprocess-316160864/.local/share/x-twitter-pp-cli/data.db\n"
+    },
+    {
+      "command": "workflow status",
+      "kind": "json_fidelity",
+      "args": [
+        "workflow",
+        "status",
+        "--json"
+      ],
+      "status": "pass",
+      "output_sample": "{\n  \"news\": 10,\n  \"openapi-json\": 1,\n  \"tweets\": 21,\n  \"tweets-search-stream-rules\": 1,\n  \"tweets-search-stream-rules-counts\": 1,\n  \"users\": 1\n}\n"
+    },
+    {
+      "command": "workflow status",
+      "kind": "error_path",
+      "args": null,
+      "status": "skip",
+      "reason": "no positional argument"
+    }
+  ],
+  "ran_at": "2026-06-05T20:22:11.513169Z"
+}

--- a/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-article-native-elements.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/x-twitter-article-native-elements.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "x-twitter-article-native-elements",
+  "applied_at": "2026-06-05",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Render sniffed X Article native tweet, divider, and markdown table entities from articles-publish-md.",
+  "reason": "The generated hand-authored Article markdown converter did not emit the Draft.js entity shapes used by X's Article editor for these native elements.",
+  "files": [
+    "internal/cli/articles_publish_md.go",
+    "internal/cli/articles_publish_md_test.go"
+  ],
+  "validated_outcome": "go test ./...",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1059"
+}

--- a/library/social-and-messaging/x-twitter/SKILL.md
+++ b/library/social-and-messaging/x-twitter/SKILL.md
@@ -29,13 +29,15 @@ This skill drives the `x-twitter-pp-cli` binary. **You must verify the CLI is in
 2. Verify: `x-twitter-pp-cli --version`
 3. Ensure the reported install directory is on `$PATH` for the agent/runtime that will invoke this skill.
 
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/social-and-messaging/x-twitter/cmd/x-twitter-pp-cli@latest
 ```
 
 If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
+
+Mirrors the official X v2 API and adds what no other X tool has: a local SQLite store you can sync once and query many times with FTS5 search and group-by analytics, agent-native --json/--select output, and an MCP server that exposes the whole surface to AI agents through token-efficient orchestration plus named multi-step intents. Reconstruct conversation threads offline with `thread show`, compose self-reply threads from markdown with `thread compose`, author long-form X Articles from markdown with `articles-publish-md`, and rescue your bookmark graveyard with `users bookmarks find` — keyword and author search over your synced bookmarks, which X itself gives you no way to search.
 
 ## When to Use This CLI
 

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -394,7 +394,8 @@ func parseFrontmatter(yamlSrc string, fm *articleFrontmatter) {
 // italic (*...*). Fenced code blocks and markdown tables are emitted as X
 // Articles MARKDOWN entities bound to atomic Draft.js blocks. Image lines are
 // emitted as placeholder MEDIA entities in dry-run output, then rebound to
-// uploaded media IDs before live publish.
+// uploaded media IDs before live publish. Setext headings are intentionally
+// unsupported; use ## for header-two because --- is reserved for dividers.
 func MarkdownBodyToDraftJS(md string) draftContentState {
 	cs := draftContentState{}
 	lines := strings.Split(md, "\n")
@@ -571,7 +572,7 @@ func parseTweetStatusLine(line string) (string, bool) {
 		return "", false
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	if len(parts) < 3 || parts[0] == "" || parts[1] != "status" {
+	if len(parts) != 3 || parts[0] == "" || parts[1] != "status" {
 		return "", false
 	}
 	tweetID := parts[2]

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md.go
@@ -5,8 +5,9 @@
 //
 // CURRENT SCOPE: article body + media. Supported block types:
 // paragraph, header-one, header-two, unordered-list-item, ordered-list-item,
-// blockquote, fenced code blocks, markdown image blocks, plus bold/italic
-// inline styles. Cover image uses the captured upload + UpdateCoverMedia flow.
+// blockquote, fenced code blocks, markdown table blocks, markdown image blocks,
+// tweet embeds, dividers, plus bold/italic inline styles. Cover image uses the
+// captured upload + UpdateCoverMedia flow.
 
 package cli
 
@@ -15,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -387,11 +389,12 @@ func parseFrontmatter(yamlSrc string, fm *articleFrontmatter) {
 
 // MarkdownBodyToDraftJS converts a markdown body to a Draft.js content_state.
 // Supports: paragraph, header-one (# ), header-two (## ), unordered-list-item,
-// ordered-list-item, blockquote, markdown image lines, plus inline bold
-// (**...**) and italic (*...*). Fenced code blocks are emitted as X Articles
-// MARKDOWN entities bound to atomic Draft.js blocks. Image lines are emitted as
-// placeholder MEDIA entities in dry-run output, then rebound to uploaded media
-// IDs before live publish.
+// ordered-list-item, blockquote, markdown image lines, standalone tweet URLs,
+// standalone dividers (---), markdown tables, plus inline bold (**...**) and
+// italic (*...*). Fenced code blocks and markdown tables are emitted as X
+// Articles MARKDOWN entities bound to atomic Draft.js blocks. Image lines are
+// emitted as placeholder MEDIA entities in dry-run output, then rebound to
+// uploaded media IDs before live publish.
 func MarkdownBodyToDraftJS(md string) draftContentState {
 	cs := draftContentState{}
 	lines := strings.Split(md, "\n")
@@ -417,6 +420,19 @@ func MarkdownBodyToDraftJS(md string) draftContentState {
 		}
 		if alt, path, ok := parseMarkdownImageLine(trim); ok {
 			appendArticleMediaEntityBlock(&cs, path, alt)
+			continue
+		}
+		if tableLines, next, ok := collectMarkdownTable(lines, i); ok {
+			appendMarkdownEntityBlock(&cs, strings.Join(tableLines, "\n"))
+			i = next - 1
+			continue
+		}
+		if tweetID, ok := parseTweetStatusLine(trim); ok {
+			appendTweetEntityBlock(&cs, tweetID)
+			continue
+		}
+		if trim == "---" {
+			appendDividerEntityBlock(&cs)
 			continue
 		}
 		blk := draftBlock{
@@ -453,37 +469,33 @@ func MarkdownBodyToDraftJS(md string) draftContentState {
 }
 
 func appendMarkdownEntityBlock(cs *draftContentState, markdown string) {
-	entityIndex := len(cs.EntityMap)
-	cs.EntityMap = append(cs.EntityMap, draftEntity{
-		Key: strconv.Itoa(entityIndex),
-		Value: draftEntityValue{
-			Data:       map[string]any{"markdown": markdown},
-			Type:       "MARKDOWN",
-			Mutability: "Mutable",
-		},
-	})
-	cs.Blocks = append(cs.Blocks, draftBlock{
-		Data:              map[string]any{},
-		Text:              " ",
-		Key:               randBlockKey(),
-		Type:              "atomic",
-		EntityRanges:      []map[string]any{{"key": entityIndex, "offset": 0, "length": 1}},
-		InlineStyleRanges: []inlineStyle{},
-	})
+	appendAtomicEntityBlock(cs, "MARKDOWN", "Mutable", map[string]any{"markdown": markdown})
 }
 
 func appendArticleMediaEntityBlock(cs *draftContentState, sourcePath string, altText string) {
-	entityIndex := len(cs.EntityMap)
 	data := map[string]any{"source_path": sourcePath}
 	if altText != "" {
 		data["alt_text"] = altText
 	}
+	appendAtomicEntityBlock(cs, "MEDIA", "Immutable", data)
+}
+
+func appendTweetEntityBlock(cs *draftContentState, tweetID string) {
+	appendAtomicEntityBlock(cs, "TWEET", "Immutable", map[string]any{"tweet_id": tweetID})
+}
+
+func appendDividerEntityBlock(cs *draftContentState) {
+	appendAtomicEntityBlock(cs, "DIVIDER", "Immutable", map[string]any{})
+}
+
+func appendAtomicEntityBlock(cs *draftContentState, entityType string, mutability string, data map[string]any) {
+	entityIndex := len(cs.EntityMap)
 	cs.EntityMap = append(cs.EntityMap, draftEntity{
 		Key: strconv.Itoa(entityIndex),
 		Value: draftEntityValue{
 			Data:       data,
-			Type:       "MEDIA",
-			Mutability: "Immutable",
+			Type:       entityType,
+			Mutability: mutability,
 		},
 	})
 	cs.Blocks = append(cs.Blocks, draftBlock{
@@ -543,6 +555,88 @@ func parseMarkdownImageLine(line string) (string, string, bool) {
 		return "", "", false
 	}
 	return altText, sourcePath, true
+}
+
+func parseTweetStatusLine(line string) (string, bool) {
+	u, err := url.Parse(line)
+	if err != nil {
+		return "", false
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", false
+	}
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	if host != "x.com" && host != "twitter.com" {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 3 || parts[0] == "" || parts[1] != "status" {
+		return "", false
+	}
+	tweetID := parts[2]
+	if tweetID == "" {
+		return "", false
+	}
+	for _, r := range tweetID {
+		if r < '0' || r > '9' {
+			return "", false
+		}
+	}
+	return tweetID, true
+}
+
+func collectMarkdownTable(lines []string, start int) ([]string, int, bool) {
+	if start+1 >= len(lines) {
+		return nil, start, false
+	}
+	first := strings.TrimRight(lines[start], " \t")
+	second := strings.TrimRight(lines[start+1], " \t")
+	if !isMarkdownTableRow(first) || !isMarkdownTableSeparatorRow(second) {
+		return nil, start, false
+	}
+
+	tableLines := []string{first, second}
+	next := start + 2
+	for next < len(lines) {
+		line := strings.TrimRight(lines[next], " \t")
+		if strings.TrimSpace(line) == "" || !isMarkdownTableRow(line) {
+			break
+		}
+		tableLines = append(tableLines, line)
+		next++
+	}
+	return tableLines, next, true
+}
+
+func isMarkdownTableRow(line string) bool {
+	return len(splitMarkdownTableRow(line)) >= 2
+}
+
+func isMarkdownTableSeparatorRow(line string) bool {
+	cells := splitMarkdownTableRow(line)
+	if len(cells) < 2 {
+		return false
+	}
+	for _, cell := range cells {
+		trimmed := strings.TrimSpace(cell)
+		trimmed = strings.TrimPrefix(trimmed, ":")
+		trimmed = strings.TrimSuffix(trimmed, ":")
+		if len(trimmed) < 3 || strings.Trim(trimmed, "-") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func splitMarkdownTableRow(line string) []string {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	if !strings.Contains(trimmed, "|") {
+		return nil
+	}
+	return strings.Split(trimmed, "|")
 }
 
 // extractInlineStyles scans a string for **bold** and *italic* markers and

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -1,6 +1,9 @@
 package cli
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestMarkdownBodyToDraftJSImageLine(t *testing.T) {
 	contentState := MarkdownBodyToDraftJS("Before\n\n![body alt](./body.png)\n\nAfter")
@@ -122,4 +125,85 @@ func TestMarkdownBodyToDraftJSCodeFence(t *testing.T) {
 	if entity.Value.Data["markdown"] != wantMarkdown {
 		t.Fatalf("unexpected markdown entity data:\nwant: %q\n got: %q", wantMarkdown, entity.Value.Data["markdown"])
 	}
+}
+
+func TestMarkdownBodyToDraftJSTweetEmbedLines(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("Before\n\nhttps://x.com/alice/status/2061877533885473181\n\nhttps://twitter.com/bob/status/2062703227972293057?ref=article\n\nAfter https://x.com/alice/status/1")
+
+	if len(contentState.Blocks) != 4 {
+		t.Fatalf("expected 4 blocks, got %d", len(contentState.Blocks))
+	}
+	firstTweet := requireAtomicEntity(t, contentState, 1, 0, "TWEET", "Immutable")
+	if firstTweet.Data["tweet_id"] != "2061877533885473181" {
+		t.Fatalf("expected first tweet_id, got %#v", firstTweet.Data["tweet_id"])
+	}
+	secondTweet := requireAtomicEntity(t, contentState, 2, 1, "TWEET", "Immutable")
+	if secondTweet.Data["tweet_id"] != "2062703227972293057" {
+		t.Fatalf("expected second tweet_id, got %#v", secondTweet.Data["tweet_id"])
+	}
+	if contentState.Blocks[3].Type != "unstyled" {
+		t.Fatalf("expected non-standalone tweet URL to remain text, got %q", contentState.Blocks[3].Type)
+	}
+	if contentState.Blocks[3].Text != "After https://x.com/alice/status/1" {
+		t.Fatalf("unexpected final paragraph text: %q", contentState.Blocks[3].Text)
+	}
+}
+
+func TestMarkdownBodyToDraftJSDivider(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("Before\n\n---\n\nAfter")
+
+	if len(contentState.Blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(contentState.Blocks))
+	}
+	entity := requireAtomicEntity(t, contentState, 1, 0, "DIVIDER", "Immutable")
+	if len(entity.Data) != 0 {
+		t.Fatalf("expected empty divider data, got %#v", entity.Data)
+	}
+}
+
+func TestMarkdownBodyToDraftJSTable(t *testing.T) {
+	contentState := MarkdownBodyToDraftJS("Before\n\n| Feature | Status |\n|---|---:|\n| Tweet | Native embed |\n| Divider | Native rule |\n\nAfter")
+
+	if len(contentState.Blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(contentState.Blocks))
+	}
+	entity := requireAtomicEntity(t, contentState, 1, 0, "MARKDOWN", "Mutable")
+	wantMarkdown := "| Feature | Status |\n|---|---:|\n| Tweet | Native embed |\n| Divider | Native rule |"
+	if entity.Data["markdown"] != wantMarkdown {
+		t.Fatalf("unexpected table markdown:\nwant: %q\n got: %q", wantMarkdown, entity.Data["markdown"])
+	}
+}
+
+func requireAtomicEntity(t *testing.T, contentState draftContentState, blockIndex int, entityIndex int, entityType string, mutability string) draftEntityValue {
+	t.Helper()
+	if blockIndex >= len(contentState.Blocks) {
+		t.Fatalf("block index %d out of range; got %d blocks", blockIndex, len(contentState.Blocks))
+	}
+	block := contentState.Blocks[blockIndex]
+	if block.Type != "atomic" {
+		t.Fatalf("expected block %d to be atomic, got %q", blockIndex, block.Type)
+	}
+	if block.Text != " " {
+		t.Fatalf("expected atomic block text to be a single space, got %q", block.Text)
+	}
+	if len(block.EntityRanges) != 1 {
+		t.Fatalf("expected one entity range, got %d", len(block.EntityRanges))
+	}
+	if block.EntityRanges[0]["key"] != entityIndex {
+		t.Fatalf("expected atomic block to reference entity key %d, got %#v", entityIndex, block.EntityRanges[0]["key"])
+	}
+	if entityIndex >= len(contentState.EntityMap) {
+		t.Fatalf("entity index %d out of range; got %d entities", entityIndex, len(contentState.EntityMap))
+	}
+	entity := contentState.EntityMap[entityIndex]
+	if entity.Key != strconv.Itoa(entityIndex) {
+		t.Fatalf("expected entity key %d, got %q", entityIndex, entity.Key)
+	}
+	if entity.Value.Type != entityType {
+		t.Fatalf("expected %s entity, got %q", entityType, entity.Value.Type)
+	}
+	if entity.Value.Mutability != mutability {
+		t.Fatalf("expected %s entity mutability, got %q", mutability, entity.Value.Mutability)
+	}
+	return entity.Value
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_publish_md_test.go
@@ -128,10 +128,10 @@ func TestMarkdownBodyToDraftJSCodeFence(t *testing.T) {
 }
 
 func TestMarkdownBodyToDraftJSTweetEmbedLines(t *testing.T) {
-	contentState := MarkdownBodyToDraftJS("Before\n\nhttps://x.com/alice/status/2061877533885473181\n\nhttps://twitter.com/bob/status/2062703227972293057?ref=article\n\nAfter https://x.com/alice/status/1")
+	contentState := MarkdownBodyToDraftJS("Before\n\nhttps://x.com/alice/status/2061877533885473181\n\nhttps://twitter.com/bob/status/2062703227972293057?ref=article\n\nAfter https://x.com/alice/status/1\n\nhttps://x.com/alice/status/2061877533885473181/photo/1")
 
-	if len(contentState.Blocks) != 4 {
-		t.Fatalf("expected 4 blocks, got %d", len(contentState.Blocks))
+	if len(contentState.Blocks) != 5 {
+		t.Fatalf("expected 5 blocks, got %d", len(contentState.Blocks))
 	}
 	firstTweet := requireAtomicEntity(t, contentState, 1, 0, "TWEET", "Immutable")
 	if firstTweet.Data["tweet_id"] != "2061877533885473181" {
@@ -146,6 +146,12 @@ func TestMarkdownBodyToDraftJSTweetEmbedLines(t *testing.T) {
 	}
 	if contentState.Blocks[3].Text != "After https://x.com/alice/status/1" {
 		t.Fatalf("unexpected final paragraph text: %q", contentState.Blocks[3].Text)
+	}
+	if contentState.Blocks[4].Type != "unstyled" {
+		t.Fatalf("expected media sub-page tweet URL to remain text, got %q", contentState.Blocks[4].Type)
+	}
+	if contentState.Blocks[4].Text != "https://x.com/alice/status/2061877533885473181/photo/1" {
+		t.Fatalf("unexpected media sub-page paragraph text: %q", contentState.Blocks[4].Text)
 	}
 }
 


### PR DESCRIPTION
## x-twitter

Closes #1059.

⚠️ **Replaces existing `x-twitter`** — published CLI hotfix for native X Article editor elements.

The only X CLI with an offline, searchable local mirror — full-text search and analytics over your archived posts without re-spending per-read API credits — plus a full-surface MCP server and honest tier/reachability diagnostics.

**API:** x-twitter | **Category:** social-and-messaging | **Press version:** 4.20.1  
**Spec:** Not specified

### Publication Path

Reprint/replace — `library/social-and-messaging/x-twitter` already exists in the published library, and this PR updates that entry in place.

### CLI Shape

```text
X Twitter CLI — The only X CLI with an offline, searchable local mirror — full-text search and analytics over your archived posts without re-…

Highlights (not in the official API docs):
  • thread show   Rebuild a full conversation thread from your locally synced posts — ordered and depth-tagged — without re-spending API read credits.
  • thread compose   Split a markdown file into a numbered, 280-char-packed self-reply thread; prints by default and only posts with --post.
  • articles-publish-md   Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft saves a draft, --post publishes publicly.

Agent mode: add --agent to any command for JSON output + non-interactive mode.
Health check: run 'x-twitter-pp-cli doctor' to verify auth and connectivity.
See README.md or the bundled SKILL.md for recipes.

Usage:
  x-twitter-pp-cli [command]

Available Commands:
  agent-context       Emit structured JSON describing this CLI for agents
  analytics           Run analytics queries on locally synced data
  api                 Browse all API endpoints by interface name
  articles            X Articles (long-form posts) authoring + media upload
  articles-publish-md Convert a markdown file to an X Article (preview by default; --draft or --post to write)
  auth                Manage authentication for X
  completion          Generate the autocompletion script for the specified shell
  doctor              Check CLI health
  evaluate-note       Endpoint to evaluate a community note.
  feedback            Record feedback about this CLI (local by default; upstream opt-in)
  help                Help about any command
  import              Import data from JSONL file via API create/upsert calls
  jobs                List and inspect async jobs tracked by this CLI
  openapi-json        Retrieves the full OpenAPI Specification in JSON format. (See https://github.
  profile             Named sets of flags saved for reuse
  search              Full-text search across synced data or live API
  sync                Sync API data to local SQLite for offline search and analysis
  tail                Stream live changes by polling the API at regular intervals
  thread              Compose new post threads or rebuild existing ones from synced posts
  trends              Retrieves trending topics for a specific location identified by its WOEID.
  usage               Retrieves usage statistics for Posts over a specified number of days.
  version             Print version
  which               Find the command that implements a capability
  workflow            Compound workflows that combine multiple API operations

Flags:
      --agent                   Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)
      --allow-partial-failure   Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit
      --compact                 Return only key fields (id, name, status, timestamps) for minimal token usage
      --config string           Config file path
      --csv                     Output as CSV (table and array responses)
      --data-source string      Data source for read commands: auto (live with local fallback), live (API only), local (synced data only) (default "auto")
      --deliver string          Route output to a sink: stdout (default), file:<path>, webhook:<url>
      --dry-run                 Show request without sending
  -h, --help                    help for x-twitter-pp-cli
      --human-friendly          Enable colored output and rich formatting
      --idempotent              Treat already-existing create results as a successful no-op
      --ignore-missing          Treat missing delete targets as a successful no-op
      --json                    Output as JSON
      --max-age duration        Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables (default 30m0s)
      --no-cache                Bypass response cache
      --no-color                Disable colored output
      --no-input                Disable all interactive prompts (for CI/agents)
      --plain                   Output as plain tab-separated text
      --profile string          Apply values from a saved profile (see 'x-twitter-pp-cli profile list')
      --quiet                   Bare output, one value per line
      --rate-limit float        Max requests per second (0 to disable)
      --select string           Comma-separated fields to include in output (e.g. --select id,name,status)
      --timeout duration        Request timeout (default 1m0s)
  -v, --version                 version for x-twitter-pp-cli
      --yes                     Skip confirmation prompts (for agents and scripts)

Use "x-twitter-pp-cli [command] --help" for more information about a command.
```

### What This CLI Does

This update keeps the existing X/Twitter CLI surface and improves `articles-publish-md` so markdown can render native X Article editor entities from sniffed ArticleEntityUpdateContent JSON:

- standalone X/Twitter status URLs emit native `TWEET` embeds
- standalone `---` emits a native `DIVIDER`
- markdown tables emit the Article editor's `MARKDOWN` atomic entity shape
- existing Article media/GIF upload handling is preserved

### Novel Commands

- **`thread show`** — Offline thread reconstruction: Rebuild a full conversation thread from your locally synced posts — ordered and depth-tagged — without re-spending API read credits.
- **`thread compose`** — Markdown to tweet thread: Split a markdown file into a numbered, 280-char-packed self-reply thread; prints by default and only posts with --post.
- **`articles-publish-md`** — Markdown to X Article: Parse a markdown file with YAML frontmatter into the Draft.js content_state JSON X's Articles editor accepts; previews by default; --draft saves a draft, --post publishes publicly.
- **`users bookmarks find`** — Offline bookmark search: Search your synced bookmarks by keyword and/or author, offline — X has no bookmark search and its API exposes no bookmark timestamp, so the local store rebuilds the missing retrieval layer without re-spending read credits.

### Manuscripts

- [proofs/phase5-acceptance.json](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/phase5-acceptance.json)
- [proofs/publish-live-gate.json](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/publish-live-gate.json)
- [proofs/shipcheck.json](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/proofs/shipcheck.json)
- [research/absorb-manifest.md](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/research/absorb-manifest.md)
- [research/brief.md](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/research/brief.md)
- [research/novel-features-brainstorm.md](https://github.com/mvanhorn/printing-press-library/blob/3b30e79de9f35dce03040c560deaf1b52e26ab2f/library/social-and-messaging/x-twitter/.manuscripts/20260603-230951/research/novel-features-brainstorm.md)

### Validation Results

| Check | Result |
|---|---|
| Manifest | PASS |
| Transcendence | PASS |
| Phase 5 | PASS |
| go mod tidy | PASS |
| govulncheck | PASS |
| go vet | PASS |
| go build | PASS |
| --help | PASS |
| --version | PASS |
| verify-skill | PASS |
| Manuscripts | PASS |
| Live publish gate | PASS: full live dogfood, 351 tests passed |
| Scoped published-module build | PASS |
| Scoped published-module govulncheck | PASS: no reachable vulnerabilities |
| Focused converter tests | PASS: `go test ./...` |

### Gaps

None known. X Article publishing was not exercised with `--post`; validation stayed draft/dry-run and read-only/live-gate scoped.
