### PR TITLE
fix(cli): improve Chrome cookie profile selection

### DIFF
--- a/library/commerce/amazon-orders/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/commerce/amazon-orders/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260510-105710",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/commerce/amazon-orders",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -50,9 +50,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -118,7 +124,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -512,7 +518,7 @@ func chromeDataDir() (string, error) {
 // shelled out to the binary. countCookiesForDomain now reads the cookie DB via
 // the in-binary modernc.org/sqlite driver, so the guard is no longer needed —
 // keeping it broke profile auto-detection on hosts without `sqlite3` in PATH.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -547,17 +553,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -585,6 +597,82 @@ func readProfileDisplayName(prefsPath string) string {
 }
 
 // PATCH(greptile-countcookies-sql-injection): swapped fmt.Sprintf + sqlite3 shell-out for database/sql with a bind parameter so host_key cannot be influenced by untrusted callers.
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro&_journal_mode=OFF&_busy_timeout=2000")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer db.Close()
+
+	placeholders := make([]string, 0, len(requiredCookies))
+	args := make([]any, 0, len(requiredCookies)+1)
+	args = append(args, domainPattern)
+	for _, name := range requiredCookies {
+		placeholders = append(placeholders, "?")
+		args = append(args, name)
+	}
+	query := "SELECT DISTINCT name FROM cookies WHERE host_key LIKE ? AND name IN (" + strings.Join(placeholders, ",") + ")"
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts
 // matching rows via a parameterized read-only query through the in-binary
 // SQLite driver. host_key is plaintext so no decryption is needed.
@@ -648,47 +736,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -700,13 +806,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -791,7 +904,7 @@ print(json.dumps(chrome_cookies(url, **kwargs)))`
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -764,10 +764,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/commerce/amazon-orders/internal/cli/auth.go
+++ b/library/commerce/amazon-orders/internal/cli/auth.go
@@ -777,8 +777,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/commerce/ebay/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/commerce/ebay/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "",
+  "base_printing_press_version": "3.0.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/commerce/ebay",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/commerce/ebay/internal/cli/auth.go
+++ b/library/commerce/ebay/internal/cli/auth.go
@@ -720,8 +720,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/commerce/ebay/internal/cli/auth.go
+++ b/library/commerce/ebay/internal/cli/auth.go
@@ -707,10 +707,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/commerce/ebay/internal/cli/auth.go
+++ b/library/commerce/ebay/internal/cli/auth.go
@@ -41,9 +41,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -95,7 +101,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -474,7 +480,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -512,17 +518,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -547,6 +559,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -602,47 +679,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -654,13 +749,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -732,7 +834,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/commerce/facebook-marketplace/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/commerce/facebook-marketplace/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260518-135804",
+  "base_printing_press_version": "4.6.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/commerce/facebook-marketplace",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/commerce/facebook-marketplace/internal/cli/auth.go
+++ b/library/commerce/facebook-marketplace/internal/cli/auth.go
@@ -745,8 +745,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/commerce/facebook-marketplace/internal/cli/auth.go
+++ b/library/commerce/facebook-marketplace/internal/cli/auth.go
@@ -732,10 +732,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/commerce/facebook-marketplace/internal/cli/auth.go
+++ b/library/commerce/facebook-marketplace/internal/cli/auth.go
@@ -43,9 +43,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -102,7 +108,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -490,7 +496,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -525,17 +531,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -560,6 +572,81 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro&_journal_mode=OFF&_busy_timeout=2000")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer db.Close()
+
+	placeholders := make([]string, 0, len(requiredCookies))
+	args := make([]any, 0, len(requiredCookies)+1)
+	args = append(args, domainPattern)
+	for _, name := range requiredCookies {
+		placeholders = append(placeholders, "?")
+		args = append(args, name)
+	}
+	query := "SELECT DISTINCT name FROM cookies WHERE host_key LIKE ? AND name IN (" + strings.Join(placeholders, ",") + ")"
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -617,47 +704,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -669,13 +774,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -747,7 +859,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/commerce/harris-teeter/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/commerce/harris-teeter/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260517-190052",
+  "base_printing_press_version": "4.0.2",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/commerce/harris-teeter",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/commerce/harris-teeter/internal/cli/auth.go
+++ b/library/commerce/harris-teeter/internal/cli/auth.go
@@ -36,9 +36,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -89,7 +95,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if tool != "" && cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -244,7 +250,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -282,17 +288,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -317,6 +329,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -372,47 +449,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -424,13 +519,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -502,7 +604,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/commerce/harris-teeter/internal/cli/auth.go
+++ b/library/commerce/harris-teeter/internal/cli/auth.go
@@ -477,10 +477,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/commerce/harris-teeter/internal/cli/auth.go
+++ b/library/commerce/harris-teeter/internal/cli/auth.go
@@ -490,8 +490,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/commerce/offerup/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/commerce/offerup/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260531-200239",
+  "base_printing_press_version": "4.19.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/commerce/offerup",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/commerce/offerup/internal/cli/auth.go
+++ b/library/commerce/offerup/internal/cli/auth.go
@@ -591,8 +591,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/commerce/offerup/internal/cli/auth.go
+++ b/library/commerce/offerup/internal/cli/auth.go
@@ -578,10 +578,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/commerce/offerup/internal/cli/auth.go
+++ b/library/commerce/offerup/internal/cli/auth.go
@@ -40,9 +40,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -132,7 +138,7 @@ profile by name when the installed backend supports it.`,
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
 				profileDir := ""
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -345,7 +351,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -383,17 +389,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -418,6 +430,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -473,47 +550,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -525,13 +620,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -658,7 +760,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/education/ankiweb/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/education/ankiweb/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260525-182034",
+  "base_printing_press_version": "4.16.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/education/ankiweb",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/education/ankiweb/internal/cli/auth.go
+++ b/library/education/ankiweb/internal/cli/auth.go
@@ -42,9 +42,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -136,7 +142,7 @@ profile by name when the installed backend supports it.`,
 
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -224,7 +230,7 @@ func tryCaptureAnkiuserCookies(w io.Writer, in io.Reader, knownProfileDir, profi
 	}
 	profileDir := knownProfileDir
 	if profileDir == "" && cookieToolSupportsProfiles(tool.name) {
-		profileDir, err = resolveChromeProfile(w, in, domain, profileFlag)
+		profileDir, err = resolveChromeProfile(w, in, domain, profileFlag, requiredAuthCookies())
 		if err != nil {
 			return "", err
 		}
@@ -392,7 +398,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -427,17 +433,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -462,6 +474,81 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro&_journal_mode=OFF&_busy_timeout=2000")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer db.Close()
+
+	placeholders := make([]string, 0, len(requiredCookies))
+	args := make([]any, 0, len(requiredCookies)+1)
+	args = append(args, domainPattern)
+	for _, name := range requiredCookies {
+		placeholders = append(placeholders, "?")
+		args = append(args, name)
+	}
+	query := "SELECT DISTINCT name FROM cookies WHERE host_key LIKE ? AND name IN (" + strings.Join(placeholders, ",") + ")"
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -520,47 +607,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -572,13 +677,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -705,7 +817,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/education/ankiweb/internal/cli/auth.go
+++ b/library/education/ankiweb/internal/cli/auth.go
@@ -648,8 +648,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/education/ankiweb/internal/cli/auth.go
+++ b/library/education/ankiweb/internal/cli/auth.go
@@ -635,10 +635,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/food-and-dining/allrecipes/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/food-and-dining/allrecipes/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "",
+  "base_printing_press_version": "3.8.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/food-and-dining/allrecipes",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/food-and-dining/allrecipes/internal/cli/auth.go
+++ b/library/food-and-dining/allrecipes/internal/cli/auth.go
@@ -734,8 +734,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/food-and-dining/allrecipes/internal/cli/auth.go
+++ b/library/food-and-dining/allrecipes/internal/cli/auth.go
@@ -721,10 +721,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/food-and-dining/allrecipes/internal/cli/auth.go
+++ b/library/food-and-dining/allrecipes/internal/cli/auth.go
@@ -41,9 +41,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -100,7 +106,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -488,7 +494,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -526,17 +532,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -561,6 +573,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -616,47 +693,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -668,13 +763,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -746,7 +848,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/food-and-dining/jimmy-johns/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/food-and-dining/jimmy-johns/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260511-034611",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/food-and-dining/jimmy-johns",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/food-and-dining/jimmy-johns/internal/cli/auth.go
+++ b/library/food-and-dining/jimmy-johns/internal/cli/auth.go
@@ -477,10 +477,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/food-and-dining/jimmy-johns/internal/cli/auth.go
+++ b/library/food-and-dining/jimmy-johns/internal/cli/auth.go
@@ -37,9 +37,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -91,7 +97,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -244,7 +250,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -282,17 +288,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -317,6 +329,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -372,47 +449,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -424,13 +519,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -502,7 +604,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/food-and-dining/jimmy-johns/internal/cli/auth.go
+++ b/library/food-and-dining/jimmy-johns/internal/cli/auth.go
@@ -490,8 +490,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/food-and-dining/ordertogo/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/food-and-dining/ordertogo/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260510-083403",
+  "base_printing_press_version": "4.2.2",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/food-and-dining/ordertogo",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/food-and-dining/ordertogo/internal/cli/auth.go
+++ b/library/food-and-dining/ordertogo/internal/cli/auth.go
@@ -487,8 +487,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/food-and-dining/ordertogo/internal/cli/auth.go
+++ b/library/food-and-dining/ordertogo/internal/cli/auth.go
@@ -39,9 +39,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -241,7 +247,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -279,17 +285,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -314,6 +326,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -369,47 +446,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -421,13 +516,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -499,7 +601,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/food-and-dining/ordertogo/internal/cli/auth.go
+++ b/library/food-and-dining/ordertogo/internal/cli/auth.go
@@ -474,10 +474,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/food-and-dining/pagliacci/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/food-and-dining/pagliacci/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260503-000558",
+  "base_printing_press_version": "3.7.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/food-and-dining/pagliacci",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/food-and-dining/pagliacci/internal/cli/auth.go
+++ b/library/food-and-dining/pagliacci/internal/cli/auth.go
@@ -36,9 +36,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"customerId", "authToken"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -90,7 +96,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -297,7 +303,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -335,17 +341,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -370,6 +382,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -425,47 +502,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -477,13 +572,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -555,7 +657,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/food-and-dining/pagliacci/internal/cli/auth.go
+++ b/library/food-and-dining/pagliacci/internal/cli/auth.go
@@ -543,8 +543,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/food-and-dining/pagliacci/internal/cli/auth.go
+++ b/library/food-and-dining/pagliacci/internal/cli/auth.go
@@ -530,10 +530,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/marketing/erank/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/marketing/erank/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260531-142147",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/marketing/erank",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/marketing/erank/internal/cli/auth.go
+++ b/library/marketing/erank/internal/cli/auth.go
@@ -934,8 +934,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/marketing/erank/internal/cli/auth.go
+++ b/library/marketing/erank/internal/cli/auth.go
@@ -46,9 +46,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"er_sess_x", "sid_er", "XSRF-TOKEN"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -138,7 +144,7 @@ profile by name when the installed backend supports it.`,
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
 				profileDir := ""
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -688,7 +694,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -726,17 +732,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -761,6 +773,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -816,47 +893,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -868,13 +963,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -1001,7 +1103,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/marketing/erank/internal/cli/auth.go
+++ b/library/marketing/erank/internal/cli/auth.go
@@ -921,10 +921,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/media-and-entertainment/podcast-goat/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/media-and-entertainment/podcast-goat/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260517-103310",
+  "base_printing_press_version": "4.8.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go",
+    "internal/cli/auth_login_chrome.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/media-and-entertainment/podcast-goat",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
+++ b/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
@@ -557,10 +557,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
+++ b/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
@@ -570,8 +570,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
+++ b/library/media-and-entertainment/podcast-goat/internal/cli/auth.go
@@ -42,9 +42,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -108,7 +114,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool.name) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -324,7 +330,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -362,17 +368,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -397,6 +409,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -452,47 +529,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -504,13 +599,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -619,7 +721,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/media-and-entertainment/podcast-goat/internal/cli/auth_login_chrome.go
+++ b/library/media-and-entertainment/podcast-goat/internal/cli/auth_login_chrome.go
@@ -70,7 +70,7 @@ Equivalent shorthand: ` + "`auth login --chrome --service <name>`" + ` (use this
 			if err != nil {
 				return authErr(fmt.Errorf("no cookie extraction tool found: %w", err))
 			}
-			profileDir, err := resolveChromeProfile(cmd.OutOrStdout(), os.Stdin, domain, flagProfile)
+			profileDir, err := resolveChromeProfile(cmd.OutOrStdout(), os.Stdin, domain, flagProfile, requiredAuthCookies())
 			if err != nil {
 				return authErr(err)
 			}

--- a/library/media-and-entertainment/skool/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/media-and-entertainment/skool/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260510-114931",
+  "base_printing_press_version": "4.0.6",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/media-and-entertainment/skool",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/media-and-entertainment/skool/internal/cli/auth.go
+++ b/library/media-and-entertainment/skool/internal/cli/auth.go
@@ -45,9 +45,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -99,7 +105,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -239,7 +245,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -277,17 +283,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -312,6 +324,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -381,47 +458,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -433,13 +528,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -511,7 +613,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/media-and-entertainment/skool/internal/cli/auth.go
+++ b/library/media-and-entertainment/skool/internal/cli/auth.go
@@ -486,10 +486,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/media-and-entertainment/skool/internal/cli/auth.go
+++ b/library/media-and-entertainment/skool/internal/cli/auth.go
@@ -499,8 +499,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/media-and-entertainment/substack/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/media-and-entertainment/substack/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260531-014452",
+  "base_printing_press_version": "4.19.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/media-and-entertainment/substack",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/media-and-entertainment/substack/internal/cli/auth.go
+++ b/library/media-and-entertainment/substack/internal/cli/auth.go
@@ -631,8 +631,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/media-and-entertainment/substack/internal/cli/auth.go
+++ b/library/media-and-entertainment/substack/internal/cli/auth.go
@@ -618,10 +618,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/media-and-entertainment/substack/internal/cli/auth.go
+++ b/library/media-and-entertainment/substack/internal/cli/auth.go
@@ -9,6 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gorilla/websocket"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/cliutil"
+	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
 	"github.com/spf13/cobra"
 	"io"
 	"net/http"
@@ -18,9 +21,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/client"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/cliutil"
-	"github.com/mvanhorn/printing-press-library/library/media-and-entertainment/substack/internal/config"
 	"time"
 )
 
@@ -41,9 +41,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"substack.sid"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -128,7 +134,7 @@ profile by name when the installed backend supports it.`,
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
 				profileDir := ""
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -385,7 +391,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -423,17 +429,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -458,6 +470,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -513,47 +590,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -565,13 +660,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -698,7 +800,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/other/gisis/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/other/gisis/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260527-211808",
+  "base_printing_press_version": "4.18.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/other/gisis",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/other/gisis/internal/cli/auth.go
+++ b/library/other/gisis/internal/cli/auth.go
@@ -626,8 +626,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/other/gisis/internal/cli/auth.go
+++ b/library/other/gisis/internal/cli/auth.go
@@ -613,10 +613,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/other/gisis/internal/cli/auth.go
+++ b/library/other/gisis/internal/cli/auth.go
@@ -42,9 +42,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"IMOWEBACC"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -140,7 +146,7 @@ GISIS_KOOKY_BROWSER (e.g. "brave") to scope kooky to one browser.`,
 				// Step 2: Resolve which Chrome profile to use when the backend can honor it
 				profileDir := ""
 				if cookieToolSupportsProfiles(tool.name) {
-					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+					profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 					if err != nil {
 						loginURL := "https://" + strings.TrimPrefix(domain, ".")
 						fmt.Fprintln(w, "")
@@ -380,7 +386,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -418,17 +424,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -453,6 +465,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -508,47 +585,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -560,13 +655,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -703,7 +805,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/other/gravitus/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/other/gravitus/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260517-231116",
+  "base_printing_press_version": "4.11.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/other/gravitus",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/other/gravitus/internal/cli/auth.go
+++ b/library/other/gravitus/internal/cli/auth.go
@@ -493,8 +493,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/other/gravitus/internal/cli/auth.go
+++ b/library/other/gravitus/internal/cli/auth.go
@@ -37,9 +37,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -103,7 +109,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool.name) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -247,7 +253,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -285,17 +291,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -320,6 +332,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -375,47 +452,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -427,13 +522,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -542,7 +644,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/other/gravitus/internal/cli/auth.go
+++ b/library/other/gravitus/internal/cli/auth.go
@@ -480,10 +480,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/productivity/myfitnesspal/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/productivity/myfitnesspal/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260508-133559",
+  "base_printing_press_version": "4.0.6",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/productivity/myfitnesspal",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/productivity/myfitnesspal/internal/cli/auth.go
+++ b/library/productivity/myfitnesspal/internal/cli/auth.go
@@ -720,8 +720,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/productivity/myfitnesspal/internal/cli/auth.go
+++ b/library/productivity/myfitnesspal/internal/cli/auth.go
@@ -707,10 +707,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/productivity/myfitnesspal/internal/cli/auth.go
+++ b/library/productivity/myfitnesspal/internal/cli/auth.go
@@ -41,9 +41,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -95,7 +101,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -474,7 +480,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -512,17 +518,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -547,6 +559,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -602,47 +679,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -654,13 +749,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -740,7 +842,7 @@ func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 		cleanDomain = "www." + cleanDomain
 	}
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/social-and-messaging/x-twitter/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "Teach x.com auth login to scan Chrome profiles for auth_token and ct0.",
+  "reason": "x-twitter auth previously called pycookiecheat without a cookie DB path, so users logged in under non-Default Chrome profiles were reported as unauthenticated.",
+  "files": [
+    "internal/cli/x_auth_login.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/social-and-messaging/x-twitter",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -46,6 +48,7 @@ func xCookieFilePath() (string, error) {
 
 func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var chrome bool
+	var profile string
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Capture x.com session cookies for X Articles (use --chrome)",
@@ -56,8 +59,11 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 			"only sets up the cookie session the `articles ...` commands read.\n\n" +
 			"auth_token is an httpOnly cookie, so this shells out to a cookie reader that\n" +
 			"can see it: pycookiecheat (recommended: pip install pycookiecheat), or the\n" +
-			"press-auth companion. Make sure you're logged into x.com in Chrome first.",
-		Example: "  x-twitter-pp-cli auth login --chrome",
+			"press-auth companion. Make sure you're logged into x.com in Chrome first.\n\n" +
+			"If you use multiple Chrome profiles, this command checks each profile for\n" +
+			"auth_token + ct0. Use --profile to force a specific Chrome profile.",
+		Example: "  x-twitter-pp-cli auth login --chrome\n" +
+			"  x-twitter-pp-cli auth login --chrome --profile \"Profile 1\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 			if !chrome {
@@ -75,7 +81,7 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 
-			authToken, ct0, source, err := captureXSessionCookies(w)
+			authToken, ct0, source, err := captureXSessionCookies(w, profile)
 			if err != nil {
 				return err
 			}
@@ -108,6 +114,7 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&chrome, "chrome", false, "Capture cookies from your logged-in Chrome session")
 	cmd.Flags().BoolVar(&chrome, "browser", false, "Alias for --chrome")
+	cmd.Flags().StringVar(&profile, "profile", "", "Chrome profile name or directory (e.g. \"Default\", \"Profile 1\", \"Work\")")
 	return cmd
 }
 
@@ -115,13 +122,32 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 // installer is to have them: pycookiecheat first (the recommended pip install,
 // reads Chrome's cookie DB including httpOnly cookies), then the press-auth
 // companion. Returns actionable install + manual guidance when neither works.
-func captureXSessionCookies(w io.Writer) (authToken, ct0, source string, err error) {
+func captureXSessionCookies(w io.Writer, profile string) (authToken, ct0, source string, err error) {
 	if bin, lookErr := exec.LookPath("pycookiecheat"); lookErr == nil {
-		at, c, ok := cookiesFromPycookiecheat(bin)
-		if ok {
-			return at, c, "pycookiecheat", nil
+		profiles, profileErr := chromeCookieProfiles(profile)
+		if profileErr != nil {
+			if profile != "" {
+				return "", "", "", fmt.Errorf("resolving Chrome profile: %w", profileErr)
+			}
+			fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); trying pycookiecheat default profile.\n", profileErr)
 		}
-		fmt.Fprintln(w, "pycookiecheat is installed but found no x.com session — are you logged into x.com in Chrome?")
+		for _, candidate := range profiles {
+			at, c, ok := cookiesFromPycookiecheat(bin, candidate.CookiePath)
+			if ok {
+				return at, c, "pycookiecheat (" + candidate.DisplayName + ")", nil
+			}
+		}
+		if len(profiles) == 0 && profile == "" {
+			at, c, ok := cookiesFromPycookiecheat(bin, "")
+			if ok {
+				return at, c, "pycookiecheat", nil
+			}
+		}
+		if profile != "" {
+			fmt.Fprintf(w, "pycookiecheat is installed but found no x.com session in Chrome profile %q.\n", profile)
+		} else {
+			fmt.Fprintln(w, "pycookiecheat is installed but found no x.com session in any Chrome profile — are you logged into x.com in Chrome?")
+		}
 	}
 	if bin, lookErr := exec.LookPath("press-auth"); lookErr == nil {
 		at, c, ok := cookiesFromPressAuth(bin)
@@ -135,8 +161,12 @@ func captureXSessionCookies(w io.Writer) (authToken, ct0, source string, err err
 
 // cookiesFromPycookiecheat runs `pycookiecheat https://x.com`, which prints a
 // flat {cookie_name: value} JSON object read from Chrome's cookie DB.
-func cookiesFromPycookiecheat(bin string) (authToken, ct0 string, ok bool) {
-	out, err := exec.Command(bin, "https://"+xCookieDomain).Output()
+func cookiesFromPycookiecheat(bin, cookiePath string) (authToken, ct0 string, ok bool) {
+	args := []string{"https://" + xCookieDomain}
+	if cookiePath != "" {
+		args = []string{"-c", cookiePath, "https://" + xCookieDomain}
+	}
+	out, err := exec.Command(bin, args...).Output()
 	if err != nil {
 		return "", "", false
 	}
@@ -147,6 +177,105 @@ func cookiesFromPycookiecheat(bin string) (authToken, ct0 string, ok bool) {
 	authToken = jar["auth_token"]
 	ct0 = jar["ct0"]
 	return authToken, ct0, authToken != "" && ct0 != ""
+}
+
+type xChromeCookieProfile struct {
+	Dir         string
+	DisplayName string
+	CookiePath  string
+}
+
+func chromeCookieProfiles(profile string) ([]xChromeCookieProfile, error) {
+	dataDir, err := chromeUserDataDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read Chrome data directory: %w", err)
+	}
+
+	var profiles []xChromeCookieProfile
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := entry.Name()
+		if dir != "Default" && !strings.HasPrefix(dir, "Profile ") {
+			continue
+		}
+		cookiePath := filepath.Join(dataDir, dir, "Cookies")
+		if _, err := os.Stat(cookiePath); err != nil {
+			continue
+		}
+		displayName := readChromeProfileDisplayName(filepath.Join(dataDir, dir, "Preferences"))
+		if displayName == "" {
+			displayName = dir
+		}
+		profiles = append(profiles, xChromeCookieProfile{
+			Dir:         dir,
+			DisplayName: displayName,
+			CookiePath:  cookiePath,
+		})
+	}
+
+	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].Dir == "Default" {
+			return true
+		}
+		if profiles[j].Dir == "Default" {
+			return false
+		}
+		return profiles[i].Dir < profiles[j].Dir
+	})
+
+	if profile == "" {
+		return profiles, nil
+	}
+	lower := strings.ToLower(profile)
+	for _, candidate := range profiles {
+		if strings.ToLower(candidate.Dir) == lower || strings.ToLower(candidate.DisplayName) == lower {
+			return []xChromeCookieProfile{candidate}, nil
+		}
+	}
+	return nil, fmt.Errorf("Chrome profile %q not found", profile)
+}
+
+func chromeUserDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Google", "Chrome"), nil
+	case "linux":
+		return filepath.Join(home, ".config", "google-chrome"), nil
+	case "windows":
+		localAppData := os.Getenv("LOCALAPPDATA")
+		if localAppData == "" {
+			localAppData = filepath.Join(home, "AppData", "Local")
+		}
+		return filepath.Join(localAppData, "Google", "Chrome", "User Data"), nil
+	default:
+		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+}
+
+func readChromeProfileDisplayName(prefsPath string) string {
+	data, err := os.ReadFile(prefsPath)
+	if err != nil {
+		return ""
+	}
+	var prefs struct {
+		Profile struct {
+			Name string `json:"name"`
+		} `json:"profile"`
+	}
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		return ""
+	}
+	return prefs.Profile.Name
 }
 
 // cookiesFromPressAuth runs `press-auth cookies x.com`, which prints a Cookie

--- a/library/travel/airbnb/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/travel/airbnb/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "",
+  "base_printing_press_version": "3.6.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/travel/airbnb",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/travel/airbnb/internal/cli/auth.go
+++ b/library/travel/airbnb/internal/cli/auth.go
@@ -478,10 +478,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/travel/airbnb/internal/cli/auth.go
+++ b/library/travel/airbnb/internal/cli/auth.go
@@ -36,9 +36,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -90,7 +96,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -245,7 +251,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -283,17 +289,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -318,6 +330,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -373,47 +450,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -425,13 +520,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -503,7 +605,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/travel/airbnb/internal/cli/auth.go
+++ b/library/travel/airbnb/internal/cli/auth.go
@@ -491,8 +491,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/travel/alaska-airlines/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/travel/alaska-airlines/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260512-151223",
+  "base_printing_press_version": "4.5.1",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/travel/alaska-airlines",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/travel/alaska-airlines/internal/cli/auth.go
+++ b/library/travel/alaska-airlines/internal/cli/auth.go
@@ -39,9 +39,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"AS_ACNT", "AS_NAME", "guestsession", "guestidentity", "ASSession", "ASSessionSSL", "as_pers"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -93,7 +99,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -301,7 +307,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -336,17 +342,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -371,6 +383,81 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro&_journal_mode=OFF&_busy_timeout=2000")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer db.Close()
+
+	placeholders := make([]string, 0, len(requiredCookies))
+	args := make([]any, 0, len(requiredCookies)+1)
+	args = append(args, domainPattern)
+	for _, name := range requiredCookies {
+		placeholders = append(placeholders, "?")
+		args = append(args, name)
+	}
+	query := "SELECT DISTINCT name FROM cookies WHERE host_key LIKE ? AND name IN (" + strings.Join(placeholders, ",") + ")"
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -428,47 +515,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -480,13 +585,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -558,7 +670,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/travel/alaska-airlines/internal/cli/auth.go
+++ b/library/travel/alaska-airlines/internal/cli/auth.go
@@ -543,10 +543,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/travel/alaska-airlines/internal/cli/auth.go
+++ b/library/travel/alaska-airlines/internal/cli/auth.go
@@ -556,8 +556,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/travel/booking-com/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/travel/booking-com/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260519-175228",
+  "base_printing_press_version": "4.9.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/travel/booking-com",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/travel/booking-com/internal/cli/auth.go
+++ b/library/travel/booking-com/internal/cli/auth.go
@@ -41,9 +41,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{"aws-waf-token", "bkng", "bkng_sso_session", "cgumid", "bkng_prue"}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -102,7 +108,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool.name) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -327,7 +333,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -365,17 +371,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -400,6 +412,71 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	quotedNames := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		quotedNames = append(quotedNames, sqlQuoteLiteral(name))
+	}
+	query := fmt.Sprintf("SELECT DISTINCT name FROM cookies WHERE host_key LIKE %s AND name IN (%s)", sqlQuoteLiteral(domainPattern), strings.Join(quotedNames, ","))
+	out, err := exec.Command("sqlite3", tmpPath, query).Output()
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name := strings.TrimSpace(line)
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
+}
+
+func sqlQuoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -470,47 +547,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -522,13 +617,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -637,7 +739,7 @@ func extractCookies(tool cookieTool, domain, profileDir string) (string, error) 
 func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/travel/booking-com/internal/cli/auth.go
+++ b/library/travel/booking-com/internal/cli/auth.go
@@ -575,10 +575,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {

--- a/library/travel/booking-com/internal/cli/auth.go
+++ b/library/travel/booking-com/internal/cli/auth.go
@@ -588,8 +588,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/travel/pointhound/.printing-press-patches/chrome-profile-cookie-selection.json
+++ b/library/travel/pointhound/.printing-press-patches/chrome-profile-cookie-selection.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 2,
+  "id": "chrome-profile-cookie-selection",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260511-212436",
+  "base_printing_press_version": "4.4.0",
+  "summary": "Prefer Chrome profiles with required auth cookies during browser-cookie login.",
+  "reason": "Profile auto-detection previously ranked profiles only by total target-domain cookie count and skipped explicit Default-profile pycookiecheat paths, which could choose a profile with guest or challenge cookies instead of the authenticated session.",
+  "files": [
+    "internal/cli/auth.go"
+  ],
+  "validated_outcome": "go test ./... passed from library/travel/pointhound",
+  "upstream_issue": "https://github.com/mvanhorn/printing-press-library/issues/1064"
+}

--- a/library/travel/pointhound/internal/cli/auth.go
+++ b/library/travel/pointhound/internal/cli/auth.go
@@ -40,9 +40,15 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 
 // chromeProfile holds info about a discovered Chrome profile.
 type chromeProfile struct {
-	Dir         string // directory name (e.g. "Default", "Profile 1")
-	DisplayName string // human-readable name from Preferences
-	CookieCount int    // number of cookies matching the target domain
+	Dir                 string   // directory name (e.g. "Default", "Profile 1")
+	DisplayName         string   // human-readable name from Preferences
+	CookieCount         int      // number of cookies matching the target domain
+	RequiredCookieCount int      // number of required auth cookies present
+	MissingCookies      []string // required auth cookies absent from this profile
+}
+
+func requiredAuthCookies() []string {
+	return []string{}
 }
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
@@ -94,7 +100,7 @@ profile by name when the installed backend supports it.`,
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
 			if cookieToolSupportsProfiles(tool) {
-				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
+				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag, requiredAuthCookies())
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
 					fmt.Fprintln(w, "")
@@ -229,7 +235,7 @@ func chromeDataDir() (string, error) {
 }
 
 // discoverChromeProfiles finds Chrome profiles and counts cookies matching the domain.
-func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
+func discoverChromeProfiles(domain string, requiredCookies []string) ([]chromeProfile, error) {
 	dataDir, err := chromeDataDir()
 	if err != nil {
 		return nil, err
@@ -263,17 +269,23 @@ func discoverChromeProfiles(domain string) ([]chromeProfile, error) {
 			displayName = name
 		}
 
-		count := countCookiesForDomain(cookiesDB, domainPattern)
+		inspection := inspectCookiesForDomain(cookiesDB, domainPattern, requiredCookies)
 
 		profiles = append(profiles, chromeProfile{
-			Dir:         name,
-			DisplayName: displayName,
-			CookieCount: count,
+			Dir:                 name,
+			DisplayName:         displayName,
+			CookieCount:         inspection.Count,
+			RequiredCookieCount: inspection.RequiredCookieCount,
+			MissingCookies:      inspection.MissingCookies,
 		})
 	}
 
-	// Sort: profiles with cookies first, then by directory name
+	// Sort: profiles with required auth cookies first, then with the most
+	// target-domain cookies, then by directory name for determinism.
 	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].RequiredCookieCount != profiles[j].RequiredCookieCount {
+			return profiles[i].RequiredCookieCount > profiles[j].RequiredCookieCount
+		}
 		if profiles[i].CookieCount != profiles[j].CookieCount {
 			return profiles[i].CookieCount > profiles[j].CookieCount
 		}
@@ -298,6 +310,81 @@ func readProfileDisplayName(prefsPath string) string {
 		return ""
 	}
 	return prefs.Profile.Name
+}
+
+type chromeCookieInspection struct {
+	Count               int
+	RequiredCookieCount int
+	MissingCookies      []string
+}
+
+func inspectCookiesForDomain(cookiesDB, domainPattern string, requiredCookies []string) chromeCookieInspection {
+	result := chromeCookieInspection{Count: countCookiesForDomain(cookiesDB, domainPattern)}
+	if len(requiredCookies) == 0 {
+		return result
+	}
+
+	missing := make(map[string]bool, len(requiredCookies))
+	for _, name := range requiredCookies {
+		missing[name] = true
+	}
+
+	tmpFile, err := os.CreateTemp("", "cookies-probe-*.db")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+	defer os.Remove(tmpPath + "-wal")
+	defer os.Remove(tmpPath + "-shm")
+
+	if err := copyFileIfExists(cookiesDB, tmpPath); err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	_ = copyFileIfExists(cookiesDB+"-wal", tmpPath+"-wal")
+	_ = copyFileIfExists(cookiesDB+"-shm", tmpPath+"-shm")
+
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro&_journal_mode=OFF&_busy_timeout=2000")
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer db.Close()
+
+	placeholders := make([]string, 0, len(requiredCookies))
+	args := make([]any, 0, len(requiredCookies)+1)
+	args = append(args, domainPattern)
+	for _, name := range requiredCookies {
+		placeholders = append(placeholders, "?")
+		args = append(args, name)
+	}
+	query := "SELECT DISTINCT name FROM cookies WHERE host_key LIKE ? AND name IN (" + strings.Join(placeholders, ",") + ")"
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		result.MissingCookies = requiredCookies
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if missing[name] {
+			delete(missing, name)
+			result.RequiredCookieCount++
+		}
+	}
+	for _, name := range requiredCookies {
+		if missing[name] {
+			result.MissingCookies = append(result.MissingCookies, name)
+		}
+	}
+	return result
 }
 
 // countCookiesForDomain copies the Cookies DB (plus WAL/SHM) to temp and counts matching rows.
@@ -355,47 +442,65 @@ func copyFileIfExists(src, dst string) error {
 
 // resolveChromeProfile determines which Chrome profile to read cookies from.
 // Priority: --profile flag > auto-detect (single match) > interactive prompt.
-func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) (string, error) {
+func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, requiredCookies []string) (string, error) {
 	if profileFlag != "" {
 		return resolveProfileByName(profileFlag)
 	}
 
-	profiles, err := discoverChromeProfiles(domain)
+	profiles, err := discoverChromeProfiles(domain, requiredCookies)
 	if err != nil {
 		// Profile probing is optional; cookie extraction can still succeed without it.
 		fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); continuing without auto-detection.\n", err)
 		return "", nil
 	}
 
-	// Filter to profiles that have cookies for this domain
+	// Prefer profiles that contain every required auth cookie. If the CLI does
+	// not know specific cookie names, fall back to any target-domain cookie.
+	var withRequired []chromeProfile
 	var withCookies []chromeProfile
 	for _, p := range profiles {
+		if len(requiredCookies) > 0 && p.RequiredCookieCount == len(requiredCookies) {
+			withRequired = append(withRequired, p)
+		}
 		if p.CookieCount > 0 {
 			withCookies = append(withCookies, p)
 		}
 	}
 
-	switch len(withCookies) {
+	if len(withRequired) > 0 {
+		return chooseChromeProfile(w, r, withRequired, domain, true)
+	}
+	if len(withCookies) > 0 {
+		return chooseChromeProfile(w, r, withCookies, domain, false)
+	}
+	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {
+	label := "cookies"
+	if required {
+		label = "required cookies"
+	}
+
+	switch len(profiles) {
 	case 0:
 		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
-		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s)\n", withCookies[0].DisplayName, withCookies[0].Dir)
-		return withCookies[0].Dir, nil
+		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
+		return profiles[0].Dir, nil
 	default:
-		// Multiple profiles have cookies.
-		// Non-interactive: pick the profile with the most cookies (already sorted).
-		// Interactive: ask the user.
+		// Multiple profiles have matching cookies. Non-interactive runs pick the
+		// strongest match; terminals get an explicit choice.
 		if !isTerminal(w) {
-			// Non-interactive — auto-select the best profile (most cookies, first in sorted list)
-			selected := withCookies[0]
-			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d cookies)\n", selected.DisplayName, selected.Dir, selected.CookieCount)
+			selected := profiles[0]
+			fmt.Fprintf(w, "Auto-selected Chrome profile: %s (%s, %d %s)\n", selected.DisplayName, selected.Dir, profileCookieCount(selected, required), label)
 			fmt.Fprintf(w, "Use --profile to select a different profile.\n")
 			return selected.Dir, nil
 		}
 
 		fmt.Fprintf(w, "Multiple Chrome profiles have cookies for %s:\n", domain)
-		for i, p := range withCookies {
-			fmt.Fprintf(w, "  %d. %s (%s, %d cookies)\n", i+1, p.DisplayName, p.Dir, p.CookieCount)
+		for i, p := range profiles {
+			fmt.Fprintf(w, "  %d. %s (%s, %d %s)\n", i+1, p.DisplayName, p.Dir, profileCookieCount(p, required), label)
 		}
 		fmt.Fprintf(w, "Which profile? [1]: ")
 
@@ -407,13 +512,20 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string) 
 				fmt.Sscanf(text, "%d", &choice)
 			}
 		}
-		if choice < 1 || choice > len(withCookies) {
+		if choice < 1 || choice > len(profiles) {
 			choice = 1
 		}
-		selected := withCookies[choice-1]
+		selected := profiles[choice-1]
 		fmt.Fprintf(w, "Using profile: %s (%s)\n", selected.DisplayName, selected.Dir)
 		return selected.Dir, nil
 	}
+}
+
+func profileCookieCount(profile chromeProfile, required bool) int {
+	if required {
+		return profile.RequiredCookieCount
+	}
+	return profile.CookieCount
 }
 
 // resolveProfileByName finds a Chrome profile directory by its display name.
@@ -485,7 +597,7 @@ func extractCookies(tool, domain, profileDir string) (string, error) {
 func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
-	if profileDir != "" && profileDir != "Default" {
+	if profileDir != "" {
 		dataDir, err := chromeDataDir()
 		if err == nil {
 			cookiePath = filepath.Join(dataDir, profileDir, "Cookies")

--- a/library/travel/pointhound/internal/cli/auth.go
+++ b/library/travel/pointhound/internal/cli/auth.go
@@ -483,8 +483,6 @@ func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, dom
 	}
 
 	switch len(profiles) {
-	case 0:
-		return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
 	case 1:
 		fmt.Fprintf(w, "Auto-detected Chrome profile: %s (%s, %d %s)\n", profiles[0].DisplayName, profiles[0].Dir, profileCookieCount(profiles[0], required), label)
 		return profiles[0].Dir, nil

--- a/library/travel/pointhound/internal/cli/auth.go
+++ b/library/travel/pointhound/internal/cli/auth.go
@@ -470,10 +470,26 @@ func resolveChromeProfile(w io.Writer, r io.Reader, domain, profileFlag string, 
 	if len(withRequired) > 0 {
 		return chooseChromeProfile(w, r, withRequired, domain, true)
 	}
+	if len(requiredCookies) > 0 {
+		printMissingCookieHint(w, profiles, requiredCookies)
+	}
 	if len(withCookies) > 0 {
 		return chooseChromeProfile(w, r, withCookies, domain, false)
 	}
 	return "", fmt.Errorf("no Chrome profile has cookies for %s", domain)
+}
+
+func printMissingCookieHint(w io.Writer, profiles []chromeProfile, requiredCookies []string) {
+	if len(requiredCookies) == 0 {
+		return
+	}
+	for _, p := range profiles {
+		if p.CookieCount == 0 || len(p.MissingCookies) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "Chrome profile %s (%s) is missing required cookies: %s\n", p.DisplayName, p.Dir, strings.Join(p.MissingCookies, ", "))
+		return
+	}
 }
 
 func chooseChromeProfile(w io.Writer, r io.Reader, profiles []chromeProfile, domain string, required bool) (string, error) {


### PR DESCRIPTION
## Summary

- Fix Chrome browser-cookie auth profile selection across published CLIs that rely on Chrome cookies.
- Patch x-twitter's hand-authored auth flow so `auth login --chrome` scans Chrome profiles for `auth_token` + `ct0` and accepts `--profile`.
- Add `.printing-press-patches/chrome-profile-cookie-selection.json` ledgers for each touched CLI.

## Published CLI Metadata

**API:** multiple published CLIs | **Category:** commerce, education, food-and-dining, marketing, media-and-entertainment, other, productivity, social-and-messaging, travel | **Press version:** existing per CLI  
**Spec:** existing published CLI sources  
**Required env:** unchanged

## What Changed

Chrome profile auto-detection now tracks required auth-cookie names where the printed CLI already validates named cookies after extraction. Those CLIs prefer profiles containing the full required cookie set, then fall back to profiles with any target-domain cookies.

For generic cookie CLIs without named cookie contracts, behavior remains the existing target-domain-cookie fallback, but pycookiecheat now receives explicit Chrome cookie DB paths for all selected profiles, including `Default`.

x-twitter was hand-authored and did not use the generated resolver. Its auth login now discovers Chrome profiles, tries each profile's Cookies DB with pycookiecheat, and only succeeds when both `auth_token` and `ct0` are present. It does not print cookie values.

Root cause: the older profile resolver ranked profiles by total target-domain cookie count. That can select a profile containing guest, challenge, or analytics cookies while missing the profile that has the actual authenticated session cookies. x-twitter was stricter and called pycookiecheat without a cookie DB path, so users logged into non-Default Chrome profiles were reported as unauthenticated.

## CLI Shape

```bash
$ x-twitter-pp-cli auth login --help
Usage:
  x-twitter-pp-cli auth login [flags]

Flags:
      --browser          Alias for --chrome
      --chrome           Capture cookies from your logged-in Chrome session
      --profile string   Chrome profile name or directory (e.g. "Default", "Profile 1", "Work")
```

## What This CLI Does

This is a targeted patch to existing published CLIs. It does not add new API surfaces beyond x-twitter's `--profile` flag for its existing `auth login --chrome` command. Other affected CLIs keep their existing auth command shape while improving the automatic profile choice.

## Manuscripts

- Not applicable: this PR patches existing published CLI source without reprinting.

## Validation

- [x] `go test ./...` from every touched CLI root
- [x] `python3 .github/scripts/verify-skill/verify_skill.py --dir library/<category>/<slug>/` for every touched CLI root
- [x] `GOTOOLCHAIN=go1.26.4 go build ./...` from every touched CLI root
- [x] `GOTOOLCHAIN=go1.26.4 go vet ./...` from every touched CLI root
- [x] `GOTOOLCHAIN=go1.26.4 govulncheck ./...` from every touched CLI root
- [x] `git diff --check`

Notes:
- `govulncheck` initially failed under local `go1.26.3` because the vulnerability database flags standard-library issues fixed in `go1.26.4`; rerunning with `GOTOOLCHAIN=go1.26.4` passed.
- `verify-skill` reported 0 errors and likely false positives for Skool and GISIS positional-arg examples; the checker marked those as likely false positives and continued.

## Safety Review

- No live auth capture was run while validating this PR.
- Named required-cookie preference is limited to CLIs that already validate those exact cookie names after extraction: Pagliacci, eRank, Substack, GISIS, Alaska Airlines, and Booking.com.
- Generic cookie CLIs retain their previous fallback behavior and only gain explicit cookie DB paths for selected profiles.
- x-twitter does not log or persist cookie values beyond the existing cookies.json write path after successful login.
- Static checks confirmed no stale old resolver call signatures, old `discoverChromeProfiles(domain)` calls, old skipped-Default pycookiecheat path, or old x-twitter `cookiesFromPycookiecheat(bin)` call remains.

Closes #1064.
