### PR TITLE
fix(x-twitter): provide user id for articles list

### DIFF
--- a/library/social-and-messaging/x-twitter/.printing-press-patches/articles-list-cookie-user-id.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/articles-list-cookie-user-id.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 2,
+  "id": "articles-list-cookie-user-id",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "X Articles list must supply the signed-in browser user's id from the cookie session when building the ArticleEntitiesSlice GraphQL variables.",
+  "reason": "The Articles surface is authenticated by x.com browser cookies, not by the v2 OAuth token path; omitting userId produces a GraphQL validation failure even when auth_token and ct0 are valid.",
+  "files": [
+    "internal/cli/articles_list.go",
+    "internal/cli/x_auth_login.go",
+    "internal/client/cookies.go"
+  ],
+  "validated_outcome": "go test ./internal/cli ./internal/client and go build ./cmd/x-twitter-pp-cli passed from library/social-and-messaging/x-twitter with GOCACHE=/private/tmp/pp-go-cache"
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
@@ -35,6 +35,20 @@ func newArticlesListCmd(flags *rootFlags) *cobra.Command {
 			}
 			if flagVariables != "" {
 				params["variables"] = fmt.Sprintf("%v", flagVariables)
+			} else {
+				cookies, err := client.LoadCookieAuth()
+				if err != nil {
+					return classifyAPIError(err, flags)
+				}
+				userID := cookies.ArticleUserID()
+				if userID == "" {
+					return fmt.Errorf("articles list requires the signed-in X user id; re-run `x-twitter-pp-cli auth login --chrome` to refresh cookies with the twid user id, or pass --variables '{\"userId\":\"<x-user-id>\"}'")
+				}
+				variables, err := json.Marshal(map[string]string{"userId": userID})
+				if err != nil {
+					return err
+				}
+				params["variables"] = string(variables)
 			}
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "articles", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,7 +82,7 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 				return nil
 			}
 
-			authToken, ct0, source, err := captureXSessionCookies(w, profile)
+			authToken, ct0, userID, source, err := captureXSessionCookies(w, profile)
 			if err != nil {
 				return err
 			}
@@ -96,6 +97,7 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 			doc := map[string]string{
 				"auth_token":  authToken,
 				"ct0":         ct0,
+				"user_id":     userID,
 				"web_bearer":  xWebBearer,
 				"captured_at": time.Now().UTC().Format("2006-01-02"),
 			}
@@ -122,25 +124,25 @@ func newXAuthLoginCmd(flags *rootFlags) *cobra.Command {
 // installer is to have them: pycookiecheat first (the recommended pip install,
 // reads Chrome's cookie DB including httpOnly cookies), then the press-auth
 // companion. Returns actionable install + manual guidance when neither works.
-func captureXSessionCookies(w io.Writer, profile string) (authToken, ct0, source string, err error) {
+func captureXSessionCookies(w io.Writer, profile string) (authToken, ct0, userID, source string, err error) {
 	if bin, lookErr := exec.LookPath("pycookiecheat"); lookErr == nil {
 		profiles, profileErr := chromeCookieProfiles(profile)
 		if profileErr != nil {
 			if profile != "" {
-				return "", "", "", fmt.Errorf("resolving Chrome profile: %w", profileErr)
+				return "", "", "", "", fmt.Errorf("resolving Chrome profile: %w", profileErr)
 			}
 			fmt.Fprintf(w, "Could not inspect Chrome profiles (%v); trying pycookiecheat default profile.\n", profileErr)
 		}
 		for _, candidate := range profiles {
-			at, c, ok := cookiesFromPycookiecheat(bin, candidate.CookiePath)
+			at, c, uid, ok := cookiesFromPycookiecheat(bin, candidate.CookiePath)
 			if ok {
-				return at, c, "pycookiecheat (" + candidate.DisplayName + ")", nil
+				return at, c, uid, "pycookiecheat (" + candidate.DisplayName + ")", nil
 			}
 		}
 		if len(profiles) == 0 && profile == "" {
-			at, c, ok := cookiesFromPycookiecheat(bin, "")
+			at, c, uid, ok := cookiesFromPycookiecheat(bin, "")
 			if ok {
-				return at, c, "pycookiecheat", nil
+				return at, c, uid, "pycookiecheat", nil
 			}
 		}
 		if profile != "" {
@@ -150,33 +152,34 @@ func captureXSessionCookies(w io.Writer, profile string) (authToken, ct0, source
 		}
 	}
 	if bin, lookErr := exec.LookPath("press-auth"); lookErr == nil {
-		at, c, ok := cookiesFromPressAuth(bin)
+		at, c, uid, ok := cookiesFromPressAuth(bin)
 		if ok {
-			return at, c, "press-auth", nil
+			return at, c, uid, "press-auth", nil
 		}
 		fmt.Fprintf(w, "press-auth is installed but has no captured x.com session. Run: press-auth login %s\n", xCookieDomain)
 	}
-	return "", "", "", fmt.Errorf("%s", xCookieManualGuidance())
+	return "", "", "", "", fmt.Errorf("%s", xCookieManualGuidance())
 }
 
 // cookiesFromPycookiecheat runs `pycookiecheat https://x.com`, which prints a
 // flat {cookie_name: value} JSON object read from Chrome's cookie DB.
-func cookiesFromPycookiecheat(bin, cookiePath string) (authToken, ct0 string, ok bool) {
+func cookiesFromPycookiecheat(bin, cookiePath string) (authToken, ct0, userID string, ok bool) {
 	args := []string{"https://" + xCookieDomain}
 	if cookiePath != "" {
 		args = []string{"-c", cookiePath, "https://" + xCookieDomain}
 	}
 	out, err := exec.Command(bin, args...).Output()
 	if err != nil {
-		return "", "", false
+		return "", "", "", false
 	}
 	var jar map[string]string
 	if err := json.Unmarshal(out, &jar); err != nil {
-		return "", "", false
+		return "", "", "", false
 	}
 	authToken = jar["auth_token"]
 	ct0 = jar["ct0"]
-	return authToken, ct0, authToken != "" && ct0 != ""
+	userID = xUserIDFromTWID(jar["twid"])
+	return authToken, ct0, userID, authToken != "" && ct0 != "" && userID != ""
 }
 
 type xChromeCookieProfile struct {
@@ -280,10 +283,10 @@ func readChromeProfileDisplayName(prefsPath string) string {
 
 // cookiesFromPressAuth runs `press-auth cookies x.com`, which prints a Cookie
 // header line ("auth_token=...; ct0=...; ...") for the captured session.
-func cookiesFromPressAuth(bin string) (authToken, ct0 string, ok bool) {
+func cookiesFromPressAuth(bin string) (authToken, ct0, userID string, ok bool) {
 	out, err := exec.Command(bin, "cookies", xCookieDomain).Output()
 	if err != nil {
-		return "", "", false
+		return "", "", "", false
 	}
 	for _, pair := range strings.Split(strings.TrimSpace(string(out)), ";") {
 		pair = strings.TrimSpace(pair)
@@ -296,9 +299,31 @@ func cookiesFromPressAuth(bin string) (authToken, ct0 string, ok bool) {
 			authToken = strings.TrimSpace(value)
 		case "ct0":
 			ct0 = strings.TrimSpace(value)
+		case "twid":
+			userID = xUserIDFromTWID(strings.TrimSpace(value))
 		}
 	}
-	return authToken, ct0, authToken != "" && ct0 != ""
+	return authToken, ct0, userID, authToken != "" && ct0 != "" && userID != ""
+}
+
+func xUserIDFromTWID(twid string) string {
+	twid = strings.TrimSpace(twid)
+	if twid == "" {
+		return ""
+	}
+	if decoded, err := url.QueryUnescape(twid); err == nil {
+		twid = decoded
+	}
+	twid = strings.TrimPrefix(twid, "\"")
+	twid = strings.TrimSuffix(twid, "\"")
+	twid = strings.TrimPrefix(twid, "u%3D")
+	twid = strings.TrimPrefix(twid, "u=")
+	for _, r := range twid {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return twid
 }
 
 func xCookieManualGuidance() string {
@@ -311,7 +336,7 @@ func xCookieManualGuidance() string {
 		"       go install github.com/mvanhorn/cli-printing-press/v4/cmd/press-auth@latest\n" +
 		"       press-auth login " + xCookieDomain + "\n" +
 		"  3. Manual: in Chrome (logged into x.com) open DevTools -> Application -> Cookies\n" +
-		"     -> https://x.com, copy auth_token and ct0, then write:\n" +
+		"     -> https://x.com, copy auth_token, ct0, and twid (u=<user id>), then write:\n" +
 		"       " + path + "\n" +
-		"     {\"auth_token\":\"<auth_token>\",\"ct0\":\"<ct0>\",\"web_bearer\":\"" + xWebBearer + "\"}"
+		"     {\"auth_token\":\"<auth_token>\",\"ct0\":\"<ct0>\",\"user_id\":\"<twid user id>\",\"web_bearer\":\"" + xWebBearer + "\"}"
 }

--- a/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/x_auth_login.go
@@ -179,7 +179,7 @@ func cookiesFromPycookiecheat(bin, cookiePath string) (authToken, ct0, userID st
 	authToken = jar["auth_token"]
 	ct0 = jar["ct0"]
 	userID = xUserIDFromTWID(jar["twid"])
-	return authToken, ct0, userID, authToken != "" && ct0 != "" && userID != ""
+	return authToken, ct0, userID, authToken != "" && ct0 != ""
 }
 
 type xChromeCookieProfile struct {
@@ -303,7 +303,7 @@ func cookiesFromPressAuth(bin string) (authToken, ct0, userID string, ok bool) {
 			userID = xUserIDFromTWID(strings.TrimSpace(value))
 		}
 	}
-	return authToken, ct0, userID, authToken != "" && ct0 != "" && userID != ""
+	return authToken, ct0, userID, authToken != "" && ct0 != ""
 }
 
 func xUserIDFromTWID(twid string) string {

--- a/library/social-and-messaging/x-twitter/internal/cli/x_auth_login_test.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/x_auth_login_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import "testing"
+
+func TestXUserIDFromTWID(t *testing.T) {
+	tests := []struct {
+		name string
+		twid string
+		want string
+	}{
+		{name: "plain escaped", twid: "u%3D1234567890", want: "1234567890"},
+		{name: "plain equals", twid: "u=1234567890", want: "1234567890"},
+		{name: "quoted escaped", twid: "\"u%3D1234567890\"", want: "1234567890"},
+		{name: "url encoded quotes", twid: "%22u%3D1234567890%22", want: "1234567890"},
+		{name: "reject non numeric", twid: "u%3Dabc123", want: ""},
+		{name: "reject empty", twid: "", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := xUserIDFromTWID(tc.twid); got != tc.want {
+				t.Fatalf("xUserIDFromTWID(%q) = %q, want %q", tc.twid, got, tc.want)
+			}
+		})
+	}
+}

--- a/library/social-and-messaging/x-twitter/internal/client/cookies.go
+++ b/library/social-and-messaging/x-twitter/internal/client/cookies.go
@@ -24,6 +24,7 @@ type cookieAuth struct {
 	AuthToken  string `json:"auth_token"`
 	CT0        string `json:"ct0"`
 	WebBearer  string `json:"web_bearer"`
+	UserID     string `json:"user_id"`
 	CapturedAt string `json:"captured_at"`
 }
 
@@ -48,6 +49,13 @@ func LoadCookieAuth() (*cookieAuth, error) {
 		return nil, fmt.Errorf("cookies file %s is missing one of auth_token, ct0, web_bearer", path)
 	}
 	return &c, nil
+}
+
+func (c *cookieAuth) ArticleUserID() string {
+	if c == nil {
+		return ""
+	}
+	return c.UserID
 }
 
 // applyCookieAuth attaches Source B auth headers to req. Used for hosts


### PR DESCRIPTION
## Summary

Fixes `x-twitter-pp-cli articles list` when the CLI is authenticated through `auth login --chrome`.

The command was reaching X's Articles GraphQL endpoint with valid browser-session cookies, but it omitted the required userId GraphQL variable. X then returned `GRAPHQL_VALIDATION_FAILED` with path ["variable", "userId"].

## Root Cause

`auth login --chrome` captured `auth_token` and `ct0`, but discarded the twid cookie that carries the signed-in browser user's numeric id. articles list then had no browser-session-derived user id and sent an incomplete ArticleEntitiesSlice request. OAuth user-context lookup can also identify the user, but Articles are explicitly set up through browser cookie auth and should not depend on a separate OAuth token.

## Changes

- Capture twid during `auth login --chrome` and persist it as `user_id` in `cookies.json`.
- Teach articles list to auto-fill variables={"userId":"..."} from cookie auth unless --variables is supplied.
- Keep `--variables` as an explicit override for manual GraphQL requests.
- Add a focused parser test for the twid cookie forms Chrome/cookie helpers may return.
- Record the catalog-side customization in .printing-press-patches/.

## Validation

- go test ./internal/cli ./internal/client from library/social-and-messaging/x-twitter
- go build ./cmd/x-twitter-pp-cli from library/social-and-messaging/x-twitter
- go test ./... from library/social-and-messaging/x-twitter
- Dry-run with a temporary cookie config confirmed articles list emits ?variables={"userId":"1234567890"} before making a request.