### PR TITLE
fix(x-twitter): include articles lifecycle variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled Go binaries (generated CLIs)
 *-pp-cli
+*-pp-mcp
 *-pp-cli-[0-9]*
 # But allow CLI source directories in the library
 !library/**/*-pp-cli/

--- a/library/social-and-messaging/x-twitter/.printing-press-patches/articles-list-lifecycle-variable.json
+++ b/library/social-and-messaging/x-twitter/.printing-press-patches/articles-list-lifecycle-variable.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 2,
+  "id": "articles-list-lifecycle-variable",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260603-230951",
+  "base_printing_press_version": "4.20.1",
+  "summary": "X Articles list must supply the ArticleEntitiesSlice lifecycle variable alongside the signed-in browser user id.",
+  "reason": "The live x.com GraphQL operation rejects requests that omit lifecycle even when cookie auth and userId are valid; the CLI should default to Draft while preserving explicit lifecycle and full --variables overrides.",
+  "files": [
+    "internal/cli/articles_list.go"
+  ],
+  "validated_outcome": "Optional lifecycle values Draft and Published were accepted by the live ArticleEntitiesSlice endpoint."
+}

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
@@ -45,6 +45,9 @@ func newArticlesListCmd(flags *rootFlags) *cobra.Command {
 				if userID == "" {
 					return fmt.Errorf("articles list requires the signed-in X user id; re-run `x-twitter-pp-cli auth login --chrome` to refresh cookies with the twid user id, or pass --variables '{\"userId\":\"<x-user-id>\"}'")
 				}
+				if flagLifecycle != "Draft" && flagLifecycle != "Published" {
+					return usageErr(fmt.Errorf("invalid --lifecycle %q: must be Draft or Published", flagLifecycle))
+				}
 				variables, err := json.Marshal(map[string]string{
 					"userId":    userID,
 					"lifecycle": flagLifecycle,

--- a/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
+++ b/library/social-and-messaging/x-twitter/internal/cli/articles_list.go
@@ -15,6 +15,7 @@ import (
 
 func newArticlesListCmd(flags *rootFlags) *cobra.Command {
 	var flagFeatures string
+	var flagLifecycle string
 	var flagVariables string
 
 	cmd := &cobra.Command{
@@ -44,7 +45,10 @@ func newArticlesListCmd(flags *rootFlags) *cobra.Command {
 				if userID == "" {
 					return fmt.Errorf("articles list requires the signed-in X user id; re-run `x-twitter-pp-cli auth login --chrome` to refresh cookies with the twid user id, or pass --variables '{\"userId\":\"<x-user-id>\"}'")
 				}
-				variables, err := json.Marshal(map[string]string{"userId": userID})
+				variables, err := json.Marshal(map[string]string{
+					"userId":    userID,
+					"lifecycle": flagLifecycle,
+				})
 				if err != nil {
 					return err
 				}
@@ -93,6 +97,7 @@ func newArticlesListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&flagFeatures, "features", "", "")
+	cmd.Flags().StringVar(&flagLifecycle, "lifecycle", "Draft", "Article lifecycle to list when --variables is not supplied (Draft or Published)")
 	cmd.Flags().StringVar(&flagVariables, "variables", "", "")
 
 	return cmd


### PR DESCRIPTION
## Summary

Follow-up to #1068. After articles list began supplying the required userId, the live X Articles GraphQL endpoint exposed the next required variable: lifecycle.

This makes x-twitter-pp-cli articles list send both browser-session-derived userId and a lifecycle value when --variables is not supplied.

## Changes

- Add --lifecycle to articles list, defaulting to Draft.
- Include lifecycle in the default ArticleEntitiesSlice GraphQL variables alongside userId.
- Preserve --variables as a full override for callers that need custom GraphQL variables.
- Add a patch metadata entry for the live Articles GraphQL shape requirement.

## Validation

- Reproduced post-#1068 live failure: GRAPHQL_VALIDATION_FAILED for missing lifecycle.
- Confirmed both Draft and Published lifecycle values are accepted by the live endpoint when supplied manually.
- Installed the patched build locally and confirmed x-twitter-pp-cli articles list succeeds live with output redirected.
- go test ./internal/cli ./internal/client from library/social-and-messaging/x-twitter.
- go build ./cmd/x-twitter-pp-cli from library/social-and-messaging/x-twitter.
- go test ./... from library/social-and-messaging/x-twitter.