### PR TITLE
fix(elevenlabs): route file params as uploads

### DIFF
--- a/library/ai/elevenlabs/.printing-press-patches/multipart-file-upload-routing.json
+++ b/library/ai/elevenlabs/.printing-press-patches/multipart-file-upload-routing.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 2,
+  "id": "multipart-file-upload-routing",
+  "applied_at": "2026-06-06",
+  "base_run_id": "20260513T152516Z-e836a3fe",
+  "base_printing_press_version": "4.5.2",
+  "summary": "Route single-path file params through fileFields (real multipart upload) instead of fields (text), so the file bytes are sent rather than the literal path string.",
+  "reason": "speech-to-text, dubbing create, pronunciation-dictionaries add-from-file, and studio add-project/edit-project-content placed single-path file params in the text-field map; encodeMultipartBody writes those with WriteField, so the upload transmitted the path string (e.g. \"/x.mp3\") instead of the file. Confirmed against client.go encodeMultipartBody (fields->WriteField, fileFields->os.Open+CreateFormFile). Sibling commands (audio-isolation, forced-alignment, music separate-song-stems) already use fileFields correctly. Generator-template-shaped: file-typed multipart params should default to fileFields. The studio from_document cases were surfaced by a second Codex review pass.",
+  "files": [
+    "internal/cli/speech-to-text_speech_to_text.go",
+    "internal/cli/dubbing_create.go",
+    "internal/cli/pronunciation-dictionaries_add-from-file.go",
+    "internal/cli/studio_add-project.go",
+    "internal/cli/studio_edit-project-content.go"
+  ],
+  "validated_outcome": "go build ./... && go vet ./... && go test ./... all pass. STT --file, dubbing --file/--csv-file/--foreground-audio-file/--background-audio-file, pronunciation add-from-file --file, and studio add-project/edit-project-content --from-document now upload the file contents.",
+  "notes": "Not fixed here (separate, larger change requiring a multipart client that can emit repeated form parts): multi-file ARRAY params that are JSON-array-of-paths guarded by json.Valid — voices add/add-pvc-samples/edit_voice/request-pvc-manual-verification (--files) and music video-to (--videos). The client's fileFields map[string]string cannot express repeated parts, so these remain a known limitation. audio-native --image is a URL (not a file) and is correctly a text field."
+}

--- a/library/ai/elevenlabs/internal/cli/dubbing_create.go
+++ b/library/ai/elevenlabs/internal/cli/dubbing_create.go
@@ -49,10 +49,12 @@ func newDubbingCreateCmd(flags *rootFlags) *cobra.Command {
 			fields := map[string]string{}
 			fileFields := map[string]string{}
 			if bodyBackgroundAudioFile != "" {
-				fields["background_audio_file"] = bodyBackgroundAudioFile
+				// PATCH: file upload, not a text field.
+				fileFields["background_audio_file"] = bodyBackgroundAudioFile
 			}
 			if bodyCsvFile != "" {
-				fields["csv_file"] = bodyCsvFile
+				// PATCH: file upload, not a text field.
+				fileFields["csv_file"] = bodyCsvFile
 			}
 			if bodyCsvFps != "" {
 				fields["csv_fps"] = bodyCsvFps
@@ -70,10 +72,12 @@ func newDubbingCreateCmd(flags *rootFlags) *cobra.Command {
 				fields["end_time"] = bodyEndTime
 			}
 			if bodyFile != "" {
-				fields["file"] = bodyFile
+				// PATCH: the source media is an upload, not a text field.
+				fileFields["file"] = bodyFile
 			}
 			if bodyForegroundAudioFile != "" {
-				fields["foreground_audio_file"] = bodyForegroundAudioFile
+				// PATCH: file upload, not a text field.
+				fileFields["foreground_audio_file"] = bodyForegroundAudioFile
 			}
 			if bodyHighestResolution != false {
 				fields["highest_resolution"] = fmt.Sprintf("%v", bodyHighestResolution)

--- a/library/ai/elevenlabs/internal/cli/pronunciation-dictionaries_add-from-file.go
+++ b/library/ai/elevenlabs/internal/cli/pronunciation-dictionaries_add-from-file.go
@@ -40,7 +40,8 @@ func newPronunciationDictionariesAddFromFileCmd(flags *rootFlags) *cobra.Command
 				fields["description"] = bodyDescription
 			}
 			if bodyFile != "" {
-				fields["file"] = bodyFile
+				// PATCH: the .pls lexicon is an upload, not a text field.
+				fileFields["file"] = bodyFile
 			}
 			if bodyName != "" {
 				fields["name"] = bodyName

--- a/library/ai/elevenlabs/internal/cli/speech-to-text_speech_to_text.go
+++ b/library/ai/elevenlabs/internal/cli/speech-to-text_speech_to_text.go
@@ -88,7 +88,9 @@ func newSpeechToTextSpeechToTextCmd(flags *rootFlags) *cobra.Command {
 				fields["entity_redaction_mode"] = bodyEntityRedactionMode
 			}
 			if bodyFile != "" {
-				fields["file"] = bodyFile
+				// PATCH: file is an upload, not a text field — route to fileFields
+				// so the bytes are sent, not the literal path string.
+				fileFields["file"] = bodyFile
 			}
 			if bodyFileFormat != "" {
 				fields["file_format"] = bodyFileFormat

--- a/library/ai/elevenlabs/internal/cli/studio_add-project.go
+++ b/library/ai/elevenlabs/internal/cli/studio_add-project.go
@@ -106,7 +106,8 @@ func newStudioAddProjectCmd(flags *rootFlags) *cobra.Command {
 				fields["from_content_json"] = bodyFromContentJson
 			}
 			if bodyFromDocument != "" {
-				fields["from_document"] = bodyFromDocument
+				// PATCH: from_document is a file upload (.epub/.pdf/.txt), not a text field.
+				fileFields["from_document"] = bodyFromDocument
 			}
 			if bodyFromUrl != "" {
 				fields["from_url"] = bodyFromUrl

--- a/library/ai/elevenlabs/internal/cli/studio_edit-project-content.go
+++ b/library/ai/elevenlabs/internal/cli/studio_edit-project-content.go
@@ -43,7 +43,8 @@ func newStudioEditProjectContentCmd(flags *rootFlags) *cobra.Command {
 				fields["from_content_json"] = bodyFromContentJson
 			}
 			if bodyFromDocument != "" {
-				fields["from_document"] = bodyFromDocument
+				// PATCH: from_document is a file upload (.epub/.pdf/.txt), not a text field.
+				fileFields["from_document"] = bodyFromDocument
 			}
 			if bodyFromUrl != "" {
 				fields["from_url"] = bodyFromUrl


### PR DESCRIPTION
## Summary
- route file path fields through multipart fileFields for dubbing, pronunciation dictionaries, speech-to-text, and studio project content commands
- add a schema_version 2 patch record documenting the published-library customization

## Validation
- go test ./... (library/ai/elevenlabs)
- go vet ./... (library/ai/elevenlabs)