### PR TITLE
docs: stop telling manual submitters to edit generated registry.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,14 @@ If you prefer to submit manually:
 
 1. Generate your CLI with `/printing-press <API>`
 2. Verify it passes quality gates: `go build ./...`, `go vet ./...`
-3. Fork this repo and create a branch: `feat/<cli-name>`
-4. Add your CLI under `library/<category>/<cli-name>/` with:
+3. Fork this repo and create a branch: `feat/<slug>`
+4. Add your CLI under `library/<category>/<slug>/` with:
    - The full CLI source code
    - `.printing-press.json` manifest
+   - `SKILL.md` and `.goreleaser.yaml`
+   - `manifest.json` (only if the CLI ships an MCP server)
    - `.manuscripts/` directory with research and proof artifacts
-5. Update `registry.json` with your CLI's entry
+5. **Do not edit `registry.json` or `cli-skills/pp-*/SKILL.md` in the PR.** They are generated artifacts, regenerated after merge by `generate-registry.yml` and `generate-skills.yml`, and the generated-artifact guard in CI fails any PR that modifies them. Instead, make sure the source files under `library/<category>/<slug>/` are present: `registry.json` is generated from `.printing-press.json` + `manifest.json` + `.goreleaser.yaml`, and `cli-skills/pp-<slug>/SKILL.md` is mirrored from `library/<category>/<slug>/SKILL.md`.
 6. Open a PR
 
 ### Quality Expectations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you prefer to submit manually:
    - `SKILL.md` and `.goreleaser.yaml`
    - `manifest.json` (only if the CLI ships an MCP server)
    - `.manuscripts/` directory with research and proof artifacts
-5. **Do not edit `registry.json` or `cli-skills/pp-*/SKILL.md` in the PR.** They are generated artifacts, regenerated after merge by `generate-registry.yml` and `generate-skills.yml`, and the generated-artifact guard in CI fails any PR that modifies them. Instead, make sure the source files under `library/<category>/<slug>/` are present: `registry.json` is generated from `.printing-press.json` + `manifest.json` + `.goreleaser.yaml`, and `cli-skills/pp-<slug>/SKILL.md` is mirrored from `library/<category>/<slug>/SKILL.md`.
+5. **Do not edit `registry.json` or `cli-skills/pp-*/SKILL.md` in the PR.** They are generated artifacts, regenerated after merge by `generate-registry.yml` and `generate-skills.yml`, and the generated-artifact guard in CI fails any PR that modifies them. Instead, make sure the source files under `library/<category>/<slug>/` are present: `registry.json` is generated from `.printing-press.json` + `.goreleaser.yaml` (plus `manifest.json` if the CLI ships an MCP server), and `cli-skills/pp-<slug>/SKILL.md` is mirrored from `library/<category>/<slug>/SKILL.md`.
 6. Open a PR
 
 ### Quality Expectations


### PR DESCRIPTION
## What

Fixes the stale Manual Submission guidance in `CONTRIBUTING.md`.

Step 5 told manual contributors to **"Update `registry.json` with your CLI's entry"** — but `registry.json` (and `cli-skills/pp-*/SKILL.md`) are generated artifacts, regenerated post-merge by `generate-registry.yml` / `generate-skills.yml`. The `Fail on changes to generated artifacts` step in `verify-library-conventions.yml` hard-fails any PR that modifies them, so the old instruction sent manual contributors straight into a CI failure.

## Changes

- **Step 5** now tells contributors **not** to edit `registry.json` or `cli-skills/pp-*/SKILL.md`, explains they regenerate after merge, and points to the source files that produce them (`.printing-press.json` + `manifest.json` + `.goreleaser.yaml` → registry; `library/<category>/<slug>/SKILL.md` → skill mirror).
- **Step 4** now lists `SKILL.md` and `.goreleaser.yaml` (required source files), plus `manifest.json` for MCP-shipping CLIs.
- Aligned the directory/branch placeholders to the canonical `<slug>` (was `<cli-name>`), matching the rest of the repo conventions.

Docs-only change to repo-root `CONTRIBUTING.md` — no library, registry, cli-skills, or npm-package files touched, so no generated-artifact regen and no npm release are triggered.

Fixes #1043
