### PR TITLE
chore: tune Greptile helper readiness markers

### DIFF
--- a/.github/scripts/pr-review-state/greptile_feedback.py
+++ b/.github/scripts/pr-review-state/greptile_feedback.py
@@ -23,7 +23,6 @@ ACTIONABLE_MARKERS = (
     "remaining open item",
     "Safe to merge after fixing",
     "Safe to merge after reviewing",
-    "needs attention",
 )
 
 
@@ -250,10 +249,13 @@ def main() -> int:
     latest = latest_greptile_comment(pr["comments"]["nodes"])
     latest_body = latest.get("body", "") if latest else ""
     latest_reviewed = reviewed_commit(latest_body) if latest else None
+    head = pr["headRefOid"]
+    latest_reviewed_matches_head = (
+        latest_reviewed is not None and head.startswith(latest_reviewed)
+    )
     markers = [marker for marker in ACTIONABLE_MARKERS if marker in latest_body]
     greptile_review = check_bucket(checks, "Greptile Review")
     greptile_gate = check_bucket(checks, "Greptile policy gate")
-    head = pr["headRefOid"]
 
     print(f"PR: {pr['url']}")
     print(f"Head SHA: {head}")
@@ -264,7 +266,7 @@ def main() -> int:
     print(f"Latest Greptile actionable markers: {', '.join(markers) if markers else 'none'}")
 
     ready = True
-    if latest_reviewed != head:
+    if not latest_reviewed_matches_head:
         ready = False
         print("NOT READY: latest Greptile comment does not match PR head")
     if greptile_review != "pass":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Greptile feedback is not limited to GitHub review threads. It also edits top-lev
 python3 .github/scripts/pr-review-state/greptile_feedback.py <PR_NUMBER>
 ```
 
-`PR_NUMBER` is the GitHub pull request number, for example `1093` — not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/printing-press-library` and exits non-zero until all of these are true: Greptile Review passes, Greptile policy gate passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, `needs attention`, or `Safe to merge after fixing/reviewing`.
+`PR_NUMBER` is the GitHub pull request number, for example `1093` — not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/printing-press-library` and exits non-zero until all of these are true: Greptile Review passes, Greptile policy gate passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, or `Safe to merge after fixing/reviewing`.
 
 If you (an agent) opened the PR, you own driving it to ready-to-merge:
 


### PR DESCRIPTION
## Summary
- remove the overly broad `needs attention` substring from Greptile actionable markers
- allow the reviewed-commit check to match abbreviated Greptile commit SHAs against the full PR head SHA
- keep AGENTS.md aligned with the helper marker list

## Validation
- python3 -m py_compile .github/scripts/pr-review-state/greptile_feedback.py
- git diff --check -- AGENTS.md .github/scripts/pr-review-state/greptile_feedback.py
- python3 .github/scripts/pr-review-state/greptile_feedback.py 1095